### PR TITLE
Fix a misnomer in Config::permanentlyFreeze().

### DIFF
--- a/Source/WTF/wtf/WTFConfig.cpp
+++ b/Source/WTF/wtf/WTFConfig.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -109,12 +109,12 @@ void Config::permanentlyFreeze()
 #if ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 #if PLATFORM(COCOA)
     enum {
-        AllowPermissionChangesAfterThis = false,
-        DisallowPermissionChangesAfterThis = true
+        DontUpdateMaximumPermission = false,
+        UpdateMaximumPermission = true
     };
 
     // There's no going back now!
-    result = vm_protect(mach_task_self(), reinterpret_cast<vm_address_t>(&WebConfig::g_config), ConfigSizeToProtect, DisallowPermissionChangesAfterThis, VM_PROT_READ);
+    result = vm_protect(mach_task_self(), reinterpret_cast<vm_address_t>(&WebConfig::g_config), ConfigSizeToProtect, UpdateMaximumPermission, VM_PROT_READ);
 #elif OS(LINUX)
     result = mprotect(&WebConfig::g_config, ConfigSizeToProtect, PROT_READ);
 #elif OS(WINDOWS)


### PR DESCRIPTION
#### 50ae87b49b3150bb49ed052e38630f4f6c628dab
<pre>
Fix a misnomer in Config::permanentlyFreeze().
<a href="https://bugs.webkit.org/show_bug.cgi?id=243980">https://bugs.webkit.org/show_bug.cgi?id=243980</a>
&lt;rdar://problem/98710591&gt;

Reviewed by Justin Michaud.

The purpose of the `true` value passed to `vm_protect` is not to
`DisallowPermissionChangesAfterThis`, but to `UpdateMaximumPermission`.
Rename the related enums accordingly to reflect this.

* Source/WTF/wtf/WTFConfig.cpp:
(WTF::Config::permanentlyFreeze):

Canonical link: <a href="https://commits.webkit.org/253481@main">https://commits.webkit.org/253481@main</a>
</pre>
