### PR TITLE
Web Inspector: REGRESSION(253272@main): Assertion Failed: View.js:243

### DIFF
--- a/LayoutTests/inspector/view/basics-expected.txt
+++ b/LayoutTests/inspector/view/basics-expected.txt
@@ -88,11 +88,17 @@ PASS: Parent detached from root view should have 0 dirty descendants.
 PASS: Root view should not be dirty.
 PASS: Parent detached from root view should not be dirty.
 PASS: Child attached to detached parent view should not be dirty.
+- Dirtying parent.
+PASS: Root view should have 0 dirty descendants.
+PASS: Parent attached to root view should have 0 dirty descendants.
+PASS: Root view should not be dirty.
+PASS: Parent detached from root view should be dirty.
+PASS: Child attached to parent view should not be dirty.
 - Dirtying child.
 PASS: Root view should have 0 dirty descendants.
 PASS: Parent attached to root view should have 1 dirty descendants.
 PASS: Root view should not be dirty.
-PASS: Parent detached from root view should not be dirty.
+PASS: Parent detached from root view should be dirty.
 PASS: Child attached to parent view should be dirty.
 - Adding parent view to root view.
 PASS: Root view should have 1 dirty descendant.

--- a/LayoutTests/inspector/view/basics.html
+++ b/LayoutTests/inspector/view/basics.html
@@ -228,12 +228,20 @@ function test()
             InspectorTest.expectFalse(parent._dirty, "Parent detached from root view should not be dirty.");
             InspectorTest.expectFalse(child._dirty, "Child attached to detached parent view should not be dirty.");
 
+            InspectorTest.log("- Dirtying parent.");
+            parent.needsLayout();
+            InspectorTest.expectEqual(rootView._dirtyDescendantsCount, 0, "Root view should have 0 dirty descendants.");
+            InspectorTest.expectEqual(parent._dirtyDescendantsCount, 0, "Parent attached to root view should have 0 dirty descendants.");
+            InspectorTest.expectFalse(rootView._dirty, "Root view should not be dirty.");
+            InspectorTest.expectTrue(parent._dirty, "Parent detached from root view should be dirty.");
+            InspectorTest.expectFalse(child._dirty, "Child attached to parent view should not be dirty.");
+
             InspectorTest.log("- Dirtying child.");
             child.needsLayout();
             InspectorTest.expectEqual(rootView._dirtyDescendantsCount, 0, "Root view should have 0 dirty descendants.");
             InspectorTest.expectEqual(parent._dirtyDescendantsCount, 1, "Parent attached to root view should have 1 dirty descendants.");
             InspectorTest.expectFalse(rootView._dirty, "Root view should not be dirty.");
-            InspectorTest.expectFalse(parent._dirty, "Parent detached from root view should not be dirty.");
+            InspectorTest.expectTrue(parent._dirty, "Parent detached from root view should be dirty.");
             InspectorTest.expectTrue(child._dirty, "Child attached to parent view should be dirty.");
 
             InspectorTest.log("- Adding parent view to root view.");

--- a/Source/WebInspectorUI/UserInterface/Views/View.js
+++ b/Source/WebInspectorUI/UserInterface/Views/View.js
@@ -240,8 +240,6 @@ WI.View = class View extends WI.Object
         if (this._parentView === parentView)
             return;
 
-        console.assert(this._parentView || !(this._isDirty || this._dirtyDescendantsCount));
-
         let dirtyDescendantsCount = this._dirtyDescendantsCount;
         if (this._dirty)
             ++dirtyDescendantsCount;


### PR DESCRIPTION
#### 23cac2eaef9c61cd82e64be4e48a2dab6590731e
<pre>
Web Inspector: REGRESSION(253272@main): Assertion Failed: View.js:243
<a href="https://bugs.webkit.org/show_bug.cgi?id=243950">https://bugs.webkit.org/show_bug.cgi?id=243950</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/View.js:
(WI.View.prototype._didMoveToParent):
After 253272@main this assertion is no longer valid because `_dirty` and/or `_dirtyDescendantsCount`
can be modified regardless of whether or not there&apos;s a `_parentView`.

* LayoutTests/inspector/view/basics.html:
* LayoutTests/inspector/view/basics-expected.txt:
Add another test case that triggered the assertion to verify its erroneousness.

Canonical link: <a href="https://commits.webkit.org/253478@main">https://commits.webkit.org/253478@main</a>
</pre>












































<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c9fb58358565beb0568079e2eb3a3ea3e34d85b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/86179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30103 "Built successfully") | [✅ ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/95042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/148740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28475 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/90310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/91761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/26439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/26336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/943 "Built successfully and passed tests") | [✅ ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/28012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/27949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->