### PR TITLE
[css-flexbox] WPT sync

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1426,14 +1426,25 @@ webkit.org/b/136754 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe
 webkit.org/b/210243 imported/w3c/web-platform-tests/css/css-flexbox/percentage-size-quirks-002.html [ Failure ]
 webkit.org/b/136754 imported/w3c/web-platform-tests/css/css-flexbox/scrollbars-no-margin.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-flexbox/fieldset-baseline-alignment.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-004.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-007.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-001.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-002.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-003.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-004.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-007.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-001.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-002.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-003.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-004.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-005.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-006.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-007.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-008.html [ ImageOnlyFailure ]
+webkit.org/b/116117 imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-009.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-flexbox/stretch-flex-item-checkbox-input.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-flexbox/stretch-flex-item-radio-input.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-flexbox/webkit-box-vertical-writing-mode.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-005.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-006.html [ ImageOnlyFailure ]
 
 # grid layout tests
 webkit.org/b/231021 imported/w3c/web-platform-tests/css/css-grid/grid-with-dynamic-img.html [ ImageOnlyFailure ]
@@ -4426,6 +4437,8 @@ webkit.org/b/221474 imported/w3c/web-platform-tests/css/css-flexbox/svg-root-as-
 
 # align baseline in flexbox.
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-001.html [ ImageOnlyFailure ]
+webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-003.html [ ImageOnlyFailure ]
+webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-004.html [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-001a.xhtml [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-001b.xhtml [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-006.xhtml [ ImageOnlyFailure ]
@@ -4440,12 +4453,6 @@ webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/synthesize-v
 # Flex item's min|max content contributions
 webkit.org/b/230747 imported/w3c/web-platform-tests/css/css-flexbox/flex-container-max-content-001.html [ ImageOnlyFailure ]
 webkit.org/b/230747 imported/w3c/web-platform-tests/css/css-flexbox/flex-container-min-content-001.html [ ImageOnlyFailure ]
-
-# break request in flexbox.
-webkit.org/b/221480 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001a.html [ ImageOnlyFailure ]
-webkit.org/b/221480 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001b.html [ ImageOnlyFailure ]
-webkit.org/b/221480 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001a.html [ ImageOnlyFailure ]
-webkit.org/b/221480 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001b.html [ ImageOnlyFailure ]
 
 # min-size:auto in flexbox.
 webkit.org/b/221481 imported/w3c/web-platform-tests/css/css-flexbox/flex-minimum-height-flex-items-023.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-003-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-003-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-003.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#synthesize-baseline">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: flex; align-items: baseline; writing-mode: vertical-lr; text-orientation: sideways; background: red;">
+  <div style="height: 50px; width: 100px; background: green;"></div>
+  <div style="height: 50px; width: 100px; background: green; line-height: 0;">
+    <span style="width: 10px; height: 10px; display: inline-block;"></span>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-004-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-004-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-004.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#synthesize-baseline">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: flex; align-items: baseline; writing-mode: vertical-lr; background: red;">
+  <div style="height: 50px; width: 100px; background: green;"></div>
+  <div style="height: 50px; width: 100px; background: green; line-height: 0;">
+    <span style="width: 100px; height: 10px; display: inline-block;"></span>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001-ref.html
@@ -56,16 +56,16 @@
     <div class="item fullCrossSize" style="float: left"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize"></div>
-    <div class="item halfCrossSize"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize"></div>
-    <div class="item halfCrossSize"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize"></div>
-    <div class="item halfCrossSize"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
   </div>
   <div style="clear: both"></div>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001a-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001a-expected.html
@@ -56,16 +56,16 @@
     <div class="item fullCrossSize" style="float: left"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize"></div>
-    <div class="item halfCrossSize"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize"></div>
-    <div class="item halfCrossSize"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize"></div>
-    <div class="item halfCrossSize"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
   </div>
   <div style="clear: both"></div>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001a.html
@@ -7,7 +7,7 @@
 <head>
   <title>CSS Test: Testing page-break-before in horizontal multi-line flex containers</title>
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
-  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#algo-line-break">
+  <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#change-201409-algo-breaks">
   <link rel="match" href="flexbox-break-request-horiz-001-ref.html">
   <meta charset="utf-8">
   <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001b-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001b-expected.html
@@ -56,16 +56,16 @@
     <div class="item fullCrossSize" style="float: left"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize"></div>
-    <div class="item halfCrossSize"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize"></div>
-    <div class="item halfCrossSize"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize"></div>
-    <div class="item halfCrossSize"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize" style="float: left"></div>
   </div>
   <div style="clear: both"></div>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001b.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001b.html
@@ -7,7 +7,7 @@
 <head>
   <title>CSS Test: Testing page-break-after in horizontal multi-line flex containers</title>
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
-  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#algo-line-break">
+  <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#change-201409-algo-breaks">
   <link rel="match" href="flexbox-break-request-horiz-001-ref.html">
   <meta charset="utf-8">
   <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001-ref.html
@@ -56,16 +56,16 @@
     <div class="item fullCrossSize"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize" style="float: left"></div>
-    <div class="item halfCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize"></div>
+    <div class="item fullCrossSize"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize" style="float: left"></div>
-    <div class="item halfCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize"></div>
+    <div class="item fullCrossSize"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize" style="float: left"></div>
-    <div class="item halfCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize"></div>
+    <div class="item fullCrossSize"></div>
   </div>
   <div style="clear: both"></div>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001a-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001a-expected.html
@@ -56,16 +56,16 @@
     <div class="item fullCrossSize"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize" style="float: left"></div>
-    <div class="item halfCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize"></div>
+    <div class="item fullCrossSize"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize" style="float: left"></div>
-    <div class="item halfCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize"></div>
+    <div class="item fullCrossSize"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize" style="float: left"></div>
-    <div class="item halfCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize"></div>
+    <div class="item fullCrossSize"></div>
   </div>
   <div style="clear: both"></div>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001a.html
@@ -7,7 +7,7 @@
 <head>
   <title>CSS Test: Testing page-break-before in vertical multi-line flex containers</title>
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
-  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#algo-line-break">
+  <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#change-201409-algo-breaks">
   <link rel="match" href="flexbox-break-request-vert-001-ref.html">
   <meta charset="utf-8">
   <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001b-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001b-expected.html
@@ -56,16 +56,16 @@
     <div class="item fullCrossSize"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize" style="float: left"></div>
-    <div class="item halfCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize"></div>
+    <div class="item fullCrossSize"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize" style="float: left"></div>
-    <div class="item halfCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize"></div>
+    <div class="item fullCrossSize"></div>
   </div>
   <div class="flexbox">
-    <div class="item halfCrossSize" style="float: left"></div>
-    <div class="item halfCrossSize" style="float: left"></div>
+    <div class="item fullCrossSize"></div>
+    <div class="item fullCrossSize"></div>
   </div>
   <div style="clear: both"></div>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001b.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001b.html
@@ -7,7 +7,7 @@
 <head>
   <title>CSS Test: Testing page-break-after in vertical multi-line flex containers</title>
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
-  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#algo-line-break">
+  <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#change-201409-algo-breaks">
   <link rel="match" href="flexbox-break-request-vert-001-ref.html">
   <meta charset="utf-8">
   <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-005-expected.html
@@ -7,18 +7,10 @@ div {
   height: 50px;
   width: 100px;
 }
-span {
-  display: inline-block;
-  background-color: green;
-  height: 50px;
-  width: 40px;
-}
 br { margin: 50px; }
 </style>
 
 <p>Test passes if there is <strong>no red</strong> visible on the page.</p>
 <div></div>
-
 <br>
-
-<span></span>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-005.html
@@ -2,8 +2,8 @@
 <title>CSS Flexible Box Test: Aspect ratio handling of images</title>
 <link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com" />
 <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#min-size-auto" />
+<link rel="help" href="https://github.com/web-platform-tests/wpt/issues/31609" />
 <link rel="match" href="reference/flexbox-min-width-auto-005-ref.html" />
-<meta name="assert" content="Test that min-width:auto does not incorrectly stretch items with aspect ratio" />
 
 <style>
 .reference-overlapped-red {
@@ -29,7 +29,7 @@ br { margin: 50px; }
 
 <br>
 
-<div class="reference-overlapped-red" style="width: 40px;"></div>
+<div class="reference-overlapped-red"></div>
 <div style="display: flex">
     <div class="constrained-flex">
         <img src="support/40x20-green.png" />

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-006-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-006-expected.html
@@ -5,28 +5,14 @@
 .box {
   width: 100px;
   height: 100px;
+  background: green;
   border: 1px solid black;
-}
-#green-square {
-    background: green;
-    margin-top: 40px;
-    width: 20px;
-    height: 20px;
-}
-#green-rectange {
-    background: green;
-    width: 60px;
-    height: 100px;
 }
 </style>
 
-<p>Test passes if there are a (vertically centered) 20x20 and a 60x100 green boxes enclosed on each 100x100 square.</p>
-<div class="box">
-    <div id="green-square"></div>
-</div>
+<p>Test passes if there are two 100x100 green squares.</p>
+<div class="box"></div>
 
 <br>
 
-<div class="box">
-    <div id="green-rectange"></div>
-</div>
+<div class="box"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-006.html
@@ -2,18 +2,10 @@
 <title>CSS Flexible Box Test: Aspect ratio handling of images</title>
 <link rel="author" title="Sergio Villar Senin" href="mailto:svillar@igalia.com" />
 <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#min-size-auto" />
+<link rel="help" href="https://github.com/web-platform-tests/wpt/issues/31609" />
 <link rel="match" href="reference/flexbox-min-width-auto-006-ref.html" />
-<meta name="assert" content="Test that min-width:auto does not incorrectly stretch items with aspect ratio" />
 
 <style>
-#reference-overlapped-red {
-    position: relative;
-    background-color: red;
-    width: 10px;
-    height: 10px;
-    top: 40px;
-    z-index: -1;
-}
 .constrained-width-flex {
     width: 100px;
     display: flex;
@@ -25,7 +17,7 @@
 }
 </style>
 
-<p>Test passes if there are a (vertically centered) 20x20 and a 60x100 green boxes enclosed on each 100x100 square.</p>
+<p>Test passes if there are two 100x100 green squares.</p>
 
 <div class="constrained-width-flex">
     <div class="constrained-height-flex">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox_direction-row-reverse-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox_direction-row-reverse-expected.html
@@ -1,25 +1,19 @@
 <!DOCTYPE html>
 <title>flexbox | flex-direction: row-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
+<link rel="stylesheet" href="/fonts/ahem.css">
 <style>
-* {font-family: monospace;}
-body {
-	width: 10em;
-}
-ul {
-	background: blue;
-	padding: 0;
-	margin: 0;
+#container {
+	width: 13em;
+	font: 40px "Ahem";
+	background: black;
 	list-style: none;
-}
-li {
-	color: white;
-	margin: 0;
-	width: 3.3333em;
-	display: inline-block;
+        text-align: right;
 }
 </style>
-
+This test makes sure that the flex-direction: row-reverse CSS property correctly orders items.
+<div id="container">
 <ul>
-	<li>EFGH</li><li>ABCD</li><li>IJKL</li>
+<span style="color: red;">E</span><span style="color: purple;">F</span><span style="color: grey;">G</span><span style="color: bisque;">H</span><span style="color: lightblue;">A</span><span style="color: turquoise;">B</span><span style="color: coral;">C</span><span style="color: violet;">D</span><span style="color: green;">I</span><span style="color: blue;">J</span><span style="color: cyan;">K</span><span style="color: magenta;">L</span>
 </ul>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox_direction-row-reverse-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox_direction-row-reverse-ref.html
@@ -1,25 +1,19 @@
 <!DOCTYPE html>
 <title>flexbox | flex-direction: row-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
+<link rel="stylesheet" href="/fonts/ahem.css">
 <style>
-* {font-family: monospace;}
-body {
-	width: 10em;
-}
-ul {
-	background: blue;
-	padding: 0;
-	margin: 0;
+#container {
+	width: 13em;
+	font: 40px "Ahem";
+	background: black;
 	list-style: none;
-}
-li {
-	color: white;
-	margin: 0;
-	width: 3.3333em;
-	display: inline-block;
+        text-align: right;
 }
 </style>
-
+This test makes sure that the flex-direction: row-reverse CSS property correctly orders items.
+<div id="container">
 <ul>
-	<li>EFGH</li><li>ABCD</li><li>IJKL</li>
+<span style="color: red;">E</span><span style="color: purple;">F</span><span style="color: grey;">G</span><span style="color: bisque;">H</span><span style="color: lightblue;">A</span><span style="color: turquoise;">B</span><span style="color: coral;">C</span><span style="color: violet;">D</span><span style="color: green;">I</span><span style="color: blue;">J</span><span style="color: cyan;">K</span><span style="color: magenta;">L</span>
 </ul>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox_direction-row-reverse.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox_direction-row-reverse.html
@@ -1,32 +1,29 @@
 <!DOCTYPE html>
 <title>flexbox | flex-direction: row-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
 <link rel="match" href="flexbox_direction-row-reverse-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
 <style>
-* {font-family: monospace;}
-body {
-	width: 10em;
+#container {
+	font: 40px "Ahem";
+	width: 13em;
 }
 ul {
-	background: blue;
-	padding: 0;
-	margin: 0;
+	background: black;
 	list-style: none;
 
 	display: flex;
 	flex-direction: row-reverse;
 }
 li {
-	color: white;
 	margin: 0;
-	width: 10em;
+	width: 4em;
 }
 </style>
-
-<ul>
-	<li>IJKL</li>
-	<li>ABCD</li>
-	<li>EFGH</li>
-</ul>
+This test makes sure that the flex-direction: row-reverse CSS property correctly orders items.
+<div id="container"><ul>
+	<li><span style="color:     green;">I</span><span style="color:      blue;">J</span><span style="color:  cyan;">K</span><span style="color: magenta;">L</span></li>
+	<li><span style="color: lightblue;">A</span><span style="color: turquoise;">B</span><span style="color: coral;">C</span><span style="color:  violet;">D</span></li>
+	<li><span style="color:       red;">E</span><span style="color:    purple;">F</span><span style="color:  grey;">G</span><span style="color:  bisque;">H</span></li>
+</ul></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-001-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-001-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-001.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<link rel="author" title="David Grogan" href="mailto:dgrogan@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert"
+  content="column-wrap container's max-content width is big enough that items don't overflow when the container has fixed height and items have fixed width and height. Old algorithm gave max-content width of 50px." />
+
+<style>
+  #reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+  }
+
+  .item {
+    /* Remove min-height so we don't have to think about it. */
+    min-height: 0px;
+    width: 50px;
+    flex: 0 0 100px
+  }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.
+</p>
+
+<div id=reference-overlapped-red></div>
+
+<div
+  style="display: flex; flex-flow: column wrap; height: 100px; width: max-content; background: green;"
+  class=flex>
+  <div class="item"></div>
+  <div class="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-002-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-002-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-002.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<link rel="author" title="David Grogan" href="mailto:dgrogan@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert"
+  content="column-wrap container's max-content width is big enough that items don't overflow when the container has indefinite height but fixed max-height and items have fixed width and height. Old algorithm gave max-content width of 50px." />
+
+<style>
+  #reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+  }
+
+  .item {
+    /* Remove min-height so we don't have to think about it. */
+    min-height: 0px;
+    width: 50px;
+    flex: 0 0 100px
+  }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.
+</p>
+
+<div id=reference-overlapped-red></div>
+
+<div
+  style="display: flex; flex-flow: column wrap; max-height: 100px; width: max-content; background: green;"
+  class=flex>
+  <div class="item"></div>
+  <div class="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-003-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-003-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-003.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<link rel="author" title="David Grogan" href="mailto:dgrogan@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert"
+  content="Cross-axis borders are accounted for when determining inline content sizes of column-wrap flexboxes." />
+
+<style>
+  #reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+  }
+
+  .item {
+    /* Remove min-height so we don't have to think about it. */
+    min-height: 0px;
+    width: 40px;
+    flex: 0 0 100px;
+  }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.
+</p>
+
+<div id=reference-overlapped-red></div>
+
+<div
+  style="display: flex; flex-flow: column wrap; max-height: 100px; width: max-content; background: green; padding-left: 5px; border-left: 9px solid green; border-right: 6px solid green;">
+  <div class="item"></div>
+  <div class="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-004-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-004-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-004.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<link rel="author" title="David Grogan" href="mailto:dgrogan@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<meta name="assert"
+  content="Item with width:100% doesn't contribute to max-content size but does get 100px width after final layout. The item also overflows the container." />
+
+<style>
+  .item {
+    /* Remove min-height so we don't have to think about it. */
+    min-height: 0px;
+    flex: 0 0 100px;
+    outline: 1px solid;
+  }
+</style>
+
+<div
+  style="display: flex; flex-flow: column wrap; width: max-content; height: 100px; background: green; position: relative;"
+  data-expected-width="100">
+  <div class="item" style="width: 100px;"></div>
+  <div class="item" style="width: 100%;" data-expected-width="100"
+    data-offset-x="100"></div>
+</div>
+
+<script>
+  checkLayout('body > div');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-005-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-005-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-005.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<link rel="author" title="David Grogan" href="mailto:dgrogan@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<meta name="assert"
+  content="The item still has sufficient available size at the time fit-content is resolved. (A bug in the code could cause the right-most item to have a width of 75px.)">
+
+<style>
+  .item {
+    /* Remove min-height so we don't have to think about it. */
+    min-height: 0px;
+    flex: 0 0 100px;
+    outline: 1px solid;
+  }
+
+  .grandchild {
+    width: 75px;
+    float: left;
+  }
+</style>
+
+<div
+  style="display: flex; flex-flow: column wrap; width: max-content; height: 100px; background: green; position: relative;"
+  data-expected-width="250">
+  <div class="item" style="width: 100px;"></div>
+  <div class="item" style="width: fit-content;" data-expected-width="150"
+    data-offset-x="100">
+    <!-- This item has min-content=75 and max-content=150. -->
+    <div class="grandchild"></div>
+    <div class="grandchild"></div>
+  </div>
+</div>
+
+<script>
+  checkLayout('body > div');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-006-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-006-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-006.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<link rel="author" title="David Grogan" href="mailto:dgrogan@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert"
+  content="flex item order is accounted for when determining inline content sizes of column-wrap flexboxes.">
+
+<style>
+  #reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+  }
+
+  .item {
+    /* Remove min-height so we don't have to think about it. */
+    min-height: 0px;
+    width: 50px;
+    flex: 0 0 auto;
+  }
+
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.
+</p>
+
+<div id=reference-overlapped-red></div>
+
+<!--  An implementation that ignored order could make the max-content size of this flexbox 150px. -->
+<div
+  style="display: flex; flex-flow: column wrap; width: max-content; height: 100px; background: green;">
+  <div class="item" style="height: 90px; order: 0;"></div>
+  <div class="item" style="height: 100px; order: 2;"></div>
+  <div class="item" style="height: 10px; order: 1;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-007-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-007-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-007.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<link rel="author" title="David Grogan" href="mailto:dgrogan@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert"
+  content="column wrap max-content width calculation works for wrap-reverse containers" />
+
+<style>
+  #reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+  }
+
+  .item {
+    /* Remove min-height so we don't have to think about it. */
+    min-height: 0px;
+    flex: 0 0 100px;
+  }
+
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.
+</p>
+
+<div id=reference-overlapped-red></div>
+
+<div
+  style="display: flex; flex-flow: column wrap-reverse; height: 100px; width: max-content; background: green;">
+  <div class="item" style="width: 30px;"></div>
+  <div class="item" style="width: 70px;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-008-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-008-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-008.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<link rel="author" title="David Grogan" href="mailto:dgrogan@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert"
+  content="column wrap max-content width calculation works for align-content:space-around containers" />
+
+<style>
+  #reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+  }
+
+  .item {
+    /* Remove min-height so we don't have to think about it. */
+    min-height: 0px;
+    flex: 0 0 100px;
+  }
+
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.
+</p>
+
+<div id=reference-overlapped-red></div>
+
+<div
+  style="display: flex; flex-flow: column wrap; height: 100px; width: max-content; align-content: space-around; background: green;">
+  <div class="item" style="width: 30px;"></div>
+  <div class="item" style="width: 70px;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-009-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-009-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-009.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-009.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<link rel="author" title="David Grogan" href="mailto:dgrogan@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert"
+  content="column wrap container's intrinsic width changes when its height changes." />
+
+<style>
+  #reference-overlapped-red {
+    position: absolute;
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+  }
+  span {
+    width: 50px;
+    height: 100px;
+  }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.
+<div id=reference-overlapped-red></div>
+
+<div style="display: flex; height: 200px;" id="target">
+  <div
+    style="display: flex; flex-flow: column wrap; width: max-content; background: green;">
+    <span></span>
+    <span></span>
+  </div>
+</div>
+
+<script>
+  target.offsetLeft;
+  // With original height of 200px, both items fit in one flex line.
+  // With height 100px, there are two lines and the items are side-by-side.
+  target.style.height = "100px";
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-005-expected.txt
@@ -1,78 +1,96 @@
 
 FAIL .floating-flexbox 1 assert_equals:
 <div class="floating-flexbox" data-expected-width="300">
