### PR TITLE
Speed up CachedResource::hasClients()

### DIFF
--- a/Source/WTF/wtf/WeakHashCountedSet.h
+++ b/Source/WTF/wtf/WeakHashCountedSet.h
@@ -50,6 +50,7 @@ public:
     const_iterator find(const ValueType& value) const { return m_impl.find(value); }
     bool contains(const ValueType& value) const { return m_impl.contains(value); }
 
+    bool isEmptyIgnoringNullReferences() const { return m_impl.isEmptyIgnoringNullReferences(); }
     unsigned computeSize() const { return m_impl.computeSize(); }
 
     // Increments the count if an equal value is already present.

--- a/Source/WTF/wtf/WeakHashMap.h
+++ b/Source/WTF/wtf/WeakHashMap.h
@@ -303,10 +303,13 @@ public:
 
     bool isEmptyIgnoringNullReferences() const
     {
-        auto result = begin() == end();
-        if (UNLIKELY(result && m_map.size()))
+        if (m_map.isEmpty())
+            return true;
+
+        auto onlyContainsNullReferences = begin() == end();
+        if (UNLIKELY(onlyContainsNullReferences))
             const_cast<WeakHashMap&>(*this).clear();
-        return result;
+        return onlyContainsNullReferences;
     }
 
     bool hasNullReferences() const

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -141,7 +141,7 @@ public:
 
     WEBCORE_EXPORT void addClient(CachedResourceClient&);
     WEBCORE_EXPORT void removeClient(CachedResourceClient&);
-    bool hasClients() const { return m_clients.computeSize() || m_clientsAwaitingCallback.computeSize(); }
+    bool hasClients() const { return !m_clients.isEmptyIgnoringNullReferences() || !m_clientsAwaitingCallback.isEmptyIgnoringNullReferences(); }
     bool hasClient(const CachedResourceClient& client) { return m_clients.contains(client) || m_clientsAwaitingCallback.contains(client); }
     bool deleteIfPossible();
 


### PR DESCRIPTION
#### a90a53c4a1a4586de30f9eaa709fc42532eaf703
<pre>
Speed up CachedResource::hasClients()
<a href="https://bugs.webkit.org/show_bug.cgi?id=244140">https://bugs.webkit.org/show_bug.cgi?id=244140</a>

Reviewed by Darin Adler.

Previously, CachedResource::hasClients() would call WeakHashMap::computeSize()
on up to 2 maps. Each call would iterate all map entries to remove null
WeakPtrs from the map. This was a lot of unnecessary work but just checking
if the map is empty. We now rely on WeakHashMap::isEmptyIgnoringNullReferences()
instead as it is cheaper.

* Source/WTF/wtf/WeakHashCountedSet.h:
(WTF::WeakHashCountedSet::isEmptyIgnoringNullReferences const):
* Source/WTF/wtf/WeakHashMap.h:
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::hasClients const):

Canonical link: <a href="https://commits.webkit.org/253619@main">https://commits.webkit.org/253619@main</a>
</pre>



<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/818d9d4ad4eb44971a1dda622dbcd7c18ee08368

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95366 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149079 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28868 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25408 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90610 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92135 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23397 "Found 2 new test failures: animations/no-style-recalc-during-accelerated-animation.html, animations/steps-transform-rendering-updates.html") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73468 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23456 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78406 "Passed tests") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66461 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78454 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26740 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12630 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72092 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26654 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13645 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25754 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2578 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28333 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36508 "Found 1 new test failure: media/media-source/media-source-seek-detach-crash.html") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/74872 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32925 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16552 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode") | 
<!--EWS-Status-Bubble-End-->