### PR TITLE
[ews] Mark old commits on PRs as obsolete in Django app database

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -309,6 +309,7 @@ class GitHubEWS(GitHub):
             if new_comment_id != -1:
                 change.set_comment_id(new_comment_id)
                 _log.info('Set new comment id as {} for hash: {}.'.format(new_comment_id, sha))
+            Change.mark_old_changes_as_obsolete(pr_id, sha)
         else:
             _log.info('Updating comment for hash: {}, pr_id: {}, pr_id from db: {}.'.format(sha, pr_id, change.pr_id))
             new_comment_id = gh.update_or_leave_comment_on_pr(pr_id, comment_text, comment_id=comment_id)

--- a/Tools/CISupport/ews-app/ews/models/patch.py
+++ b/Tools/CISupport/ews-app/ews/models/patch.py
@@ -97,6 +97,19 @@ class Change(models.Model):
             return None
 
     @classmethod
+    def mark_old_changes_as_obsolete(cls, pr_id, change_id):
+        changes = Change.objects.filter(pr_id=pr_id).order_by('-created')
+        if not change or len(changes) == 1:
+            return
+        for change in changes[1:]:
+            if not change.obsolete:
+                if change.change_id == change_id:
+                    _log.info('Marking change {} on pr {} as obsolete, even though we just received builds for it. Latest commit:'.format(change_id, pr_id, change[0].pr_id))
+                change.obsolete = obsolete
+                change.save()
+                _log.info('Marked change {} on pr {} as obsolete'.format(change_id, pr_id))
+
+    @classmethod
     def set_sent_to_buildbot(cls, change_id, value, commit_queue=False):
         if commit_queue:
             return Change._set_sent_to_commit_queue(change_id, sent_to_commit_queue=value)


### PR DESCRIPTION
#### dfc6c1f1d4be3dd93f229c4d60a16e46a9691612
<pre>
[ews] Mark old commits on PRs as obsolete in Django app database
<a href="https://bugs.webkit.org/show_bug.cgi?id=243998">https://bugs.webkit.org/show_bug.cgi?id=243998</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS.add_or_update_comment_for_change_id):
* Tools/CISupport/ews-app/ews/models/patch.py:
(Change.mark_old_changes_as_obsolete):

Canonical link: <a href="https://commits.webkit.org/253475@main">https://commits.webkit.org/253475@main</a>
</pre>














<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d485e80c56dd25350a662f2bb2e456fd74dcca9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17170 "Built successfully") | [✅ ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/95029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148724 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28460 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90295 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91745 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26424 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26321 "Built successfully") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/13429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/940 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/27997 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/27934 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->