### PR TITLE
RemoteImageBufferProxy::getPixelBuffer() uses too small PixelBuffer for resolutionScale() > 1 ImageBuffers

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -193,7 +193,9 @@ RefPtr<PixelBuffer> RemoteImageBufferProxy::getPixelBuffer(const PixelBufferForm
         return nullptr;
     auto& mutableThis = const_cast<RemoteImageBufferProxy&>(*this);
     mutableThis.flushDrawingContextAsync();
-    auto pixelBuffer = allocator.createPixelBuffer(destinationFormat, srcRect.size());
+    IntRect sourceRectScaled = srcRect;
+    sourceRectScaled.scale(resolutionScale());
+    auto pixelBuffer = allocator.createPixelBuffer(destinationFormat, sourceRectScaled.size());
     if (!pixelBuffer)
         return nullptr;
     if (!m_remoteRenderingBackendProxy->getPixelBufferForImageBuffer(m_renderingResourceIdentifier, destinationFormat, srcRect, { pixelBuffer->bytes(), pixelBuffer->sizeInBytes() }))


### PR DESCRIPTION
#### bb61b0638af6d7cb00109995ba8ad80fe74fdcde
<pre>
RemoteImageBufferProxy::getPixelBuffer() uses too small PixelBuffer for resolutionScale() &gt; 1 ImageBuffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=244118">https://bugs.webkit.org/show_bug.cgi?id=244118</a>
rdar://problem/98873549

Reviewed by Said Abou-Hallawa.

ImageBuffer:getPixelBuffer() is defined to return PixelBuffer of the &quot;backend physical size&quot;
instead of &quot;logical size&quot;.

This would cause WP allocate PixelBuffer based on the logical size, allocate SharedMemory
of same size, but GPUP try to write the physical sized PixelBuffer to this.

This would fail the check &quot;Shmem for return of getPixelBuffer is too small&quot; on normal
circumstances.

However, currently this does not fire, as there are no real clients using
getPixelBuffer() with resolutionScale() != 1.

The page color sampler WebCore::sampleColor() is the only client for the scenario.
There the function will render logical 1,1 ImageBitmap scaled to deviceScaleFactor.
This would produce 4 byte PixelBuffer in WP side, but 16 byte PixelBuffer in GPUP
side. However, this failure would be masked by the SharedMemory implementation
inaccuracy where 4 byte SharedMemory would appear as 16384 size. Note: even though
the failure was masked, the result was incorrect as GPUP would write 2x2 image
and WP would read 1x1 out of the SharedMemory.

Once the inaccuracy was fixed in bug 240056, the GPUP check would fire.

Adds a ImageBuffer test that expresses the API contract as a test.
However, this test does not fail for unfixed WebKit, as the test
runs only in-process WebCore ImageBuffer variants, not the RemoteImageBufferProxy.

* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::getPixelBuffer const):
* Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp:
(TestWebKitAPI::imageBufferPixelIs):
(TestWebKitAPI::AnyScaleTest::deviceScaleFactor const):
(TestWebKitAPI::AnyScaleTest::imageBufferOptions const):
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/253639@main">https://commits.webkit.org/253639@main</a>
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba998c7299fa68bbc14514479885bd40db8c81b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86473 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30400 "failed Failed to compile WebKit Reverted pull request changes (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95321 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149033 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28821 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25372 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78633 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90565 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23366 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73437 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23421 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66425 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26706 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12606 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26620 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13619 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2585 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36494 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32901 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->