### PR TITLE
LibraryPathDiagnostics prints UUIDs with bytes in the reverse order

### DIFF
--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -59,6 +59,13 @@ static char const * const libraryListEnvironmentVariableName = "LIBRARY_PATH_DIA
 #endif
 static char const * const bundleListEnvironmentVariableName = "LIBRARY_PATH_DIAGNOSTICS_BUNDLES";
 
+static String uuidToString(const uuid_t& uuid)
+{
+    uuid_string_t uuid_string = { };
+    uuid_unparse(uuid, uuid_string);
+    return String::fromUTF8(uuid_string);
+}
+
 class LibraryPathDiagnosticsLogger final {
 public:
     LibraryPathDiagnosticsLogger();
@@ -147,7 +154,7 @@ void LibraryPathDiagnosticsLogger::logDYLDSharedCacheInfo(void)
 
     auto sharedCacheInfo = JSON::Object::create();
     sharedCacheInfo->setString("Path"_s, FileSystem::realPath(String::fromUTF8(dyld_shared_cache_file_path())));
-    sharedCacheInfo->setString("UUID"_s, UUID(Span<const uint8_t, 16> { uuid }).toString());
+    sharedCacheInfo->setString("UUID"_s, uuidToString(uuid));
 
     logObject({ "SharedCache"_s }, WTFMove(sharedCacheInfo));
 }
@@ -188,7 +195,7 @@ void LibraryPathDiagnosticsLogger::logDynamicLibraryInfo(const String& installNa
     auto libraryObject = JSON::Object::create();
 
     libraryObject->setString("Path"_s, FileSystem::realPath(String::fromUTF8(info.dli_fname)));
-    libraryObject->setString("UUID"_s, UUID(Span<const uint8_t, 16> { uuid }).toString());
+    libraryObject->setString("UUID"_s, uuidToString(uuid));
 
 #if HAVE(SHARED_REGION_SPI)
     libraryObject->setBoolean("InSharedCache"_s, isAddressInSharedRegion(header));


### PR DESCRIPTION
#### 2fe54ca19ac0a4e19b9ac578df7a4e0737c15251
<pre>
LibraryPathDiagnostics prints UUIDs with bytes in the reverse order
<a href="https://bugs.webkit.org/show_bug.cgi?id=244011">https://bugs.webkit.org/show_bug.cgi?id=244011</a>
rdar://98737098

Reviewed by Saam Barati.

In <a href="https://bugs.webkit.org/show_bug.cgi?id=243458">https://bugs.webkit.org/show_bug.cgi?id=243458</a>, I added code in LibraryPathDiagnostics that
attempts to convert `uuid_t` returned by DYLD API to `WTF::UUID`, but I didn&apos;t realize that these
two types don&apos;t agree on endianness -- the former appears to be big-endian while the latter is
little-endian. The natural consequence of this is that the UUIDs printed in the logs are shown
with their bytes in the reverse order of what they should be.

Fix this by removing the conversion between the two UUID types altogether, and simply use the
platform API `uuid_unparse()` to produce the string representations of `uuid_t`s. Considering
how infrequently this type is used in the WebKit codebase (this is the second usage of this
type, other than ProcessLauncherCocoa), I chose to implement this as a local helper function
rather than building this conversion into WTF&apos;s UUID type directly. Doing so would require
either building in the assumption that `uuid_t` is stored big-endian on all platforms, or we&apos;d
need to use an inefficient implementation that performs this conversion by round-tripping the
UUID through a string representation. This conversion isn&apos;t actually needed at the moment, so
I&apos;d rather not do either of those when the tool already exists to do what *actually* needs to
be done -- convert the `uuid_t` to a string.

* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
(WTF::uuidToString):
(WTF::LibraryPathDiagnosticsLogger::logDYLDSharedCacheInfo):
(WTF::LibraryPathDiagnosticsLogger::logDynamicLibraryInfo):

Canonical link: <a href="https://commits.webkit.org/253545@main">https://commits.webkit.org/253545@main</a>
</pre>
