### PR TITLE
[JSC] Optimize async/await and microtask queue part 1

### DIFF
--- a/LayoutTests/inspector/canvas/recording-bitmaprenderer-frameCount-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-bitmaprenderer-frameCount-expected.txt
@@ -19,6 +19,5 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
         3: (anonymous function)
-        4: (anonymous function)
       snapshot: <filtered>
 

--- a/LayoutTests/inspector/canvas/recording-bitmaprenderer-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-bitmaprenderer-full-expected.txt
@@ -19,7 +19,6 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
         3: (anonymous function)
-        4: (anonymous function)
       snapshot: <filtered>
   1: (duration)
     0: width

--- a/LayoutTests/inspector/canvas/recording-bitmaprenderer-memoryLimit-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-bitmaprenderer-memoryLimit-expected.txt
@@ -19,6 +19,5 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
         3: (anonymous function)
-        4: (anonymous function)
       snapshot: <filtered>
 

--- a/Source/JavaScriptCore/builtins/AsyncFromSyncIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncFromSyncIteratorPrototype.js
@@ -24,6 +24,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@linkTimeConstant
+function asyncFromSyncIteratorOnRejected(error, promise)
+{
+    "use strict";
+
+    return @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, error);
+}
+
+@linkTimeConstant
+function asyncFromSyncIteratorOnFulfilledContinue(result, promise)
+{
+    "use strict";
+
+    return @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, { value: result, done: false });
+}
+
+@linkTimeConstant
+function asyncFromSyncIteratorOnFulfilledDone(result, promise)
+{
+    "use strict";
+
+    return @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, { value: result, done: true });
+}
+
 function next(value)
 {
     "use strict";
@@ -40,11 +64,8 @@ function next(value)
 
     try {
         var nextResult = @argumentCount() === 0 ? nextMethod.@call(syncIterator) : nextMethod.@call(syncIterator, value);
-        var nextDone = !!nextResult.done;
-        var nextValue = nextResult.value;
-        @resolveWithoutPromiseForAsyncAwait(nextValue,
-            function (result) { @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, { value: result, done: nextDone }); },
-            function (error) { @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, error); });
+        var onFulfilled = nextResult.done ? @asyncFromSyncIteratorOnFulfilledDone : @asyncFromSyncIteratorOnFulfilledContinue;
+        @resolveWithoutPromiseForAsyncAwait(nextResult.value, onFulfilled, @asyncFromSyncIteratorOnRejected, promise);
     } catch (e) {
         @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, e);
     }
@@ -87,11 +108,8 @@ function return(value)
             return promise;
         }
 
-        var resultDone = !!returnResult.done;
-        var resultValue = returnResult.value;
-        @resolveWithoutPromiseForAsyncAwait(resultValue,
-            function (result) { @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, { value: result, done: resultDone }); },
-            function (error) { @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, error); });
+        var onFulfilled = returnResult.done ? @asyncFromSyncIteratorOnFulfilledDone : @asyncFromSyncIteratorOnFulfilledContinue;
+        @resolveWithoutPromiseForAsyncAwait(returnResult.value, onFulfilled, @asyncFromSyncIteratorOnRejected, promise);
     } catch (e) {
         @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, e);
     }
@@ -134,11 +152,8 @@ function throw(exception)
             return promise;
         }
         
-        var throwDone = !!throwResult.done;
-        var throwValue = throwResult.value;
-        @resolveWithoutPromiseForAsyncAwait(throwValue,
-            function (result) { @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, { value: result, done: throwDone }); },
-            function (error) { @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, error); });
+        var onFulfilled = throwResult.done ? @asyncFromSyncIteratorOnFulfilledDone : @asyncFromSyncIteratorOnFulfilledContinue;
+        @resolveWithoutPromiseForAsyncAwait(throwResult.value, onFulfilled, @asyncFromSyncIteratorOnRejected, promise);
     } catch (e) {
         @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, e);
     }

--- a/Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js
@@ -120,19 +120,29 @@ function asyncGeneratorResolve(generator, value, done)
 }
 
 @linkTimeConstant
