### PR TITLE
REGRESSION(253424@main): [ iOS ] fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-readonly.html is a constant failure

### DIFF
--- a/LayoutTests/fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-readonly-expected.html
+++ b/LayoutTests/fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-readonly-expected.html
@@ -2,6 +2,6 @@
 <html>
 <body>
 <p>This tests that the AutoFill button does not render when the field becomes read only.</p>
-<input type="password" id="password" readonly style="width: 100px; margin: 0;">
+<input type="password" id="password" readonly style="width: 100px; margin: 5px;">
 </body>
 </html>

--- a/LayoutTests/fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-readonly.html
+++ b/LayoutTests/fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-readonly.html
@@ -2,7 +2,7 @@
 <html>
 <body>
 <p>This tests that the AutoFill button does not render when the field becomes read only.</p>
-<input type="password" id="password" style="width: 100px; margin: 0;">
+<input type="password" id="password" style="width: 100px; margin: 5px;">
 <script>
 if (window.testRunner)
     testRunner.waitUntilDone();

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3724,8 +3724,6 @@ imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of
 webkit.org/b/241095 imported/w3c/web-platform-tests/css/css-ui/appearance-textfield-001.html [ ImageOnlyFailure ]
 webkit.org/b/241095 imported/w3c/web-platform-tests/css/css-ui/webkit-appearance-textfield-001.html [ ImageOnlyFailure ]
 
-webkit.org/b/244065 fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-readonly.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/244134 animations/no-style-recalc-during-accelerated-animation.html [ Pass Failure ]
 webkit.org/b/244134 animations/steps-transform-rendering-updates.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 507d0ea1f4c92b006946f3334df115cc86970bf5
<pre>
REGRESSION(253424@main): [ iOS ] fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-readonly.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244065">https://bugs.webkit.org/show_bug.cgi?id=244065</a>
&lt;rdar://98804440&gt;

Reviewed by Aditya Keerthi.

* LayoutTests/fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-readonly-expected.html:
* LayoutTests/fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-readonly.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253696@main">https://commits.webkit.org/253696@main</a>
</pre>






<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca15a5f938164a6c226fc7c23dcc27ab8f89659c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30910 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95664 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149416 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29275 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90898 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23642 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23675 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66680 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27036 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26958 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2624 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28642 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28586 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->