### PR TITLE
Rename WebCore::findHTMLTag to findTag and extend it to find SVG and MathML tags

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2573,6 +2573,9 @@ list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/XMLNSNames.cpp)
 GENERATE_DOM_NAMES(XML ${WEBCORE_DIR}/xml/xmlattrs.in)
 list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/XMLNames.cpp)
 
+GENERATE_KNOWN_TAGS(${WEBCORE_DIR}/html/HTMLTagNames.in ${WEBCORE_DIR}/svg/svgtags.in ${WEBCORE_DIR}/mathml/mathtags.in)
+list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/KnownTag.cpp)
+
 WEBKIT_COMPUTE_SOURCES(WebCore)
 
 if (MSVC)

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -3008,6 +3008,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSXRWebGLLayerInit.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSXRWebGLLayerInit.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSXSLTProcessor.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSXSLTProcessor.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/KnownTag.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/KnownTag.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/LocalizableAdditions.strings.out
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/MathMLElementFactory.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/MathMLElementFactory.h

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1622,6 +1622,8 @@ all : \
     JSMathMLElementWrapperFactory.h \
     JSSVGElementWrapperFactory.cpp \
     JSSVGElementWrapperFactory.h \
+    KnownTag.cpp \
+    KnownTag.h \
     LocalizableAdditions.strings.out \
     SVGElementFactory.cpp \
     SVGElementFactory.h \
@@ -2084,6 +2086,20 @@ MATH_ML_GENERATED_PATTERNS = $(subst .,%,$(MATH_ML_GENERATED_FILES))
 all : $(MATH_ML_GENERATED_FILES)
 $(MATH_ML_GENERATED_PATTERNS) : $(WebCore)/dom/make_names.pl $(WebCore)/bindings/scripts/Hasher.pm $(WebCore)/bindings/scripts/StaticString.pm $(WebCore)/mathml/mathtags.in $(WebCore)/mathml/mathattrs.in
 	$(PERL) $< --tags $(WebCore)/mathml/mathtags.in --attrs $(WebCore)/mathml/mathattrs.in --factory --wrapperFactory
+
+# --------
+
+# All known tag names
+
+KNOWN_TAGS_GENERATED_FILES = \
+    KnownTag.cpp \
+    KnownTag.h \
+#
+KNOWN_TAGS_GENERATED_PATTERNS = $(subst .,%,$(KNOWN_TAGS_GENERATED_FILES))
+
+all : $(KNOWN_TAGS_GENERATED_FILES)
+$(KNOWN_TAGS_GENERATED_PATTERNS) : $(WebCore)/dom/make_names.pl $(WebCore)/bindings/scripts/Hasher.pm $(WebCore)/bindings/scripts/StaticString.pm $(WebCore)/html/HTMLTagNames.in $(WebCore)/svg/svgtags.in $(WebCore)/mathml/mathtags.in
+	$(PERL) $< --knownTags --tags $(WebCore)/html/HTMLTagNames.in --tags $(WebCore)/svg/svgtags.in --tags $(WebCore)/mathml/mathtags.in
 
 # --------
 

--- a/Source/WebCore/WebCoreMacros.cmake
+++ b/Source/WebCore/WebCoreMacros.cmake
@@ -241,3 +241,20 @@ function(GENERATE_DOM_NAMES _namespace _attrs)
         COMMAND ${PERL_EXECUTABLE} ${NAMES_GENERATOR} --outputDir ${WebCore_DERIVED_SOURCES_DIR} ${_arguments} ${_additionArguments}
         VERBATIM)
 endfunction()
