### PR TITLE
Revert "SharedMemory::IPCHandle is a redundant class"

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -218,10 +218,10 @@ void RemoteRenderingBackend::getPixelBufferForImageBuffer(RenderingResourceIdent
     completionHandler();
 }
 
-void RemoteRenderingBackend::getPixelBufferForImageBufferWithNewMemory(RenderingResourceIdentifier imageBuffer, SharedMemory::Handle&& handle, PixelBufferFormat&& destinationFormat, IntRect&& srcRect, CompletionHandler<void()>&& completionHandler)
+void RemoteRenderingBackend::getPixelBufferForImageBufferWithNewMemory(RenderingResourceIdentifier imageBuffer, SharedMemory::IPCHandle&& handle, PixelBufferFormat&& destinationFormat, IntRect&& srcRect, CompletionHandler<void()>&& completionHandler)
 {
     m_getPixelBufferSharedMemory = nullptr;
-    auto sharedMemory = WebKit::SharedMemory::map(handle, WebKit::SharedMemory::Protection::ReadWrite);
+    auto sharedMemory = WebKit::SharedMemory::map(handle.handle, WebKit::SharedMemory::Protection::ReadWrite);
     MESSAGE_CHECK(sharedMemory, "Shared memory could not be mapped.");
     MESSAGE_CHECK(sharedMemory->size() <= HTMLCanvasElement::maxActivePixelMemory(), "Shared memory too big.");
     m_getPixelBufferSharedMemory = WTFMove(sharedMemory);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -110,7 +110,7 @@ private:
     // Messages to be received.
     void createImageBuffer(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat, WebCore::RenderingResourceIdentifier);
     void getPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, WebCore::PixelBufferFormat&&, WebCore::IntRect&& srcRect, CompletionHandler<void()>&&);
-    void getPixelBufferForImageBufferWithNewMemory(WebCore::RenderingResourceIdentifier, SharedMemory::Handle&&, WebCore::PixelBufferFormat&& destinationFormat, WebCore::IntRect&& srcRect, CompletionHandler<void()>&&);
+    void getPixelBufferForImageBufferWithNewMemory(WebCore::RenderingResourceIdentifier, SharedMemory::IPCHandle&&, WebCore::PixelBufferFormat&& destinationFormat, WebCore::IntRect&& srcRect, CompletionHandler<void()>&&);
     void destroyGetPixelBufferSharedMemory();
     void putPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, Ref<WebCore::PixelBuffer>&&, WebCore::IntRect&& srcRect, WebCore::IntPoint&& destPoint, WebCore::AlphaPremultiplication destFormat);
     void getShareableBitmapForImageBuffer(WebCore::RenderingResourceIdentifier, WebCore::PreserveResolution, CompletionHandler<void(ShareableBitmap::Handle&&)>&&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -25,7 +25,7 @@
 messages -> RemoteRenderingBackend NotRefCounted Stream {
     CreateImageBuffer(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose, float resolutionScale, WebCore::DestinationColorSpace colorSpace, enum:uint8_t WebCore::PixelFormat pixelFormat, WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
     GetPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, struct WebCore::PixelBufferFormat outputFormat, WebCore::IntRect srcRect) -> () Synchronous
-    GetPixelBufferForImageBufferWithNewMemory(WebCore::RenderingResourceIdentifier imageBuffer, WebKit::SharedMemory::Handle handle, struct WebCore::PixelBufferFormat outputFormat, WebCore::IntRect srcRect) -> () Synchronous NotStreamEncodable
+    GetPixelBufferForImageBufferWithNewMemory(WebCore::RenderingResourceIdentifier imageBuffer, WebKit::SharedMemory::IPCHandle handle, struct WebCore::PixelBufferFormat outputFormat, WebCore::IntRect srcRect) -> () Synchronous NotStreamEncodable
     DestroyGetPixelBufferSharedMemory()
     PutPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, Ref<WebCore::PixelBuffer> pixelBuffer,  WebCore::IntRect srcRect, WebCore::IntPoint destPoint, enum:uint8_t WebCore::AlphaPremultiplication destFormat)
     GetShareableBitmapForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, enum:uint8_t WebCore::PreserveResolution preserveResolution) -> (WebKit::ShareableBitmap::Handle handle) Synchronous NotStreamEncodableReply

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -93,9 +93,9 @@ public:
     }
 
 #if PLATFORM(COCOA)