-        <div style="flex: 1 1 200px; width:50px;">
-          <div></div>
-        </div>
-        <div style="flex: 1 1 400px; width:50px;">
-          <div></div>
-        </div>
+      <!-- min contribution: 100 -->
+      <!-- fraction: -0.5 -->
+      <!-- flex base size + product: 200px + -0.5*200px = 100px -->
+      <div style="flex: 1 1 200px; width:50px;">
+        <div></div>
       </div>
+      <!-- min contribution: 100 -->
+      <!-- fraction: -0.75 -->
+      <!-- flex base size + product: 400px + -0.5*400px = 200px -->
+      <div style="flex: 1 1 400px; width:50px;">
+        <div></div>
+      </div>
+    </div>
 width expected 300 but got 100
 FAIL .floating-flexbox 2 assert_equals:
 <div class="floating-flexbox" data-expected-width="225">
-        <div style="flex: 1 1 200px; width:50px;">
-          <div></div>
-        </div>
-        <div style="flex: 1 2 400px; width:50px;">
-          <div></div>
-        </div>
+      <div style="flex: 1 1 200px; width:50px;">
+        <div></div>
       </div>
+      <div style="flex: 1 2 400px; width:50px;">
+        <div></div>
+      </div>
+    </div>
 width expected 225 but got 100
 FAIL .floating-flexbox 3 assert_equals:
 <div class="floating-flexbox" data-expected-width="225">
