### PR TITLE
[libpas] Reduce TLC decommit frequency in mini-mode

### DIFF
--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -201,6 +201,7 @@ void enableMiniMode()
     // Speed up the scavenger.
     pas_scavenger_period_in_milliseconds = 5.;
     pas_scavenger_max_epoch_delta = 5ll * 1000ll * 1000ll;
+    pas_scavenger_thread_local_cache_decommit_tick_bit = 12;
 
     // Do eager scavenging anytime pages are allocated or committed.
     pas_physical_page_sharing_pool_balancing_enabled = true;

--- a/Source/bmalloc/libpas/src/libpas/pas_scavenger.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_scavenger.h
@@ -72,6 +72,9 @@ PAS_API extern double pas_scavenger_period_in_milliseconds; /* How long to sleep
 PAS_API extern uint64_t pas_scavenger_max_epoch_delta; /* How much to subtract from the current epoch
                                                           to compute the max epoch. */
 
+PAS_API extern uint32_t pas_scavenger_thread_local_cache_decommit_tick_bit; /* Run TLC decommit per N tick, and N is computed
+                                                                               as (1 << pas_scavenger_thread_local_cache_decommit_tick_bit). */
+
 #if PAS_OS(DARWIN)
 /* It's legal to set this anytime. */
 PAS_API void pas_scavenger_set_requested_qos_class(qos_class_t);


### PR DESCRIPTION
#### 0af892f03554e27ef4dbdc4ddd984e996290335e
<pre>
[libpas] Reduce TLC decommit frequency in mini-mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=244104">https://bugs.webkit.org/show_bug.cgi?id=244104</a>

Reviewed by NOBODY (OOPS!).

Our assumption was that mini-mode VM want to shrink memory more frequently and pas_scavenger&apos;s task heaviness
is proportional to the size of entire heap. But it seems that TLC decommit is particularly costly, so doing it
frequently in mini-mode gets many CPU cycles. Let&apos;s reduce tick counts for TLC decommit in mini-mode to keep
the pace of that the same to wall time in mini mode and non mini mode.

* Source/bmalloc/bmalloc/bmalloc.cpp:
(bmalloc::api::enableMiniMode):
* Source/bmalloc/libpas/src/libpas/pas_scavenger.c:
(scavenger_thread_main):
* Source/bmalloc/libpas/src/libpas/pas_scavenger.h:
</pre>














































<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0af892f03554e27ef4dbdc4ddd984e996290335e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86435 "failed 3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95283 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148991 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28755 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25340 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78589 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90526 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92051 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23338 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73408 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23386 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66390 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78372 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26668 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12583 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72007 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26582 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13595 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25739 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36481 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/74788 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32878 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16536 "Passed tests") | 
<!--EWS-Status-Bubble-End-->