+function asyncGeneratorYieldAwaited(result, generator)
+{
+    "use strict";
+
+    @putAsyncGeneratorInternalField(generator, @asyncGeneratorFieldSuspendReason, @AsyncGeneratorSuspendReasonYield);
+    @asyncGeneratorResolve(generator, result, false);
+}
+
+@linkTimeConstant
+function asyncGeneratorYieldOnRejected(result, generator)
+{
+    "use strict";
+
+    @doAsyncGeneratorBodyCall(generator, result, @GeneratorResumeModeThrow);
+}
+
+@linkTimeConstant
 function asyncGeneratorYield(generator, value, resumeMode)
 {
     "use strict";
 
-    function asyncGeneratorYieldAwaited(result)
-    {
-        @putAsyncGeneratorInternalField(generator, @asyncGeneratorFieldSuspendReason, @AsyncGeneratorSuspendReasonYield);
-        @asyncGeneratorResolve(generator, result, false);
-    }
-
     @putAsyncGeneratorInternalField(generator, @asyncGeneratorFieldSuspendReason, @AsyncGeneratorSuspendReasonAwait);
-
-    @awaitValue(generator, value, asyncGeneratorYieldAwaited);
+    @awaitValue(generator, value, @asyncGeneratorYieldAwaited);
 }
 
 @linkTimeConstant
@@ -140,8 +150,23 @@ function awaitValue(generator, value, onFulfilled)
 {
     "use strict";
 
-    var onRejected = function (result) { @doAsyncGeneratorBodyCall(generator, result, @GeneratorResumeModeThrow); };
-    @resolveWithoutPromiseForAsyncAwait(value, onFulfilled, onRejected);
+    @resolveWithoutPromiseForAsyncAwait(value, onFulfilled, @asyncGeneratorYieldOnRejected, generator);
+}
+
+@linkTimeConstant
+function doAsyncGeneratorBodyCallOnFulfilledNormal(result, generator)
+{
+    "use strict";
+
+    @doAsyncGeneratorBodyCall(generator, result, @GeneratorResumeModeNormal);
+}
+
+@linkTimeConstant
+function doAsyncGeneratorBodyCallOnFulfilledReturn(result, generator)
+{
+    "use strict";
+
+    @doAsyncGeneratorBodyCall(generator, result, @GeneratorResumeModeReturn);
 }
 
 @linkTimeConstant
@@ -150,10 +175,8 @@ function doAsyncGeneratorBodyCall(generator, resumeValue, resumeMode)
     "use strict";
 
     if (resumeMode === @GeneratorResumeModeReturn && @isSuspendYieldState(generator)) {
-        var onFulfilled = function(result) { @doAsyncGeneratorBodyCall(generator, result, @GeneratorResumeModeReturn); };
-
         @putAsyncGeneratorInternalField(generator, @asyncGeneratorFieldSuspendReason, @AsyncGeneratorSuspendReasonAwait);
-        @awaitValue(generator, resumeValue, onFulfilled);
+        @awaitValue(generator, resumeValue, @doAsyncGeneratorBodyCallOnFulfilledReturn);
         return;
     }
 
@@ -179,9 +202,7 @@ function doAsyncGeneratorBodyCall(generator, resumeValue, resumeMode)
 
     var reason = @getAsyncGeneratorInternalField(generator, @asyncGeneratorFieldSuspendReason);
     if (reason === @AsyncGeneratorSuspendReasonAwait) {
-        var onFulfilled = function(result) { @doAsyncGeneratorBodyCall(generator, result, @GeneratorResumeModeNormal); };
-
-        @awaitValue(generator, value, onFulfilled);
+        @awaitValue(generator, value, @doAsyncGeneratorBodyCallOnFulfilledNormal);
         return;
     }
 
@@ -193,6 +214,24 @@ function doAsyncGeneratorBodyCall(generator, resumeValue, resumeMode)
         @putAsyncGeneratorInternalField(generator, @asyncGeneratorFieldSuspendReason, @AsyncGeneratorSuspendReasonNone);
         return @asyncGeneratorResolve(generator, value, true);
     }
+}
+
+@linkTimeConstant
+function asyncGeneratorResumeNextOnFulfilled(result, generator)
+{
+    "use strict";
+
+    @putAsyncGeneratorInternalField(generator, @generatorFieldState, @AsyncGeneratorStateCompleted);
+    @asyncGeneratorResolve(generator, result, true);
+}
+
+@linkTimeConstant
+function asyncGeneratorResumeNextOnRejected(error, generator)
+{
+    "use strict";
+
+    @putAsyncGeneratorInternalField(generator, @generatorFieldState, @AsyncGeneratorStateCompleted);
+    @asyncGeneratorReject(generator, error);
 }
 
 @linkTimeConstant
