### PR TITLE
[ews] Do not clobber status-bubble from other repos

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -288,6 +288,11 @@ class GitHubEWS(GitHub):
             _log.error('Invalid pr_id: {}'.format(pr_id))
             return -1
 
+        if pr_project and pr_project != 'WebKit/WebKit':
+            _log.error('custom pr_project is not support yet.')
+            # FIXME: Add support for custom pr_project (e.g.: apple/WebKit) https://bugs.webkit.org/show_bug.cgi?id=243987
+            return -1
+
         change = Change.get_change(sha)
         if not change:
             _log.error('Change not found for hash: {}. Unable to generate github comment.'.format(sha))


### PR DESCRIPTION
#### 2065ec6b6c1512140b5ec2d2d11ce17a7a0975b8
<pre>
[ews] Do not clobber status-bubble from other repos
<a href="https://bugs.webkit.org/show_bug.cgi?id=243964">https://bugs.webkit.org/show_bug.cgi?id=243964</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS.add_or_update_comment_for_change_id):

Canonical link: <a href="https://commits.webkit.org/253471@main">https://commits.webkit.org/253471@main</a>
</pre>
