### PR TITLE
PlatformMediaSessionManager::sessionWillBeginPlayback should allow resuming media elements

### DIFF
--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -247,8 +247,15 @@ bool PlatformMediaSessionManager::sessionWillBeginPlayback(PlatformMediaSession&
         return false;
     }
 
-    if (m_currentInterruption)
-        endInterruption(PlatformMediaSession::NoFlags);
+    if (m_currentInterruption) {
+        endInterruption(
+#if USE(AUDIO_SESSION)
+            AudioSession::sharedSession().isActive() ? PlatformMediaSession::MayResumePlaying : PlatformMediaSession::NoFlags
+#else
+            PlatformMediaSession::NoFlags
+#endif
+        );
+    }
 
     if (restrictions & ConcurrentPlaybackNotPermitted) {
         forEachMatchingSession([&session](auto& oneSession) {


### PR DESCRIPTION
#### ceed2acda8b0c48a72d564fb3a4106cf557f9d26
<pre>
PlatformMediaSessionManager::sessionWillBeginPlayback should allow resuming media elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=243993">https://bugs.webkit.org/show_bug.cgi?id=243993</a>

In some cases, we end up trying to resume a media element after an end of interruption coming from PlatformMediaSessionManager::sessionWillBeginPlayback.
This for instance happens when returning to a WebRTC page from the YouTube application.
In that case, a first media element might be restarted (we get a notification from audio session to do it).
At that point, we might try to uninterrupt all media elements in PlatformMediaSessionManager::sessionWillBeginPlayback but with NoFlags, while the first media element was probably uninterrupted due to MayResumePlaying being given to endInterruption.
Given we already have one media element playing, it seems ok to try playing the other one as well.

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::sessionWillBeginPlayback):
</pre>


































































<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56f790c862e79094524f87733a752b1b3a24e1f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17618 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95533 "Hash 56f790c8 for PR 3364 does not build") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149264 "Found 1 new test failure: scrollbars/transparent-scrollbar.html") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29134 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25544 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78872 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90775 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92306 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23533 "Found 1 new test failure: fast/forms/ios/ipad/open-picker-using-keyboard.html") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73609 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23595 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66601 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26905 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12730 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26824 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13745 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36608 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33024 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->