-        <div style="flex: 1 1 200px; width:50px; min-width: 0px;">
-          <div></div>
-        </div>
-        <div style="flex: 1 2 400px; width:50px; min-width: 0px;">
-          <div></div>
-        </div>
+      <div style="flex: 1 1 200px; width:50px; min-width: 0px;">
+        <div></div>
       </div>
+      <div style="flex: 1 2 400px; width:50px; min-width: 0px;">
+        <div></div>
+      </div>
+    </div>
 width expected 225 but got 100
 FAIL .floating-flexbox 4 assert_equals:
-<div class="floating-flexbox" data-expected-width="600">
-        <div style="flex: 1 0 200px; width:50px;">
-          <div></div>
-        </div>
-        <div style="flex: 1 1 400px; width:50px;">
-          <div></div>
-        </div>
+<div class="floating-flexbox" data-expected-width="300">
+      <!-- min contribution: 100 -->
+      <!-- fraction: -inf -->
+      <!-- flex base size + product: 200px + -0.75*0px = 200px -->
+      <div style="flex: 1 0 200px; width:50px;">
+        <div></div>
       </div>
-width expected 600 but got 100
+      <!-- min contribution: 100 -->
+      <!-- fraction: -0.75 -->
+      <!-- flex base size + product: 400px + -0.75*400px = 100px -->
+      <div style="flex: 1 1 400px; width:50px;">
+        <div></div>
+      </div>
+    </div>
+width expected 300 but got 100
 FAIL .floating-flexbox 5 assert_equals:
 <div class="floating-flexbox" data-expected-width="200">
