### PR TITLE
Support importing compressed EC keys in webcrypto

### DIFF
--- a/LayoutTests/crypto/subtle/ecdsa-import-compressed-spki-key-p384-expected.txt
+++ b/LayoutTests/crypto/subtle/ecdsa-import-compressed-spki-key-p384-expected.txt
@@ -1,0 +1,16 @@
+Test importing a P-384 SPKI ECDSA COMPRESSED key
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Importing a key...
+PASS publicKey.toString() is '[object CryptoKey]'
+PASS publicKey.type is 'public'
+PASS publicKey.extractable is true
+PASS publicKey.algorithm.name is 'ECDSA'
+PASS publicKey.algorithm.namedCurve is 'P-384'
+PASS publicKey.usages is [ ]
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/ecdsa-import-compressed-spki-key-p384.html
+++ b/LayoutTests/crypto/subtle/ecdsa-import-compressed-spki-key-p384.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test importing a P-384 SPKI ECDSA COMPRESSED key ");
+jsTestIsAsync = true;
+
+
+  const spki = new Uint8Array([48, 70, 48, 16, 6, 7, 42, 134, 72, 206, 61, 2, 1, 6, 5, 43, 129, 4, 0, 34, 3, 50, 0, 2, 251, 203, 124, 105, 238, 28, 96, 87, 155, 231, 163, 52, 19, 72, 120, 217, 197, 197, 191, 53, 213, 82, 218, 182, 60, 1, 64, 57, 126, 209, 76, 239, 99, 125, 119, 32, 146, 92, 68, 105, 158, 163, 14, 114, 135, 76, 114, 251])
+  var extractable = true;
+
+  debug("Importing a key...");
+  crypto.subtle.importKey('spki', spki, { name: 'ECDSA', namedCurve: 'P-384' }, extractable, []).then(function(result){
+        publicKey = result;
+
+         shouldBe("publicKey.toString()", "'[object CryptoKey]'");
+         shouldBe("publicKey.type", "'public'");
+         shouldBe("publicKey.extractable", "true");
+         shouldBe("publicKey.algorithm.name", "'ECDSA'");
+         shouldBe("publicKey.algorithm.namedCurve", "'P-384'");
+         shouldBe("publicKey.usages", "[ ]");
+
+         finishJSTest();
+     });
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -289,6 +289,7 @@ imported/w3c/web-platform-tests/css/css-flexbox/select-element-zero-height-002.h
 # The test is marked as Timeout for wk2. It has been flaky in GTK and WPE since added.
 webaudio/Panner/hrtf-database.html [ Timeout Pass ]
 webaudio/Panner/panner-loop.html [ Timeout Pass ]
+crypto/subtle/ecdsa-import-compressed-spki-key-p384.html [ Timeout Pass ]
 
 # CSS backgrounds. Passing after WPT re-import in r277073.
 imported/w3c/web-platform-tests/css/css-backgrounds/bg-color-with-gradient.html [ Pass ]

--- a/Source/WebCore/PAL/pal/spi/cocoa/CommonCryptoSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/CommonCryptoSPI.h
@@ -91,6 +91,7 @@ typedef uint32_t CCECKeyType;
 
 enum {
     kCCImportKeyBinary = 0,
+    kCCImportKeyCompact = 2,
 };
 typedef uint32_t CCECKeyExternalFormat;
 #endif


### PR DESCRIPTION
#### c2800dd46bb2deeea08659eb0d3ae6d9eab219ac
<pre>
Support importing compressed EC keys in webcrypto
<a href="https://bugs.webkit.org/show_bug.cgi?id=244032">https://bugs.webkit.org/show_bug.cgi?id=244032</a>
rdar://86211772

Reviewed by Youenn Fablet

The compressed point format includes the least significant bit of the second coordinates in the first byte to know the orientation , so that is why the index is incremented one unit when dealing with compressed curves .  Otherwise the function ccec_compact_import_pub_size receivesthe wrong number, expecting always a number greater in just one unit.
* LayoutTests/crypto/subtle/ecdsa-import-compressed-spki-key-p384-expected.txt: Added.
* LayoutTests/crypto/subtle/ecdsa-import-compressed-spki-key-p384.html: Added.
* LayoutTests/crypto/subtle/ecdsa-import-compressed-spki-key-p384.txt: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/PAL/pal/spi/cocoa/CommonCryptoSPI.h:
* Source/WebCore/crypto/mac/CryptoKeyECMac.cpp:
(WebCore::CryptoKeyEC::platformImportSpki):

Canonical link: <a href="https://commits.webkit.org/254310@main">https://commits.webkit.org/254310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40f7b1078e277809614fdc967024bb83f168711d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97774 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/153669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31636 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27212 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80807 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92410 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25095 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75514 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25038 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68001 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29280 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14049 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29166 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15064 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3040 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37994 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34173 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->