### PR TITLE
Computed regions appear incorrect in fullscreen

### DIFF
--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -67,6 +67,10 @@
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #endif
 
+#if ENABLE(FULLSCREEN_API)
+#include "FullscreenManager.h"
+#endif
+
 namespace WebCore {
 namespace Style {
 
@@ -581,6 +585,10 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
             return true;
         if (hasInertAttribute(element))
             return true;
+#if ENABLE(FULLSCREEN_API)
+        if (m_document.fullscreenManager().fullscreenElement() && element == m_document.documentElement())
+            return true;
+#endif
         return false;
     };
     if (isInertSubtreeRoot(m_element))
@@ -590,6 +598,11 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
         // Make sure the active dialog is interactable when the whole document is blocked by the modal dialog
         if (m_element == m_document.activeModalDialog() && !hasInertAttribute(m_element))
             style.setEffectiveInert(false);
+
+#if ENABLE(FULLSCREEN_API)
+        if (m_element == m_document.fullscreenManager().fullscreenElement() && !hasInertAttribute(m_element))
+            style.setEffectiveInert(false);
+#endif
 
         style.setEventListenerRegionTypes(computeEventListenerRegionTypes(m_document, style, *m_element, m_parentStyle.eventListenerRegionTypes()));
 


### PR DESCRIPTION
#### c72a5407c8e91c7a3dec6815a922816423ccbfd4
<pre>
Computed regions appear incorrect in fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=244056">https://bugs.webkit.org/show_bug.cgi?id=244056</a>
&lt;rdar://97562328&gt;

Reviewed by Tim Nguyen.

When in fullscreen, only allow elements under the fullscreen
element to be non-inert. That effectively disables them
from interaction during fullscreen.

* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):

Canonical link: <a href="https://commits.webkit.org/253803@main">https://commits.webkit.org/253803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a39b1586a1ce93ddb6b19794421b6126c1364a31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96047 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149657 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29528 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25796 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91104 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23844 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73897 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79099 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27257 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12937 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27200 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13951 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2683 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36800 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28825 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33228 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->