### PR TITLE
DTMF tonechange event sometimes doesn't fire

### DIFF
--- a/LayoutTests/webrtc/dtmf-gc-expected.txt
+++ b/LayoutTests/webrtc/dtmf-gc-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Make sure DTMF does not get GCed while it can fire events
+

--- a/LayoutTests/webrtc/dtmf-gc.html
+++ b/LayoutTests/webrtc/dtmf-gc.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+        <script src="../resources/gc.js"></script>
+    </head>
+    <body>
+        <video id="video" autoplay playsInline></video>
+        <script src ="routines.js"></script>
+        <script>
+
+promise_test(async (test) => {
+    let sender;
+    const localStream = await navigator.mediaDevices.getUserMedia({audio:true, video:true});
+    const stream = await new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            sender = firstConnection.addTrack(localStream.getAudioTracks()[0], localStream);
+            firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
+        }, (secondConnection) => {
+            secondConnection.ontrack = (trackEvent) => {
+                resolve(trackEvent.streams[0]);
+            };
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+
+    video.srcObject = stream;
+    await video.play();
+
+    const string = '0123456789ABCD';
+    let counter = 0;
+    const promise = new Promise((resolve, reject) => {
+        sender.dtmf.ontonechange = () => {
+            if (++counter === string.length)
+                resolve();
+        };
+        setTimeout(() => reject('dtmf timed out with counter ' + counter), 5000);
+    });
+    sender.dtmf.insertDTMF(string);
+
+    gc();
+    gc();
+    gc();
+
+    return promise;
+}, "Make sure DTMF does not get GCed while it can fire events");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
@@ -145,6 +145,7 @@ void RTCDTMFSender::toneTimerFired()
 
 void RTCDTMFSender::stop()
 {
+    m_isPendingPlayoutTask = false;
     m_backend = nullptr;
     m_toneTimer.stop();
 }

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
@@ -61,6 +61,7 @@ private:
 
     EventTargetInterface eventTargetInterface() const final { return RTCDTMFSenderEventTargetInterfaceType; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    bool virtualHasPendingActivity() const final { return m_isPendingPlayoutTask; }
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }


### PR DESCRIPTION
#### 90a55799cf723bbab94fda18afd65d27d54f27fa
<pre>
DTMF tonechange event sometimes doesn&apos;t fire
<a href="https://bugs.webkit.org/show_bug.cgi?id=242187">https://bugs.webkit.org/show_bug.cgi?id=242187</a>
rdar://problem/96593903

Reviewed by Eric Carlson.

Make sure that DTMF sender does not get GCed until it sent all tones or is stopped.

* LayoutTests/webrtc/dtmf-gc-expected.txt: Added.
* LayoutTests/webrtc/dtmf-gc.html: Added.
* Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp:
* Source/WebCore/Modules/mediastream/RTCDTMFSender.h:

Canonical link: <a href="https://commits.webkit.org/253551@main">https://commits.webkit.org/253551@main</a>
</pre>
