### PR TITLE
jsc executable should display 'n' suffix for BigInt values

### DIFF
--- a/Source/JavaScriptCore/runtime/JSCJSValue.cpp
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.cpp
@@ -473,9 +473,11 @@ WTF::String JSValue::toWTFStringForConsole(JSGlobalObject* globalObject) const
     String result = string->value(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     if (isString())
-        return tryMakeString("\"", result, "\"");
+        return tryMakeString('"', result, '"');
     if (jsDynamicCast<JSArray*>(*this))
-        return tryMakeString("[", result, "]");
+        return tryMakeString('[', result, ']');
+    if (jsDynamicCast<JSBigInt*>(*this))
+        return tryMakeString(result, 'n');
     return result;
 }
 


### PR DESCRIPTION
#### 6fbaa3f5aacb4914045b9d00464506c84700a3f9
<pre>
jsc executable should display &apos;n&apos; suffix for BigInt values
<a href="https://bugs.webkit.org/show_bug.cgi?id=244016">https://bugs.webkit.org/show_bug.cgi?id=244016</a>

Reviewed by Justin Michaud.

Other JS engine REPLs, like that of V8 and SM, display an `n` suffix when displaying a BigInt value. We should too.

* Source/JavaScriptCore/runtime/JSCJSValue.cpp:
(JSC::JSValue::toWTFStringForConsole const):

Canonical link: <a href="https://commits.webkit.org/253503@main">https://commits.webkit.org/253503@main</a>
</pre>
