### PR TITLE
[GStreamer] User-supplied GST_PLUGIN_FEATURE is ignored when running tests

### DIFF
--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -128,7 +128,7 @@ class GtkPort(Port):
                              'PLUGIN_PATH_1_0'):
             self._copy_value_from_environ_if_set(environment, 'GST_%s' % gst_variable)
 
-        gst_feature_rank_override = environment.get('GST_PLUGIN_FEATURE_RANK')
+        gst_feature_rank_override = os.environ.get('GST_PLUGIN_FEATURE_RANK')
         environment['GST_PLUGIN_FEATURE_RANK'] = 'fakeaudiosink:max'
         if gst_feature_rank_override:
             environment['GST_PLUGIN_FEATURE_RANK'] += ',%s' % gst_feature_rank_override

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -100,7 +100,7 @@ class WPEPort(Port):
                              'PLUGIN_PATH_1_0'):
             self._copy_value_from_environ_if_set(environment, 'GST_%s' % gst_variable)
 
-        gst_feature_rank_override = environment.get('GST_PLUGIN_FEATURE_RANK')
+        gst_feature_rank_override = os.environ.get('GST_PLUGIN_FEATURE_RANK')
         environment['GST_PLUGIN_FEATURE_RANK'] = 'fakeaudiosink:max'
         if gst_feature_rank_override:
             environment['GST_PLUGIN_FEATURE_RANK'] += ',%s' % gst_feature_rank_override


### PR DESCRIPTION
#### 1920c34921d6708860f8676062e71a904c0239ca
<pre>
[GStreamer] User-supplied GST_PLUGIN_FEATURE is ignored when running tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=244157">https://bugs.webkit.org/show_bug.cgi?id=244157</a>

Reviewed by Žan Doberšek.

Use the GST_PLUGIN_FEATURE_RANK value from the host environment instead of the pristine one which is
guaranteed to not have it.

* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort.setup_environ_for_server):
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort.setup_environ_for_server):

Canonical link: <a href="https://commits.webkit.org/253640@main">https://commits.webkit.org/253640@main</a>
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6632740b46e886194bdc30fe7f52c835fb39e2c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95422 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149142 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29001 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25453 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78755 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90666 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23440 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73513 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23506 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/90185 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78446 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78805 "Found 1 new API test failure: TestWebKitAPI.VideoControlsManager.VideoControlsManagerMultipleVideosScrollPlayingVideoWithSoundOutOfView") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66511 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26797 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12656 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26716 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13671 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2586 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36530 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32950 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->