### PR TITLE
[Win] Add functions to access bundle resources

### DIFF
--- a/Source/WebCore/platform/win/WebCoreBundleWin.h
+++ b/Source/WebCore/platform/win/WebCoreBundleWin.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,19 +24,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef WebCoreBundleWin_h
-#define WebCoreBundleWin_h
+#pragma once
+
+#include <wtf/Forward.h>
 
 #if USE(CF)
-
 typedef struct __CFBundle* CFBundleRef;
+#endif
 
 namespace WebCore {
 
+#if USE(CF)
 CFBundleRef webKitBundle();
-
-}
-
 #endif
 
-#endif // WebCoreBundleWin_h
+String webKitBundlePath();
+String webKitBundlePath(StringView path);
+String webKitBundlePath(StringView name, StringView type, StringView directory);
+String webKitBundlePath(const Vector<StringView>& components);
+
+}

--- a/Source/WebCore/rendering/RenderThemeWin.cpp
+++ b/Source/WebCore/rendering/RenderThemeWin.cpp
@@ -966,21 +966,12 @@ Color RenderThemeWin::systemColor(CSSValueID cssValueId, OptionSet<StyleColorOpt
 #if ENABLE(VIDEO)
 String RenderThemeWin::stringWithContentsOfFile(const String& name, const String& type)
 {
-#if USE(CF)
-    RetainPtr<CFURLRef> requestedURLRef = adoptCF(CFBundleCopyResourceURL(webKitBundle(), name.createCFString().get(), type.createCFString().get(), 0));
-    if (!requestedURLRef)
-        return String();
+    auto path = webKitBundlePath(name, type, emptyString());
+    if (!path)
+        return { };
 
-    UInt8 requestedFilePath[MAX_PATH];
-    if (!CFURLGetFileSystemRepresentation(requestedURLRef.get(), false, requestedFilePath, MAX_PATH))
-        return String();
-
-    auto contents = FileSystem::readEntireFile(requestedFilePath);
-
+    auto contents = FileSystem::readEntireFile(path);
     return contents ? String::adopt(WTFMove(*contents)) : String();
-#else
-    return emptyString();
-#endif
 }
 
 String RenderThemeWin::mediaControlsStyleSheet()

--- a/Source/WebKit/UIProcess/win/WebProcessPoolWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebProcessPoolWin.cpp
@@ -39,19 +39,6 @@
 namespace WebKit {
 
 #if ENABLE(REMOTE_INSPECTOR)
-static String backendCommandsPath()
-{
-    RetainPtr<CFURLRef> urlRef = adoptCF(CFBundleCopyResourceURL(WebCore::webKitBundle(), CFSTR("InspectorBackendCommands"), CFSTR("js"), CFSTR("WebInspectorUI\\Protocol")));
-    if (!urlRef)
-        return { };
-
-    char path[MAX_PATH];
-    if (!CFURLGetFileSystemRepresentation(urlRef.get(), false, reinterpret_cast<UInt8*>(path), MAX_PATH))
-        return { };
-
-    return String::fromUTF8(path);
-}
-
 static void initializeRemoteInspectorServer(StringView address)
 {
     if (Inspector::RemoteInspectorServer::singleton().isRunning())
@@ -66,7 +53,8 @@ static void initializeRemoteInspectorServer(StringView address)
     if (!port)
         return;
 
-    Inspector::RemoteInspector::singleton().setBackendCommandsPath(backendCommandsPath());
+    auto backendCommands = WebCore::webKitBundlePath({ "WebKit.Resources"_s, "WebInspectorUI"_s, "Protocol"_s, "InspectorBackendCommands.js"_s });
+    Inspector::RemoteInspector::singleton().setBackendCommandsPath(backendCommands);
     Inspector::RemoteInspectorServer::singleton().start(host.utf8().data(), port.value());
 }
 #endif

--- a/Tools/TestWebKitAPI/PlatformWin.cmake
+++ b/Tools/TestWebKitAPI/PlatformWin.cmake
@@ -29,6 +29,7 @@ list(APPEND TestWebCore_SOURCES
 
     Tests/WebCore/win/DIBPixelData.cpp
     Tests/WebCore/win/LinkedFonts.cpp
+    Tests/WebCore/win/WebCoreBundle.cpp
 
     win/TestWebCoreStubs.cpp
 )

--- a/Tools/TestWebKitAPI/Tests/WebCore/win/WebCoreBundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/win/WebCoreBundle.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Test.h"
+#include <WebCore/WebCoreBundleWin.h>
+#include <wtf/FileSystem.h>
+
+class WebCoreBundleTest : public testing::Test {
+public:
+    void SetUp() override
+    {
+        WCHAR buffer[MAX_PATH];
+        DWORD length = ::GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+        if (!length || (length == MAX_PATH && GetLastError() == ERROR_INSUFFICIENT_BUFFER))
+            return;
+
+        String path(buffer, length);
+        m_root = FileSystem::pathByAppendingComponent(FileSystem::parentPath(path), "WebKit.resources"_s);
+    }
+
+protected:
+    String m_root;
+};
+
+TEST_F(WebCoreBundleTest, BundleRootPath)
+{
+    auto actual = WebCore::webKitBundlePath();
+    EXPECT_STREQ(m_root.utf8().data(), actual.utf8().data());
+}
+
+TEST_F(WebCoreBundleTest, BundlePathFromPath)
+{
+    auto actual = WebCore::webKitBundlePath("WebInspectorUI\\Protocol\\InspectorBackendCommands.js"_s);
+    auto expected = FileSystem::pathByAppendingComponents(m_root, { "WebInspectorUI"_s, "Protocol"_s, "InspectorBackendCommands.js"_s });
+    EXPECT_STREQ(expected.utf8().data(), actual.utf8().data());
+}
+
+TEST_F(WebCoreBundleTest, BundlePathFromNameTypeDirectory)
+{
+    auto actual = WebCore::webKitBundlePath("InspectorBackendCommands"_s, "js"_s, "WebInspectorUI\\Protocol"_s);
+    auto expected = FileSystem::pathByAppendingComponents(m_root, { "WebInspectorUI"_s, "Protocol"_s, "InspectorBackendCommands.js"_s });
+    EXPECT_STREQ(expected.utf8().data(), actual.utf8().data());
+
+    actual = WebCore::webKitBundlePath("mediaControlsLocalizedStrings"_s, "js"_s, ""_s);
+    expected = FileSystem::pathByAppendingComponents(m_root, { "en.lproj"_s, "mediaControlsLocalizedStrings.js"_s });
+    EXPECT_STREQ(expected.utf8().data(), actual.utf8().data());
+
+    actual = WebCore::webKitBundlePath("file-does-not"_s, "exist"_s, "file"_s);
+    expected = emptyString();
+    EXPECT_STREQ(expected.utf8().data(), actual.utf8().data());
+}
+
+TEST_F(WebCoreBundleTest, BundlePathFromComponents)
+{
+    auto actual = WebCore::webKitBundlePath({ "WebInspectorUI"_s, "Protocol"_s, "InspectorBackendCommands.js"_s });
+    auto expected = FileSystem::pathByAppendingComponents(m_root, { "WebInspectorUI"_s, "Protocol"_s, "InspectorBackendCommands.js"_s });
+    EXPECT_STREQ(expected.utf8().data(), actual.utf8().data());
+}
+


### PR DESCRIPTION
#### e5946f5567d06386d9d43168a6f688144840aab5
<pre>
[Win] Add functions to access bundle resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=244096">https://bugs.webkit.org/show_bug.cgi?id=244096</a>

Reviewed by Darin Adler.

The Windows ports have a `WebKit.resources` directory which contains assets, such as the
WebInspector UI, that are used by the engine. WebCoreBundle has a function to get a `CFBundle` that
is then queried to get the actual resource. Instead of using the bundle directly functions are
added that request the location of the resource. When `USE(CF)` these functions use the `CFBundle`
to determine the location, otherwise `WTF::FileSystem` is used to get the location.

This is another patch that gets the WinCairo build closer to removing CF usage.

* Source/WebCore/platform/win/WebCoreBundleWin.cpp:
(WebCore::webKitBundlePath):
(WebCore::dllDirectory):
* Source/WebCore/platform/win/WebCoreBundleWin.h:
* Source/WebCore/rendering/RenderThemeWin.cpp:
(WebCore::RenderThemeWin::stringWithContentsOfFile):
* Source/WebKit/UIProcess/Inspector/win/InspectorResourceURLSchemeHandler.cpp:
(WebKit::InspectorResourceURLSchemeHandler::platformStartTask):
* Source/WebKit/UIProcess/win/WebProcessPoolWin.cpp:
(WebKit::initializeRemoteInspectorServer):
* Tools/TestWebKitAPI/PlatformWin.cmake:
* Tools/TestWebKitAPI/Tests/WebCore/win/WebCoreBundle.cpp: Added.

Canonical link: <a href="https://commits.webkit.org/253925@main">https://commits.webkit.org/253925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32c5d182e18ed505d9153693ad685cea440fc423

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96692 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150102 "Found 1 new test failure: fast/css/aspect-ratio-min-height-replaced.html") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91440 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29919 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26101 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91463 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93083 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74250 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24005 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67023 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27629 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13194 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27582 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14210 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2756 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37073 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33488 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->