### PR TITLE
[JSC] Not generating import.meta object if it is not referenced

### DIFF
--- a/JSTests/modules/import-meta-eval-function-and-more.js
+++ b/JSTests/modules/import-meta-eval-function-and-more.js
@@ -1,0 +1,13 @@
+import { shouldThrow } from "./resources/assert.js";
+
+shouldThrow(() => {
+    eval('import.meta');
+}, `SyntaxError: import.meta is only valid inside modules.`);
+
+shouldThrow(() => {
+    new Function('import.meta')();
+}, `SyntaxError: import.meta is only valid inside modules.`);
+
+shouldThrow(() => {
+    (void 0, eval)('import.meta');
+}, `SyntaxError: import.meta is only valid inside modules.`);

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -154,6 +154,7 @@ public:
     bool hasTailCalls() const { return m_hasTailCalls; }
     void setHasTailCalls() { m_hasTailCalls = true; }
     bool allowDirectEvalCache() const { return !(m_features & NoEvalCacheFeature); }
+    bool usesImportMeta() const { return m_features & ImportMetaFeature; }
 
     bool hasExpressionInfo() { return m_expressionInfo.size(); }
     const FixedVector<ExpressionRangeInfo>& expressionInfo() { return m_expressionInfo; }

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
@@ -280,7 +280,7 @@ private:
     unsigned m_typeProfilingEndOffset;
     unsigned m_parameterCount : 31;
     unsigned m_privateBrandRequirement : 1;
-    unsigned m_features : 14;
+    unsigned m_features : bitWidthOfCodeFeatures;
     unsigned m_constructorKind : 2;
     SourceParseMode m_sourceParseMode;
     unsigned m_implementationVisibility : bitWidthOfImplementationVisibility;

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -994,7 +994,8 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, ModuleProgramNode* moduleProgramNod
     // Now declare all variables.
 
     createVariable(m_vm.propertyNames->starNamespacePrivateName, VarKind::Scope, moduleEnvironmentSymbolTable, VerifyExisting);
