### PR TITLE
Remote-related methods leak to ImageBuffer due to RemoteResourceCacheProxy using ImageBuffer instances

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -200,12 +200,6 @@ void ImageBuffer::flushContext()
     }
 }
 
-void ImageBuffer::setBackend(std::unique_ptr<ImageBufferBackend>&& backend)
-{
-    ASSERT(!m_backend);
-    m_backend = WTFMove(backend);
-}
-
 IntSize ImageBuffer::backendSize() const
 {
     if (auto* backend = ensureBackendCreated())

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -145,12 +145,9 @@ public:
     virtual void flushDrawingContext() { }
     virtual bool flushDrawingContextAsync() { return false; }
     virtual void didFlush(GraphicsContextFlushIdentifier) { }
-    virtual void backingStoreWillChange() { }
 
-    WEBCORE_EXPORT void setBackend(std::unique_ptr<ImageBufferBackend>&&);
     WEBCORE_EXPORT IntSize backendSize() const;
 
-    virtual void clearBackend() { m_backend = nullptr; }
     ImageBufferBackend* backend() const { return m_backend.get(); }
     virtual ImageBufferBackend* ensureBackendCreated() const { return m_backend.get(); }
 
@@ -170,7 +167,6 @@ public:
     AffineTransform baseTransform() const { return m_backendInfo.baseTransform; }
     size_t memoryCost() const { return m_backendInfo.memoryCost; }
     size_t externalMemoryCost() const { return m_backendInfo.externalMemoryCost; }
-    void setBackendInfo(ImageBufferBackend::Info&& parameters) { m_backendInfo = WTFMove(parameters); }
 
     WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImage(BackingStoreCopy = CopyBackingStore) const;
     WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImageForDrawing(BackingStoreCopy = CopyBackingStore) const;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListImageBuffer.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListImageBuffer.h
@@ -84,12 +84,6 @@ public:
             m_drawingContext.replayDisplayList(WebCore::ImageBuffer::context());
     }
 
-    void clearBackend() final
-    {
-        m_drawingContext.displayList().clear();
-        WebCore::ImageBuffer::clearBackend();
-    }
-
 protected:
     DrawingContext m_drawingContext;
     std::unique_ptr<ItemBufferWritingClient> m_writingClient;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(GPU_PROCESS)
 
-#include "RemoteRenderingBackendProxy.h"
 #include <WebCore/DisplayListRecorder.h>
 #include <WebCore/DrawGlyphsRecorder.h>
 #include <WebCore/GraphicsContext.h>
@@ -36,10 +35,11 @@
 namespace WebKit {
 
 class RemoteRenderingBackendProxy;
+class RemoteImageBufferProxy;
 
 class RemoteDisplayListRecorderProxy : public WebCore::DisplayList::Recorder {
 public:
-    RemoteDisplayListRecorderProxy(WebCore::ImageBuffer&, RemoteRenderingBackendProxy&, const WebCore::FloatRect& initialClip, const WebCore::AffineTransform&);
+    RemoteDisplayListRecorderProxy(RemoteImageBufferProxy&, RemoteRenderingBackendProxy&, const WebCore::FloatRect& initialClip, const WebCore::AffineTransform&);
     ~RemoteDisplayListRecorderProxy() = default;
 
     void convertToLuminanceMask() final;
@@ -47,15 +47,7 @@ public:
     void flushContext(WebCore::GraphicsContextFlushIdentifier);
 
 private:
-    template<typename T>
-    void send(T&& message)
-    {
-        if (UNLIKELY(!(m_renderingBackend && m_imageBuffer)))
-            return;
-
-        m_imageBuffer->backingStoreWillChange();
-        m_renderingBackend->sendToStream(WTFMove(message), m_destinationBufferIdentifier);
-    }
+    template<typename T> void send(T&& message);
 
     friend class WebCore::DrawGlyphsRecorder;
 
@@ -142,7 +134,7 @@ private:
     RefPtr<WebCore::ImageBuffer> createAlignedImageBuffer(const WebCore::FloatRect&, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMethod>) const final;
 
     WebCore::RenderingResourceIdentifier m_destinationBufferIdentifier;
-    WeakPtr<WebCore::ImageBuffer> m_imageBuffer;
+    WeakPtr<RemoteImageBufferProxy> m_imageBuffer;
     WeakPtr<RemoteRenderingBackendProxy> m_renderingBackend;
 };
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "ImageBufferBackendHandle.h"
 #include "RemoteDisplayListRecorderProxy.h"
 #include <WebCore/ImageBuffer.h>
 #include <wtf/Condition.h>
@@ -54,6 +55,12 @@ public:
 
     void waitForDidFlushOnSecondaryThread(WebCore::GraphicsContextFlushIdentifier);
 
+    WebCore::ImageBufferBackend* ensureBackendCreated() const final;
+    void didFlush(WebCore::GraphicsContextFlushIdentifier) final;
+
+    void clearBackend();
+    void backingStoreWillChange();
+    void didCreateImageBufferBackend(ImageBufferBackendHandle&&);
 private:
     RemoteImageBufferProxy(const WebCore::ImageBufferBackend::Parameters&, const WebCore::ImageBufferBackend::Info&, RemoteRenderingBackendProxy&);
 
@@ -61,14 +68,7 @@ private:
     // only gets modified on the main thread.
     bool hasPendingFlush() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
 
-    void didFlush(WebCore::GraphicsContextFlushIdentifier) final;
-
-    void backingStoreWillChange() final;
-
     void waitForDidFlushWithTimeout();
-
-    WebCore::ImageBufferBackend* ensureBackendCreated() const final;
-    void clearBackend() final;
 
     RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) const final;
     RefPtr<WebCore::NativeImage> copyNativeImageForDrawing(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) const final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -395,21 +395,12 @@ void RemoteRenderingBackendProxy::didPaintLayers()
     m_remoteResourceCacheProxy.didPaintLayers();
 }
 
