### PR TITLE
PseudoElement should use WeakPtr<Element> instead of Element*

### DIFF
--- a/Source/WebCore/dom/PseudoElement.cpp
+++ b/Source/WebCore/dom/PseudoElement.cpp
@@ -49,7 +49,7 @@ const QualifiedName& pseudoElementTagName()
 
 PseudoElement::PseudoElement(Element& host, PseudoId pseudoId)
     : Element(pseudoElementTagName(), host.document(), CreatePseudoElement)
-    , m_hostElement(&host)
+    , m_hostElement(host)
     , m_pseudoId(pseudoId)
 {
     ASSERT(pseudoId == PseudoId::Before || pseudoId == PseudoId::After);
@@ -75,7 +75,7 @@ void PseudoElement::clearHostElement()
     InspectorInstrumentation::pseudoElementDestroyed(document().page(), *this);
 
     Styleable::fromElement(*this).elementWasRemoved();
-    
+
     m_hostElement = nullptr;
 }
 
@@ -84,8 +84,8 @@ bool PseudoElement::rendererIsNeeded(const RenderStyle& style)
     if (pseudoElementRendererIsNeeded(&style))
         return true;
 
-    if (m_hostElement) {
-        if (auto* stack = m_hostElement->keyframeEffectStack(pseudoId()))
+    if (RefPtr element = m_hostElement.get()) {
+        if (auto* stack = element->keyframeEffectStack(pseudoId()))
             return stack->requiresPseudoElement();
     }
     return false;

--- a/Source/WebCore/dom/PseudoElement.h
+++ b/Source/WebCore/dom/PseudoElement.h
@@ -37,7 +37,7 @@ public:
     static Ref<PseudoElement> create(Element& host, PseudoId);
     virtual ~PseudoElement();
 
-    Element* hostElement() const { return m_hostElement; }
+    Element* hostElement() const { return m_hostElement.get(); }
     void clearHostElement();
 
     bool rendererIsNeeded(const RenderStyle&) override;
@@ -50,7 +50,7 @@ private:
 
     PseudoId customPseudoId() const override { return m_pseudoId; }
 
-    Element* m_hostElement;
+    WeakPtr<Element> m_hostElement;
     PseudoId m_pseudoId;
 };
 


### PR DESCRIPTION
#### c2adf3f6626d27dce1a56abb8fdf86706164698d
<pre>
PseudoElement should use WeakPtr&lt;Element&gt; instead of Element*
<a href="https://bugs.webkit.org/show_bug.cgi?id=244080">https://bugs.webkit.org/show_bug.cgi?id=244080</a>

Reviewed by Chris Dumez.

* Source/WebCore/dom/PseudoElement.cpp:
(WebCore::PseudoElement::PseudoElement):
(WebCore::PseudoElement::clearHostElement):
(WebCore::PseudoElement::rendererIsNeeded):
* Source/WebCore/dom/PseudoElement.h:

Canonical link: <a href="https://commits.webkit.org/253571@main">https://commits.webkit.org/253571@main</a>
</pre>










<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3289c938dfc6250efa6a490f5dfa748bdbb2239

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95225 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148935 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28730 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25301 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78527 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90471 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91980 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23341 "Passed tests") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66346 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26614 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26527 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13552 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28205 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/984 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32833 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->