### PR TITLE
Non-unified build fixes, mid August 2022 edition

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
@@ -23,6 +23,7 @@
 #if USE(ATSPI)
 #include "AccessibilityAtspi.h"
 #include "AccessibilityAtspiEnums.h"
+#include "AccessibilityObject.h"
 #include "AccessibilityObjectInterface.h"
 #include "Document.h"
 #include "FrameView.h"

--- a/Source/WebCore/css/query/GenericMediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/GenericMediaQueryEvaluator.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSValueKeywords.h"
 #include "GenericMediaQueryTypes.h"
 #include "LayoutUnit.h"
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -55,6 +55,7 @@
 #include "PerformanceLoggingClient.h"
 #include "PluginViewBase.h"
 #include "ProgressTracker.h"
+#include "RenderAncestorIterator.h"
 #include "RenderEmbeddedObject.h"
 #include "RenderFragmentContainer.h"
 #include "RenderFragmentedFlow.h"

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -25,6 +25,7 @@
 #include "LegacyRenderSVGPath.h"
 #include "RenderAncestorIterator.h"
 #include "RenderLayer.h"
+#include "RenderSVGHiddenContainer.h"
 #include "RenderSVGPath.h"
 #include "RenderSVGResource.h"
 #include "SVGMatrix.h"


### PR DESCRIPTION
#### 24d2fe36f844ac1d81adff8410038b9a0b342c58
<pre>
Non-unified build fixes, mid August 2022 edition

Unreviewed non-unified build fixes.

* Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp:
  Add missing AccessibilityObject.h header inclusion.
* Source/WebCore/css/query/GenericMediaQueryEvaluator.h: Add missing
  CSSValueKeywords.h header inclusion.
* Source/WebCore/rendering/RenderLayerBacking.cpp: Add missing
  RenderAncestorIterator.h header inclusion.
* Source/WebCore/svg/SVGGraphicsElement.cpp: Add missing
  RenderSVGHiddenContainer.h header inclusion.

Canonical link: <a href="https://commits.webkit.org/253519@main">https://commits.webkit.org/253519@main</a>
</pre>
