### PR TITLE
Cleanup directionality code

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -1493,25 +1493,17 @@ bool equalIgnoringASCIICaseNonNull(const StringImpl* a, const StringImpl* b)
     return equalIgnoringASCIICase(*a, *b);
 }
 
-UCharDirection StringImpl::defaultWritingDirection(bool* hasStrongDirectionality)
+std::optional<UCharDirection> StringImpl::defaultWritingDirection()
 {
     for (auto codePoint : StringView(this).codePoints()) {
         auto charDirection = u_charDirection(codePoint);
-        if (charDirection == U_LEFT_TO_RIGHT) {
-            if (hasStrongDirectionality)
-                *hasStrongDirectionality = true;
+        if (charDirection == U_LEFT_TO_RIGHT)
             return U_LEFT_TO_RIGHT;
-        }
         if (charDirection == U_RIGHT_TO_LEFT || charDirection == U_RIGHT_TO_LEFT_ARABIC) {
-            if (hasStrongDirectionality)
-                *hasStrongDirectionality = true;
             return U_RIGHT_TO_LEFT;
         }
     }
-
-    if (hasStrongDirectionality)
-        *hasStrongDirectionality = false;
-    return U_LEFT_TO_RIGHT;
+    return std::nullopt;
 }
 
 Ref<StringImpl> StringImpl::adopt(StringBuffer<LChar>&& buffer)

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -475,7 +475,7 @@ public:
     WTF_EXPORT_PRIVATE Ref<StringImpl> replace(StringView, StringView);
     WTF_EXPORT_PRIVATE Ref<StringImpl> replace(unsigned start, unsigned length, StringView);
 
-    WTF_EXPORT_PRIVATE UCharDirection defaultWritingDirection(bool* hasStrongDirectionality = nullptr);
+    WTF_EXPORT_PRIVATE std::optional<UCharDirection> defaultWritingDirection();
 
 #if USE(CF)
     RetainPtr<CFStringRef> createCFString();

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -300,7 +300,7 @@ public:
     WTF_EXPORT_PRIVATE static String fromCodePoint(UChar32 codePoint);
 
     // Determines the writing direction using the Unicode Bidi Algorithm rules P2 and P3.
-    UCharDirection defaultWritingDirection(bool* hasStrongDirectionality = nullptr) const;
+    std::optional<UCharDirection> defaultWritingDirection() const;
 
     bool isAllASCII() const { return !m_impl || m_impl->isAllASCII(); }
     bool isAllLatin1() const { return !m_impl || m_impl->isAllLatin1(); }
@@ -497,13 +497,11 @@ template<size_t inlineCapacity> inline String String::make8BitFrom16BitSource(co
     return make8BitFrom16BitSource(buffer.data(), buffer.size());
 }
 
-inline UCharDirection String::defaultWritingDirection(bool* hasStrongDirectionality) const
+inline std::optional<UCharDirection> String::defaultWritingDirection() const
 {
     if (m_impl)
-        return m_impl->defaultWritingDirection(hasStrongDirectionality);
-    if (hasStrongDirectionality)
-        *hasStrongDirectionality = false;
-    return U_LEFT_TO_RIGHT;
+        return m_impl->defaultWritingDirection();
+    return std::nullopt;
 }
 
 inline void String::clearImplIfNotShared()

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -90,7 +90,8 @@ public:
 
     TextDirection computeDirectionality() const;
     bool hasDirectionAuto() const;
-    TextDirection directionalityIfhasDirAutoAttribute(bool& isAuto) const;
+
+    std::optional<TextDirection> directionalityIfDirIsAuto() const;
 
     virtual bool isTextControlInnerTextElement() const { return false; }
     virtual bool isSearchFieldResultsButtonElement() const { return false; }
@@ -181,7 +182,12 @@ private:
     void dirAttributeChanged(const AtomString&);
     void adjustDirectionalityIfNeededAfterChildAttributeChanged(Element* child);
     void adjustDirectionalityIfNeededAfterChildrenChanged(Element* beforeChange, ChildChange::Type);
-    TextDirection directionality(Node** strongDirectionalityTextNode= 0) const;
+
+    struct TextDirectionWithStrongDirectionalityNode {
+        TextDirection direction;
+        RefPtr<Node> strongDirectionalityNode;
+    };
+    TextDirectionWithStrongDirectionalityNode directionality() const;
 
     enum class AllowPercentage : bool { No, Yes };
     enum class UseCSSPXAsUnitType : bool { No, Yes };

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -821,10 +821,8 @@ String HTMLTextFormControlElement::directionForFormData() const
                 return TextDirection::RTL;
             if (equalLettersIgnoringASCIICase(value, "ltr"_s))
                 return TextDirection::LTR;
