### PR TITLE
The "Around the World" carousel is broken on https://focal-theme-carbon.myshopify.com/

### DIFF
--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1660,7 +1660,7 @@ void RenderLayerScrollableArea::updateScrollableAreaSet(bool hasOverflow)
 
 #if ENABLE(IOS_TOUCH_EVENTS)
     if (addedOrRemoved) {
-        if (isScrollable && !canUseCompositedScrolling())
+        if (needsToBeRegistered && !canUseCompositedScrolling())
             registerAsTouchEventListenerForScrolling();
         else {
             // We only need the touch listener for unaccelerated overflow scrolling, so if we became


### PR DESCRIPTION
#### 711178d9ca19e24c3f7dd39bf9206b543dc0a243
<pre>
The &quot;Around the World&quot; carousel is broken on <a href="https://focal-theme-carbon.myshopify.com/">https://focal-theme-carbon.myshopify.com/</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=242224">https://bugs.webkit.org/show_bug.cgi?id=242224</a>

Unreviewed iOS build fix.

* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateScrollableAreaSet):

Canonical link: <a href="https://commits.webkit.org/253511@main">https://commits.webkit.org/253511@main</a>
</pre>
