### PR TITLE
[Gardening]: [Windows-EWS] fast/text/punctuation-break-all.html is a constant image failure

### DIFF
--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -5115,3 +5115,6 @@ webkit.org/b/241377 fast/css3-text/css3-text-decoration/repaint/underline-outsid
 webkit.org/b/241382 html5lib/generated/run-tests19-data.html [ Pass Crash ]
 
 webkit.org/b/243648 scrollbars/transparent-scrollbar.html [ ImageOnlyFailure ]
+
+webkit.org/b/243992 fast/text/punctuation-break-all.html [ ImageOnlyFailure ]
+


### PR DESCRIPTION
#### c3a027b02b2aa2c2f563f13c3b4a49a247eda258
<pre>
[Gardening]: [Windows-EWS] fast/text/punctuation-break-all.html is a constant image failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243992">https://bugs.webkit.org/show_bug.cgi?id=243992</a>
&lt;rdar://98721908&gt;

Unreviewed test gardening.

* LayoutTests/platform/win/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253494@main">https://commits.webkit.org/253494@main</a>
</pre>
