### PR TITLE
Build fix after 253497@main

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
@@ -27,14 +27,10 @@
 
 #if HAVE(ASC_AUTH_UI) || HAVE(UNIFIED_ASC_AUTH_UI)
 
-#if USE(APPLE_INTERNAL_SDK) && HAVE(ASC_WEBKIT_SPI)
-#import <AuthenticationServicesCore/ASCWebKitSPISupport.h>
-#else
 @interface ASCWebKitSPISupport : NSObject
 @property (class, nonatomic) BOOL shouldUseAlternateCredentialStore;
 + (BOOL)arePasskeysDisallowedForRelyingParty:(nonnull NSString *)relyingParty;
 @end
-#endif
 
 // FIXME: Most of the forward declarations below should be behind a non-Apple-internal SDK compile-time flag.
 // When building with an Apple-internal SDK, we should instead import the private headers directly from the

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -520,7 +520,7 @@ void WebAuthenticatorCoordinatorProxy::isConditionalMediationAvailable(QueryComp
 void WebAuthenticatorCoordinatorProxy::isUserVerifyingPlatformAuthenticatorAvailable(const SecurityOriginData& data, QueryCompletionHandler&& handler)
 {
     if ([getASCWebKitSPISupportClass() shouldUseAlternateCredentialStore]) {
-        handler(![getASCWebKitSPISupportClass() arePasskeysDisallowedForRelyingParty:data.securityOrigin()->domain()]);
+        handler(![getASCWebKitSPISupportClass() respondsToSelector:@selector(arePasskeysDisallowedForRelyingParty:)] || ![getASCWebKitSPISupportClass() arePasskeysDisallowedForRelyingParty:data.securityOrigin()->domain()]);
         return;
     }
 


### PR DESCRIPTION
#### f098d8e84da7a9e55144ac6c65093914c251fbbe
<pre>
Build fix after 253497@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=244037">https://bugs.webkit.org/show_bug.cgi?id=244037</a>

Unreviewed.

* Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
Forward declare SPI for internal sdk.

Canonical link: <a href="https://commits.webkit.org/253526@main">https://commits.webkit.org/253526@main</a>
</pre>
