### PR TITLE
[FreeType] Move the font set cache to FontCache

### DIFF
--- a/Source/WebCore/platform/FreeType.cmake
+++ b/Source/WebCore/platform/FreeType.cmake
@@ -8,6 +8,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/freetype/FontCacheFreeType.cpp
     platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
     platform/graphics/freetype/FontPlatformDataFreeType.cpp
+    platform/graphics/freetype/FontSetCache.cpp
     platform/graphics/freetype/GlyphPageTreeNodeFreeType.cpp
     platform/graphics/freetype/RefPtrFontconfig.cpp
     platform/graphics/freetype/SimpleFontDataFreeType.cpp
@@ -19,6 +20,7 @@ list(APPEND WebCore_SOURCES
 
 list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/freetype/FcUniquePtr.h
+    platform/graphics/freetype/FontSetCache.h
     platform/graphics/freetype/RefPtrFontconfig.h
 
     platform/graphics/harfbuzz/HbUniquePtr.h

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -72,6 +72,10 @@
 #include <mlang.h>
 #endif
 
+#if USE(FREETYPE)
+#include "FontSetCache.h"
+#endif
+
 namespace WebCore {
 
 class Font;
@@ -187,6 +191,10 @@ public:
 
     bool useBackslashAsYenSignForFamily(const AtomString& family);
 
+#if USE(FREETYPE)
+    static bool configurePatternForFontDescription(FcPattern*, const FontDescription&);
+#endif
+
 private:
     void invalidate();
     void releaseNoncriticalMemory();
@@ -244,6 +252,10 @@ private:
     SystemFontDatabaseCoreText m_systemFontDatabaseCoreText;
 
     friend class ComplexTextController;
+#endif
+
+#if USE(FREETYPE)
+    FontSetCache m_fontSetCache;
 #endif
 
     friend class Font;

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -25,7 +25,6 @@
 
 #include "CairoUniquePtr.h"
 #include "CairoUtilities.h"
-#include "CharacterProperties.h"
 #include "FcUniquePtr.h"
 #include "FloatConversion.h"
 #include "Font.h"
@@ -82,7 +81,7 @@ static int fontWeightToFontconfigWeight(FontSelectionValue weight)
     return FC_WEIGHT_ULTRABLACK;
 }
 
-static bool configurePatternForFontDescription(FcPattern* pattern, const FontDescription& fontDescription)
+bool FontCache::configurePatternForFontDescription(FcPattern* pattern, const FontDescription& fontDescription)
 {
     if (!FcPatternAddInteger(pattern, FC_SLANT, fontDescription.italic() ? FC_SLANT_ITALIC : FC_SLANT_ROMAN))
         return false;
@@ -124,154 +123,9 @@ static void getFontPropertiesFromPattern(FcPattern* pattern, const FontDescripti
     }
 }
 
-struct CachedPattern {
-    // The pattern is owned by the CachedFontSet.
-    FcPattern* pattern { nullptr };
-    FcCharSet* charSet { nullptr };
-};
-
-class CachedFontSet {
-    WTF_MAKE_NONCOPYABLE(CachedFontSet); WTF_MAKE_FAST_ALLOCATED;
-public:
-    explicit CachedFontSet(RefPtr<FcPattern>&& pattern)
-        : m_pattern(WTFMove(pattern))
-    {
-        FcResult result;
-        m_fontSet.reset(FcFontSort(nullptr, m_pattern.get(), FcTrue, nullptr, &result));
-        for (int i = 0; i < m_fontSet->nfont; ++i) {
-            FcPattern* pattern = m_fontSet->fonts[i];
-            FcCharSet* charSet;
-
-            if (FcPatternGetCharSet(pattern, FC_CHARSET, 0, &charSet) == FcResultMatch)
-                m_patterns.append({ pattern, charSet });
-        }
-    }
-
-    RefPtr<FcPattern> bestForCharacters(const UChar* characters, unsigned length)
-    {
-        if (m_patterns.isEmpty()) {
-            FcResult result;
-            return adoptRef(FcFontMatch(nullptr, m_pattern.get(), &result));
-        }
-
-        FcUniquePtr<FcCharSet> fontConfigCharSet(FcCharSetCreate());
-        UTF16UChar32Iterator iterator(characters, length);
-        UChar32 character = iterator.next();
-        bool hasNonIgnorableCharacters = false;
-        while (character != iterator.end()) {
-            if (!isDefaultIgnorableCodePoint(character)) {
-                FcCharSetAddChar(fontConfigCharSet.get(), character);
-                hasNonIgnorableCharacters = true;
-            }
-            character = iterator.next();
-        }
-
-        FcPattern* bestPattern = nullptr;
-        int minScore = std::numeric_limits<int>::max();
-        if (hasNonIgnorableCharacters) {
-            for (const auto& cachedPattern : m_patterns) {
-                if (!cachedPattern.charSet)
-                    continue;
-
-                int score = FcCharSetSubtractCount(fontConfigCharSet.get(), cachedPattern.charSet);
-                if (!score)
-                    return adoptRef(FcFontRenderPrepare(nullptr, m_pattern.get(), cachedPattern.pattern));
-
-                if (score < minScore) {
-                    bestPattern = cachedPattern.pattern;
-                    minScore = score;
-                }
-            }
-        }
-
-        if (bestPattern)
-            return adoptRef(FcFontRenderPrepare(nullptr, m_pattern.get(), bestPattern));
-
-        // If there aren't fonts with the given characters or all characters are ignorable, the first one is the best match.
-        return adoptRef(FcFontRenderPrepare(nullptr, m_pattern.get(), m_patterns[0].pattern));
-    }
-
-private:
-    RefPtr<FcPattern> m_pattern;
-    FcUniquePtr<FcFontSet> m_fontSet;
-    Vector<CachedPattern> m_patterns;
-};
-
-struct FallbackFontDescriptionKey {
-    FontDescriptionKey descriptionKey;
-    bool coloredFont { false };
-
-    FallbackFontDescriptionKey() = default;
-
-    FallbackFontDescriptionKey(const FontDescription& description, FontCache::PreferColoredFont preferColoredFont)
-        : descriptionKey(description)
-        , coloredFont(preferColoredFont == FontCache::PreferColoredFont::Yes)
-    {
-    }
-
-    explicit FallbackFontDescriptionKey(WTF::HashTableDeletedValueType deletedValue)
-        : descriptionKey(deletedValue)
-    {
-    }
-
-    bool operator==(const FallbackFontDescriptionKey& other) const
-    {
-        return descriptionKey == other.descriptionKey && coloredFont == other.coloredFont;
-    }
-
-    bool operator!=(const FallbackFontDescriptionKey& other) const
-    {
-        return !(*this == other);
-    }
-
-    bool isHashTableDeletedValue() const { return descriptionKey.isHashTableDeletedValue(); }
-
-};
-
-inline void add(Hasher& hasher, const FallbackFontDescriptionKey& key)
-{
-    add(hasher, key.descriptionKey, key.coloredFont);
-}
-
-struct FallbackFontDescriptionKeyHash {
-    static unsigned hash(const FallbackFontDescriptionKey& key) { return computeHash(key); }
-    static bool equal(const FallbackFontDescriptionKey& a, const FallbackFontDescriptionKey& b) { return a == b; }
-    static const bool safeToCompareToEmptyOrDeleted = true;
-};
-
-using SystemFallbackFontSetCache = HashMap<FallbackFontDescriptionKey, std::unique_ptr<CachedFontSet>, FallbackFontDescriptionKeyHash, SimpleClassHashTraits<FallbackFontDescriptionKey>>;
-static SystemFallbackFontSetCache& systemFallbackFontSetCache()
-{
-    // FIXME: This should be moved to FontCache since it can be accessed from worker threads.
-    static NeverDestroyed<SystemFallbackFontSetCache> cache;
-    return cache.get();
-}
-
 RefPtr<Font> FontCache::systemFallbackForCharacters(const FontDescription& description, const Font&, IsForPlatformFont, PreferColoredFont preferColoredFont, const UChar* characters, unsigned length)
 {
-    auto addResult = systemFallbackFontSetCache().ensure(FallbackFontDescriptionKey(description, preferColoredFont), [&description, preferColoredFont]() -> std::unique_ptr<CachedFontSet> {
-        RefPtr<FcPattern> pattern = adoptRef(FcPatternCreate());
-        FcPatternAddBool(pattern.get(), FC_SCALABLE, FcTrue);
-#ifdef FC_COLOR
-        if (preferColoredFont == PreferColoredFont::Yes)
-            FcPatternAddBool(pattern.get(), FC_COLOR, FcTrue);
-#else
-        UNUSED_VARIABLE(preferColoredFont);
-#endif
-        if (!configurePatternForFontDescription(pattern.get(), description))
-            return nullptr;
-
-        FcConfigSubstitute(nullptr, pattern.get(), FcMatchPattern);
-        cairo_ft_font_options_substitute(getDefaultCairoFontOptions(), pattern.get());
-        FcDefaultSubstitute(pattern.get());
-
-        return makeUnique<CachedFontSet>(WTFMove(pattern));
-    });
-
-    if (!addResult.iterator->value)
-        return nullptr;
-
-    RefPtr<FcPattern> resultPattern = addResult.iterator->value->bestForCharacters(characters, length);
+    RefPtr<FcPattern> resultPattern = m_fontSetCache.bestForCharacters(description, preferColoredFont == PreferColoredFont::Yes, characters, length);
     if (!resultPattern)
         return nullptr;
 
@@ -285,7 +139,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacters(const FontDescription& descr
 
 void FontCache::platformPurgeInactiveFontData()
 {
-    systemFallbackFontSetCache().clear();
+    m_fontSetCache.clear();
 }
 
 static Vector<String> patternToFamilies(FcPattern& pattern)

--- a/Source/WebCore/platform/graphics/freetype/FontSetCache.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontSetCache.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "FontSetCache.h"
+
+#include "CairoUtilities.h"
+#include "CharacterProperties.h"
+#include "FontCache.h"
+#include "UTF16UChar32Iterator.h"
+
+namespace WebCore {
+
+FontSetCache::FontSet::FontSet(RefPtr<FcPattern>&& fontPattern)
+    : pattern(WTFMove(fontPattern))
+{
+    FcResult result;
+    fontSet.reset(FcFontSort(nullptr, pattern.get(), FcTrue, nullptr, &result));
+    for (int i = 0; i < fontSet->nfont; ++i) {
+        FcPattern* fontSetPattern = fontSet->fonts[i];
+        FcCharSet* charSet;
+
+        if (FcPatternGetCharSet(fontSetPattern, FC_CHARSET, 0, &charSet) == FcResultMatch)
+            patterns.append({ fontSetPattern, charSet });
+    }
+}
+
+RefPtr<FcPattern> FontSetCache::bestForCharacters(const FontDescription& fontDescription, bool preferColoredFont, const UChar* characters, unsigned length)
+{
+    auto addResult = m_cache.ensure(FontSetCacheKey(fontDescription, preferColoredFont), [&fontDescription, preferColoredFont]() -> std::unique_ptr<FontSetCache::FontSet> {
+        RefPtr<FcPattern> pattern = adoptRef(FcPatternCreate());
+        FcPatternAddBool(pattern.get(), FC_SCALABLE, FcTrue);
+#ifdef FC_COLOR
+        if (preferColoredFont)
+            FcPatternAddBool(pattern.get(), FC_COLOR, FcTrue);
+#else
+        UNUSED_VARIABLE(preferColoredFont);
+#endif
+        if (!FontCache::configurePatternForFontDescription(pattern.get(), fontDescription))
+            return nullptr;
+
+        FcConfigSubstitute(nullptr, pattern.get(), FcMatchPattern);
+        cairo_ft_font_options_substitute(getDefaultCairoFontOptions(), pattern.get());
+        FcDefaultSubstitute(pattern.get());
+        return makeUnique<FontSetCache::FontSet>(WTFMove(pattern));
+    });
+
+    if (!addResult.iterator->value)
+        return nullptr;
+
+    auto& cachedFontSet = *addResult.iterator->value;
+    if (cachedFontSet.patterns.isEmpty()) {
+        FcResult result;
+        return adoptRef(FcFontMatch(nullptr, cachedFontSet.pattern.get(), &result));
+    }
+
+    FcUniquePtr<FcCharSet> fontConfigCharSet(FcCharSetCreate());
+    UTF16UChar32Iterator iterator(characters, length);
+    UChar32 character = iterator.next();
+    bool hasNonIgnorableCharacters = false;
+    while (character != iterator.end()) {
+        if (!isDefaultIgnorableCodePoint(character)) {
+            FcCharSetAddChar(fontConfigCharSet.get(), character);
+            hasNonIgnorableCharacters = true;
+        }
+        character = iterator.next();
+    }
+
+    FcPattern* bestPattern = nullptr;
+    if (hasNonIgnorableCharacters) {
+        int minScore = std::numeric_limits<int>::max();
+        for (const auto& [pattern, charSet] : cachedFontSet.patterns) {
+            if (!charSet)
+                continue;
+
+            int score = FcCharSetSubtractCount(fontConfigCharSet.get(), charSet);
+            if (!score) {
+                bestPattern = pattern;
+                break;
+            }
+
+            if (score < minScore) {
+                bestPattern = pattern;
+                minScore = score;
+            }
+        }
+    }
+
+    // If there aren't fonts with the given characters or all characters are ignorable, the first one is the best match.
+    if (!bestPattern)
+        bestPattern = cachedFontSet.patterns[0].first;
+
+    return adoptRef(FcFontRenderPrepare(nullptr, cachedFontSet.pattern.get(), bestPattern));
+}
+
+void FontSetCache::clear()
+{
+    m_cache.clear();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/freetype/FontSetCache.h
+++ b/Source/WebCore/platform/graphics/freetype/FontSetCache.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "FcUniquePtr.h"
+#include "FontCascadeCache.h"
+#include "FontDescription.h"
+#include "RefPtrFontconfig.h"
+#include <wtf/HashMap.h>
+#include <wtf/HashTraits.h>
+#include <wtf/Hasher.h>
+
+namespace WebCore {
+
+struct FontSetCacheKey {
+    FontSetCacheKey() = default;
+
+    FontSetCacheKey(const FontDescription& description, bool coloredFont)
+        : descriptionKey(description)
+        , preferColoredFont(coloredFont)
+    {
+    }
+
+    explicit FontSetCacheKey(WTF::HashTableDeletedValueType deletedValue)
+        : descriptionKey(deletedValue)
+    {
+    }
+
+    bool operator==(const FontSetCacheKey& other) const
+    {
+        return descriptionKey == other.descriptionKey && preferColoredFont == other.preferColoredFont;
+    }
+
+    bool operator!=(const FontSetCacheKey& other) const
+    {
+        return !(*this == other);
+    }
+
+    bool isHashTableDeletedValue() const { return descriptionKey.isHashTableDeletedValue(); }
+
+    FontDescriptionKey descriptionKey;
+    bool preferColoredFont { false };
+};
+
+inline void add(Hasher& hasher, const FontSetCacheKey& key)
+{
+    add(hasher, key.descriptionKey, key.preferColoredFont);
+}
+
+struct FontSetCacheKeyHash {
+    static unsigned hash(const FontSetCacheKey& key) { return computeHash(key); }
+    static bool equal(const FontSetCacheKey& a, const FontSetCacheKey& b) { return a == b; }
+    static const bool safeToCompareToEmptyOrDeleted = true;
+};
+
+class FontSetCache {
+    WTF_MAKE_NONCOPYABLE(FontSetCache);
+public:
+    FontSetCache() = default;
+
+    RefPtr<FcPattern> bestForCharacters(const FontDescription&, bool, const UChar*, unsigned);
+    void clear();
+
+private:
+    struct FontSet {
+        WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+        explicit FontSet(RefPtr<FcPattern>&&);
+
+        RefPtr<FcPattern> pattern;
+        FcUniquePtr<FcFontSet> fontSet;
+        Vector<std::pair<FcPattern*, FcCharSet*>> patterns;
+    };
+
+    HashMap<FontSetCacheKey, std::unique_ptr<FontSet>, FontSetCacheKeyHash, SimpleClassHashTraits<FontSetCacheKey>> m_cache;
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### 115d9297ff1ae8ce0d01358d42d3f7bc8b33e577
<pre>
[FreeType] Move the font set cache to FontCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=244195">https://bugs.webkit.org/show_bug.cgi?id=244195</a>

Reviewed by Michael Catanzaro.

With OffscreenCanvas the font set cache can be used from worker threads,
so move it to FontCache to ensure there&apos;s one cache per thread instead.

* Source/WebCore/platform/FreeType.cmake:
* Source/WebCore/platform/graphics/FontCache.h:
* Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp:
(WebCore::FontCache::configurePatternForFontDescription):
(WebCore::FontCache::systemFallbackForCharacters):
(WebCore::FontCache::platformPurgeInactiveFontData):
(WebCore::configurePatternForFontDescription): Deleted.
(): Deleted.
(WebCore::CachedFontSet::CachedFontSet): Deleted.
(WebCore::CachedFontSet::bestForCharacters): Deleted.
(WebCore::FallbackFontDescriptionKey::FallbackFontDescriptionKey): Deleted.
(WebCore::FallbackFontDescriptionKey::operator== const): Deleted.
(WebCore::FallbackFontDescriptionKey::operator!= const): Deleted.
(WebCore::FallbackFontDescriptionKey::isHashTableDeletedValue const): Deleted.
(WebCore::add): Deleted.
(WebCore::FallbackFontDescriptionKeyHash::hash): Deleted.
(WebCore::FallbackFontDescriptionKeyHash::equal): Deleted.
(WebCore::systemFallbackFontSetCache): Deleted.
* Source/WebCore/platform/graphics/freetype/FontSetCache.cpp: Added.
(WebCore::FontSetCache::FontSet::FontSet):
(WebCore::FontSetCache::bestForCharacters):
(WebCore::FontSetCache::clear):
* Source/WebCore/platform/graphics/freetype/FontSetCache.h: Added.
(WebCore::FontSetCacheKey::FontSetCacheKey):
(WebCore::FontSetCacheKey::operator== const):
(WebCore::FontSetCacheKey::operator!= const):
(WebCore::FontSetCacheKey::isHashTableDeletedValue const):
(WebCore::add):
(WebCore::FontSetCacheKeyHash::hash):
(WebCore::FontSetCacheKeyHash::equal):

Canonical link: <a href="https://commits.webkit.org/253672@main">https://commits.webkit.org/253672@main</a>
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63ef8014b9e63ec0719ba0edbea67948274bbba2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95505 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149239 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29097 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25525 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78864 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90748 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23509 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73586 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23587 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66594 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26878 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12716 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26797 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13731 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2606 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36591 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33010 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->