### PR TITLE
Leak of id<MTLArgumentEncoder> in rx::(anonymous)::InitArgumentBufferEncoder()

### DIFF
--- a/Source/ThirdParty/ANGLE/changes.diff
+++ b/Source/ThirdParty/ANGLE/changes.diff
@@ -229,6 +229,19 @@ index 4af875e23275bb98e69a3644be4c7f41a7e5c11c..7d722dc9cb89ec148d33cf69fc8b00fa
      if (@available(ios 14.0, macOS 11.0, *))
      {
          return [mMetalDevice supports32BitFloatFiltering];
+diff --git a/src/libANGLE/renderer/metal/ProgramMtl.mm b/src/libANGLE/renderer/metal/ProgramMtl.mm
+index 3032feb4fc1fb7761e2e3127c75ebf10cf5fe2b8..696df7dd99727e3220b219e93605c4a67c27553a 100644
+--- a/src/libANGLE/renderer/metal/ProgramMtl.mm
++++ b/src/libANGLE/renderer/metal/ProgramMtl.mm
+@@ -173,7 +173,7 @@ void InitArgumentBufferEncoder(mtl::Context *context,
+                                uint32_t bufferIndex,
+                                ProgramArgumentBufferEncoderMtl *encoder)
+ {
+-    encoder->metalArgBufferEncoder = [function newArgumentEncoderWithBufferIndex:bufferIndex];
++    encoder->metalArgBufferEncoder = mtl::adoptObjCObj([function newArgumentEncoderWithBufferIndex:bufferIndex]);
+     if (encoder->metalArgBufferEncoder)
+     {
+         encoder->bufferPool.initialize(context, encoder->metalArgBufferEncoder.get().encodedLength,
 diff --git a/src/libANGLE/renderer/metal/mtl_buffer_pool.h b/src/libANGLE/renderer/metal/mtl_buffer_pool.h
 index c3be11f78156c7fab4ee8a90733de2f3b049de7e..204ebb949873112c010242b2b16b0860cd40c00a 100644
 --- a/src/libANGLE/renderer/metal/mtl_buffer_pool.h

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramMtl.mm
@@ -173,7 +173,7 @@ void InitArgumentBufferEncoder(mtl::Context *context,
                                uint32_t bufferIndex,
                                ProgramArgumentBufferEncoderMtl *encoder)
 {
-    encoder->metalArgBufferEncoder = [function newArgumentEncoderWithBufferIndex:bufferIndex];
+    encoder->metalArgBufferEncoder = mtl::adoptObjCObj([function newArgumentEncoderWithBufferIndex:bufferIndex]);
     if (encoder->metalArgBufferEncoder)
     {
         encoder->bufferPool.initialize(context, encoder->metalArgBufferEncoder.get().encodedLength,


### PR DESCRIPTION
#### 06f2309860842383d90df8482abdb072d91c4f5d
<pre>
Leak of id&lt;MTLArgumentEncoder&gt; in rx::(anonymous)::InitArgumentBufferEncoder()
<a href="https://bugs.webkit.org/show_bug.cgi?id=244008">https://bugs.webkit.org/show_bug.cgi?id=244008</a>
&lt;rdar://98747531&gt;

Reviewed by Kimmo Kinnunen and Dean Jackson.

* Source/ThirdParty/ANGLE/changes.diff: Update.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramMtl.mm:
(rx::(anonymous)::InitArgumentBufferEncoder):
- Use mtl::adoptObjCObj() to fix the leak since
  -newArgumentEncoderWithBufferIndex: returns a +1 retained object.

Canonical link: <a href="https://commits.webkit.org/253525@main">https://commits.webkit.org/253525@main</a>
</pre>
