### PR TITLE
Handle Enumerate in HTMLBodyElement and HTMLFrameElement

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/Body-FrameSet-Event-Handlers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/Body-FrameSet-Event-Handlers-expected.txt
@@ -1,0 +1,50 @@
+
+PASS Set HTMLBodyElement.onblur
+PASS Enumerate HTMLBodyElement.onblur
+PASS Reflect HTMLBodyElement.onblur
+PASS Forward HTMLBodyElement.onblur to Window
+PASS Set HTMLFrameSetElement.onblur
+PASS Enumerate HTMLFrameSetElement.onblur
+PASS Reflect HTMLFrameSetElement.onblur
+PASS Forward HTMLFrameSetElement.onblur to Window
+PASS Set HTMLBodyElement.onerror
+PASS Enumerate HTMLBodyElement.onerror
+PASS Reflect HTMLBodyElement.onerror
+PASS Forward HTMLBodyElement.onerror to Window
+PASS Set HTMLFrameSetElement.onerror
+PASS Enumerate HTMLFrameSetElement.onerror
+PASS Reflect HTMLFrameSetElement.onerror
+PASS Forward HTMLFrameSetElement.onerror to Window
+PASS Set HTMLBodyElement.onfocus
+PASS Enumerate HTMLBodyElement.onfocus
+PASS Reflect HTMLBodyElement.onfocus
+PASS Forward HTMLBodyElement.onfocus to Window
+PASS Set HTMLFrameSetElement.onfocus
+PASS Enumerate HTMLFrameSetElement.onfocus
+PASS Reflect HTMLFrameSetElement.onfocus
+PASS Forward HTMLFrameSetElement.onfocus to Window
+PASS Set HTMLBodyElement.onload
+PASS Enumerate HTMLBodyElement.onload
+PASS Reflect HTMLBodyElement.onload
+PASS Forward HTMLBodyElement.onload to Window
+PASS Set HTMLFrameSetElement.onload
+PASS Enumerate HTMLFrameSetElement.onload
+PASS Reflect HTMLFrameSetElement.onload
+PASS Forward HTMLFrameSetElement.onload to Window
+PASS Set HTMLBodyElement.onscroll
+PASS Enumerate HTMLBodyElement.onscroll
+PASS Reflect HTMLBodyElement.onscroll
+PASS Forward HTMLBodyElement.onscroll to Window
+PASS Set HTMLFrameSetElement.onscroll
+PASS Enumerate HTMLFrameSetElement.onscroll
+PASS Reflect HTMLFrameSetElement.onscroll
+PASS Forward HTMLFrameSetElement.onscroll to Window
+PASS Set HTMLBodyElement.onresize
+PASS Enumerate HTMLBodyElement.onresize
+PASS Reflect HTMLBodyElement.onresize
+PASS Forward HTMLBodyElement.onresize to Window
+PASS Set HTMLFrameSetElement.onresize
+PASS Enumerate HTMLFrameSetElement.onresize
+PASS Reflect HTMLFrameSetElement.onresize
+PASS Forward HTMLFrameSetElement.onresize to Window
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/Body-FrameSet-Event-Handlers.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/Body-FrameSet-Event-Handlers.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<title>HTMLBodyElement and HTMLFrameSetElement Event Handler Tests</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function getObject(interface) {
+    switch(interface) {
+        case "Element":
+            var e = document.createElementNS("http://example.com/", "example");
+            assert_true(e instanceof Element);
+            assert_false(e instanceof HTMLElement);
+            assert_false(e instanceof SVGElement);
+            return e;
+        case "HTMLElement":
+            var e = document.createElement("html");
+            assert_true(e instanceof HTMLElement);
+            return e;
+        case "HTMLBodyElement":
+            var e = document.createElement("body");
+            assert_true(e instanceof HTMLBodyElement);
+            return e;
+        case "HTMLFormElement":
+            var e = document.createElement("form");
+            assert_true(e instanceof HTMLFormElement);
+            return e;
+        case "HTMLFrameSetElement":
+            var e = document.createElement("frameset");
+            assert_true(e instanceof HTMLFrameSetElement);
+            return e;
+        case "SVGElement":
+            var e = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+            assert_true(e instanceof SVGElement);
+            return e;
+        case "Document":
+            assert_true(document instanceof Document);
+            return document;
+        case "Window":
+            assert_true(window instanceof Window);
+            return window;
+    }
+    assert_unreached();
+}
+
+function testSet(interface, attribute) {
+    test(function() {
+        var object = getObject(interface);
+        function nop() {}
+        assert_equals(object[attribute], null, "Initially null");
+        object[attribute] = nop;
+        assert_equals(object[attribute], nop, "Return same function");
+        object[attribute] = "";
+        assert_equals(object[attribute], null, "Return null after setting string");
+        object[attribute] = null;
+        assert_equals(object[attribute], null, "Finally null");
+    }, "Set " + interface + "." + attribute);
+}
+
+function testReflect(interface, attribute) {
+    test(function() {
+        var element = getObject(interface);
+        assert_false(element.hasAttribute(attribute), "Initially missing");
+        element.setAttribute(attribute, "return");
+        assert_equals(element.getAttribute(attribute), "return", "Return same string");
+        assert_equals(typeof element[attribute], "function", "Convert to function");
+        element.removeAttribute(attribute);
+    }, "Reflect " + interface + "." + attribute);
+}
+
+function testForwardToWindow(interface, attribute) {
+    test(function() {
+        var element = getObject(interface);
+        window[attribute] = null;
+        element.setAttribute(attribute, "return");
+        assert_equals(typeof window[attribute], "function", "Convert to function");
+        assert_equals(window[attribute], element[attribute], "Forward content attribute");
+        function nop() {}
+        element[attribute] = nop;
+        assert_equals(window[attribute], nop, "Forward IDL attribute");
+        window[attribute] = null;
+    }, "Forward " + interface + "." + attribute + " to Window");
+}
+
+// Object.propertyIsEnumerable cannot be used because it doesn't
+// work with properties inherited through the prototype chain.
+function getEnumerable(interface) {
+    var enumerable = {};
+    for (var attribute in getObject(interface)) {
+        enumerable[attribute] = true;
+    }
+    return enumerable;
+}
+
+var enumerableCache = {};
+function testEnumerate(interface, attribute) {
+    if (!(interface in enumerableCache)) {
+        enumerableCache[interface] = getEnumerable(interface);
+    }
+    test(function() {
+        assert_true(enumerableCache[interface][attribute]);
+    }, "Enumerate " + interface + "." + attribute);
+}
+
+[
+    "onblur",
+    "onerror",
+    "onfocus",
+    "onload",
+    "onscroll",
+    "onresize"
+].forEach(function(attribute) {
+    testSet("HTMLBodyElement", attribute);
+    testEnumerate("HTMLBodyElement", attribute);
+    testReflect("HTMLBodyElement", attribute);
+    testForwardToWindow("HTMLBodyElement", attribute);
+    testSet("HTMLFrameSetElement", attribute);
+    testEnumerate("HTMLFrameSetElement", attribute);
+    testReflect("HTMLFrameSetElement", attribute);
+    testForwardToWindow("HTMLFrameSetElement", attribute);
+});
+</script>
+</html>

