### PR TITLE
[ews] Fold Github status bubbles for old commits

### DIFF
--- a/Tools/CISupport/ews-app/ews/models/patch.py
+++ b/Tools/CISupport/ews-app/ews/models/patch.py
@@ -100,7 +100,7 @@ class Change(models.Model):
     def mark_old_changes_as_obsolete(cls, pr_id, change_id):
         changes = Change.objects.filter(pr_id=pr_id).order_by('-created')
         if not changes or len(changes) == 1:
-            return
+            return []
         for change in changes[1:]:
             if not change.obsolete:
                 if change.change_id == change_id:
@@ -108,6 +108,7 @@ class Change(models.Model):
                 change.obsolete = True
                 change.save()
                 _log.info('Marked change {} on pr {} as obsolete'.format(change.change_id, pr_id))
+        return changes[1:]
 
     @classmethod
     def set_sent_to_buildbot(cls, change_id, value, commit_queue=False):


### PR DESCRIPTION
#### 366d27232fe402b953e9cf2e421337087fdce85f
<pre>
[ews] Fold Github status bubbles for old commits
<a href="https://bugs.webkit.org/show_bug.cgi?id=244047">https://bugs.webkit.org/show_bug.cgi?id=244047</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS.generate_comment_text_for_change):
(GitHubEWS.add_or_update_comment_for_change_id):
* Tools/CISupport/ews-app/ews/models/patch.py:
(Change.mark_old_changes_as_obsolete):

Canonical link: <a href="https://commits.webkit.org/253535@main">https://commits.webkit.org/253535@main</a>
</pre>













<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddc744d893ab089beac3437c9056cb56144156f9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86313 "Passed style check") | [✅ ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/69/builds/30234 "Build was cancelled") | [✅ ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95162 "Built successfully") | [✅ ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/148870 "Build was cancelled") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90297 "Passed tests") | [✅ ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/64/builds/28597 "Build was cancelled") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/90418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91912 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/64/builds/28597 "Build was cancelled") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/64/builds/28597 "Build was cancelled") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26556 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26465 "Built successfully") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/971 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28141 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28080 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->