-        <div style="flex: 0 0 50px; width: 200px;">
-          <div></div>
-        </div>
-        <div style="flex: 0 0 50px; width: 200px;">
-          <div></div>
-        </div>
+      <div style="flex: 0 0 50px; width: 200px;">
+        <div></div>
       </div>
+      <div style="flex: 0 0 50px; width: 200px;">
+        <div></div>
+      </div>
+    </div>
 width expected 200 but got 400
 FAIL .floating-flexbox 6 assert_equals:
 <div class="floating-flexbox" data-expected-width="600">
-        <!-- contribution: 200 -->
-        <!-- fraction: 150 -->
-        <!-- 50 + 1*150 = 200 -->
-        <div style="flex: 1 0 50px; width: 200px;">
-          <div></div>
-        </div>
-        <!-- contribution: 200 -->
-        <!-- fraction: 100 -->
-        <!-- 100 + 2*150 = 400 -->
-        <div style="flex: 2 0 100px; width: 200px;">
-          <div></div>
-        </div>
+      <!-- contribution: 200 -->
+      <!-- fraction: 150 -->
+      <!-- 50 + 1*150 = 200 -->
+      <div style="flex: 1 0 50px; width: 200px;">
+        <div></div>
       </div>
+      <!-- contribution: 200 -->
+      <!-- fraction: 100 -->
+      <!-- 100 + 2*150 = 400 -->
+      <div style="flex: 2 0 100px; width: 200px;">
+        <div></div>
+      </div>
+    </div>
 width expected 600 but got 400
 FAIL .floating-flexbox 7 assert_equals:
 <div class="floating-flexbox" data-expected-width="400">
