### PR TITLE
data-x-2="" not represented in dataset

### DIFF
--- a/LayoutTests/fast/dom/dataset-expected.txt
+++ b/LayoutTests/fast/dom/dataset-expected.txt
@@ -13,6 +13,10 @@ PASS testGet('data---foo---bar', '-Foo--Bar') is true
 PASS testGet('data-foo-', 'foo-') is true
 PASS testGet('data-foo--', 'foo--') is true
 PASS testGet('data-Foo', 'foo') is true
+PASS testGet('data-x-2', 'x-2') is true
+PASS testGet('data-2-x', '2X') is true
+PASS testGet('data-2', '2') is true
+PASS testGet('data-x3', 'x3') is true
 PASS testGet('data-', '') is true
 PASS testGet('data-à', 'à') is true
 PASS document.body.dataset.nonExisting is undefined.

--- a/LayoutTests/fast/dom/dataset.html
+++ b/LayoutTests/fast/dom/dataset.html
@@ -24,6 +24,10 @@ shouldBeTrue("testGet('data---foo---bar', '-Foo--Bar')");
 shouldBeTrue("testGet('data-foo-', 'foo-')");
 shouldBeTrue("testGet('data-foo--', 'foo--')");
 shouldBeTrue("testGet('data-Foo', 'foo')"); // HTML lowercases all attributes.
+shouldBeTrue("testGet('data-x-2', 'x-2')");
+shouldBeTrue("testGet('data-2-x', '2X')");
+shouldBeTrue("testGet('data-2', '2')");
+shouldBeTrue("testGet('data-x3', 'x3')");
 shouldBeTrue("testGet('data-', '')");
 shouldBeTrue("testGet('data-\xE0', '\xE0')");
 shouldBeUndefined("document.body.dataset.nonExisting");

--- a/Source/WebCore/dom/DatasetDOMStringMap.cpp
+++ b/Source/WebCore/dom/DatasetDOMStringMap.cpp
@@ -71,33 +71,6 @@ static String convertAttributeNameToPropertyName(const String& name)
     return stringBuilder.toString();
 }
 
-static bool propertyNameMatchesAttributeName(const String& propertyName, const String& attributeName)
-{
-    if (!attributeName.startsWith("data-"_s))
-        return false;
-
-    unsigned propertyLength = propertyName.length();
-    unsigned attributeLength = attributeName.length();
-
-    unsigned a = 5;
-    unsigned p = 0;
-    bool wordBoundary = false;
-    while (a < attributeLength && p < propertyLength) {
-        const UChar currentAttributeNameChar = attributeName[a];
-        if (currentAttributeNameChar == '-' && a + 1 < attributeLength && attributeName[a + 1] != '-')
-            wordBoundary = true;
-        else {
-            if ((wordBoundary ? toASCIIUpper(currentAttributeNameChar) : currentAttributeNameChar) != propertyName[p])
-                return false;
-            p++;
-            wordBoundary = false;
-        }
-        a++;
-    }
-
-    return (a == attributeLength && p == propertyLength);
-}
-
 static bool isValidPropertyName(const String& name)
 {
     unsigned length = name.length();
@@ -160,10 +133,9 @@ bool DatasetDOMStringMap::isSupportedPropertyName(const String& propertyName) co
 
     auto attributeIteratorAccessor = m_element.attributesIterator();
     if (attributeIteratorAccessor.attributeCount() == 1) {
-        // If the node has a single attribute, it is the dataset member accessed in most cases.
-        // Building a new AtomString in that case is overkill so we do a direct character comparison.
+        // Avoid creating AtomString when there is only one attribute.
         const auto& attribute = *attributeIteratorAccessor.begin();
-        if (propertyNameMatchesAttributeName(propertyName, attribute.localName()))
+        if (convertAttributeNameToPropertyName(attribute.localName()) == propertyName)
             return true;
     } else {
         auto attributeName = convertPropertyNameToAttributeName(propertyName);
@@ -197,10 +169,9 @@ const AtomString* DatasetDOMStringMap::item(const String& propertyName) const
         AttributeIteratorAccessor attributeIteratorAccessor = m_element.attributesIterator();
 
         if (attributeIteratorAccessor.attributeCount() == 1) {
-            // If the node has a single attribute, it is the dataset member accessed in most cases.
-            // Building a new AtomString in that case is overkill so we do a direct character comparison.
+            // Avoid creating AtomString when there is only one attribute.
             const Attribute& attribute = *attributeIteratorAccessor.begin();
-            if (propertyNameMatchesAttributeName(propertyName, attribute.localName()))
+            if (convertAttributeNameToPropertyName(attribute.localName()) == propertyName)
                 return &attribute.value();
         } else {
             AtomString attributeName = convertPropertyNameToAttributeName(propertyName);


### PR DESCRIPTION
#### 8a40482a9c1025c3579f72e2a9eee64c369bd0e6
<pre>
data-x-2=&quot;&quot; not represented in dataset
<a href="https://bugs.webkit.org/show_bug.cgi?id=123890">https://bugs.webkit.org/show_bug.cgi?id=123890</a>

Reviewed by Brent Fulgham.

The bug was caused by propertyNameMatchesAttributeName implementing comparison incorrectly.

Fixed the bug by eliminating this function and reusing convertAttributeNameToPropertyName
when there is exactly one attribute. While the new code does allocate a String object,
it&apos;s still faster than creating a AtomString.

* LayoutTests/fast/dom/dataset-expected.txt:
* LayoutTests/fast/dom/dataset.html: Added a test case.

* Source/WebCore/dom/DatasetDOMStringMap.cpp:
(WebCore::propertyNameMatchesAttributeName): Deleted.
(WebCore::DatasetDOMStringMap::isSupportedPropertyName const):
(WebCore::DatasetDOMStringMap::item const):

Canonical link: <a href="https://commits.webkit.org/253625@main">https://commits.webkit.org/253625@main</a>
</pre>



<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26defcae75869c14ef3548fd66115d80eea609a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95408 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149127 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28981 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25442 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78733 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90651 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23429 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73502 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23489 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78437 "Passed tests") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66494 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26782 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12646 "Found 1 new test failure: http/tests/media/clearkey/collect-webkit-media-session.html") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26701 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13661 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28379 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36521 "Found 1 new test failure: media/media-source/media-source-seek-detach-crash.html") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1000 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32940 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->