### PR TITLE
Move "viewportMetaTag*" into PerProcessState

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -158,6 +158,9 @@ struct PerWebProcessState {
 
     BOOL avoidsUnsafeArea { YES };
 
+    BOOL viewportMetaTagWidthWasExplicit { NO };
+    BOOL viewportMetaTagCameFromImageDocument { NO };
+
     std::optional<WebCore::FloatSize> lastSentViewLayoutSize;
     std::optional<int32_t> lastSentDeviceOrientation;
 
@@ -236,11 +239,7 @@ struct PerWebProcessState {
     std::optional<CGSize> _maximumUnobscuredSizeOverride;
     CGRect _inputViewBoundsInWindow;
 
-    // FIXME: More of these should move into _perProcessState.
-    BOOL _viewportMetaTagWidthWasExplicit;
-    BOOL _viewportMetaTagCameFromImageDocument;
     BOOL _fastClickingIsDisabled;
-
     BOOL _allowsLinkPreview;
 
     UIEdgeInsets _obscuredInsets;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -999,8 +999,8 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
     [self _updateScrollViewForTransaction:layerTreeTransaction];
 
     _perProcessState.viewportMetaTagWidth = layerTreeTransaction.viewportMetaTagWidth();
-    _viewportMetaTagWidthWasExplicit = layerTreeTransaction.viewportMetaTagWidthWasExplicit();
-    _viewportMetaTagCameFromImageDocument = layerTreeTransaction.viewportMetaTagCameFromImageDocument();
+    _perProcessState.viewportMetaTagWidthWasExplicit = layerTreeTransaction.viewportMetaTagWidthWasExplicit();
+    _perProcessState.viewportMetaTagCameFromImageDocument = layerTreeTransaction.viewportMetaTagCameFromImageDocument();
     _perProcessState.initialScaleFactor = layerTreeTransaction.initialScaleFactor();
 
     if (_page->inStableState() && layerTreeTransaction.isInStableState() && [_stableStatePresentationUpdateCallbacks count]) {
@@ -1714,7 +1714,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
         return NO;
 
     // If the viewport width was not explicit, we allow double tap gestures.
-    if (!_viewportMetaTagWidthWasExplicit || _viewportMetaTagCameFromImageDocument)
+    if (!_perProcessState.viewportMetaTagWidthWasExplicit || _perProcessState.viewportMetaTagCameFromImageDocument)
         return YES;
 
     // If the page set a viewport width that wasn't the device width, then it was


### PR DESCRIPTION
#### 84f547237bc57d93b4f5b79eff64589e5ab3aa5c
<pre>
Move &quot;viewportMetaTag*&quot; into PerProcessState
<a href="https://bugs.webkit.org/show_bug.cgi?id=243997">https://bugs.webkit.org/show_bug.cgi?id=243997</a>

Reviewed by Tim Horton, Wenson Hsieh.

`viewportMetaTagWidthWasExplicit` and `viewportMetaTagCameFromImageDocument` so need to be moved
into `PerProcessState`.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLayerTree:]):
(-[WKWebView _allowsDoubleTapGestures]):

Canonical link: <a href="https://commits.webkit.org/253486@main">https://commits.webkit.org/253486@main</a>
</pre>
