### PR TITLE
[ews] Add Github status-bubbles for various jsc and gtk-wk2 queues

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -191,12 +191,12 @@ class GitHubEWS(GitHub):
     STATUS_BUBBLE_END = u'<!--EWS-Status-Bubble-End-->'
     STATUS_BUBBLE_ROWS = [['style', 'ios', 'mac', 'wpe', 'win'],  # FIXME: generate this list dynamically to have merge queue show up on top
                           ['bindings', 'ios-sim', 'mac-debug', 'gtk', 'wincairo'],
-                          ['webkitperl', 'ios-wk2', 'mac-AS-debug', 'api-gtk', ''],
-                          ['webkitpy', 'api-ios', 'api-mac', '', ''],
-                          ['services', 'tv', 'mac-wk1', '', ''],
-                          ['merge', 'tv-sim', 'mac-wk2', '', ''],
-                          ['unsafe-merge', 'watch', 'mac-AS-debug-wk2', '', ''],
-                          ['', 'watch-sim', '', '', '']]
+                          ['webkitperl', 'ios-wk2', 'mac-AS-debug', 'gtk-wk2', ''],
+                          ['webkitpy', 'api-ios', 'api-mac', 'api-gtk', ''],
+                          ['jsc', 'tv', 'mac-wk1', 'jsc-armv7', ''],
+                          ['services', 'tv-sim', 'mac-wk2', 'jsc-armv7-tests', ''],
+                          ['merge', 'watch', 'mac-AS-debug-wk2', 'jsc-mips', ''],
+                          ['unsafe-merge', 'watch-sim', 'mac-wk2-stress', 'jsc-mips-tests', '']]
 
     @classmethod
     def generate_updated_pr_description(self, description, ews_comment):


### PR DESCRIPTION
#### 8acf264abcb18e27b30e6c53305eec160ab30ac3
<pre>
[ews] Add Github status-bubbles for various jsc and gtk-wk2 queues
<a href="https://bugs.webkit.org/show_bug.cgi?id=244085">https://bugs.webkit.org/show_bug.cgi?id=244085</a>

Reviewed by Jonathan Bedard.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS):

Canonical link: <a href="https://commits.webkit.org/253561@main">https://commits.webkit.org/253561@main</a>
</pre>





















<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/058d118089e1964ae2fb49e4cb0cc2bb187e6be1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95253 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148961 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90388 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28690 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78557 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90497 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92006 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/23361 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/66367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26640 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26553 "Built successfully") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/13570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28231 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/979 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28171 "Built successfully") | [✅ ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/32853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->