### PR TITLE
[Modern Media Controls] add a way to show stats about the <video>

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -1430,6 +1430,18 @@ ShouldDeferAsynchronousScriptsUntilAfterDocumentLoadOrFirstPaint:
     WebCore:
       default: true
 
+ShowMediaStatsContextMenuItemEnabled:
+  type: bool
+  humanReadableName: "Show Media Stats"
+  humanReadableDescription: "Adds a 'Media Stats' context menu item to <video> when the Develop menu is enabled"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 SpeechRecognitionEnabled:
   type: bool
   humanReadableName: "SpeechRecognition API"

--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
@@ -122,6 +122,37 @@
     mix-blend-mode: plus-lighter;
 }
 
+.stats-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: calc(100% - 40px);
+    height: calc(100% - 40px);
+    padding: 20px;
+    pointer-events: none;
+}
+
+.stats-container > table {
+    padding: 5px;
+    font-size: 11px;
+    font-family: sans-serif;
+    color: hsl(0, 0%, 95%);
+    background-color: hsla(0, 0%, 25%, 0.6);
+    border-radius: 5px;
+    -webkit-backdrop-filter: blur(5px);
+}
+
+.stats-container > table > tr > :is(th, td) {
+    margin: 0;
+    padding: 0;
+    pointer-events: auto;
+}
+
+.stats-container > table > tr > th {
+    padding-inline-end: 5px;
+    text-align: end;
+}
+
 @keyframes fade-in {
     from { opacity: 0 }
     to   { opacity: 1 }

--- a/Source/WebCore/Modules/modern-media-controls/main.js
+++ b/Source/WebCore/Modules/modern-media-controls/main.js
@@ -43,19 +43,12 @@ function createControls(shadowRoot, media, host)
     return new MediaController(shadowRoot, media, host);
 }
 
-function UIString(stringToLocalize, replacementString)
+function UIString(stringToLocalize, ...replacementStrings)
 {
-    let allLocalizedStrings = {};
-    try {
-        allLocalizedStrings = UIStrings;
-    } catch (error) {}
+    let localizedString = window.UIStrings?.[stringToLocalize] ?? stringToLocalize;
 
-    const localizedString = allLocalizedStrings[stringToLocalize];
-    if (!localizedString)
-        return stringToLocalize;
-
-    if (replacementString)
-        return localizedString.replace("%s", replacementString);
+    for (let replacementString of replacementStrings)
+        localizedString = localizedString.replace("%s", replacementString);
 
     return localizedString;
 }

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -205,6 +205,64 @@ class MediaController
         }
     }
 
+    // HTMLMediaElement
+
+    setShowingStats(shouldShowStats)
+    {
+        if (!(this.media instanceof HTMLVideoElement))
+            return false;
+
+        if (!shouldShowStats) {
+            this._statsContainer?.remove();
+            this._statsContainer = null;
+            return false;
+        }
+
+        if (this._statsContainer)
+            return true;
+
+        this._statsContainer = this.container.appendChild(document.createElement("div"))
+        this._statsContainer.className = "stats-container";
+
+        let table = this._statsContainer.appendChild(document.createElement("table"));
+
+        function createRow(label) {
+            let rowElement = table.appendChild(document.createElement("tr"));
+
+            let labelElement = rowElement.appendChild(document.createElement("th"));
+            labelElement.textContent = label;
+
+            let valueElement = rowElement.appendChild(document.createElement("td"));
+            return valueElement;
+        }
+        let viewportValueElement = createRow(UIString("Viewport"));
+        let framesValueElement = createRow(UIString("Frames"));
+        let resolutionValueElement = createRow(UIString("Resolution"));
+        let codecsValueElement = createRow(UIString("Codecs"));
+        let colorValueElement = createRow(UIString("Color"));
+
+        let update = () => {
+            if (!this._statsContainer)
+                return;
+
+            let quality = this.media.getVideoPlaybackQuality();
+            let videoTrack = this.media.videoTracks.item(this.media.videoTracks.selectedIndex);
+            let videoTrackConfiguration = videoTrack.configuration;
+            let videoColorSpace = videoTrackConfiguration?.colorSpace;
+
+            viewportValueElement.textContent = UIString("%s\u00d7%s", this.controls.width, this.controls.height) + (window.devicePixelRatio !== 1 ? " " + UIString("(%s)", UIString("%s\u00d7", window.devicePixelRatio)) : "");
+            framesValueElement.textContent = UIString("%s dropped of %s", quality.droppedVideoFrames, quality.totalVideoFrames);
+            resolutionValueElement.textContent = UIString("%s\u00d7%s", videoTrackConfiguration?.width, videoTrackConfiguration?.height) + " " + UIString("(%s)", UIString("%sfps", videoTrackConfiguration?.framerate));
+            codecsValueElement.textContent = videoTrackConfiguration?.codec;
+            colorValueElement.textContent = UIString("%s / %s / %s", videoColorSpace?.primaries, videoColorSpace?.transfer, videoColorSpace?.matrix);
+
+            window.requestAnimationFrame(update);
+        };
+        update();
+
+        return true;
+    }
+
     // Private
 
     _supportingObjectClasses()

