### PR TITLE
[Gardening]: REGRESSION (252960@main): [ macOS Debug ] imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-after-mutate.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2297,3 +2297,6 @@ webkit.org/b/243515 [ Monterey+ ] svg/compositing/outermost-svg-directly-composi
 
 # The following test only fail on Mac EWS bots.
 webkit.org/b/244012 imported/w3c/web-platform-tests/css/css-transforms/transform-3d-rotateY-stair-below-001.xht [ Pass ImageOnlyFailure ]
+
+webkit.org/b/244014 [ Debug ] imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-after-mutate.html  [ Pass Failure ]
+


### PR DESCRIPTION
#### ee3946a1daaddc4b333913f1be6d9cfc288a24e5
<pre>
[Gardening]: REGRESSION (252960@main): [ macOS Debug ] imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-after-mutate.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244014">https://bugs.webkit.org/show_bug.cgi?id=244014</a>
&lt;rdar://98757197&gt;

Unreviewed test gardening.

* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253496@main">https://commits.webkit.org/253496@main</a>
</pre>
