### PR TITLE
iOS: Text insertion caret can get out of sync with the page content

### DIFF
--- a/Source/WebKit/Shared/EditorState.cpp
+++ b/Source/WebKit/Shared/EditorState.cpp
@@ -56,84 +56,91 @@ TextStream& operator<<(TextStream& ts, const EditorState& editorState)
     if (!editorState.canEnableAutomaticSpellingCorrection)
         ts.dumpProperty("canEnableAutomaticSpellingCorrection", editorState.canEnableAutomaticSpellingCorrection);
 #endif
-    if (editorState.isMissingPostLayoutData())
-        ts.dumpProperty("isMissingPostLayoutData()", editorState.isMissingPostLayoutData());
 
-    if (editorState.isMissingPostLayoutData())
-        return ts;
+    ts.dumpProperty("hasPostLayoutData", editorState.hasPostLayoutData());
 
-    TextStream::GroupScope scope(ts);
-    ts << "postLayoutData";
-    if (editorState.postLayoutData->typingAttributes != AttributeNone)
-        ts.dumpProperty("typingAttributes", editorState.postLayoutData->typingAttributes);
-#if PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)
-    if (editorState.postLayoutData->caretRectAtStart != IntRect())
-        ts.dumpProperty("caretRectAtStart", editorState.postLayoutData->caretRectAtStart);
-#endif
+    if (editorState.hasPostLayoutData()) {
+        TextStream::GroupScope scope(ts);
+        ts << "postLayoutData";
+        if (editorState.postLayoutData->typingAttributes != AttributeNone)
+            ts.dumpProperty("typingAttributes", editorState.postLayoutData->typingAttributes);
 #if PLATFORM(COCOA)
-    if (editorState.postLayoutData->selectedTextLength)
-        ts.dumpProperty("selectedTextLength", editorState.postLayoutData->selectedTextLength);
-    if (editorState.postLayoutData->textAlignment != NoAlignment)
-        ts.dumpProperty("textAlignment", editorState.postLayoutData->textAlignment);
-    if (editorState.postLayoutData->textColor.isValid())
-        ts.dumpProperty("textColor", editorState.postLayoutData->textColor);
-    if (editorState.postLayoutData->enclosingListType != NoList)
-        ts.dumpProperty("enclosingListType", editorState.postLayoutData->enclosingListType);
-    if (editorState.postLayoutData->baseWritingDirection != WebCore::WritingDirection::Natural)
-        ts.dumpProperty("baseWritingDirection", static_cast<uint8_t>(editorState.postLayoutData->baseWritingDirection));
+        if (editorState.postLayoutData->selectedTextLength)
+            ts.dumpProperty("selectedTextLength", editorState.postLayoutData->selectedTextLength);
+        if (editorState.postLayoutData->textAlignment != NoAlignment)
+            ts.dumpProperty("textAlignment", editorState.postLayoutData->textAlignment);
+        if (editorState.postLayoutData->textColor.isValid())
+            ts.dumpProperty("textColor", editorState.postLayoutData->textColor);
+        if (editorState.postLayoutData->enclosingListType != NoList)
+            ts.dumpProperty("enclosingListType", editorState.postLayoutData->enclosingListType);
+        if (editorState.postLayoutData->baseWritingDirection != WebCore::WritingDirection::Natural)
+            ts.dumpProperty("baseWritingDirection", static_cast<uint8_t>(editorState.postLayoutData->baseWritingDirection));
 #endif // PLATFORM(COCOA)
 #if PLATFORM(IOS_FAMILY)
-    if (editorState.postLayoutData->selectionClipRect != IntRect())
-        ts.dumpProperty("selectionClipRect", editorState.postLayoutData->selectionClipRect);
-    if (editorState.postLayoutData->caretRectAtEnd != IntRect())
-        ts.dumpProperty("caretRectAtEnd", editorState.postLayoutData->caretRectAtEnd);
-    if (!editorState.postLayoutData->selectionGeometries.isEmpty())
-        ts.dumpProperty("selectionGeometries", editorState.postLayoutData->selectionGeometries);
-    if (!editorState.postLayoutData->markedTextRects.isEmpty())
-        ts.dumpProperty("markedTextRects", editorState.postLayoutData->markedTextRects);
-    if (editorState.postLayoutData->markedText.length())
-        ts.dumpProperty("markedText", editorState.postLayoutData->markedText);
-    if (editorState.postLayoutData->markedTextCaretRectAtStart != IntRect())
-        ts.dumpProperty("markedTextCaretRectAtStart", editorState.postLayoutData->markedTextCaretRectAtStart);
-    if (editorState.postLayoutData->markedTextCaretRectAtEnd != IntRect())
-        ts.dumpProperty("markedTextCaretRectAtEnd", editorState.postLayoutData->markedTextCaretRectAtEnd);
-    if (editorState.postLayoutData->wordAtSelection.length())
-        ts.dumpProperty("wordAtSelection", editorState.postLayoutData->wordAtSelection);
-    if (editorState.postLayoutData->characterAfterSelection)
-        ts.dumpProperty("characterAfterSelection", editorState.postLayoutData->characterAfterSelection);
-    if (editorState.postLayoutData->characterBeforeSelection)
-        ts.dumpProperty("characterBeforeSelection", editorState.postLayoutData->characterBeforeSelection);
-    if (editorState.postLayoutData->twoCharacterBeforeSelection)
-        ts.dumpProperty("twoCharacterBeforeSelection", editorState.postLayoutData->twoCharacterBeforeSelection);
+        if (editorState.postLayoutData->markedText.length())
+            ts.dumpProperty("markedText", editorState.postLayoutData->markedText);
+        if (editorState.postLayoutData->wordAtSelection.length())
+            ts.dumpProperty("wordAtSelection", editorState.postLayoutData->wordAtSelection);
+        if (editorState.postLayoutData->characterAfterSelection)
+            ts.dumpProperty("characterAfterSelection", editorState.postLayoutData->characterAfterSelection);
+        if (editorState.postLayoutData->characterBeforeSelection)
+            ts.dumpProperty("characterBeforeSelection", editorState.postLayoutData->characterBeforeSelection);
+        if (editorState.postLayoutData->twoCharacterBeforeSelection)
+            ts.dumpProperty("twoCharacterBeforeSelection", editorState.postLayoutData->twoCharacterBeforeSelection);
 
-    if (editorState.postLayoutData->isReplaceAllowed)
-        ts.dumpProperty("isReplaceAllowed", editorState.postLayoutData->isReplaceAllowed);
-    if (editorState.postLayoutData->hasContent)
-        ts.dumpProperty("hasContent", editorState.postLayoutData->hasContent);
-    ts.dumpProperty("isStableStateUpdate", editorState.postLayoutData->isStableStateUpdate);
-    if (editorState.postLayoutData->insideFixedPosition)
-        ts.dumpProperty("insideFixedPosition", editorState.postLayoutData->insideFixedPosition);
-    if (editorState.postLayoutData->caretColor.isValid())
-        ts.dumpProperty("caretColor", editorState.postLayoutData->caretColor);
+        if (editorState.postLayoutData->isReplaceAllowed)
+            ts.dumpProperty("isReplaceAllowed", editorState.postLayoutData->isReplaceAllowed);
+        if (editorState.postLayoutData->hasContent)
+            ts.dumpProperty("hasContent", editorState.postLayoutData->hasContent);
+        ts.dumpProperty("isStableStateUpdate", editorState.postLayoutData->isStableStateUpdate);
+        if (editorState.postLayoutData->insideFixedPosition)
+            ts.dumpProperty("insideFixedPosition", editorState.postLayoutData->insideFixedPosition);
+        if (editorState.postLayoutData->caretColor.isValid())
+            ts.dumpProperty("caretColor", editorState.postLayoutData->caretColor);
 #endif
 #if PLATFORM(MAC)
-    if (editorState.postLayoutData->selectionBoundingRect != IntRect())
-        ts.dumpProperty("selectionBoundingRect", editorState.postLayoutData->selectionBoundingRect);
-    if (editorState.postLayoutData->candidateRequestStartPosition)
-        ts.dumpProperty("candidateRequestStartPosition", editorState.postLayoutData->candidateRequestStartPosition);
-    if (editorState.postLayoutData->paragraphContextForCandidateRequest.length())
-        ts.dumpProperty("paragraphContextForCandidateRequest", editorState.postLayoutData->paragraphContextForCandidateRequest);
-    if (editorState.postLayoutData->stringForCandidateRequest.length())
-        ts.dumpProperty("stringForCandidateRequest", editorState.postLayoutData->stringForCandidateRequest);
+        if (editorState.postLayoutData->selectionBoundingRect != IntRect())
+            ts.dumpProperty("selectionBoundingRect", editorState.postLayoutData->selectionBoundingRect);
+        if (editorState.postLayoutData->candidateRequestStartPosition)
+            ts.dumpProperty("candidateRequestStartPosition", editorState.postLayoutData->candidateRequestStartPosition);
+        if (editorState.postLayoutData->paragraphContextForCandidateRequest.length())
+            ts.dumpProperty("paragraphContextForCandidateRequest", editorState.postLayoutData->paragraphContextForCandidateRequest);
+        if (editorState.postLayoutData->stringForCandidateRequest.length())
+            ts.dumpProperty("stringForCandidateRequest", editorState.postLayoutData->stringForCandidateRequest);
 #endif
 
-    if (editorState.postLayoutData->canCut)
-        ts.dumpProperty("canCut", editorState.postLayoutData->canCut);
-    if (editorState.postLayoutData->canCopy)
-        ts.dumpProperty("canCopy", editorState.postLayoutData->canCopy);
-    if (editorState.postLayoutData->canPaste)
-        ts.dumpProperty("canPaste", editorState.postLayoutData->canPaste);
+        if (editorState.postLayoutData->canCut)
+            ts.dumpProperty("canCut", editorState.postLayoutData->canCut);
+        if (editorState.postLayoutData->canCopy)
+            ts.dumpProperty("canCopy", editorState.postLayoutData->canCopy);
+        if (editorState.postLayoutData->canPaste)
+            ts.dumpProperty("canPaste", editorState.postLayoutData->canPaste);
+    }
 
