### PR TITLE
Class matching fails after moving an element from a quirks-mode document to a standards-mode document.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/quirks/classname-query-after-sibling-adoption-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/quirks/classname-query-after-sibling-adoption-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Quirks mode elements with class names should remain queriable regardless of sibling adoption into standards mode documents assert_true: expected true got false
+PASS Quirks mode elements with class names should remain queriable regardless of sibling adoption into standards mode documents
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2411,6 +2411,7 @@ void Element::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
     ASSERT_WITH_SECURITY_IMPLICATION(&document() == &newDocument);
 
     if (oldDocument.inQuirksMode() != document().inQuirksMode()) {
+        ensureUniqueElementData();
         // ElementData::m_classNames or ElementData::m_idForStyleResolution need to be updated with the right case.
         if (hasID())
             attributeChanged(idAttr, nullAtom(), getIdAttribute());


### PR DESCRIPTION
#### 2837601ea97b7debfdbeaeb971a0838c733a989d
<pre>
Class matching fails after moving an element from a quirks-mode document to a standards-mode document.
<a href="https://bugs.webkit.org/show_bug.cgi?id=173528">https://bugs.webkit.org/show_bug.cgi?id=173528</a>
rdar://98786212

Reviewed by Ryosuke Niwa.

Imports a fix from Chromium to make a unique copy of element data when moving elements between quirks and standards mode documents.
Chromium revision: <a href="https://chromium.googlesource.com/chromium/src.git/+/3d8dd287aeb97d6dbb658da989ac4a4c95853dc7">https://chromium.googlesource.com/chromium/src.git/+/3d8dd287aeb97d6dbb658da989ac4a4c95853dc7</a>

* LayoutTests/imported/w3c/web-platform-tests/quirks/classname-query-after-sibling-adoption-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::didMoveToNewDocument):

Canonical link: <a href="https://commits.webkit.org/253975@main">https://commits.webkit.org/253975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b228b9b0d15ea50832de05c0cc0c728fa3f5492

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96812 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150573 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91563 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30044 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26184 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79705 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91565 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24271 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74363 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24106 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79236 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79445 "Found 1 new API test failure: TestWebKitAPI.VideoControlsManager.VideoControlsManagerMultipleVideosScrollPlayingVideoWithSoundOutOfView") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67122 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27748 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13275 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27705 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14291 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2798 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37165 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29311 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33568 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->