### PR TITLE
[Alternate WebM Player] Lots of crackling noises can be heard with file when player is enabled.

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
@@ -161,7 +161,7 @@ public:
             m_processedMediaSamples = { };
         }
 
-        void reset()
+        virtual void reset()
         {
             resetCompletedFramesState();
             m_completePacketSize = std::nullopt;
@@ -240,12 +240,16 @@ public:
 
     private:
         webm::Status consumeFrameData(webm::Reader&, const webm::FrameMetadata&, uint64_t*, const MediaTime&) final;
+        void reset() final;
         void resetCompletedFramesState() final;
         const char* logClassName() const { return "AudioTrackData"; }
 
         MediaTime m_packetDuration;
         uint8_t m_framesPerPacket { 0 };
         Seconds m_frameDuration { 0_s };
+        size_t m_frames { 0 };
+        bool m_inBlock { false };
+        MediaTime m_lastFrameTime { MediaTime::invalidTime() };
         size_t mNumFramesInCompleteBlock { 0 };
     };
 


### PR DESCRIPTION
#### 97d8051840a4179f12b2df15d5a85f0e1c23515e
<pre>
[Alternate WebM Player] Lots of crackling noises can be heard with file when player is enabled.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242678">https://bugs.webkit.org/show_bug.cgi?id=242678</a>
&lt;rdar://96935878&gt;

Reviewed by NOBODY (OOPS!).

This changes fixes to existing issues in the webm parser:
1- A WebM block can contain multiple frames, which would have
   made all of them have the same time
2- If the container using times using a different timescale than the content,
   apparent overlap due to rounding errors can appear.

For 1, we now accrue the number of frames parsed to properly determine the
actual presentation time of the frame within the block.
For 2, we check of the gap between the real end time of a frame (calculated from
the number of frames parsed and the content sampling rate) and the new block&apos;s time.
If the gap is smaller than the smallest value possible in the container&apos;s timescale,
we ignore the container&apos;s timestamp and calculate them ourselves from the actual content.

Samples exhibiting both issues are using the vorbis decoder which isn&apos;t available on
The EWS machines, making automatic testing difficult ; so tested manually.

* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::resetState):
(WebCore::WebMParser::reset):
(WebCore::WebMParser::AudioTrackData::reset):
(WebCore::WebMParser::AudioTrackData::consumeFrameData):
(WebCore::SourceBufferParserWebM::setLogger):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:
(WebCore::WebMParser::TrackData::reset):
</pre>











































<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97d8051840a4179f12b2df15d5a85f0e1c23515e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95626 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149378 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29236 "Built successfully") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25613 "failed Failed to checkout and rebase branch from PR 3449") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78955 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90861 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23608 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73683 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23650 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66655 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26998 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12774 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26920 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13788 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36654 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28548 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33067 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->