### PR TITLE
Fix error message for O.p.toString on revoked proxy

### DIFF
--- a/JSTests/stress/array-isarray-error-message.js
+++ b/JSTests/stress/array-isarray-error-message.js
@@ -1,0 +1,25 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+var r = Proxy.revocable({}, {});
+r.revoke();
+
+shouldThrow(() => {
+    Array.isArray(r.proxy);
+}, `TypeError: Array.isArray cannot be called on a Proxy that has been revoked`);
+
+shouldThrow(() => {
+    Object.prototype.toString.call(r.proxy);
+}, `TypeError: Object.prototype.toString cannot be called on a Proxy that has been revoked`);

--- a/Source/JavaScriptCore/runtime/Intrinsic.cpp
+++ b/Source/JavaScriptCore/runtime/Intrinsic.cpp
@@ -169,6 +169,8 @@ const char* intrinsicName(Intrinsic intrinsic)
         return "ObjectIsIntrinsic";
     case ObjectKeysIntrinsic:
         return "ObjectKeysIntrinsic";
+    case ObjectToStringIntrinsic:
+        return "ObjectToStringIntrinsic";
     case ReflectGetPrototypeOfIntrinsic:
         return "ReflectGetPrototypeOfIntrinsic";
     case StringPrototypeCodePointAtIntrinsic:

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -100,6 +100,7 @@ enum Intrinsic : uint8_t {
     ObjectGetPrototypeOfIntrinsic,
     ObjectIsIntrinsic,
     ObjectKeysIntrinsic,
+    ObjectToStringIntrinsic,
     ReflectGetPrototypeOfIntrinsic,
     StringPrototypeCodePointAtIntrinsic,
     StringPrototypeValueOfIntrinsic,

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -802,7 +802,7 @@ void JSGlobalObject::init(VM& vm)
     m_functionPrototype->addFunctionProperties(vm, this, &callFunction, &applyFunction, &hasInstanceSymbolFunction);
     m_objectProtoToStringFunction.initLater(
         [] (const Initializer<JSFunction>& init) {
-            init.set(JSFunction::create(init.vm, init.owner, 0, init.vm.propertyNames->toString.string(), objectProtoFuncToString, ImplementationVisibility::Public));
+            init.set(JSFunction::create(init.vm, init.owner, 0, init.vm.propertyNames->toString.string(), objectProtoFuncToString, ImplementationVisibility::Public, ObjectToStringIntrinsic));
         });
     m_arrayProtoToStringFunction.initLater(
         [] (const Initializer<JSFunction>& init) {


### PR DESCRIPTION
#### 6797a0c13ebe0586517aa27b8d7bd7607f5f7863
<pre>
Fix error message for O.p.toString on revoked proxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=242342">https://bugs.webkit.org/show_bug.cgi?id=242342</a>

Reviewed by NOBODY (OOPS!).

* JSTests/stress/array-isarray-error-message.js: Added.
* Source/JavaScriptCore/runtime/ArrayConstructor.cpp:
* Source/JavaScriptCore/runtime/Intrinsic.cpp:
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
</pre>


























































<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6797a0c13ebe0586517aa27b8d7bd7607f5f7863

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95171 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148880 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28713 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25264 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78458 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90426 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23289 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73327 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23306 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66312 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78271 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26566 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12498 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/71893 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26475 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13510 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25723 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28151 "Hash 6797a0c1 for PR 3424 does not build") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36424 "Found 1 new test failure: media/media-source/media-source-seek-detach-crash.html") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/74675 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32791 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16518 "Passed tests") | 
<!--EWS-Status-Bubble-End-->