### PR TITLE
RTCDTMFSenderBackend::onTonePlayed callback does not need any parameter

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
@@ -55,7 +55,7 @@ RTCDTMFSender::RTCDTMFSender(ScriptExecutionContext& context, RTCRtpSender& send
     , m_sender(sender)
     , m_backend(WTFMove(backend))
 {
-    m_backend->onTonePlayed([this](const String&) {
+    m_backend->onTonePlayed([this] {
         onTonePlayed();
     });
 }
@@ -129,7 +129,7 @@ void RTCDTMFSender::playNextTone()
     auto currentTone = m_tones.left(1);
     m_tones = m_tones.substring(1);
 
-    m_backend->playTone(currentTone, m_duration, m_interToneGap);
+    m_backend->playTone(currentTone[0], m_duration, m_interToneGap);
     dispatchEvent(RTCDTMFToneChangeEvent::create(currentTone));
 }
 

--- a/Source/WebCore/platform/mediastream/RTCDTMFSenderBackend.h
+++ b/Source/WebCore/platform/mediastream/RTCDTMFSenderBackend.h
@@ -35,8 +35,8 @@ namespace WebCore {
 class RTCDTMFSenderBackend {
 public:
     virtual bool canInsertDTMF() = 0;
-    virtual void playTone(const String& tone, size_t duration, size_t interToneGap) = 0;
-    virtual void onTonePlayed(Function<void(const String&)>&&) = 0;
+    virtual void playTone(const char tone, size_t duration, size_t interToneGap) = 0;
+    virtual void onTonePlayed(Function<void()>&&) = 0;
 
     virtual String tones() const = 0;
     virtual size_t duration() const = 0;

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.cpp
@@ -53,9 +53,9 @@ bool LibWebRTCDTMFSenderBackend::canInsertDTMF()
     return m_sender->CanInsertDtmf();
 }
 
-void LibWebRTCDTMFSenderBackend::playTone(const String& tone, size_t duration, size_t interToneGap)
+void LibWebRTCDTMFSenderBackend::playTone(const char tone, size_t duration, size_t interToneGap)
 {
-    bool ok = m_sender->InsertDtmf(tone.utf8().data(), duration, interToneGap);
+    bool ok = m_sender->InsertDtmf(std::string(1, tone), duration, interToneGap);
     ASSERT_UNUSED(ok, ok);
 }
 
@@ -79,15 +79,13 @@ void LibWebRTCDTMFSenderBackend::OnToneChange(const std::string& tone, const std
     // We are just interested in notifying the end of the tone, which corresponds to the empty string.
     if (!tone.empty())
         return;
-    callOnMainThread([this, weakThis = WeakPtr { *this }, tone = toWTFString(tone)] {
-        if (!weakThis)
-            return;
-        if (m_onTonePlayed)
-            m_onTonePlayed(tone);
+    callOnMainThread([this, weakThis = WeakPtr { *this }] {
+        if (weakThis && m_onTonePlayed)
+            m_onTonePlayed();
     });
 }
 
-void LibWebRTCDTMFSenderBackend::onTonePlayed(Function<void(const String&)>&& onTonePlayed)
+void LibWebRTCDTMFSenderBackend::onTonePlayed(Function<void()>&& onTonePlayed)
 {
     m_onTonePlayed = WTFMove(onTonePlayed);
 }

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.h
@@ -49,8 +49,8 @@ public:
 private:
     // RTCDTMFSenderBackend
     bool canInsertDTMF() final;
-    void playTone(const String& tone, size_t duration, size_t interToneGap) final;
-    void onTonePlayed(Function<void(const String&)>&&) final;
+    void playTone(const char tone, size_t duration, size_t interToneGap) final;
+    void onTonePlayed(Function<void()>&&) final;
     String tones() const final;
     size_t duration() const final;
     size_t interToneGap() const final;
@@ -59,7 +59,7 @@ private:
     void OnToneChange(const std::string& tone, const std::string&) final;
 
     rtc::scoped_refptr<webrtc::DtmfSenderInterface> m_sender;
-    Function<void(const String&)> m_onTonePlayed;
+    Function<void()> m_onTonePlayed;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 42a10b5f848f3e0efa78777793fa3507f4e049fd
<pre>
RTCDTMFSenderBackend::onTonePlayed callback does not need any parameter
<a href="https://bugs.webkit.org/show_bug.cgi?id=244027">https://bugs.webkit.org/show_bug.cgi?id=244027</a>
rdar://problem/98774949

Reviewed by Eric Carlson.

The callback does not need any parameter since we ask the backend to play one tone at a time.
Update the code accordingly.
Make it clear that we play one tone at a time by passing a char instead of of a 1-char string.

Covered by existing tests.

* Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp:
(WebCore::RTCDTMFSender::RTCDTMFSender):
(WebCore::RTCDTMFSender::playNextTone):
* Source/WebCore/platform/mediastream/RTCDTMFSenderBackend.h:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.cpp:
(WebCore::LibWebRTCDTMFSenderBackend::playTone):
(WebCore::LibWebRTCDTMFSenderBackend::OnToneChange):
(WebCore::LibWebRTCDTMFSenderBackend::onTonePlayed):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.h:

Canonical link: <a href="https://commits.webkit.org/253550@main">https://commits.webkit.org/253550@main</a>
</pre>
