### PR TITLE
The "Around the World" carousel is broken on https://focal-theme-carbon.myshopify.com/

### DIFF
--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden-and-layout-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden-and-layout-expected.txt
@@ -1,0 +1,5 @@
+PASS scrollContainer.scrollLeft is 500
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden-and-layout.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden-and-layout.html
@@ -14,6 +14,10 @@
             width: 400%;
             background-image: repeating-linear-gradient(to right, white, silver 250px);
         }
+        
+        body.changed .contents {
+            height: 120%;
+        }
     </style>
     <script src="../../../resources/ui-helper.js"></script>
     <script src="../../../resources/js-test-pre.js"></script>
@@ -32,6 +36,8 @@
                 left: 500,
                 behavior: 'smooth'
             });
+            
+            document.body.classList.add('changed');
             
             await UIHelper.waitForScrollCompletion();
             

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -449,7 +449,6 @@ private:
     bool m_inLiveResize { false };
     bool m_scrollOriginChanged { false };
     bool m_scrollShouldClearLatchedState { false };
-    bool m_hasActiveScrollAnimation { false };
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ScrollableArea&);

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1645,10 +1645,10 @@ void RenderLayerScrollableArea::updateScrollableAreaSet(bool hasOverflow)
     if (HTMLFrameOwnerElement* owner = frameView.frame().ownerElement())
         isVisibleToHitTest &= owner->renderer() && owner->renderer()->visibleToHitTesting();
 
-    bool isScrollable = hasOverflow && isVisibleToHitTest;
+    bool needsToBeRegistered = (hasOverflow && isVisibleToHitTest) || scrollAnimationStatus() == ScrollAnimationStatus::Animating;
     bool addedOrRemoved = false;
 
-    if (isScrollable) {
+    if (needsToBeRegistered) {
         if (!m_registeredScrollableArea) {
             addedOrRemoved = frameView.addScrollableArea(this);
             m_registeredScrollableArea = true;


### PR DESCRIPTION
#### ca608f18f0892f484ab949a0ff0d4d8703d5b637
<pre>
The &quot;Around the World&quot; carousel is broken on <a href="https://focal-theme-carbon.myshopify.com/">https://focal-theme-carbon.myshopify.com/</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=242224">https://bugs.webkit.org/show_bug.cgi?id=242224</a>
&lt;rdar://96453957&gt;

Reviewed by Tim Horton.

251454@main fixed a bug where an animated programmatic scroll on an `overflow:hidden` element failed to scroll
because we didn&apos;t register the ScrollableArea with the FrameView.

However, if layout runs while the scroll is in progress, then we unregister the ScrollableArea, which
prematurely stops the scrolling. Fix by having `RenderLayerScrollableArea::updateScrollableAreaSet()`
check to see if an animated scroll is active before unregistering.

* LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden-and-layout-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden-and-layout.html: Copied from LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden.html.
* LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden.html: Remove a redundant rule.
* Source/WebCore/platform/ScrollableArea.h: m_hasActiveScrollAnimation was unused, so remove it.
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateScrollableAreaSet):

Canonical link: <a href="https://commits.webkit.org/253493@main">https://commits.webkit.org/253493@main</a>
</pre>
