### PR TITLE
[Flatpak SDK] Enable openh264 GStreamer plugin

### DIFF
--- a/Tools/buildstream/elements/sdk/gst-plugins-bad.bst
+++ b/Tools/buildstream/elements/sdk/gst-plugins-bad.bst
@@ -6,6 +6,12 @@ sources:
 # https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/2341/
 - kind: patch
   path: patches/gst-plugins-bad-mr-2341.patch
+# https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/2918 (candidate for 1.20 backport)
+- kind: patch
+  path: patches/gst-plugins-bad-openh264-Register-debug-categories-earlier.patch
+# https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/2919 (candidate for 1.20 backport)
+- kind: patch
+  path: patches/gst-plugins-bad-openh264enc-Fix-constrained-high-encoding.patch
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
 depends:
@@ -83,7 +89,6 @@ variables:
     -Dopenaptx=disabled
     -Dopencv=disabled
     -Dopenexr=disabled
-    -Dopenh264=disabled
     -Dopenmpt=disabled
     -Dopenni2=disabled
     -Dopensles=disabled

--- a/Tools/buildstream/elements/sdk/libopenh264.bst
+++ b/Tools/buildstream/elements/sdk/libopenh264.bst
@@ -9,7 +9,8 @@ depends:
 sources:
 - kind: git
   url: github_com:cisco/openh264.git
-  ref: 2122fe08cc8fe69899c3e257d0ee030c28a64174
+  track: master
+  ref: 2e637867315ffeda3cd8970825ec86acc3fc4a30
 variables:
   meson-local: >-
     -Dtests=disabled

--- a/Tools/buildstream/patches/gst-plugins-bad-openh264-Register-debug-categories-earlier.patch
+++ b/Tools/buildstream/patches/gst-plugins-bad-openh264-Register-debug-categories-earlier.patch
@@ -1,0 +1,82 @@
+From 860015ddf1b860307f30d1650f939ff64a2ded54 Mon Sep 17 00:00:00 2001
+From: Philippe Normand <philn@igalia.com>
+Date: Sat, 20 Aug 2022 16:15:15 +0100
+Subject: [PATCH] openh264: Register debug categories earlier
+
+Otherwise the GST_ERROR message logged in case of ABI mismatch would be done on
+an uninitialized category.
+---
+ .../ext/openh264/gstopenh264dec.cpp                | 11 +++++------
+ .../ext/openh264/gstopenh264enc.cpp                | 14 +++++++-------
+ 2 files changed, 12 insertions(+), 13 deletions(-)
+
+diff --git a/ext/openh264/gstopenh264dec.cpp b/ext/openh264/gstopenh264dec.cpp
+index e42dc093b7..6d3464628f 100644
+--- a/ext/openh264/gstopenh264dec.cpp
++++ b/ext/openh264/gstopenh264dec.cpp
+@@ -86,10 +86,7 @@ GST_STATIC_PAD_TEMPLATE ("src",
+ 
+ /* class initialization */
+ 
+-G_DEFINE_TYPE_WITH_CODE (GstOpenh264Dec, gst_openh264dec,
+-    GST_TYPE_VIDEO_DECODER,
+-    GST_DEBUG_CATEGORY_INIT (gst_openh264dec_debug_category, "openh264dec", 0,
+-        "debug category for openh264dec element"));
++G_DEFINE_TYPE (GstOpenh264Dec, gst_openh264dec, GST_TYPE_VIDEO_DECODER);
+ GST_ELEMENT_REGISTER_DEFINE_CUSTOM (openh264dec, openh264dec_element_init);
+ 
+ static void
+@@ -455,10 +452,12 @@ gst_openh264dec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
+ static gboolean
+ openh264dec_element_init (GstPlugin * plugin)
+ {
++  GST_DEBUG_CATEGORY_INIT (gst_openh264dec_debug_category, "openh264dec", 0,
++      "debug category for openh264dec element");
+   if (openh264_element_init (plugin))
+     return gst_element_register (plugin, "openh264dec", GST_RANK_MARGINAL,
+         GST_TYPE_OPENH264DEC);
+ 
+- GST_ERROR ("Incorrect library version loaded, expecting %s", g_strCodecVer);
+- return FALSE;
++  GST_ERROR ("Incorrect library version loaded, expecting %s", g_strCodecVer);
++  return FALSE;
+ }
+diff --git a/ext/openh264/gstopenh264enc.cpp b/ext/openh264/gstopenh264enc.cpp
+index 30af8e2677..9df5196152 100644
+--- a/ext/openh264/gstopenh264enc.cpp
++++ b/ext/openh264/gstopenh264enc.cpp
+@@ -234,10 +234,7 @@ GST_STATIC_PAD_TEMPLATE ("src",
+ /* class initialization */
+ 
+ G_DEFINE_TYPE_WITH_CODE (GstOpenh264Enc, gst_openh264enc,
+-    GST_TYPE_VIDEO_ENCODER,
+-    G_IMPLEMENT_INTERFACE (GST_TYPE_PRESET, NULL);
+-    GST_DEBUG_CATEGORY_INIT (gst_openh264enc_debug_category, "openh264enc", 0,
+-        "debug category for openh264enc element"));
++    GST_TYPE_VIDEO_ENCODER, G_IMPLEMENT_INTERFACE (GST_TYPE_PRESET, NULL));
+ GST_ELEMENT_REGISTER_DEFINE_CUSTOM (openh264enc, openh264enc_element_init);
+ 
+ static void
+@@ -1056,13 +1053,16 @@ gst_openh264enc_finish (GstVideoEncoder * encoder)
+ 
+   return GST_FLOW_OK;
+ }
++
+ static gboolean
+ openh264enc_element_init (GstPlugin * plugin)
+ {
++  GST_DEBUG_CATEGORY_INIT (gst_openh264enc_debug_category, "openh264enc", 0,
++      "debug category for openh264enc element");
+   if (openh264_element_init (plugin))
+     return gst_element_register (plugin, "openh264enc", GST_RANK_MARGINAL,
+-                                 GST_TYPE_OPENH264ENC);
++        GST_TYPE_OPENH264ENC);
+ 
+- GST_ERROR ("Incorrect library version loaded, expecting %s", g_strCodecVer);
+- return FALSE;
++  GST_ERROR ("Incorrect library version loaded, expecting %s", g_strCodecVer);
++  return FALSE;
+ }
+-- 
+2.37.1
+

