### PR TITLE
Assertion failure when using evaluated empty catch block

### DIFF
--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4694,6 +4694,10 @@ void TryNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
         }
 
         generator.emitProfileControlFlow(m_tryBlock->endOffset() + 1);
+
+        if (generator.shouldBeConcernedWithCompletionValue())
+            generator.emitLoad(tryCatchDst.get(), jsUndefined());
+
         if (m_finallyBlock)
             generator.emitNode(tryCatchDst.get(), m_catchBlock);
         else


### PR DESCRIPTION
#### 507c4b0c74e7348f49521b48e8dd38f85285e3d8
<pre>
Assertion failure when using evaluated empty catch block
<a href="https://bugs.webkit.org/show_bug.cgi?id=244066">https://bugs.webkit.org/show_bug.cgi?id=244066</a>
rdar://98663583

Reviewed by Yusuke Suzuki.

Fixes an issue where catch clauses may not return undefined if the catch block is empty, instead potentially returning lingering values from the try block which may be used erroneously.

* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::TryNode::emitBytecode):

Canonical link: <a href="https://commits.webkit.org/253605@main">https://commits.webkit.org/253605@main</a>
</pre>

















<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30abc5d1d596567df1fa31502104ffddad319f40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30439 "Built successfully") | [✅ ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95360 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149073 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28862 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90604 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92129 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23451 "Unexpected infrastructure issue: The layout-test run with change generated no list of results and exited with error, retrying with the hope it was a random infrastructure error.
Retrying build [retry count is 0 of 3]") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/66456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78448 "Built successfully and passed tests") | [✅ ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/26734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72086 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26648 "Built successfully") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25752 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2568 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28327 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/74866 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28268 "Built successfully") | [✅ ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16549 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode") | 
<!--EWS-Status-Bubble-End-->