@@ -223,15 +262,7 @@ function asyncGeneratorResumeNext(generator)
         if (state === @AsyncGeneratorStateCompleted) {
             if (next.resumeMode === @GeneratorResumeModeReturn) {
                 @putAsyncGeneratorInternalField(generator, @generatorFieldState, @AsyncGeneratorStateAwaitingReturn);
-                @resolveWithoutPromiseForAsyncAwait(next.value,
-                    function (result) {
-                        @putAsyncGeneratorInternalField(generator, @generatorFieldState, @AsyncGeneratorStateCompleted);
-                        @asyncGeneratorResolve(generator, result, true);
-                    },
-                    function (error) {
-                        @putAsyncGeneratorInternalField(generator, @generatorFieldState, @AsyncGeneratorStateCompleted);
-                        @asyncGeneratorReject(generator, error);
-                    });
+                @resolveWithoutPromiseForAsyncAwait(next.value, @asyncGeneratorResumeNextOnFulfilled, @asyncGeneratorResumeNextOnRejected, generator);
                 return;
             }
 

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -93,6 +93,7 @@ namespace JSC {
     macro(get) \
     macro(set) \
     macro(clear) \
+    macro(context) \
     macro(delete) \
     macro(size) \
     macro(shift) \

--- a/Source/JavaScriptCore/builtins/InternalPromiseConstructor.js
+++ b/Source/JavaScriptCore/builtins/InternalPromiseConstructor.js
@@ -73,7 +73,7 @@ function internalAll(array)
                 var value = array[index];
                 @putByValDirect(values, index, @undefined);
                 ++remainingElementsCount;
-                @resolveWithoutPromise(value, newResolveElement(index), reject);
+                @resolveWithoutPromise(value, newResolveElement(index), reject, @undefined);
             }
         }
     } catch (error) {

--- a/Source/JavaScriptCore/builtins/PromisePrototype.js
+++ b/Source/JavaScriptCore/builtins/PromisePrototype.js
@@ -49,7 +49,7 @@ function then(onFulfilled, onRejected)
         promise = promiseOrCapability.@promise;
     }
 
-    @performPromiseThen(this, onFulfilled, onRejected, promiseOrCapability);
+    @performPromiseThen(this, onFulfilled, onRejected, promiseOrCapability, @undefined);
     return promise;
 }
 

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
@@ -87,6 +87,7 @@ BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry(VM& vm)
     m_generatorFieldNext.set(m_vm, jsNumber(static_cast<unsigned>(JSGenerator::Field::Next)));
     m_generatorFieldThis.set(m_vm, jsNumber(static_cast<unsigned>(JSGenerator::Field::This)));
     m_generatorFieldFrame.set(m_vm, jsNumber(static_cast<unsigned>(JSGenerator::Field::Frame)));
+    m_generatorFieldContext.set(m_vm, jsNumber(static_cast<unsigned>(JSGenerator::Field::Context)));
     m_GeneratorResumeModeNormal.set(m_vm, jsNumber(static_cast<int32_t>(JSGenerator::ResumeMode::NormalMode)));
     m_GeneratorResumeModeThrow.set(m_vm, jsNumber(static_cast<int32_t>(JSGenerator::ResumeMode::ThrowMode)));
     m_GeneratorResumeModeReturn.set(m_vm, jsNumber(static_cast<int32_t>(JSGenerator::ResumeMode::ReturnMode)));

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -130,6 +130,7 @@ enum class LinkTimeConstant : int32_t;
     macro(generatorFieldNext) \
     macro(generatorFieldThis) \
     macro(generatorFieldFrame) \
+    macro(generatorFieldContext) \
     macro(GeneratorResumeModeNormal) \
     macro(GeneratorResumeModeThrow) \
     macro(GeneratorResumeModeReturn) \

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -707,6 +707,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
 
         emitNewGenerator(m_generatorRegister);
         emitNewPromise(promiseRegister(), m_isBuiltinFunction);
+        emitPutInternalField(generatorRegister(), static_cast<unsigned>(JSGenerator::Field::Context), promiseRegister());
         break;
     }
 

--- a/Source/JavaScriptCore/debugger/Debugger.cpp
+++ b/Source/JavaScriptCore/debugger/Debugger.cpp
@@ -1267,24 +1267,24 @@ void Debugger::didReachDebuggerStatement(CallFrame* callFrame)
     updateCallFrame(lexicalGlobalObjectForCallFrame(m_vm, callFrame), callFrame, AttemptPause);
 }
 
