### PR TITLE
:has(:lang(~)) doesn't get invalidated

### DIFF
--- a/LayoutTests/fast/css/lang-pseudo-container-query-invalidation-expected.html
+++ b/LayoutTests/fast/css/lang-pseudo-container-query-invalidation-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/css/lang-pseudo-container-query-invalidation-xhtml-expected.html
+++ b/LayoutTests/fast/css/lang-pseudo-container-query-invalidation-xhtml-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/css/lang-pseudo-container-query-invalidation-xhtml.xhtml
+++ b/LayoutTests/fast/css/lang-pseudo-container-query-invalidation-xhtml.xhtml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html class="reftest-wait" xmlns="http://www.w3.org/1999/xhtml">
+<body>
+    <section class="lang"><div xml:lang="zh" lang="ja"></div></section>
+    <section class="lang"><div id="ja" xml:lang="ja" lang="ja"></div></section>
+    <div><section class="lang" id="fr" lang="fr" style="-webkit-locale: 'en'"><div></div></section></div>
+    <div><section class="lang" id="es" xml:lang="es"><div></div></section></div>
+    <section class="lang"><div id="kr" xml:lang="kr" lang="en"></div></section>
+    <style>
+        body > * { background: red; }
+        section, div { width: 100px; height: 20px; }
+        .lang:has(:lang(zh)) { background: green; }
+        .lang:has(:lang(ja)) { background: red; }
+        div:has(.lang:lang(fr)) { background: red; }
+        div:has(.lang:lang(en)) { background: green; }
+        div:has(#es:lang(es)) { background: red; }
+        div:has(#es:lang(en)) { background: green; }
+        .lang:has(#kr:lang(kr)) { background: red; }
+        .lang:has(#kr:lang(kr)) { background: green; }
+        div:has(.lang > :lang(pt)) { background: red; }
+    </style>
+    <script>
+        requestAnimationFrame(() => {
+            setTimeout(() => {
+                document.getElementById('ja').setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:lang', 'zh');
+                document.getElementById('fr').setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:lang', 'en');
+                document.getElementById('es').setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:lang', 'en');
+                document.getElementById('kr').removeAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:lang');
+                document.documentElement.className = '';
+            }, 0);
+        });
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/css/lang-pseudo-container-query-invalidation.html
+++ b/LayoutTests/fast/css/lang-pseudo-container-query-invalidation.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<body>
+    <section class="lang"><div lang="en"></div></section>
+    <section class="lang" id="fr" lang="fr"><div></div></section>
+    <section class="lang" id="ja" lang="ja" style="-webkit-locale: 'en'"><div></div></section>
+    <div><section class="lang" id="zh" lang="zh" style="-webkit-locale: 'en'"><span></span></section></div>
+    <div id="kr" class="lang" lang="kr"></div>
+    <style>
+        div { width: 100px; height: 20px; }
+        .lang div:lang(en) { background: green; }
+        .lang div:lang(fr) { background: red; }
+        .lang div:lang(ja) { background: red; }
+        div:has(.lang :lang(zh)) { background: red; }
+        div:has(.lang :lang(en)) { background: green; }
+        .lang:lang(kr) { background: red; }
+        .lang div:lang(kr) { background: green; }
+    </style>
+    <script>
+        requestAnimationFrame(() => {
+            setTimeout(() => {
+                fr.lang = 'en';
+                ja.lang = 'en';
+                zh.lang = 'en';
+                kr.appendChild(document.createElement('div'));
+                document.documentElement.className = '';
+            }, 0);
+        });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -204,7 +204,7 @@ ALWAYS_INLINE bool matchesLangPseudoClass(const Element& element, const Vector<A
         language = downcast<WebVTTElement>(element).language();
     else
 #endif
-        language = element.computeInheritedLanguage();
+        language = element.effectiveLang();
 
     if (language.isEmpty())
         return false;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1918,6 +1918,15 @@ static inline bool isElementsArrayReflectionAttribute(const QualifiedName& name)
         || name == HTMLNames::aria_ownsAttr;
 }
 
+static inline AtomString effectiveLangFromAttribute(const Element& element)
+{
+    if (auto* elementData = element.elementData()) {
+        if (auto* attribute = elementData->findLanguageAttribute())
+            return attribute->value();
+    }
+    return nullAtom();
+}
+
 void Element::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason)
 {
     bool valueIsSameAsBefore = oldValue == newValue;
@@ -1961,6 +1970,28 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
             if (auto* shadowRoot = this->shadowRoot()) {
                 shadowRoot->invalidatePartMappings();
                 Style::Invalidator::invalidateShadowParts(*shadowRoot);
+            }
+        } else if (name == HTMLNames::langAttr || name.matches(XMLNames::langAttr)) {
+            Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassLang, Style::PseudoClassChangeInvalidation::AnyValue);
+            AtomString newValue = effectiveLangFromAttribute(*this);
+            auto setEffectiveLang = [&](Element& element) {
+                if (!newValue.isNull())
+                    element.ensureElementRareData().setEffectiveLang(newValue);
+                else if (hasRareData())
+                    element.elementRareData()->setEffectiveLang(nullAtom());                
+            };
+            setEffectiveLang(*this);
+            for (auto it = descendantsOfType<Element>(*this).begin(); it;) {
+                auto& element = *it;
+                if (auto* elementData = element.elementData()) {
+                    if (auto* attribute = elementData->findLanguageAttribute()) {
+                        it.traverseNextSkippingChildren();
+                        continue;
+                    }
+                }
+                Style::PseudoClassChangeInvalidation styleInvalidation(element, CSSSelector::PseudoClassLang, Style::PseudoClassChangeInvalidation::AnyValue);
+                setEffectiveLang(element);
+                it.traverseNext();
             }
         }
     }
@@ -2485,6 +2516,20 @@ Node::InsertedIntoAncestorResult Element::insertedIntoAncestor(InsertionType ins
             CustomElementReactionQueue::enqueueConnectedCallbackIfNeeded(*this);
     }
 
+    [&]() {
+        if (auto* parent = parentOrShadowHostElement(); parent && UNLIKELY(parent->hasRareData())) {
+            auto lang = parent->elementRareData()->effectiveLang();
+            if (!lang.isNull() && effectiveLangFromAttribute(*this).isNull()) {
+                ensureElementRareData().setEffectiveLang(lang);
+                return;
+            }
+        }
+        if (UNLIKELY(hasRareData())) {
+            if (!elementRareData()->effectiveLang().isNull() && effectiveLangFromAttribute(*this).isNull())
+                ensureElementRareData().setEffectiveLang(nullAtom());
+        }
+    }();
+
     if (shouldAutofocus(*this))
         document().topDocument().appendAutofocusCandidate(*this);
 
@@ -2548,6 +2593,11 @@ void Element::removedFromAncestor(RemovalType removalType, ContainerNode& oldPar
     clearAfterPseudoElement();
 
     ContainerNode::removedFromAncestor(removalType, oldParentOfRemovedTree);
+
+    if (UNLIKELY(hasRareData()) && !elementRareData()->effectiveLang().isNull()) {
+        if (effectiveLangFromAttribute(*this).isNull())
+            elementRareData()->setEffectiveLang(nullAtom());
+    }
 
     if (hasPendingResources())
         document().accessSVGExtensions().removeElementFromPendingResources(*this);
@@ -3823,6 +3873,16 @@ AtomString Element::computeInheritedLanguage() const
             if (auto* attribute = elementData->findLanguageAttribute())
                 return attribute->value();
         }
+    }
+    return document().contentLanguage();
+}
+
+AtomString Element::effectiveLang() const
+{
+    if (hasRareData()) {
+        auto lang = elementRareData()->effectiveLang();
+        if (!lang.isNull())
+            return lang;
     }
     return document().contentLanguage();
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -420,6 +420,7 @@ public:
     void setChildIndex(unsigned);
 
     WEBCORE_EXPORT AtomString computeInheritedLanguage() const;
+    AtomString effectiveLang() const;
     Locale& locale() const;
 
     virtual bool accessKeyAction(bool /*sendToAnyEvent*/) { return false; }

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 struct SameSizeAsElementRareData : NodeRareData {
     IntPoint savedLayerScrollPosition;
     Vector<std::unique_ptr<ElementAnimationRareData>> animationRareData;
-    void* pointers[11];
+    void* pointers[12];
     void* intersectionObserverData;
 #if ENABLE(CSS_TYPED_OM)
     void* typedOMData[2];

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -72,6 +72,9 @@ public:
     RenderStyle* computedStyle() const { return m_computedStyle.get(); }
     void setComputedStyle(std::unique_ptr<RenderStyle> computedStyle) { m_computedStyle = WTFMove(computedStyle); }
 
+    const AtomString& effectiveLang() const { return m_effectiveLang; }
+    void setEffectiveLang(const AtomString& lang) { m_effectiveLang = lang; }
+
     DOMTokenList* classList() const { return m_classList.get(); }
     void setClassList(std::unique_ptr<DOMTokenList> classList) { m_classList = WTFMove(classList); }
 
@@ -119,10 +122,12 @@ public:
             result.add(UseType::ScrollingPosition);
         if (m_computedStyle)
             result.add(UseType::ComputedStyle);
-        if (m_dataset)
-            result.add(UseType::Dataset);
+        if (m_effectiveLang)
+            result.add(UseType::LangEffective);
         if (m_classList)
             result.add(UseType::ClassList);
+        if (m_dataset)
+            result.add(UseType::Dataset);
         if (m_shadowRoot)
             result.add(UseType::ShadowRoot);
         if (m_customElementReactionQueue)
@@ -159,6 +164,7 @@ private:
     IntPoint m_savedLayerScrollPosition;
     std::unique_ptr<RenderStyle> m_computedStyle;
 
+    AtomString m_effectiveLang;
     std::unique_ptr<DatasetDOMStringMap> m_dataset;
     std::unique_ptr<DOMTokenList> m_classList;
     RefPtr<ShadowRoot> m_shadowRoot;

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -269,6 +269,7 @@ public:
         Nonce = 1 << 18,
         ComputedStyleMap = 1 << 19,
         ExplicitlySetAttrElementsMap = 1 << 20,
+        EffectiveLang = 1 << 21,
     };
 #endif
 

--- a/Source/WebCore/style/PseudoClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/PseudoClassChangeInvalidation.cpp
@@ -52,7 +52,7 @@ Vector<PseudoClassInvalidationKey, 4> makePseudoClassInvalidationKeys(CSSSelecto
     return keys;
 };
 
-void PseudoClassChangeInvalidation::computeInvalidation(CSSSelector::PseudoClassType pseudoClass, bool value, InvalidationScope invalidationScope)
+void PseudoClassChangeInvalidation::computeInvalidation(CSSSelector::PseudoClassType pseudoClass, Value value, InvalidationScope invalidationScope)
 {
     bool shouldInvalidateCurrent = false;
     bool mayAffectStyleInShadowTree = false;
@@ -76,7 +76,7 @@ void PseudoClassChangeInvalidation::computeInvalidation(CSSSelector::PseudoClass
         collectRuleSets(key, value, invalidationScope);
 }
 
-void PseudoClassChangeInvalidation::collectRuleSets(const PseudoClassInvalidationKey& key, bool value, InvalidationScope invalidationScope)
+void PseudoClassChangeInvalidation::collectRuleSets(const PseudoClassInvalidationKey& key, Value value, InvalidationScope invalidationScope)
 {
     auto& ruleSets = m_element.styleResolver().ruleSets();
     auto* invalidationRuleSets = ruleSets.pseudoClassInvalidationRuleSets(key);
@@ -101,7 +101,13 @@ void PseudoClassChangeInvalidation::collectRuleSets(const PseudoClassInvalidatio
         if (!shouldInvalidate)
             continue;
 
-        bool invalidateBeforeChange = invalidationRuleSet.isNegation == IsNegation::Yes ? value : !value;
+        if (value == Value::Any) {
+            Invalidator::addToMatchElementRuleSets(m_beforeChangeRuleSets, invalidationRuleSet);
+            Invalidator::addToMatchElementRuleSets(m_afterChangeRuleSets, invalidationRuleSet);
+            continue;
+        }
+
+        bool invalidateBeforeChange = invalidationRuleSet.isNegation == IsNegation::Yes ? value == Value::True : value == Value::False;
         if (invalidateBeforeChange)
             Invalidator::addToMatchElementRuleSets(m_beforeChangeRuleSets, invalidationRuleSet);
         else


### PR DESCRIPTION
#### d66896dfcf4fa8f57a526003cfe8144e0360adda
<pre>
:has(:lang(~)) doesn&apos;t get invalidated
<a href="https://bugs.webkit.org/show_bug.cgi?id=243172">https://bugs.webkit.org/show_bug.cgi?id=243172</a>

Reviewed by Antti Koivisto.

Make container query work with :lang pseudo class.

This patch introduces ElementRareData::effectiveLang to store the language of each element,
and uses Style::PseudoClassChangeInvalidation to invalidate styles for :lang pseudo class.

* LayoutTests/fast/css/lang-pseudo-container-query-invalidation-expected.html: Added.
* LayoutTests/fast/css/lang-pseudo-container-query-invalidation-xhtml-expected.html: Added.
* LayoutTests/fast/css/lang-pseudo-container-query-invalidation-xhtml.xhtml: Added.
* LayoutTests/fast/css/lang-pseudo-container-query-invalidation.html: Added.

* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesLangPseudoClass): Use newly introduced effectiveLang.

* Source/WebCore/dom/Element.cpp:
(WebCore::effectiveLangFromAttribute):
(WebCore::Element::attributeChanged): Added the style invalidation logic for :lang.
(WebCore::Element::insertedIntoAncestor): Propagate the lang attribute from the parent.
(WebCore::Element::removedFromAncestor): Clear the effective lang when appropriate.
(WebCore::Element::effectiveLang const): Added.

* Source/WebCore/dom/Element.h:

* Source/WebCore/dom/ElementRareData.cpp:
(WebCore::SameSizeAsElementRareData):

* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::effectiveLang const): Added.
(WebCore::ElementRareData::setEffectiveLang): Added.
(WebCore::ElementRareData::useTypes const):

* Source/WebCore/dom/NodeRareData.h:
* Source/WebCore/style/PseudoClassChangeInvalidation.cpp:
(WebCore::Style::PseudoClassChangeInvalidation::computeInvalidation):
(WebCore::Style::PseudoClassChangeInvalidation::collectRuleSets):
* Source/WebCore/style/PseudoClassChangeInvalidation.h:
(WebCore::Style::PseudoClassChangeInvalidation::Value): Added.
(WebCore::Style::PseudoClassChangeInvalidation::PseudoClassChangeInvalidation): Added a new variant
which takes AnyValueTag as an argument.

* Tools/TestWebKitAPI/Tests/WebCore/DocumentOrder.cpp:
(TestWebKitAPI::createDocument): Initialize XMLNames via ProcessWarming.
</pre>