### PR TITLE
Use `[[no_unique_address]]` directly

### DIFF
--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -521,18 +521,6 @@
 #define IGNORE_NULL_CHECK_WARNINGS_BEGIN IGNORE_WARNINGS_BEGIN("nonnull")
 #define IGNORE_NULL_CHECK_WARNINGS_END IGNORE_WARNINGS_END
 
-/* NO_UNIQUE_ADDRESS */
-
-#if !defined(NO_UNIQUE_ADDRESS) && defined(__has_cpp_attribute)
-#if __has_cpp_attribute(no_unique_address)
-#define NO_UNIQUE_ADDRESS [[no_unique_address]] // NOLINT: check-webkit-style does not understand annotations.
-#endif
-#endif
-
-#if !defined(NO_UNIQUE_ADDRESS)
-#define NO_UNIQUE_ADDRESS
-#endif
-
 /* TLS_MODEL_INITIAL_EXEC */
 
 #if !defined(TLS_MODEL_INITIAL_EXEC) && defined(__has_attribute)

--- a/Source/WTF/wtf/ThreadAssertions.h
+++ b/Source/WTF/wtf/ThreadAssertions.h
@@ -43,7 +43,7 @@ namespace WTF {
 // private:
 //     void doTaskImpl() WTF_REQUIRES_CAPABILITY(m_ownerThread);
 //     int m_value WTF_GUARDED_BY_CAPABILITY(m_ownerThread) { 0 };
-//     NO_UNIQUE_ADDRESS ThreadAssertion m_ownerThread;
+//     [[no_unique_address]] ThreadAssertion m_ownerThread;
 // };
 class WTF_CAPABILITY("is current") ThreadAssertion {
 public:

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -94,7 +94,7 @@ private:
     std::unique_ptr<WebCore::LocalSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
     std::unique_ptr<LayerHostingContext> m_layerHostingContext;
     SharedVideoFrameReader m_sharedVideoFrameReader;
-    ThreadAssertion m_consumeThread NO_UNIQUE_ADDRESS;
+    ThreadAssertion m_consumeThread [[no_unique_address]];
 
 };
 


### PR DESCRIPTION
#### 8b2d5a3ec8ddfd750280558b6a588d64627f45a4
<pre>
Use `[[no_unique_address]]` directly
<a href="https://bugs.webkit.org/show_bug.cgi?id=244059">https://bugs.webkit.org/show_bug.cgi?id=244059</a>

Reviewed by NOBODY (OOPS!).

All of our supporting compilers now have C++20 [[no_unique_address]] feature. We should directly use it.

* Source/WTF/wtf/Compiler.h:
* Source/WTF/wtf/ThreadAssertions.h:
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h:
</pre>








































<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b2d5a3ec8ddfd750280558b6a588d64627f45a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86326 "failed 1 style error") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30247 "Hash 8b2d5a3e for PR 3426 does not build") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17297 "Hash 8b2d5a3e for PR 3426 does not build") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95173 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148883 "Built successfully and passed tests") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28610 "Hash 8b2d5a3e for PR 3426 does not build") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25266 "Hash 8b2d5a3e for PR 3426 does not build") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78460 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90428 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91926 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/64/builds/28610 "Hash 8b2d5a3e for PR 3426 does not build") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73329 "Hash 8b2d5a3e for PR 3426 does not build") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66311 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/64/builds/28610 "Hash 8b2d5a3e for PR 3426 does not build") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/17297 "Hash 8b2d5a3e for PR 3426 does not build") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26568 "Hash 8b2d5a3e for PR 3426 does not build") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/17297 "Hash 8b2d5a3e for PR 3426 does not build") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26478 "Hash 8b2d5a3e for PR 3426 does not build") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/17297 "Hash 8b2d5a3e for PR 3426 does not build") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28154 "Hash 8b2d5a3e for PR 3426 does not build") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/73329 "Hash 8b2d5a3e for PR 3426 does not build") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28093 "Hash 8b2d5a3e for PR 3426 does not build") | | | 
<!--EWS-Status-Bubble-End-->