-    void audioSamplesStorageChanged(const SharedMemory::Handle& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
+    void audioSamplesStorageChanged(const SharedMemory::IPCHandle& ipcHandle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
     {
-        m_ringBuffer = WebCore::CARingBuffer::adoptStorage(makeUniqueRef<ReadOnlySharedRingBufferStorage>(handle), description, numberOfFrames);
+        m_ringBuffer = WebCore::CARingBuffer::adoptStorage(makeUniqueRef<ReadOnlySharedRingBufferStorage>(ipcHandle.handle), description, numberOfFrames);
     }
 #endif
 
@@ -211,10 +211,10 @@ void RemoteAudioDestinationManager::stopAudioDestination(RemoteAudioDestinationI
 }
 
 #if PLATFORM(COCOA)
-void RemoteAudioDestinationManager::audioSamplesStorageChanged(RemoteAudioDestinationIdentifier identifier, const SharedMemory::Handle& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
+void RemoteAudioDestinationManager::audioSamplesStorageChanged(RemoteAudioDestinationIdentifier identifier, const SharedMemory::IPCHandle& ipcHandle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
 {
     if (auto* item = m_audioDestinations.get(identifier))
-        item->audioSamplesStorageChanged(handle, description, numberOfFrames);
+        item->audioSamplesStorageChanged(ipcHandle, description, numberOfFrames);
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
@@ -68,7 +68,7 @@ private:
     void startAudioDestination(RemoteAudioDestinationIdentifier, CompletionHandler<void(bool)>&&);
     void stopAudioDestination(RemoteAudioDestinationIdentifier, CompletionHandler<void(bool)>&&);
 #if PLATFORM(COCOA)
-    void audioSamplesStorageChanged(RemoteAudioDestinationIdentifier, const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void audioSamplesStorageChanged(RemoteAudioDestinationIdentifier, const SharedMemory::IPCHandle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
 #endif
 
     HashMap<RemoteAudioDestinationIdentifier, UniqueRef<RemoteAudioDestination>> m_audioDestinations;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
@@ -31,7 +31,7 @@ messages -> RemoteAudioDestinationManager NotRefCounted {
     StartAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier) -> (bool isPlaying)
     StopAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier) -> (bool isPlaying)
 #if PLATFORM(COCOA)
-    AudioSamplesStorageChanged(WebKit::RemoteAudioDestinationIdentifier identifier, WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
+    AudioSamplesStorageChanged(WebKit::RemoteAudioDestinationIdentifier identifier, WebKit::SharedMemory::IPCHandle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
@@ -72,7 +72,14 @@ void RemoteAudioSourceProviderProxy::storageChanged(SharedMemory* memory, const 
     SharedMemory::Handle handle;
     if (memory)
         memory->createHandle(handle, SharedMemory::Protection::ReadOnly);
-    m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioStorageChanged { m_identifier, handle, format, frameCount }, 0);
+
+    // FIXME: Send the actual data size with IPCHandle.
+#if OS(DARWIN) || OS(WINDOWS)
+    uint64_t dataSize = handle.size();
+#else
+    uint64_t dataSize = 0;
+#endif
+    m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioStorageChanged { m_identifier, SharedMemory::IPCHandle { WTFMove(handle),  dataSize }, format, frameCount }, 0);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
@@ -91,12 +91,15 @@ void RemoteMediaResourceManager::dataSent(RemoteMediaResourceIdentifier identifi
     resource->dataSent(bytesSent, totalBytesToBeSent);
 }
 
-void RemoteMediaResourceManager::dataReceived(RemoteMediaResourceIdentifier identifier, IPC::SharedBufferReference&& buffer, CompletionHandler<void(std::optional<SharedMemory::Handle>&&)>&& completionHandler)
+void RemoteMediaResourceManager::dataReceived(RemoteMediaResourceIdentifier identifier, IPC::SharedBufferReference&& buffer, CompletionHandler<void(std::optional<SharedMemory::IPCHandle>&&)>&& completionHandler)
 {
     SharedMemory::Handle handle;
 
     auto invokeCallbackAtScopeExit = makeScopeExit([&] {
-        completionHandler(WTFMove(handle));
+        std::optional<SharedMemory::IPCHandle> response;
+        if (!handle.isNull())
+            response = SharedMemory::IPCHandle { WTFMove(handle), buffer.size() };
+        completionHandler(WTFMove(response));
     });
 
     auto* resource = m_remoteMediaResources.get(identifier);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h
@@ -67,7 +67,7 @@ private:
     void responseReceived(RemoteMediaResourceIdentifier, const WebCore::ResourceResponse&, bool, CompletionHandler<void(WebCore::ShouldContinuePolicyCheck)>&&);
     void redirectReceived(RemoteMediaResourceIdentifier, WebCore::ResourceRequest&&, const WebCore::ResourceResponse&, CompletionHandler<void(WebCore::ResourceRequest&&)>&&);
     void dataSent(RemoteMediaResourceIdentifier, uint64_t, uint64_t);
-    void dataReceived(RemoteMediaResourceIdentifier, IPC::SharedBufferReference&&, CompletionHandler<void(std::optional<WebKit::SharedMemory::Handle>&&)>&&);
+    void dataReceived(RemoteMediaResourceIdentifier, IPC::SharedBufferReference&&, CompletionHandler<void(std::optional<WebKit::SharedMemory::IPCHandle>&&)>&&);
     void accessControlCheckFailed(RemoteMediaResourceIdentifier, const WebCore::ResourceError&);
     void loadFailed(RemoteMediaResourceIdentifier, const WebCore::ResourceError&);
     void loadFinished(RemoteMediaResourceIdentifier, const WebCore::NetworkLoadMetrics&);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.messages.in
@@ -29,7 +29,7 @@ messages -> RemoteMediaResourceManager NotRefCounted {
     ResponseReceived(WebKit::RemoteMediaResourceIdentifier identifier, WebCore::ResourceResponse response, bool didPassAccessControlCheck) -> (enum:bool WebCore::ShouldContinuePolicyCheck shouldContinue)
     RedirectReceived(WebKit::RemoteMediaResourceIdentifier identifier, WebCore::ResourceRequest request, WebCore::ResourceResponse response) -> (WebCore::ResourceRequest returnRequest)
     DataSent(WebKit::RemoteMediaResourceIdentifier identifier, uint64_t bytesSent, uint64_t totalBytesToBeSent)
-    DataReceived(WebKit::RemoteMediaResourceIdentifier identifier, IPC::SharedBufferReference data) -> (std::optional<WebKit::SharedMemory::Handle> remoteData)
+    DataReceived(WebKit::RemoteMediaResourceIdentifier identifier, IPC::SharedBufferReference data) -> (std::optional<WebKit::SharedMemory::IPCHandle> remoteData)
     AccessControlCheckFailed(WebKit::RemoteMediaResourceIdentifier identifier, WebCore::ResourceError error)
     LoadFailed(WebKit::RemoteMediaResourceIdentifier identifier, WebCore::ResourceError error)
     LoadFinished(WebKit::RemoteMediaResourceIdentifier identifier, WebCore::NetworkLoadMetrics metrics)

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -89,7 +89,7 @@ private:
     void setActive(bool);
     void canSwitchToType(const WebCore::ContentType&, CompletionHandler<void(bool)>&&);
     void setMode(WebCore::SourceBufferAppendMode);
-    void append(IPC::SharedBufferReference&&, CompletionHandler<void(std::optional<WebKit::SharedMemory::Handle>&&)>&&);
+    void append(IPC::SharedBufferReference&&, CompletionHandler<void(std::optional<WebKit::SharedMemory::IPCHandle>&&)>&&);
     void abort();
     void resetParserState();
     void removedFromMediaSource();

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
@@ -29,7 +29,7 @@ messages -> RemoteSourceBufferProxy NotRefCounted {
     SetActive(bool active)
     CanSwitchToType(WebCore::ContentType contentType) -> (bool canSwitch) Synchronous
     SetMode(WebCore::SourceBufferAppendMode appendMode)
-    Append(IPC::SharedBufferReference data) -> (std::optional<WebKit::SharedMemory::Handle> remoteData)
+    Append(IPC::SharedBufferReference data) -> (std::optional<WebKit::SharedMemory::IPCHandle> remoteData)
     Abort()
     ResetParserState()
     RemovedFromMediaSource()

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
@@ -180,9 +180,9 @@ void RemoteVideoFrameObjectHeap::setSharedVideoFrameSemaphore(IPC::Semaphore&& s
     m_sharedVideoFrameReader.setSemaphore(WTFMove(semaphore));
 }
 
-void RemoteVideoFrameObjectHeap::setSharedVideoFrameMemory(const SharedMemory::Handle& handle)
+void RemoteVideoFrameObjectHeap::setSharedVideoFrameMemory(const SharedMemory::IPCHandle& ipcHandle)
 {
-    m_sharedVideoFrameReader.setSharedMemory(handle);
+    m_sharedVideoFrameReader.setSharedMemory(ipcHandle);
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
@@ -68,7 +68,7 @@ private:
     void pixelBuffer(RemoteVideoFrameReadReference&&, CompletionHandler<void(RetainPtr<CVPixelBufferRef>)>&&);
     void convertFrameBuffer(SharedVideoFrame&&, CompletionHandler<void(WebCore::DestinationColorSpace)>&&);
     void setSharedVideoFrameSemaphore(IPC::Semaphore&&);
-    void setSharedVideoFrameMemory(const SharedMemory::Handle&);
+    void setSharedVideoFrameMemory(const SharedMemory::IPCHandle&);
 #endif
 
     void createPixelConformerIfNeeded();

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.messages.in
@@ -27,7 +27,7 @@ messages -> RemoteVideoFrameObjectHeap NotRefCounted {
     GetVideoFrameBuffer(WebKit::RemoteVideoFrameReadReference read, bool canSendIOSurface)
     PixelBuffer(WebKit::RemoteVideoFrameReadReference read) -> (RetainPtr<CVPixelBufferRef> result) Synchronous
     SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore)
-    SetSharedVideoFrameMemory(WebKit::SharedMemory::Handle storageHandle)
+    SetSharedVideoFrameMemory(WebKit::SharedMemory::IPCHandle storageHandle)
     ConvertFrameBuffer(struct WebKit::SharedVideoFrame frame) -> (WebCore::DestinationColorSpace space) Synchronous
 #endif
     ReleaseVideoFrame(WebKit::RemoteVideoFrameWriteReference write)

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -90,7 +90,7 @@ private:
     void encodeFrame(RTCEncoderIdentifier, SharedVideoFrame&&, uint32_t timeStamp, bool shouldEncodeAsKeyFrame);
     void setEncodeRates(RTCEncoderIdentifier, uint32_t bitRate, uint32_t frameRate);
     void setSharedVideoFrameSemaphore(RTCEncoderIdentifier, IPC::Semaphore&&);
-    void setSharedVideoFrameMemory(RTCEncoderIdentifier, const SharedMemory::Handle&);
+    void setSharedVideoFrameMemory(RTCEncoderIdentifier, const SharedMemory::IPCHandle&);
     void setRTCLoggingLevel(WTFLogLevel);
 
     struct Encoder {

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
@@ -37,7 +37,7 @@ messages -> LibWebRTCCodecsProxy NotRefCounted {
     EncodeFrame(WebKit::RTCEncoderIdentifier id, struct WebKit::SharedVideoFrame buffer, uint32_t timeStamp, bool shouldEncodeAsKeyFrame)
     SetEncodeRates(WebKit::RTCEncoderIdentifier id, uint32_t bitRate, uint32_t frameRate)
     SetSharedVideoFrameSemaphore(WebKit::RTCEncoderIdentifier id, IPC::Semaphore semaphore)
-    SetSharedVideoFrameMemory(WebKit::RTCEncoderIdentifier id, WebKit::SharedMemory::Handle storageHandle)
+    SetSharedVideoFrameMemory(WebKit::RTCEncoderIdentifier id, WebKit::SharedMemory::IPCHandle storageHandle)
     SetRTCLoggingLevel(WTFLogLevel level)
 }
 

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
@@ -283,7 +283,7 @@ void LibWebRTCCodecsProxy::setSharedVideoFrameSemaphore(RTCEncoderIdentifier ide
     encoder->frameReader->setSemaphore(WTFMove(semaphore));
 }
 
-void LibWebRTCCodecsProxy::setSharedVideoFrameMemory(RTCEncoderIdentifier identifier, const SharedMemory::Handle& handle)
+void LibWebRTCCodecsProxy::setSharedVideoFrameMemory(RTCEncoderIdentifier identifier, const SharedMemory::IPCHandle& ipcHandle)
 {
     assertIsCurrent(workQueue());
     auto* encoder = findEncoder(identifier);
@@ -292,7 +292,7 @@ void LibWebRTCCodecsProxy::setSharedVideoFrameMemory(RTCEncoderIdentifier identi
         return;
     }
 
-    encoder->frameReader->setSharedMemory(handle);
+    encoder->frameReader->setSharedMemory(ipcHandle);
 }
 
 bool LibWebRTCCodecsProxy::allowsExitUnderMemoryPressure() const

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -119,10 +119,10 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::deleteUnit(AudioMed
         m_gpuConnectionToWebProcess.gpuProcess().tryExitIfUnusedAndUnderMemoryPressure();
 }
 
-void RemoteAudioMediaStreamTrackRendererInternalUnitManager::startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, const SharedMemory::Handle& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames, IPC::Semaphore&& semaphore)
+void RemoteAudioMediaStreamTrackRendererInternalUnitManager::startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, const SharedMemory::IPCHandle& ipcHandle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames, IPC::Semaphore&& semaphore)
 {
     if (auto* unit = m_units.get(identifier))
-        unit->start(handle, description, numberOfFrames, WTFMove(semaphore));
+        unit->start(ipcHandle.handle, description, numberOfFrames, WTFMove(semaphore));
 }
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::stopUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
@@ -64,7 +64,7 @@ private:
     // Messages
     void createUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, CompletionHandler<void(const WebCore::CAAudioStreamDescription&, size_t)>&& callback);
     void deleteUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
-    void startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames, IPC::Semaphore&&);
+    void startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, const SharedMemory::IPCHandle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames, IPC::Semaphore&&);
     void stopUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
     void setAudioOutputDevice(AudioMediaStreamTrackRendererInternalUnitIdentifier, const String&);
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
@@ -27,7 +27,7 @@ messages -> RemoteAudioMediaStreamTrackRendererInternalUnitManager NotRefCounted
     CreateUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier) -> (WebCore::CAAudioStreamDescription description, size_t frameChunkSize)
     DeleteUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
 
-    StartUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames, IPC::Semaphore renderSemaphore)
+    StartUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, WebKit::SharedMemory::IPCHandle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames, IPC::Semaphore renderSemaphore)
     StopUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
 
     SetAudioOutputDevice(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, String deviceId)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
@@ -64,13 +64,13 @@ RemoteMediaRecorder::~RemoteMediaRecorder()
 {
 }
 
-void RemoteMediaRecorder::audioSamplesStorageChanged(const SharedMemory::Handle& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
+void RemoteMediaRecorder::audioSamplesStorageChanged(const SharedMemory::IPCHandle& ipcHandle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
 {
     MESSAGE_CHECK(m_ringBuffer);
 
     m_description = description;
 
-    m_ringBuffer = CARingBuffer::adoptStorage(makeUniqueRef<ReadOnlySharedRingBufferStorage>(handle), description, numberOfFrames).moveToUniquePtr();
+    m_ringBuffer = CARingBuffer::adoptStorage(makeUniqueRef<ReadOnlySharedRingBufferStorage>(ipcHandle.handle), description, numberOfFrames).moveToUniquePtr();
     m_audioBufferList = makeUnique<WebAudioBufferList>(m_description);
 }
 
@@ -124,9 +124,9 @@ void RemoteMediaRecorder::setSharedVideoFrameSemaphore(IPC::Semaphore&& semaphor
     m_sharedVideoFrameReader.setSemaphore(WTFMove(semaphore));
 }
 
-void RemoteMediaRecorder::setSharedVideoFrameMemory(const SharedMemory::Handle& handle)
+void RemoteMediaRecorder::setSharedVideoFrameMemory(const SharedMemory::IPCHandle& ipcHandle)
 {
-    m_sharedVideoFrameReader.setSharedMemory(handle);
+    m_sharedVideoFrameReader.setSharedMemory(ipcHandle);
 }
 
 }

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
@@ -69,7 +69,7 @@ private:
     RemoteMediaRecorder(GPUConnectionToWebProcess&, MediaRecorderIdentifier, Ref<WebCore::MediaRecorderPrivateWriter>&&, bool recordAudio);
 
     // IPC::MessageReceiver
-    void audioSamplesStorageChanged(const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void audioSamplesStorageChanged(const SharedMemory::IPCHandle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
     void audioSamplesAvailable(MediaTime, uint64_t numberOfFrames);
     void videoFrameAvailable(SharedVideoFrame&&);
     void fetchData(CompletionHandler<void(IPC::DataReference&&, double)>&&);
@@ -77,7 +77,7 @@ private:
     void pause(CompletionHandler<void()>&&);
     void resume(CompletionHandler<void()>&&);
     void setSharedVideoFrameSemaphore(IPC::Semaphore&&);
-    void setSharedVideoFrameMemory(const SharedMemory::Handle&);
+    void setSharedVideoFrameMemory(const SharedMemory::IPCHandle&);
 
     GPUConnectionToWebProcess& m_gpuConnectionToWebProcess;
     MediaRecorderIdentifier m_identifier;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.messages.in
@@ -24,7 +24,7 @@
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM)
 
 messages -> RemoteMediaRecorder NotRefCounted {
-    AudioSamplesStorageChanged(WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
+    AudioSamplesStorageChanged(WebKit::SharedMemory::IPCHandle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
     AudioSamplesAvailable(MediaTime time, uint64_t numberOfFrames)
     VideoFrameAvailable(struct WebKit::SharedVideoFrame frame)
     FetchData() -> (IPC::DataReference buffer, double timeCode)
@@ -32,7 +32,7 @@ messages -> RemoteMediaRecorder NotRefCounted {
     Pause() -> ()
     Resume() -> ()
     SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore)
-    SetSharedVideoFrameMemory(WebKit::SharedMemory::Handle storageHandle)
+    SetSharedVideoFrameMemory(WebKit::SharedMemory::IPCHandle storageHandle)
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
@@ -143,9 +143,9 @@ void RemoteSampleBufferDisplayLayer::setSharedVideoFrameSemaphore(IPC::Semaphore
     m_sharedVideoFrameReader.setSemaphore(WTFMove(semaphore));
 }
 
-void RemoteSampleBufferDisplayLayer::setSharedVideoFrameMemory(const SharedMemory::Handle& handle)
+void RemoteSampleBufferDisplayLayer::setSharedVideoFrameMemory(const SharedMemory::IPCHandle& ipcHandle)
 {
-    m_sharedVideoFrameReader.setSharedMemory(handle);
+    m_sharedVideoFrameReader.setSharedMemory(ipcHandle);
 }
 
 }

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -78,7 +78,7 @@ private:
     void enqueueVideoFrame(SharedVideoFrame&&);
     void clearVideoFrames();
     void setSharedVideoFrameSemaphore(IPC::Semaphore&&);
-    void setSharedVideoFrameMemory(const SharedMemory::Handle&);
+    void setSharedVideoFrameMemory(const SharedMemory::IPCHandle&);
 
     // IPC::MessageSender
     IPC::Connection* messageSenderConnection() const final;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in
@@ -37,7 +37,7 @@ messages -> RemoteSampleBufferDisplayLayer NotRefCounted {
     Play()
     Pause()
     SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore)
-    SetSharedVideoFrameMemory(WebKit::SharedMemory::Handle storageHandle)
+    SetSharedVideoFrameMemory(WebKit::SharedMemory::IPCHandle storageHandle)
 }
 
 #endif

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
@@ -86,7 +86,13 @@ void WebSWOriginStore::sendStoreHandle(WebSWServerConnection& connection)
     SharedMemory::Handle handle;
     if (!m_store.createSharedMemoryHandle(handle))
         return;
-    connection.send(Messages::WebSWClientConnection::SetSWOriginTableSharedMemory(handle));
+
+#if (OS(DARWIN) || OS(WINDOWS)) && !USE(UNIX_DOMAIN_SOCKETS)
+    uint64_t dataSize = handle.size();
+#else
+    uint64_t dataSize = 0;
+#endif
+    connection.send(Messages::WebSWClientConnection::SetSWOriginTableSharedMemory(SharedMemory::IPCHandle { WTFMove(handle), dataSize }));
 }
 
 void WebSWOriginStore::didInvalidateSharedMemory()

--- a/Source/WebKit/Platform/IPC/JSIPCBinding.h
+++ b/Source/WebKit/Platform/IPC/JSIPCBinding.h
@@ -69,7 +69,7 @@ template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, URL
 template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, WebCore::RegistrableDomain&&);
 
 template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, IPC::Semaphore&&);
-template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, WebKit::SharedMemory::Handle&&);
+template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, WebKit::SharedMemory::IPCHandle&&);
 
 template<typename T, std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, T)

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
@@ -53,7 +53,7 @@ void SharedBufferReference::encode(Encoder& encoder) const
         auto sharedMemoryBuffer = m_memory ? m_memory : SharedMemory::copyBuffer(*m_buffer);
         sharedMemoryBuffer->createHandle(handle, SharedMemory::Protection::ReadOnly);
     }
