### PR TITLE
Input[type=date] with invalid date should return empty string for value IDL attribute instead of the default value

### DIFF
--- a/LayoutTests/fast/forms/date-multiple-fields/date-multiple-fields-keyboard-events-expected.txt
+++ b/LayoutTests/fast/forms/date-multiple-fields/date-multiple-fields-keyboard-events-expected.txt
@@ -1,0 +1,79 @@
+Multiple fields UI of month input type with keyboard events
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Please run this with DumpRenderTree.
+
+Test following keys:
+Digits
+Left/Right - Move focus field inside element
+Up/Down - Increment/decrement value of focus field
+Tab - Move focus field
+Backspace - Make value empty
+
+ == Digit keys ==
+ PASS input.value is "0012-09-20"
+ == Digit keys starting with zero ==
+ PASS input.value is "0044-02-03"
+ == Digit keys and backspace key ==
+ PASS input.value is "0008-05-06"
+ == Digit keys with maximum value ==
+ PASS input.value is "2014-05-06"
+ == Digit keys with minimum value ==
+ PASS input.value is "1999-05-06"
+ == Entering "00" to month ==
+ PASS input.value is "2013-01-16"
+ == Entering "13" to month ==
+ PASS input.value is "2013-12-16"
+ == Left/Right keys ==
+ PASS input.value is "2012-09-06"
+ PASS document.activeElement.id is "input"
+ == Up/Down keys ==
+ PASS input.value is "2012-10-29"
+ PASS input.value is "2012-08-29"
+ == Up/Down keys on empty value ==
+ PASS input.value is currentYear + "-11-01"
+ == Up/Down keys on empty value 2 ==
+ PASS input.value is currentYear + "-02-28"
+ == Tab key ==
+ PASS input.value is "2012-09-05"
+ PASS input.value is "2012-09-07"
+ PASS document.activeElement.id is "after"
+ == Shfit+Tab key ==
+ PASS input.value is "0003-09-30"
+ PASS document.activeElement.id is "before"
+ == Up key on maximum value ==
+ PASS input.value is "0001-10-14"
+ == Up key with a maximum attribute ==
+ PASS input.value is "1000-01-01"
+ == Down key on minimum value ==
+ PASS input.value is ""
+ == Down key with a minimum attribute ==
+ PASS input.value is ""
+ == Inconsistent min-max attributes ==
+ PASS input.value is "1000-12-31"
+ PASS input.value is "1999-12-31"
+ == Make an invalid date ==
+ PASS input.value is ""
+ PASS input.value is ""
+ == Backspace key ==
+ PASS input.value is ""
+ == Delete key ==
+ PASS input.value is ""
+ == Typeahead ==
+ PASS input.value is "2012-12-01"
+ PASS input.value is "2012-12-02"
+ == RTL focus navigation ==
+ The tests in this block fail on platforms without the lang-attribute-aware-form-control-UI feature.
+ PASS input.value is "2012-09-01"
+ PASS input.value is "2012-02-01"
+ PASS input.value is "2012-03-01"
+ == Disabled/readonly ==
+ PASS input.value is "2012-10-08"
+ PASS input.value is "2012-11-08"
+ PASS input.value is "2012-11-08"
+ PASS input.value is "2012-12-08"
+ PASS successfullyParsed is true
+ 
+ TEST COMPLETE

