### PR TITLE
Don't use Vector<UChar> to build strings

### DIFF
--- a/Source/WebCore/platform/text/LocaleICU.cpp
+++ b/Source/WebCore/platform/text/LocaleICU.cpp
@@ -36,6 +36,7 @@
 #include <unicode/udatpg.h>
 #include <unicode/uloc.h>
 #include <wtf/DateMath.h>
+#include <wtf/text/StringBuffer.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
@@ -73,9 +74,9 @@ String LocaleICU::decimalSymbol(UNumberFormatSymbol symbol)
     ASSERT(U_SUCCESS(status) || needsToGrowToProduceBuffer(status));
     if (U_FAILURE(status) && !needsToGrowToProduceBuffer(status))
         return String();
-    Vector<UChar> buffer(bufferLength);
+    StringBuffer buffer(static_cast<unsigned>(bufferLength));
     status = U_ZERO_ERROR;
-    unum_getSymbol(m_numberFormat, symbol, buffer.data(), bufferLength, &status);
+    unum_getSymbol(m_numberFormat, symbol, buffer.characters(), bufferLength, &status);
     if (U_FAILURE(status))
         return String();
     return String::adopt(WTFMove(buffer));
@@ -88,9 +89,9 @@ String LocaleICU::decimalTextAttribute(UNumberFormatTextAttribute tag)
     ASSERT(U_SUCCESS(status) || needsToGrowToProduceBuffer(status));
     if (U_FAILURE(status) && !needsToGrowToProduceBuffer(status))
         return String();
-    Vector<UChar> buffer(bufferLength);
+    StringBuffer buffer(static_cast<unsigned>(bufferLength));
     status = U_ZERO_ERROR;
-    unum_getTextAttribute(m_numberFormat, tag, buffer.data(), bufferLength, &status);
+    unum_getTextAttribute(m_numberFormat, tag, buffer.characters(), bufferLength, &status);
     ASSERT(U_SUCCESS(status));
     if (U_FAILURE(status))
         return String();
@@ -153,9 +154,9 @@ static String getDateFormatPattern(const UDateFormat* dateFormat)
     int32_t length = udat_toPattern(dateFormat, TRUE, 0, 0, &status);
     if (!needsToGrowToProduceBuffer(status) || !length)
         return emptyString();
-    Vector<UChar> buffer(length);
+    StringBuffer buffer(static_cast<unsigned>(length));
     status = U_ZERO_ERROR;
-    udat_toPattern(dateFormat, TRUE, buffer.data(), length, &status);
+    udat_toPattern(dateFormat, TRUE, buffer.characters(), length, &status);
     if (U_FAILURE(status))
         return emptyString();
     return String::adopt(WTFMove(buffer));
@@ -175,9 +176,9 @@ std::unique_ptr<Vector<String>> LocaleICU::createLabelVector(const UDateFormat* 
         int32_t length = udat_getSymbols(dateFormat, type, startIndex + i, 0, 0, &status);
         if (!needsToGrowToProduceBuffer(status))
             return makeUnique<Vector<String>>();
-        Vector<UChar> buffer(length);
+        StringBuffer buffer(static_cast<unsigned>(length));
         status = U_ZERO_ERROR;
-        udat_getSymbols(dateFormat, type, startIndex + i, buffer.data(), length, &status);
+        udat_getSymbols(dateFormat, type, startIndex + i, buffer.characters(), length, &status);
         if (U_FAILURE(status))
             return makeUnique<Vector<String>>();
         labels->uncheckedAppend(String::adopt(WTFMove(buffer)));
@@ -262,9 +263,9 @@ static String getFormatForSkeleton(const char* locale, const UChar* skeleton, in
     status = U_ZERO_ERROR;
     int32_t length = udatpg_getBestPattern(patternGenerator, skeleton, skeletonLength, 0, 0, &status);
     if (needsToGrowToProduceBuffer(status) && length) {
-        Vector<UChar> buffer(length);
+        StringBuffer buffer(static_cast<unsigned>(length));
         status = U_ZERO_ERROR;
-        udatpg_getBestPattern(patternGenerator, skeleton, skeletonLength, buffer.data(), length, &status);
+        udatpg_getBestPattern(patternGenerator, skeleton, skeletonLength, buffer.characters(), length, &status);
         if (U_SUCCESS(status))
             format = String::adopt(WTFMove(buffer));
     }


### PR DESCRIPTION
#### dc480e6b09e207560b409bc632468f8e2b5fb5a9
<pre>
Don&apos;t use Vector&lt;UChar&gt; to build strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=119319">https://bugs.webkit.org/show_bug.cgi?id=119319</a>

Reviewed by NOBODY (OOPS!).

Merge <a href="https://chromium.googlesource.com/chromium/blink/+/9fda929af533c3c1aa3961c4818ea30ed7499021">https://chromium.googlesource.com/chromium/blink/+/9fda929af533c3c1aa3961c4818ea30ed7499021</a>

* Source/WebCore/platform/text/LocaleICU.cpp:
(WebCore::LocaleICU::decimalSymbol):
(WebCore::LocaleICU::decimalTextAttribute):
(WebCore::getDateFormatPattern):
(WebCore::LocaleICU::createLabelVector):
(WebCore::getFormatForSkeleton):
</pre>






























<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc480e6b09e207560b409bc632468f8e2b5fb5a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17570 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95474 "Hash dc480e6b for PR 3518 does not build") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149200 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29058 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78809 "Hash dc480e6b for PR 3518 does not build") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90717 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23485 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73558 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/78809 "Hash dc480e6b for PR 3518 does not build") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78490 "Passed tests") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/78809 "Hash dc480e6b for PR 3518 does not build") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26847 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26767 "Built successfully") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/13708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36567 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28388 "Built successfully") | [✅ ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/32987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->