### PR TITLE
[WebGL] Allow GCGLSpan to be assigned.

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsTypesGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsTypesGL.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/ArrayBufferView.h>
 #include <cstdint>
 #include <limits>
 #include <type_traits>
@@ -118,10 +119,13 @@ struct GCGLSpan<T, gcGLSpanDynamicExtent> {
         : data(array.data())
         , bufSize(array.size())
     { }
+    GCGLSpan(const ArrayBufferView& view)
+        : GCGLSpan(view.baseAddress(), view.byteLength())
+    { }
     T& operator[](size_t i) { RELEASE_ASSERT(data && i < bufSize); return data[i]; }
     T& operator*() { RELEASE_ASSERT(data && bufSize); return *data; }
     T* data;
-    const size_t bufSize;
+    size_t bufSize;
 };
 
 template<>
@@ -145,8 +149,11 @@ struct GCGLSpan<GCGLvoid> {
         : data(array.data())
         , bufSize(array.size() * sizeof(U))
     { }
+    GCGLSpan(const ArrayBufferView& view)
+        : GCGLSpan(view.baseAddress(), view.byteLength())
+    { }
     GCGLvoid* data;
-    const size_t bufSize;
+    size_t bufSize;
 };
 
 template<>
@@ -169,8 +176,11 @@ struct GCGLSpan<const GCGLvoid> {
         : data(other.data)
         , bufSize(other.bufSize * sizeof(U))
     { }
+    GCGLSpan(const ArrayBufferView& view)
+        : GCGLSpan(view.baseAddress(), view.byteLength())
+    { }
     const GCGLvoid* data;
-    const size_t bufSize;
+    size_t bufSize;
 };
 
 template<typename T, size_t N>


### PR DESCRIPTION
#### b237a7c11f6ff9bca0c5d601dce2ebbef4b2ecc7
<pre>
[WebGL] Allow GCGLSpan to be assigned.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244078">https://bugs.webkit.org/show_bug.cgi?id=244078</a>
rdar://problem/98818853

Reviewed by Kimmo Kinnunen.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSourceHelper):
(WebCore::WebGLRenderingContextBase::texImageImpl): Remove the std::optional
wrapping of GCGLSpan now that GCGLSpan is assignable.
* Source/WebCore/platform/graphics/GraphicsTypesGL.h:
(GCGLSpan&lt;GCGLvoid&gt;::GCGLSpan): Implement assignment operator for GCGLSpan. This
neccessitates removing the const on bufSize member.

Canonical link: <a href="https://commits.webkit.org/253574@main">https://commits.webkit.org/253574@main</a>
</pre>









<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8485220c7fb6959aa4ea5f79d1e8445ebf637da3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95235 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148943 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28738 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25306 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78536 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90479 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91988 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23347 "Passed tests") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66352 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26622 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26535 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13555 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2544 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28213 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32836 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->