### PR TITLE
Add debugging visualization for overlay regions

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -555,11 +555,36 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
 #endif // HAVE(PEPPER_UI_CORE)
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+static void addDebugOverlays(CALayer *layer, const Vector<CGRect>& overlayRegions)
+{
+    NSString *overlayDebugKey = @"WKOverlayRegionDebugFill";
+    if (![[NSUserDefaults standardUserDefaults] boolForKey:overlayDebugKey])
+        return;
+
+    Vector<CALayer *> layersToRemove;
+    for (CALayer *sublayer in layer.sublayers) {
+        if ([sublayer valueForKey:overlayDebugKey])
+            layersToRemove.append(sublayer);
+    }
+
+    for (CALayer *sublayer : layersToRemove)
+        [sublayer removeFromSuperlayer];
+
+    for (CGRect rect : overlayRegions) {
+        auto debugLayer = adoptNS([[CALayer alloc] init]);
+        [debugLayer setFrame:rect];
+        [debugLayer setBackgroundColor:WebCore::cachedCGColor({ WebCore::SRGBA<float>(1, 0, 0, .3) }).get()];
+        [debugLayer setValue:@YES forKey:overlayDebugKey];
+        [layer addSublayer:debugLayer.get()];
+    }
+}
+
 - (bool)_updateOverlayRegions:(const Vector<CGRect> &)overlayRegions
 {
     if (_overlayRegions == overlayRegions)
         return false;
 
+    addDebugOverlays(_internalDelegate.layer, overlayRegions);
     [self willChangeValueForKey:@"overlayRegions"];
     _overlayRegions = overlayRegions;
     [self didChangeValueForKey:@"overlayRegions"];


### PR DESCRIPTION
#### 321418df5a19145978600edb29f6dbd7ac239e11
<pre>
Add debugging visualization for overlay regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=244094">https://bugs.webkit.org/show_bug.cgi?id=244094</a>
&lt;rdar://98837141&gt;

Reviewed by Tim Horton.

Add debugging visualization for overlay regions.

* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(addDebugOverlays):
(-[WKScrollView _updateOverlayRegions:]):

Canonical link: <a href="https://commits.webkit.org/253600@main">https://commits.webkit.org/253600@main</a>
</pre>



<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bf605202ef7744fc0a42d07f020c611959d7c13

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95261 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28698 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25326 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78565 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90505 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23276 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73394 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23368 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78288 "Passed tests") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66374 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26647 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12570 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26561 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13574 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2565 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36478 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32857 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->