### PR TITLE
[ews] Add basic hover over text support to Github status-bubbles

### DIFF
--- a/Tools/CISupport/ews-app/ews/models/patch.py
+++ b/Tools/CISupport/ews-app/ews/models/patch.py
@@ -99,15 +99,15 @@ class Change(models.Model):
     @classmethod
     def mark_old_changes_as_obsolete(cls, pr_id, change_id):
         changes = Change.objects.filter(pr_id=pr_id).order_by('-created')
-        if not change or len(changes) == 1:
+        if not changes or len(changes) == 1:
             return
         for change in changes[1:]:
             if not change.obsolete:
                 if change.change_id == change_id:
                     _log.info('Marking change {} on pr {} as obsolete, even though we just received builds for it. Latest commit:'.format(change_id, pr_id, change[0].pr_id))
-                change.obsolete = obsolete
+                change.obsolete = True
                 change.save()
-                _log.info('Marked change {} on pr {} as obsolete'.format(change_id, pr_id))
+                _log.info('Marked change {} on pr {} as obsolete'.format(change.change_id, pr_id))
 
     @classmethod
     def set_sent_to_buildbot(cls, change_id, value, commit_queue=False):


### PR DESCRIPTION
#### 610abf5fe7fcba11de0e3835a656502404833878
<pre>
[ews] Add basic hover over text support to Github status-bubbles
<a href="https://bugs.webkit.org/show_bug.cgi?id=244007">https://bugs.webkit.org/show_bug.cgi?id=244007</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS.github_status_for_queue):

Canonical link: <a href="https://commits.webkit.org/253490@main">https://commits.webkit.org/253490@main</a>
</pre>















<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6b425ce7009b03306b04c35b35a1d30b4fe37c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86217 "Passed style check") | [✅ ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/69/builds/30140 "Build was cancelled") | [✅ ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/95061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/148767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90203 "Passed tests") | [✅ ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/64/builds/28503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/90334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91816 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/64/builds/28503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/64/builds/28503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/26463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/26371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/952 "Built successfully and passed tests") | [✅ ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/28047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/27986 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->