-        <div style="flex: 0 1 200px; width: 50px;">
-          <div></div>
-        </div>
-        <div style="flex: 2 0 100px; width: 200px;">
-          <div></div>
-        </div>
+      <!-- min contribution: 100 -->
+      <!-- fraction: -0.5 -->
+      <!-- flex base size + product: = 200px + 50px*0 = 200px -->
+      <div style="flex: 0 1 200px; width: 50px;">
+        <div></div>
       </div>
+      <!-- min contribution: 200 -->
+      <!-- fraction: (200px - 100px) / 2 = 50px -->
+      <!-- flex base size + product: = 100px + 50px*2 = 200px -->
+      <div style="flex: 2 0 100px; width: 200px;">
+        <div></div>
+      </div>
+    </div>
 width expected 400 but got 250
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-005.html
@@ -34,90 +34,107 @@
 </style>
 
 <body onload="checkLayout('.floating-flexbox')">
-  <main>
-    <div class="zero-width">
-      <div class="floating-flexbox" data-expected-width="300">
-        <div style="flex: 1 1 200px; width:50px;">
-          <div></div>
-        </div>
-        <div style="flex: 1 1 400px; width:50px;">
-          <div></div>
-        </div>
+  <div class="zero-width">
+    <div class="floating-flexbox" data-expected-width="300">
+      <!-- min contribution: 100 -->
+      <!-- fraction: -0.5 -->
+      <!-- flex base size + product: 200px + -0.5*200px = 100px -->
+      <div style="flex: 1 1 200px; width:50px;">
+        <div></div>
+      </div>
+      <!-- min contribution: 100 -->
+      <!-- fraction: -0.75 -->
+      <!-- flex base size + product: 400px + -0.5*400px = 200px -->
+      <div style="flex: 1 1 400px; width:50px;">
+        <div></div>
       </div>
     </div>