--- a/LayoutTests/fast/forms/date-multiple-fields/date-multiple-fields-keyboard-events.html
+++ b/LayoutTests/fast/forms/date-multiple-fields/date-multiple-fields-keyboard-events.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<p>
+Please run this with DumpRenderTree.
+</p>
+Test following keys:
+<ul>
+    <li>Digits</li>
+    <li>Left/Right - Move focus field inside element</li>
+    <li>Up/Down - Increment/decrement value of focus field</li>
+    <li>Tab - Move focus field</li>
+    <li>Backspace - Make value empty</li>
+</ul>
+<input id="before">
+<input id="input" type="date">
+<input id="after">
+<div id="console"></div>
+<script>
+description('Multiple fields UI of month input type with keyboard events');
+if (window.internals)
+    internals.settings.setLangAttributeAwareFormControlUIEnabled(true);
+var input = document.getElementById('input');
+
+function keyDown(key, modifiers)
+{
+    if (!window.eventSender)
+        return;
+    eventSender.keyDown(key, modifiers);
+}
+
+function beginTest(opt_title, opt_value, opt_min, opt_max)
+{
+    if (opt_title)
+        debug('== ' + opt_title + ' ==');
+    input.value = opt_value || '';
+    input.min = opt_min ? opt_min : '';
+    input.max = opt_max ? opt_max : '';
+    input.blur();
+    input.focus();
+}
+
+// We assume the date format is MM/dd/yyyy.
+
+beginTest('Digit keys');
+keyDown('9'); // -> 09/[dd]/yyyy
+keyDown('2'); // -> 09/[02]/yyyy
+keyDown('0'); // -> 09/20/[yyyy]
+keyDown('1'); // -> 09/20/[0001]
+keyDown('2'); // -> 09/20/[0012]
+keyDown('A'); // Ignored.
+shouldBeEqualToString('input.value', '0012-09-20');
+
+beginTest('Digit keys starting with zero');
+keyDown('0'); // -> [00]/dd/yyyy
+keyDown('2'); // -> 02/[dd]/yyyy
+keyDown('0'); // -> 02/[00]/yyyy
+keyDown('3'); // -> 02/03/[yyyy]
+keyDown('0'); // -> 02/03/[0000]
+keyDown('0'); // -> 02/03/[0000]
+keyDown('0'); // -> 02/03/[0000]
+keyDown('4'); // -> 02/03/[0004]
+keyDown('4'); // -> 02/03/[0044]
+shouldBeEqualToString('input.value', '0044-02-03');
+
+beginTest('Digit keys and backspace key');
+keyDown('1'); // -> [01]/dd/yyyy
+keyDown("\b"); // -> [mm]/20/2012
+keyDown('5'); // -> 05/[dd]/yyyy
+keyDown('6'); // -> 05/06/[yyyy]
+keyDown("\b"); // -> 05/06/[yyyy]
+keyDown('7'); // -> 05/06/[0007]
+keyDown("\b"); // -> 05/06/[yyyy]
+keyDown('8'); // -> 05/06/[0008]
+shouldBeEqualToString('input.value', '0008-05-06');
+
+beginTest('Digit keys with maximum value', null, null, '2013-01-01');
+keyDown('5'); // -> 05/[dd]/yyyy
+keyDown('6'); // -> 05/06/[yyyy]
+keyDown('2'); // -> 05/06/[0002]
+keyDown('0'); // -> 05/06/[0020]
+keyDown('1'); // -> 05/06/[0201]
+keyDown('4'); // -> 05/06/[2014] We accept a value larger than the maximum.
+shouldBeEqualToString('input.value', '2014-05-06');
+keyDown('5'); // -> 05/06/[0145] We don't accept a value of which the number of digits is longer than one of the maximum.
+shouldBeEqualToString('input.value', '0145-05-06');
+
+beginTest('Digit keys with minimum value', null, '2013-01-01');
+keyDown('5'); // -> 05/[dd]/yyyy
+keyDown('6'); // -> 05/06/[yyyy]
+keyDown('1'); // -> 05/06/[0001]
+keyDown('9'); // -> 05/06/[0019]
+keyDown('9'); // -> 05/06/[0199]
+keyDown('9'); // -> 05/06/1999
+shouldBeEqualToString('input.value', '1999-05-06');
+
+beginTest('Entering "00" to month', '2013-04-16');
+keyDown('0'); // -> [00]/16/2013
+keyDown('0'); // -> 01/[16]/2013
+shouldBeEqualToString('input.value', '2013-01-16');
+
+beginTest('Entering "13" to month', '2013-04-16');
+keyDown('1'); // -> [01]/16/2013
+keyDown('3'); // -> 12/[16]/2013
+shouldBeEqualToString('input.value', '2013-12-16');
+
+beginTest('Left/Right keys', '2012-09-29');
+keyDown('rightArrow'); // -> 09/[29]/2012
+keyDown('5'); // -> 09/05/[2012]
+keyDown('leftArrow'); // -> 09/[05]/2012
+keyDown('6'); // -> 09/06/[2012]
+shouldBeEqualToString('input.value', '2012-09-06');
+keyDown('leftArrow'); // -> 09/[06]/2012
+keyDown('leftArrow'); // -> [09]/06/2012
+keyDown('leftArrow'); // -> [09]/06/2012
+shouldBeEqualToString('document.activeElement.id', 'input');
+
+beginTest('Up/Down keys', '2012-09-29');
+keyDown('upArrow'); // -> [10]/29/2012
+shouldBeEqualToString('input.value', '2012-10-29');
+keyDown('downArrow'); // -> [09]/29/2012
+keyDown('downArrow'); // -> [08]/29/2012
+shouldBeEqualToString('input.value', '2012-08-29');
+
+beginTest('Up/Down keys on empty value');
+keyDown('downArrow'); //  -> [12]/dd/yyyy
+keyDown('downArrow'); //  -> [11]/dd/yyyy
+keyDown('rightArrow'); // -> 11/[dd]/yyyy
+keyDown('upArrow'); //    -> 11/[01]/yyyy
+keyDown('upArrow'); //    -> 11/[02]/yyyy
+keyDown('downArrow'); //  -> 11/[01]/yyyy
+keyDown('rightArrow'); // -> 11/01/[yyyy]
+var currentYear = new Date().getFullYear();
+keyDown('upArrow'); // -> 11/01/[current year]
+shouldBe('input.value', 'currentYear + "-11-01"');
+
+beginTest('Up/Down keys on empty value 2');
+keyDown('upArrow'); //    -> [01]/dd/yyyy
+keyDown('upArrow'); //    -> [02]/dd/yyyy
+keyDown('rightArrow'); // -> 02/[dd]/yyyy
+keyDown('downArrow'); //  -> 02/[31]/yyyy
+keyDown('downArrow'); //  -> 02/[30]/yyyy
+keyDown('downArrow'); //  -> 02/[29]/yyyy
+keyDown('downArrow'); //  -> 02/[28]/yyyy
+keyDown('rightArrow'); // -> 02/28/[yyyy]
+currentYear = new Date().getFullYear();
+keyDown('downArrow'); // -> 02/28/[current year]
+shouldBe('input.value', 'currentYear + "-02-28"');
+
+beginTest('Tab key', '2012-09-30');
+keyDown('\t'); // -> 09/[30]/2012
+keyDown('5'); // -> 09/05/[2012]
+shouldBeEqualToString('input.value', '2012-09-05');
+keyDown('\t', ['shiftKey']); // -> 09/[05]/2012
+keyDown('7'); // -> 09/07/[2012]
+shouldBeEqualToString('input.value', '2012-09-07');
+keyDown('\t'); // -> Focus out.
+shouldBeEqualToString('document.activeElement.id', 'after');
+
+beginTest('Shfit+Tab key', '2012-09-30');
+after.focus();
+keyDown('\t', ['shiftKey']); // -> 09/30/[yyyy]
+keyDown('3'); // -> 09/30/[0003]
+shouldBeEqualToString('input.value', '0003-09-30');
+keyDown('\t', ['shiftKey']); // -> 09/[30]/0003
+keyDown('\t', ['shiftKey']); // -> [09]/30/0003
+keyDown('\t', ['shiftKey']); // -> Focus out.
+shouldBeEqualToString('document.activeElement.id', 'before');
+
+beginTest('Up key on maximum value', '275760-09-13');
+keyDown('upArrow'); // -> [10]/13/275760
+keyDown('\t'); //      -> 10/[13]/275760
+keyDown('upArrow'); // -> 10/[14]/275760
+keyDown('\t'); //      -> 10/14/[275760]
+keyDown('upArrow'); // -> 10/14/[0001]
+shouldBeEqualToString('input.value', '0001-10-14');
+beginTest('Up key with a maximum attribute', '1999-12-31', '1000-01-01', '1999-12-31');
+keyDown('upArrow'); // -> [01]/31/1999
+keyDown('\t'); //      -> 01/[31]/1999
+keyDown('upArrow'); // -> 01/[01]/1999
+keyDown('\t'); //      -> 01/01/[1999]
+keyDown('upArrow'); // -> 01/01/[1000]
+shouldBeEqualToString('input.value', '1000-01-01');
+
+beginTest('Down key on minimum value', '0001-01-01', 'bad min', 'wrong max');
+keyDown('downArrow'); // -> [12]/01/0001
+keyDown('\t'); //        -> 12/[01]/0001
+keyDown('downArrow'); // -> 12/[31]/0001
+keyDown('\t'); //        -> 12/31/[0001]
+keyDown('downArrow'); // -> 12/31/[275760], which is greater than the hard limit.
+shouldBeEqualToString('input.value', '');
+beginTest('Down key with a minimum attribute', '1000-01-01', '1000-01-01');
+keyDown('downArrow'); // -> [12]/01/1000
+keyDown('\t'); //        -> 12/[01]/1000
+keyDown('downArrow'); // -> 12/[31]/1000
+keyDown('\t'); //        -> 12/31/[1000]
+keyDown('downArrow'); // -> 12/31/275760, which is greater than the hard limit.
+shouldBeEqualToString('input.value', '');
+
+beginTest('Inconsistent min-max attributes', '1999-12-31', '1999-12-31', '1000-01-01');
+keyDown('\t'); // -> 12/[31]/1999
+keyDown('\t'); // -> 12/31/[1999]
+keyDown('upArrow'); // -> 12/31/[1000].  1000 is the swapped minimum year.
+shouldBeEqualToString('input.value', '1000-12-31');
+keyDown('downArrow'); // -> 12/31/[1999]
+shouldBeEqualToString('input.value', '1999-12-31');
+
+beginTest('Make an invalid date', '2012-02-01');
+keyDown('\t'); //        -> 02/[01]/2012
+keyDown('downArrow'); // -> 02/[31]/2012
+shouldBeEqualToString('input.value', ''); // 2012-02-31 is not a valid date.
+input.setAttribute('value', '2012-02-01');
+beginTest(undefined, '2012-02-01');
+keyDown('\t'); //        -> 02/[01]/2012
+keyDown('downArrow'); // -> 02/[31]/2012
+shouldBeEqualToString('input.value', ''); // 2012-02-31 is not a valid date.
+input.removeAttribute('value');
+
+beginTest('Backspace key', '2012-09-20');
+keyDown("\b"); // -> [mm]/20/2012
+shouldBeEqualToString('input.value', '');
+
+beginTest('Delete key', '2012-09-30');
+keyDown("delete"); // -> [mm]/30/2012
+shouldBeEqualToString('input.value', '');
+
+beginTest('Typeahead', '2012-12-31');
+keyDown('rightArrow'); // -> 12/[31]/2012
+keyDown('1'); //          -> 12/[01]/2012
+shouldBeEqualToString('input.value', '2012-12-01');
+keyDown('leftArrow'); //  -> [12]/01/2012
+keyDown('rightArrow'); // -> 12/[01]/2012
+keyDown('2'); //          -> 12/[02]/2012
+shouldBeEqualToString('input.value', '2012-12-02');
+
+input.setAttribute("lang", "he-il");
+beginTest('RTL focus navigation', '2012-09-28');
+debug('The tests in this block fail on platforms without the lang-attribute-aware-form-control-UI feature.');
+// Both of the logical order and visual order are: dd/MM/yyyy
+// Initial state:            [28]/09/2012
+keyDown('upArrow'); //    -> [29]/09/2012
+keyDown('rightArrow'); // -> [01]/09/2012
+keyDown('1'); //          -> [01]/09/2012
+shouldBeEqualToString('input.value', '2012-09-01');
+keyDown('\t'); //         -> 01/[09]/2012
+keyDown('2'); //          -> 01/02/[2012]
+shouldBeEqualToString('input.value', '2012-02-01');
+keyDown('\t', ['shiftKey']); // -> 01/[02]/2012/
+keyDown('3'); //          -> 01/03/[2012]
+shouldBeEqualToString('input.value', '2012-03-01');
+input.removeAttribute("lang");
+
+beginTest('Disabled/readonly', '2012-10-08');
+input.disabled = true;
+keyDown('upArrow'); // 10/08/2012
+shouldBeEqualToString('input.value', '2012-10-08');
+input.disabled = false;
+input.focus();
+keyDown('upArrow'); // [11]/08/2012
+shouldBeEqualToString('input.value', '2012-11-08');
+input.readOnly = true;
+keyDown('upArrow'); // 11/08/2012
+shouldBeEqualToString('input.value', '2012-11-08');
+input.readOnly = false;
+input.focus();
+keyDown('upArrow'); // [12]/08/2012
+shouldBeEqualToString('input.value', '2012-12-08');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -227,7 +227,7 @@ String BaseDateAndTimeInputType::visibleValue() const
 
 String BaseDateAndTimeInputType::sanitizeValue(const String& proposedValue) const
 {
-    return typeMismatchFor(proposedValue) ? String() : proposedValue;
+    return typeMismatchFor(proposedValue) ? emptyString() : proposedValue;
 }
 
 bool BaseDateAndTimeInputType::supportsReadOnly() const