--- a/Tools/buildstream/patches/gst-plugins-bad-openh264enc-Fix-constrained-high-encoding.patch
+++ b/Tools/buildstream/patches/gst-plugins-bad-openh264enc-Fix-constrained-high-encoding.patch
@@ -1,0 +1,34 @@
+From d0c86388822fd40d804c8ed787e2ad600176be13 Mon Sep 17 00:00:00 2001
+From: Philippe Normand <philn@igalia.com>
+Date: Sat, 20 Aug 2022 16:57:27 +0100
+Subject: [PATCH] openh264enc: Fix constrained-high encoding
+
+constrained-high is high without B-frames, there is no EProfileIdc for this, so
+assume high instead of hitting an assert down the line.
+---
+ .../gst-plugins-bad/ext/openh264/gstopenh264enc.cpp        | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/ext/openh264/gstopenh264enc.cpp b/ext/openh264/gstopenh264enc.cpp
+index 30af8e2677..3328d01d99 100644
+--- a/ext/openh264/gstopenh264enc.cpp
++++ b/ext/openh264/gstopenh264enc.cpp
+@@ -711,11 +711,12 @@ gst_openh264enc_get_profile_from_caps (GstCaps *outcaps, GstCaps *allowed_caps)
+ 
+   gst_structure_set (s, "profile", G_TYPE_STRING, profile, NULL);
+   if (!g_strcmp0 (profile, "constrained-baseline") ||
+-       !g_strcmp0 (profile, "baseline"))
++      !g_strcmp0 (profile, "baseline"))
+     return PRO_BASELINE;
+-   else if (!g_strcmp0 (profile, "main"))
++  else if (!g_strcmp0 (profile, "main"))
+     return PRO_MAIN;
+-   else if (!g_strcmp0 (profile, "high"))
++  else if (!g_strcmp0 (profile, "high") ||
++      !g_strcmp0 (profile, "constrained-high"))
+     return PRO_HIGH;
+ 
+   g_assert_not_reached ();
+-- 
+2.37.1
+


### PR DESCRIPTION
#### 265bd1b6664a340b84f9cc6cd9c0441e967b05c6
<pre>
[Flatpak SDK] Enable openh264 GStreamer plugin
<a href="https://bugs.webkit.org/show_bug.cgi?id=244158">https://bugs.webkit.org/show_bug.cgi?id=244158</a>

Reviewed by Adrian Perez de Castro.

This encoder claims to support the constrained-high profile whereas x264enc doesn&apos;t, so this encoder
will be used for some WebRTC layout tests requiring that profile.

* Tools/buildstream/elements/sdk/gst-plugins-bad.bst:
* Tools/buildstream/elements/sdk/libopenh264.bst:
* Tools/buildstream/patches/gst-plugins-bad-openh264-Register-debug-categories-earlier.patch: Added.
* Tools/buildstream/patches/gst-plugins-bad-openh264enc-Fix-constrained-high-encoding.patch: Added.

Canonical link: <a href="https://commits.webkit.org/253627@main">https://commits.webkit.org/253627@main</a>
</pre>



<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5303dd7763df1ce738370d180b48e65d8a9960b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95423 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149143 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29002 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25454 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78749 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90667 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23441 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73514 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23503 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78447 "Passed tests") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66508 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26798 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12657 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26717 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13672 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36532 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1001 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32951 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->