### PR TITLE
REGRESSION(253037@main): [ iOS macOS ] http/tests/workers/service/basic-timeout.https.html is a constant timeout

### DIFF
--- a/LayoutTests/http/tests/workers/service/basic-timeout.https-expected.txt
+++ b/LayoutTests/http/tests/workers/service/basic-timeout.https-expected.txt
@@ -1,14 +1,13 @@
+Tests various navigation time out cases for service workers.
 
-URL 0 - https://127.0.0.1:8443/workers/service/resources/timeout-fallback.html
-Status code 0 - 200
-Source' header 0 - null
-URL 1 - https://127.0.0.1:8443/workers/service/resources/timeout-no-fallback.html
-Status code 1 - 404
-Source' header 1 - null
-URL 2 - https://127.0.0.1:8443/workers/service/resources/succeed-fallback-check.py
-Status code 2 - 200
-Source' header 2 - network
-URL 3 - https://127.0.0.1:8443/workers/service/resources/succeed-fallback-check.py
-Status code 3 - 200
-Source' header 3 - network
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS frameText(testFrame1) is "Timeout resource fetched from network"
+PASS frameText(testFrame2) is "Not Found"
+PASS frameText(testFrame3) is "Success!"
+PASS frameText(testFrame4) is "Success!"
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/http/tests/workers/service/basic-timeout.https.html
+++ b/LayoutTests/http/tests/workers/service/basic-timeout.https.html
@@ -1,6 +1,7 @@
 <html>
 <head>
 <script src="resources/sw-test-pre.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
 </head>
 <body>
 

--- a/LayoutTests/http/tests/workers/service/resources/basic-timeout.js
+++ b/LayoutTests/http/tests/workers/service/resources/basic-timeout.js
@@ -1,75 +1,79 @@
 async function test()
 {
-    var urlResults = new Array;
-    var statusResults = new Array;
-    var headerResults = new Array;
+    let frameLoadedCount = 0;
+    const expectedFrameLoadedCount = 3;
 
-    function finishThisTest()
+    function addTestFrame(url, onloadFunction)
     {
-        for (var i = 0; i < urlResults.length; ++i) {
-            log("URL " + i + " - " + urlResults[i]);
-            log("Status code " + i + " - " + statusResults[i]);
-            log("Source' header " + i + " - " + headerResults[i]);
-        }
-        finishSWTest();
+        const iframe = frame.contentDocument.createElement("iframe");
+        iframe.src = url;
+        const iframeTimeoutHandle = setInterval(() => {
+            if (iframe.contentDocument.URL != "" && iframe.contentDocument.URL != "about:blank") {
+                clearTimeout(iframeTimeoutHandle);
+                onloadFunction();
+            }
+        }, 100);
+        iframe.onload = () => {
+            clearTimeout(iframeTimeoutHandle);
+            onloadFunction();
+        };
+        frame.contentDocument.body.appendChild(iframe);
+        return iframe;
     }
-    
+
+    frameText = function(testFrame)
+    {
+        let innerText = testFrame.contentDocument.body.innerText;
+        const newLineIndex = innerText.indexOf('\n');
+        if (newLineIndex > 0)
+            innerText = innerText.slice(0, newLineIndex);
+        return innerText;
+    }
+
+    function testFrame4Loaded()
+    {
+        // Currently goes to the network because the service worker registration is inert.
+        shouldBeEqualToString("frameText(testFrame4)", "Success!");
+
+        frame.remove();
+        finishJSTest();
+    }
+
+    function frameLoaded()
+    {
+        if (++frameLoadedCount < expectedFrameLoadedCount)
+            return;
+
+        shouldBeEqualToString("frameText(testFrame1)", "Timeout resource fetched from network"); // Load should fall back to the network.
+        shouldBeEqualToString("frameText(testFrame2)", "Not Found"); // Load should have went to network and failed with 404.
+        shouldBeEqualToString("frameText(testFrame3)", "Success!"); // Load should fall back to the network.
+
+        // Now we can fetch that same URL again, which *could* relaunch the service worker and handle it there, but for now this service worker registration is inert and fetches through it will go to the network instead.
+        // I'm leaving this in to cover future cases where we do relaunch the SW to handle it.
+        if (window.testRunner)
+            testRunner.setServiceWorkerFetchTimeout(60);
+        testFrame4 = addTestFrame("succeed-fallback-check.py", testFrame4Loaded);
+    }
+
+    description("Tests various navigation time out cases for service workers.");
+    jsTestIsAsync = true;
+ 
     try {
-        var frame = await interceptedFrame("resources/basic-timeout-worker.js", "/workers/service/resources/");
-        var fetch = frame.contentWindow.fetch;
+        frame = await interceptedFrame("resources/basic-timeout-worker.js", "/workers/service/resources/");
 
         if (window.testRunner)
             testRunner.setServiceWorkerFetchTimeout(0);
-        
-        // The following two fetches should time out immediately
-        fetch("timeout-fallback.html").then(function(response) {
-            urlResults[0] = response.url;
-            statusResults[0] = response.status;
-            headerResults[0] = response.headers.get("Source");       
-        }, function(error) {
-            log(error);
-        });
+       
+        // The following two loads should time out immediately.
+        testFrame1 = addTestFrame("timeout-fallback.html", frameLoaded);
+        testFrame2 = addTestFrame("timeout-no-fallback.html", frameLoaded);
 
-        fetch("timeout-no-fallback.html").then(function(response) {
-            urlResults[1] = response.url;
-            statusResults[1] = response.status;
-            headerResults[1] = response.headers.get("Source");   
-        }, function(error) {
-            log(error);
-        });
-
-        if (window.testRunner)
-            testRunner.setServiceWorkerFetchTimeout(60);
-
-        // The service worker knows how to handle the following fetch *and* has 60 seconds to do so.
-        // But will be cancelled with the above fetches since we're terminating the service worker, and 
-        // therefore it will then fallback to the network.
-        fetch("succeed-fallback-check.py").then(function(response) {
-            urlResults[2] = response.url;
-            statusResults[2] = response.status;
-            headerResults[2] = response.headers.get("Source");   
-            setTimeout(checkSuccessAgain, 0);
-        }, function(error) {
-            log(error);
-            finishSWTest();
-        });
-        
-        // Now we can fetch that same URL again, which *could* relaunch the service worker and handle it there, but for now this service worker registration is inert and fetches through it will go to the network instead.
-        // I'm leaving this in to cover future cases where we do relaunch the SW to handle it.
-        function checkSuccessAgain() {
-            fetch("succeed-fallback-check.py").then(function(response) {
-                urlResults[3] = response.url;
-                statusResults[3] = response.status;
-                headerResults[3] = response.headers.get("Source");   
-                finishThisTest();
-            }, function(error) {
-                log(error);
-                finishSWTest();
-            });
-        }
+        // This load would have been properly handled by the service worker but will go to network anyway
+        // because the service worker was hung by the previous loads.
+        testFrame3 = addTestFrame("succeed-fallback-check.py", frameLoaded);
     } catch(e) {
         log("Got exception: " + e);
-        finishSWTest();
+        finishJSTest();
     }
 }
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1244,8 +1244,6 @@ webkit.org/b/201981 imported/w3c/web-platform-tests/service-workers/service-work
 webkit.org/b/238738 http/wpt/service-workers/navigate-iframes-window-client.https.html [ Failure ]
 webkit.org/b/238738238738 imported/w3c/web-platform-tests/service-workers/service-worker/windowclient-navigate.https.html [ Failure ]
 
