### PR TITLE
[JSC][armv7] Fix spec-tests/memory.wast.js

### DIFF
--- a/JSTests/wasm/regress/243901.js
+++ b/JSTests/wasm/regress/243901.js
@@ -1,0 +1,36 @@
+//@ skip if $architecture != "arm"
+
+import {throws} from "../assert.js"
+
+function module(bytes, valid = true) {
+    let buffer = new ArrayBuffer(bytes.length);
+    let view = new Uint8Array(buffer);
+    for (let i = 0; i < bytes.length; ++i) {
+        view[i] = bytes.charCodeAt(i);
+    }
+    return new WebAssembly.Module(buffer);
+}
+
+/*
+ * (module
+ *   (memory 65536)
+ *   (func (export entry)
+ *     (param)
+ *     (result i64)
+ *     (i32.const 65535)
+ *     (i32.const 255)
+ *     (i32.store8)
+ *     (i64.const 0)
+ *     (return)))
+ */
+
+const wasmModule = module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x05\x01\x60\x00\x01\x7e\x03\x02\x01\x00\x05\x05\x01\x00\x80\x80\x04\x07\x09\x01\x05\x65\x6e\x74\x72\x79\x00\x00\x0a\x11\x01\x0f\x00\x41\xff\xff\x03\x41\xff\x01\x3a\x00\x00\x42\x00\x0f\x0b");
+
+throws (
+    () => {
+        const instance = new WebAssembly.Instance(wasmModule);
+        instance.exports.entry();
+    },
+    RangeError,
+    "Out of memory"
+);

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -392,11 +392,6 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
     if (initialBytes > MAX_ARRAY_BUFFER_SIZE)
         return nullptr; // Client will throw OOMError.
 
-#if USE(JSVALUE32_64)
-    if (maximumBytes > MAX_ARRAY_BUFFER_SIZE)
-        return nullptr; // Client will throw OOMError.
-#endif
-
     if (maximum && !maximumBytes) {
         // User specified a zero maximum, initial size must also be zero.
         RELEASE_ASSERT(!initialBytes);


### PR DESCRIPTION
#### 7962ecf8c1ca032aec9476805a0588cc7872b127
<pre>
[JSC][armv7] Fix spec-tests/memory.wast.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=244048">https://bugs.webkit.org/show_bug.cgi?id=244048</a>

Reviewed by Yusuke Suzuki.

After <a href="https://bugs.webkit.org/show_bug.cgi?id=243901">https://bugs.webkit.org/show_bug.cgi?id=243901</a> we will fail to instantiate
any module that specifies a too-high (over MAX_ARRAY_BUFFER_SIZE) memory
maximum; really, we should delay these errors until after the program actually
requests too much memory; the too-high maximum shouldn&apos;t cause more problems
problems, as usually we are checking its page size, and other calls to `bytes()`
are protected by comparisions to `MAX_ARRAY_BUFFER_SIZE`)

I also added a regression test for the original bug; without these patches, it
will fail with a bounds check while executing the code, instead of failing to
initialize the requested memory.

* JSTests/wasm/regress/243901.js: Added.
(from.string_appeared_here.module):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::tryCreate):
(JSC::Wasm::Memory::growShared):
(JSC::Wasm::Memory::grow):

Canonical link: <a href="https://commits.webkit.org/253655@main">https://commits.webkit.org/253655@main</a>
</pre>


<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/422c1701af143cabe39cef6d2ecade16c4e8215a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95517 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149248 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29118 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25533 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78855 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90759 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23521 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73595 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23582 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66588 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78609 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26889 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12722 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72246 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26809 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13737 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25796 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2594 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36599 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75029 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33016 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16596 "Passed tests") | 
<!--EWS-Status-Bubble-End-->