### PR TITLE
run-webkit-tests warmup process invocation interferes with debugging

### DIFF
--- a/Tools/Scripts/webkitpy/port/mac.py
+++ b/Tools/Scripts/webkitpy/port/mac.py
@@ -332,9 +332,12 @@ class MacPort(DarwinPort):
 
     def setup_test_run(self, device_type=None):
         super(MacPort, self).setup_test_run(device_type)
-        _log.debug('Warming up the runner ...')
-        warmup_driver = self.create_driver(0)
-        warmup_driver.run_test(DriverInput('file:///warmup-does-not-exist', 60000., None, should_run_pixel_test=False), stop_when_done=True)
+        # Warm-up can be disabled with `--no-timeout`. This is useful when trying to avoid debugger
+        # attaching to the warmup process when debugging with `lldb --wait-for --attach-name ...`.
+        if not self.get_option("no_timeout"):
+            _log.debug('Warming up the runner ...')
+            warmup_driver = self.create_driver(0)
+            warmup_driver.run_test(DriverInput('file:///warmup-does-not-exist', 60000., None, should_run_pixel_test=False), stop_when_done=True)
 
 
 class MacCatalystPort(MacPort):


### PR DESCRIPTION
#### 6cc481094e1864a0384b876e470158dd24bed986
<pre>
run-webkit-tests warmup process invocation interferes with debugging
<a href="https://bugs.webkit.org/show_bug.cgi?id=244021">https://bugs.webkit.org/show_bug.cgi?id=244021</a>
rdar://problem/98768070

Reviewed by Antti Koivisto.

Only run warmup layout test runner when `--no-timeout` is not used.
The potential OS level binary verification increasing the test
duration does not matter if `--no-timeout` is passed.

The warmup process makes it harder for a developer to use the pattern of
attaching lldb to the first WP with `lldb --wait-for --attach-name &lt;wp&gt;`.
This can be overcome by skipping the warmup when `--no-timeout` is used.

When debugging, it&apos;s typical that --no-timeout is used.

* Tools/Scripts/webkitpy/port/mac.py:
(MacPort.setup_test_run):

Canonical link: <a href="https://commits.webkit.org/253516@main">https://commits.webkit.org/253516@main</a>
</pre>
