### PR TITLE
[WTF] Remove pthread_main_np use in MainThreadGeneric.

### DIFF
--- a/Source/WTF/wtf/generic/MainThreadGeneric.cpp
+++ b/Source/WTF/wtf/generic/MainThreadGeneric.cpp
@@ -32,32 +32,26 @@
 
 #include "config.h"
 #include <pthread.h>
-#if HAVE(PTHREAD_NP_H)
-#include <pthread_np.h>
-#endif
 
 #include <wtf/RunLoop.h>
 
 namespace WTF {
 
-#if !HAVE(PTHREAD_MAIN_NP)
 static pthread_t mainThread;
-#endif
 
 void initializeMainThreadPlatform()
 {
-#if !HAVE(PTHREAD_MAIN_NP)
+    // WebKit APIs must be consistently used from exactly one thread. The thread that initializes WebKit
+    // is considered the "WebKit main thread," and it is an error to use WebKit APIs from any other thread.
+    // The WebKit main thread need not be the application's actual OS-level main thread, which might be
+    // controlled by a language runtime or virtual machine; for example, in Eclipse, the OS main thread is
+    // controlled by the JVM, while the separate WebKit main thread runs all the GUI and WebKit stuff.
     mainThread = pthread_self();
-#endif
 }
 
 bool isMainThread()
 {
-#if HAVE(PTHREAD_MAIN_NP)
-    return pthread_main_np();
-#else
     return pthread_equal(pthread_self(), mainThread);
-#endif
 }
 
 } // namespace WTF


### PR DESCRIPTION
#### 799dd04c3edbd3352761e2559165f1e514384ad5
<pre>
[WTF] Remove pthread_main_np use in MainThreadGeneric.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244153">https://bugs.webkit.org/show_bug.cgi?id=244153</a>

Reviewed by Michael Catanzaro.

It was determined in <a href="https://bugs.webkit.org/show_bug.cgi?id=243401">https://bugs.webkit.org/show_bug.cgi?id=243401</a> that
isMainThread() can not simply check if the current thread is the initial
process thread but must compare the current thread against the thread
set when initializeMainThreadPlatform is called to handle cases when
WebKit is run under applications like Eclipse which don&apos;t initialize
WebKit in the main process thread.

As such we should not use pthread_main_np() which compares the current
thread against the initial process thread.

* Source/WTF/wtf/generic/MainThreadGeneric.cpp:
(WTF::initializeMainThreadPlatform):
(WTF::isMainThread):

Canonical link: <a href="https://commits.webkit.org/253647@main">https://commits.webkit.org/253647@main</a>
</pre>









<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e764185a71f348422efcc55a9648faabd987a9eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30737 "Built successfully") | [✅ ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95521 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149252 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29122 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78859 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90763 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23522 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73598 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23585 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/66592 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78613 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26893 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72250 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26812 "Built successfully") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25798 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2591 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28491 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/36601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75033 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28435 "Built successfully") | [✅ ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16598 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode") | 
<!--EWS-Status-Bubble-End-->