-void RemoteRenderingBackendProxy::didCreateImageBufferBackend(ImageBufferBackendHandle handle, RenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteRenderingBackendProxy::didCreateImageBufferBackend(ImageBufferBackendHandle&& handle, RenderingResourceIdentifier renderingResourceIdentifier)
 {
     auto imageBuffer = m_remoteResourceCacheProxy.cachedImageBuffer(renderingResourceIdentifier);
     if (!imageBuffer)
         return;
-    
-    if (imageBuffer->renderingMode() == RenderingMode::Accelerated && std::holds_alternative<ShareableBitmap::Handle>(handle))
-        imageBuffer->setBackendInfo(ImageBuffer::populateBackendInfo<UnacceleratedImageBufferShareableBackend>(imageBuffer->parameters()));
-    
-    if (imageBuffer->renderingMode() == RenderingMode::Unaccelerated)
-        imageBuffer->setBackend(UnacceleratedImageBufferShareableBackend::create(imageBuffer->parameters(), WTFMove(handle)));
-    else if (imageBuffer->canMapBackingStore())
-        imageBuffer->setBackend(AcceleratedImageBufferShareableMappedBackend::create(imageBuffer->parameters(), WTFMove(handle)));
-    else
-        imageBuffer->setBackend(AcceleratedImageBufferRemoteBackend::create(imageBuffer->parameters(), WTFMove(handle)));
+    imageBuffer->didCreateImageBufferBackend(WTFMove(handle));
 }
 
 void RemoteRenderingBackendProxy::didFlush(GraphicsContextFlushIdentifier flushIdentifier, RenderingResourceIdentifier renderingResourceIdentifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -171,7 +171,7 @@ private:
     void destroyGetPixelBufferSharedMemory();
 
     // Messages to be received.
-    void didCreateImageBufferBackend(ImageBufferBackendHandle, WebCore::RenderingResourceIdentifier);
+    void didCreateImageBufferBackend(ImageBufferBackendHandle&&, WebCore::RenderingResourceIdentifier);
     void didFlush(WebCore::GraphicsContextFlushIdentifier, WebCore::RenderingResourceIdentifier);
     void didFinalizeRenderingUpdate(RenderingUpdateID didRenderingUpdateID);
     void didMarkLayersAsVolatile(MarkSurfacesAsVolatileRequestIdentifier, const Vector<WebCore::RenderingResourceIdentifier>& markedVolatileBufferIdentifiers, bool didMarkAllLayerAsVolatile);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -46,26 +46,27 @@ RemoteResourceCacheProxy::~RemoteResourceCacheProxy()
     clearDecomposedGlyphsMap();
 }
 
-void RemoteResourceCacheProxy::cacheImageBuffer(WebCore::ImageBuffer& imageBuffer)
+void RemoteResourceCacheProxy::cacheImageBuffer(RemoteImageBufferProxy& imageBuffer)
 {
     auto addResult = m_imageBuffers.add(imageBuffer.renderingResourceIdentifier(), imageBuffer);
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 }
 
-ImageBuffer* RemoteResourceCacheProxy::cachedImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier) const
+RemoteImageBufferProxy* RemoteResourceCacheProxy::cachedImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier) const
 {
     return m_imageBuffers.get(renderingResourceIdentifier).get();
 }
 
