### PR TITLE
[Gardening]: [ EWS MacOS ] imported/w3c/web-platform-tests/css/css-transforms/transform-3d-rotateY-stair-below-001.xht is a constant failure

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2294,3 +2294,6 @@ webkit.org/b/242226 http/tests/media/modern-media-controls/time-control [ Pass C
 webkit.org/b/243515 svg/compositing/svg-poster-circle.html [ Pass ImageOnlyFailure ]
 webkit.org/b/243515 [ Monterey+ ] svg/compositing/outermost-svg-with-border-padding.html [ Pass ImageOnlyFailure ]
 webkit.org/b/243515 [ Monterey+ ] svg/compositing/outermost-svg-directly-composited-transformed-group-child.html [ Pass ImageOnlyFailure ]
+
+# The following test only fail on Mac EWS bots.
+webkit.org/b/244012 imported/w3c/web-platform-tests/css/css-transforms/transform-3d-rotateY-stair-below-001.xht [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### a440a53ae868d467333d41c1ea6e417e169fe05e
<pre>
[Gardening]: [ EWS MacOS ] imported/w3c/web-platform-tests/css/css-transforms/transform-3d-rotateY-stair-below-001.xht is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244012">https://bugs.webkit.org/show_bug.cgi?id=244012</a>

Unreviewed test gardening.

* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253492@main">https://commits.webkit.org/253492@main</a>
</pre>