-    encoder << WTFMove(handle);
+    encoder << SharedMemory::IPCHandle { WTFMove(handle), m_size };
 #endif
 }
 
@@ -82,11 +82,11 @@ std::optional<SharedBufferReference> SharedBufferReference::decode(Decoder& deco
         return { IPC::SharedBufferReference(WTFMove(buffer)) };
     }
 
-    SharedMemory::Handle handle;
-    if (!decoder.decode(handle))
+    SharedMemory::IPCHandle ipcHandle;
+    if (!decoder.decode(ipcHandle))
         return std::nullopt;
 
-    auto sharedMemoryBuffer = SharedMemory::map(handle, SharedMemory::Protection::ReadOnly);
+    auto sharedMemoryBuffer = SharedMemory::map(ipcHandle.handle, SharedMemory::Protection::ReadOnly);
     if (!sharedMemoryBuffer)
         return std::nullopt;
 

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
@@ -46,8 +46,8 @@ StreamConnectionBuffer::StreamConnectionBuffer(size_t memorySize)
     ASSERT(m_dataSize <= maximumSize());
 }
 
-StreamConnectionBuffer::StreamConnectionBuffer(Ref<WebKit::SharedMemory>&& memory)
-    : m_dataSize(memory->size() - headerSize())
+StreamConnectionBuffer::StreamConnectionBuffer(Ref<WebKit::SharedMemory>&& memory, size_t memorySize)
+    : m_dataSize(memorySize - headerSize())
     , m_sharedMemory(WTFMove(memory))
 {
     ASSERT(m_dataSize > 0);
@@ -72,22 +72,25 @@ void StreamConnectionBuffer::encode(Encoder& encoder) const
     WebKit::SharedMemory::Handle handle;
     if (!m_sharedMemory->createHandle(handle, WebKit::SharedMemory::Protection::ReadWrite))
         CRASH();
-    encoder << handle;
+    WebKit::SharedMemory::IPCHandle ipcHandle { WTFMove(handle), m_sharedMemory->size() };
+    encoder << ipcHandle;
 }
 
 std::optional<StreamConnectionBuffer> StreamConnectionBuffer::decode(Decoder& decoder)
 {
-    auto handle = decoder.decode<WebKit::SharedMemory::Handle>();
-    if (UNLIKELY(!decoder.isValid()))
+    std::optional<WebKit::SharedMemory::IPCHandle> ipcHandle;
+    decoder >> ipcHandle;
+    if (!ipcHandle)
         return std::nullopt;
-    if (UNLIKELY(handle->size() <= headerSize()))
+    size_t dataSize = static_cast<size_t>(ipcHandle->dataSize);
+    if (dataSize <= headerSize())
         return std::nullopt;
-    if (UNLIKELY(handle->size() > headerSize() + maximumSize()))
+    if (dataSize > headerSize() + maximumSize())
         return std::nullopt;
-    auto sharedMemory = WebKit::SharedMemory::map(*handle, WebKit::SharedMemory::Protection::ReadWrite);
-    if (UNLIKELY(!sharedMemory))
+    auto sharedMemory = WebKit::SharedMemory::map(ipcHandle->handle, WebKit::SharedMemory::Protection::ReadWrite);
+    if (!sharedMemory || sharedMemory->size() < dataSize)
         return std::nullopt;
-    return StreamConnectionBuffer { sharedMemory.releaseNonNull() };
+    return StreamConnectionBuffer { sharedMemory.releaseNonNull(), dataSize };
 }
 
 Span<uint8_t> StreamConnectionBuffer::headerForTesting()

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
@@ -117,7 +117,7 @@ public:
     Span<uint8_t> dataForTesting();
 
 private:
-    StreamConnectionBuffer(Ref<WebKit::SharedMemory>&&);
+    StreamConnectionBuffer(Ref<WebKit::SharedMemory>&&, size_t memorySize);
 
     struct Header {
         Atomic<ServerOffset> serverOffset;

--- a/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
+++ b/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
@@ -142,23 +142,31 @@ void SharedMemory::Handle::clear()
     m_size = 0;
 }
 
-void SharedMemory::Handle::encode(IPC::Encoder& encoder) const
+void SharedMemory::IPCHandle::encode(IPC::Encoder& encoder) const
 {
-    encoder << static_cast<uint64_t>(m_size);
-    encoder << MachSendRight::adopt(m_port);
-    m_port = MACH_PORT_NULL;
+    encoder << static_cast<uint64_t>(handle.m_size);
+    encoder << dataSize;
+    encoder << MachSendRight::adopt(handle.m_port);
+    handle.m_port = MACH_PORT_NULL;
 }
 
-bool SharedMemory::Handle::decode(IPC::Decoder& decoder, Handle& handle)
+bool SharedMemory::IPCHandle::decode(IPC::Decoder& decoder, IPCHandle& ipcHandle)
 {
-    ASSERT(!handle.m_port);
-    ASSERT(!handle.m_size);
+    ASSERT(!ipcHandle.handle.m_port);
+    ASSERT(!ipcHandle.handle.m_size);
+
+    SharedMemory::Handle handle;
+
     uint64_t bufferSize;
     if (!decoder.decode(bufferSize))
         return false;
 
-    auto roundedSize = safeRoundPage(bufferSize);
-    if (UNLIKELY(!roundedSize))
+    uint64_t dataLength;
+    if (!decoder.decode(dataLength))
+        return false;
+
+    // SharedMemory::Handle::size() is rounded up to the nearest page.
+    if (dataLength > bufferSize)
         return false;
 
     auto sendRight = decoder.decode<MachSendRight>();
@@ -167,6 +175,8 @@ bool SharedMemory::Handle::decode(IPC::Decoder& decoder, Handle& handle)
     
     handle.m_size = bufferSize;
     handle.m_port = sendRight->leakSendRight();
+    ipcHandle.handle = WTFMove(handle);
+    ipcHandle.dataSize = dataLength;
     return true;
 }
 
@@ -288,15 +298,10 @@ RefPtr<SharedMemory> SharedMemory::map(const Handle& handle, Protection protecti
 {
     if (handle.isNull())
         return nullptr;
-    auto roundedSize = safeRoundPage(handle.m_size);
-    if (UNLIKELY(!roundedSize)) {
-        RELEASE_LOG_ERROR(VirtualMemory, "%p - SharedMemory::map: Failed to map %zu bytes due to overflow", nullptr, handle.m_size);
-        return nullptr;
-    }
 
     vm_prot_t vmProtection = machProtection(protection);
     mach_vm_address_t mappedAddress = 0;
-    kern_return_t kr = mach_vm_map(mach_task_self(), &mappedAddress, *roundedSize, 0, VM_FLAGS_ANYWHERE, handle.m_port, 0, false, vmProtection, vmProtection, VM_INHERIT_NONE);
+    kern_return_t kr = mach_vm_map(mach_task_self(), &mappedAddress, handle.m_size, 0, VM_FLAGS_ANYWHERE, handle.m_port, 0, false, vmProtection, vmProtection, VM_INHERIT_NONE);
 #if RELEASE_LOG_DISABLED
     if (kr != KERN_SUCCESS)
         return nullptr;
@@ -365,7 +370,7 @@ bool SharedMemory::createHandle(Handle& handle, Protection protection)
         return false;
 
     handle.m_port = sendRight.leakSendRight();
-    handle.m_size = m_size;
+    handle.m_size = *roundedSize;
 
     return true;
 }

--- a/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
@@ -79,19 +79,25 @@ bool SharedMemory::Handle::isNull() const
     return m_attachment.isNull();
 }
 
-void SharedMemory::Handle::encode(IPC::Encoder& encoder) const
+void SharedMemory::IPCHandle::encode(IPC::Encoder& encoder) const
 {
-    encoder << releaseAttachment();
+    encoder << handle.releaseAttachment();
+    encoder << dataSize;
 }
 
-bool SharedMemory::Handle::decode(IPC::Decoder& decoder, SharedMemory::Handle& handle)
+bool SharedMemory::IPCHandle::decode(IPC::Decoder& decoder, IPCHandle& ipcHandle)
 {
-    ASSERT_ARG(handle, handle.isNull());
+    ASSERT_ARG(ipcHandle.handle, ipcHandle.handle.isNull());
     IPC::Attachment attachment;
     if (!decoder.decode(attachment))
         return false;
-    handle.m_size = attachment.size();
-    handle.adoptAttachment(WTFMove(attachment));
+
+    uint64_t dataSize;
+    if (!decoder.decode(dataSize))
+        return false;
+
+    ipcHandle.handle.adoptAttachment(WTFMove(attachment));
+    ipcHandle.dataSize = dataSize;
     return true;
 }
 

--- a/Source/WebKit/Platform/win/SharedMemoryWin.cpp
+++ b/Source/WebKit/Platform/win/SharedMemoryWin.cpp
@@ -61,24 +61,34 @@ bool SharedMemory::Handle::isNull() const
     return !m_handle;
 }
 