-void Debugger::didQueueMicrotask(JSGlobalObject* globalObject, const Microtask& microtask)
+void Debugger::didQueueMicrotask(JSGlobalObject* globalObject, MicrotaskIdentifier identifier)
 {
     dispatchFunctionToObservers([&] (Observer& observer) {
-        observer.didQueueMicrotask(globalObject, microtask);
+        observer.didQueueMicrotask(globalObject, identifier);
     });
 }
 
-void Debugger::willRunMicrotask(JSGlobalObject* globalObject, const Microtask& microtask)
+void Debugger::willRunMicrotask(JSGlobalObject* globalObject, MicrotaskIdentifier identifier)
 {
     dispatchFunctionToObservers([&] (Observer& observer) {
-        observer.willRunMicrotask(globalObject, microtask);
+        observer.willRunMicrotask(globalObject, identifier);
     });
 }
 
-void Debugger::didRunMicrotask(JSGlobalObject* globalObject, const Microtask& microtask)
+void Debugger::didRunMicrotask(JSGlobalObject* globalObject, MicrotaskIdentifier identifier)
 {
     dispatchFunctionToObservers([&] (Observer& observer) {
-        observer.didRunMicrotask(globalObject, microtask);
+        observer.didRunMicrotask(globalObject, identifier);
     });
 }
 

--- a/Source/JavaScriptCore/debugger/Debugger.h
+++ b/Source/JavaScriptCore/debugger/Debugger.h
@@ -138,9 +138,9 @@ public:
     void didExecuteProgram(CallFrame*);
     void didReachDebuggerStatement(CallFrame*);
 
-    JS_EXPORT_PRIVATE void didQueueMicrotask(JSGlobalObject*, const Microtask&);
-    JS_EXPORT_PRIVATE void willRunMicrotask(JSGlobalObject*, const Microtask&);
-    JS_EXPORT_PRIVATE void didRunMicrotask(JSGlobalObject*, const Microtask&);
+    JS_EXPORT_PRIVATE void didQueueMicrotask(JSGlobalObject*, MicrotaskIdentifier);
+    JS_EXPORT_PRIVATE void willRunMicrotask(JSGlobalObject*, MicrotaskIdentifier);
+    JS_EXPORT_PRIVATE void didRunMicrotask(JSGlobalObject*, MicrotaskIdentifier);
 
     void registerCodeBlock(CodeBlock*);
     void forEachRegisteredCodeBlock(const Function<void(CodeBlock*)>&);
@@ -182,9 +182,9 @@ public:
 
         virtual void willEnter(CallFrame*) { }
 
-        virtual void didQueueMicrotask(JSGlobalObject*, const Microtask&) { }
-        virtual void willRunMicrotask(JSGlobalObject*, const Microtask&) { }
-        virtual void didRunMicrotask(JSGlobalObject*, const Microtask&) { }
+        virtual void didQueueMicrotask(JSGlobalObject*, MicrotaskIdentifier) { }
+        virtual void willRunMicrotask(JSGlobalObject*, MicrotaskIdentifier) { }
+        virtual void didRunMicrotask(JSGlobalObject*, MicrotaskIdentifier) { }
 
         virtual void didPause(JSGlobalObject*, DebuggerCallFrame&, JSValue /* exceptionOrCaughtValue */) { }
         virtual void didContinue() { }

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -815,6 +815,7 @@ void Heap::beginMarking()
     TimingScope timingScope(*this, "Heap::beginMarking");
     m_jitStubRoutines->clearMarks();
     m_objectSpace.beginMarking();
+    vm().beginMarking();
     setMutatorShouldBeFenced(true);
 }
 
@@ -2835,9 +2836,11 @@ void Heap::addCoreConstraints()
                 scanExternalRememberedSet(vm, visitor);
             }
 
