### PR TITLE
WorkerScriptLoader should match the SW registration in case its response is coming from the memory cache

### DIFF
--- a/LayoutTests/http/wpt/service-workers/controlled-dedicatedworker-memory-cache.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/controlled-dedicatedworker-memory-cache.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Verify first dedicated worker is not controlled
+PASS Register service worker
+PASS Verify memory-cache dedicated worker is controlled
+

--- a/LayoutTests/http/wpt/service-workers/controlled-dedicatedworker-memory-cache.https.html
+++ b/LayoutTests/http/wpt/service-workers/controlled-dedicatedworker-memory-cache.https.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+</head>
+<body>
+<script>
+promise_test(async (test) => {
+    worker = new Worker('resources/controlled-worker.js');
+    const event = await new Promise(resolve => worker.onmessage = resolve);
+    assert_false(event.data.isControlled);
+}, "Verify first dedicated worker is not controlled");
+
+promise_test(async (test) => {
+    const registration = await navigator.serviceWorker.register("skipFetchEvent-worker.js", { scope : 'resources' });
+    activeWorker = registration.active;
+    if (activeWorker)
+        return;
+
+    activeWorker = registration.installing;
+    await new Promise(resolve => {
+        activeWorker.addEventListener('statechange', () => {
+            if (activeWorker.state === "activated")
+                resolve();
+        });
+    });
+}, "Register service worker");
+
+promise_test(async (test) => {
+    worker = new Worker('resources/controlled-worker.js');
+    const event = await new Promise(resolve => worker.onmessage = resolve);
+    assert_true(event.data.isControlled);
+}, "Verify memory-cache dedicated worker is controlled");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/resources/controlled-worker.js.headers
+++ b/LayoutTests/http/wpt/service-workers/resources/controlled-worker.js.headers
@@ -1,0 +1,1 @@
+Cache-Control: max-age=3600

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1188,15 +1188,8 @@ static void logResourceRevalidationDecision(CachedResource::RevalidationDecision
 }
 
 #if ENABLE(SERVICE_WORKER)
-static inline bool mustReloadFromServiceWorkerOptions(Document* document, const ResourceLoaderOptions& options, const ResourceLoaderOptions& cachedOptions)
+static inline bool mustReloadFromServiceWorkerOptions(const ResourceLoaderOptions& options, const ResourceLoaderOptions& cachedOptions)
 {
-    // When Loading a worker script and there is an active service worker, it is important to bypass the memory cache for the fetching of the script. If we
-    // don't then the worker won't be controlled by the service worker and the loads from the worker won't be intercepted by the service worker.
-    if ((cachedOptions.destination == FetchOptions::Destination::Worker || cachedOptions.destination == FetchOptions::Destination::Sharedworker)
-        && options.serviceWorkersMode != ServiceWorkersMode::None && document && document->activeServiceWorker()) {
-        return true;
-    }
-
     // FIXME: We should validate/specify this behavior.
     if (options.serviceWorkerRegistrationIdentifier != cachedOptions.serviceWorkerRegistrationIdentifier)
         return true;
@@ -1222,7 +1215,7 @@ CachedResourceLoader::RevalidationPolicy CachedResourceLoader::determineRevalida
         return Reload;
 
 #if ENABLE(SERVICE_WORKER)
-    if (mustReloadFromServiceWorkerOptions(document(), cachedResourceRequest.options(), existingResource->options())) {
+    if (mustReloadFromServiceWorkerOptions(cachedResourceRequest.options(), existingResource->options())) {
         LOG(ResourceLoading, "CachedResourceLoader::determineRevalidationPolicy reloading because selected service worker may differ");
         return Reload;
     }

--- a/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/Source/WebCore/workers/WorkerScriptLoader.h
@@ -140,6 +140,8 @@ private:
     ResourceError m_error;
     ScriptExecutionContextIdentifier m_clientIdentifier;
 #if ENABLE(SERVICE_WORKER)
+    bool m_isMatchingServiceWorkerRegistration { false };
+    std::optional<SecurityOriginData> m_topOriginForServiceWorkerRegistration;
     std::optional<ServiceWorkerData> m_activeServiceWorkerData;
 #endif
     String m_userAgentForSharedWorker;


### PR DESCRIPTION
#### bf313f5b4e80e852a4b7d77d534700a292568431
<pre>
WorkerScriptLoader should match the SW registration in case its response is coming from the memory cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=244035">https://bugs.webkit.org/show_bug.cgi?id=244035</a>
rdar://problem/98784463

Reviewed by Chris Dumez.

Do in WorkerScriptLoader like done in DocumentLoader: when resource is loaded from memory cache, we do not know
whether the worker will be controlled. We ask network process to get the actual service worker information.
Remove the heuristic recently added since it was not covering all cases (in particular the case of a document that is not controlled).

Covered by added test.

* LayoutTests/http/wpt/service-workers/controlled-dedicatedworker-memory-cache.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/controlled-dedicatedworker-memory-cache.https.html: Added.
* LayoutTests/http/wpt/service-workers/resources/controlled-worker.js.headers: Added.
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::mustReloadFromServiceWorkerOptions):
(WebCore::CachedResourceLoader::determineRevalidationPolicy const):
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::loadAsynchronously):
(WebCore::WorkerScriptLoader::didReceiveResponse):
(WebCore::WorkerScriptLoader::notifyFinished):
* Source/WebCore/workers/WorkerScriptLoader.h:

Canonical link: <a href="https://commits.webkit.org/253592@main">https://commits.webkit.org/253592@main</a>
</pre>


















<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf2674594e3b83291ab708c42055051e841e6153

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95319 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149031 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28802 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78640 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90561 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92086 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/23423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/66427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26703 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26617 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13616 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2560 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28296 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28237 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32899 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->