### PR TITLE
[Gardening]: Text decorations' starting and ending positions should be pixel snapped

### DIFF
--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -5118,3 +5118,6 @@ webkit.org/b/243648 scrollbars/transparent-scrollbar.html [ ImageOnlyFailure ]
 
 webkit.org/b/243992 fast/text/punctuation-break-all.html [ ImageOnlyFailure ]
 
+webkit.org/b/142087 fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-inherit.html [ ImageOnlyFailure ]
+webkit.org/b/142087 fast/css3-text/css3-text-decoration/no-gap-between-two-rounded-textboxes.html [ ImageOnlyFailure ]
+

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -2122,3 +2122,6 @@ webgl/2.0.y/conformance/extensions/webgl-multi-draw.html [ Failure ]
 webgl/2.0.y/conformance2/extensions/webgl-multi-draw-instanced-base-vertex-base-instance.html [ Failure ]
 
 webkit.org/b/243992 fast/text/punctuation-break-all.html [ ImageOnlyFailure ]
+
+webkit.org/b/142087 fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-inherit.html [ ImageOnlyFailure ]
+webkit.org/b/142087 fast/css3-text/css3-text-decoration/no-gap-between-two-rounded-textboxes.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 7aab1e115ce4d6e0989de831cdae3b5fef46cf4c
<pre>
[Gardening]: Text decorations&apos; starting and ending positions should be pixel snapped
<a href="https://bugs.webkit.org/show_bug.cgi?id=142087">https://bugs.webkit.org/show_bug.cgi?id=142087</a>
&lt;rdar://19985648&gt;

Unreviewed test gardening.

* LayoutTests/platform/win/TestExpectations:
* LayoutTests/platform/wincairo/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253517@main">https://commits.webkit.org/253517@main</a>
</pre>