+
+
+macro(GENERATE_KNOWN_TAGS _tagsfiles)
+    set(NAMES_GENERATOR ${WEBCORE_DIR}/dom/make_names.pl)
+    set(_arguments --knownTags)
+    foreach (f ${_tagsfiles})
+        set(_arguments "${_arguments}" --tags ${f})
+    endforeach ()
+    set(_outputfiles ${WebCore_DERIVED_SOURCES_DIR}/KnownTag.cpp ${WebCore_DERIVED_SOURCES_DIR}/KnownTag.h)
+
+    add_custom_command(
+        OUTPUT  ${_outputfiles}
+        MAIN_DEPENDENCY ${_tagsfiles}
+        DEPENDS ${MAKE_NAMES_DEPENDENCIES} ${NAMES_GENERATOR} ${SCRIPTS_BINDINGS}
+        COMMAND ${PERL_EXECUTABLE} ${NAMES_GENERATOR} --outputDir ${WebCore_DERIVED_SOURCES_DIR} ${_arguments}
+        VERBATIM)
+endmacro()

--- a/Source/WebCore/html/parser/AtomHTMLToken.h
+++ b/Source/WebCore/html/parser/AtomHTMLToken.h
@@ -29,6 +29,7 @@
 #include "HTMLNameCache.h"
 #include "HTMLNames.h"
 #include "HTMLToken.h"
+#include "KnownTag.h"
 #include <wtf/HashSet.h>
 #include <wtf/text/AtomStringHash.h>
 
@@ -238,7 +239,7 @@ inline AtomHTMLToken::AtomHTMLToken(HTMLToken& token)
     case Type::StartTag:
     case Type::EndTag:
         m_selfClosing = token.selfClosing();
-        m_name = HTMLNames::findHTMLTag(token.name());
+        m_name = findTag(token.name());
         if (UNLIKELY(m_name.isNull()))
             m_name = AtomString(token.name().data(), token.name().size());
         initializeAttributes(token.attributes());


### PR DESCRIPTION
#### fdf12c1ae711262b6e4a339c47730802a65f4bea
<pre>
Rename WebCore::findHTMLTag to findTag and extend it to find SVG and MathML tags
<a href="https://bugs.webkit.org/show_bug.cgi?id=244020">https://bugs.webkit.org/show_bug.cgi?id=244020</a>
rdar://problem/98767683

Reviewed by NOBODY (OOPS!).

We currently generate the WebCore::findHTMLTag function and use this in the
AtomHTMLToken constructor. We can extend this to look for any known tag name
(HTML, SVG, or MathML) by reworking make-names.pl a bit.

This isn&apos;t helpful for Speedometer performance, since parsing non-HTML tags is
rare, but local testing shows it to be a neutral change. Handling all known tag
names will set the stage for a later patch that does improve Speedometer
performance.

We generate a new pair of files, KnownTag.h and KnownTag.cpp, move the
old findHTMLTag function there, and rename it to findTag.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/WebCoreMacros.cmake:

Build system changes to invoke make_names.pl to generate
KnownTag.{h,cpp}.

* Source/WebCore/dom/make_names.pl:
(readKnownTags):

Read a list of tag name files. Any duplicate tag name found in a
subsequent file is ignored (e.g. the SVG script tag will be ignored if
the HTML tag name file is parsed first). Since the %parameters hash
doesn&apos;t make much sense when parsing multiple files, it&apos;s cleared out
by the end of the function, but the namespace for each tag (which comes
from the parameters object) is recorded on the tag object.

(printNamesHeaderFile):
(printNamesCppFile):

Remove the findHTMLTag generation from generated HTMLNames.{h,cpp} etc.

(printKnownTagsHeaderFile):
(printKnownTagsCppFile):

Generated findTag in KnownTag.{h,cpp}. Use the namespace stored on the
tag object to decide the QualifiedName on which to look up the local
name.

(findMaxTagLength): Just refer to the global %allTags variable, like other
functions do.

(tagsWithLength): Simplify.

(generateFindTagForLength): We need to replace &quot;_&quot;s with &quot;-&quot;s when generating
the big switch statement, since the tag names it&apos;s operating on have already
been converted into identifiers.

* Source/WebCore/html/parser/AtomHTMLToken.h:
(WebCore::AtomHTMLToken::AtomHTMLToken):

Call the new findTag function.
</pre>






















































































































<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdf12c1ae711262b6e4a339c47730802a65f4bea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95184 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148895 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28718 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25275 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78492 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90437 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23294 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73338 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23336 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66341 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26579 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12518 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26489 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13533 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36434 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32814 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->