### PR TITLE
Utilities for ANGLE should be guarded by USE(ANGLE) not ENABLE(WEBGL)

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "ANGLEUtilitiesCocoa.h"
 
-#if ENABLE(WEBGL)
+#if USE(ANGLE)
 #include "ANGLEHeaders.h"
 #include "ANGLEUtilities.h"
 #include "Logging.h"

--- a/Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(WEBGL)
+#if USE(ANGLE)
 
 #include "GraphicsTypesGL.h"
 


### PR DESCRIPTION
#### 3fe4b72d1b53723c4b560e782be2cbeac925cc34
<pre>
Utilities for ANGLE should be guarded by USE(ANGLE) not ENABLE(WEBGL)
<a href="https://bugs.webkit.org/show_bug.cgi?id=244070">https://bugs.webkit.org/show_bug.cgi?id=244070</a>
rdar://98809413

Reviewed by Tim Horton and Ryosuke Niwa.

* Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.cpp:
* Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.h:
ENABLE(WEBGL) -&gt; USE(ANGLE)

Canonical link: <a href="https://commits.webkit.org/253552@main">https://commits.webkit.org/253552@main</a>
</pre>










<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e33911bfc198ea7e4109407a631516b0a2d061c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95198 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148910 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28638 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78486 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90450 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23229 "Passed tests") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23325 "Passed tests") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66331 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26593 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26503 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13526 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2531 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28180 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32807 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->