### PR TITLE
Resolve cases when border and padding are added twice to computed min and max sizes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4702,7 +4702,6 @@ webkit.org/b/214462 imported/w3c/web-platform-tests/css/css-scoping/slotted-plac
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/abspos-014.html [ ImageOnlyFailure ]
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/abspos-020.html [ ImageOnlyFailure ]
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-004.html [ ImageOnlyFailure ]
-webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-026.html [ ImageOnlyFailure ]
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-038.html [ ImageOnlyFailure ]
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/floats-aspect-ratio-001.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#min-width" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing/#box-sizing" />
+    <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=243887" />
+    <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+  </head>
+    <style>
+      div {
+        width: 100px;
+        height: 100px;
+        background-color: green;
+      }
+    </style>
+  <body>
+    <div></div>
+  </body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#min-width" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing/#box-sizing" />
+    <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=243887" />
+    <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+  </head>
+  <!-- The box should be a 100px x 100px green square. The initial width should
+       be 90px due to the  transferred min-width constraint from the specified
+       min-height. Since box-sizing is border-box, 10px will be removed from
+       the min-height (padding on the top and bottom of the box), and 90px will
+       be used to compute the transferred min-width. 5px of padding will then
+       be added on all sides of the 90px x 90px box to give it a resulting
+       size of 100px x 100px. -->
+  <style>
+    .flexContainer {
+      display: flex;
+      flex-direction: column;
+      float: left;
+    }
+    .item {
+      background: green;
+      padding-left: 25px;
+      padding-right: 25px;
+      box-sizing: border-box;
+    }
+  </style>
+  <body>
+    <div class="flexContainer">
+      <div class="item" style="min-height:100px; aspect-ratio: 1/1;"></div>
+    </div>
+  </body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#min-width" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing/#box-sizing" />
+    <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=243887" />
+    <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+  </head>
+    <style>
+      div {
+        width: 100px;
+        height: 100px;
+        background-color: green;
+      }
+    </style>
+  <body>
+    <div></div>
+  </body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#min-width" />
+    <link rel="help" href="https://drafts.csswg.org/css-sizing/#box-sizing" />
+    <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=243887" />
+    <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+  </head>
+  <!-- Item div should be a 100px x 100px square. Content width will be 90px,
+       which comes from the min-height constraint being transferred to the
+       min-width. 5px padding on all sides will give the box a resulting
+       size of 100x x 100px. -->
+  <style>
+    .flexContainer {
+      display: flex;
+      flex-direction: column;
+      float: left;
+    }
+    .item {
+      background: green;
+      padding: 5px 5px 5px 5px;
+    }
+  </style>
+  <body>
+    <div class="flexContainer">
+      <div class="item" style="min-height:90px; aspect-ratio: 1/1;"></div>
+    </div>
+  </body>
+</html>
+

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2287,9 +2287,11 @@ void RenderBlock::computePreferredLogicalWidths()
     if (!isTableCell() && lengthToUse.isFixed() && lengthToUse.value() >= 0
         && !(isDeprecatedFlexItem() && !lengthToUse.intValue()))
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(lengthToUse);
-    else if (shouldComputeLogicalWidthFromAspectRatio())
-        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = computeLogicalWidthFromAspectRatio();
-    else
+    else if (shouldComputeLogicalWidthFromAspectRatio()) {
+        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = (computeLogicalWidthFromAspectRatio() - borderAndPaddingLogicalWidth());
+        m_minPreferredLogicalWidth = std::max(0_lu, m_minPreferredLogicalWidth);
+        m_maxPreferredLogicalWidth = std::max(0_lu, m_maxPreferredLogicalWidth);
+    } else 
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
 
     RenderBox::computePreferredLogicalWidths(styleToUse.logicalMinWidth(), styleToUse.logicalMaxWidth(), borderAndPaddingLogicalWidth());

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3559,8 +3559,10 @@ void RenderBox::computePreferredLogicalWidths()
 
 void RenderBox::computePreferredLogicalWidths(const Length& minWidth, const Length& maxWidth, LayoutUnit borderAndPadding)
 {
-    if (shouldComputeLogicalHeightFromAspectRatio()) {
+    if (!style().logicalWidth().isFixed() && shouldComputeLogicalHeightFromAspectRatio()) {
         auto [logicalMinWidth, logicalMaxWidth] = computeMinMaxLogicalWidthFromAspectRatio();
+        logicalMinWidth = std::max(logicalMinWidth - borderAndPadding, 0_lu);
+        logicalMaxWidth = std::max(logicalMaxWidth - borderAndPadding, 0_lu);
         m_minPreferredLogicalWidth = std::clamp(m_minPreferredLogicalWidth, logicalMinWidth, logicalMaxWidth);
         m_maxPreferredLogicalWidth = std::clamp(m_maxPreferredLogicalWidth, logicalMinWidth, logicalMaxWidth);
     }


### PR DESCRIPTION
#### 0599c10f90042d00785952e18f8897082d655ca3
<pre>
Resolve cases when border and padding are added twice to computed min and max sizes
<a href="https://bugs.webkit.org/show_bug.cgi?id=243887">https://bugs.webkit.org/show_bug.cgi?id=243887</a>
rdar://98577125

Reviewed by Rob Buis.

This patch fixes a miscellaneous bug which would result in the
border and padding on boxes to get added twice in certain cases. This
is because inlineSizeFromAspectRatio returns the sizes of the border
box when the box sizing is content box. This is what is used to
compute logicalMinWidth and logicalMaxWidth, so those become
border box values. If the border and padding is not removed it is
possible for m_minPreferredLogicalWidth or m_maxPreferredLogicalWidth
to get clamped to one of those values. At the end of the method the
border and padding would once again get added on, which would result
in an incorrect box size. This could also happen in
RenderBlock::computePreferredLogicalWidths if the width is calculated
from the aspect ratio. This is because this branch of the code uses the
same inlineSizeFromAspectRatio method to do so.

Some of the logic inside of RenderBox::computePreferredLogicalWidths has
also been adjusted to no longer bother with checking transferred sizes
if a definite width is provided. This is because m_minPreferredLogicalWidth
and m_maxPreferredLogicalWidth will be set to the defined logical width
in RenderBlock::computePreferredLogicalWidths. If this is done, then
the transferred sizes will have no impact on these values. This is
because:

1.) If m_minPreferredLogicalWidth is greater than the logical width or
m_maxPreferredLogicalWidth is smaller than the logical width, they would
have been sized to the logical width anyway
2.) The clamping will have no effect if 1 does or does not occur. If 1
does occur, then m_minPreferredLogicalWidth and/or m_maxPreferredLogicalWidth
will already be the value of the logical width. If 1 does not ocur, then
m_minPreferredLogicalWidth and m_maxPreferredLogicalWidth are already
within the bounds of the transferred sizes and nothing will happen.

Transferred sizes spec: <a href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers">https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers</a>

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::computePreferredLogicalWidths):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computePreferredLogicalWidths):

Canonical link: <a href="https://commits.webkit.org/254190@main">https://commits.webkit.org/254190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f89c60eaa4315f28e88f43dc2c4038d6261e0133

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97217 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152711 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30606 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26545 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80170 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91956 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24667 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74718 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24633 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67617 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28235 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13600 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28333 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2947 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37475 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33822 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->