### PR TITLE
color-scheme should not propagate to viewport background if set on <body>

### DIFF
--- a/LayoutTests/css-dark-mode/color-scheme-scrollbar-expected.txt
+++ b/LayoutTests/css-dark-mode/color-scheme-scrollbar-expected.txt
@@ -1,13 +1,13 @@
 
 PASS Set dark appearance
 PASS Set view to transparent
-PASS Body Element color scheme is light and dark
-PASS Document Element color scheme is auto
+PASS Document Element color scheme is light and dark
+PASS Body Element color scheme is light and dark (inherited from document element)
 PASS Document scrollbar overlay style is light
 PASS Document scrollbar is using dark appearance
 PASS Element scrollbar overlay style is default
 PASS Element scrollbar is using dark appearance
-PASS Set color scheme to light on the document element
+PASS Set color scheme to light on the document element, but to light/dark on body
 PASS Body Element color scheme is light and dark 2
 PASS Document Element color scheme is light
 PASS Document scrollbar overlay style is default

--- a/LayoutTests/css-dark-mode/color-scheme-scrollbar.html
+++ b/LayoutTests/css-dark-mode/color-scheme-scrollbar.html
@@ -4,7 +4,7 @@
 <script src="../resources/testharnessreport.js"></script>
 
 <style>
-body {
+:root {
     color-scheme: light dark;
 }
 
@@ -41,12 +41,12 @@ test(function() {
 }, "Set view to transparent");
 
 test(function() {
-    test_prop(document.body, "color-scheme", "light dark");
-}, "Body Element color scheme is light and dark");
+    test_prop(document.documentElement, "color-scheme", "light dark");
+}, "Document Element color scheme is light and dark");
 
 test(function() {
-    test_prop(document.documentElement, "color-scheme", "auto");
-}, "Document Element color scheme is auto");
+    test_prop(document.body, "color-scheme", "light dark");
+}, "Body Element color scheme is light and dark (inherited from document element)");
 
 test(function() {
     if (!window.internals)
@@ -74,9 +74,9 @@ test(function() {
 
 test(function() {
     let styleElement = document.createElement("style");
-    styleElement.textContent = ":root { color-scheme: light }";
+    styleElement.textContent = ":root { color-scheme: light } \n body { color-scheme: light dark; }";
     document.head.appendChild(styleElement);
-}, "Set color scheme to light on the document element");
+}, "Set color scheme to light on the document element, but to light/dark on body");
 
 test(function() {
     test_prop(document.body, "color-scheme", "light dark");

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -2073,8 +2073,7 @@ RenderObject* FrameView::rendererForColorScheme() const
     auto* documentElementRenderer = documentElement ? documentElement->renderer() : nullptr;
     if (documentElementRenderer && documentElementRenderer->style().hasExplicitlySetColorScheme())
         return documentElementRenderer;
-    auto* bodyElement = document ? document->bodyOrFrameset() : nullptr;
-    return bodyElement ? bodyElement->renderer() : nullptr;
+    return nullptr;
 }
 #endif
 


### PR DESCRIPTION
#### cbdcbdd4e8f1b5144374bef91ba9e45483f6072f
<pre>
color-scheme should not propagate to viewport background if set on &lt;body&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=243757">https://bugs.webkit.org/show_bug.cgi?id=243757</a>

Reviewed by Simon Fraser.

Change to web compatible behavior where setting the color-scheme on &lt;body&gt; no longer propagates it to &lt;html&gt; tag for scrollbar and
webpage background purposes. This change puts WebKit in-line with Gecko &amp; Blink.

* LayoutTests/css-dark-mode/color-scheme-scrollbar-expected.txt:
* LayoutTests/css-dark-mode/color-scheme-scrollbar.html:
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::rendererForColorScheme const):

Canonical link: <a href="https://commits.webkit.org/253565@main">https://commits.webkit.org/253565@main</a>
</pre>










<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cab2e637a9dcf5d7005d2e4a058f3da098b004e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95207 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148919 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90347 "Passed tests") | [✅ ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/64/builds/28728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25295 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78499 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90459 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23238 "Passed tests") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23337 "Passed tests") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78248 "Build was cancelled") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66342 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26602 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26512 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13538 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28189 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/980 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32819 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->