--- a/Source/WebCore/html/HTMLBodyElement.idl
+++ b/Source/WebCore/html/HTMLBodyElement.idl
@@ -29,15 +29,20 @@
     [CEReactions=NotNeeded, Reflect] attribute [LegacyNullToEmptyString] DOMString text;
     [CEReactions=NotNeeded, Reflect] attribute [LegacyNullToEmptyString] DOMString vLink;
 
+    [WindowEventHandler] attribute EventHandler onblur;
+    [WindowEventHandler] attribute EventHandler onerror;
+    [WindowEventHandler] attribute EventHandler onfocus;
+    [WindowEventHandler] attribute EventHandler onload;
+    [WindowEventHandler] attribute EventHandler onresize;
+    [WindowEventHandler] attribute EventHandler onscroll;
+
+    // See these 2 issues for onfocusin and onfocusout.
+    // https://github.com/w3c/uievents/issues/88
+    // https://github.com/whatwg/html/issues/3514
+    [WindowEventHandler] attribute EventHandler onfocusin;
+    [WindowEventHandler] attribute EventHandler onfocusout;
+
     // Non-standard
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onblur;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onerror;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onfocus;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onfocusin;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onfocusout;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onload;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onresize;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onscroll;
     [NotEnumerable, WindowEventHandler, Conditional=MOUSE_FORCE_EVENTS] attribute EventHandler onwebkitmouseforcechanged;
     [NotEnumerable, WindowEventHandler, Conditional=MOUSE_FORCE_EVENTS] attribute EventHandler onwebkitmouseforcedown;
     [NotEnumerable, WindowEventHandler, Conditional=MOUSE_FORCE_EVENTS] attribute EventHandler onwebkitmouseforcewillbegin;

--- a/Source/WebCore/html/HTMLFrameSetElement.idl
+++ b/Source/WebCore/html/HTMLFrameSetElement.idl
@@ -24,15 +24,18 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString cols;
     [CEReactions=NotNeeded, Reflect] attribute DOMString rows;
 
-    // Non-standard
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onblur;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onerror;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onfocus;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onfocusin;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onfocusout;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onload;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onresize;
-    [NotEnumerable, WindowEventHandler] attribute EventHandler onscroll;
+    [WindowEventHandler] attribute EventHandler onblur;
+    [WindowEventHandler] attribute EventHandler onerror;
+    [WindowEventHandler] attribute EventHandler onfocus;
+    [WindowEventHandler] attribute EventHandler onload;
+    [WindowEventHandler] attribute EventHandler onresize;
+    [WindowEventHandler] attribute EventHandler onscroll;
+
+    // See these 2 issues for onfocusin and onfocusout.
+    // https://github.com/w3c/uievents/issues/88
+    // https://github.com/whatwg/html/issues/3514
+    [WindowEventHandler] attribute EventHandler onfocusin;
+    [WindowEventHandler] attribute EventHandler onfocusout;
 
     // Non-standard named getter
     // FIXME: This is not in the standard, can we remove this?


### PR DESCRIPTION
#### 948da4088dfbbd561749b29c8f5ee9a0722c2edd
<pre>
Handle Enumerate in HTMLBodyElement and HTMLFrameElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=244178">https://bugs.webkit.org/show_bug.cgi?id=244178</a>

Reviewed by Brent Fulgham.

Add support for enumerating over additional methods (listed below) in HTMLBodyElement and HTMLFrameSetElement.

onblur
onerror
onfocus
onfocusin
onfocusout
onload
onresize
onscroll

* Source/WebCore/html/HTMLBodyElement.idl:
* Source/WebCore/html/HTMLFrameSetElement.idl:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/Body-FrameSet-Event-Handlers-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/dom/events/Body-FrameSet-Event-Handlers-expected.txt

Canonical link: <a href="https://commits.webkit.org/253840@main">https://commits.webkit.org/253840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2e732c8b6184dd21a0aff25a105eb5a0c575d08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96235 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149779 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29654 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91215 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23957 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74008 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79178 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27379 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13015 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27326 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14030 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2702 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29011 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/36886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28950 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33307 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->