### PR TITLE
Web Inspector: Elements Tab: create an Event badge for nodes that have event listeners

### DIFF
--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Event-attribute-expected.txt
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Event-attribute-expected.txt
@@ -1,0 +1,35 @@
+Tests for the CSS.nodeLayoutFlagsChanged event with the Event enum.
+
+
+== Running test suite: CSS.nodeLayoutFlagsChanged.Event
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Attribute.Initial
+PASS: Should have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Attribute.Removed.Parent
+Removing attribute event listener from parent...
+PASS: Should have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Attribute.Removed.Child
+Removing attribute event listener from child...
+PASS: Should have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Attribute.Removed
+Removing attribute event listener...
+PASS: Should not have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Attribute.Added.Parent
+Adding attribute event listener to parent...
+PASS: Should not have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Attribute.Added.Child
+Adding attribute event listener to child...
+PASS: Should not have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Attribute.Added
+Adding attribute event listener...
+PASS: Should have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Attribute.RapidChange
+Rapidly changing attribute event listener...
+PASS: Should have Event layout flag.
+

--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Event-attribute.html
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Event-attribute.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CSS.nodeLayoutFlagsChanged.Event");
+
+    function addTestCase({name, description, selector, setup, domNodeHandler})
+    {
+        suite.addTestCase({
+            name,
+            description,
+            setup,
+            async test() {
+                let documentNode = await WI.domManager.requestDocument();
+                let nodeId = await documentNode.querySelector(selector);
+                let domNode = WI.domManager.nodeForId(nodeId);
+                InspectorTest.assert(domNode, `Should find DOM Node for selector '${selector}'.`);
+                await domNodeHandler(domNode);
+            },
+        });
+    }
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Attribute.Initial",
+        description: "Test node with an attribute event listener.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Attribute.Removed.Parent",
+        description: "Test that removing an attribute event listener from a parent has no effect on the child.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+
+            InspectorTest.log("Removing attribute event listener from parent...");
+            let listener = domNode.singleFireEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags of child.");
+            });
+            await InspectorTest.evaluateInPage(`document.querySelector("#parent").onclick = null`);
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Attribute.Removed.Child",
+        description: "Test that removing an attribute event listener from a child has no effect on the parent.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+
+            InspectorTest.log("Removing attribute event listener from child...");
+            let listener = domNode.singleFireEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags of parent.");
+            });
+            await InspectorTest.evaluateInPage(`document.querySelector("#child").onclick = null`);
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Attribute.Removed",
+        description: "Test removing an attribute event listener.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+
+            InspectorTest.log("Removing attribute event listener...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                InspectorTest.evaluateInPage(`document.querySelector("#target").onclick = null`),
+            ]);
+
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should not have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Attribute.Added.Parent",
+        description: "Test that adding an attribute event listener to a parent has no effect on the child.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should not have Event layout flag.");
+
+            InspectorTest.log("Adding attribute event listener to parent...");
+            let listener = domNode.singleFireEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags of child.");
+            });
+            await InspectorTest.evaluateInPage(`document.querySelector("#parent").onclick = (function parentClick2() { })`);
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should not have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Attribute.Added.Child",
+        description: "Test that adding an attribute event listener to a child has no effect on the parent.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should not have Event layout flag.");
+
+            InspectorTest.log("Adding attribute event listener to child...");
+            let listener = domNode.singleFireEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags of parent.");
+            });
+            await InspectorTest.evaluateInPage(`document.querySelector("#child").onclick = (function childClick2() { })`);
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should not have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Attribute.Added",
+        description: "Test adding an attribute event listener.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should not have Event layout flag.");
+
+            InspectorTest.log("Adding attribute event listener...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                InspectorTest.evaluateInPage(`document.querySelector("#target").onclick = (function targetClick2() { })`),
+            ]);
+
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Attribute.RapidChange",
+        description: "Test rapidly removing and adding an attribute event listener.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+
+            InspectorTest.log("Rapidly changing attribute event listener...");
+            let listener = domNode.singleFireEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags.");
+            });
+            await InspectorTest.evaluateInPage(`for (let i = 0; i < 10; ++i) { let old = document.querySelector("#target").onclick; document.querySelector("#target").onclick = null; document.querySelector("#target").onclick = old; }`);
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Tests for the CSS.nodeLayoutFlagsChanged event with the Event enum.</p>
+
+    <div id="parent" onclick="(function parentClick(event) { })()">
+        <div id="target" onclick="(function targetClick(event) { })()">
+            <div id="child" onclick="(function childClick(event) { })()">
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Event-script-expected.txt
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Event-script-expected.txt
@@ -1,0 +1,35 @@
+Tests for the CSS.nodeLayoutFlagsChanged event with the Event enum.
+
+
+== Running test suite: CSS.nodeLayoutFlagsChanged.Event
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Script.Initial
+PASS: Should have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Script.Removed.Parent
+Removing JS event listener from parent...
+PASS: Should have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Script.Removed.Child
+Removing JS event listener from child...
+PASS: Should have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Script.Removed
+Removing JS event listener...
+PASS: Should not have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Script.Added.Parent
+Adding JS event listener to parent...
+PASS: Should not have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Script.Added.Child
+Adding JS event listener to child...
+PASS: Should not have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Script.Added
+Adding JS event listener...
+PASS: Should have Event layout flag.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Event.Script.RapidChange
+Rapidly changing JS event listener...
+PASS: Should have Event layout flag.
+

