### PR TITLE
Use iterative algorithm for resetStyleForNonRenderedDescendants

### DIFF
--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -38,6 +38,7 @@
 #include "HTMLNames.h"
 #include "HTMLTemplateElement.h"
 #include "ProcessingInstruction.h"
+#include "TemplateContentDocumentFragment.h"
 #include "XLinkNames.h"
 #include "XMLNSNames.h"
 #include "XMLNames.h"
@@ -201,34 +202,64 @@ String MarkupAccumulator::serializeNodes(Node& targetNode, SerializedNodes root,
 
 void MarkupAccumulator::serializeNodesWithNamespaces(Node& targetNode, SerializedNodes root, const Namespaces* namespaces, Vector<QualifiedName>* tagNamesToSkip)
 {
-    if (tagNamesToSkip && is<Element>(targetNode)) {
-        for (auto& name : *tagNamesToSkip) {
-            if (downcast<Element>(targetNode).hasTagName(name))
-                return;
-        }
-    }
-
-    Namespaces namespaceHash;
+    WTF::Vector<Namespaces> namespaceStack;
     if (namespaces)
-        namespaceHash = *namespaces;
+        namespaceStack.append(*namespaces);
     else if (inXMLFragmentSerialization()) {
         // Make sure xml prefix and namespace are always known to uphold the constraints listed at http://www.w3.org/TR/xml-names11/#xmlReserved.
+        Namespaces namespaceHash;
         namespaceHash.set(xmlAtom().impl(), XMLNames::xmlNamespaceURI->impl());
         namespaceHash.set(XMLNames::xmlNamespaceURI->impl(), xmlAtom().impl());
-    }
+        namespaceStack.append(WTFMove(namespaceHash));
+    } else
+        namespaceStack.constructAndAppend();
 
-    if (root == SerializedNodes::SubtreeIncludingNode)
-        startAppendingNode(targetNode, &namespaceHash);
+    const Node* current = &targetNode;
+    do {
+        bool shouldSkipNode = false;
+        if (tagNamesToSkip && is<Element>(current)) {
+            for (auto& name : *tagNamesToSkip) {
+                if (downcast<Element>(current)->hasTagName(name))
+                    shouldSkipNode = true;
+            }
+        }
 
-    if (targetNode.document().isHTMLDocument() && elementCannotHaveEndTag(targetNode))
-        return;
+        bool shouldAppendNode = !shouldSkipNode && !(current == &targetNode && root != SerializedNodes::SubtreeIncludingNode);
+        if (shouldAppendNode)
+            startAppendingNode(*current, &namespaceStack.last());
 
-    Node* current = targetNode.hasTagName(templateTag) ? downcast<HTMLTemplateElement>(targetNode).content().firstChild() : targetNode.firstChild();
-    for ( ; current; current = current->nextSibling())
-        serializeNodesWithNamespaces(*current, SerializedNodes::SubtreeIncludingNode, &namespaceHash, tagNamesToSkip);
+        if (!shouldSkipNode) {
+            auto firstChild = current->hasTagName(templateTag) ? downcast<HTMLTemplateElement>(current)->content().firstChild() : current->firstChild();
+            if (firstChild) {
+                current = firstChild;
+                namespaceStack.append(namespaceStack.last());
+                continue;
+            }
+        }
 
-    if (root == SerializedNodes::SubtreeIncludingNode)
-        endAppendingNode(targetNode);
+        bool shouldEmitCloseTag = !(targetNode.document().isHTMLDocument() && elementCannotHaveEndTag(*current));
+        if (shouldAppendNode && shouldEmitCloseTag)
+            endAppendingNode(*current);
+
+        while (current != &targetNode) {
+            auto nextSibling = current->nextSibling();
+            if (nextSibling) {
+                current = nextSibling;
+                namespaceStack.removeLast();
+                namespaceStack.append(namespaceStack.last());
+                break;
+            }
+            current = current->parentNode();
+            namespaceStack.removeLast();
+            if (auto* fragment = dynamicDowncast<TemplateContentDocumentFragment>(current))
+                current = fragment->host();
+
+            shouldAppendNode = !(current == &targetNode && root != SerializedNodes::SubtreeIncludingNode);
+            shouldEmitCloseTag = !(targetNode.document().isHTMLDocument() && elementCannotHaveEndTag(*current));
+            if (shouldAppendNode && shouldEmitCloseTag)
+                endAppendingNode(*current);
+        }
+    } while (current != &targetNode);
 }
 
 String MarkupAccumulator::resolveURLIfNeeded(const Element& element, const String& urlString) const

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -160,15 +160,20 @@ std::unique_ptr<RenderStyle> TreeResolver::styleForStyleable(const Styleable& st
 
 static void resetStyleForNonRenderedDescendants(Element& current)
 {
-    for (auto& child : childrenOfType<Element>(current)) {
+    auto descendants = descendantsOfType<Element>(current);
+    for (auto it = descendants.begin(); it != descendants.end();) {
+        auto& child = *it;
         if (child.needsStyleRecalc()) {
             child.resetComputedStyle();
             child.resetStyleRelations();
             child.setHasValidStyle();
         }
 
-        if (child.childNeedsStyleRecalc())
-            resetStyleForNonRenderedDescendants(child);
+        if (child.childNeedsStyleRecalc()) {
+            it.traverseNext();
+            child.clearChildNeedsStyleRecalc();
+        } else
+            it.traverseNextSkippingChildren();
     }
     current.clearChildNeedsStyleRecalc();
 }


### PR DESCRIPTION
#### e6464f789ffff32da7d79093767f96895b652bff
<pre>
Use iterative algorithm for resetStyleForNonRenderedDescendants
<a href="https://bugs.webkit.org/show_bug.cgi?id=243957">https://bugs.webkit.org/show_bug.cgi?id=243957</a>
&lt;rdar://98752283&gt;

Reviewed by NOBODY (OOPS!).

resetStyleForNonRenderedDescendants is implemented using recursion which
means it&apos;s susceptible to stack overflows on very deep DOM trees. This
change uses an iterative algorithm to avoid stack overflows.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::resetStyleForNonRenderedDescendants):
</pre>