### PR TITLE
[Gardening]: [ Windows-EWS ] fast/text/punctuation-break-all.html is a constant image failure

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -2121,3 +2121,4 @@ fast/canvas/toDataURL-alpha-permutation.html [ ImageOnlyFailure ]
 webgl/2.0.y/conformance/extensions/webgl-multi-draw.html [ Failure ]
 webgl/2.0.y/conformance2/extensions/webgl-multi-draw-instanced-base-vertex-base-instance.html [ Failure ]
 
+webkit.org/b/243992 fast/text/punctuation-break-all.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 66e25bab4b36a0733a6bb27d63d80f58415b43f9
<pre>
[Gardening]: [ Windows-EWS ] fast/text/punctuation-break-all.html is a constant image failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243992">https://bugs.webkit.org/show_bug.cgi?id=243992</a>
&lt;rdar://98721908&gt;

Unreviewed test gardening.

* LayoutTests/platform/wincairo/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253466@main">https://commits.webkit.org/253466@main</a>
</pre>
