### PR TITLE
Add more legacy error codes to WKErrorPrivate.h

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKErrorPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKErrorPrivate.h
@@ -28,7 +28,9 @@
 WK_EXTERN NSString * const _WKLegacyErrorDomain WK_API_AVAILABLE(macos(10.11), ios(8.3));
 
 typedef NS_ENUM(NSInteger, _WKLegacyErrorCode) {
+    _WKErrorCodeCannotShowURL WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA)) = 101,
     _WKErrorCodeFrameLoadInterruptedByPolicyChange WK_API_AVAILABLE(macos(10.11), ios(9.0)) = 102,
+    _WKErrorCodeFrameLoadBlockedByContentBlocker WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA)) = 104,
     _WKErrorCodeFrameLoadBlockedByRestrictions WK_API_AVAILABLE(macos(10.15), ios(13.0)) = 106,
     _WKLegacyErrorPlugInWillHandleLoad = 204,
 } WK_API_AVAILABLE(macos(10.11), ios(8.3));


### PR DESCRIPTION
#### a7352cc33bf5e90854fce5644c1b04df8c0a972d
<pre>
Add more legacy error codes to WKErrorPrivate.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=244138">https://bugs.webkit.org/show_bug.cgi?id=244138</a>
rdar://98848435

Reviewed by Chris Dumez.

* Source/WebKit/UIProcess/API/Cocoa/WKErrorPrivate.h:
Add _WKErrorCodeCannotShowURL and _WKErrorCodeFrameLoadBlockedByContentBlocker from WKErrorRef.h.

Canonical link: <a href="https://commits.webkit.org/253609@main">https://commits.webkit.org/253609@main</a>
</pre>












<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93c8f473c1a79d678ed0e43b94033e0025fa870a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30446 "Built successfully") | [✅ ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95367 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28869 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78684 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90611 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92136 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23457 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78405 "Build is in progress") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66462 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26741 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26655 "Built successfully") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2570 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28334 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28275 "Built successfully") | [✅ ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->