-    createVariable(m_vm.propertyNames->builtinNames().metaPrivateName(), VarKind::Scope, moduleEnvironmentSymbolTable, VerifyExisting);
+    if (moduleProgramNode->features() & ImportMetaFeature)
+        createVariable(m_vm.propertyNames->builtinNames().metaPrivateName(), VarKind::Scope, moduleEnvironmentSymbolTable, VerifyExisting);
 
     for (auto& entry : moduleProgramNode->varDeclarations()) {
         ASSERT(!entry.value.isLet() && !entry.value.isConst());

--- a/Source/JavaScriptCore/parser/ModuleAnalyzer.cpp
+++ b/Source/JavaScriptCore/parser/ModuleAnalyzer.cpp
@@ -34,9 +34,9 @@
 
 namespace JSC {
 
-ModuleAnalyzer::ModuleAnalyzer(JSGlobalObject* globalObject, const Identifier& moduleKey, const SourceCode& sourceCode, const VariableEnvironment& declaredVariables, const VariableEnvironment& lexicalVariables)
+ModuleAnalyzer::ModuleAnalyzer(JSGlobalObject* globalObject, const Identifier& moduleKey, const SourceCode& sourceCode, const VariableEnvironment& declaredVariables, const VariableEnvironment& lexicalVariables, CodeFeatures features)
     : m_vm(globalObject->vm())
-    , m_moduleRecord(m_vm, JSModuleRecord::create(globalObject, m_vm, globalObject->moduleRecordStructure(), moduleKey, sourceCode, declaredVariables, lexicalVariables))
+    , m_moduleRecord(JSModuleRecord::create(globalObject, m_vm, globalObject->moduleRecordStructure(), moduleKey, sourceCode, declaredVariables, lexicalVariables, features))
 {
 }
 
@@ -149,7 +149,7 @@ JSModuleRecord* ModuleAnalyzer::analyze(ModuleProgramNode& moduleProgramNode)
     if (UNLIKELY(Options::dumpModuleRecord()))
         m_moduleRecord->dump();
 
-    return m_moduleRecord.get();
+    return m_moduleRecord;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/parser/ModuleAnalyzer.h
+++ b/Source/JavaScriptCore/parser/ModuleAnalyzer.h
@@ -35,14 +35,15 @@ class ScriptFetchParameters;
 
 class ModuleAnalyzer {
     WTF_MAKE_NONCOPYABLE(ModuleAnalyzer);
+    WTF_FORBID_HEAP_ALLOCATION;
 public:
-    ModuleAnalyzer(JSGlobalObject*, const Identifier& moduleKey, const SourceCode&, const VariableEnvironment& declaredVariables, const VariableEnvironment& lexicalVariables);
+    ModuleAnalyzer(JSGlobalObject*, const Identifier& moduleKey, const SourceCode&, const VariableEnvironment& declaredVariables, const VariableEnvironment& lexicalVariables, CodeFeatures);
 
     JSModuleRecord* analyze(ModuleProgramNode&);
 
     VM& vm() { return m_vm; }
 
-    JSModuleRecord* moduleRecord() { return m_moduleRecord.get(); }
+    JSModuleRecord* moduleRecord() { return m_moduleRecord; }
 
     void appendRequestedModule(const Identifier&, RefPtr<ScriptFetchParameters>&&);
 
@@ -50,7 +51,7 @@ private:
     void exportVariable(ModuleProgramNode&, const RefPtr<UniquedStringImpl>&, const VariableEnvironmentEntry&);
 
     VM& m_vm;
-    Strong<JSModuleRecord> m_moduleRecord;
+    JSModuleRecord* m_moduleRecord;
     IdentifierSet m_requestedModules;
 };
 

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -335,6 +335,8 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
         features |= NoEvalCacheFeature;
     if (scope->hasNonSimpleParameterList())
         features |= NonSimpleParameterListFeature;
+    if (scope->usesImportMeta())
+        features |= ImportMetaFeature;
 
 #if ASSERT_ENABLED
     if (m_parsingBuiltin && isProgramParseMode(parseMode)) {
@@ -5211,6 +5213,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
             if (matchContextualKeyword(m_vm.propertyNames->builtinNames().metaPublicName())) {
                 semanticFailIfFalse(m_scriptMode == JSParserScriptMode::Module, "import.meta is only valid inside modules");
                 base = context.createImportMetaExpr(location, createResolveAndUseVariable(context, &m_vm.propertyNames->metaPrivateName, false, expressionStart, location));
+                currentScope()->setUsesImportMeta();
                 next();
             } else {
                 failIfTrue(match(IDENT), "\"import.\" can only be followed with meta");

--- a/Source/JavaScriptCore/parser/ParserModes.h
+++ b/Source/JavaScriptCore/parser/ParserModes.h
@@ -330,9 +330,11 @@ const CodeFeatures SuperCallFeature =              1 << 8;
 const CodeFeatures SuperPropertyFeature =          1 << 9;
 const CodeFeatures NewTargetFeature =              1 << 10;
 const CodeFeatures NoEvalCacheFeature =            1 << 11;
+const CodeFeatures ImportMetaFeature =             1 << 12;
 
-const CodeFeatures AllFeatures = EvalFeature | ArgumentsFeature | WithFeature | ThisFeature | NonSimpleParameterListFeature | ShadowsArgumentsFeature | ArrowFunctionFeature | AwaitFeature | SuperCallFeature | SuperPropertyFeature | NewTargetFeature | NoEvalCacheFeature;
-static_assert(AllFeatures < (1 << 14), "CodeFeatures must be 14bits");
+const CodeFeatures AllFeatures = EvalFeature | ArgumentsFeature | WithFeature | ThisFeature | NonSimpleParameterListFeature | ShadowsArgumentsFeature | ArrowFunctionFeature | AwaitFeature | SuperCallFeature | SuperPropertyFeature | NewTargetFeature | NoEvalCacheFeature | ImportMetaFeature;
+static constexpr unsigned bitWidthOfCodeFeatures = 14;
+static_assert(AllFeatures <= (1 << bitWidthOfCodeFeatures) - 1, "CodeFeatures must fit within 14 bits");
 
 typedef uint8_t InnerArrowFunctionCodeFeatures;
     

--- a/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
+++ b/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
@@ -34,22 +34,23 @@
 namespace JSC {
 
 struct SourceProviderCacheItemCreationParameters {
-    unsigned lastTokenLine;
-    unsigned lastTokenStartOffset;
-    unsigned lastTokenEndOffset;
-    unsigned lastTokenLineStartOffset;
-    unsigned endFunctionOffset;
-    unsigned parameterCount;
-    bool needsFullActivation;
-    bool usesEval;
-    LexicalScopeFeatures lexicalScopeFeatures;
-    bool needsSuperBinding;
-    InnerArrowFunctionCodeFeatures innerArrowFunctionFeatures;
+    unsigned lastTokenLine { 0 };
+    unsigned lastTokenStartOffset { 0 };
+    unsigned lastTokenEndOffset { 0 };
+    unsigned lastTokenLineStartOffset { 0 };
+    unsigned endFunctionOffset { 0 };
+    unsigned parameterCount { 0 };
+    LexicalScopeFeatures lexicalScopeFeatures { 0 };
+    InnerArrowFunctionCodeFeatures innerArrowFunctionFeatures { 0 };
     Vector<UniquedStringImpl*, 8> usedVariables;
-    bool isBodyArrowExpression { false };
     JSTokenType tokenType { CLOSEBRACE };
     ConstructorKind constructorKind;
     SuperBinding expectedSuperBinding;
+    bool needsFullActivation : 1 { false };
+    bool usesEval : 1 { false };
+    bool usesImportMeta : 1 { false };
+    bool needsSuperBinding : 1 { false };
+    bool isBodyArrowExpression : 1 { false };
 };
 
 #if COMPILER(MSVC)
@@ -102,6 +103,7 @@ public:
     unsigned tokenType : 24; // JSTokenType
     unsigned innerArrowFunctionFeatures : 6; // InnerArrowFunctionCodeFeatures
     unsigned constructorKind : 2; // ConstructorKind
+    bool usesImportMeta : 1 { false };
 
     PackedPtr<UniquedStringImpl>* usedVariables() const { return const_cast<PackedPtr<UniquedStringImpl>*>(m_variables); }
 
@@ -142,6 +144,7 @@ inline SourceProviderCacheItem::SourceProviderCacheItem(const SourceProviderCach
     , tokenType(static_cast<unsigned>(parameters.tokenType))
     , innerArrowFunctionFeatures(static_cast<unsigned>(parameters.innerArrowFunctionFeatures))
     , constructorKind(static_cast<unsigned>(parameters.constructorKind))
+    , usesImportMeta(parameters.usesImportMeta)
 {
     ASSERT(tokenType == static_cast<unsigned>(parameters.tokenType));
     ASSERT(innerArrowFunctionFeatures == static_cast<unsigned>(parameters.innerArrowFunctionFeatures));

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -82,7 +82,7 @@ bool checkModuleSyntax(JSGlobalObject* globalObject, const SourceCode& source, P
         return false;
 
     PrivateName privateName(PrivateName::Description, "EntryPointModule"_s);
-    ModuleAnalyzer moduleAnalyzer(globalObject, Identifier::fromUid(privateName), source, moduleProgramNode->varDeclarations(), moduleProgramNode->lexicalVariables());
+    ModuleAnalyzer moduleAnalyzer(globalObject, Identifier::fromUid(privateName), source, moduleProgramNode->varDeclarations(), moduleProgramNode->lexicalVariables(), moduleProgramNode->features());
     moduleAnalyzer.analyze(*moduleProgramNode);
     return true;
 }

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -364,7 +364,7 @@ JSC_DEFINE_HOST_FUNCTION(moduleLoaderParseModule, (JSGlobalObject* globalObject,
         RELEASE_AND_RETURN(scope, JSValue::encode(rejectWithError(error.toErrorObject(globalObject, sourceCode))));
     ASSERT(moduleProgramNode);
 
-    ModuleAnalyzer moduleAnalyzer(globalObject, moduleKey, sourceCode, moduleProgramNode->varDeclarations(), moduleProgramNode->lexicalVariables());
+    ModuleAnalyzer moduleAnalyzer(globalObject, moduleKey, sourceCode, moduleProgramNode->varDeclarations(), moduleProgramNode->lexicalVariables(), moduleProgramNode->features());
     RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
 
     scope.release();

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
@@ -44,17 +44,18 @@ Structure* JSModuleRecord::createStructure(VM& vm, JSGlobalObject* globalObject,
     return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
 }
 
-JSModuleRecord* JSModuleRecord::create(JSGlobalObject* globalObject, VM& vm, Structure* structure, const Identifier& moduleKey, const SourceCode& sourceCode, const VariableEnvironment& declaredVariables, const VariableEnvironment& lexicalVariables)
+JSModuleRecord* JSModuleRecord::create(JSGlobalObject* globalObject, VM& vm, Structure* structure, const Identifier& moduleKey, const SourceCode& sourceCode, const VariableEnvironment& declaredVariables, const VariableEnvironment& lexicalVariables, CodeFeatures features)
 {
-    JSModuleRecord* instance = new (NotNull, allocateCell<JSModuleRecord>(vm)) JSModuleRecord(vm, structure, moduleKey, sourceCode, declaredVariables, lexicalVariables);
+    JSModuleRecord* instance = new (NotNull, allocateCell<JSModuleRecord>(vm)) JSModuleRecord(vm, structure, moduleKey, sourceCode, declaredVariables, lexicalVariables, features);
     instance->finishCreation(globalObject, vm);
     return instance;
 }
-JSModuleRecord::JSModuleRecord(VM& vm, Structure* structure, const Identifier& moduleKey, const SourceCode& sourceCode, const VariableEnvironment& declaredVariables, const VariableEnvironment& lexicalVariables)
+JSModuleRecord::JSModuleRecord(VM& vm, Structure* structure, const Identifier& moduleKey, const SourceCode& sourceCode, const VariableEnvironment& declaredVariables, const VariableEnvironment& lexicalVariables, CodeFeatures features)
     : Base(vm, structure, moduleKey)
     , m_sourceCode(sourceCode)
     , m_declaredVariables(declaredVariables)
     , m_lexicalVariables(lexicalVariables)
+    , m_features(features)
 {
 }
 
@@ -228,7 +229,7 @@ void JSModuleRecord::instantiateDeclarations(JSGlobalObject* globalObject, Modul
         }
     }
 
-    {
+    if (m_features & ImportMetaFeature) {
         JSObject* metaProperties = globalObject->moduleLoader()->createImportMetaProperties(globalObject, identifierToJSValue(vm, moduleKey()), this, scriptFetcher);
         RETURN_IF_EXCEPTION(scope, void());
         bool putResult = false;

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.h
@@ -52,7 +52,7 @@ public:
     }
 
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
-    static JSModuleRecord* create(JSGlobalObject*, VM&, Structure*, const Identifier&, const SourceCode&, const VariableEnvironment&, const VariableEnvironment&);
+    static JSModuleRecord* create(JSGlobalObject*, VM&, Structure*, const Identifier&, const SourceCode&, const VariableEnvironment&, const VariableEnvironment&, CodeFeatures);
 
     Synchronousness link(JSGlobalObject*, JSValue scriptFetcher);
     JS_EXPORT_PRIVATE JSValue evaluate(JSGlobalObject*, JSValue sentValue, JSValue resumeMode);
@@ -62,7 +62,7 @@ public:
     const VariableEnvironment& lexicalVariables() const { return m_lexicalVariables; }
 
 private:
-    JSModuleRecord(VM&, Structure*, const Identifier&, const SourceCode&, const VariableEnvironment&, const VariableEnvironment&);
+    JSModuleRecord(VM&, Structure*, const Identifier&, const SourceCode&, const VariableEnvironment&, const VariableEnvironment&, CodeFeatures);
 
     void finishCreation(JSGlobalObject*, VM&);
 
@@ -74,6 +74,7 @@ private:
     VariableEnvironment m_declaredVariables;
     VariableEnvironment m_lexicalVariables;
     WriteBarrier<ModuleProgramExecutable> m_moduleProgramExecutable;
+    CodeFeatures m_features;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/SyntheticModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/SyntheticModuleRecord.cpp
@@ -96,7 +96,6 @@ SyntheticModuleRecord* SyntheticModuleRecord::tryCreateWithExportNamesAndValues(
     ASSERT(exportNames.size() == exportValues.size());
 
     auto* moduleRecord = create(globalObject, vm, globalObject->syntheticModuleRecordStructure(), moduleKey);
-    moduleRecord->addExportEntry(ExportEntry::createLocal(vm.propertyNames->defaultKeyword, vm.propertyNames->defaultKeyword));
 
     SymbolTable* exportSymbolTable = SymbolTable::create(vm);
     {
@@ -106,6 +105,7 @@ SyntheticModuleRecord* SyntheticModuleRecord::tryCreateWithExportNamesAndValues(
     for (auto& exportName : exportNames) {
         auto offset = exportSymbolTable->takeNextScopeOffset(NoLockingNecessary);
         exportSymbolTable->set(NoLockingNecessary, exportName.impl(), SymbolTableEntry(VarOffset(offset)));
+        moduleRecord->addExportEntry(ExportEntry::createLocal(exportName, exportName));
     }
 
     JSModuleEnvironment* moduleEnvironment = JSModuleEnvironment::create(vm, globalObject, nullptr, exportSymbolTable, jsTDZValue(), moduleRecord);


### PR DESCRIPTION
#### 1e07f486b4a0bf18fe258b8d1a5f6cb343f0d5b4
<pre>
[JSC] Not generating import.meta object if it is not referenced
<a href="https://bugs.webkit.org/show_bug.cgi?id=244176">https://bugs.webkit.org/show_bug.cgi?id=244176</a>

Reviewed by Ross Kirsling.

`import.meta` is only available in modules. And eval, function constructor etc. cannot evaluate it.
This means that we can detect `import.meta` existence when parsing statically.
This patch collects this information and avoid to materialize it if it is not referenced.

* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
(JSC::UnlinkedCodeBlock::usesImportMeta const):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
* Source/JavaScriptCore/parser/ModuleAnalyzer.cpp:
(JSC::ModuleAnalyzer::ModuleAnalyzer):
(JSC::ModuleAnalyzer::analyze):
* Source/JavaScriptCore/parser/ModuleAnalyzer.h:
(JSC::ModuleAnalyzer::moduleRecord):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseInner):
(JSC::Parser&lt;LexerType&gt;::parseMemberExpression):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope::Scope):
(JSC::Scope::isLexicalScope const):
(JSC::Scope::usesEval const):
(JSC::Scope::usesImportMeta const):
(JSC::Scope::setUsesImportMeta):
(JSC::Scope::setExpectedSuperBinding):
(JSC::Scope::expectedSuperBinding const):
(JSC::Scope::setConstructorKind):
(JSC::Scope::constructorKind const):
(JSC::Scope::collectFreeVariables):
(JSC::Scope::fillParametersForSourceProviderCache):
(JSC::Scope::restoreFromSourceProviderCache):
(JSC::Scope::isLexicalScope): Deleted.
(JSC::Scope::usesEval): Deleted.
* Source/JavaScriptCore/parser/ParserModes.h:
* Source/JavaScriptCore/parser/SourceProviderCacheItem.h:
(JSC::SourceProviderCacheItem::SourceProviderCacheItem):
* Source/JavaScriptCore/runtime/Completion.cpp:
(JSC::checkModuleSyntax):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSModuleRecord.cpp:
(JSC::JSModuleRecord::create):
(JSC::JSModuleRecord::JSModuleRecord):
(JSC::JSModuleRecord::instantiateDeclarations):
* Source/JavaScriptCore/runtime/JSModuleRecord.h:
* Source/JavaScriptCore/runtime/SyntheticModuleRecord.cpp:
(JSC::SyntheticModuleRecord::tryCreateWithExportNamesAndValues):

Canonical link: <a href="https://commits.webkit.org/253636@main">https://commits.webkit.org/253636@main</a>
</pre>





























<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e97f598ae2c67516f156e992f59cdab3b9a53aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95483 "Built successfully") | [✅ ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/149209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29070 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25507 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78820 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90726 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92257 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73565 "Built successfully") | [✅ ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/23556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/66563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78575 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26856 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72213 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26776 "Built successfully") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/13715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/25785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28453 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/36575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/74995 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1005 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28397 "Built successfully") | [✅ ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/32994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/16582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->