-            if (vm.smallStrings.needsToBeVisited(*m_collectionScope)) {
+            {
                 SetRootMarkReasonScope rootScope(visitor, RootMarkReason::StrongReferences);
-                vm.smallStrings.visitStrongReferences(visitor);
+                if (vm.smallStrings.needsToBeVisited(*m_collectionScope))
+                    vm.smallStrings.visitStrongReferences(visitor);
+                vm.visitAggregate(visitor);
             }
             
             {

--- a/Source/JavaScriptCore/runtime/JSGenerator.h
+++ b/Source/JavaScriptCore/runtime/JSGenerator.h
@@ -29,9 +29,9 @@
 
 namespace JSC {
 
-class JSGenerator final : public JSInternalFieldObjectImpl<5> {
+class JSGenerator final : public JSInternalFieldObjectImpl<6> {
 public:
-    using Base = JSInternalFieldObjectImpl<5>;
+    using Base = JSInternalFieldObjectImpl<6>;
 
     // JSGenerator has one inline storage slot, which is pointing internalField(0).
     static size_t allocationSize(Checked<size_t> inlineCapacity)
@@ -77,13 +77,15 @@ public:
         Next,
         This,
         Frame,
+        Context,
     };
-    static_assert(numberOfInternalFields == 5);
+    static_assert(numberOfInternalFields == 6);
     static std::array<JSValue, numberOfInternalFields> initialValues()
     {
         return { {
             jsNull(),
             jsNumber(static_cast<int32_t>(State::Init)),
+            jsUndefined(),
             jsUndefined(),
             jsUndefined(),
             jsUndefined(),

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -1209,6 +1209,7 @@ public:
     static RuntimeFlags javaScriptRuntimeFlags(const JSGlobalObject*) { return RuntimeFlags(); }
 
     JS_EXPORT_PRIVATE void queueMicrotask(Ref<Microtask>&&);
+    JS_EXPORT_PRIVATE void queueMicrotask(JSValue job, JSValue, JSValue, JSValue, JSValue);
 
     static void reportViolationForUnsafeEval(const JSGlobalObject*, JSString*) { }
 

--- a/Source/JavaScriptCore/runtime/JSMicrotask.h
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.h
@@ -26,13 +26,14 @@
 #pragma once
 
 #include "JSCast.h"
+#include "Microtask.h"
 #include "Structure.h"
 
 namespace JSC {
 
-class Microtask;
 class JSArray;
 
 JS_EXPORT_PRIVATE Ref<Microtask> createJSMicrotask(VM&, JSValue job, JSValue, JSValue, JSValue, JSValue);
+JS_EXPORT_PRIVATE void runJSMicrotask(JSGlobalObject*, MicrotaskIdentifier, JSValue job, JSValue, JSValue, JSValue, JSValue);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -263,6 +263,7 @@ void JSPromise::performPromiseThen(JSGlobalObject* globalObject, JSFunction* onF
     arguments.append(onFulFilled);
     arguments.append(onRejected);
     arguments.append(resultCapability);
+    arguments.append(jsUndefined());
     ASSERT(!arguments.hasOverflowed());
     call(globalObject, performPromiseThenFunction, callData, jsUndefined(), arguments);
 }

--- a/Source/JavaScriptCore/runtime/Microtask.h
+++ b/Source/JavaScriptCore/runtime/Microtask.h
@@ -25,19 +25,34 @@
 
 #pragma once
 
+#include <wtf/ObjectIdentifier.h>
 #include <wtf/RefCounted.h>
 
 namespace JSC {
 
 class CallFrame;
+class JSGlobalObject;
+
+enum MicrotaskIdentifierType { };
+using MicrotaskIdentifier = ObjectIdentifier<MicrotaskIdentifierType>;
 
 class Microtask : public RefCounted<Microtask> {
 public:
+    Microtask()
+        : m_identifier(MicrotaskIdentifier::generateThreadSafe())
+    {
+    }
+
     virtual ~Microtask()
     {
     }
 
+    MicrotaskIdentifier identifier() const { return m_identifier; }
+
     virtual void run(JSGlobalObject*) = 0;
+
+protected:
+    MicrotaskIdentifier m_identifier;
 };
 
 } // namespace JSC

--- a/Source/WebCore/bindings/js/JSDOMMicrotask.cpp
+++ b/Source/WebCore/bindings/js/JSDOMMicrotask.cpp
@@ -68,7 +68,7 @@ void JSDOMMicrotask::run(JSGlobalObject* globalObject)
     ASSERT(callData.type != CallData::Type::None);
 
     if (UNLIKELY(globalObject->hasDebugger()))
-        globalObject->debugger()->willRunMicrotask(globalObject, *this);
+        globalObject->debugger()->willRunMicrotask(globalObject, identifier());
 
     NakedPtr<JSC::Exception> returnedException = nullptr;
     JSExecState::profiledCall(lexicalGlobalObject, JSC::ProfilingReason::Microtask, job, callData, jsUndefined(), ArgList(), returnedException);
@@ -76,7 +76,7 @@ void JSDOMMicrotask::run(JSGlobalObject* globalObject)
         reportException(lexicalGlobalObject, returnedException);
 
     if (UNLIKELY(globalObject->hasDebugger()))
-        globalObject->debugger()->didRunMicrotask(globalObject, *this);
+        globalObject->debugger()->didRunMicrotask(globalObject, identifier());
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### ecb9f873dce9e00649d9f3d5bc668d5fd4e9bcb1
<pre>
[JSC] Optimize async/await and microtask queue part 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=244165">https://bugs.webkit.org/show_bug.cgi?id=244165</a>

Reviewed by Ross Kirsling.

This patch improves our async await performance, including microtask queue implementation in JSC side.

1. Promise reaction now delivers |context| value additionally. It is passed as a second argument to the
fulfill / reject handlers if it exists. In async function code, we need to have generator reference in
the promise handlers, and we end up allocating a closure for them capturing |generator|. But (1) this
kind of case is common and (2) allocating closure is costly. In this patch, we additionally pass context
parameter so that handlers can get |generator| tied to this handler registration. This removes closure
allocations and improve async / await performance. Currently this context parameter is usable only when
using resolveWithoutPromise APIs. Keep in mind that we could attempt to optimize the current implementation
by making promiseOrCapability field to promiseOrCapabilityOrContext. So if users would like to use it,
not passing a promise as a context for the future refactoring, it could be broken.

2. We found that MicrotaskQueue can get *super* large. And current heap-allocated JSMicrotask and Strong&lt;&gt; implementation
is too costly for these cases. In this patch, we redesign MicrotaskQueue in JSC VM: QueuedTask holds JSValues directly,
and JSC GC scans this queue to keep them alive. We also make QueuedTask non heap-allocated structure so MicrotaskQueue
enqueue/dequeue and scanning (for GC) is super fast. We also introduce optimization to reduce scanning cost in GC by
maintaining scanning cursor so that we do not take much time in GC scanning. Currently these optimization is only applied
to JSC VM&apos;s MicrotaskQueue: WebCore has different implementation, so this is not applied to WebContent use case.
But we first would like to apply it to JavaScriptCore.framework use case, and then, we will apply this optimization / redesign
current WebCore MicrotaskQueue mechanism to be faster one later.

This offers 4% improvement in JetStream2/async-fs since it is using async / await.

* LayoutTests/inspector/canvas/recording-bitmaprenderer-frameCount-expected.txt:
* LayoutTests/inspector/canvas/recording-bitmaprenderer-full-expected.txt:
* LayoutTests/inspector/canvas/recording-bitmaprenderer-memoryLimit-expected.txt:
* Source/JavaScriptCore/builtins/AsyncFromSyncIteratorPrototype.js:
(linkTimeConstant.asyncFromSyncIteratorOnRejected):
(linkTimeConstant.asyncFromSyncIteratorOnFulfilledContinue):
(linkTimeConstant.asyncFromSyncIteratorOnFulfilledDone):
(return):
(throw):
(next.try): Deleted.
(next): Deleted.
(return.try): Deleted.
(throw.try): Deleted.
* Source/JavaScriptCore/builtins/AsyncFunctionPrototype.js:
(linkTimeConstant.asyncFunctionResumeOnFulfilled):
(linkTimeConstant.asyncFunctionResumeOnRejected):
(linkTimeConstant.asyncFunctionResume):
* Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js:
(linkTimeConstant.asyncGeneratorYieldAwaited):
(linkTimeConstant.asyncGeneratorYieldOnRejected):
(linkTimeConstant.asyncGeneratorYield):
(linkTimeConstant.awaitValue):
(linkTimeConstant.doAsyncGeneratorBodyCallOnFulfilledNormal):
(linkTimeConstant.doAsyncGeneratorBodyCallOnFulfilledReturn):
(linkTimeConstant.doAsyncGeneratorBodyCall):
(linkTimeConstant.asyncGeneratorResumeNextOnFulfilled):
(linkTimeConstant.asyncGeneratorResumeNextOnRejected):
(linkTimeConstant.asyncGeneratorResumeNext):
(asyncGeneratorYieldAwaited): Deleted.
(onRejected): Deleted.
(onFulfilled): Deleted.
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/InternalPromiseConstructor.js:
(internalAll):
* Source/JavaScriptCore/builtins/PromiseOperations.js:
(linkTimeConstant.pushNewPromiseReaction):
(linkTimeConstant.triggerPromiseReactions):
(linkTimeConstant.promiseReactionJobWithoutPromise):
(linkTimeConstant.resolveWithoutPromise):
(linkTimeConstant.rejectWithoutPromise):
(linkTimeConstant.fulfillWithoutPromise):
(linkTimeConstant.resolveWithoutPromiseForAsyncAwait):
(linkTimeConstant.createResolvingFunctionsWithoutPromise):
(linkTimeConstant.promiseReactionJob):
(linkTimeConstant.promiseResolveThenableJobFast):
(linkTimeConstant.promiseResolveThenableJobWithoutPromiseFast):
(linkTimeConstant.promiseResolveThenableJobWithDerivedPromise):
(linkTimeConstant.performPromiseThen):
* Source/JavaScriptCore/builtins/PromisePrototype.js:
(then):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp:
(JSC::BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::generatorInternalFieldIndex):
(JSC::FunctionNode::emitBytecode):
* Source/JavaScriptCore/debugger/Debugger.cpp:
(JSC::Debugger::didQueueMicrotask):
(JSC::Debugger::willRunMicrotask):
(JSC::Debugger::didRunMicrotask):
* Source/JavaScriptCore/debugger/Debugger.h:
(JSC::Debugger::Observer::didQueueMicrotask):
(JSC::Debugger::Observer::willRunMicrotask):
(JSC::Debugger::Observer::didRunMicrotask):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::beginMarking):
(JSC::Heap::addCoreConstraints):
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::asyncCallIdentifier):
(Inspector::InspectorDebuggerAgent::didScheduleAsyncCall):
(Inspector::InspectorDebuggerAgent::didCancelAsyncCall):
(Inspector::InspectorDebuggerAgent::willDispatchAsyncCall):
(Inspector::InspectorDebuggerAgent::didDispatchAsyncCall):
(Inspector::InspectorDebuggerAgent::didQueueMicrotask):
(Inspector::InspectorDebuggerAgent::willRunMicrotask):
(Inspector::InspectorDebuggerAgent::didRunMicrotask):
(Inspector::InspectorDebuggerAgent::didClearAsyncStackTraceData):
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h:
* Source/JavaScriptCore/runtime/JSGenerator.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSGlobalObject::queueMicrotask):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::runJSMicrotask):
(JSC::JSMicrotask::run):
* Source/JavaScriptCore/runtime/JSMicrotask.h:
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::performPromiseThen):
* Source/JavaScriptCore/runtime/Microtask.h:
(JSC::Microtask::Microtask):
(JSC::Microtask::identifier const):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::queueMicrotask):
(JSC::VM::drainMicrotasks):
(JSC::VM::beginMarking):
(JSC::VM::visitAggregateImpl):
(JSC::QueuedTask::run):
(JSC::MicrotaskQueue::visitAggregateImpl):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::QueuedTask::QueuedTask):
(JSC::QueuedTask::identifier const):
(JSC::MicrotaskQueue::dequeue):
(JSC::MicrotaskQueue::enqueue):
(JSC::MicrotaskQueue::isEmpty const):
(JSC::MicrotaskQueue::clear):
(JSC::MicrotaskQueue::beginMarking):
* Source/WTF/wtf/Deque.h:
(WTF::DequeIterator::operator+=):
(WTF::DequeIterator::operator+ const):
(WTF::DequeConstIterator::operator+=):
(WTF::DequeConstIterator::operator+ const):
(WTF::inlineCapacity&gt;::increment):
* Source/WebCore/bindings/js/JSDOMMicrotask.cpp:
(WebCore::JSDOMMicrotask::run):

Canonical link: <a href="https://commits.webkit.org/253651@main">https://commits.webkit.org/253651@main</a>
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a72a26f332dc05fa2615f2004c38d872885727b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95495 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149223 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29084 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25517 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90738 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92268 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23502 "Found 1 new test failure: imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73576 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23569 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66575 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78587 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26868 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12709 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72224 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26787 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13724 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25791 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2593 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36584 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75007 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28409 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33003 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16591 "Passed tests") | 
<!--EWS-Status-Bubble-End-->