--- a/Source/WebCore/Modules/modern-media-controls/media/overflow-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/overflow-support.js
@@ -66,7 +66,9 @@ class OverflowSupport extends MediaControllerSupport
     {
         this.control.enabled = this.mediaController.canShowMediaControlsContextMenu;
 
-        let defaultContextMenuOptions = {};
+        let defaultContextMenuOptions = {
+            includeShowMediaStats: true,
+        };
 
         if (this._includePlaybackRates)
             defaultContextMenuOptions.includePlaybackRates = true;

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -907,6 +907,9 @@
 /* Show fonts context menu item */
 "Show Fonts" = "Show Fonts";
 
+/* Media stats context menu item */
+"Show Media Stats" = "Show Media Stats";
+
 /* menu item title */
 "Show Spelling and Grammar" = "Show Spelling and Grammar";
 

--- a/Source/WebCore/en.lproj/modern-media-controls-localized-strings.js
+++ b/Source/WebCore/en.lproj/modern-media-controls-localized-strings.js
@@ -1,7 +1,15 @@
-const UIStrings = {
+var UIStrings = {
+    "%s / %s / %s": "%s / %s / %s",
+    "%s dropped of %s": "%s dropped of %s",
+    "%s\u00d7": "%s\u00d7",
+    "%s\u00d7%s": "%s\u00d7%s",
+    "%sfps": "%sfps",
+    "(%s)": "(%s)",
     "AirPlay": "AirPlay",
     "Apple TV": "Apple TV",
     "Audio Controls": "Audio Controls",
+    "Codecs": "Codecs",
+    "Color": "Color",
     "Duration: %s": "Duration: %s",
     "Enter Full Screen": "Enter Full Screen",
     "Enter Picture in Picture": "Enter Picture in Picture",
@@ -9,6 +17,7 @@ const UIStrings = {
     "Exit Full Screen": "Exit Full Screen",
     "Error": "Error",
     "Forward": "Forward",
+    "Frames": "Frames",
     "Invalid": "Invalid",
     "Live Broadcast": "Live Broadcast",
     "Loading\u2026": "Loading\u2026",
@@ -19,6 +28,7 @@ const UIStrings = {
     "Picture in Picture": "Picture in Picture",
     "Play": "Play",
     "Remaining: %s": "Remaining: %s",
+    "Resolution": "Resolution",
     "Rewind": "Rewind",
     "Skip Back 10 Seconds": "Skip Back 10 Seconds",
     "Skip Back 15 Seconds": "Skip Back 15 Seconds",
@@ -29,4 +39,5 @@ const UIStrings = {
     "This video is playing on \u201C%s\u201D.": "This video is playing on \u201C%s\u201D.",
     "Unmute": "Unmute",
     "Video Controls": "Video Controls",
+    "Viewport": "Viewport",
 };

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -612,6 +612,9 @@ public:
     void updateMediaPlayer(IntSize, bool);
     WEBCORE_EXPORT bool elementIsHidden() const;
 
+    bool showingStats() const { return m_showingStats; }
+    void setShowingStats(bool);
+
 protected:
     HTMLMediaElement(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLMediaElement();
@@ -1249,6 +1252,8 @@ private:
     AudioSessionCategory m_categoryAtMostRecentPlayback;
 #endif
     bool m_wasInterruptedForInvisibleAutoplay { false };
+
+    bool m_showingStats { false };
 };
 
 String convertEnumerationToString(HTMLMediaElement::AutoplayEventPlaybackState);

--- a/Source/WebCore/page/ContextMenuController.h
+++ b/Source/WebCore/page/ContextMenuController.h
@@ -58,7 +58,7 @@ public:
     void populate();
     WEBCORE_EXPORT void didDismissContextMenu();
     WEBCORE_EXPORT void contextMenuItemSelected(ContextMenuAction, const String& title);
-    void addInspectElementItem();
+    void addDebuggingItems();
 
     WEBCORE_EXPORT void checkOrEnableIfNeeded(ContextMenuItem&) const;
 

--- a/Source/WebCore/platform/ContextMenuItem.cpp
+++ b/Source/WebCore/platform/ContextMenuItem.cpp
@@ -255,6 +255,7 @@ bool isValidContextMenuAction(ContextMenuAction action)
     case ContextMenuAction::ContextMenuItemTagCopyMediaLinkToClipboard:
     case ContextMenuAction::ContextMenuItemTagToggleMediaControls:
     case ContextMenuAction::ContextMenuItemTagToggleMediaLoop:
+    case ContextMenuAction::ContextMenuItemTagShowMediaStats:
     case ContextMenuAction::ContextMenuItemTagEnterVideoFullscreen:
     case ContextMenuAction::ContextMenuItemTagMediaPlayPause:
     case ContextMenuAction::ContextMenuItemTagMediaMute:

--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -153,7 +153,8 @@ enum ContextMenuAction {
     ContextMenuItemPDFSinglePageContinuous,
     ContextMenuItemPDFTwoPages,
     ContextMenuItemPDFTwoPagesContinuous,
-    ContextMenuItemLastNonCustomTag = ContextMenuItemPDFTwoPagesContinuous,
+    ContextMenuItemTagShowMediaStats,
+    ContextMenuItemLastNonCustomTag = ContextMenuItemTagShowMediaStats,
     ContextMenuItemBaseCustomTag = 5000,
     ContextMenuItemLastCustomTag = 5999,
     ContextMenuItemBaseApplicationTag = 10000

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -1361,6 +1361,11 @@ String addAudioTrackKindCommentarySuffix(const String& text)
 
 #endif // USE(CF)
 
+String contextMenuItemTagShowMediaStats()
+{
+    return WEB_UI_STRING("Show Media Stats", "Media stats context menu item");
+}
+
 #endif // ENABLE(VIDEO)
 
 String snapshottedPlugInLabelTitle()

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -346,6 +346,7 @@ namespace WebCore {
     String audioTrackKindCommentaryDisplayName();
     String addAudioTrackKindCommentarySuffix(const String&);
 #endif // USE(CF)
+    String contextMenuItemTagShowMediaStats();
 #endif // ENABLE(VIDEO)
 
     String snapshottedPlugInLabelTitle();

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -465,6 +465,14 @@ void HitTestResult::toggleMediaLoopPlayback() const
 #endif
 }
 
+void HitTestResult::toggleShowMediaStats() const
+{
+#if ENABLE(VIDEO)
+    if (HTMLMediaElement* mediaElt = mediaElement())
+        mediaElt->setShowingStats(!mediaElt->showingStats());
+#endif
+}
+
 bool HitTestResult::mediaIsInFullscreen() const
 {
 #if ENABLE(VIDEO)
@@ -514,6 +522,15 @@ bool HitTestResult::mediaLoopEnabled() const
 #if ENABLE(VIDEO)
     if (HTMLMediaElement* mediaElt = mediaElement())
         return mediaElt->loop();
+#endif
+    return false;
+}
+
+bool HitTestResult::mediaStatsShowing() const
+{
+#if ENABLE(VIDEO)
+    if (HTMLMediaElement* mediaElt = mediaElement())
+        return mediaElt->showingStats();
 #endif
     return false;
 }

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -111,11 +111,13 @@ public:
     WEBCORE_EXPORT bool isContentEditable() const;
     void toggleMediaControlsDisplay() const;
     void toggleMediaLoopPlayback() const;
+    void toggleShowMediaStats() const;
     WEBCORE_EXPORT bool mediaIsInFullscreen() const;
     void toggleMediaFullscreenState() const;
     void enterFullscreenForVideo() const;
     bool mediaControlsEnabled() const;
     bool mediaLoopEnabled() const;
+    bool mediaStatsShowing() const;
     bool mediaPlaying() const;
     bool mediaSupportsFullscreen() const;
     void toggleMediaPlayState() const;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
@@ -50,6 +50,7 @@ NSString * const _WKMenuItemIdentifierReload = @"WKMenuItemIdentifierReload";
 NSString * const _WKMenuItemIdentifierRevealImage = @"WKMenuItemIdentifierRevealImage";
 NSString * const _WKMenuItemIdentifierSearchWeb = @"WKMenuItemIdentifierSearchWeb";
 NSString * const _WKMenuItemIdentifierShowHideMediaControls = @"WKMenuItemIdentifierShowHideMediaControls";
+NSString * const _WKMenuItemIdentifierShowHideMediaStats = @"WKMenuItemIdentifierShowHideMediaStats";
 NSString * const _WKMenuItemIdentifierToggleEnhancedFullScreen = @"WKMenuItemIdentifierToggleEnhancedFullScreen";
 NSString * const _WKMenuItemIdentifierToggleFullScreen = @"WKMenuItemIdentifierToggleFullScreen";
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
@@ -48,6 +48,7 @@ WK_EXTERN NSString * const _WKMenuItemIdentifierReload WK_API_AVAILABLE(macos(10
 WK_EXTERN NSString * const _WKMenuItemIdentifierRevealImage WK_API_AVAILABLE(macos(12.0), ios(15.0));
 WK_EXTERN NSString * const _WKMenuItemIdentifierSearchWeb WK_API_AVAILABLE(macos(10.12), ios(10.0));
 WK_EXTERN NSString * const _WKMenuItemIdentifierShowHideMediaControls WK_API_AVAILABLE(macos(10.12), ios(10.0));
+WK_EXTERN NSString * const _WKMenuItemIdentifierShowHideMediaStats WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 WK_EXTERN NSString * const _WKMenuItemIdentifierToggleEnhancedFullScreen WK_API_AVAILABLE(macos(10.14), ios(12.0));
 WK_EXTERN NSString * const _WKMenuItemIdentifierToggleFullScreen WK_API_AVAILABLE(macos(10.12), ios(10.0));
 

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -807,6 +807,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (NSArray<UIMenuElement *> *)_uiMenuElementsForMediaControlContextMenuItems:(Vector<WebCore::MediaControlsContextMenuItem>&&)items
 {
     return createNSArray(items, [&] (WebCore::MediaControlsContextMenuItem& item) -> UIMenuElement * {
+        if (item.id == WebCore::MediaControlsContextMenuItem::invalidID && item.title.isEmpty() && item.icon.isEmpty() && item.children.isEmpty())
+            return [UIMenu menuWithTitle:@"" image:nil identifier:nil options:UIMenuOptionsDisplayInline children:@[]];
+
         UIImage *image = !item.icon.isEmpty() ? [UIImage systemImageNamed:WTFMove(item.icon)] : nil;
 
         if (!item.children.isEmpty())

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -549,6 +549,9 @@ static NSString *menuItemIdentifier(const WebCore::ContextMenuAction action)
     case ContextMenuItemTagToggleMediaControls:
         return _WKMenuItemIdentifierShowHideMediaControls;
 
+    case ContextMenuItemTagShowMediaStats:
+        return _WKMenuItemIdentifierShowHideMediaStats;
+
     case ContextMenuItemTagToggleVideoEnhancedFullscreen:
         return _WKMenuItemIdentifierToggleEnhancedFullScreen;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4295,6 +4295,9 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
     m_useSceneKitForModel = store.getBoolValueForKey(WebPreferencesKey::useSceneKitForModelKey());
 #endif
 
+    if (settings.showMediaStatsContextMenuItemEnabled())
+        settings.setTrackConfigurationEnabled(true);
+
     m_page->settingsDidChange();
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -419,9 +419,6 @@ static std::optional<NSInteger> toTag(WebCore::ContextMenuAction action)
 {
     using namespace WebCore;
     switch (action) {
-    case ContextMenuItemTagNoAction:
-        return std::nullopt;
-
     case ContextMenuItemTagOpenLinkInNewWindow:
         return WebMenuItemTagOpenLinkInNewWindow;
     case ContextMenuItemTagDownloadLinkToDisk:
@@ -590,21 +587,12 @@ static std::optional<NSInteger> toTag(WebCore::ContextMenuAction action)
         return WebMenuItemTagDictationAlternative;
     case ContextMenuItemTagToggleVideoFullscreen:
         return WebMenuItemTagToggleVideoFullscreen;
-    case ContextMenuItemTagAddHighlightToCurrentQuickNote:
-    case ContextMenuItemTagAddHighlightToNewQuickNote:
-        return std::nullopt;
     case ContextMenuItemTagShareMenu:
         return WebMenuItemTagShareMenu;
     case ContextMenuItemTagToggleVideoEnhancedFullscreen:
         return WebMenuItemTagToggleVideoEnhancedFullscreen;
     case ContextMenuItemTagTranslate:
         return WebMenuItemTagTranslate;
-    case ContextMenuItemTagCopySubject:
-    case ContextMenuItemTagLookUpImage:
-    case ContextMenuItemPDFSinglePageContinuous:
-    case ContextMenuItemPDFTwoPages:
-    case ContextMenuItemPDFTwoPagesContinuous:
-        return std::nullopt;
 
     case ContextMenuItemBaseCustomTag ... ContextMenuItemLastCustomTag:
         // We just pass these through.
@@ -612,6 +600,10 @@ static std::optional<NSInteger> toTag(WebCore::ContextMenuAction action)
 
     case ContextMenuItemBaseApplicationTag:
         ASSERT_NOT_REACHED();
+        break;
+
+    default:
+        break;
     }
 
     return std::nullopt;


### PR DESCRIPTION
#### e5887c759dce8d3396d463f6cc46ab0d7c177bf4
<pre>
[Modern Media Controls] add a way to show stats about the &lt;video&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=244101">https://bugs.webkit.org/show_bug.cgi?id=244101</a>
&lt;rdar://problem/98847210&gt;

Reviewed by Eric Carlson.

This will allow developers to gleam more information about the current state of `&lt;video&gt;` at a
glance, rather than having to use JS APIs to gather that info. This can also be expanded to shows
information that doesn&apos;t have an equivalent JS API.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
Add an experimental setting for this feature.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updatePreferences):
If this new experimental setting is enabled, also require `TrackConfigurationEnabled` as that&apos;s
needed for many of the stats to be shown.

* Source/WebCore/Modules/modern-media-controls/controls/media-controls.css:
(.stats-container): Added.
(.stats-container &gt; table): Added.
(.stats-container &gt; table &gt; tr &gt; :is(th, td)): Added.
(.stats-container &gt; table &gt; tr &gt; th): Added.
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype.setShowingStats): Added.
(MediaController.prototype.setShowingStats.createRow): Added.
When &quot;Show Media Stats&quot; is enabled, show a basic `&lt;table&gt;` containing rows for each stat that&apos;s
centered inside the `&lt;video&gt;`.

* Source/WebCore/Modules/modern-media-controls/media/overflow-support.js:
(OverflowSupport.prototype.syncControl):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::showMediaControlsContextMenu):
Also allow the (modern) media controls JS to provide `&quot;includeShowMediaStats&quot;`, which does the same
acts the same as the general context menu item.

* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::showingStats const): Added.
The source of truth for &quot;are we showing media stats&quot; is in a member variable.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setShowingStats): Added.
Invoke some JS to create/remove the `&lt;table&gt;`, updating the member variable depending on the result.

* Source/WebCore/platform/ContextMenuItem.h:
* Source/WebCore/platform/ContextMenuItem.cpp:
(WebCore::isValidContextMenuAction):
* Source/WebCore/page/ContextMenuController.h:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::showContextMenu):
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::addDebuggingItems): Renamed from `addInspectElementItem`.
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebCore/rendering/HitTestResult.h:
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::toggleShowMediaStats const): Added.
(WebCore::HitTestResult::mediaStatsShowing const): Added.
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::menuItemIdentifier):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(toTag):
Create a new `ContextMenuItemTagShowMediaStats`, adding it after `ContextMenuItemTagInspectElement`.

* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant _uiMenuElementsForMediaControlContextMenuItems:]):
Add a way to create a separator in the (modern) media controls context menu on iOS.

* Source/WebCore/en.lproj/modern-media-controls-localized-strings.js:
* Source/WebCore/Modules/modern-media-controls/main.js:
(UIString):
Allow for multiple replacements in a single string.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::contextMenuItemTagShowMediaStats): Added.

Canonical link: <a href="https://commits.webkit.org/253583@main">https://commits.webkit.org/253583@main</a>
</pre>










<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25103a9244fa558ba00f3aceb65f3fb7c9550b75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30377 "Built successfully") | [✅ ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95302 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149013 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90445 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28778 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78610 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90546 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92073 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23404 "Passed tests") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66408 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78393 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26689 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72029 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26603 "Built successfully") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25745 "Passed tests") | 
| [✅ ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/2553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28282 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/74810 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28223 "Built successfully") | [✅ ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16542 "Passed tests") | 
<!--EWS-Status-Bubble-End-->