### PR DESCRIPTION
<pre>

Input[type=date] with invalid date should return empty string for value IDL attribute instead of the default value
<a href="https://bugs.webkit.org/show_bug.cgi?id=120038">https://bugs.webkit.org/show_bug.cgi?id=120038</a>

Reviewed by NOBODY (OOPS!).

Merge <a href="https://chromium.googlesource.com/chromium/blink/+/cb52052e3522824fa9ffc73cb34667492d47d976">https://chromium.googlesource.com/chromium/blink/+/cb52052e3522824fa9ffc73cb34667492d47d976</a>

* LayoutTests/fast/forms/date-multiple-field/date-multiple-fields-keyboard-events-expected.txt: Added.
* LayoutTests/fast/forms/date-multiple-field/date-multiple-fields-keyboard-events.html: Added.
* Source/WebCore/html/BaseDateAndTimeInputType.cpp
(WebCore::BaseDateAndTimeInputType::visibleValue): Modified BaseDateAndTimeInputType::sanitizeValue so it should return an empty string if the input string is invalid.

</pre>




















































































































































<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b63d9931e9c5f0d31c721a7dfec46562b701d63f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96070 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149674 "Found 1 new test failure: fast/forms/date-multiple-fields/date-multiple-fields-keyboard-events.html") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29545 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25809 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79227 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91119 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92709 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23862 "Found 1 new test failure: fast/forms/date-multiple-fields/date-multiple-fields-keyboard-events.html") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73912 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23808 "Found 1 new test failure: fast/forms/date-multiple-fields/date-multiple-fields-keyboard-events.html") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66820 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27273 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12946 "Found 2 new test failures: fast/forms/date-multiple-fields/date-multiple-fields-keyboard-events.html, workers/bomb.html") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27217 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13960 "Found 1 new test failure: fast/forms/date-multiple-fields/date-multiple-fields-keyboard-events.html") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28901 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36812 "Found 1 new test failure: fast/forms/date-multiple-fields/date-multiple-fields-keyboard-events.html") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33237 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->