### PR TITLE
Element code shouldn't know about the RenderListBox rendering

### DIFF
--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -35,6 +35,8 @@
 
 namespace WebCore {
 
+class HTMLOptGroupElement;
+class HTMLOptionElement;
 class HTMLSelectElement;
 
 class RenderListBox final : public RenderBlockFlow, public ScrollableArea {
@@ -49,8 +51,11 @@ public:
 
     void setOptionsChanged(bool changed) { m_optionsChanged = changed; }
 
-    int listIndexAtOffset(const LayoutSize&);
-    LayoutRect itemBoundingBoxRect(const LayoutPoint&, int index);
+    int listIndexAtOffset(const LayoutSize&) const;
+    LayoutRect itemBoundingBoxRect(const LayoutPoint&, int index) const;
+
+    std::optional<LayoutRect> localBoundsOfOption(const HTMLOptionElement&) const;
+    std::optional<LayoutRect> localBoundsOfOptGroup(const HTMLOptGroupElement&) const;
 
     bool scrollToRevealElementAtListIndex(int index);
     bool listIndexIsVisible(int index);
@@ -171,6 +176,9 @@ private:
     int numVisibleItems(ConsiderPadding = ConsiderPadding::No) const;
     int numItems() const;
     LayoutUnit listHeight() const;
+
+    std::optional<int> optionRowIndex(const HTMLOptionElement&) const;
+
     void paintScrollbar(PaintInfo&, const LayoutPoint&);
     void paintItemForeground(PaintInfo&, const LayoutPoint&, int listIndex);
     void paintItemBackground(PaintInfo&, const LayoutPoint&, int listIndex);


### PR DESCRIPTION
#### d270433c39ef19982598c6546b07f6dbbfde27e2
<pre>
Element code shouldn&apos;t know about the RenderListBox rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=244072">https://bugs.webkit.org/show_bug.cgi?id=244072</a>

Reviewed by Alan Bujtas.

Element::getClientRects() has some custom code for HTMLOptionElement and HTMLOptGroupElement
because they are special; they don&apos;t have their own renderers, but are draws as rows of the
RenderListBox. But Element code shouldn&apos;t know about the details of RenderListBox, so move
some code from listBoxElementBoundingBox() to RenderListBox.

* Source/WebCore/dom/Element.cpp:
(WebCore::listBoxElementBoundingBox):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::itemBoundingBoxRect const): Made const.
(WebCore::RenderListBox::optionRowIndex const): Helper that gets the row for an
&lt;option&gt;. This is not HTMLOptionElement::index(), because that only tracks &lt;option&gt;s,
yet &lt;optgroup&gt; elements have a header row. I believe the old code got this wrong.
(WebCore::RenderListBox::localBoundsOfOption const):
(WebCore::RenderListBox::localBoundsOfOptGroup const):
(WebCore::RenderListBox::listIndexAtOffset const): Made const
(WebCore::RenderListBox::itemBoundingBoxRect): Deleted.
(WebCore::RenderListBox::listIndexAtOffset): Deleted.
* Source/WebCore/rendering/RenderListBox.h:

Canonical link: <a href="https://commits.webkit.org/253563@main">https://commits.webkit.org/253563@main</a>
</pre>








<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f5f3833c67ef47ca1d9a4e3aef4fb652529f91c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17326 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95202 "Hash 3f5f3833 for PR 3436 does not build") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148914 "Found 2 new test failures: fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-inherit.html, fast/text/punctuation-break-all.html") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28642 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25291 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78491 "Hash 3f5f3833 for PR 3436 does not build") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90454 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91958 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23233 "Found 4 new test failures: editing/pasteboard/4944770-2.html, imported/w3c/web-platform-tests/FileAPI/url/sandboxed-iframe.html, imported/w3c/web-platform-tests/css/css-transforms/preserve3d-and-flattening-z-order-008.html, imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree.html") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/78491 "Hash 3f5f3833 for PR 3436 does not build") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/78491 "Hash 3f5f3833 for PR 3436 does not build") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26597 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12517 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26507 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13532 "Found 2 new test failures: imported/w3c/web-platform-tests/FileAPI/url/sandboxed-iframe.html, imported/w3c/web-platform-tests/css/css-transforms/transform-3d-rotateY-stair-below-001.xht") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2536 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28184 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32813 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->