--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Event-script.html
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Event-script.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CSS.nodeLayoutFlagsChanged.Event");
+
+    function addTestCase({name, description, selector, setup, domNodeHandler})
+    {
+        suite.addTestCase({
+            name,
+            description,
+            setup,
+            async test() {
+                let documentNode = await WI.domManager.requestDocument();
+                let nodeId = await documentNode.querySelector(selector);
+                let domNode = WI.domManager.nodeForId(nodeId);
+                InspectorTest.assert(domNode, `Should find DOM Node for selector '${selector}'.`);
+                await domNodeHandler(domNode);
+            },
+        });
+    }
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Script.Initial",
+        description: "Test node with a JS event listener.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Script.Removed.Parent",
+        description: "Test that removing a JS event listener from a parent has no effect on the child.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+
+            InspectorTest.log("Removing JS event listener from parent...");
+            let listener = domNode.singleFireEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags of child.");
+            });
+            await InspectorTest.evaluateInPage(`document.querySelector("#parent").removeEventListener("click", handler)`);
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Script.Removed.Child",
+        description: "Test that removing a JS event listener from a child has no effect on the parent.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+
+            InspectorTest.log("Removing JS event listener from child...");
+            let listener = domNode.singleFireEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags of parent.");
+            });
+            await InspectorTest.evaluateInPage(`document.querySelector("#child").removeEventListener("click", handler)`);
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Script.Removed",
+        description: "Test removing a JS event listener.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+
+            InspectorTest.log("Removing JS event listener...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                InspectorTest.evaluateInPage(`document.querySelector("#target").removeEventListener("click", handler)`),
+            ]);
+
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should not have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Script.Added.Parent",
+        description: "Test that adding a JS event listener to a parent has no effect on the child.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should not have Event layout flag.");
+
+            InspectorTest.log("Adding JS event listener to parent...");
+            let listener = domNode.singleFireEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags of child.");
+            });
+            await InspectorTest.evaluateInPage(`document.querySelector("#parent").addEventListener("click", handler)`);
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should not have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Script.Added.Child",
+        description: "Test that adding a JS event listener to a child has no effect on the parent.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should not have Event layout flag.");
+
+            InspectorTest.log("Adding JS event listener to child...");
+            let listener = domNode.singleFireEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags of parent.");
+            });
+            await InspectorTest.evaluateInPage(`document.querySelector("#child").addEventListener("click", handler)`);
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should not have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Script.Added",
+        description: "Test adding a JS event listener.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should not have Event layout flag.");
+
+            InspectorTest.log("Adding JS event listener...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                InspectorTest.evaluateInPage(`document.querySelector("#target").addEventListener("click", handler)`),
+            ]);
+
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Event.Script.RapidChange",
+        description: "Test rapidly removing and adding a JS event listener.",
+        selector: "#target",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+
+            InspectorTest.log("Rapidly changing JS event listener...");
+            let listener = domNode.singleFireEventListener(WI.DOMNode.Event.LayoutFlagsChanged, (event) => {
+                InspectorTest.fail("Should not change layout flags.");
+            });
+            await InspectorTest.evaluateInPage(`for (let i = 0; i < 10; ++i) { document.querySelector("#target").removeEventListener("click", handler); document.querySelector("#target").addEventListener("click", handler); }`);
+            domNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Event), "Should have Event layout flag.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Tests for the CSS.nodeLayoutFlagsChanged event with the Event enum.</p>
+
+    <div id="parent">
+        <div id="target">
+            <div id="child">
+        </div>
+    </div>
+    <script>
+        function handler() { }
+
+        document.querySelector("#parent").addEventListener("click", handler);
+        document.querySelector("#target").addEventListener("click", handler);
+        document.querySelector("#child").addEventListener("click", handler);
+    </script>
+</body>
+</html>

