### PR TITLE
Add a --detailed-breakdown option to compare-results

### DIFF
--- a/Tools/Scripts/compare-results
+++ b/Tools/Scripts/compare-results
@@ -100,6 +100,15 @@ def jetStream2Breakdown(jsonObject):
         result[test] = breakdown._results["JetStream2.0"]["tests"][test]["metrics"]["Score"][None]["current"]
     return result
 
+def detailedJetStream2Breakdown(jsonObject):
+    breakdown = BenchmarkResults(jsonObject)
+    result = {}
+    result[unitMarker] = "ms"
+    for test in breakdown._results["JetStream2.0"]["tests"].keys():
+        for subtest in breakdown._results["JetStream2.0"]["tests"][test]["tests"]:
+            result[test + "-" + subtest] = breakdown._results["JetStream2.0"]["tests"][test]["tests"][subtest]["metrics"]["Time"][None]["current"]
+    return result
+
 def motionMarkBreakdown(jsonObject):
     breakdown = BenchmarkResults(jsonObject)
 
@@ -515,14 +524,16 @@ def getOptions():
     parser.add_argument("--breakdown", action="store_true",
         default=False, help="Print a per subtest breakdown.")
 
-    parser.add_argument("--sync-vs-async", action="store_true",
-        default=False, help="Print a per subtest breakdown in Speedometer2 by sync and async time.")
+    parser.add_argument("--detailed-breakdown", action="store_true",
+        default=False, help="Print a detailed breakdown per subtest.")
 
     return parser.parse_known_args()[0]
 
 
 def main():
     args = getOptions()
+    if args.detailed_breakdown:
+        args.breakdown = True
 
     # Flatten the list of lists of JSON files.
     a = itertools.chain.from_iterable(args.a)
@@ -544,7 +555,10 @@ def main():
     
     if typeA == JetStream2:
         if args.breakdown:
-            dumpBreakdowns(jetStream2Breakdown(a), jetStream2Breakdown(b))
+            if args.detailed_breakdown:
+                dumpBreakdowns(detailedJetStream2Breakdown(a), detailedJetStream2Breakdown(b))
+            else:
+                dumpBreakdowns(jetStream2Breakdown(a), jetStream2Breakdown(b))
 
         ttest(typeA, JetStream2Results(a), JetStream2Results(b))
 
@@ -552,7 +566,7 @@ def main():
             writeCSV(jetStream2Breakdown(a), jetStream2Breakdown(b), args.csv)
     elif typeA == Speedometer2:
         if args.breakdown:
-            if args.sync_vs_async:
+            if args.detailed_breakdown:
                 dumpBreakdowns(speedometer2BreakdownSyncAsync(a), speedometer2BreakdownSyncAsync(b))
             else:
                 dumpBreakdowns(speedometer2Breakdown(a), speedometer2Breakdown(b))


### PR DESCRIPTION
#### 1a002141eb345ccc7a56f0c130138f13f4c25fd4
<pre>
Add a --detailed-breakdown option to compare-results
<a href="https://bugs.webkit.org/show_bug.cgi?id=244171">https://bugs.webkit.org/show_bug.cgi?id=244171</a>

Reviewed by Mark Lam.

Add this option and implement it for JetStream2 breakdowns. So now we
can see scores for each subtest. For example, we can see results like:

$ ./Tools/Scripts/compare-results -a &lt;JS2-a&gt; -b &lt;JS2-b&gt;  --detailed-breakdown