-void RemoteResourceCacheProxy::releaseImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteResourceCacheProxy::releaseImageBuffer(RemoteImageBufferProxy& imageBuffer)
 {
-    auto iterator = m_imageBuffers.find(renderingResourceIdentifier);
+    auto identifier = imageBuffer.renderingResourceIdentifier();
+    auto iterator = m_imageBuffers.find(identifier);
     RELEASE_ASSERT(iterator != m_imageBuffers.end());
 
     auto success = m_imageBuffers.remove(iterator);
     ASSERT_UNUSED(success, success);
 
-    m_remoteRenderingBackendProxy.releaseRemoteResource(renderingResourceIdentifier);
+    m_remoteRenderingBackendProxy.releaseRemoteResource(identifier);
 }
 
 inline static RefPtr<ShareableBitmap> createShareableBitmapFromNativeImage(NativeImage& image)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -40,6 +40,7 @@ class ImageBuffer;
 
 namespace WebKit {
 
+class RemoteImageBufferProxy;
 class RemoteRenderingBackendProxy;
 
 class RemoteResourceCacheProxy : public WebCore::NativeImage::Observer, public WebCore::DecomposedGlyphs::Observer {
@@ -47,9 +48,9 @@ public:
     RemoteResourceCacheProxy(RemoteRenderingBackendProxy&);
     ~RemoteResourceCacheProxy();
 
-    void cacheImageBuffer(WebCore::ImageBuffer&);
-    WebCore::ImageBuffer* cachedImageBuffer(WebCore::RenderingResourceIdentifier) const;
-    void releaseImageBuffer(WebCore::RenderingResourceIdentifier);
+    void cacheImageBuffer(RemoteImageBufferProxy&);
+    RemoteImageBufferProxy* cachedImageBuffer(WebCore::RenderingResourceIdentifier) const;
+    void releaseImageBuffer(RemoteImageBufferProxy&);
 
     void recordNativeImageUse(WebCore::NativeImage&);
     void recordFontUse(WebCore::Font&);
@@ -64,7 +65,7 @@ public:
     unsigned imagesCount() const { return m_nativeImages.size(); }
 
 private:
-    using ImageBufferHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<WebCore::ImageBuffer>>;
+    using ImageBufferHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<RemoteImageBufferProxy>>;
     using NativeImageHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<WebCore::NativeImage>>;
     using FontHashMap = HashMap<WebCore::RenderingResourceIdentifier, uint64_t>;
     using DecomposedGlyphsHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<WebCore::DecomposedGlyphs>>;


### PR DESCRIPTION
#### d0e581de24078de378cb4ad11ad580ea859d25d5
<pre>
Remote-related methods leak to ImageBuffer due to RemoteResourceCacheProxy using ImageBuffer instances
<a href="https://bugs.webkit.org/show_bug.cgi?id=244119">https://bugs.webkit.org/show_bug.cgi?id=244119</a>
rdar://problem/98877510

Reviewed by Simon Fraser.

RemoteResourceCacheProxy holds only RemoteImageBufferProxy instances.
Make the hash map holding the instances reflect this.

This allows us to use RemoteImageBufferProxy in RemoteResourceCacheProxy code.
This allows us to remove some RemoteImageBufferProxy-only features from ImageBuffer.

This is work towards being able to use remote image buffers across GPUP threads.

* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::didFlush):
(WebCore::ImageBuffer::backingStoreWillChange): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::RemoteDisplayListRecorderProxy):
(WebKit::RemoteDisplayListRecorderProxy::send):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
(WebKit::RemoteDisplayListRecorderProxy::send): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::~RemoteImageBufferProxy):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::cacheImageBuffer):
(WebKit::RemoteResourceCacheProxy::cachedImageBuffer const):
(WebKit::RemoteResourceCacheProxy::releaseImageBuffer):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::setBackend): Deleted.
* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::externalMemoryCost const):
(WebCore::ImageBuffer::clearBackend): Deleted.
(WebCore::ImageBuffer::setBackendInfo): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListImageBuffer.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::didCreateImageBufferBackend):
(WebKit::RemoteImageBufferProxy::clearBackend):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::didCreateImageBufferBackend):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:

Canonical link: <a href="https://commits.webkit.org/253686@main">https://commits.webkit.org/253686@main</a>
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01372a7a7e477a27ad7f565eba7bb88ab3b42448

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95325 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149038 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90465 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28826 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25376 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78637 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90570 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23367 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73441 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23425 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66426 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26710 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12609 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26624 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13622 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2618 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36495 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32904 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->