--- a/LayoutTests/inspector/dom/getEventListenersForNode-expected.txt
+++ b/LayoutTests/inspector/dom/getEventListenersForNode-expected.txt
@@ -2,7 +2,7 @@ Testing DOMAgent.getEventListenersForNode.
 
 
 == Running test suite: DOM.getEventListenersForNode
--- Running test case: DOM.getEventListenersForNode.Basic
+-- Running test case: DOM.getEventListenersForNode.Child.IncludeAncestors
 Event: A
 Target: body
 Capture: true
@@ -84,5 +84,106 @@ Event: error
 Target: window
 Capture: false
 Attribute: true
+
+
+-- Running test case: DOM.getEventListenersForNode.Child.ExcludeAncestors
+Event: E
+Target: div#x
+Capture: false
+Attribute: false
+Handler Name: ObjectEventHandler
+The Event Listener has a source location.
+
+Event: D
+Target: div#x
+Capture: false
+Attribute: false
+Handler Name: handleEvent
+The Event Listener has a source location.
+
+Event: C
+Target: div#x
+Capture: false
+Attribute: false
+The Event Listener has a source location.
+
+Event: B
+Target: div#x
+Capture: false
+Attribute: false
+Handler Name: xB
+Once: true
+The Event Listener has a source location.
+
+Event: A
+Target: div#x
+Capture: false
+Attribute: false
+Handler Name: xA
+The Event Listener has a source location.
+
+Event: click
+Target: div#x
+Capture: false
+Attribute: true
+Handler Name: onclick
+The Event Listener has a source location.
+
+
+-- Running test case: DOM.getEventListenersForNode.Body.IncludeAncestors
+Event: A
+Target: body
+Capture: true
+Attribute: false
+Handler Name: bodyA
+The Event Listener has a source location.
+
+Event: B
+Target: body
+Capture: true
+Attribute: false
+The Event Listener has a source location.
+
+Event: B
+Target: #document
+Capture: false
+Attribute: false
+Passive: true
+The Event Listener has a source location.
+
+Event: A
+Target: #document
+Capture: false
+Attribute: false
+Handler Name: documentA
+Passive: true
+The Event Listener has a source location.
+
+Event: load
+Target: window
+Capture: false
+Attribute: true
+Handler Name: onload
+The Event Listener has a source location.
+
+Event: error
+Target: window
+Capture: false
+Attribute: true
+
+
+-- Running test case: DOM.getEventListenersForNode.Body.ExcludeAncestors
+Event: A
+Target: body
+Capture: true
+Attribute: false
+Handler Name: bodyA
+The Event Listener has a source location.
+
+Event: B
+Target: body
+Capture: true
+Attribute: false
+The Event Listener has a source location.
 
 

