### PR TITLE
REGRESSION(253549@main): [ iOS ] 2X animations/(Layout tests) are constant failures

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3723,3 +3723,4 @@ imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of
 webkit.org/b/244065 fast/forms/auto-fill-button/hide-auto-fill-button-when-input-becomes-readonly.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/244134 animations/no-style-recalc-during-accelerated-animation.html [ Pass Failure ]
+webkit.org/b/244134 animations/steps-transform-rendering-updates.html [ Pass Failure ]


### PR DESCRIPTION
#### 3a98b80449e7245b57aa009bd94aea4aa4a24f8c
<pre>
REGRESSION(253549@main): [ iOS ] 2X animations/(Layout tests) are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=244134">https://bugs.webkit.org/show_bug.cgi?id=244134</a>
&lt;rdar://98894287&gt;

Reviewed by NOBODY (OOPS!).

Add a bit more slop to the number of allowed style updates, since UI-side compositing
and differences in timer firing on iOS can result in more updates there.

Also turn off speculative tile updating in these tests to avoid that being a source
of noise.

* LayoutTests/animations/no-style-recalc-during-accelerated-animation-expected.txt:
* LayoutTests/animations/no-style-recalc-during-accelerated-animation.html:
* LayoutTests/animations/steps-transform-rendering-updates-expected.txt:
* LayoutTests/animations/steps-transform-rendering-updates.html:
* LayoutTests/platform/ios/TestExpectations:
</pre>