### PR TITLE
Revert [253441@main] [REBASLINE] imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree.html is a constant failure on IOS

### DIFF
--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
@@ -1,8 +1,8 @@
 
 PASS getComputedStyle returns no style for detached element
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 395
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 395
-FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 395
-FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 395
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 394
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 394
+FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 394
+FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 394
 PASS getComputedStyle returns no style for shadow tree outside of flattened tree
 


### PR DESCRIPTION
#### b591063234427dcb9387e32d8639384f81116766
<pre>
Revert [253441@main] [REBASLINE] imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree.html is a constant failure on IOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=243958">https://bugs.webkit.org/show_bug.cgi?id=243958</a>

Unreviewed Revert.

* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253484@main">https://commits.webkit.org/253484@main</a>
</pre>
