### PR TITLE
NetworkCache uses URL instead of URI as a part of caching key

### DIFF
--- a/LayoutTests/http/tests/cache/disk-cache/disk-cache-fragments-expected.txt
+++ b/LayoutTests/http/tests/cache/disk-cache/disk-cache-fragments-expected.txt
@@ -1,0 +1,23 @@
+Test that URLs with different fragments should be cached.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+running 1 tests
+
+--------Testing loads from disk cache--------
+response headers: {"Cache-control":"max-age=100"}
+response source: Disk cache
+
+--------Testing loads through memory cache (XHR behavior)--------
+response headers: {"Cache-control":"max-age=100"}
+response source: Memory cache
+
+--------Testing loads through memory cache (subresource behavior)--------
+response headers: {"Cache-control":"max-age=100"}
+response source: Memory cache
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/cache/disk-cache/disk-cache-fragments.html
+++ b/LayoutTests/http/tests/cache/disk-cache/disk-cache-fragments.html
@@ -1,0 +1,23 @@
+<script src="/js-test-resources/js-test-pre.js"></script>
+<script src="resources/cache-test.js"></script>
+<body>
+<script>
+
+var testMatrix =
+[
+ [
+  { responseHeaders: { 'Cache-control': 'max-age=100' } },
+  ],
+];
+
+description("Test that URLs with different fragments should be cached.");
+
+var tests = generateTests(testMatrix);
+debug("running " + tests.length + " tests");
+debug("");
+
+requireFragment(tests);
+runTests(tests);
+
+</script>
+<script src="/js-test-resources/js-test-post.js"></script>

--- a/LayoutTests/http/tests/cache/disk-cache/resources/cache-test.js
+++ b/LayoutTests/http/tests/cache/disk-cache/resources/cache-test.js
@@ -58,10 +58,25 @@ function generateTestURL(test)
     return testURL;
 }
 
+function requireFragment(tests) {
+    for (var i = 0; i < tests.length; ++i) {
+        tests[i].fragment = true;
+    }
+}
+
+function addFragmentToURL(testURL) {
+    testURL = testURL.split("#")[0];
+    testURL += "#" + Math.floor((Math.random() * 1000000000000));
+    return testURL;
+}
+
 function loadResource(test, onload)
 {
     if (!test.url)
         test.url = generateTestURL(test);
+
+    if (test.fragment)
+        test.url = addFragmentToURL(test.url);
 
     test.xhr = new XMLHttpRequest();
     test.xhr.onload = onload;

--- a/LayoutTests/http/tests/inspector/network/local-resource-override-basic-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/local-resource-override-basic-expected.txt
@@ -79,7 +79,7 @@ Content: PASS
 Creating Local Resource Override for: http://127.0.0.1:8000/inspector/network/resources/override.txt
 Triggering load...
 Resource Loaded:
-URL: http://127.0.0.1:8000/inspector/network/resources/override.txt#frag
+URL: http://127.0.0.1:8000/inspector/network/resources/override.txt
 MIME Type: text/plain
 Status: 200 OK
 Response Source: Symbol(inspector-override)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -156,7 +156,7 @@ Key Cache::makeCacheKey(const WebCore::ResourceRequest& request)
     // FIXME: This implements minimal Range header disk cache support. We don't parse
     // ranges so only the same exact range request will be served from the cache.
     String range = request.httpHeaderField(WebCore::HTTPHeaderName::Range);
-    return { request.cachePartition(), resourceType(), range, request.url().string(), m_storage->salt() };
+    return { request.cachePartition(), resourceType(), range, request.url().stringWithoutFragmentIdentifier(), m_storage->salt() };
 }
 
 static bool cachePolicyAllowsExpired(WebCore::ResourceRequestCachePolicy policy)
@@ -367,7 +367,7 @@ void Cache::retrieve(const WebCore::ResourceRequest& request, const GlobalFrameI
 {
     ASSERT(request.url().protocolIsInHTTPFamily());
 
-    LOG(NetworkCache, "(NetworkProcess) retrieving %s priority %d", request.url().string().ascii().data(), static_cast<int>(request.priority()));
+    LOG(NetworkCache, "(NetworkProcess) retrieving %s priority %d", request.url().stringWithoutFragmentIdentifier().ascii().data(), static_cast<int>(request.priority()));
 
     Key storageKey = makeCacheKey(request);
     auto priority = static_cast<unsigned>(request.priority());
@@ -466,7 +466,7 @@ std::unique_ptr<Entry> Cache::store(const WebCore::ResourceRequest& request, con
 {
     ASSERT(responseData);
 
-    LOG(NetworkCache, "(NetworkProcess) storing %s, partition %s", request.url().string().latin1().data(), makeCacheKey(request).partition().latin1().data());
+    LOG(NetworkCache, "(NetworkProcess) storing %s, partition %s", request.url().stringWithoutFragmentIdentifier().latin1().data(), makeCacheKey(request).partition().latin1().data());
 
     StoreDecision storeDecision = makeStoreDecision(request, response, responseData ? responseData->size() : 0);
     if (storeDecision != StoreDecision::Yes) {


### PR DESCRIPTION
#### d62692ae68ab0d2c11d038b640ae032eeab64faf
<pre>
NetworkCache uses URL instead of URI as a part of caching key
<a href="https://bugs.webkit.org/show_bug.cgi?id=244000">https://bugs.webkit.org/show_bug.cgi?id=244000</a>

Reviewed by Alex Christensen.

Per [1], the key is composed of, at a minimum, the request method and target URI.
But in NetworkCache, Cache::makeCacheKey uses URL as a part of key instead. This patch
uses url().stringWithoutFragmentIdentifier() instead of url() as a part of the key.

[1] <a href="https://httpwg.org/specs/rfc9111.html#caching.overview">https://httpwg.org/specs/rfc9111.html#caching.overview</a>

* LayoutTests/http/tests/cache/disk-cache/disk-cache-fragments-expected.txt: Added.
* LayoutTests/http/tests/cache/disk-cache/disk-cache-fragments.html: Added.
* LayoutTests/http/tests/cache/disk-cache/resources/cache-test.js:
(requireFragment):
(addFragmentToURL):
(loadResource):
* LayoutTests/http/tests/inspector/network/local-resource-override-basic-expected.txt:
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::makeCacheKey):
(WebKit::NetworkCache::Cache::retrieve):
(WebKit::NetworkCache::Cache::store):

Canonical link: <a href="https://commits.webkit.org/253567@main">https://commits.webkit.org/253567@main</a>
</pre>















<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69df8aee85503021c2d6f75eb9657b6364aa5c95

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95262 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148970 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28699 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90506 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92015 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23369 "Unexpected infrastructure issue: The layout-test run with change generated no list of results and exited with error, retrying with the hope it was a random infrastructure error.
Retrying build [retry count is 0 of 3]") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66375 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26648 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26562 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13576 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2540 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28240 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32859 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->