### PR TITLE
Port Compression Streams to Apple Compression Framework

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.js
@@ -49,34 +49,37 @@ const badChunks = [
   },
 ];
 
-for (const chunk of badChunks) {
-  promise_test(async t => {
-    const ds = new DecompressionStream('gzip');
+// Test Case Design
+// We need to wait until after we close the writable stream to check if the decoded stream is valid.
+// We can end up in a state where all reads/writes are valid, but upon closing the writable stream an error is detected.
+// (Example: A zlib encoded chunk w/o the checksum).
+
+async function decompress(chunk, format, t)
+{
+    const ds = new DecompressionStream(format);
     const reader = ds.readable.getReader();
     const writer = ds.writable.getWriter();
-    const writePromise = writer.write(chunk.value);
-    const readPromise = reader.read();
-    await promise_rejects_js(t, TypeError, writePromise, 'write should reject');
-    await promise_rejects_js(t, TypeError, readPromise, 'read should reject');
+
+    writer.write(chunk.value).then(() => {}, () => {});
+    reader.read().then(() => {}, () => {});
+
+    await promise_rejects_js(t, TypeError, writer.close(), 'writer.close() should reject');
+    await promise_rejects_js(t, TypeError, writer.closed, 'write.closed should reject');
+
+    await promise_rejects_js(t, TypeError, reader.read(), 'reader.read() should reject');
+    await promise_rejects_js(t, TypeError, reader.closed, 'read.closed should reject');
+}
+
+for (const chunk of badChunks) {
+  promise_test(async t => {
+    await decompress(chunk, 'gzip', t);
   }, `chunk of type ${chunk.name} should error the stream for gzip`);
 
   promise_test(async t => {
-    const ds = new DecompressionStream('deflate');
-    const reader = ds.readable.getReader();
-    const writer = ds.writable.getWriter();
-    const writePromise = writer.write(chunk.value);
-    const readPromise = reader.read();
-    await promise_rejects_js(t, TypeError, writePromise, 'write should reject');
-    await promise_rejects_js(t, TypeError, readPromise, 'read should reject');
+    await decompress(chunk, 'deflate', t);
   }, `chunk of type ${chunk.name} should error the stream for deflate`);
 
   promise_test(async t => {
-    const ds = new DecompressionStream('deflate-raw');
-    const reader = ds.readable.getReader();
-    const writer = ds.writable.getWriter();
-    const writePromise = writer.write(chunk.value);
-    const readPromise = reader.read();
-    await promise_rejects_js(t, TypeError, writePromise, 'write should reject');
-    await promise_rejects_js(t, TypeError, readPromise, 'read should reject');
+    await decompress(chunk, 'deflate-raw', t);
   }, `chunk of type ${chunk.name} should error the stream for deflate-raw`);
 }

--- a/Source/WebCore/Modules/compression/DecompressionStream.js
+++ b/Source/WebCore/Modules/compression/DecompressionStream.js
@@ -55,7 +55,7 @@ function initializeDecompressionStream(format)
 
         try {
             const decoder = @getByIdDirectPrivate(this, "DecompressionStreamDecoder");
-            let buffer = decoder.@decode(chunk);
+            const buffer = decoder.@decode(chunk);
 
             if (buffer) {
                 const transformStream = @getByIdDirectPrivate(this, "DecompressionStreamTransform");
@@ -68,19 +68,18 @@ function initializeDecompressionStream(format)
 
         return @Promise.@resolve();
     };
-    const flushAlgorithm = () => {
-        const decoder = @getByIdDirectPrivate(this, "DecompressionStreamDecoder");
-        
-        let buffer;
+    const flushAlgorithm = () => {        
         try {
-        buffer = decoder.@flush();
+            const decoder = @getByIdDirectPrivate(this, "DecompressionStreamDecoder");
+            const buffer = decoder.@flush();
+
+            if (buffer) {
+                const transformStream = @getByIdDirectPrivate(this, "DecompressionStreamTransform");
+                const controller = @getByIdDirectPrivate(transformStream, "controller");
+                @transformStreamDefaultControllerEnqueue(controller, buffer);
+            }
         } catch (e) {
             return @Promise.@reject(@makeTypeError(e.message));
-        }
-        if (buffer) {
-            const transformStream = @getByIdDirectPrivate(this, "DecompressionStreamTransform");
-            const controller = @getByIdDirectPrivate(transformStream, "controller");
-            @transformStreamDefaultControllerEnqueue(controller, buffer);
         }
 
         return @Promise.@resolve();

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp
@@ -43,45 +43,51 @@ ExceptionOr<RefPtr<Uint8Array>> DecompressionStreamDecoder::decode(const BufferS
         return compressedDataCheck.releaseException();
 
     auto compressedData = compressedDataCheck.returnValue();
-    if (!compressedData.size())
+    if (!compressedData->byteLength())
         return nullptr;
     
-    return Uint8Array::tryCreate(compressedData.data(), compressedData.size());
+    return Uint8Array::tryCreate(static_cast<uint8_t *>(compressedData->data()), compressedData->byteLength());
 }
 
 ExceptionOr<RefPtr<Uint8Array>> DecompressionStreamDecoder::flush()
 {
-    finish = true;
+    m_finish = true;
 
     auto compressedDataCheck = decompress(0, 0);
     if (compressedDataCheck.hasException())
         return compressedDataCheck.releaseException();
     
     auto compressedData = compressedDataCheck.returnValue();
-    if (!compressedData.size())
+    if (!compressedData->byteLength())
         return nullptr;
     
-    return Uint8Array::tryCreate(compressedData.data(), compressedData.size());
+    return Uint8Array::tryCreate(static_cast<uint8_t *>(compressedData->data()), compressedData->byteLength());
+}
+
+inline ExceptionOr<RefPtr<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompress(const uint8_t* input, const size_t inputLength)
+{
+#if PLATFORM(COCOA)
+    if (m_usingAppleCompressionFramework)
+        return decompressAppleCompressionFramework(input, inputLength);
+#endif
+
+    return decompressZlib(input, inputLength);
 }
 
 ExceptionOr<bool> DecompressionStreamDecoder::initialize() 
 {
     int result = Z_OK;
-
-    initailized = true;
-    zstream.opaque = 0;
-    zstream.zalloc = 0;
-    zstream.zfree = 0;
+    m_initialized = true;
 
     switch (m_format) {
     case Formats::CompressionFormat::Deflate:
-        result = inflateInit2(&zstream, -15);
+        result = inflateInit2(&m_zstream, -15);
         break;
     case Formats::CompressionFormat::Zlib:
-        result = inflateInit2(&zstream, 15);
+        result = inflateInit2(&m_zstream, 15);
         break;
     case Formats::CompressionFormat::Gzip:
-        result = inflateInit2(&zstream, 15 + 16);
+        result = inflateInit2(&m_zstream, 15 + 16);
         break;
     default:
         RELEASE_ASSERT_NOT_REACHED();
@@ -94,57 +100,109 @@ ExceptionOr<bool> DecompressionStreamDecoder::initialize()
     return true;
 }
 
-ExceptionOr<Vector<uint8_t>> DecompressionStreamDecoder::decompress(const uint8_t* input, const size_t inputLength)
+ExceptionOr<RefPtr<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompressZlib(const uint8_t* input, const size_t inputLength)
 {
-    size_t index = 0, allocateSize = startingAllocationSize, totalSize = 0;
-    Vector<Vector<uint8_t>>storage;
-    storage.reserveCapacity(128);
+    size_t allocateSize = startingAllocationSize;
+    auto storage = SharedBufferBuilder();
 
     int result;    
     bool shouldDecompress = true;
 
-    zstream.next_in = const_cast<z_const Bytef*>(input);
-    zstream.avail_in = inputLength;
+    m_zstream.next_in = const_cast<z_const Bytef*>(input);
+    m_zstream.avail_in = inputLength;
 
-    if (!initailized) {
+    if (!m_initialized) {
         auto initializeResult = initialize();
         if (initializeResult.hasException())
             return initializeResult.releaseException();
     }
 
     while (shouldDecompress) {
-        storage.append(Vector<uint8_t>(allocateSize));
-        totalSize += allocateSize;
+        auto output = Vector<uint8_t>(allocateSize);
 
-        zstream.next_out = storage[index].data();
-        zstream.avail_out = storage[index].size();
+        m_zstream.next_out = output.data();
+        m_zstream.avail_out = output.size();
 
-        result = inflate(&zstream, (finish) ? Z_FINISH : Z_NO_FLUSH);
+        result = inflate(&m_zstream, (m_finish) ? Z_FINISH : Z_NO_FLUSH);
         
         if (result != Z_OK && result != Z_STREAM_END && result != Z_BUF_ERROR)
             return Exception { TypeError, "Failed to Decode Data."_s };
 
-        if ((result == Z_STREAM_END && zstream.avail_in)
-            || (result == Z_BUF_ERROR && finish))
+        if ((result == Z_STREAM_END && m_zstream.avail_in)
+            || (result == Z_BUF_ERROR && m_finish))
             return Exception { TypeError, "Extra bytes past the end."_s };
 
-        if (!zstream.avail_in)
+        if (!m_zstream.avail_in) {
             shouldDecompress = false;
-        else {
-            index++;
+            output.resize(allocateSize - m_zstream.avail_out);
+        } else {
             if (allocateSize < maxAllocationSize)
                 allocateSize *= 2;
         }
+
+        storage.append(output);
     }
 
-    storage.at(index).resize(allocateSize - zstream.avail_out);
-    totalSize -= zstream.avail_out;
-
-    Vector<uint8_t> output;
-    output.reserveCapacity(totalSize);
-    for (auto& storageElement : storage)
-        output.append(storageElement.data(), storageElement.size());
-
-    return output;
+    return storage.takeAsArrayBuffer();
 }
+
+#if PLATFORM(COCOA)
+ExceptionOr<bool> DecompressionStreamDecoder::initializeAppleCompressionFramework() 
+{
+    m_initialized = true;
+
+    auto result = compression_stream_init(&m_stream, COMPRESSION_STREAM_DECODE, COMPRESSION_ZLIB);
+    if (result != COMPRESSION_STATUS_OK)
+        return Exception { TypeError, "Initialization Failed."_s };
+
+    return true;
+}
+
+ExceptionOr<RefPtr<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompressAppleCompressionFramework(const uint8_t* input, const size_t inputLength)
+{
+    size_t allocateSize = startingAllocationSize;
+    auto storage = SharedBufferBuilder();
+
+    compression_status result;    
+    bool shouldDecompress = true;
+
+    if (!m_initialized) {
+        auto initializeResult = initializeAppleCompressionFramework();
+        if (initializeResult.hasException())
+            return initializeResult.releaseException();
+    }
+
+    m_stream.src_ptr = input;
+    m_stream.src_size = inputLength;
+    
+    while (shouldDecompress) {
+        auto output = Vector<uint8_t>(allocateSize);
+
+        m_stream.dst_ptr = output.data();
+        m_stream.dst_size = output.size();
+
+        result = compression_stream_process(&m_stream, (m_finish) ? COMPRESSION_STREAM_FINALIZE : 0);
+        
+        if (result == COMPRESSION_STATUS_ERROR)
+            return Exception { TypeError, "Failed to Decode Data."_s };
+
+        if ((result == COMPRESSION_STATUS_END && m_stream.src_size)
+            || (m_finish && m_stream.src_size))
+            return Exception { TypeError, "Extra bytes past the end."_s };
+
+        if (!m_stream.src_size) {
+            shouldDecompress = false;
+            output.resize(allocateSize - m_stream.dst_size);
+        } else {
+            if (allocateSize < maxAllocationSize)
+                allocateSize *= 2;
+        }
+
+        storage.append(output);
+    }
+
+    return storage.takeAsArrayBuffer();
+}
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
@@ -25,8 +25,14 @@
 #pragma once
 
 #include "BufferSource.h"
+#if PLATFORM(COCOA)
+#include <compression.h>
+#endif
+#include <cstring>
 #include "ExceptionOr.h"
 #include "Formats.h"
+#include "SharedBuffer.h"
+#include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -46,8 +52,14 @@ public:
 
     ~DecompressionStreamDecoder()
     {
-        if (initailized)
-            deflateEnd(&zstream);
+        if (m_initialized) {
+            if (m_usingAppleCompressionFramework) {
+#if PLATFORM(COCOA)
+                compression_stream_destroy(&m_stream);
+#endif
+            } else
+                deflateEnd(&m_zstream);
+        }
     }
 
 private:
@@ -60,18 +72,37 @@ private:
     const size_t startingAllocationSize = 16384; // 16KB
     const size_t maxAllocationSize = 1073741824; // 1GB
     
-    bool initailized { false };
-    bool finish { false };
-    z_stream zstream;
+    bool m_initialized { false };
+    bool m_finish { false };
+    z_stream m_zstream;
+
+    bool m_usingAppleCompressionFramework { false };
+
+    inline ExceptionOr<RefPtr<JSC::ArrayBuffer>> decompress(const uint8_t* input, const size_t inputLength);
+
+#if PLATFORM(COCOA)
+    compression_stream m_stream;
+    ExceptionOr<RefPtr<JSC::ArrayBuffer>> decompressAppleCompressionFramework(const uint8_t* input, const size_t inputLength);
+    ExceptionOr<bool> initializeAppleCompressionFramework();
+#endif
 
     Formats::CompressionFormat m_format;
 
-    ExceptionOr<Vector<uint8_t>> decompress(const uint8_t* input, const size_t inputLength);
+    ExceptionOr<RefPtr<JSC::ArrayBuffer>> decompressZlib(const uint8_t* input, const size_t inputLength);
     ExceptionOr<bool> initialize();
 
     explicit DecompressionStreamDecoder(unsigned char format) 
         : m_format(static_cast<Formats::CompressionFormat>(format))
     {
+
+    std::memset(&m_zstream, 0, sizeof(m_zstream));
+
+#if PLATFORM(COCOA)
+    std::memset(&m_stream, 0, sizeof(m_stream));
+
+    if (m_format == Formats::CompressionFormat::Deflate)
+        m_usingAppleCompressionFramework = true;
+#endif
     }
 };
 } // namespace WebCore


### PR DESCRIPTION
#### 92a21241fd9b82ff695f130feb2b77326556fe3c
<pre>
Port Compression Streams to Apple Compression Framework
<a href="https://bugs.webkit.org/show_bug.cgi?id=244009">https://bugs.webkit.org/show_bug.cgi?id=244009</a>

Reviewed by Youenn Fablet.

This change ports the decompression deflate-raw to use the Apple Compression Framework.
All Compression and Decompression using Deflate or Gzip will still rely on Zlib, and all other
platforms will continue using Zlib.

Syncing WPT test changes from <a href="https://github.com/web-platform-tests/wpt/pull/35560">https://github.com/web-platform-tests/wpt/pull/35560</a>

* LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.js:
(const.chunk.of.badChunks.promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/compression/decompression-bad-chunks.tentative.any.serviceworker-expected.txt:
* Source/WebCore/Modules/compression/DecompressionStream.js:
(initializeDecompressionStream):
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp:
(WebCore::DecompressionStreamDecoder::decode):
(WebCore::DecompressionStreamDecoder::flush):
(WebCore::DecompressionStreamDecoder::initialize):
(WebCore::DecompressionStreamDecoder::decompressZlib):
(WebCore::DecompressionStreamDecoder::initializeAppleCompressionFramework):
(WebCore::DecompressionStreamDecoder::decompressAppleCompressionFramework):
(WebCore::DecompressionStreamDecoder::decompress): Deleted.
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.h:
(WebCore::DecompressionStreamDecoder::~DecompressionStreamDecoder):
(WebCore::DecompressionStreamDecoder::DecompressionStreamDecoder):

Canonical link: <a href="https://commits.webkit.org/253697@main">https://commits.webkit.org/253697@main</a>
</pre>







<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baeedf1bf002c399b63f747ca67fa3bbd4f2d566

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95657 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149409 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29268 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90892 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23638 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23676 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78634 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66681 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27029 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26951 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/13805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2622 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28635 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28579 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/33084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->