-            if (equalLettersIgnoringASCIICase(value, "auto"_s)) {
-                bool isAuto;
-                return element.directionalityIfhasDirAutoAttribute(isAuto);
-            }
+            if (equalLettersIgnoringASCIICase(value, "auto"_s))
+                return element.directionalityIfDirIsAuto().value();
         }
         return TextDirection::LTR;
     }();

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -813,8 +813,7 @@ void InputType::setValue(const String& sanitizedValue, bool valueChanged, TextFi
     bool wasInRange = isInRange(element()->value());
     bool inRange = isInRange(sanitizedValue);
 
-    bool dummy;
-    auto oldDirection = element()->directionalityIfhasDirAutoAttribute(dummy);
+    auto oldDirection = element()->directionalityIfDirIsAuto();
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (wasInRange != inRange)
@@ -822,7 +821,7 @@ void InputType::setValue(const String& sanitizedValue, bool valueChanged, TextFi
 
     element()->setValueInternal(sanitizedValue, eventBehavior);
 
-    if (oldDirection != element()->directionalityIfhasDirAutoAttribute(dummy))
+    if (oldDirection.value_or(TextDirection::LTR) != element()->directionalityIfDirIsAuto().value_or(TextDirection::LTR))
         element()->invalidateStyleInternal();
 
     switch (eventBehavior) {

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -595,10 +595,9 @@ void ElementRuleCollector::matchAllRules(bool matchAuthorAndUserStyles, bool inc
         addElementStyleProperties(styledElement.additionalPresentationalHintStyle(), RuleSet::cascadeLayerPriorityForPresentationalHints);
 
         if (is<HTMLElement>(styledElement)) {
-            bool isAuto;
-            auto textDirection = downcast<HTMLElement>(styledElement).directionalityIfhasDirAutoAttribute(isAuto);
-            auto& properties = textDirection == TextDirection::LTR ? leftToRightDeclaration() : rightToLeftDeclaration();
-            if (isAuto)
+            auto result = downcast<HTMLElement>(styledElement).directionalityIfDirIsAuto();
+            auto& properties = result.value_or(TextDirection::LTR) == TextDirection::LTR ? leftToRightDeclaration() : rightToLeftDeclaration();
+            if (result)
                 addMatchedProperties({ &properties }, DeclarationOrigin::Author);
         }
     }


### PR DESCRIPTION
#### 2622f839cafe16caaca28a445723699c3e7607b3
<pre>
Cleanup directionality code
<a href="https://bugs.webkit.org/show_bug.cgi?id=244076">https://bugs.webkit.org/show_bug.cgi?id=244076</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::defaultWritingDirection): Made this function return std::optional&lt;UCharDirection&gt;
instead of taking an out argument.
* Source/WTF/wtf/text/StringImpl.h:

* Source/WTF/wtf/text/WTFString.h:
(WTF::String::defaultWritingDirection const): Ditto.

* Source/WebCore/html/HTMLElement.cpp:
(WebCore::isLTROrRTLIgnoringCase): Deleted.
(WebCore::HTMLElement::collectPresentationalHintsForAttribute):
(WebCore::HTMLElement::computeDirectionality const):
(WebCore::HTMLElement::directionalityIfDirIsAuto const): Renamed from directionalityIfhasDirAutoAttribute.
This function now returns TextDirectionAutoResult instead of taking a boolean out argument.
(WebCore::HTMLElement::directionality const): Now returns TextDirectionWithStrongDirectionalityNode
instead of taking pointer to Node* as an out argument.
(WebCore::HTMLElement::adjustDirectionalityIfNeededAfterChildAttributeChanged):
(WebCore::HTMLElement::calculateAndAdjustDirectionality):

* Source/WebCore/html/HTMLElement.h:
(WebCore::HTMLElement::TextDirectionWithStrongDirectionalityNode):

* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::directionForFormData const):

* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::setValue):

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::matchAllRules):

Canonical link: <a href="https://commits.webkit.org/253589@main">https://commits.webkit.org/253589@main</a>
</pre>













<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cc502ca5ac40b1feb251e67fada7c23fb2671f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95292 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149001 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28765 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78599 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90535 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92061 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23397 "Passed tests") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66401 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78382 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26678 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72017 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26592 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13604 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25742 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28271 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/74798 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/986 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28211 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32887 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16539 "Passed tests") | 
<!--EWS-Status-Bubble-End-->