### PR TITLE
[git-webkit] Automatically CC radar when creating bugs

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.7.1',
+    version='0.8.0',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 7, 1)
+version = Version(0, 8, 0)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -601,3 +601,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
             error_messages += 'Documentation URL: {}\n'.format(documentation_url)
 
         return 'Error Message: {}\n{}'.format(message, ''.join(error_messages))
+
+    def cc_radar(self, issue, block=False, timeout=None):
+        sys.stderr.write('No radar CC implemented for GitHub Issues\n')
+        return None

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -194,6 +194,9 @@ class Issue(object):
     def set_component(self, project=None, component=None, version=None):
         return self.tracker.set(self, project=project, component=component, version=version)
 
+    def cc_radar(self, block=False, timeout=None):
+        return self.tracker.cc_radar(self, block=block, timeout=timeout)
+
     def __hash__(self):
         return hash(self.link)
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/base.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/base.py
@@ -59,3 +59,4 @@ class Base(object):
                 self.users.add(type(self).transform_user(user))
 
         self.issues[id] = copy.deepcopy(bug_data)
+        return id

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
@@ -27,14 +27,22 @@ USERS = User.Mapping()
 USERS.create(
     name='Tim Contributor',
     emails=['tcontributor@example.com'],
+    username='tcontributor@example.com',
 )
 USERS.create(
     name='Felix Filer',
     emails=['ffiler@example.com'],
+    username='ffiler@example.com',
 )
 USERS.create(
     name='Wilma Watcher',
     emails=['wwatcher@example.com'],
+    username='wwatcher@example.com',
+)
+USERS.create(
+    name='Radar WebKit Bug Importer',
+    emails=['webkit-bug-importer@group.apple.com'],
+    username='webkit-bug-importer@group.apple.com',
 )
 
 ISSUES = [

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -455,3 +455,7 @@ class Tracker(GenericTracker):
         if assign:
             result.assign(self.me())
         return result
+
+    def cc_radar(self, issue, block=False, timeout=None):
+        # cc-ing radar is a no-op for radar
+        return issue

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.6.1',
+    version='5.6.2',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,14 +46,14 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 6, 1)
+version = Version(5, 6, 2)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))
 AutoInstall.register(Package('monotonic', Version(1, 5)))
 AutoInstall.register(Package('xmltodict', Version(0, 11, 0)))
 AutoInstall.register(Package('markupsafe', Version(1, 1, 1), pypi_name='MarkupSafe'))
-AutoInstall.register(Package('webkitbugspy', Version(0, 3, 1)), local=True)
+AutoInstall.register(Package('webkitbugspy', Version(0, 8, 0)), local=True)
 
 if sys.version_info < (3, 0):
     AutoInstall.register(Package('inspect2', Version(0, 1, 2)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -47,6 +47,7 @@ from .setup_git_svn import SetupGitSvn
 from .setup import Setup
 from .track import Track
 
+from webkitbugspy import log as webkitbugspy_log
 from webkitcorepy import arguments, log as webkitcorepy_log
 from webkitscmpy import local, log, remote
 
@@ -58,7 +59,7 @@ def main(
 ):
     logging.basicConfig(level=logging.WARNING)
 
-    loggers = [logging.getLogger(), webkitcorepy_log,  log] + (loggers or [])
+    loggers = [logging.getLogger(), webkitcorepy_log,  webkitbugspy_log, log] + (loggers or [])
 
     parser = argparse.ArgumentParser(
         description='Custom git tooling from the WebKit team to interact with a ' +

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
@@ -26,7 +26,7 @@ import sys
 from .command import Command
 from .commit import Commit
 
-from webkitbugspy import Tracker
+from webkitbugspy import Tracker, radar
 from webkitcorepy import run, string_utils, Terminal
 from webkitscmpy import local, log, remote
 
@@ -139,6 +139,10 @@ class Branch(Command):
                 log.warning("'{}' has no spaces, assuming user intends it to be a branch name".format(args.issue))
 
         if issue:
+            for tracker in Tracker._trackers:
+                if isinstance(tracker, radar.Tracker) and tracker.radarclient():
+                    issue.cc_radar(block=True)
+                    break
             args._title = issue.title
             args._bug_urls = Commit.bug_urls(issue)
 

--- a/metadata/trackers.json
+++ b/metadata/trackers.json
@@ -10,6 +10,10 @@
         ],
         "redact" : {
             "product:Security": true
+        }, "radar_importer": {
+            "name": "Radar WebKit Bug Importer",
+            "emails": ["webkit-bug-importer@group.apple.com"],
+            "username": "webkit-bug-importer@group.apple.com"
         }
     },
     {


### PR DESCRIPTION
#### 291e6f5f407d5dd7e26946791bad5f95cf668eb1
<pre>
[git-webkit] Automatically CC radar when creating bugs
<a href="https://bugs.webkit.org/show_bug.cgi?id=244109">https://bugs.webkit.org/show_bug.cgi?id=244109</a>
&lt;rdar://problem/98857423&gt;

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.Encoder.default): Encode Radar importer.
(Tracker.__init__): Add Radar importer.
(Tracker.populate): Prefer Radar importer bugs to ones mentioned in the description.
(Tracker.cc_radar): CC the Radar importer.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
(Tracker.cc_radar): Add.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
(Issue.cc_radar): Add.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/base.py:
(Base.add): Return issue ID.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
(Bugzilla._issue): Handle CC addition and add comment if the Radar importer is CCed.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py: Add Radar importer.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.cc_radar): Add.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py:
(Tracker.from_json): Handle radar_importer object.
(Tracker.cc_radar): Add.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py: Add webkitbugspy logger.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch.main): CC radar importer if user has radarclient.
* metadata/trackers.json: Add radar importer.

Canonical link: <a href="https://commits.webkit.org/254281@main">https://commits.webkit.org/254281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52e1d10436c66df0a20782361e371d6e7a9fcd3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97810 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31671 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27260 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80842 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92446 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25126 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75569 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25063 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/92209 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80010 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68026 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29356 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/87677 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29201 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15090 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3022 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32632 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31326 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34199 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->