### PR TITLE
[GStreamer] Fix WebRTC build.......

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp
@@ -43,7 +43,7 @@ bool GStreamerDTMFSenderBackend::canInsertDTMF()
     return false;
 }
 
-void GStreamerDTMFSenderBackend::playTone(const String&, size_t, size_t)
+void GStreamerDTMFSenderBackend::playTone(const char, size_t, size_t)
 {
     notImplemented();
 }
@@ -66,7 +66,7 @@ size_t GStreamerDTMFSenderBackend::interToneGap() const
     return 0;
 }
 
-void GStreamerDTMFSenderBackend::onTonePlayed(Function<void(const String&)>&& onTonePlayed)
+void GStreamerDTMFSenderBackend::onTonePlayed(Function<void()>&& onTonePlayed)
 {
     m_onTonePlayed = WTFMove(onTonePlayed);
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.h
@@ -36,13 +36,13 @@ public:
 private:
     // RTCDTMFSenderBackend
     bool canInsertDTMF() final;
-    void playTone(const String& tone, size_t duration, size_t interToneGap) final;
-    void onTonePlayed(Function<void(const String&)>&&) final;
+    void playTone(const char tone, size_t duration, size_t interToneGap) final;
+    void onTonePlayed(Function<void()>&&) final;
     String tones() const final;
     size_t duration() const final;
     size_t interToneGap() const final;
 
-    Function<void(const String&)> m_onTonePlayed;
+    Function<void()> m_onTonePlayed;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### ea7115eaf77664280685e3bcb0571912194342f1
<pre>
[GStreamer] Fix WebRTC build.......
<a href="https://bugs.webkit.org/show_bug.cgi?id=244082">https://bugs.webkit.org/show_bug.cgi?id=244082</a>

Unreviewed.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp:
(WebCore::GStreamerDTMFSenderBackend::playTone):
(WebCore::GStreamerDTMFSenderBackend::onTonePlayed):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.h:

Canonical link: <a href="https://commits.webkit.org/253555@main">https://commits.webkit.org/253555@main</a>
</pre>
























<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdd7f060b3d9430c2e177264b1380b6ab70a77f9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30305 "Built successfully") | [✅ ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/95233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/148941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28670 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/90477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91986 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/78534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26620 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26533 "Built successfully") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28211 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/974 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28151 "Built successfully") | [✅ ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->