### PR TITLE
[libpas] Remove static initializers of configs with GCC

### DIFF
--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -671,6 +671,8 @@ set(bmalloc_INTERFACE_LIBRARIES bmalloc)
 set(bmalloc_INTERFACE_INCLUDE_DIRECTORIES ${bmalloc_FRAMEWORK_HEADERS_DIR})
 set(bmalloc_INTERFACE_DEPENDENCIES bmalloc_CopyHeaders)
 
+add_definitions(-D_GNU_SOURCE)
+
 WEBKIT_FRAMEWORK_DECLARE(bmalloc)
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 
@@ -685,15 +687,11 @@ WEBKIT_FRAMEWORK_TARGET(bmalloc)
 
 set_source_files_properties(
     libpas/src/libpas/pas_bitfit_page_config_kind.c
-    libpas/src/libpas/pas_thread_local_cache.c
     libpas/src/libpas/jit_heap.c
-    libpas/src/libpas/jit_heap_config.c
     libpas/src/libpas/bmalloc_heap.c
     libpas/src/libpas/bmalloc_heap_config.c
-    libpas/src/libpas/pas_utility_heap_config.c
     libpas/src/libpas/pas_heap_config_kind.c
     libpas/src/libpas/pas_segregated_page_config_kind.c
-    libpas/src/libpas/pas_fast_megapage_cache.c
     PROPERTIES LANGUAGE CXX)
 
 WEBKIT_ADD_TARGET_CXX_FLAGS(bmalloc

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_kind.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_kind.c
@@ -64,14 +64,14 @@ bool pas_bitfit_page_config_kind_for_each(
     return true;    
 }
 
-const pas_bitfit_page_config* pas_bitfit_page_config_kind_for_config_table[
+const pas_page_base_config* pas_bitfit_page_config_kind_for_config_table[
     0
 #define PAS_DEFINE_BITFIT_PAGE_CONFIG_KIND(name, value) + 1
 #include "pas_bitfit_page_config_kind.def"
 #undef PAS_DEFINE_BITFIT_PAGE_CONFIG_KIND
     ] = {
 #define PAS_DEFINE_BITFIT_PAGE_CONFIG_KIND(name, value) \
-    (const pas_bitfit_page_config*)(value).base.page_config_ptr,
+    (value).base.page_config_ptr,
 #include "pas_bitfit_page_config_kind.def"
 #undef PAS_DEFINE_BITFIT_PAGE_CONFIG_KIND
 };

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_kind.h
@@ -30,7 +30,9 @@
 
 PAS_BEGIN_EXTERN_C;
 
+struct pas_page_base_config;
 struct pas_bitfit_page_config;
+typedef struct pas_page_base_config pas_page_base_config;
 typedef struct pas_bitfit_page_config pas_bitfit_page_config;
 
 enum pas_bitfit_page_config_kind {
@@ -52,12 +54,12 @@ PAS_API bool pas_bitfit_page_config_kind_for_each(
     pas_bitfit_page_config_kind_callback callback,
     void *arg);
 
-PAS_API extern const pas_bitfit_page_config* pas_bitfit_page_config_kind_for_config_table[];
+PAS_API extern const pas_page_base_config* pas_bitfit_page_config_kind_for_config_table[];
 
 static inline const pas_bitfit_page_config* pas_bitfit_page_config_kind_get_config(
     pas_bitfit_page_config_kind kind)
 {
-    return pas_bitfit_page_config_kind_for_config_table[kind];
+    return (const pas_bitfit_page_config*)pas_bitfit_page_config_kind_for_config_table[kind];
 }
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_utils.h
@@ -45,13 +45,7 @@ typedef struct {
 
 #define PAS_BASIC_BITFIT_PAGE_CONFIG_DECLARATIONS(name, config_value, ...) \
     PAS_BASIC_PAGE_BASE_CONFIG_DECLARATIONS( \
-        name, (config_value).base, \
-        .header_placement_mode = \
-            ((pas_basic_bitfit_page_config_declarations_arguments){__VA_ARGS__}) \
-            .header_placement_mode, \
-        .header_table = \
-            ((pas_basic_bitfit_page_config_declarations_arguments){__VA_ARGS__}) \
-            .header_table)
+        name, (config_value).base, __VA_ARGS__)
 
 PAS_END_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
@@ -421,25 +421,25 @@ typedef struct {
     \
     PAS_BASIC_SEGREGATED_PAGE_CONFIG_DECLARATIONS( \
         name ## _small_segregated, (upcase_name ## _HEAP_CONFIG).small_segregated_config, \
-        .header_placement_mode = pas_page_header_at_head_of_page, \
-        .header_table = NULL); \
+        pas_page_header_at_head_of_page, \
+        NULL); \
     PAS_BASIC_SEGREGATED_PAGE_CONFIG_DECLARATIONS( \
         name ## _medium_segregated, (upcase_name ## _HEAP_CONFIG).medium_segregated_config, \
-        .header_placement_mode = pas_page_header_in_table, \
-        .header_table = &name ## _medium_page_header_table); \
+        pas_page_header_in_table, \
+        &name ## _medium_page_header_table); \
     \
     PAS_BASIC_BITFIT_PAGE_CONFIG_DECLARATIONS( \
         name ## _small_bitfit, (upcase_name ## _HEAP_CONFIG).small_bitfit_config, \
-        .header_placement_mode = pas_page_header_at_head_of_page, \
-        .header_table = NULL); \
+        pas_page_header_at_head_of_page, \
+        NULL); \
     PAS_BASIC_BITFIT_PAGE_CONFIG_DECLARATIONS( \
         name ## _medium_bitfit, (upcase_name ## _HEAP_CONFIG).medium_bitfit_config, \
-        .header_placement_mode = pas_page_header_in_table, \
-        .header_table = &name ## _medium_page_header_table); \
+        pas_page_header_in_table, \
+        &name ## _medium_page_header_table); \
     PAS_BASIC_BITFIT_PAGE_CONFIG_DECLARATIONS( \
         name ## _marge_bitfit, (upcase_name ## _HEAP_CONFIG).marge_bitfit_config, \
-        .header_placement_mode = pas_page_header_in_table, \
-        .header_table = &name ## _marge_page_header_table); \
+        pas_page_header_in_table, \
+        &name ## _marge_page_header_table); \
     \
     struct pas_dummy
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h
@@ -54,16 +54,12 @@ typedef struct {
                                             are dealing with. */
 } pas_basic_page_base_config_declarations_arguments;
 
-#define PAS_BASIC_PAGE_BASE_CONFIG_DECLARATIONS(name, config_value, ...) \
-    static const pas_page_header_placement_mode name ## _header_placement_mode = \
-        ((pas_basic_page_base_config_declarations_arguments){__VA_ARGS__}) \
-        .header_placement_mode; \
-    \
+#define PAS_BASIC_PAGE_BASE_CONFIG_DECLARATIONS(name, config_value, header_placement_mode_value, header_table_value) \
+    static const pas_page_header_placement_mode name ## _header_placement_mode = (header_placement_mode_value); \
     static PAS_ALWAYS_INLINE pas_page_base* \
     name ## _page_header_for_boundary(void* boundary) \
     { \
-        pas_basic_page_base_config_declarations_arguments arguments = \
-            ((pas_basic_page_base_config_declarations_arguments){__VA_ARGS__}); \
+        pas_basic_page_base_config_declarations_arguments arguments = { .header_placement_mode = (header_placement_mode_value), .header_table = (header_table_value) }; \
         pas_page_base_config config; \
         \
         config = (config_value); \
@@ -90,8 +86,7 @@ typedef struct {
     static PAS_ALWAYS_INLINE void* \
     name ## _boundary_for_page_header(pas_page_base* page) \
     { \
-        pas_basic_page_base_config_declarations_arguments arguments = \
-            ((pas_basic_page_base_config_declarations_arguments){__VA_ARGS__}); \
+        pas_basic_page_base_config_declarations_arguments arguments = { .header_placement_mode = (header_placement_mode_value), .header_table = (header_table_value) }; \
         pas_page_base_config config; \
         \
         config = (config_value); \

--- a/Source/bmalloc/libpas/src/libpas/pas_page_header_table.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_header_table.h
@@ -45,10 +45,10 @@ struct pas_page_header_table {
 };
 
 #define PAS_PAGE_HEADER_TABLE_INITIALIZER(passed_page_size) \
-    ((pas_page_header_table){ \
+    { \
          .page_size = (passed_page_size), \
          .hashtable = PAS_LOCK_FREE_READ_PTR_PTR_HASHTABLE_INITIALIZER \
-     })
+    }
 
 static inline unsigned pas_page_header_table_hash(const void* key, void* arg)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind.c
@@ -60,14 +60,14 @@ bool pas_segregated_page_config_kind_for_each(
     return true;    
 }
 
-const pas_segregated_page_config* pas_segregated_page_config_kind_for_config_table[
+const pas_page_base_config* pas_segregated_page_config_kind_for_config_table[
     0
 #define PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND(name, value) + 1
 #include "pas_segregated_page_config_kind.def"
 #undef PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND
     ] = {
 #define PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND(name, value) \
-    (const pas_segregated_page_config*)(value).base.page_config_ptr,
+    (value).base.page_config_ptr,
 #include "pas_segregated_page_config_kind.def"
 #undef PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND
 };

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind.h
@@ -30,7 +30,9 @@
 
 PAS_BEGIN_EXTERN_C;
 
+struct pas_page_base_config;
 struct pas_segregated_page_config;
+typedef struct pas_page_base_config pas_page_base_config;
 typedef struct pas_segregated_page_config pas_segregated_page_config;
 
 enum pas_segregated_page_config_kind {
@@ -52,12 +54,12 @@ PAS_API bool pas_segregated_page_config_kind_for_each(
     pas_segregated_page_config_kind_callback callback,
     void *arg);
 
-PAS_API extern const pas_segregated_page_config* pas_segregated_page_config_kind_for_config_table[];
+PAS_API extern const pas_page_base_config* pas_segregated_page_config_kind_for_config_table[];
 
 static inline const pas_segregated_page_config* pas_segregated_page_config_kind_get_config(
     pas_segregated_page_config_kind kind)
 {
-    return pas_segregated_page_config_kind_for_config_table[kind];
+    return (const pas_segregated_page_config*)pas_segregated_page_config_kind_for_config_table[kind];
 }
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_utils.h
@@ -80,12 +80,7 @@ typedef struct {
 #define PAS_BASIC_SEGREGATED_PAGE_CONFIG_DECLARATIONS(name, config_value, ...) \
     PAS_BASIC_PAGE_BASE_CONFIG_DECLARATIONS( \
         name, (config_value).base, \
-        .header_placement_mode = \
-            ((pas_basic_segregated_page_config_declarations_arguments){__VA_ARGS__}) \
-            .header_placement_mode, \
-        .header_table = \
-            ((pas_basic_segregated_page_config_declarations_arguments){__VA_ARGS__}) \
-            .header_table); \
+        __VA_ARGS__); \
     \
     struct pas_dummy
 


### PR DESCRIPTION
#### 8cd341b07917045fc8fcbc16b4f9fcb05d3d29f8
<pre>
[libpas] Remove static initializers of configs with GCC
<a href="https://bugs.webkit.org/show_bug.cgi?id=243984">https://bugs.webkit.org/show_bug.cgi?id=243984</a>

Reviewed by Mark Lam.

GCC cannot handle constants well compared to clang, and it emits static initializers incorrectly.
We modify the code a bit to avoid generating static initializers with GCC for libpas configs.

* Source/bmalloc/CMakeLists.txt:
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_kind.c:
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_kind.h:
(pas_bitfit_page_config_kind_get_config):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_utils.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h:
* Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h:
* Source/bmalloc/libpas/src/libpas/pas_page_header_table.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind.c:
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind.h:
(pas_segregated_page_config_kind_get_config):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_utils.h:

Canonical link: <a href="https://commits.webkit.org/253488@main">https://commits.webkit.org/253488@main</a>
</pre>