+    ts.dumpProperty("hasVisualData", editorState.hasVisualData());
+
+    if (editorState.hasVisualData()) {
+        TextStream::GroupScope scope(ts);
+        ts << "visualData";
+#if PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)
+        if (editorState.visualData->caretRectAtStart != IntRect())
+            ts.dumpProperty("caretRectAtStart", editorState.visualData->caretRectAtStart);
+#endif
+#if PLATFORM(IOS_FAMILY)
+        if (editorState.visualData->selectionClipRect != IntRect())
+            ts.dumpProperty("selectionClipRect", editorState.visualData->selectionClipRect);
+        if (editorState.visualData->caretRectAtEnd != IntRect())
+            ts.dumpProperty("caretRectAtEnd", editorState.visualData->caretRectAtEnd);
+        if (!editorState.visualData->selectionGeometries.isEmpty())
+            ts.dumpProperty("selectionGeometries", editorState.visualData->selectionGeometries);
+        if (!editorState.visualData->markedTextRects.isEmpty())
+            ts.dumpProperty("markedTextRects", editorState.visualData->markedTextRects);
+        if (editorState.visualData->markedTextCaretRectAtStart != IntRect())
+            ts.dumpProperty("markedTextCaretRectAtStart", editorState.visualData->markedTextCaretRectAtStart);
+        if (editorState.visualData->markedTextCaretRectAtEnd != IntRect())
+            ts.dumpProperty("markedTextCaretRectAtEnd", editorState.visualData->markedTextCaretRectAtEnd);
+#endif
+    }
     return ts;
 }
 

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -38,13 +38,11 @@ struct WebKit::EditorState {
     bool canEnableAutomaticSpellingCorrection;
 #endif
     std::optional<WebKit::EditorState::PostLayoutData> postLayoutData;
+    std::optional<WebKit::EditorState::VisualData> visualData;
 };
 
 [Nested] struct WebKit::EditorState::PostLayoutData {
     uint32_t typingAttributes;
-#if PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)
-    WebCore::IntRect caretRectAtStart;
-#endif
 #if PLATFORM(COCOA)
     uint64_t selectedTextLength;
     uint32_t textAlignment;
@@ -53,13 +51,7 @@ struct WebKit::EditorState {
     WebCore::WritingDirection baseWritingDirection;
 #endif
 #if PLATFORM(IOS_FAMILY)
-    WebCore::IntRect selectionClipRect;
-    WebCore::IntRect caretRectAtEnd;
-    Vector<WebCore::SelectionGeometry> selectionGeometries;
-    Vector<WebCore::SelectionGeometry> markedTextRects;
     String markedText;
-    WebCore::IntRect markedTextCaretRectAtStart;
-    WebCore::IntRect markedTextCaretRectAtEnd;
     String wordAtSelection;
     UChar32 characterAfterSelection;
     UChar32 characterBeforeSelection;
@@ -96,4 +88,18 @@ struct WebKit::EditorState {
     bool canCut;
     bool canCopy;
     bool canPaste;
+};
+
+[Nested] struct WebKit::EditorState::VisualData {
+#if PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)
+    WebCore::IntRect caretRectAtStart;
+#endif
+#if PLATFORM(IOS_FAMILY)
+    WebCore::IntRect selectionClipRect;
+    WebCore::IntRect caretRectAtEnd;
+    Vector<WebCore::SelectionGeometry> selectionGeometries;
+    Vector<WebCore::SelectionGeometry> markedTextRects;
+    WebCore::IntRect markedTextCaretRectAtStart;
+    WebCore::IntRect markedTextCaretRectAtEnd;
+#endif
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1781,7 +1781,7 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 
 static NSDictionary *dictionaryRepresentationForEditorState(const WebKit::EditorState& state)
 {
-    if (state.isMissingPostLayoutData())
+    if (!state.hasPostLayoutData())
         return @{ @"post-layout-data" : @NO };
 
     auto& postLayoutData = *state.postLayoutData;

--- a/Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp
@@ -118,7 +118,7 @@ WebKitEditorState* webkitEditorStateCreate(WebPageProxy& page)
 
 void webkitEditorStateChanged(WebKitEditorState* editorState, const EditorState& newState)
 {
-    if (newState.isMissingPostLayoutData())
+    if (!newState.hasPostLayoutData())
         return;
 
     unsigned typingAttributes = WEBKIT_EDITOR_TYPING_ATTRIBUTE_NONE;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -2551,8 +2551,8 @@ void webkitWebViewBaseSetInputMethodState(WebKitWebViewBase* webkitWebViewBase, 
 void webkitWebViewBaseUpdateTextInputState(WebKitWebViewBase* webkitWebViewBase)
 {
     const auto& editorState = webkitWebViewBase->priv->pageProxy->editorState();
-    if (!editorState.isMissingPostLayoutData()) {
-        webkitWebViewBase->priv->inputMethodFilter.notifyCursorRect(editorState.postLayoutData->caretRectAtStart);
+    if (editorState.hasPostLayoutAndVisualData()) {
+        webkitWebViewBase->priv->inputMethodFilter.notifyCursorRect(editorState.visualData->caretRectAtStart);
         webkitWebViewBase->priv->inputMethodFilter.notifySurrounding(editorState.postLayoutData->surroundingContext, editorState.postLayoutData->surroundingContextCursorPosition,
             editorState.postLayoutData->surroundingContextSelectionPosition);
     }

--- a/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
@@ -377,8 +377,8 @@ void View::setInputMethodState(std::optional<InputMethodState>&& state)
 void View::selectionDidChange()
 {
     const auto& editorState = m_pageProxy->editorState();
-    if (!editorState.isMissingPostLayoutData()) {
-        m_inputMethodFilter.notifyCursorRect(editorState.postLayoutData->caretRectAtStart);
+    if (editorState.hasPostLayoutAndVisualData()) {
+        m_inputMethodFilter.notifyCursorRect(editorState.visualData->caretRectAtStart);
         m_inputMethodFilter.notifySurrounding(editorState.postLayoutData->surroundingContext, editorState.postLayoutData->surroundingContextCursorPosition,
             editorState.postLayoutData->surroundingContextSelectionPosition);
     }

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -129,6 +129,8 @@ public:
 
     virtual void dispatchPresentationCallbacksAfterFlushingLayers(const Vector<CallbackID>&) { }
 
+    virtual bool shouldCoalesceVisualEditorStateUpdates() const { return false; }
+
     WebPageProxy& page() const { return m_webPageProxy; }
     WebProcessProxy& process() { return m_process.get(); }
     const WebProcessProxy& process() const { return m_process.get(); }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -69,6 +69,8 @@ public:
 protected:
     void updateDebugIndicatorPosition();
 
+    bool shouldCoalesceVisualEditorStateUpdates() const override { return true; }
+
 private:
     void sizeDidChange() final;
     void deviceScaleFactorDidChange() final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -129,7 +129,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(const RemoteLayerTreeTrans
     m_transactionIDForPendingCACommit = layerTreeTransaction.transactionID();
     m_activityStateChangeID = layerTreeTransaction.activityStateChangeID();
 
-    bool didUpdateEditorState = layerTreeTransaction.hasEditorState() && m_webPageProxy.updateEditorState(layerTreeTransaction.editorState());
+    bool didUpdateEditorState = layerTreeTransaction.hasEditorState() && m_webPageProxy.updateEditorState(layerTreeTransaction.editorState(), WebPageProxy::ShouldMergeVisualEditorState::Yes);
 
     if (m_remoteLayerTreeHost->updateLayerTree(layerTreeTransaction)) {
         if (layerTreeTransaction.transactionID() >= m_transactionIDForUnhidingContent)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1755,7 +1755,8 @@ public:
     void createSandboxExtensionsIfNeeded(const Vector<String>& files, SandboxExtension::Handle& fileReadHandle, Vector<SandboxExtension::Handle>& fileUploadHandles);
 #endif
     void editorStateChanged(const EditorState&);
-    bool updateEditorState(const EditorState& newEditorState);
+    enum class ShouldMergeVisualEditorState : uint8_t { No, Yes, Default };
+    bool updateEditorState(const EditorState& newEditorState, ShouldMergeVisualEditorState = ShouldMergeVisualEditorState::Default);
     void scheduleFullEditorStateUpdate();
     void dispatchDidUpdateEditorState();
 

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -768,7 +768,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     // Updating the selection requires a full editor state. If the editor state is missing post layout
     // data then it means there is a layout pending and we're going to be called again after the layout
     // so we delay the selection update.
-    if (!_page->editorState().isMissingPostLayoutData())
+    if (_page->editorState().hasPostLayoutAndVisualData())
         [self _updateChangedSelection];
 }
 

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -776,7 +776,7 @@ void WebPageProxy::moveSelectionByOffset(int32_t offset, CompletionHandler<void(
 
 void WebPageProxy::interpretKeyEvent(const EditorState& state, bool isCharEvent, CompletionHandler<void(bool)>&& completionHandler)
 {
-    m_editorState = state;
+    updateEditorState(state);
     if (m_keyEventQueue.isEmpty())
         completionHandler(false);
     else
@@ -1117,7 +1117,7 @@ void WebPageProxy::didUpdateEditorState(const EditorState& oldEditorState, const
 
 void WebPageProxy::dispatchDidUpdateEditorState()
 {
-    if (!m_waitingForPostLayoutEditorStateUpdateAfterFocusingElement || m_editorState.isMissingPostLayoutData())
+    if (!m_waitingForPostLayoutEditorStateUpdateAfterFocusingElement || !m_editorState.hasPostLayoutData())
         return;
 
     pageClient().didUpdateEditorState();
@@ -1176,16 +1176,16 @@ WebCore::FloatRect WebPageProxy::selectionBoundingRectInRootViewCoordinates() co
     if (m_editorState.selectionIsNone)
         return { };
 
-    if (m_editorState.isMissingPostLayoutData())
+    if (!m_editorState.hasVisualData())
         return { };
 
     WebCore::FloatRect bounds;
-    auto& postLayoutData = *m_editorState.postLayoutData;
+    auto& visualData = *m_editorState.visualData;
     if (m_editorState.selectionIsRange) {
-        for (auto& geometry : postLayoutData.selectionGeometries)
+        for (auto& geometry : visualData.selectionGeometries)
             bounds.unite(geometry.rect());
     } else
-        bounds = postLayoutData.caretRectAtStart;
+        bounds = visualData.caretRectAtStart;
 
     return bounds;
 }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2701,7 +2701,7 @@ void WebViewImpl::selectionDidChange()
         m_softSpaceRange = NSMakeRange(NSNotFound, 0);
 #if HAVE(TOUCH_BAR)
     updateTouchBar();
-    if (!m_page->editorState().isMissingPostLayoutData())
+    if (m_page->editorState().hasPostLayoutData())
         requestCandidatesForSelectionIfNeeded();
 #endif
 
@@ -3156,7 +3156,7 @@ void WebViewImpl::requestCandidatesForSelectionIfNeeded()
     if (!editorState.isContentEditable)
         return;
 
-    if (editorState.isMissingPostLayoutData())
+    if (!editorState.hasPostLayoutData())
         return;
 
     auto& postLayoutData = *editorState.postLayoutData;
@@ -3188,7 +3188,7 @@ void WebViewImpl::handleRequestedCandidates(NSInteger sequenceNumber, NSArray<NS
 
     // FIXME: It's pretty lame that we have to depend on the most recent EditorState having post layout data,
     // and that we just bail if it is missing.
-    if (editorState.isMissingPostLayoutData())
+    if (!editorState.hasPostLayoutData())
         return;
 
     auto& postLayoutData = *editorState.postLayoutData;
@@ -3237,7 +3237,7 @@ void WebViewImpl::handleAcceptedCandidate(NSTextCheckingResult *acceptedCandidat
 
     // FIXME: It's pretty lame that we have to depend on the most recent EditorState having post layout data,
     // and that we just bail if it is missing.
-    if (editorState.isMissingPostLayoutData())
+    if (!editorState.hasPostLayoutData())
         return;
 
     auto& postLayoutData = *editorState.postLayoutData;
@@ -5639,7 +5639,7 @@ void WebViewImpl::updateTextTouchBar()
     // the text when changing selection throughout the document.
     if (isRichlyEditableForTouchBar()) {
         const EditorState& editorState = m_page->editorState();
-        if (!editorState.isMissingPostLayoutData()) {
+        if (editorState.hasPostLayoutData()) {
             [m_textTouchBarItemController setTextIsBold:(bool)(m_page->editorState().postLayoutData->typingAttributes & AttributeBold)];
             [m_textTouchBarItemController setTextIsItalic:(bool)(m_page->editorState().postLayoutData->typingAttributes & AttributeItalics)];
             [m_textTouchBarItemController setTextIsUnderlined:(bool)(m_page->editorState().postLayoutData->typingAttributes & AttributeUnderline)];

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -436,7 +436,7 @@ void WebPage::getProcessDisplayName(CompletionHandler<void(String&&)>&& completi
 
 void WebPage::getPlatformEditorStateCommon(const Frame& frame, EditorState& result) const
 {
-    if (result.isMissingPostLayoutData())
+    if (!result.hasPostLayoutAndVisualData())
         return;
 
     const auto& selection = frame.selection().selection();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2334,6 +2334,7 @@ private:
         ScheduledDuringAccessibilitySelectionChange,
     };
     PendingEditorStateUpdateStatus m_pendingEditorStateUpdateStatus { PendingEditorStateUpdateStatus::NotScheduled };
+    bool m_needsEditorStateVisualDataUpdate { false };
 
 #if ENABLE(META_VIEWPORT)
     WebCore::ViewportConfiguration m_viewportConfiguration;

--- a/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
@@ -101,11 +101,12 @@ void WebPage::sendMessageToWebExtension(UserMessage&& message)
 
 void WebPage::getPlatformEditorState(Frame& frame, EditorState& result) const
 {
-    if (result.isMissingPostLayoutData() || !frame.view() || frame.view()->needsLayout())
+    if (!result.hasPostLayoutAndVisualData() || !frame.view() || frame.view()->needsLayout())
         return;
 
     auto& postLayoutData = *result.postLayoutData;
-    postLayoutData.caretRectAtStart = frame.selection().absoluteCaretBounds();
+    auto& visualData = *result.visualData;
+    visualData.caretRectAtStart = frame.selection().absoluteCaretBounds();
 
     const VisibleSelection& selection = frame.selection().selection();
     if (selection.isNone())

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -286,21 +286,24 @@ void WebPage::getPlatformEditorState(Frame& frame, EditorState& result) const
 {
     getPlatformEditorStateCommon(frame, result);
 
-    if (result.isMissingPostLayoutData())
+    if (!result.hasPostLayoutAndVisualData())
         return;
+
     ASSERT(frame.view());
     auto& postLayoutData = *result.postLayoutData;
+    auto& visualData = *result.visualData;
+
     Ref view = *frame.view();
 
     if (frame.editor().hasComposition()) {
         if (auto compositionRange = frame.editor().compositionRange()) {
-            postLayoutData.markedTextRects = RenderObject::collectSelectionGeometries(*compositionRange);
-            convertContentToRootView(view, postLayoutData.markedTextRects);
+            visualData.markedTextRects = RenderObject::collectSelectionGeometries(*compositionRange);
+            convertContentToRootView(view, visualData.markedTextRects);
 
             postLayoutData.markedText = plainTextForContext(*compositionRange);
             VisibleSelection compositionSelection(*compositionRange);
-            postLayoutData.markedTextCaretRectAtStart = view->contentsToRootView(compositionSelection.visibleStart().absoluteCaretBounds(nullptr /* insideFixed */));
-            postLayoutData.markedTextCaretRectAtEnd = view->contentsToRootView(compositionSelection.visibleEnd().absoluteCaretBounds(nullptr /* insideFixed */));
+            visualData.markedTextCaretRectAtStart = view->contentsToRootView(compositionSelection.visibleStart().absoluteCaretBounds(nullptr /* insideFixed */));
+            visualData.markedTextCaretRectAtEnd = view->contentsToRootView(compositionSelection.visibleEnd().absoluteCaretBounds(nullptr /* insideFixed */));
 
         }
     }
@@ -311,9 +314,9 @@ void WebPage::getPlatformEditorState(Frame& frame, EditorState& result) const
     bool startNodeIsInsideFixedPosition = false;
     bool endNodeIsInsideFixedPosition = false;
     if (selection.isCaret()) {
-        postLayoutData.caretRectAtStart = view->contentsToRootView(frame.selection().absoluteCaretBounds(&startNodeIsInsideFixedPosition));
+        visualData.caretRectAtStart = view->contentsToRootView(frame.selection().absoluteCaretBounds(&startNodeIsInsideFixedPosition));
         endNodeIsInsideFixedPosition = startNodeIsInsideFixedPosition;
-        postLayoutData.caretRectAtEnd = postLayoutData.caretRectAtStart;
+        visualData.caretRectAtEnd = visualData.caretRectAtStart;
         // FIXME: The following check should take into account writing direction.
         postLayoutData.isReplaceAllowed = result.isContentEditable && atBoundaryOfGranularity(selection.start(), TextGranularity::WordGranularity, SelectionDirection::Forward);
 
@@ -323,13 +326,13 @@ void WebPage::getPlatformEditorState(Frame& frame, EditorState& result) const
         if (selection.isContentEditable())
             charactersAroundPosition(selection.start(), postLayoutData.characterAfterSelection, postLayoutData.characterBeforeSelection, postLayoutData.twoCharacterBeforeSelection);
     } else if (selection.isRange()) {
-        postLayoutData.caretRectAtStart = view->contentsToRootView(VisiblePosition(selection.start()).absoluteCaretBounds(&startNodeIsInsideFixedPosition));
-        postLayoutData.caretRectAtEnd = view->contentsToRootView(VisiblePosition(selection.end()).absoluteCaretBounds(&endNodeIsInsideFixedPosition));
+        visualData.caretRectAtStart = view->contentsToRootView(VisiblePosition(selection.start()).absoluteCaretBounds(&startNodeIsInsideFixedPosition));
+        visualData.caretRectAtEnd = view->contentsToRootView(VisiblePosition(selection.end()).absoluteCaretBounds(&endNodeIsInsideFixedPosition));
         selectedRange = selection.toNormalizedRange();
         String selectedText;
         if (selectedRange) {
-            postLayoutData.selectionGeometries = RenderObject::collectSelectionGeometries(*selectedRange);
-            convertContentToRootView(view, postLayoutData.selectionGeometries);
+            visualData.selectionGeometries = RenderObject::collectSelectionGeometries(*selectedRange);
+            convertContentToRootView(view, visualData.selectionGeometries);
             selectedText = plainTextForDisplay(*selectedRange);
             postLayoutData.selectedTextLength = selectedText.length();
             const int maxSelectedTextLength = 200;
@@ -381,7 +384,7 @@ void WebPage::getPlatformEditorState(Frame& frame, EditorState& result) const
         }
 
         if (RefPtr editableRootOrFormControl = enclosingTextFormControl(selection.start()) ?: selection.rootEditableElement()) {
-            postLayoutData.selectionClipRect = rootViewInteractionBounds(*editableRootOrFormControl);
+            visualData.selectionClipRect = rootViewInteractionBounds(*editableRootOrFormControl);
             postLayoutData.editableRootIsTransparentOrFullyClipped = result.isContentEditable && isTransparentOrFullyClipped(*editableRootOrFormControl);
         }
         computeEditableRootHasContentAndPlainText(selection, postLayoutData);

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -153,7 +153,7 @@ void WebPage::getPlatformEditorState(Frame& frame, EditorState& result) const
 
     result.canEnableAutomaticSpellingCorrection = result.isContentEditable && frame.editor().canEnableAutomaticSpellingCorrection();
 
-    if (result.isMissingPostLayoutData())
+    if (!result.hasPostLayoutAndVisualData())
         return;
 
     auto& selection = frame.selection().selection();


### PR DESCRIPTION
#### 31c6ba7d4ea89e6add0f115823031e728f092663
<pre>
iOS: Text insertion caret can get out of sync with the page content
<a href="https://bugs.webkit.org/show_bug.cgi?id=244105">https://bugs.webkit.org/show_bug.cgi?id=244105</a>
rdar://96977291

Reviewed by Wenson Hsieh.

When remote layer tree transactions are slow to flush, intermediate EditorState
updates (from e.g. interpretKeyEvent or other sources) can cause the
UI-process-drawn text insertion caret to jump ahead of the current page tiles.
This is especially egregious when deleting a character, as the insertion
point shows up in between the soon-to-be-deleted character and the previous
character *before* the deleted one disappears.

The problem is exacerbated on slow hardware, or expensive pages.

To fix this, separate &quot;visual&quot; parts of EditorState out into their own
sub-struct, and only update it for EditorState updates that come inside
remote layer tree transactions. Other changes to EditorState will propagate
forward the existing &quot;visual&quot; data, until a new transaction comes in to replace it.

* Source/WebKit/Shared/EditorState.cpp:
(WebKit::EditorState::encode const):
(WebKit::EditorState::decode):
(WebKit::EditorState::PostLayoutData::encode const):
(WebKit::EditorState::PostLayoutData::decode):
(WebKit::EditorState::VisualData::encode const):
(WebKit::EditorState::VisualData::decode):
(WebKit::operator&lt;&lt;):
* Source/WebKit/Shared/EditorState.h:
(WebKit::EditorState::hasPostLayoutData const):
(WebKit::EditorState::ensurePostLayoutData):
(WebKit::EditorState::hasVisualData const):
(WebKit::EditorState::hasPostLayoutAndVisualData const):
(WebKit::EditorState::postLayoutData):
(WebKit::EditorState::postLayoutData const const):
(WebKit::EditorState::visualData):
(WebKit::EditorState::visualData const const):
(WebKit::EditorState::ensureVisualData):
Factor out some geometry into VisualData.
Add hasPostLayoutData and make isMissingPostLayoutData private, to make
the API the same between postLayoutData and visualData.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
Update EditorState, explicitly allowing VisualData merging.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateFontAttributesAfterEditorStateChange):
(WebKit::WebPageProxy::updateEditorState):
* Source/WebKit/UIProcess/WebPageProxy.h:
For UI-side compositing clients, make updateEditorState only merge VisualData
changes if they come in a layer tree transaction. Otherwise, we maintain the
existing VisualData. This gets a little tricky, because we need to merge
VisualData changes even if the new EditorState is otherwise stale, and
also need to avoid all of this work (and just take the current incoming
EditorState) for non-UI-side-compositing clients.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getPlatformEditorStateCommon const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::editorState const):
Generate VisualData whenever we would generate PostLayoutData.

(WebKit::WebPage::willCommitLayerTree):
(WebKit::WebPage::sendEditorStateUpdate):
(WebKit::WebPage::scheduleFullEditorStateUpdate):
Ensure that if we have scheduled *any* EditorState update since the last transaction,
the next layer tree transaction includes an EditorState update (so that we receive
and merge VisualData).

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp:
(WebKit::WebPage::getPlatformEditorState const):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getPlatformEditorState const):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::getPlatformEditorState const):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _didCommitLayerTree:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(dictionaryRepresentationForEditorState):
* Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp:
(webkitEditorStateChanged):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseUpdateTextInputState):
* Source/WebKit/UIProcess/API/wpe/WPEView.cpp:
(WKWPE::View::selectionDidChange):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(WebKit::WKSelectionDrawingInfo::WKSelectionDrawingInfo):
(-[WKContentView shouldHideSelectionWhenScrolling]):
(-[WKContentView rectToRevealWhenZoomingToFocusedElement]):
(-[WKContentView _selectionClipRect]):
(-[WKContentView canShowNonEmptySelectionView]):
(-[WKContentView webSelectionRects]):
(-[WKContentView _lookupForWebView:]):
(-[WKContentView _shareForWebView:]):
(-[WKContentView _translateForWebView:]):
(-[WKContentView _addShortcutForWebView:]):
(-[WKContentView _cascadeInteractionTintColor]):
(-[WKContentView _showDictionary:]):
(-[WKContentView removeBackgroundMenu]):
(-[WKContentView doAfterComputingImageAnalysisResultsForBackgroundRemoval:]):
(-[WKContentView textFirstRect]):
(-[WKContentView textLastRect]):
(-[WKContentView textInRange:]):
(-[WKContentView selectedTextRange]):
(-[WKContentView markedTextRange]):
(-[WKContentView hasText]):
(-[WKContentView _updateSelectionAssistantSuppressionState]):
(-[WKContentView _selectionChanged]):
(-[WKContentView _updateChangedSelection:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::interpretKeyEvent):
(WebKit::WebPageProxy::dispatchDidUpdateEditorState):
(WebKit::WebPageProxy::selectionBoundingRectInRootViewCoordinates const):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::selectionDidChange):
(WebKit::WebViewImpl::requestCandidatesForSelectionIfNeeded):
(WebKit::WebViewImpl::handleRequestedCandidates):
(WebKit::WebViewImpl::handleAcceptedCandidate):
(WebKit::WebViewImpl::updateTextTouchBar):
Adopt VisualData everywhere.

Canonical link: <a href="https://commits.webkit.org/255884@main">https://commits.webkit.org/255884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/145ea892a6e9ecfa8655da5bff96f058d4d90d3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103447 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3021 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31247 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86137 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99458 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2154 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80241 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29179 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84080 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72127 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37642 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17624 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35501 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4062 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41447 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38115 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->