-webkit.org/b/208369 http/tests/workers/service/basic-timeout.https.html [ Failure Timeout Pass ]
-
 webkit.org/b/215638 http/tests/websocket/tests/hybi/invalid-continuation.html [ Failure ]
 webkit.org/b/215638 http/tests/websocket/tests/hybi/stop-on-resume-in-error-handler.html [ Failure ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3055,8 +3055,6 @@ webkit.org/b/204757 imported/w3c/web-platform-tests/fetch/api/request/destinatio
 
 webkit.org/b/203222 svg/wicd/rightsizing-grid.xhtml [ Pass Failure ]
 
-webkit.org/b/206864 http/tests/workers/service/basic-timeout.https.html [ Pass Failure Timeout ]
-
 webkit.org/b/206754 imported/w3c/web-platform-tests/css/css-backgrounds/background-image-centered-with-border-radius.html [ ImageOnlyFailure ]
 webkit.org/b/206754 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-body.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -993,8 +993,6 @@ webkit.org/b/199089 [ Debug ] plugins/window-open.html [ Skip ]
 
 webkit.org/b/205808 fast/text/international/unicode-bidi-other-neutrals.html [ Pass Failure ]
 
-webkit.org/b/206864 http/tests/workers/service/basic-timeout.https.html [ Pass Failure Timeout ]
-
 # <rdar://problem/60929239> [ macOS wk2 ] editing/selection/caret-at-bidi-boundary.html is a flaky timeout
 webkit.org/b/206696 editing/selection/caret-at-bidi-boundary.html [ Pass Timeout ]
 


### PR DESCRIPTION
#### a7d733519a166f912e7a6aa80d8662aeb30fb352
<pre>
REGRESSION(253037@main): [ iOS macOS ] http/tests/workers/service/basic-timeout.https.html is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=244001">https://bugs.webkit.org/show_bug.cgi?id=244001</a>
&lt;rdar://98739421&gt;

Reviewed by Youenn Fablet.

After 253037@main, we no longer terminate service workers that do not respond in a timely
fashion to loads, unless those loads are navigations.

This test was testing the hung service worker termination logic using fetch requests
and would thus no longer behave as expected after 253037@main. To address the issue,
I rewrote the test to use iframe navigations instead of fetch requests.

* LayoutTests/http/tests/workers/service/basic-timeout.https-expected.txt:
* LayoutTests/http/tests/workers/service/basic-timeout.https.html:
* LayoutTests/http/tests/workers/service/resources/basic-timeout.js:
(async test.addTestFrame):
(async test.frameText):
(async test.testFrame4Loaded):
(async test.frameLoaded):
(async test):
(async test.finishThisTest): Deleted.
(async test.try): Deleted.
(async test.try.checkSuccessAgain): Deleted.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253540@main">https://commits.webkit.org/253540@main</a>
</pre>
