### PR TITLE
XSLImportRule and XSLStyleSheet should use weak pointers instead of raw pointers

### DIFF
--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -120,7 +120,7 @@ void ProcessingInstruction::checkStyleSheet()
             // to kick off import/include loads that can hang off some parent sheet.
             if (m_isXSL) {
                 URL finalURL({ }, m_localHref);
-                m_sheet = XSLStyleSheet::createEmbedded(this, finalURL);
+                m_sheet = XSLStyleSheet::createEmbedded(*this, finalURL);
                 m_loading = false;
                 document().scheduleToApplyXSLTransforms();
             }
@@ -228,7 +228,7 @@ void ProcessingInstruction::setCSSStyleSheet(const String& href, const URL& base
 void ProcessingInstruction::setXSLStyleSheet(const String& href, const URL& baseURL, const String& sheet)
 {
     ASSERT(m_isXSL);
-    m_sheet = XSLStyleSheet::create(this, href, baseURL);
+    m_sheet = XSLStyleSheet::create(*this, href, baseURL);
     Ref<Document> protect(document());
     parseStyleSheet(sheet);
 }

--- a/Source/WebCore/xml/XSLImportRule.h
+++ b/Source/WebCore/xml/XSLImportRule.h
@@ -35,13 +35,13 @@ class CachedXSLStyleSheet;
 class XSLImportRule : private CachedStyleSheetClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    XSLImportRule(XSLStyleSheet* parentSheet, const String& href);
+    XSLImportRule(XSLStyleSheet& parentSheet, const String& href);
     virtual ~XSLImportRule();
     
     const String& href() const { return m_strHref; }
     XSLStyleSheet* styleSheet() const { return m_styleSheet.get(); }
 
-    XSLStyleSheet* parentStyleSheet() const { return m_parentStyleSheet; }
+    XSLStyleSheet* parentStyleSheet() const { return m_parentStyleSheet.get(); }
     void setParentStyleSheet(XSLStyleSheet* styleSheet) { m_parentStyleSheet = styleSheet; }
 
     bool isLoading();
@@ -50,11 +50,11 @@ public:
 private:
     void setXSLStyleSheet(const String& href, const URL& baseURL, const String& sheet) override;
     
-    XSLStyleSheet* m_parentStyleSheet;
+    WeakPtr<XSLStyleSheet> m_parentStyleSheet;
     String m_strHref;
     RefPtr<XSLStyleSheet> m_styleSheet;
     CachedResourceHandle<CachedXSLStyleSheet> m_cachedSheet;
-    bool m_loading;
+    bool m_loading { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -36,19 +36,21 @@ namespace WebCore {
 class CachedResourceLoader;
 class XSLImportRule;
     
-class XSLStyleSheet final : public StyleSheet {
+class XSLStyleSheet final : public StyleSheet, public CanMakeWeakPtr<XSLStyleSheet> {
 public:
-    static Ref<XSLStyleSheet> create(XSLImportRule* parentImport, const String& originalURL, const URL& finalURL)
+    static Ref<XSLStyleSheet> create(XSLStyleSheet* parentSheet, const String& originalURL, const URL& finalURL)
     {
-        return adoptRef(*new XSLStyleSheet(parentImport, originalURL, finalURL));
+        return adoptRef(*new XSLStyleSheet(parentSheet, originalURL, finalURL));
     }
-    static Ref<XSLStyleSheet> create(ProcessingInstruction* parentNode, const String& originalURL, const URL& finalURL)
+
+    static Ref<XSLStyleSheet> create(ProcessingInstruction& parentNode, const String& originalURL, const URL& finalURL)
     {
-        return adoptRef(*new XSLStyleSheet(parentNode, originalURL, finalURL, false));
+        return adoptRef(*new XSLStyleSheet(&parentNode, originalURL, finalURL, false));
     }
-    static Ref<XSLStyleSheet> createEmbedded(ProcessingInstruction* parentNode, const URL& finalURL)
+
+    static Ref<XSLStyleSheet> createEmbedded(ProcessingInstruction& parentNode, const URL& finalURL)
     {
-        return adoptRef(*new XSLStyleSheet(parentNode, finalURL.string(), finalURL, true));
+        return adoptRef(*new XSLStyleSheet(&parentNode, finalURL.string(), finalURL, true));
     }
 
     // Taking an arbitrary node is unsafe, because owner node pointer can become stale.
@@ -72,7 +74,7 @@ public:
     CachedResourceLoader* cachedResourceLoader();
 
     Document* ownerDocument();
-    XSLStyleSheet* parentStyleSheet() const override { return m_parentStyleSheet; }
+    XSLStyleSheet* parentStyleSheet() const override { return m_parentStyleSheet.get(); }
     void setParentStyleSheet(XSLStyleSheet* parent);
 
     xmlDocPtr document();
@@ -87,7 +89,7 @@ public:
     String type() const override { return "text/xml"_s; }
     bool disabled() const override { return m_isDisabled; }
     void setDisabled(bool b) override { m_isDisabled = b; }
-    Node* ownerNode() const override { return m_ownerNode; }
+    Node* ownerNode() const override { return m_ownerNode.get(); }
     String href() const override { return m_originalURL; }
     String title() const override { return { }; }
 
@@ -97,14 +99,14 @@ public:
 
 private:
     XSLStyleSheet(Node* parentNode, const String& originalURL, const URL& finalURL, bool embedded);
-    XSLStyleSheet(XSLImportRule* parentImport, const String& originalURL, const URL& finalURL);
+    XSLStyleSheet(XSLStyleSheet* parentSheet, const String& originalURL, const URL& finalURL);
 
     bool isXSLStyleSheet() const override { return true; }
     String debugDescription() const final;
 
     void clearXSLStylesheetDocument();
 
-    Node* m_ownerNode;
+    WeakPtr<Node> m_ownerNode;
     String m_originalURL;
     URL m_finalURL;
     bool m_isDisabled { false };
@@ -118,7 +120,7 @@ private:
     bool m_stylesheetDocTaken { false };
     bool m_compilationFailed { false };
 
-    XSLStyleSheet* m_parentStyleSheet { nullptr };
+    WeakPtr<XSLStyleSheet> m_parentStyleSheet;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
+++ b/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
@@ -46,15 +46,14 @@
 
 namespace WebCore {
 
-XSLStyleSheet::XSLStyleSheet(XSLImportRule* parentRule, const String& originalURL, const URL& finalURL)
+XSLStyleSheet::XSLStyleSheet(XSLStyleSheet* parentSheet, const String& originalURL, const URL& finalURL)
     : m_ownerNode(nullptr)
     , m_originalURL(originalURL)
     , m_finalURL(finalURL)
     , m_embedded(false)
     , m_processed(false) // Child sheets get marked as processed when the libxslt engine has finally seen them.
+    , m_parentStyleSheet(parentSheet)
 {
-    if (parentRule)
-        m_parentStyleSheet = parentRule->parentStyleSheet();
 }
 
 XSLStyleSheet::XSLStyleSheet(Node* parentNode, const String& originalURL, const URL& finalURL,  bool embedded)
@@ -89,7 +88,7 @@ void XSLStyleSheet::checkLoaded()
 {
     if (isLoading())
         return;
-    if (XSLStyleSheet* styleSheet = parentStyleSheet())
+    if (RefPtr styleSheet = parentStyleSheet())
         styleSheet->checkLoaded();
     if (ownerNode())
         ownerNode()->sheetLoaded();
@@ -233,7 +232,7 @@ void XSLStyleSheet::loadChildSheets()
 
 void XSLStyleSheet::loadChildSheet(const String& href)
 {
-    auto childRule = makeUnique<XSLImportRule>(this, href);
+    auto childRule = makeUnique<XSLImportRule>(*this, href);
     m_children.append(childRule.release());
     m_children.last()->loadSheet();
 }
@@ -268,19 +267,18 @@ void XSLStyleSheet::setParentStyleSheet(XSLStyleSheet* parent)
 
 Document* XSLStyleSheet::ownerDocument()
 {
-    for (XSLStyleSheet* styleSheet = this; styleSheet; styleSheet = styleSheet->parentStyleSheet()) {
-        Node* node = styleSheet->ownerNode();
-        if (node)
+    for (RefPtr styleSheet = this; styleSheet; styleSheet = styleSheet->parentStyleSheet()) {
+        if (auto* node = styleSheet->ownerNode())
             return &node->document();
     }
-    return 0;
+    return nullptr;
 }
 
 xmlDocPtr XSLStyleSheet::locateStylesheetSubResource(xmlDocPtr parentDoc, const xmlChar* uri)
 {
     bool matchedParent = (parentDoc == document());
     for (auto& import : m_children) {
-        XSLStyleSheet* child = import->styleSheet();
+        RefPtr child = import->styleSheet();
         if (!child)
             continue;
         if (matchedParent) {
@@ -303,7 +301,7 @@ xmlDocPtr XSLStyleSheet::locateStylesheetSubResource(xmlDocPtr parentDoc, const 
             }
             continue;
         }
-        xmlDocPtr result = import->styleSheet()->locateStylesheetSubResource(parentDoc, uri);
+        xmlDocPtr result = child->locateStylesheetSubResource(parentDoc, uri);
         if (result)
             return result;
     }


### PR DESCRIPTION
#### 896fddc4ea9a19ef7d322097501f479ba0604a80
<pre>
XSLImportRule and XSLStyleSheet should use weak pointers instead of raw pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=244181">https://bugs.webkit.org/show_bug.cgi?id=244181</a>

Reviewed by Darin Adler.

Deploy WeakPtr where raw pointers are used.

* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::setXSLStyleSheet):
* Source/WebCore/xml/XSLImportRule.cpp:
(WebCore::XSLImportRule::XSLImportRule):
(WebCore::XSLImportRule::setXSLStyleSheet):
(WebCore::XSLImportRule::loadSheet):
* Source/WebCore/xml/XSLImportRule.h:
(WebCore::XSLImportRule::parentStyleSheet const):
* Source/WebCore/xml/XSLStyleSheet.h:
* Source/WebCore/xml/XSLStyleSheetLibxslt.cpp:
(WebCore::XSLStyleSheet::XSLStyleSheet):
(WebCore::XSLStyleSheet::checkLoaded):
(WebCore::XSLStyleSheet::loadChildSheet):
(WebCore::XSLStyleSheet::ownerDocument):
(WebCore::XSLStyleSheet::locateStylesheetSubResource):

Canonical link: <a href="https://commits.webkit.org/253695@main">https://commits.webkit.org/253695@main</a>
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57d92473bb889afaa874fa2b1a1b4a1058cf57e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95601 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149350 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29212 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25596 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78936 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90838 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23588 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73665 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23633 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78907 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66640 "Found 1 new API test failure: /WebKit2Gtk/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26975 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12761 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26898 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13775 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36640 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1029 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33054 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->