### PR TITLE
Reset state in testapi's testModuleBytecodeCache() before starting the test.

### DIFF
--- a/Source/JavaScriptCore/API/tests/testapi.mm
+++ b/Source/JavaScriptCore/API/tests/testapi.mm
@@ -2119,6 +2119,17 @@ static void testModuleBytecodeCache()
         NSURL *barFakePath = [NSURL fileURLWithPath:@"/directory/bar.js"];
         NSURL *bazFakePath = [NSURL fileURLWithPath:@"/otherDirectory/baz.js"];
 
+        NSFileManager* fileManager = [NSFileManager defaultManager];
+
+        // Clear out any potential old data left over from previous failed runs.
+        // This resets the slate clean for this run of the test.
+        [fileManager removeItemAtURL:fooPath error:nil];
+        [fileManager removeItemAtURL:barPath error:nil];
+        [fileManager removeItemAtURL:bazPath error:nil];
+        [fileManager removeItemAtURL:fooCachePath error:nil];
+        [fileManager removeItemAtURL:barCachePath error:nil];
+        [fileManager removeItemAtURL:bazCachePath error:nil];
+
         [fooSource writeToURL:fooPath atomically:NO encoding:NSASCIIStringEncoding error:nil];
         [barSource writeToURL:barPath atomically:NO encoding:NSASCIIStringEncoding error:nil];
         [bazSource writeToURL:bazPath atomically:NO encoding:NSASCIIStringEncoding error:nil];
@@ -2151,7 +2162,6 @@ static void testModuleBytecodeCache()
             JSC::Options::forceDiskCache() = false;
         }
 
-        NSFileManager* fileManager = [NSFileManager defaultManager];
         BOOL removedAll = true;
         removedAll &= [fileManager removeItemAtURL:fooPath error:nil];
         removedAll &= [fileManager removeItemAtURL:barPath error:nil];


### PR DESCRIPTION
#### 92c64e3b4c250cd1b734035172ada24318d4ee37
<pre>
Reset state in testapi&apos;s testModuleBytecodeCache() before starting the test.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244170">https://bugs.webkit.org/show_bug.cgi?id=244170</a>
&lt;rdar://98950007&gt;

Reviewed by Saam Barati.

There may be leftover state from a previous failed test run in the file system.  If we
don&apos;t clean this up before running the test, the test can fail perpetually until the
machine is rebooted.  This results in wasted engineering effort to diagnose this failure.
This patch ensures the state is clean before starting the test.

* Source/JavaScriptCore/API/tests/testapi.mm:
(testModuleBytecodeCache):

Canonical link: <a href="https://commits.webkit.org/253633@main">https://commits.webkit.org/253633@main</a>
</pre>






<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/879686e9f659be068eb2d7cec3cfd1be9af9f5dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95461 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149186 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29044 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25488 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90705 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23473 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73547 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23539 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78478 "Passed tests") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66545 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78554 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26835 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12683 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72192 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26754 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13698 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25782 "Passed tests") | 
| [✅ ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/2581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36557 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/74973 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1004 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32977 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16579 "Passed tests") | 
<!--EWS-Status-Bubble-End-->