--- a/LayoutTests/inspector/dom/getEventListenersForNode.html
+++ b/LayoutTests/inspector/dom/getEventListenersForNode.html
@@ -4,21 +4,36 @@
 <script src="../../http/tests/inspector/resources/inspector-test.js"></script>
 <script>
 function test() {
-    let domNode = null;
-
     let suite = InspectorTest.createAsyncSuite("DOM.getEventListenersForNode");
 
-    suite.addTestCase({
-        name: "DOM.getEventListenersForNode.Basic",
-        description: "Ensure all applicable fields of each event listener is supplied.",
-        test(resolve, reject) {
-            DOMAgent.getEventListenersForNode(domNode.id, (error, eventListeners) => {
-                if (error) {
-                    reject(error);
-                    return;
-                }
-
-                for (let eventListener of eventListeners) {
+    [
+        {
+            name: "DOM.getEventListenersForNode.Child.IncludeAncestors",
+            selector: "#x",
+        },
+        {
+            name: "DOM.getEventListenersForNode.Child.ExcludeAncestors",
+            selector: "#x",
+            includeAncestors: false,
+        },
+        {
+            name: "DOM.getEventListenersForNode.Body.IncludeAncestors",
+            selector: "body",
+            includeAncestors: true,
+        },
+        {
+            name: "DOM.getEventListenersForNode.Body.ExcludeAncestors",
+            selector: "body",
+            includeAncestors: false,
+        },
+    ].forEach(({name, selector, includeAncestors}) => {
+        suite.addTestCase({
+            name,
+            async test(resolve, reject) {
+                let documentNode = await WI.domManager.requestDocument();
+                let nodeId = await documentNode.querySelector(selector);
+                let {listeners} = await DOMAgent.getEventListenersForNode(nodeId, includeAncestors);
+                for (let eventListener of listeners) {
                     InspectorTest.log(`Event: ${eventListener.type}`);
                     if (eventListener.nodeId) {
                         let node = WI.domManager.nodeForId(eventListener.nodeId);
@@ -40,25 +55,11 @@ function test() {
 
                     InspectorTest.log("");
                 }
-
-                resolve();
-            });
-        }
-    });
-
-    WI.domManager.requestDocument((documentNode) => {
-        documentNode.querySelector("div#x", (contentNodeId) => {
-            if (!contentNodeId) {
-                InspectorTest.fail("DOM node not found.");
-                InspectorTest.completeTest();
-                return;
-            }
-
-            domNode = WI.domManager.nodeForId(contentNodeId);
-
-            suite.runTestCasesAndFinish();
+            },
         });
     });
+
+    suite.runTestCasesAndFinish();
 }
 </script>
 </head>

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -274,7 +274,8 @@
             "enum": [
                 "rendered",
                 "flex",
-                "grid"
+                "grid",
+                "event"
             ],
             "description": "Relevant layout information about the node. Things not in this list are not important to Web Inspector."
         },

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -307,7 +307,8 @@
             "name": "getEventListenersForNode",
             "description": "Returns event listeners relevant to the node.",
             "parameters": [
-                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get listeners for." }
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get listeners for." },
+                { "name": "includeAncestors", "type": "boolean", "optional": true, "description": "Controls whether ancestor event listeners are included. Defaults to true." }
             ],
             "returns": [
                 { "name": "listeners", "type": "array", "items": { "$ref": "EventListener"}, "description": "Array of relevant listeners." }

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -353,6 +353,8 @@ void InspectorInstrumentation::didAddEventListenerImpl(InstrumentingAgents& inst
         webDebuggerAgent->didAddEventListener(target, eventType, listener, capture);
     if (auto* domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->didAddEventListener(target);
+    if (auto* cssAgent = instrumentingAgents.enabledCSSAgent())
+        cssAgent->didAddEventListener(target);
 }
 
 void InspectorInstrumentation::willRemoveEventListenerImpl(InstrumentingAgents& instrumentingAgents, EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)
@@ -361,6 +363,8 @@ void InspectorInstrumentation::willRemoveEventListenerImpl(InstrumentingAgents& 
         webDebuggerAgent->willRemoveEventListener(target, eventType, listener, capture);
     if (auto* domAgent = instrumentingAgents.persistentDOMAgent())
         domAgent->willRemoveEventListener(target, eventType, listener, capture);
+    if (auto* cssAgent = instrumentingAgents.enabledCSSAgent())
+        cssAgent->willRemoveEventListener(target);
 }
 
 bool InspectorInstrumentation::isEventListenerDisabledImpl(InstrumentingAgents& instrumentingAgents, EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -124,7 +124,7 @@ public:
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::DataBinding>>> getDataBindingsForNode(Inspector::Protocol::DOM::NodeId);
     Inspector::Protocol::ErrorStringOr<String> getAssociatedDataForNode(Inspector::Protocol::DOM::NodeId);
 #endif
-    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::EventListener>>> getEventListenersForNode(Inspector::Protocol::DOM::NodeId);
+    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::EventListener>>> getEventListenersForNode(Inspector::Protocol::DOM::NodeId, std::optional<bool>&& includeAncestors);
     Inspector::Protocol::ErrorStringOr<void> setEventListenerDisabled(Inspector::Protocol::DOM::EventListenerId, bool);
     Inspector::Protocol::ErrorStringOr<void> setBreakpointForEventListener(Inspector::Protocol::DOM::EventListenerId, RefPtr<JSON::Object>&& options);
     Inspector::Protocol::ErrorStringOr<void> removeBreakpointForEventListener(Inspector::Protocol::DOM::EventListenerId);

--- a/Source/WebInspectorUI/UserInterface/Views/DOMNodeDetailsSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMNodeDetailsSidebarPanel.css
@@ -50,16 +50,6 @@ body[dir=rtl] .sidebar > .panel.dom-node-details .details-section.dom-node-event
     filter: brightness(0.5);
 }
 
-.sidebar > .panel.dom-node-details .details-section.dom-node-event-listeners .details-section.event-listener-section > .header > .event-listener-options {
-    display: none;
-    width: 15px;
-    height: 15px;
-}
-
-.sidebar > .panel.dom-node-details .details-section.dom-node-event-listeners .details-section.event-listener-section:hover > .header > .event-listener-options {
-    display: block;
-}
-
 @media (prefers-color-scheme: dark) {
     .sidebar > .panel.dom-node-details .details-section.dom-node-event-listeners > .header > .filter:hover {
         filter: brightness(1.25);

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
@@ -521,6 +521,14 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
                 WI.settings.enabledDOMTreeBadgeTypes.save();
             }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.Flex));
         }
+
+        // COMPATIBILITY (macOS 13.0, iOS 16.0): the `includeAncestors` parameter of `DOM.getEventListenersForNode` did not exist yet.
+        if (InspectorBackend.hasCommand("DOM.getEventListenersForNode", "includeAncestors")) {
+            contextMenu.appendCheckboxItem(WI.UIString("Event"), () => {
+                WI.settings.enabledDOMTreeBadgeTypes.value.toggleIncludes(WI.DOMTreeElement.BadgeType.Event);
+                WI.settings.enabledDOMTreeBadgeTypes.save();
+            }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.Event));
+        }
     }
 
     _domTreeElementAdded(event)

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.css
@@ -48,6 +48,18 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-with
     color: var(--text-color);
 }
 
+.event-badge-popover-content {
+    overflow: hidden;
+}
+
+.event-badge-popover-content > .details-section.event-listeners {
+    max-height: calc(100vh - var(--tab-bar-height) - var(--console-prompt-min-height));
+    overflow: auto;
+}
+
+.event-badge-popover-content > .details-section.event-listeners .details-section {
+    border-inline: 1px solid var(--border-color);
+}
 
 @media (prefers-color-scheme: dark) {
     .tree-outline.dom .badge {

--- a/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
@@ -88,12 +88,15 @@ body[dir=rtl] .details-section > .header > .options {
 }
 
 .details-section .details-section > .header {
-    top: 21px;
     background-color: var(--background-color-content);
     font-weight: 500;
 
     /* Ensure these headers are displayed below the parent header but above scrollbars. */
     z-index: calc(var(--z-index-header) - 1);
+}
+
+.details-section:has(> .header > .title:not(:empty)) .details-section > .header {
+    top: 21px;
 }
 
 .details-section .details-section:not(.collapsed) > .header {

--- a/Source/WebInspectorUI/UserInterface/Views/DetailsSection.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DetailsSection.js
@@ -51,6 +51,7 @@ WI.DetailsSection = class DetailsSection extends WI.Object
         }
 
         this._titleElement = document.createElement("span");
+        this._titleElement.className = "title";
         this._headerElement.appendChild(this._titleElement);
 
         this._contentElement = document.createElement("div");

--- a/Source/WebInspectorUI/UserInterface/Views/EventListenerSectionGroup.css
+++ b/Source/WebInspectorUI/UserInterface/Views/EventListenerSectionGroup.css
@@ -23,6 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+.event-listener-section > .header > .event-listener-options {
+    display: none;
+    width: 15px;
+    height: 15px;
+}
+
+.event-listener-section:hover > .header > .event-listener-options {
+    display: block;
+}
+
 .event-listener-section > .content > .group > .row.simple > .value {
     white-space: nowrap;
     overflow: hidden;

--- a/Source/WebInspectorUI/UserInterface/Views/Popover.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Popover.js
@@ -114,7 +114,7 @@ WI.Popover = class Popover extends WI.Object
             previouslyFocusedElement.focus();
     }
 
-    present(targetFrame, preferredEdges)
+    present(targetFrame, preferredEdges, {updateContent, shouldAnimate} = {})
     {
         this._targetFrame = targetFrame;
         this._preferredEdges = preferredEdges;
@@ -124,7 +124,10 @@ WI.Popover = class Popover extends WI.Object
 
         this._addListenersIfNeeded();
 
-        this._update();
+        if (updateContent && this.visible)
+            this.update(shouldAnimate);
+        else
+            this._update(shouldAnimate);
     }
 
     presentNewContentWithFrame(content, targetFrame, preferredEdges)


### PR DESCRIPTION
#### 2a8187b1de2df352158fefedcf033f80d9cf74b3
<pre>
Web Inspector: Elements Tab: create an Event badge for nodes that have event listeners
<a href="https://bugs.webkit.org/show_bug.cgi?id=244124">https://bugs.webkit.org/show_bug.cgi?id=244124</a>

Reviewed by Patrick Angle.

Only show &quot;Event&quot; badges for nodes that directly have event listeners (i.e. no ancestors). This will
give developers a visual way of seeing where an event could be handled in a particular ancestor path
as they&apos;d be able to scan for &quot;Event&quot; badges to find every ancestor that has an event listener.

Clicking the &quot;Event&quot; badge will show a popover containing details about the attached event listeners,
such as capturing/bubbling, once, enabled/disabled, and breakpoint, all grouped by event type.

* Source/JavaScriptCore/inspector/protocol/CSS.json:
Add an `&quot;event&quot;` enum value to `CSS.LayoutFlag`.

* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didAddEventListenerImpl):
(WebCore::InspectorInstrumentation::willRemoveEventListenerImpl):
Also inform the `InspectorCSSAgent` that an event listener was added/removed.

* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::reset):
(WebCore::layoutFlagContextType):
(WebCore::layoutFlagsContainLayoutContextType): Added.
(WebCore::hasJSEventListener):
(WebCore::InspectorCSSAgent::layoutFlagsForNode):
(WebCore::toProtocol): Added.
(WebCore::InspectorCSSAgent::protocolLayoutFlagsForNode): Added.
(WebCore::pushChildrenNodesToFrontendIfLayoutFlagIsRelevant):
(WebCore::InspectorCSSAgent::didChangeRendererForDOMNode):
(WebCore::InspectorCSSAgent::didAddEventListener): Added.
(WebCore::InspectorCSSAgent::willRemoveEventListener): Added.
(WebCore::InspectorCSSAgent::nodeHasLayoutFlagsChange): Added.
(WebCore::InspectorCSSAgent::nodesWithPendingLayoutFlagsChangeDispatchTimerFired):
(WebCore::layoutFlagContextTypeForRenderer): Deleted.
Keep track of the layout flags for each `Node` to avoid re-dispatching the same flags to the
frontend. This is especially important for event listeners as they can be very noisy (211169@main).

* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::getEventListenersForNode):
(WebCore::InspectorDOMAgent::buildObjectForNode):
Allow `DOM.getEventListenersForNode` to control whether ancestor event listeners are included.

* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.set layoutFlags):
(WI.DOMNode.prototype.getEventListeners):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js:
(WI.DOMTreeContentView.prototype._populateConfigureDOMTreeBadgesNavigationItemContextMenu):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype._createBadge):
(WI.DOMTreeElement.prototype._createBadges):
(WI.DOMTreeElement.prototype.async _handleEventBadgeClicked): Added.
(WI.DOMTreeElement.prototype._handleBadgeDoubleClicked): Renamed from `_layoutBadgeDoubleClicked`.
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.css:
(.event-badge-popover-content): Added.
(.event-badge-popover-content &gt; .details-section.event-listeners): Added.
(.event-badge-popover-content &gt; .details-section.event-listeners .details-section): Added.
Add logic for creating an &quot;Event&quot; badge that shows the list of event listeners directly attached to
that node (i.e. no ancestors).

