### PR TITLE
[GLIB] aptIfExists always returns exit status code 0

### DIFF
--- a/Tools/glib/dependencies/apt
+++ b/Tools/glib/dependencies/apt
@@ -11,7 +11,9 @@ aptIfElse() {
 }
 
 aptIfExists() {
-    local ret=$(apt show "$1" 2>/dev/null)
+    local ret
+
+    ret=$(apt show "$1" 2>/dev/null)
     if [[ $? -ne 0 ]]; then
         return
     fi
@@ -30,12 +32,15 @@ PACKAGES=(
     bubblewrap
     cmake
     gawk
+    $(aptIfExists gi-docgen)
     gperf
     gtk-doc-tools
     intltool
     itstool
     libasound2-dev
     libatk1.0-dev
+    $(aptIfExists libavif-dev)
+    $(aptIfExists libenchant-2-dev)
     libepoxy-dev
     libevent-dev
     libfile-copy-recursive-perl
@@ -46,9 +51,11 @@ PACKAGES=(
     libjpeg-dev
     libkate-dev
     liblcms2-dev
+    $(aptIfExists libmanette-0.2-dev)
     libopenjp2-7-dev
     libpng-dev
     libseccomp-dev
+    $(aptIfExists libsoup-3.0-dev)
     libsqlite3-dev
     libsystemd-dev
     libtasn1-6-dev
@@ -56,6 +63,8 @@ PACKAGES=(
     libwayland-dev
     libwebp-dev
     libwoff-dev
+    $(aptIfExists libwpe-1.0-dev)
+    $(aptIfExists libwpebackend-fdo-1.0-dev)
     libxml2-utils
     libxslt1-dev
     ninja-build

--- a/Tools/gtk/dependencies/apt
+++ b/Tools/gtk/dependencies/apt
@@ -35,7 +35,6 @@ PACKAGES+=(
     nasm
     unifdef
     xfonts-utils
-    $(aptIfExists libenchant-dev)
 
     # These are dependencies necessary for running tests.
     cups-daemon

--- a/Tools/wpe/dependencies/apt
+++ b/Tools/wpe/dependencies/apt
@@ -12,7 +12,7 @@ PACKAGES+=(
     libgnutls28-dev
     libharfbuzz-dev
     libicu-dev
-    libwpebackend-fdo-1.0-dev
+    $(aptIfExists libopenxr-dev)
     libwpewebkit-1.0-dev
     libxml2-dev
     pkg-config


### PR DESCRIPTION
#### 0c682bc2aaaa6369dc54b2d96e0acbbe6d532fed
<pre>
[GLIB] aptIfExists always returns exit status code 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=244184">https://bugs.webkit.org/show_bug.cgi?id=244184</a>

Reviewed by Adrian Perez de Castro.

Fix `aptIfExists` function and update system library dependencies.

* Tools/glib/dependencies/apt:
* Tools/gtk/dependencies/apt:
* Tools/wpe/dependencies/apt:

Canonical link: <a href="https://commits.webkit.org/253643@main">https://commits.webkit.org/253643@main</a>
</pre>


<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f46cfe19f168e5677174482ab0cbf0a28171a250

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17588 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95494 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149222 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29083 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25516 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78832 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90737 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92267 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23501 "Found 3 new test failures: animations/no-style-recalc-during-accelerated-animation.html, animations/steps-transform-rendering-updates.html, fast/css/first-letter-first-line-hover.html") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73575 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23567 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78856 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66573 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26867 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12708 "Found 4 new test failures: accessibility/mac/text-marker-paragraph-nav.html, accessibility/mac/text-marker-sentence-nav.html, accessibility/mac/text-marker-word-nav.html, editing/text-iterator/backwards-text-iterator-basic.html") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26786 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13723 "Passed tests") | | 
| [✅ ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/2589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36583 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33002 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->