### PR TITLE
[Gardening]: REGRESSION(253037@main): [ iOS macOS ] http/tests/workers/service/basic-timeout.https.html is a constant timeout

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3055,7 +3055,7 @@ webkit.org/b/204757 imported/w3c/web-platform-tests/fetch/api/request/destinatio
 
 webkit.org/b/203222 svg/wicd/rightsizing-grid.xhtml [ Pass Failure ]
 
-webkit.org/b/206864 http/tests/workers/service/basic-timeout.https.html [ Pass Failure ]
+webkit.org/b/206864 http/tests/workers/service/basic-timeout.https.html [ Pass Failure Timeout ]
 
 webkit.org/b/206754 imported/w3c/web-platform-tests/css/css-backgrounds/background-image-centered-with-border-radius.html [ ImageOnlyFailure ]
 webkit.org/b/206754 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-body.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -993,7 +993,7 @@ webkit.org/b/199089 [ Debug ] plugins/window-open.html [ Skip ]
 
 webkit.org/b/205808 fast/text/international/unicode-bidi-other-neutrals.html [ Pass Failure ]
 
-webkit.org/b/206864 http/tests/workers/service/basic-timeout.https.html [ Pass Failure ]
+webkit.org/b/206864 http/tests/workers/service/basic-timeout.https.html [ Pass Failure Timeout ]
 
 # <rdar://problem/60929239> [ macOS wk2 ] editing/selection/caret-at-bidi-boundary.html is a flaky timeout
 webkit.org/b/206696 editing/selection/caret-at-bidi-boundary.html [ Pass Timeout ]


### PR DESCRIPTION
#### 436d8f38ce7eb65f9e3cd430f697d0b0dc0f8fe7
<pre>
[Gardening]: REGRESSION(253037@main): [ iOS macOS ] http/tests/workers/service/basic-timeout.https.html is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=244001">https://bugs.webkit.org/show_bug.cgi?id=244001</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253485@main">https://commits.webkit.org/253485@main</a>
</pre>