* Source/WebInspectorUI/UserInterface/Views/EventListenerSectionGroup.js:
(WI.EventListenerSectionGroup.groupIntoSectionsByEvent): Added.
(WI.EventListenerSectionGroup.groupIntoSectionsByTarget): Added.
(WI.EventListenerSectionGroup._createEventListenerSection): Added.
* Source/WebInspectorUI/UserInterface/Views/EventListenerSectionGroup.css:
(.event-listener-section &gt; .header &gt; .event-listener-options): Added.
(.event-listener-section:hover &gt; .header &gt; .event-listener-options): Added.
* Source/WebInspectorUI/UserInterface/Views/DOMNodeDetailsSidebarPanel.js:
(WI.DOMNodeDetailsSidebarPanel.prototype.async _refreshEventListeners):
(WI.DOMNodeDetailsSidebarPanel.prototype._refreshEventListeners.createEventListenerSection): Deleted.
(WI.DOMNodeDetailsSidebarPanel.prototype._refreshEventListeners.generateGroupsByEvent): Deleted.
(WI.DOMNodeDetailsSidebarPanel.prototype._refreshEventListeners.generateGroupsByTarget): Deleted.
(WI.DOMNodeDetailsSidebarPanel.prototype._refreshEventListeners.eventListenersCallback): Deleted.
* Source/WebInspectorUI/UserInterface/Views/DOMNodeDetailsSidebarPanel.css:
(.sidebar &gt; .panel.dom-node-details .details-section.dom-node-event-listeners .details-section.event-listener-section &gt; .header &gt; .event-listener-options): Deleted.
(.sidebar &gt; .panel.dom-node-details .details-section.dom-node-event-listeners .details-section.event-listener-section:hover &gt; .header &gt; .event-listener-options): Deleted.
Move the code that groups `WI.EventListenerSectionGroup` to be `static` methods on `WI.EventListenerSectionGroup`
so that it can be reused in other places (e.g. inside the `WI.Popover` for the &quot;Event&quot; badge).