+  </div>
 
-    <div class="zero-width">
-      <div class="floating-flexbox" data-expected-width="225">
-        <div style="flex: 1 1 200px; width:50px;">
-          <div></div>
-        </div>
-        <div style="flex: 1 2 400px; width:50px;">
-          <div></div>
-        </div>
+  <div class="zero-width">
+    <div class="floating-flexbox" data-expected-width="225">
+      <div style="flex: 1 1 200px; width:50px;">
+        <div></div>
+      </div>
+      <div style="flex: 1 2 400px; width:50px;">
+        <div></div>
       </div>
     </div>
+  </div>
 
-    <!-- This is same as above except for min-width auto is no longer in
+  <!-- This is same as above except for min-width auto is no longer in
       effect. EdgeHTML renders it differently than the above. -->
-    <div class="zero-width">
-      <div class="floating-flexbox" data-expected-width="225">
-        <div style="flex: 1 1 200px; width:50px; min-width: 0px;">
-          <div></div>
-        </div>
-        <div style="flex: 1 2 400px; width:50px; min-width: 0px;">
-          <div></div>
-        </div>
+  <div class="zero-width">
+    <div class="floating-flexbox" data-expected-width="225">
+      <div style="flex: 1 1 200px; width:50px; min-width: 0px;">
+        <div></div>
+      </div>
+      <div style="flex: 1 2 400px; width:50px; min-width: 0px;">
+        <div></div>
       </div>
     </div>
+  </div>
 
-    <div class="zero-width">
-      <div class="floating-flexbox" data-expected-width="600">
-        <div style="flex: 1 0 200px; width:50px;">
-          <div></div>
-        </div>
-        <div style="flex: 1 1 400px; width:50px;">
-          <div></div>
-        </div>
+  <div class="zero-width">
+    <div class="floating-flexbox" data-expected-width="300">
+      <!-- min contribution: 100 -->
+      <!-- fraction: -inf -->
+      <!-- flex base size + product: 200px + -0.75*0px = 200px -->
+      <div style="flex: 1 0 200px; width:50px;">
+        <div></div>
+      </div>
+      <!-- min contribution: 100 -->
+      <!-- fraction: -0.75 -->
+      <!-- flex base size + product: 400px + -0.75*400px = 100px -->
+      <div style="flex: 1 1 400px; width:50px;">
+        <div></div>
       </div>
     </div>
+  </div>
 
-    <div class="zero-width">
-      <div class="floating-flexbox" data-expected-width="200">
-        <div style="flex: 0 0 50px; width: 200px;">
-          <div></div>
-        </div>
-        <div style="flex: 0 0 50px; width: 200px;">
-          <div></div>
-        </div>
+  <div class="zero-width">
+    <div class="floating-flexbox" data-expected-width="200">
+      <div style="flex: 0 0 50px; width: 200px;">
+        <div></div>
+      </div>
+      <div style="flex: 0 0 50px; width: 200px;">
+        <div></div>
       </div>
     </div>
+  </div>
 
