### PR TITLE
[macOS] Screen recording in background tab only works for about 1 minute

### DIFF
--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -109,6 +109,7 @@ DisplayCaptureSourceCocoa::DisplayCaptureSourceCocoa(UniqueRef<Capturer>&& captu
     : RealtimeMediaSource(RealtimeMediaSource::Type::Video, WTFMove(name), WTFMove(deviceID), WTFMove(hashSalt), pageIdentifier)
     , m_capturer(WTFMove(capturer))
     , m_timer(RunLoop::current(), this, &DisplayCaptureSourceCocoa::emitFrame)
+    , m_userActivity("App nap disabled for screen capture")
 {
     m_capturer->setObserver(this);
 }
@@ -173,6 +174,7 @@ void DisplayCaptureSourceCocoa::startProducingData()
 {
     m_startTime = MonotonicTime::now();
     m_timer.startRepeating(1_s / frameRate());
+    m_userActivity.start();
 
     commitConfiguration();
     if (!m_capturer->start())
@@ -182,6 +184,7 @@ void DisplayCaptureSourceCocoa::startProducingData()
 void DisplayCaptureSourceCocoa::stopProducingData()
 {
     m_timer.stop();
+    m_userActivity.stop();
     m_elapsedTime += MonotonicTime::now() - m_startTime;
     m_startTime = MonotonicTime::nan();
 

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -30,6 +30,7 @@
 #include "CaptureDevice.h"
 #include "RealtimeMediaSource.h"
 #include "RealtimeMediaSourceSettings.h"
+#include "UserActivity.h"
 #include <wtf/Observer.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -152,6 +153,7 @@ private:
     Seconds m_elapsedTime { 0_s };
 
     RunLoop::Timer<DisplayCaptureSourceCocoa> m_timer;
+    UserActivity m_userActivity;
 
     std::unique_ptr<ImageTransferSessionVT> m_imageTransferSession;
 };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2184,7 +2184,7 @@ void WebPageProxy::updateActivityState(OptionSet<ActivityState::Flag> flagsToUpd
         m_activityState.add(ActivityState::IsAudible);
     if (flagsToUpdate & ActivityState::IsLoading && m_pageLoadState.isLoading())
         m_activityState.add(ActivityState::IsLoading);
-    if (flagsToUpdate & ActivityState::IsCapturingMedia && m_mediaState.containsAny({ MediaProducerMediaState::HasActiveAudioCaptureDevice,  MediaProducerMediaState::HasActiveVideoCaptureDevice }))
+    if (flagsToUpdate & ActivityState::IsCapturingMedia && m_mediaState.containsAny(MediaProducer::ActiveCaptureMask))
         m_activityState.add(ActivityState::IsCapturingMedia);
 }
 


### PR DESCRIPTION
#### c888c485b787e204057b56d69536aae567ab8b3a
<pre>
[macOS] Screen recording in background tab only works for about 1 minute
<a href="https://bugs.webkit.org/show_bug.cgi?id=244167">https://bugs.webkit.org/show_bug.cgi?id=244167</a>
rdar://problem/98966467

Reviewed by Chris Dumez and Eric Carlson.

Disable app nap for processes that run DisplayCaptureSourceCocoa, in our case the UIProcess, since it uses a timer.
We do so by adding a UserActivity to DisplayCaptureSourceCocoa and starting/stopping the user activity when starting/stopping the source.

We also disable app nap for pages that do screen capture (previously we were only doing this for pages doing microphone or camera capture).

* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::DisplayCaptureSourceCocoa):
(WebCore::DisplayCaptureSourceCocoa::startProducingData):
(WebCore::DisplayCaptureSourceCocoa::stopProducingData):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateActivityState):

Canonical link: <a href="https://commits.webkit.org/253769@main">https://commits.webkit.org/253769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/506b2450ddaf7c4cbc377135e8571cec2640d407

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95616 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149365 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29227 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25606 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78947 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90852 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23599 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73675 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23639 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66646 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26989 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12769 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26912 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13783 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2666 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28595 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36648 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33062 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->