* Source/WebInspectorUI/UserInterface/Views/Popover.js:
(WI.Popover.prototype.present):
Add an option to also update the sizing of the `WI.Popover` when re-presenting the same content.
This is necessary because the `WI.Popover` for the &quot;Event&quot; badge is limited in height to the size of
Web Inspector, so resizing Web Inspector should also resize the popover (not just reposition).

* Source/WebInspectorUI/UserInterface/Views/DetailsSection.js:
(WI.DetailsSection):
* Source/WebInspectorUI/UserInterface/Views/DetailsSection.css:
(.details-section .details-section &gt; .header):
(.details-section:has(&gt; .header &gt; .title:not(:empty)) .details-section &gt; .header): Added.
Don&apos;t lower the header of a subsection unless the parent section has a `title`. This is necessary
because the `WI.Popover` for the &quot;Event&quot; badge has a top-level `WI.DetailsSection` with no `title`
in order to get the same nested styling applied to the Event Listeners section in the Node panel of
the details sidebar in the Elements Tab.

* LayoutTests/inspector/css/nodeLayoutFlagsChanged-Event-attribute.html: Added.
* LayoutTests/inspector/css/nodeLayoutFlagsChanged-Event-attribute-expected.txt: Added.
* LayoutTests/inspector/css/nodeLayoutFlagsChanged-Event-script.html: Added.
* LayoutTests/inspector/css/nodeLayoutFlagsChanged-Event-script-expected.txt: Added.
* LayoutTests/inspector/dom/getEventListenersForNode.html:
* LayoutTests/inspector/dom/getEventListenersForNode-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253727@main">https://commits.webkit.org/253727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3dc1efc708c7759580c677d473900acfa23c008

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95728 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149485 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29344 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79044 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90951 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23693 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73756 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23714 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66719 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78808 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27095 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12827 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72468 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27030 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13841 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25842 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2645 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36704 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75253 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33120 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16644 "Passed tests") | 
<!--EWS-Status-Bubble-End-->