### PR TITLE
Overlay regions do not correctly handle sticky positioned scrolling nodes

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -61,7 +61,7 @@ public:
     CALayer *layerWithIDForTesting(uint64_t) const;
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    void updateOverlayRegionsWithIDs(const HashMap<WebCore::GraphicsLayer::PlatformLayerID, CGRect> &overlayRegions) { m_remoteLayerTreeHost->updateOverlayRegionsWithIDs(overlayRegions); }
+    void updateOverlayRegionIDs(const HashSet<WebCore::GraphicsLayer::PlatformLayerID> &overlayRegionIDs) { m_remoteLayerTreeHost->updateOverlayRegionIDs(overlayRegionIDs); }
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -77,8 +77,8 @@ public:
 
     bool replayCGDisplayListsIntoBackingStore() const;
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    const HashMap<WebCore::GraphicsLayer::PlatformLayerID, CGRect>& overlayRegionsWithIDs() const { return m_overlayRegionsWithIDs; }
-    void updateOverlayRegionsWithIDs(const HashMap<WebCore::GraphicsLayer::PlatformLayerID, CGRect> &overlayRegions) { m_overlayRegionsWithIDs = overlayRegions; }
+    const HashSet<WebCore::GraphicsLayer::PlatformLayerID>& overlayRegionIDs() const { return m_overlayRegionIDs; }
+    void updateOverlayRegionIDs(const HashSet<WebCore::GraphicsLayer::PlatformLayerID> &overlayRegionNodes) { m_overlayRegionIDs = overlayRegionNodes; }
 #endif
 
 private:
@@ -94,7 +94,7 @@ private:
     HashMap<WebCore::GraphicsLayer::PlatformLayerID, std::unique_ptr<RemoteLayerTreeNode>> m_nodes;
     HashMap<WebCore::GraphicsLayer::PlatformLayerID, RetainPtr<WKAnimationDelegate>> m_animationDelegates;
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    HashMap<WebCore::GraphicsLayer::PlatformLayerID, CGRect> m_overlayRegionsWithIDs;
+    HashSet<WebCore::GraphicsLayer::PlatformLayerID> m_overlayRegionIDs;
 #endif
     bool m_isDebugLayerTreeHost { false };
 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -89,7 +89,7 @@ void RemoteScrollingCoordinatorProxy::connectStateNodeLayers(ScrollingStateTree&
             auto platformLayerID = PlatformLayerID { currNode->layer() };
             currNode->setLayer(layerTreeHost.layerForID(platformLayerID));
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-            if (platformLayerID && currNode->isFixedNode())
+            if (platformLayerID && (currNode->isFixedNode() || currNode->isStickyNode()))
                 m_fixedScrollingNodeLayerIDs.add(platformLayerID);
 #endif
         }


### PR DESCRIPTION
#### 649ae3da2abe4050f58b398ea6790e5f53099761
<pre>
Overlay regions do not correctly handle sticky positioned scrolling nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=243973">https://bugs.webkit.org/show_bug.cgi?id=243973</a>
&lt;rdar://98640826&gt;

Reviewed by Tim Horton.

Sticky node regions should be added to the overlay regions but their rectangles
can move during scrolling. Also fixed or sticky rectangles can change
during page zoom.

To support this, instead of storing a list of rectangles, store a list of
layer IDs with event regions and then compute the rectangles.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(addOverlayEventRegions):
Store only the layer ID.

(-[WKWebView _updateOverlayRegions:destroyedLayers:]):
Recompute the rectangles from the current frames of the nodes whenever the layer
properties change. Scrolling and page zoom where this would be impacted both
trigger a change in layer properties.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
Renamed function.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
(WebKit::RemoteLayerTreeHost::overlayRegionIDs const):
(WebKit::RemoteLayerTreeHost::updateOverlayRegionIDs):
Renamed.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxy::connectStateNodeLayers):
Call renamed function.

Canonical link: <a href="https://commits.webkit.org/253603@main">https://commits.webkit.org/253603@main</a>
</pre>










<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbe0f34ebc7f3d9bd11ad6082b3a58c4d10d7b74

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95309 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28794 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25365 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78619 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90555 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92080 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73431 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23412 "Passed tests") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66415 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26696 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26610 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13611 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2569 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28289 "Build is in progress") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/36491 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32894 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->