-    <div class="zero-width">
-      <!-- 200 + 400 = 600 -->
-      <div class="floating-flexbox" data-expected-width="600">
-        <!-- contribution: 200 -->
-        <!-- fraction: 150 -->
-        <!-- 50 + 1*150 = 200 -->
-        <div style="flex: 1 0 50px; width: 200px;">
-          <div></div>
-        </div>
-        <!-- contribution: 200 -->
-        <!-- fraction: 100 -->
-        <!-- 100 + 2*150 = 400 -->
-        <div style="flex: 2 0 100px; width: 200px;">
-          <div></div>
-        </div>
+  <div class="zero-width">
+    <!-- 200 + 400 = 600 -->
+    <div class="floating-flexbox" data-expected-width="600">
+      <!-- contribution: 200 -->
+      <!-- fraction: 150 -->
+      <!-- 50 + 1*150 = 200 -->
+      <div style="flex: 1 0 50px; width: 200px;">
+        <div></div>
+      </div>
+      <!-- contribution: 200 -->
+      <!-- fraction: 100 -->
+      <!-- 100 + 2*150 = 400 -->
+      <div style="flex: 2 0 100px; width: 200px;">
+        <div></div>
       </div>
     </div>
+  </div>
 
-    <div class="zero-width">
-      <div class="floating-flexbox" data-expected-width="400">
-        <div style="flex: 0 1 200px; width: 50px;">
-          <div></div>
-        </div>
-        <div style="flex: 2 0 100px; width: 200px;">
-          <div></div>
-        </div>
+  <div class="zero-width">
+    <div class="floating-flexbox" data-expected-width="400">
+      <!-- min contribution: 100 -->
+      <!-- fraction: -0.5 -->
+      <!-- flex base size + product: = 200px + 50px*0 = 200px -->
+      <div style="flex: 0 1 200px; width: 50px;">
+        <div></div>
+      </div>
+      <!-- min contribution: 200 -->
+      <!-- fraction: (200px - 100px) / 2 = 50px -->
+      <!-- flex base size + product: = 100px + 50px*2 = 200px -->
+      <div style="flex: 2 0 100px; width: 200px;">
+        <div></div>
       </div>
     </div>