-void SharedMemory::Handle::encode(IPC::Encoder& encoder) const
+void SharedMemory::IPCHandle::encode(IPC::Encoder& encoder) const
 {
-    encoder << static_cast<uint64_t>(m_size);
-    encodeHandle(encoder, m_handle);
+    encoder << static_cast<uint64_t>(handle.m_size);
+    encoder << dataSize;
+    handle.encodeHandle(encoder, handle.m_handle);
 
     // Hand off ownership of our HANDLE to the receiving process. It will close it for us.
     // FIXME: If the receiving process crashes before it receives the memory, the memory will be
     // leaked. See <http://webkit.org/b/47502>.
-    m_handle = 0;
+    handle.m_handle = 0;
 }
 
-bool SharedMemory::Handle::decode(IPC::Decoder& decoder, SharedMemory::Handle& handle)
+bool SharedMemory::IPCHandle::decode(IPC::Decoder& decoder, IPCHandle& ipcHandle)
 {
-    ASSERT_ARG(handle, !handle.m_handle);
-    ASSERT_ARG(handle, !handle.m_size);
+    ASSERT_ARG(ipcHandle, !ipcHandle.handle.m_handle);
+    ASSERT_ARG(ipcHandle, !ipcHandle.handle.m_size);
+
+    SharedMemory::Handle handle;
+
+    uint64_t bufferSize;
+    if (!decoder.decode(bufferSize))
+        return false;
 
     uint64_t dataLength;
     if (!decoder.decode(dataLength))
+        return false;
+    
+    if (dataLength != bufferSize)
         return false;
     
     auto processSpecificHandle = handle.decodeHandle(decoder);
@@ -86,7 +96,9 @@ bool SharedMemory::Handle::decode(IPC::Decoder& decoder, SharedMemory::Handle& h
         return false;
 
     handle.m_handle = processSpecificHandle.value();
-    handle.m_size = dataLength;
+    handle.m_size = bufferSize;
+    ipcHandle.handle = WTFMove(handle);
+    ipcHandle.dataSize = dataLength;
     return true;
 }
 

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -72,9 +72,9 @@ void IPCStreamTester::stopListeningForIPC(Ref<IPCStreamTester>&& refFromConnecti
     workQueue().stopAndWaitForCompletion();
 }
 
-void IPCStreamTester::syncMessageReturningSharedMemory1(uint32_t byteCount, CompletionHandler<void(SharedMemory::Handle)>&& completionHandler)
+void IPCStreamTester::syncMessageReturningSharedMemory1(uint32_t byteCount, CompletionHandler<void(SharedMemory::IPCHandle)>&& completionHandler)
 {
-    auto result = [&]() -> SharedMemory::Handle {
+    auto result = [&]() -> SharedMemory::IPCHandle {
         auto sharedMemory = WebKit::SharedMemory::allocate(byteCount);
         if (!sharedMemory)
             return { };
@@ -86,7 +86,7 @@ void IPCStreamTester::syncMessageReturningSharedMemory1(uint32_t byteCount, Comp
         uint8_t* data = static_cast<uint8_t*>(sharedMemory->data());
         for (size_t i = 0; i < sharedMemory->size(); ++i)
             data[i] = i;
-        return handle;
+        return { WTFMove(handle), sharedMemory->size() };
     }();
     completionHandler(WTFMove(result));
 }

--- a/Source/WebKit/Shared/IPCStreamTester.h
+++ b/Source/WebKit/Shared/IPCStreamTester.h
@@ -58,7 +58,7 @@ private:
     IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }
 
     // Messages.
-    void syncMessageReturningSharedMemory1(uint32_t byteCount, CompletionHandler<void(SharedMemory::Handle)>&&);
+    void syncMessageReturningSharedMemory1(uint32_t byteCount, CompletionHandler<void(SharedMemory::IPCHandle)>&&);
     void syncCrashOnZero(int32_t, CompletionHandler<void(int32_t)>&&);
     void checkAutoreleasePool(CompletionHandler<void(int32_t)>&&);
 

--- a/Source/WebKit/Shared/IPCStreamTester.messages.in
+++ b/Source/WebKit/Shared/IPCStreamTester.messages.in
@@ -23,7 +23,7 @@
 #if ENABLE(IPC_TESTING_API)
 
 messages -> IPCStreamTester NotRefCounted Stream {
-    SyncMessageReturningSharedMemory1(uint32_t byteCount) -> (WebKit::SharedMemory::Handle handle) Synchronous NotStreamEncodableReply
+    SyncMessageReturningSharedMemory1(uint32_t byteCount) -> (WebKit::SharedMemory::IPCHandle handle) Synchronous NotStreamEncodableReply
     SyncCrashOnZero(int32_t value) -> (int32_t sameValue) Synchronous
 
     CheckAutoreleasePool() -> (int32_t previousUseCount) Synchronous

--- a/Source/WebKit/Shared/ShareableBitmap.cpp
+++ b/Source/WebKit/Shared/ShareableBitmap.cpp
@@ -48,15 +48,16 @@ void ShareableBitmap::Handle::takeOwnershipOfMemory(MemoryLedger ledger) const
 
 void ShareableBitmap::Handle::encode(IPC::Encoder& encoder) const
 {
-    encoder << m_handle;
+    SharedMemory::IPCHandle ipcHandle(WTFMove(m_handle), numBytesForSize(m_size, m_configuration));
+    encoder << ipcHandle;
     encoder << m_size;
     encoder << m_configuration;
 }
 
 bool ShareableBitmap::Handle::decode(IPC::Decoder& decoder, Handle& handle)
 {
-    SharedMemory::Handle memoryHandle;
-    if (!decoder.decode(memoryHandle))
+    SharedMemory::IPCHandle ipcHandle;
+    if (!decoder.decode(ipcHandle))
         return false;
     if (!decoder.decode(handle.m_size))
         return false;
@@ -64,12 +65,8 @@ bool ShareableBitmap::Handle::decode(IPC::Decoder& decoder, Handle& handle)
         return false;
     if (!decoder.decode(handle.m_configuration))
         return false;
-    auto numBytes = numBytesForSize(handle.m_size, handle.m_configuration);
-    if (numBytes.hasOverflowed())
-        return false;
-    if (memoryHandle.size() < numBytes)
-        return false;
-    handle.m_handle = WTFMove(memoryHandle);
+    
+    handle.m_handle = WTFMove(ipcHandle.handle);
     return true;
 }
 

--- a/Source/WebKit/Shared/ShareableResource.cpp
+++ b/Source/WebKit/Shared/ShareableResource.cpp
@@ -30,7 +30,6 @@
 
 #include "ArgumentCoders.h"
 #include <WebCore/SharedBuffer.h>
-#include <wtf/CheckedArithmetic.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -39,26 +38,20 @@ ShareableResource::Handle::Handle() = default;
 
 void ShareableResource::Handle::encode(IPC::Encoder& encoder) const
 {
-    encoder << m_handle;
+    encoder << SharedMemory::IPCHandle { WTFMove(m_handle), m_size };
     encoder << m_offset;
-    encoder << m_size;
 }
 
 bool ShareableResource::Handle::decode(IPC::Decoder& decoder, Handle& handle)
 {
-    SharedMemory::Handle memoryHandle;
-    if (UNLIKELY(!decoder.decode(memoryHandle)))
+    SharedMemory::IPCHandle ipcHandle;
+    if (!decoder.decode(ipcHandle))
         return false;
-    if (UNLIKELY(!decoder.decode(handle.m_offset)))
+    if (!decoder.decode(handle.m_offset))
         return false;
-    if (UNLIKELY(!decoder.decode(handle.m_size)))
-        return false;
-    auto neededSize = Checked<unsigned> { handle.m_offset } + handle.m_size;
-    if (UNLIKELY(neededSize.hasOverflowed()))
-        return false;
-    if (memoryHandle.size() < neededSize)
-        return false;
-    handle.m_handle = WTFMove(memoryHandle);
+
+    handle.m_size = ipcHandle.dataSize;
+    handle.m_handle = WTFMove(ipcHandle.handle);
     return true;
 }
 
@@ -120,6 +113,7 @@ bool ShareableResource::createHandle(Handle& handle)
 
     handle.m_offset = m_offset;
     handle.m_size = m_size;
+
     return true;
 }
 

--- a/Source/WebKit/Shared/WebCompiledContentRuleListData.cpp
+++ b/Source/WebKit/Shared/WebCompiledContentRuleListData.cpp
@@ -32,19 +32,21 @@
 #include "DataReference.h"
 
 namespace WebKit {
-static size_t ruleListDataSize(size_t topURLFiltersBytecodeOffset, size_t topURLFiltersBytecodeSize)
-{
-    return topURLFiltersBytecodeOffset + topURLFiltersBytecodeSize;
-}
 
 void WebCompiledContentRuleListData::encode(IPC::Encoder& encoder) const
 {
-    ASSERT(data->size() >= ruleListDataSize(topURLFiltersBytecodeOffset, topURLFiltersBytecodeSize));
     encoder << identifier;
 
     SharedMemory::Handle handle;
     data->createHandle(handle, SharedMemory::Protection::ReadOnly);
-    encoder << handle;
+    
+#if OS(DARWIN) || OS(WINDOWS)
+    // Exact data size is the last bytecode offset plus its size.
+    uint64_t dataSize = topURLFiltersBytecodeOffset + topURLFiltersBytecodeSize;
+#else
+    uint64_t dataSize = 0;
+#endif
+    encoder << SharedMemory::IPCHandle { WTFMove(handle), dataSize };
 
     encoder << actionsOffset;
     encoder << actionsSize;
@@ -63,8 +65,11 @@ std::optional<WebCompiledContentRuleListData> WebCompiledContentRuleListData::de
     if (!identifier)
         return std::nullopt;
 
-    SharedMemory::Handle handle;
-    if (!decoder.decode(handle))
+    SharedMemory::IPCHandle ipcHandle;
+    if (!decoder.decode(ipcHandle))
+        return std::nullopt;
+    auto data = SharedMemory::map(ipcHandle.handle, SharedMemory::Protection::ReadOnly);
+    if (!data)
         return std::nullopt;
 
     std::optional<size_t> actionsOffset;
@@ -106,11 +111,7 @@ std::optional<WebCompiledContentRuleListData> WebCompiledContentRuleListData::de
     decoder >> frameURLFiltersBytecodeSize;
     if (!frameURLFiltersBytecodeSize)
         return std::nullopt;
-    auto data = SharedMemory::map(handle, SharedMemory::Protection::ReadOnly);
-    if (!data)
-        return std::nullopt;
-    if (data->size() < ruleListDataSize(*topURLFiltersBytecodeOffset, *topURLFiltersBytecodeSize))
-        return std::nullopt;
+
     return {{
         WTFMove(*identifier),
         data.releaseNonNull(),

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -2915,7 +2915,7 @@ void ArgumentCoder<WebCore::FragmentedSharedBuffer>::encode(Encoder& encoder, co
         auto sharedMemoryBuffer = SharedMemory::copyBuffer(buffer);
         sharedMemoryBuffer->createHandle(handle, SharedMemory::Protection::ReadOnly);
     }
-    encoder << WTFMove(handle);
+    encoder << SharedMemory::IPCHandle { WTFMove(handle), bufferSize };
 #endif
 }
 
@@ -2939,11 +2939,11 @@ std::optional<Ref<WebCore::FragmentedSharedBuffer>> ArgumentCoder<WebCore::Fragm
 
     return SharedBuffer::create(WTFMove(data));
 #else
-    SharedMemory::Handle handle;
-    if (!decoder.decode(handle))
+    SharedMemory::IPCHandle ipcHandle;
+    if (!decoder.decode(ipcHandle))
         return std::nullopt;
 
-    auto sharedMemoryBuffer = SharedMemory::map(handle, SharedMemory::Protection::ReadOnly);
+    auto sharedMemoryBuffer = SharedMemory::map(ipcHandle.handle, SharedMemory::Protection::ReadOnly);
     if (!sharedMemoryBuffer)
         return std::nullopt;
 

--- a/Source/WebKit/Shared/WebHitTestResultData.h
+++ b/Source/WebKit/Shared/WebHitTestResultData.h
@@ -64,6 +64,7 @@ struct WebHitTestResultData {
     String lookupText;
     String toolTipText;
     RefPtr<SharedMemory> imageSharedMemory;
+    uint64_t imageSize;
     RefPtr<ShareableBitmap> imageBitmap;
     String sourceImageMIMEType;
 

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -222,7 +222,14 @@ private:
         SharedMemory::Handle handle;
         if (storage)
             storage->createHandle(handle, SharedMemory::Protection::ReadOnly);
-        m_connection->send(Messages::RemoteCaptureSampleManager::AudioStorageChanged(m_id, WTFMove(handle), format, frameCount, *m_captureSemaphore, m_startTime, m_frameChunkSize), 0);
+
+        // FIXME: Send the actual data size with IPCHandle.
+#if OS(DARWIN) || OS(WINDOWS)
+        uint64_t dataSize = handle.size();
+#else
+        uint64_t dataSize = 0;
+#endif
+        m_connection->send(Messages::RemoteCaptureSampleManager::AudioStorageChanged(m_id, SharedMemory::IPCHandle { WTFMove(handle),  dataSize }, format, frameCount, *m_captureSemaphore, m_startTime, m_frameChunkSize), 0);
     }
 
     bool preventSourceFromStopping()

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -258,7 +258,7 @@ void WebPageProxy::startDrag(const DragItem& dragItem, const ShareableBitmap::Ha
 // FIXME: Move these functions to WebPageProxyIOS.mm.
 #if PLATFORM(IOS_FAMILY)
 
-void WebPageProxy::setPromisedDataForImage(const String&, const SharedMemory::Handle&, const String&, const String&, const String&, const String&, const String&, const SharedMemory::Handle&, const String&)
+void WebPageProxy::setPromisedDataForImage(const String&, const SharedMemory::IPCHandle&, const String&, const String&, const String&, const String&, const String&, const SharedMemory::IPCHandle&, const String&)
 {
     notImplemented();
 }
@@ -716,11 +716,11 @@ void WebPageProxy::restoreAppHighlightsAndScrollToIndex(const Vector<Ref<SharedM
     if (!hasRunningProcess())
         return;
 
-    auto memoryHandles = WTF::compactMap(highlights, [](auto& highlight) -> std::optional<SharedMemory::Handle> {
+    auto memoryHandles = WTF::compactMap(highlights, [](auto& highlight) -> std::optional<SharedMemory::IPCHandle> {
         SharedMemory::Handle handle;
         if (!highlight->createHandle(handle, SharedMemory::Protection::ReadOnly))
             return std::nullopt;
-        return handle;
+        return SharedMemory::IPCHandle { WTFMove(handle), highlight->size() };
     });
     
     setUpHighlightsObserver();

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -690,19 +690,19 @@ std::optional<WebPasteboardProxy::PasteboardAccessType> WebPasteboardProxy::Past
 }
 
 #if ENABLE(IPC_TESTING_API)
-void WebPasteboardProxy::testIPCSharedMemory(IPC::Connection& connection, const String& pasteboardName, const String& pasteboardType, SharedMemory::Handle&& handle, std::optional<PageIdentifier> pageID, CompletionHandler<void(int64_t, String)>&& completionHandler)
+void WebPasteboardProxy::testIPCSharedMemory(IPC::Connection& connection, const String& pasteboardName, const String& pasteboardType, SharedMemory::IPCHandle&& handle, std::optional<PageIdentifier> pageID, CompletionHandler<void(int64_t, String)>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION(!pasteboardName.isEmpty(), completionHandler(-1, makeString("error")));
     MESSAGE_CHECK_COMPLETION(!pasteboardType.isEmpty(), completionHandler(-1, makeString("error")));
 
-    auto sharedMemoryBuffer = SharedMemory::map(handle, SharedMemory::Protection::ReadOnly);
+    auto sharedMemoryBuffer = SharedMemory::map(handle.handle, SharedMemory::Protection::ReadOnly);
     if (!sharedMemoryBuffer) {
         completionHandler(-1, makeString("error EOM"));
         return;
     }
 
-    String message = { static_cast<char*>(sharedMemoryBuffer->data()), static_cast<unsigned>(sharedMemoryBuffer->size()) };
-    completionHandler(sharedMemoryBuffer->size(), WTFMove(message));
+    String message = { static_cast<char*>(sharedMemoryBuffer->data()), unsigned(handle.dataSize) };
+    completionHandler(handle.dataSize, WTFMove(message));
 }
 #endif
 

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
@@ -108,10 +108,10 @@ uint64_t SpeechRecognitionRemoteRealtimeMediaSourceManager::messageSenderDestina
 
 #if PLATFORM(COCOA)
 
-void SpeechRecognitionRemoteRealtimeMediaSourceManager::setStorage(WebCore::RealtimeMediaSourceIdentifier identifier, const SharedMemory::Handle& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
+void SpeechRecognitionRemoteRealtimeMediaSourceManager::setStorage(WebCore::RealtimeMediaSourceIdentifier identifier, const SharedMemory::IPCHandle& ipcHandle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
 {
     if (auto source = m_sources.get(identifier))
-        source->setStorage(handle, description, numberOfFrames);
+        source->setStorage(ipcHandle.handle, description, numberOfFrames);
 }
 
 #endif

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
@@ -61,7 +61,7 @@ private:
     void remoteCaptureFailed(WebCore::RealtimeMediaSourceIdentifier);
     void remoteSourceStopped(WebCore::RealtimeMediaSourceIdentifier);
 #if PLATFORM(COCOA)
-    void setStorage(WebCore::RealtimeMediaSourceIdentifier, const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void setStorage(WebCore::RealtimeMediaSourceIdentifier, const SharedMemory::IPCHandle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
 #endif
 
     // IPC::MessageReceiver.

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in
@@ -28,7 +28,7 @@ messages -> SpeechRecognitionRemoteRealtimeMediaSourceManager NotRefCounted {
     RemoteCaptureFailed(WebCore::RealtimeMediaSourceIdentifier identifier)
     RemoteSourceStopped(WebCore::RealtimeMediaSourceIdentifier identifier)
 #if PLATFORM(COCOA)
-    SetStorage(WebCore::RealtimeMediaSourceIdentifier identifier, WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
+    SetStorage(WebCore::RealtimeMediaSourceIdentifier identifier, WebKit::SharedMemory::IPCHandle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
 #endif
 }
 

--- a/Source/WebKit/UIProcess/VisitedLinkStore.cpp
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.cpp
@@ -117,7 +117,14 @@ void VisitedLinkStore::sendStoreHandleToProcess(WebProcessProxy& process)
     SharedMemory::Handle handle;
     if (!m_linkHashStore.createSharedMemoryHandle(handle))
         return;
-    process.send(Messages::VisitedLinkTableController::SetVisitedLinkTable(WTFMove(handle)), identifier());
+
+    // FIXME: Get the actual size of data being sent from m_linkHashStore and send it in the SharedMemory::IPCHandle object.
+#if (OS(DARWIN) || OS(WINDOWS)) && !USE(UNIX_DOMAIN_SOCKETS)
+    uint64_t dataSize = handle.size();
+#else
+    uint64_t dataSize = 0;
+#endif
+    process.send(Messages::VisitedLinkTableController::SetVisitedLinkTable(SharedMemory::IPCHandle { WTFMove(handle), dataSize }), identifier());
 }
 
 void VisitedLinkStore::didInvalidateSharedMemory()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -893,7 +893,7 @@ public:
     void startInteractionWithPositionInformation(const InteractionInformationAtPosition&);
     void stopInteraction();
     void performActionOnElement(uint32_t action);
-    void saveImageToLibrary(const SharedMemory::Handle& imageHandle, const String& authorizationToken);
+    void saveImageToLibrary(const SharedMemory::IPCHandle& imageHandle, const String& authorizationToken);
     void focusNextFocusedElement(bool isForward, CompletionHandler<void()>&& = [] { });
     void setFocusedElementValue(const WebCore::ElementContext&, const String&);
     void setFocusedElementSelectedIndex(const WebCore::ElementContext&, uint32_t index, bool allowMultipleSelection = false);
@@ -1319,8 +1319,8 @@ public:
     void setDragCaretRect(const WebCore::IntRect&);
 #if PLATFORM(COCOA)
     void startDrag(const WebCore::DragItem&, const ShareableBitmap::Handle& dragImageHandle);
-    void setPromisedDataForImage(const String& pasteboardName, const SharedMemory::Handle& imageHandle, const String& filename, const String& extension,
-        const String& title, const String& url, const String& visibleURL, const SharedMemory::Handle& archiveHandle, const String& originIdentifier);
+    void setPromisedDataForImage(const String& pasteboardName, const SharedMemory::IPCHandle& imageHandle, const String& filename, const String& extension,
+        const String& title, const String& url, const String& visibleURL, const SharedMemory::IPCHandle& archiveHandle, const String& originIdentifier);
 #endif
 #if PLATFORM(GTK)
     void startDrag(WebCore::SelectionData&&, OptionSet<WebCore::DragOperation>, const ShareableBitmap::Handle& dragImage, WebCore::IntPoint&& dragImageHotspot);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -162,7 +162,7 @@ messages -> WebPageProxy {
 #if PLATFORM(IOS_FAMILY)
     InterpretKeyEvent(struct WebKit::EditorState state, bool isCharEvent) -> (bool handled) Synchronous
     DidReceivePositionInformation(struct WebKit::InteractionInformationAtPosition information)
-    SaveImageToLibrary(WebKit::SharedMemory::Handle handle, String authorizationToken)
+    SaveImageToLibrary(WebKit::SharedMemory::IPCHandle handle, String authorizationToken)
     ShowPlaybackTargetPicker(bool hasVideo, WebCore::IntRect elementRect, enum:uint8_t WebCore::RouteSharingPolicy policy, String routingContextUID)
     CommitPotentialTapFailed()
     DidNotHandleTapAsClick(WebCore::IntPoint point)
@@ -303,7 +303,7 @@ messages -> WebPageProxy {
 #endif
 #if PLATFORM(COCOA) && ENABLE(DRAG_SUPPORT)
     StartDrag(struct WebCore::DragItem dragItem, WebKit::ShareableBitmap::Handle dragImage)
-    SetPromisedDataForImage(String pasteboardName, WebKit::SharedMemory::Handle imageHandle, String filename, String extension, String title, String url, String visibleURL, WebKit::SharedMemory::Handle archiveHandle, String originIdentifier)
+    SetPromisedDataForImage(String pasteboardName, WebKit::SharedMemory::IPCHandle imageHandle, String filename, String extension, String title, String url, String visibleURL, WebKit::SharedMemory::IPCHandle archiveHandle, String originIdentifier)
 #endif
 #if PLATFORM(GTK) && ENABLE(DRAG_SUPPORT)
     StartDrag(WebCore::SelectionData selectionData, OptionSet<WebCore::DragOperation> dragOperationMask, WebKit::ShareableBitmap::Handle dragImage, WebCore::IntPoint dragImageHotspot)

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -108,7 +108,7 @@ private:
     void setPasteboardBufferForType(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, RefPtr<WebCore::SharedBuffer>&&, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(int64_t)>&&);
 
 #if ENABLE(IPC_TESTING_API)
-    void testIPCSharedMemory(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, WebKit::SharedMemory::Handle&&, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(int64_t, String)>&&);
+    void testIPCSharedMemory(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, WebKit::SharedMemory::IPCHandle&&, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(int64_t, String)>&&);
 #endif
 
 #endif

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
@@ -60,7 +60,7 @@ messages -> WebPasteboardProxy NotRefCounted {
     URLStringSuitableForLoading(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String url, String title) Synchronous WantsConnection
 
 #if ENABLE(IPC_TESTING_API)
-    TestIPCSharedMemory(String pasteboardName, String pasteboardType, WebKit::SharedMemory::Handle handle, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount, String buffer) Synchronous WantsConnection
+    TestIPCSharedMemory(String pasteboardName, String pasteboardType, WebKit::SharedMemory::IPCHandle handle, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount, String buffer) Synchronous WantsConnection
 #endif
 
 #endif

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -621,16 +621,16 @@ void WebPageProxy::performActionOnElement(uint32_t action)
     });
 }
 
-void WebPageProxy::saveImageToLibrary(const SharedMemory::Handle& imageHandle, const String& authorizationToken)
+void WebPageProxy::saveImageToLibrary(const SharedMemory::IPCHandle& imageHandle, const String& authorizationToken)
 {
-    MESSAGE_CHECK(!imageHandle.isNull());
+    MESSAGE_CHECK(!imageHandle.handle.isNull());
     MESSAGE_CHECK(isValidPerformActionOnElementAuthorizationToken(authorizationToken));
 
-    auto sharedMemoryBuffer = SharedMemory::map(imageHandle, SharedMemory::Protection::ReadOnly);
+    auto sharedMemoryBuffer = SharedMemory::map(imageHandle.handle, SharedMemory::Protection::ReadOnly);
     if (!sharedMemoryBuffer)
         return;
 
-    auto buffer = sharedMemoryBuffer->createSharedBuffer(sharedMemoryBuffer->size());
+    auto buffer = sharedMemoryBuffer->createSharedBuffer(imageHandle.dataSize);
     pageClient().saveImageToLibrary(WTFMove(buffer));
 }
 

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -419,8 +419,8 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem 
             [items addObject:(NSURL *)downloadableMediaURL];
     }
 
-    if (hitTestData.imageSharedMemory) {
-        if (auto image = adoptNS([[NSImage alloc] initWithData:[NSData dataWithBytes:(unsigned char*)hitTestData.imageSharedMemory->data() length:hitTestData.imageSharedMemory->size()]]))
+    if (hitTestData.imageSharedMemory && hitTestData.imageSize) {
+        if (auto image = adoptNS([[NSImage alloc] initWithData:[NSData dataWithBytes:(unsigned char*)hitTestData.imageSharedMemory->data() length:hitTestData.imageSize]]))
             [items addObject:image.get()];
     }
 

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -245,24 +245,24 @@ bool WebPageProxy::readSelectionFromPasteboard(const String& pasteboardName)
 
 #if ENABLE(DRAG_SUPPORT)
 
-void WebPageProxy::setPromisedDataForImage(const String& pasteboardName, const SharedMemory::Handle& imageHandle, const String& filename, const String& extension,
-    const String& title, const String& url, const String& visibleURL, const SharedMemory::Handle& archiveHandle, const String& originIdentifier)
+void WebPageProxy::setPromisedDataForImage(const String& pasteboardName, const SharedMemory::IPCHandle& imageHandle, const String& filename, const String& extension,
+    const String& title, const String& url, const String& visibleURL, const SharedMemory::IPCHandle& archiveHandle, const String& originIdentifier)
 {
     MESSAGE_CHECK_URL(url);
     MESSAGE_CHECK_URL(visibleURL);
-    MESSAGE_CHECK(!imageHandle.isNull());
+    MESSAGE_CHECK(!imageHandle.handle.isNull());
 
-    auto sharedMemoryImage = SharedMemory::map(imageHandle, SharedMemory::Protection::ReadOnly);
+    auto sharedMemoryImage = SharedMemory::map(imageHandle.handle, SharedMemory::Protection::ReadOnly);
     if (!sharedMemoryImage)
         return;
-    auto imageBuffer = sharedMemoryImage->createSharedBuffer(sharedMemoryImage->size());
+    auto imageBuffer = sharedMemoryImage->createSharedBuffer(imageHandle.dataSize);
 
     RefPtr<FragmentedSharedBuffer> archiveBuffer;
-    if (!archiveHandle.isNull()) {
-        auto sharedMemoryArchive = SharedMemory::map(archiveHandle, SharedMemory::Protection::ReadOnly);
+    if (!archiveHandle.handle.isNull()) {
+        auto sharedMemoryArchive = SharedMemory::map(archiveHandle.handle, SharedMemory::Protection::ReadOnly);
         if (!sharedMemoryArchive)
             return;
-        archiveBuffer = sharedMemoryArchive->createSharedBuffer(sharedMemoryArchive->size());
+        archiveBuffer = sharedMemoryArchive->createSharedBuffer(archiveHandle.dataSize);
     }
     pageClient().setPromisedDataForImage(pasteboardName, WTFMove(imageBuffer), ResourceResponseBase::sanitizeSuggestedFilename(filename), extension, title, url, visibleURL, WTFMove(archiveBuffer), originIdentifier);
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -156,7 +156,8 @@ RefPtr<ImageBuffer> RemoteRenderingBackendProxy::createImageBuffer(const FloatSi
 bool RemoteRenderingBackendProxy::getPixelBufferForImageBuffer(RenderingResourceIdentifier imageBuffer, const PixelBufferFormat& destinationFormat, const IntRect& srcRect, Span<uint8_t> result)
 {
     if (auto handle = updateSharedMemoryForGetPixelBuffer(result.size())) {
-        auto sendResult = sendSyncToStream(Messages::RemoteRenderingBackend::GetPixelBufferForImageBufferWithNewMemory(imageBuffer, WTFMove(*handle), destinationFormat, srcRect),
+        SharedMemory::IPCHandle ipcHandle { WTFMove(*handle), m_getPixelBufferSharedMemory->size() };
+        auto sendResult = sendSyncToStream(Messages::RemoteRenderingBackend::GetPixelBufferForImageBufferWithNewMemory(imageBuffer, ipcHandle, destinationFormat, srcRect),
             Messages::RemoteRenderingBackend::GetPixelBufferForImageBufferWithNewMemory::Reply());
         if (!sendResult)
             return false;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -186,7 +186,15 @@ void RemoteAudioDestinationProxy::storageChanged(SharedMemory* storage, const We
     SharedMemory::Handle handle;
     if (storage)
         storage->createHandle(handle, SharedMemory::Protection::ReadOnly);
-    m_gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::AudioSamplesStorageChanged { m_destinationID, WTFMove(handle), format, frameCount }, 0);
+
+    // FIXME: Send the actual data size with IPCHandle.
+#if OS(DARWIN) || OS(WINDOWS)
+    uint64_t dataSize = handle.size();
+#else
+    uint64_t dataSize = 0;
+#endif
+
+    m_gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::AudioSamplesStorageChanged { m_destinationID, SharedMemory::IPCHandle { WTFMove(handle), dataSize }, format, frameCount }, 0);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
@@ -90,7 +90,7 @@ void RemoteAudioSourceProviderManager::removeProvider(MediaPlayerIdentifier iden
     });
 }
 
-void RemoteAudioSourceProviderManager::audioStorageChanged(MediaPlayerIdentifier identifier, const SharedMemory::Handle& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
+void RemoteAudioSourceProviderManager::audioStorageChanged(MediaPlayerIdentifier identifier, const SharedMemory::IPCHandle& ipcHandle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
 {
     ASSERT(!WTF::isMainRunLoop());
 
@@ -99,7 +99,7 @@ void RemoteAudioSourceProviderManager::audioStorageChanged(MediaPlayerIdentifier
         RELEASE_LOG_ERROR(Media, "Unable to find provider %llu for storageChanged", identifier.toUInt64());
         return;
     }
-    iterator->value->setStorage(handle, description, numberOfFrames);
+    iterator->value->setStorage(ipcHandle.handle, description, numberOfFrames);
 }
 
 void RemoteAudioSourceProviderManager::audioSamplesAvailable(MediaPlayerIdentifier identifier, uint64_t startFrame, uint64_t numberOfFrames)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
@@ -54,7 +54,7 @@ private:
     RemoteAudioSourceProviderManager();
 
     // Messages
-    void audioStorageChanged(WebCore::MediaPlayerIdentifier, const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void audioStorageChanged(WebCore::MediaPlayerIdentifier, const SharedMemory::IPCHandle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
     void audioSamplesAvailable(WebCore::MediaPlayerIdentifier, uint64_t startFrame, uint64_t numberOfFrames);
 
     void setConnection(IPC::Connection*);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in
@@ -26,7 +26,7 @@
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
 
 messages -> RemoteAudioSourceProviderManager NotRefCounted {
-    AudioStorageChanged(WebCore::MediaPlayerIdentifier id, WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
+    AudioStorageChanged(WebCore::MediaPlayerIdentifier id, WebKit::SharedMemory::IPCHandle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
     AudioSamplesAvailable(WebCore::MediaPlayerIdentifier id, uint64_t startFrame, uint64_t numberOfFrames)
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp
@@ -77,7 +77,7 @@ void RemoteMediaResourceProxy::dataReceived(WebCore::PlatformMediaResource&, con
     m_connection->sendWithAsyncReply(Messages::RemoteMediaResourceManager::DataReceived(m_id, IPC::SharedBufferReference { buffer }), [] (auto&& bufferHandle) {
         // Take ownership of shared memory and mark it as media-related memory.
         if (bufferHandle)
-            bufferHandle->takeOwnershipOfMemory(MemoryLedger::Media);
+            bufferHandle->handle.takeOwnershipOfMemory(MemoryLedger::Media);
     }, 0);
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -87,7 +87,7 @@ void SourceBufferPrivateRemote::append(Ref<SharedBuffer>&& data)
     m_gpuProcessConnection->connection().sendWithAsyncReply(Messages::RemoteSourceBufferProxy::Append(IPC::SharedBufferReference { WTFMove(data) }), [] (auto&& bufferHandle) {
         // Take ownership of shared memory and mark it as media-related memory.
         if (bufferHandle)
-            bufferHandle->takeOwnershipOfMemory(MemoryLedger::Media);
+            bufferHandle->handle.takeOwnershipOfMemory(MemoryLedger::Media);
     }, m_remoteSourceBufferIdentifier);
 }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -202,7 +202,14 @@ void AudioMediaStreamTrackRendererInternalUnitManager::Proxy::storageChanged(Sha
     SharedMemory::Handle handle;
     if (memory)
         memory->createHandle(handle, SharedMemory::Protection::ReadOnly);
-    WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::StartUnit { m_identifier, WTFMove(handle), format, frameCount, *m_semaphore }, 0);
+
+    // FIXME: Send the actual data size with IPCHandle.
+#if OS(DARWIN) || OS(WINDOWS)
+    uint64_t dataSize = handle.size();
+#else
+    uint64_t dataSize = 0;
+#endif
+    WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::StartUnit { m_identifier, SharedMemory::IPCHandle { WTFMove(handle),  dataSize }, format, frameCount, *m_semaphore }, 0);
 }
 
 void AudioMediaStreamTrackRendererInternalUnitManager::Proxy::stop()

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.messages.in
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM)
 
 messages -> AudioMediaStreamTrackRendererInternalUnitManager NotRefCounted {
-    AudioStorageChanged(WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames, IPC::Semaphore captureSemaphore, MediaTime mediaTime, size_t frameChunkSize);
+    AudioStorageChanged(WebKit::SharedMemory::IPCHandle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames, IPC::Semaphore captureSemaphore, MediaTime mediaTime, size_t frameChunkSize);
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
@@ -152,7 +152,14 @@ void MediaRecorderPrivate::storageChanged(SharedMemory* storage, const WebCore::
     SharedMemory::Handle handle;
     if (storage)
         storage->createHandle(handle, SharedMemory::Protection::ReadOnly);
-    m_connection->send(Messages::RemoteMediaRecorder::AudioSamplesStorageChanged { WTFMove(handle), format, frameCount }, m_identifier);
+
+    // FIXME: Send the actual data size with IPCHandle.
+#if OS(DARWIN) || OS(WINDOWS)
+    uint64_t dataSize = handle.size();
+#else
+    uint64_t dataSize = 0;
+#endif
+    m_connection->send(Messages::RemoteMediaRecorder::AudioSamplesStorageChanged { SharedMemory::IPCHandle { WTFMove(handle), dataSize }, format, frameCount }, m_identifier);
 }
 
 void MediaRecorderPrivate::fetchData(CompletionHandler<void(RefPtr<WebCore::FragmentedSharedBuffer>&&, const String& mimeType, double)>&& completionHandler)

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
@@ -86,9 +86,9 @@ void RemoteVideoFrameObjectHeapProxyProcessor::setSharedVideoFrameSemaphore(IPC:
     m_sharedVideoFrameReader.setSemaphore(WTFMove(semaphore));
 }
 
-void RemoteVideoFrameObjectHeapProxyProcessor::setSharedVideoFrameMemory(const SharedMemory::Handle& handle)
+void RemoteVideoFrameObjectHeapProxyProcessor::setSharedVideoFrameMemory(const SharedMemory::IPCHandle& ipcHandle)
 {
-    m_sharedVideoFrameReader.setSharedMemory(handle);
+    m_sharedVideoFrameReader.setSharedMemory(ipcHandle);
 }
 
 RemoteVideoFrameObjectHeapProxyProcessor::Callback RemoteVideoFrameObjectHeapProxyProcessor::takeCallback(RemoteVideoFrameIdentifier identifier)

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
@@ -71,7 +71,7 @@ private:
 
     // Messages
     void setSharedVideoFrameSemaphore(IPC::Semaphore&&);
-    void setSharedVideoFrameMemory(const SharedMemory::Handle&);
+    void setSharedVideoFrameMemory(const SharedMemory::IPCHandle&);
     void newVideoFrameBuffer(RemoteVideoFrameIdentifier, std::optional<SharedVideoFrame::Buffer>&&);
     void newConvertedVideoFrameBuffer(std::optional<SharedVideoFrame::Buffer>&&);
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.messages.in
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.messages.in
@@ -24,7 +24,7 @@
 
 messages -> RemoteVideoFrameObjectHeapProxyProcessor {
     SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore)
-    SetSharedVideoFrameMemory(WebKit::SharedMemory::Handle storageHandle)
+    SetSharedVideoFrameMemory(WebKit::SharedMemory::IPCHandle storageHandle)
     NewVideoFrameBuffer(WebKit::RemoteVideoFrameIdentifier identifier, std::optional<WebKit::SharedVideoFrame::Buffer> frame)
     NewConvertedVideoFrameBuffer(std::optional<WebKit::SharedVideoFrame::Buffer> frame)
 }

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
@@ -63,7 +63,7 @@ bool SharedVideoFrameWriter::wait(const Function<void(IPC::Semaphore&)>& newSema
     return !m_isDisabled && m_semaphore->waitFor(defaultTimeout);
 }
 
-bool SharedVideoFrameWriter::allocateStorage(size_t size, const Function<void(const SharedMemory::Handle&)>& newMemoryCallback)
+bool SharedVideoFrameWriter::allocateStorage(size_t size, const Function<void(const SharedMemory::IPCHandle&)>& newMemoryCallback)
 {
     m_storage = SharedMemory::allocate(size);
     if (!m_storage)
@@ -71,11 +71,13 @@ bool SharedVideoFrameWriter::allocateStorage(size_t size, const Function<void(co
 
     SharedMemory::Handle handle;
     m_storage->createHandle(handle, SharedMemory::Protection::ReadOnly);
-    newMemoryCallback(WTFMove(handle));
+
+    auto dataSize = handle.size();
+    newMemoryCallback(SharedMemory::IPCHandle { WTFMove(handle), dataSize });
     return true;
 }
 
-bool SharedVideoFrameWriter::prepareWriting(const SharedVideoFrameInfo& info, const Function<void(IPC::Semaphore&)>& newSemaphoreCallback, const Function<void(const SharedMemory::Handle&)>& newMemoryCallback)
+bool SharedVideoFrameWriter::prepareWriting(const SharedVideoFrameInfo& info, const Function<void(IPC::Semaphore&)>& newSemaphoreCallback, const Function<void(const SharedMemory::IPCHandle&)>& newMemoryCallback)
 {
     if (!info.isReadWriteSupported()) {
         RELEASE_LOG_ERROR(WebRTC, "SharedVideoFrameWriter::prepareWriting not supported");
@@ -98,7 +100,7 @@ bool SharedVideoFrameWriter::prepareWriting(const SharedVideoFrameInfo& info, co
     return true;
 }
 
-std::optional<SharedVideoFrame> SharedVideoFrameWriter::write(const VideoFrame& frame, const Function<void(IPC::Semaphore&)>& newSemaphoreCallback, const Function<void(const SharedMemory::Handle&)>& newMemoryCallback)
+std::optional<SharedVideoFrame> SharedVideoFrameWriter::write(const VideoFrame& frame, const Function<void(IPC::Semaphore&)>& newSemaphoreCallback, const Function<void(const SharedMemory::IPCHandle&)>& newMemoryCallback)
 {
     auto buffer = writeBuffer(frame, newSemaphoreCallback, newMemoryCallback);
     if (!buffer)
@@ -106,7 +108,7 @@ std::optional<SharedVideoFrame> SharedVideoFrameWriter::write(const VideoFrame& 
     return SharedVideoFrame { frame.presentationTime(), frame.isMirrored(), frame.rotation(), WTFMove(*buffer) };
 }
 
-std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(const VideoFrame& frame, const Function<void(IPC::Semaphore&)>& newSemaphoreCallback, const Function<void(const SharedMemory::Handle&)>& newMemoryCallback)
+std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(const VideoFrame& frame, const Function<void(IPC::Semaphore&)>& newSemaphoreCallback, const Function<void(const SharedMemory::IPCHandle&)>& newMemoryCallback)
 {
     if (is<RemoteVideoFrameProxy>(frame))
         return downcast<RemoteVideoFrameProxy>(frame).newReadReference();
@@ -119,7 +121,7 @@ std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(cons
     return writeBuffer(frame.pixelBuffer(), newSemaphoreCallback, newMemoryCallback);
 }
 
-std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(CVPixelBufferRef pixelBuffer, const Function<void(IPC::Semaphore&)>& newSemaphoreCallback, const Function<void(const SharedMemory::Handle&)>& newMemoryCallback, bool canUseIOSurface)
+std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(CVPixelBufferRef pixelBuffer, const Function<void(IPC::Semaphore&)>& newSemaphoreCallback, const Function<void(const SharedMemory::IPCHandle&)>& newMemoryCallback, bool canUseIOSurface)
 {
     if (!pixelBuffer)
         return { };
@@ -143,7 +145,7 @@ std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(CVPi
 }
 
 #if USE(LIBWEBRTC)
-std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(const webrtc::VideoFrame& frame, const Function<void(IPC::Semaphore&)>& newSemaphoreCallback, const Function<void(const SharedMemory::Handle&)>& newMemoryCallback)
+std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(const webrtc::VideoFrame& frame, const Function<void(IPC::Semaphore&)>& newSemaphoreCallback, const Function<void(const SharedMemory::IPCHandle&)>& newMemoryCallback)
 {
     if (auto* provider = webrtc::videoFrameBufferProvider(frame))
         return writeBuffer(*static_cast<VideoFrame*>(provider), newSemaphoreCallback, newMemoryCallback);
@@ -154,7 +156,7 @@ std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(cons
     return writeBuffer(*frame.video_frame_buffer(), newSemaphoreCallback, newMemoryCallback);
 }
 
-std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(webrtc::VideoFrameBuffer& frameBuffer, const Function<void(IPC::Semaphore&)>& newSemaphoreCallback, const Function<void(const SharedMemory::Handle&)>& newMemoryCallback)
+std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(webrtc::VideoFrameBuffer& frameBuffer, const Function<void(IPC::Semaphore&)>& newSemaphoreCallback, const Function<void(const SharedMemory::IPCHandle&)>& newMemoryCallback)
 {
     auto scope = makeScopeExit([this] { signalInCaseOfError(); });
 
@@ -289,9 +291,9 @@ CVPixelBufferPoolRef SharedVideoFrameReader::pixelBufferPool(const SharedVideoFr
     return m_bufferPool.get();
 }
 
-bool SharedVideoFrameReader::setSharedMemory(const SharedMemory::Handle& handle)
+bool SharedVideoFrameReader::setSharedMemory(const SharedMemory::IPCHandle& ipcHandle)
 {
-    m_storage = SharedMemory::map(handle, SharedMemory::Protection::ReadOnly);
+    m_storage = SharedMemory::map(ipcHandle.handle, SharedMemory::Protection::ReadOnly);
     return !!m_storage;
 }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
@@ -68,10 +68,10 @@ class SharedVideoFrameWriter {
 public:
     SharedVideoFrameWriter();
 
-    std::optional<SharedVideoFrame> write(const WebCore::VideoFrame&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::Handle&)>&);
-    std::optional<SharedVideoFrame::Buffer> writeBuffer(CVPixelBufferRef, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::Handle&)>&, bool canSendIOSurface = true);
+    std::optional<SharedVideoFrame> write(const WebCore::VideoFrame&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::IPCHandle&)>&);
+    std::optional<SharedVideoFrame::Buffer> writeBuffer(CVPixelBufferRef, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::IPCHandle&)>&, bool canSendIOSurface = true);
 #if USE(LIBWEBRTC)
-    std::optional<SharedVideoFrame::Buffer> writeBuffer(const webrtc::VideoFrame&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::Handle&)>&);
+    std::optional<SharedVideoFrame::Buffer> writeBuffer(const webrtc::VideoFrame&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::IPCHandle&)>&);
 #endif
     void disable();
     bool isDisabled() const { return m_isDisabled; }
@@ -80,12 +80,12 @@ private:
     static constexpr Seconds defaultTimeout = 3_s;
 
     bool wait(const Function<void(IPC::Semaphore&)>&);
-    bool allocateStorage(size_t, const Function<void(const SharedMemory::Handle&)>&);
-    bool prepareWriting(const WebCore::SharedVideoFrameInfo&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::Handle&)>&);
+    bool allocateStorage(size_t, const Function<void(const SharedMemory::IPCHandle&)>&);
+    bool prepareWriting(const WebCore::SharedVideoFrameInfo&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::IPCHandle&)>&);
 
-    std::optional<SharedVideoFrame::Buffer> writeBuffer(const WebCore::VideoFrame&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::Handle&)>&);
+    std::optional<SharedVideoFrame::Buffer> writeBuffer(const WebCore::VideoFrame&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::IPCHandle&)>&);
 #if USE(LIBWEBRTC)
-    std::optional<SharedVideoFrame::Buffer> writeBuffer(webrtc::VideoFrameBuffer&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::Handle&)>&);
+    std::optional<SharedVideoFrame::Buffer> writeBuffer(webrtc::VideoFrameBuffer&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::IPCHandle&)>&);
 #endif
     void signalInCaseOfError();
 
@@ -104,7 +104,7 @@ public:
     SharedVideoFrameReader();
 
     void setSemaphore(IPC::Semaphore&& semaphore) { m_semaphore = WTFMove(semaphore); }
-    bool setSharedMemory(const SharedMemory::Handle&);
+    bool setSharedMemory(const SharedMemory::IPCHandle&);
 
     RefPtr<WebCore::VideoFrame> read(SharedVideoFrame&&);
     RetainPtr<CVPixelBufferRef> readBuffer(SharedVideoFrame::Buffer&&);

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -135,7 +135,12 @@ private:
         SharedMemory::Handle handle;
         if (storage)
             storage->createHandle(handle, SharedMemory::Protection::ReadOnly);
-        m_connection->send(Messages::SpeechRecognitionRemoteRealtimeMediaSourceManager::SetStorage(m_identifier, WTFMove(handle), description, numberOfFrames), 0);
+#if OS(DARWIN) || OS(WINDOWS)
+        uint64_t dataSize = handle.size();
+#else
+        uint64_t dataSize = 0;
+#endif
+        m_connection->send(Messages::SpeechRecognitionRemoteRealtimeMediaSourceManager::SetStorage(m_identifier, SharedMemory::IPCHandle { WTFMove(handle),  dataSize }, description, numberOfFrames), 0);
     }
 
 #endif

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -139,9 +139,9 @@ bool WebSWClientConnection::mayHaveServiceWorkerRegisteredForOrigin(const Securi
     return m_swOriginTable->contains(origin);
 }
 
-void WebSWClientConnection::setSWOriginTableSharedMemory(const SharedMemory::Handle& handle)
+void WebSWClientConnection::setSWOriginTableSharedMemory(const SharedMemory::IPCHandle& ipcHandle)
 {
-    m_swOriginTable->setSharedMemory(handle);
+    m_swOriginTable->setSharedMemory(ipcHandle.handle);
 }
 
 void WebSWClientConnection::setSWOriginTableIsImported()

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.h
@@ -110,7 +110,7 @@ private:
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final { return 0; }
 
-    void setSWOriginTableSharedMemory(const SharedMemory::Handle&);
+    void setSWOriginTableSharedMemory(const SharedMemory::IPCHandle&);
     void setSWOriginTableIsImported();
 
     void clear();

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in
@@ -35,7 +35,7 @@ messages -> WebSWClientConnection {
     NotifyClientsOfControllerChange(HashSet<WebCore::ScriptExecutionContextIdentifier> contextIdentifiers, struct WebCore::ServiceWorkerData newController)
 
     SetSWOriginTableIsImported()
-    SetSWOriginTableSharedMemory(WebKit::SharedMemory::Handle handle)
+    SetSWOriginTableSharedMemory(WebKit::SharedMemory::IPCHandle handle)
     PostMessageToServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier destinationContextIdentifier, struct WebCore::MessageWithMessagePorts message, struct WebCore::ServiceWorkerData source, String sourceOrigin)
 
     SetServiceWorkerClientIsControlled(WebCore::ScriptExecutionContextIdentifier workerIdentifier, struct WebCore::ServiceWorkerRegistrationData data) -> (bool isSuccess)

--- a/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp
@@ -84,9 +84,9 @@ void VisitedLinkTableController::addVisitedLink(Page& page, SharedStringHash lin
     WebProcess::singleton().parentProcessConnection()->send(Messages::VisitedLinkStore::AddVisitedLinkHashFromPage(webPage.webPageProxyIdentifier(), linkHash), m_identifier);
 }
 
-void VisitedLinkTableController::setVisitedLinkTable(const SharedMemory::Handle& handle)
+void VisitedLinkTableController::setVisitedLinkTable(const SharedMemory::IPCHandle& ipcHandle)
 {
-    auto sharedMemory = SharedMemory::map(handle, SharedMemory::Protection::ReadOnly);
+    auto sharedMemory = SharedMemory::map(ipcHandle.handle, SharedMemory::Protection::ReadOnly);
     if (!sharedMemory)
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.h
+++ b/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.h
@@ -47,7 +47,7 @@ private:
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    void setVisitedLinkTable(const SharedMemory::Handle&);
+    void setVisitedLinkTable(const SharedMemory::IPCHandle&);
     void visitedLinkStateChanged(const Vector<WebCore::SharedStringHash>&);
     void allVisitedLinkStateChanged();
     void removeAllVisitedLinks();

--- a/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 messages -> VisitedLinkTableController {
-    SetVisitedLinkTable(WebKit::SharedMemory::Handle handle)
+    SetVisitedLinkTable(WebKit::SharedMemory::IPCHandle ipcHandle)
     VisitedLinkStateChanged(Vector<WebCore::SharedStringHash> linkHashes)
     AllVisitedLinkStateChanged()
     RemoveAllVisitedLinks()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8035,17 +8035,17 @@ bool WebPage::createAppHighlightInSelectedRange(WebCore::CreateNewGroupForHighli
     return true;
 }
 
-void WebPage::restoreAppHighlightsAndScrollToIndex(const Vector<SharedMemory::Handle>&& memoryHandles, const std::optional<unsigned> index)
+void WebPage::restoreAppHighlightsAndScrollToIndex(const Vector<SharedMemory::IPCHandle>&& memoryHandles, const std::optional<unsigned> index)
 {
     RefPtr document = CheckedRef(m_page->focusController())->focusedOrMainFrame().document();
 
     unsigned i = 0;
-    for (const auto& handle : memoryHandles) {
-        auto sharedMemory = SharedMemory::map(handle, SharedMemory::Protection::ReadOnly);
+    for (const auto& ipcHandle : memoryHandles) {
+        auto sharedMemory = SharedMemory::map(ipcHandle.handle, SharedMemory::Protection::ReadOnly);
         if (!sharedMemory)
             continue;
 
-        document->appHighlightStorage().restoreAndScrollToAppHighlight(sharedMemory->createSharedBuffer(handle.size()), i == index ? ScrollToHighlight::Yes : ScrollToHighlight::No);
+        document->appHighlightStorage().restoreAndScrollToAppHighlight(sharedMemory->createSharedBuffer(ipcHandle.dataSize), i == index ? ScrollToHighlight::Yes : ScrollToHighlight::No);
         i++;
     }
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1500,7 +1500,7 @@ public:
     WebCore::HighlightVisibility appHighlightsVisiblility() const { return m_appHighlightsVisible; }
 
     bool createAppHighlightInSelectedRange(WebCore::CreateNewGroupForHighlight, WebCore::HighlightRequestOriginatedInApp);
-    void restoreAppHighlightsAndScrollToIndex(const Vector<SharedMemory::Handle>&&, const std::optional<unsigned> index);
+    void restoreAppHighlightsAndScrollToIndex(const Vector<SharedMemory::IPCHandle>&&, const std::optional<unsigned> index);
     void setAppHighlightsVisibility(const WebCore::HighlightVisibility);
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -667,7 +667,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
 #if ENABLE(APP_HIGHLIGHTS)
     CreateAppHighlightInSelectedRange(enum:bool WebCore::CreateNewGroupForHighlight createNewGroup, enum:bool WebCore::HighlightRequestOriginatedInApp requestOrigin)
-    RestoreAppHighlightsAndScrollToIndex(Vector<WebKit::SharedMemory::Handle> memoryHandles, std::optional<unsigned> index)
+    RestoreAppHighlightsAndScrollToIndex(Vector<WebKit::SharedMemory::IPCHandle> memoryHandles, std::optional<unsigned> index)
     SetAppHighlightsVisibility(enum:bool WebCore::HighlightVisibility highlightVisibility)
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3370,7 +3370,7 @@ void WebPage::performActionOnElement(uint32_t action, const String& authorizatio
                 return;
             sharedMemoryBuffer->createHandle(handle, SharedMemory::Protection::ReadOnly);
         }
-        send(Messages::WebPageProxy::SaveImageToLibrary(WTFMove(handle), authorizationToken));
+        send(Messages::WebPageProxy::SaveImageToLibrary(SharedMemory::IPCHandle { WTFMove(handle), buffer->size() }, authorizationToken));
     }
 }
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
@@ -128,7 +128,7 @@ void RemoteCaptureSampleManager::setVideoFrameObjectHeapProxy(RemoteVideoFrameOb
     m_videoFrameObjectHeapProxy = proxy;
 }
 
-void RemoteCaptureSampleManager::audioStorageChanged(WebCore::RealtimeMediaSourceIdentifier identifier, const SharedMemory::Handle& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames, IPC::Semaphore&& semaphore, const MediaTime& mediaTime, size_t frameChunkSize)
+void RemoteCaptureSampleManager::audioStorageChanged(WebCore::RealtimeMediaSourceIdentifier identifier, const SharedMemory::IPCHandle& ipcHandle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames, IPC::Semaphore&& semaphore, const MediaTime& mediaTime, size_t frameChunkSize)
 {
     ASSERT(!WTF::isMainRunLoop());
 
@@ -137,7 +137,7 @@ void RemoteCaptureSampleManager::audioStorageChanged(WebCore::RealtimeMediaSourc
         RELEASE_LOG_ERROR(WebRTC, "Unable to find source %llu for storageChanged", identifier.toUInt64());
         return;
     }
-    iterator->value->setStorage(handle, description, numberOfFrames, WTFMove(semaphore), mediaTime, frameChunkSize);
+    iterator->value->setStorage(ipcHandle.handle, description, numberOfFrames, WTFMove(semaphore), mediaTime, frameChunkSize);
 }
 
 void RemoteCaptureSampleManager::videoFrameAvailable(RealtimeMediaSourceIdentifier identifier, RemoteVideoFrameProxy::Properties&& properties, VideoFrameTimeMetadata metadata)

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
@@ -68,7 +68,7 @@ public:
 
 private:
     // Messages
-    void audioStorageChanged(WebCore::RealtimeMediaSourceIdentifier, const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames, IPC::Semaphore&&, const MediaTime&, size_t frameSampleSize);
+    void audioStorageChanged(WebCore::RealtimeMediaSourceIdentifier, const SharedMemory::IPCHandle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames, IPC::Semaphore&&, const MediaTime&, size_t frameSampleSize);
     void audioSamplesAvailable(WebCore::RealtimeMediaSourceIdentifier, MediaTime, uint64_t numberOfFrames);
     void videoFrameAvailable(WebCore::RealtimeMediaSourceIdentifier, RemoteVideoFrameProxy::Properties&&, WebCore::VideoFrameTimeMetadata);
     // FIXME: Will be removed once RemoteVideoFrameProxy providers are the only ones sending data.

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(MEDIA_STREAM)
 
 messages -> RemoteCaptureSampleManager NotRefCounted {
-    AudioStorageChanged(WebCore::RealtimeMediaSourceIdentifier id, WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames, IPC::Semaphore captureSemaphore, MediaTime mediaTime, size_t frameChunkSize);
+    AudioStorageChanged(WebCore::RealtimeMediaSourceIdentifier id, WebKit::SharedMemory::IPCHandle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames, IPC::Semaphore captureSemaphore, MediaTime mediaTime, size_t frameChunkSize);
     VideoFrameAvailable(WebCore::RealtimeMediaSourceIdentifier id, WebKit::RemoteVideoFrameProxy::Properties sample, struct WebCore::VideoFrameTimeMetadata metadata)
     VideoFrameAvailableCV(WebCore::RealtimeMediaSourceIdentifier id, RetainPtr<CVPixelBufferRef> pixelBuffer, WebCore::VideoFrame::Rotation rotation, bool mirrored, MediaTime presentationTime, struct WebCore::VideoFrameTimeMetadata metadata)
 


### PR DESCRIPTION
#### 5f2757904cd1d30e98c2d826bd681b3e394fff47
<pre>
Revert &quot;SharedMemory::IPCHandle is a redundant class&quot;

This reverts commit 29dff38a6ecb5e5afe1d878739c40c863811872f.

Unreviewed revert
This reverts because it broke the build for Monterey and iOS Debug.

Canonical link: <a href="https://commits.webkit.org/253521@main">https://commits.webkit.org/253521@main</a>
</pre>
