### PR TITLE
Unreviewed fix for Unified Sources build.

### DIFF
--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -33,6 +33,7 @@
 #include "CachedImage.h"
 #include "Chrome.h"
 #include "DebugOverlayRegions.h"
+#include "DebugPageOverlays.h"
 #include "EventRegion.h"
 #include "Frame.h"
 #include "FrameView.h"


### PR DESCRIPTION
#### da89ad902d18bbc6f8d03b805b8eaf859497fdf3
<pre>
Unreviewed fix for Unified Sources build.

* Source/WebCore/rendering/RenderLayerBacking.cpp:

Canonical link: <a href="https://commits.webkit.org/253612@main">https://commits.webkit.org/253612@main</a>
</pre>










































<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74853bebbfebe60843848207facaaf3bbd665c0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86542 "failed check-webkit-style (failure)") | [✅ ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/69/builds/30569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/95385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/149102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/90528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/64/builds/28948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/90628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92159 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/64/builds/28948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/78704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/64/builds/28948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/26759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/26677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/28355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/994 "Built successfully and passed tests") | [✅ ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/28298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->