---------------------------------------------------------------------------------------------------------------------------------
|              subtest              |     ms       |     ms       |  b / a   | pValue (significance using False Discovery Rate) |
---------------------------------------------------------------------------------------------------------------------------------
| 3d-cube-SP-Average                |4.937815      |5.078992      |1.028591  | 0.000297 (significant)                           |
| 3d-cube-SP-First                  |14.800000     |30.000000     |2.027027  | 0.004092 (significant)                           |
| 3d-cube-SP-Worst                  |6.650000      |7.550000      |1.135338  | 0.007057 (significant)                           |
| 3d-raytrace-SP-Average            |6.593277      |9.793277      |1.485343  | 0.352068                                         |
| 3d-raytrace-SP-First              |11.400000     |29.200000     |2.561404  | 0.005928 (significant)                           |
| 3d-raytrace-SP-Worst              |8.000000      |13.550000     |1.693750  | 0.254545                                         |
| Air-Average                       |2.919328      |2.934454      |1.005181  | 0.876293                                         |
| Air-First                         |28.400000     |41.600000     |1.464789  | 0.000009 (significant)                           |
| Air-Worst                         |10.000000     |10.300000     |1.030000  | 0.620902                                         |
| Babylon-Average                   |2.527731      |2.642017      |1.045213  | 0.019926 (significant)                           |
| Babylon-First                     |16.000000     |23.600000     |1.475000  | 0.000744 (significant)                           |
| Babylon-Worst                     |5.950000      |5.800000      |0.974790  | 0.781934                                         |
| Basic-Average                     |2.700840      |2.830252      |1.047915  | 0.004943 (significant)                           |
| Basic-First                       |11.600000     |26.800000     |2.310345  | 0.000385 (significant)                           |
| Basic-Worst                       |5.500000      |7.700000      |1.400000  | 0.000056 (significant)                           |
| Box2D-Average                     |4.200000      |4.277311      |1.018407  | 0.000713 (significant)                           |
| Box2D-First                       |30.200000     |44.400000     |1.470199  | 0.000398 (significant)                           |
| Box2D-Worst                       |6.450000      |6.800000      |1.054264  | 0.029449                                         |
| FlightPlanner-Average             |2.667227      |2.642017      |0.990548  | 0.463487                                         |
| FlightPlanner-First               |10.000000     |7.600000      |0.760000  | 0.305198                                         |
| FlightPlanner-Worst               |6.350000      |6.450000      |1.015748  | 0.841688                                         |
| HashSet-wasm-Runtime              |503.800000    |508.200000    |1.008734  | 0.596045                                         |
| HashSet-wasm-Startup              |6.600000      |18.600000     |2.818182  | 0.024033 (significant)                           |
| ML-Average                        |24.040678     |24.027119     |0.999436  | 0.951016                                         |
| ML-First                          |41.200000     |59.600000     |1.446602  | 0.000000 (significant)                           |
| ML-Worst                          |25.300000     |26.150000     |1.033597  | 0.001885 (significant)                           |
| OfflineAssembler-Average          |16.063291     |15.994937     |0.995745  | 0.642907                                         |
| OfflineAssembler-First            |29.600000     |44.000000     |1.486486  | 0.000038 (significant)                           |
| OfflineAssembler-Worst            |19.200000     |19.650000     |1.023438  | 0.242121                                         |
| UniPoker-Average                  |6.233613      |6.317647      |1.013481  | 0.004538 (significant)                           |
| UniPoker-First                    |10.400000     |21.000000     |2.019231  | 0.004963 (significant)                           |
| UniPoker-Worst                    |8.150000      |9.450000      |1.159509  | 0.038850                                         |
| WSL-MainRun                       |3188.600000   |3161.400000   |0.991470  | 0.329128                                         |
| WSL-Stdlib                        |1530.200000   |1529.400000   |0.999477  | 0.879203                                         |
| acorn-wtb-Average                 |47.650000     |48.150000     |1.010493  | 0.451767                                         |
| acorn-wtb-First                   |89.000000     |90.000000     |1.011236  | 0.351097                                         |
| acorn-wtb-Worst                   |51.800000     |51.400000     |0.992278  | 0.670716                                         |
| ai-astar-Average                  |4.764706      |4.705882      |0.987654  | 0.510042                                         |
| ai-astar-First                    |7.800000      |10.200000     |1.307692  | 0.057001                                         |
| ai-astar-Worst                    |6.500000      |6.300000      |0.969231  | 0.605035                                         |
| async-fs-Average                  |14.215385     |14.333333     |1.008297  | 0.034734                                         |
| async-fs-First                    |19.600000     |38.600000     |1.969388  | 0.001720 (significant)                           |
| async-fs-Worst                    |16.400000     |17.600000     |1.073171  | 0.004964 (significant)                           |
| babylon-wtb-Average               |39.250000     |38.950000     |0.992357  | 0.485221                                         |
| babylon-wtb-First                 |71.200000     |71.400000     |1.002809  | 0.935003                                         |
| babylon-wtb-Worst                 |43.200000     |43.800000     |1.013889  | 0.742154                                         |
| base64-SP-Average                 |4.635294      |4.705882      |1.015228  | 0.125558                                         |
| base64-SP-First                   |7.800000      |21.000000     |2.692308  | 0.000143 (significant)                           |
| base64-SP-Worst                   |5.400000      |7.700000      |1.425926  | 0.000000 (significant)                           |
| bomb-workers-Average              |38.508861     |38.210127     |0.992242  | 0.492211                                         |
| bomb-workers-First                |41.200000     |53.200000     |1.291262  | 0.000068 (significant)                           |
| bomb-workers-Worst                |42.700000     |42.350000     |0.991803  | 0.595902                                         |
| cdjs-Average                      |18.152542     |18.142373     |0.999440  | 0.883897                                         |
| cdjs-First                        |26.800000     |46.600000     |1.738806  | 0.000015 (significant)                           |
| cdjs-Worst                        |19.200000     |20.600000     |1.072917  | 0.000061 (significant)                           |
| chai-wtb-Average                  |28.250000     |27.900000     |0.987611  | 0.602845                                         |
| chai-wtb-First                    |44.800000     |47.200000     |1.053571  | 0.119265                                         |
| chai-wtb-Worst                    |34.200000     |31.400000     |0.918129  | 0.167387                                         |
| coffeescript-wtb-Average          |81.750000     |82.000000     |1.003058  | 0.767109                                         |
| coffeescript-wtb-First            |119.800000    |122.400000    |1.021703  | 0.270932                                         |
| coffeescript-wtb-Worst            |86.600000     |87.800000     |1.013857  | 0.323901                                         |
| crypto-Average                    |1.823529      |1.988235      |1.090323  | 0.000063 (significant)                           |
| crypto-First                      |5.000000      |13.000000     |2.600000  | 0.000668 (significant)                           |
| crypto-Worst                      |2.300000      |4.250000      |1.847826  | 0.000000 (significant)                           |
| crypto-aes-SP-Average             |4.080672      |4.240336      |1.039127  | 0.002218 (significant)                           |
| crypto-aes-SP-First               |9.000000      |23.200000     |2.577778  | 0.000079 (significant)                           |
| crypto-aes-SP-Worst               |5.150000      |7.200000      |1.398058  | 0.000000 (significant)                           |
| crypto-md5-SP-Average             |4.895798      |5.099160      |1.041538  | 0.002700 (significant)                           |
| crypto-md5-SP-First               |7.800000      |21.200000     |2.717949  | 0.000133 (significant)                           |
| crypto-md5-SP-Worst               |5.500000      |8.200000      |1.490909  | 0.000001 (significant)                           |
| crypto-sha1-SP-Average            |3.149580      |3.324370      |1.055496  | 0.000835 (significant)                           |
| crypto-sha1-SP-First              |9.600000      |24.800000     |2.583333  | 0.004434 (significant)                           |
| crypto-sha1-SP-Worst              |4.700000      |6.650000      |1.414894  | 0.000273 (significant)                           |
| date-format-tofte-SP-Average      |8.144538      |8.275630      |1.016096  | 0.014491 (significant)                           |
| date-format-tofte-SP-First        |13.600000     |28.600000     |2.102941  | 0.000027 (significant)                           |
| date-format-tofte-SP-Worst        |9.000000      |10.850000     |1.205556  | 0.000007 (significant)                           |
| date-format-xparb-SP-Average      |6.917647      |6.961345      |1.006317  | 0.575497                                         |
| date-format-xparb-SP-First        |14.600000     |25.200000     |1.726027  | 0.000006 (significant)                           |
| date-format-xparb-SP-Worst        |8.350000      |10.300000     |1.233533  | 0.000084 (significant)                           |
| delta-blue-Average                |1.957983      |2.057143      |1.050644  | 0.014816 (significant)                           |
| delta-blue-First                  |8.600000      |21.600000     |2.511628  | 0.037553                                         |
| delta-blue-Worst                  |3.500000      |4.950000      |1.414286  | 0.007953 (significant)                           |
| earley-boyer-Average              |2.971429      |3.152941      |1.061086  | 0.048046                                         |
| earley-boyer-First                |8.800000      |16.200000     |1.840909  | 0.000798 (significant)                           |
| earley-boyer-Worst                |4.250000      |6.100000      |1.435294  | 0.003434 (significant)                           |
| espree-wtb-Average                |49.600000     |49.500000     |0.997984  | 0.879884                                         |
| espree-wtb-First                  |83.000000     |80.400000     |0.968675  | 0.223578                                         |
| espree-wtb-Worst                  |53.000000     |51.800000     |0.977358  | 0.435574                                         |
| first-inspector-code-load-Average |15.166387     |15.257143     |1.005984  | 0.004796 (significant)                           |
| first-inspector-code-load-First   |16.400000     |33.000000     |2.012195  | 0.000156 (significant)                           |
| first-inspector-code-load-Worst   |16.050000     |17.550000     |1.093458  | 0.000779 (significant)                           |
| float-mm.c-Average                |264.528571    |264.685714    |1.000594  | 0.830270                                         |
| float-mm.c-First                  |271.800000    |298.600000    |1.098602  | 0.000052 (significant)                           |
| float-mm.c-Worst                  |268.300000    |268.400000    |1.000373  | 0.895999                                         |
| gaussian-blur-Average             |6.610084      |6.707563      |1.014747  | 0.229253                                         |
| gaussian-blur-First               |12.000000     |21.000000     |1.750000  | 0.000080 (significant)                           |
| gaussian-blur-Worst               |7.000000      |8.700000      |1.242857  | 0.000054 (significant)                           |
| gbemu-Average                     |15.973109     |15.292437     |0.957386  | 0.029106                                         |
| gbemu-First                       |52.200000     |66.200000     |1.268199  | 0.000003 (significant)                           |
| gbemu-Worst                       |35.300000     |27.300000     |0.773371  | 0.059627                                         |
| gcc-loops-wasm-Runtime            |1664.400000   |1676.800000   |1.007450  | 0.000118 (significant)                           |
| gcc-loops-wasm-Startup            |4.000000      |8.800000      |2.200000  | 0.014300 (significant)                           |
| hash-map-Average                  |4.969748      |5.067227      |1.019614  | 0.020019 (significant)                           |
| hash-map-First                    |11.400000     |27.800000     |2.438596  | 0.000750 (significant)                           |
| hash-map-Worst                    |6.950000      |9.250000      |1.330935  | 0.000017 (significant)                           |
| jshint-wtb-Average                |61.000000     |61.400000     |1.006557  | 0.680842                                         |
| jshint-wtb-First                  |100.000000    |98.000000     |0.980000  | 0.212580                                         |
| jshint-wtb-Worst                  |64.600000     |64.800000     |1.003096  | 0.877809                                         |
| json-parse-inspector-Average      |14.347368     |14.515789     |1.011739  | 0.000393 (significant)                           |
| json-parse-inspector-First        |14.200000     |17.200000     |1.211268  | 0.000005 (significant)                           |
| json-parse-inspector-Worst        |16.500000     |16.400000     |0.993939  | 0.698401                                         |
| json-stringify-inspector-Average  |13.578947     |13.536842     |0.996899  | 0.546671                                         |
| json-stringify-inspector-First    |13.400000     |13.400000     |1.000000  | 1.000000                                         |
| json-stringify-inspector-Worst    |16.500000     |16.400000     |0.993939  | 0.811769                                         |
| lebab-wtb-Average                 |49.700000     |48.750000     |0.980885  | 0.211678                                         |
| lebab-wtb-First                   |94.600000     |97.400000     |1.029598  | 0.111391                                         |
| lebab-wtb-Worst                   |60.000000     |57.600000     |0.960000  | 0.437108                                         |
| mandreel-Average                  |19.278481     |19.400000     |1.006303  | 0.142383                                         |
| mandreel-First                    |65.600000     |56.200000     |0.856707  | 0.064914                                         |
| mandreel-Worst                    |23.500000     |23.450000     |0.997872  | 0.741900                                         |
| multi-inspector-code-load-Average |5.942857      |5.406723      |0.909785  | 0.238059                                         |
| multi-inspector-code-load-First   |16.400000     |34.600000     |2.109756  | 0.000006 (significant)                           |
| multi-inspector-code-load-Worst   |15.900000     |17.600000     |1.106918  | 0.000009 (significant)                           |
| n-body-SP-Average                 |2.759664      |2.910924      |1.054811  | 0.000001 (significant)                           |
| n-body-SP-First                   |5.000000      |12.600000     |2.520000  | 0.000361 (significant)                           |
| n-body-SP-Worst                   |3.000000      |5.000000      |1.666667  | 0.000014 (significant)                           |
| navier-stokes-Average             |4.193277      |4.223529      |1.007214  | 0.393015                                         |
| navier-stokes-First               |10.600000     |25.800000     |2.433962  | 0.000774 (significant)                           |
| navier-stokes-Worst               |5.700000      |7.900000      |1.385965  | 0.001846 (significant)                           |
| octane-code-load-Average          |2.971429      |3.115966      |1.048643  | 0.000028 (significant)                           |
| octane-code-load-First            |4.000000      |11.400000     |2.850000  | 0.000007 (significant)                           |
| octane-code-load-Worst            |3.350000      |5.700000      |1.701493  | 0.000001 (significant)                           |
| octane-zlib-Average               |131.257143    |134.128571    |1.021876  | 0.102195                                         |
| octane-zlib-First                 |281.800000    |314.400000    |1.115685  | 0.000004 (significant)                           |
| octane-zlib-Worst                 |132.700000    |135.300000    |1.019593  | 0.147536                                         |
| pdfjs-Average                     |13.848739     |13.981513     |1.009587  | 0.029834                                         |
| pdfjs-First                       |34.200000     |33.400000     |0.976608  | 0.546680                                         |
| pdfjs-Worst                       |19.100000     |18.900000     |0.989529  | 0.716785                                         |
| prepack-wtb-Average               |46.150000     |45.600000     |0.988082  | 0.089060                                         |
| prepack-wtb-First                 |110.400000    |109.000000    |0.987319  | 0.357134                                         |
| prepack-wtb-Worst                 |56.400000     |51.800000     |0.918440  | 0.022462 (significant)                           |
| quicksort-wasm-Runtime            |22.400000     |39.600000     |1.767857  | 0.000014 (significant)                           |
| quicksort-wasm-Startup            |1.600000      |8.200000      |5.125000  | 0.000002 (significant)                           |
| raytrace-Average                  |3.070588      |3.109244      |1.012589  | 0.102451                                         |
| raytrace-First                    |10.800000     |24.200000     |2.240741  | 0.000166 (significant)                           |
| raytrace-Worst                    |5.050000      |7.450000      |1.475248  | 0.000022 (significant)                           |
| regex-dna-SP-Average              |9.305882      |9.600000      |1.031606  | 0.015819 (significant)                           |
| regex-dna-SP-First                |10.800000     |25.400000     |2.351852  | 0.000040 (significant)                           |
| regex-dna-SP-Worst                |10.050000     |12.950000     |1.288557  | 0.000042 (significant)                           |
| regexp-Average                    |7.944538      |8.000000      |1.006981  | 0.321014                                         |
| regexp-First                      |10.000000     |13.600000     |1.360000  | 0.000125 (significant)                           |
| regexp-Worst                      |10.550000     |10.900000     |1.033175  | 0.020853 (significant)                           |
| richards-Average                  |3.579832      |3.737815      |1.044131  | 0.000477 (significant)                           |
| richards-First                    |7.600000      |19.200000     |2.526316  | 0.000207 (significant)                           |
| richards-Worst                    |4.000000      |6.100000      |1.525000  | 0.000151 (significant)                           |
| richards-wasm-Runtime             |415.800000    |439.600000    |1.057239  | 0.000015 (significant)                           |
| richards-wasm-Startup             |1.600000      |4.600000      |2.875000  | 0.000461 (significant)                           |
| segmentation-Average              |66.400000     |65.754286     |0.990275  | 0.023137 (significant)                           |
| segmentation-First                |133.800000    |158.600000    |1.185351  | 0.000049 (significant)                           |
| segmentation-Worst                |85.266667     |81.400000     |0.954652  | 0.127446                                         |
| splay-Average                     |6.838655      |6.919328      |1.011797  | 0.425222                                         |
| splay-First                       |8.800000      |14.800000     |1.681818  | 0.000631 (significant)                           |
| splay-Worst                       |19.950000     |16.300000     |0.817043  | 0.245283                                         |
| stanford-crypto-aes-Average       |7.400000      |7.411765      |1.001590  | 0.685433                                         |
| stanford-crypto-aes-First         |12.800000     |21.600000     |1.687500  | 0.000488 (significant)                           |
| stanford-crypto-aes-Worst         |8.550000      |9.950000      |1.163743  | 0.000407 (significant)                           |
| stanford-crypto-pbkdf2-Average    |4.615126      |4.717647      |1.022214  | 0.014409 (significant)                           |
| stanford-crypto-pbkdf2-First      |6.200000      |18.400000     |2.967742  | 0.000162 (significant)                           |
| stanford-crypto-pbkdf2-Worst      |5.250000      |8.150000      |1.552381  | 0.000059 (significant)                           |
| stanford-crypto-sha256-Average    |4.638655      |4.600000      |0.991667  | 0.674776                                         |
| stanford-crypto-sha256-First      |8.400000      |16.800000     |2.000000  | 0.005270 (significant)                           |
| stanford-crypto-sha256-Worst      |5.400000      |7.200000      |1.333333  | 0.000626 (significant)                           |
| string-unpack-code-SP-Average     |9.436975      |9.509244      |1.007658  | 0.037338                                         |
| string-unpack-code-SP-First       |11.600000     |25.000000     |2.155172  | 0.000052 (significant)                           |
| string-unpack-code-SP-Worst       |11.200000     |14.500000     |1.294643  | 0.048462                                         |
| tagcloud-SP-Average               |11.440336     |11.225210     |0.981196  | 0.072126                                         |
| tagcloud-SP-First                 |15.400000     |33.200000     |2.155844  | 0.000272 (significant)                           |
| tagcloud-SP-Worst                 |15.950000     |14.800000     |0.927900  | 0.120373                                         |
| tsf-wasm-Runtime                  |183.600000    |194.400000    |1.058824  | 0.003660 (significant)                           |
| tsf-wasm-Startup                  |5.600000      |9.200000      |1.642857  | 0.118867                                         |
| typescript-Average                |110.400000    |109.642857    |0.993142  | 0.550709                                         |
| typescript-First                  |243.600000    |251.800000    |1.033662  | 0.003223 (significant)                           |
| typescript-Worst                  |139.200000    |139.000000    |0.998563  | 0.931142                                         |
| uglify-js-wtb-Average             |83.100000     |84.600000     |1.018051  | 0.057653                                         |
| uglify-js-wtb-First               |169.600000    |172.600000    |1.017689  | 0.107862                                         |
| uglify-js-wtb-Worst               |95.000000     |95.800000     |1.008421  | 0.350554                                         |
---------------------------------------------------------------------------------------------------------------------------------

a mean = 293.80743
b mean = 232.37638
pValue = 0.0000000005
(Bigger means are better.)
1.264 times worse
Results ARE significant

* Tools/Scripts/compare-results:
(jetStream2Breakdown):
(detailedJetStream2Breakdown):
(getOptions):
(main):

Canonical link: <a href="https://commits.webkit.org/253646@main">https://commits.webkit.org/253646@main</a>
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a52303e53bd28b9fecd92b2fca75029bc069c4c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95464 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149189 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90607 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29047 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25490 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78796 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90707 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23475 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73549 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23540 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66546 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26837 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12685 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26757 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13700 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2590 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36559 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32979 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->