-  </main>
+  </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-008-expected.txt
@@ -1,0 +1,35 @@
+
+FAIL .min-width-flexbox 1 assert_equals:
+<div class="min-width-flexbox" data-expected-width="300"><div data-expected-width="200" style="flex: 0 1 200px; width: 500px;"><div></div></div><div data-expected-width="100" style="flex: 0 0 100px; width: 200px;"><div></div></div></div>
+width expected 300 but got 700
+FAIL .min-width-flexbox 2 assert_equals:
+<div class="min-width-flexbox" data-expected-width="310"><div data-expected-width="200" style="flex: 0 1 200px; width: 500px;"><div></div></div><div data-expected-width="101" style="flex: 0.1 0 100px; width: 200px;"><div></div></div></div>
+width expected 310 but got 700
+FAIL .min-width-flexbox 3 assert_equals:
+<div class="min-width-flexbox" data-expected-width="330"><div data-expected-width="203" style="flex: 0.1 1 200px; width: 500px;"><div></div></div><div data-expected-width="103" style="flex: 0.1 0 100px; width: 200px;"><div></div></div></div>
+width expected 330 but got 700
+FAIL .min-width-flexbox 4 assert_equals:
+<div class="min-width-flexbox" data-expected-width="420"><div data-expected-width="248" style="flex: 0.4 1 200px; width: 500px;"><div></div></div><div data-expected-width="148" style="flex: 0.4 0 100px; width: 200px;"><div></div></div></div>
+width expected 420 but got 700
+FAIL .min-width-flexbox 5 assert_equals:
+<div class="min-width-flexbox" data-expected-width="450"><div data-expected-width="275" style="flex: 0.5 1 200px; width: 500px;"><div></div></div><div data-expected-width="175" style="flex: 0.5 0 100px; width: 200px;"><div></div></div></div>
+width expected 450 but got 700
+FAIL .min-width-flexbox 6 assert_equals:
+<div class="min-width-flexbox" data-expected-width="637.5"><div data-expected-width="368.75" style="flex: 0.75 1 200px; width: 500px;"><div></div></div><div data-expected-width="268.75" style="flex: 0.75 0 100px; width: 200px;"><div></div></div></div>
+width expected 637.5 but got 700
+FAIL .min-width-flexbox 7 assert_equals:
+<div class="min-width-flexbox" data-expected-width="900"><div data-expected-width="500" style="flex: 1 1 200px; width: 500px;"><div></div></div><div data-expected-width="400" style="flex: 1 0 100px; width: 200px;"><div></div></div></div>
+width expected 900 but got 700
+FAIL .min-width-flexbox 8 assert_equals:
+<div class="min-width-flexbox" data-expected-width="400"><div data-expected-width="200" style="flex: 0 1 200px; width: 500px;"><div></div></div><div data-expected-width="200" style="flex: 2 0 100px; width: 200px;"><div></div></div></div>
+width expected 400 but got 700
+FAIL .min-width-flexbox 9 assert_equals:
+<div class="min-width-flexbox" data-expected-width="405"><div data-expected-width="205" style="flex: 0.1 1 200px; width: 500px;"><div></div></div><div data-expected-width="200" style="flex: 2 0 100px; width: 200px;"><div></div></div></div>
+width expected 405 but got 700
+FAIL .min-width-flexbox 10 assert_equals:
+<div class="min-width-flexbox" data-expected-width="432"><div data-expected-width="212" style="flex: 0.2 1 200px; width: 500px;"><div></div></div><div data-expected-width="220" style="flex: 2 0 100px; width: 200px;"><div></div></div></div>
+width expected 432 but got 700
+FAIL .min-width-flexbox 11 assert_equals:
+<div class="min-width-flexbox" data-expected-width="900"><div data-expected-width="500" style="flex: 2 1 200px; width: 500px;"><div></div></div><div data-expected-width="400" style="flex: 2 0 100px; width: 200px;"><div></div></div></div>
+width expected 900 but got 700
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-008.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<link rel="author" title="David Grogan" href="mailto:dgrogan@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#intrinsic-sizes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<meta name="assert"
+  content="min-content width is calculated correctly in a variety of scenarios with two flex items. These cases were used as examples when deriving the intrinsic size algorithm. " />
+
+<style>
+  .min-width-flexbox {
+    display: flex;
+    outline: 5px solid blue;
+    height: 100px;
+    width: min-content;
+    margin-bottom: 20px;
+  }
+
+  .min-width-flexbox>div:nth-child(1) {
+    background: yellow;
+  }
+
+  .min-width-flexbox>div:nth-child(2) {
+    background: orange;
+  }
+
+  .min-width-flexbox>div>div {
+    width: 100px;
+  }
+
+</style>
+
+<body onload="checkLayout('.min-width-flexbox')">
+  <div id=log></div>
+</body>
+
+<script>
+  // These are from the table in https://github.com/w3c/csswg-drafts/issues/7189#issuecomment-1172771501
+  var test_cases = [
+    [0, 0, 200, 100, 300],
+    [0, .1, 200, 101, 310],
+    [.1, .1, 203, 103, 330],
+    [.4, .4, 248, 148, 420],
+    [.5, .5, 275, 175, 450],
+    [.75, .75, 368.75, 268.75, 637.5],
+    [1, 1, 500, 400, 900],
+    [0, 2, 200, 200, 400],
+    [.1, 2, 205, 200, 405],
+    [.2, 2, 212, 220, 432],
+    [2, 2, 500, 400, 900],
+  ];
+  test_cases.forEach(test_case => {
+    var flexbox = document.createElement('div');
+    flexbox.className = "min-width-flexbox";
+    flexbox.setAttribute("data-expected-width", test_case[4]);
+
+    var child1 = document.createElement('div');
+    child1.style.flex = "0 1 200px";
+    child1.style.width = "500px";
+    child1.style.flexGrow = test_case[0];
+    child1.setAttribute("data-expected-width", test_case[2]);
+    child1.appendChild(document.createElement('div'));
+
+    var child2 = document.createElement('div');
+    child2.style.flex = "0 0 100px";
+    child2.style.width = "200px";
+    child2.style.flexGrow = test_case[1];
+    child2.setAttribute("data-expected-width", test_case[3]);
+    child2.appendChild(document.createElement('div'));
+
+    flexbox.appendChild(child1);
+    flexbox.appendChild(child2);
+    document.body.appendChild(flexbox);
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/w3c-import.log
@@ -14,6 +14,24 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-001-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-001.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-002-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-002.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-003-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-003.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-004-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-004.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-005-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-005.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-006-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-006.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-007-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-007.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-008-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-008.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-009-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-009.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-001-expected.xht
 /LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-002-expected.xht
@@ -27,3 +45,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-006.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-007-expected.xht
 /LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-007.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-008.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/w3c-import.log
@@ -146,6 +146,10 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-002-expected.xht
 /LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-002.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-003-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-003.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-004-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-004.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/box-sizing-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/box-sizing-min-max-sizes-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/break-nested-float-in-flex-item-001-print-expected.html

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1617,7 +1617,6 @@ webkit.org/b/211856 media/video-poster-set-after-playback.html [ Pass Failure ]
 http/tests/frame-throttling/raf-throttle-in-cross-origin-subframe.html [ Pass Failure ]
 
 # These tests fail due to slight differences in font rendering.
-webkit.org/b/211891 imported/w3c/web-platform-tests/css/css-flexbox/flexbox_direction-row-reverse.html [ ImageOnlyFailure ]
 webkit.org/b/211891 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-vert-003.xhtml [ ImageOnlyFailure ]
 webkit.org/b/211891 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-vert-004.xhtml [ ImageOnlyFailure ]
 webkit.org/b/211891 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-vert-rtl-001.xhtml [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 04764ba93c05ae2cbb50855c4477e1c02f657ee7
<pre>
[css-flexbox] WPT sync
<a href="https://bugs.webkit.org/show_bug.cgi?id=244051">https://bugs.webkit.org/show_bug.cgi?id=244051</a>

Reviewed by Tim Nguyen.

Synchronize our flexbox WPT with upstream as of 6c0f5fbdfdfae22295b3beafc415991d9c4f30ac

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-003-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-004-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-004.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001a-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001a.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001b-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-horiz-001b.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001a-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001a.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001b-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-break-request-vert-001b.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-005-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-005.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-006-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-006.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox_direction-row-reverse-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox_direction-row-reverse-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox_direction-row-reverse.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-001-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-002-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-003-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-004-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-004.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-005-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-005.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-006-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-006.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-007-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-007.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-008-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-008.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-009-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/col-wrap-009.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-005.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-008-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-008.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/w3c-import.log:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253547@main">https://commits.webkit.org/253547@main</a>
</pre>











<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f63eaaeb6c654c8cee5b61b860ab85c83592292

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95167 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148876 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28603 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78455 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90423 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23200 "Passed tests") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23299 "Passed tests") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66305 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26562 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26471 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13507 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2527 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28147 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32788 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->