### PR TITLE
Implement list of available images matching logic

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-available-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-available-expected.txt
@@ -1,5 +1,5 @@
 
 
 
-FAIL The list of available images gets checked before deciding to make a load lazy assert_equals: The list of available images should be checked before delaying the image load expected 256 but got 0
+PASS The list of available images gets checked before deciding to make a load lazy
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-use-list-of-available-images-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-use-list-of-available-images-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Lazyload images can load immediately from the list of available images promise_test: Unhandled rejection with value: object "Error: The `loading=lazy` image should load immediately from the list of available images, beating this timeout promise."
+PASS Lazyload images can load immediately from the list of available images
 

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -43,6 +43,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "LazyLoadImageObserver.h"
 #include "Logging.h"
+#include "MemoryCache.h"
 #include "Page.h"
 #include "RenderImage.h"
 #include "RenderSVGImage.h"
@@ -192,6 +193,22 @@ void ImageLoader::clearImageWithoutConsideringPendingLoadEvent()
         imageResource->resetAnimation();
 }
 
+// https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data:list-of-available-images
+bool ImageLoader::canReuseFromListOfAvailableImages(const CachedResourceRequest& request, const String& crossOriginAttribute)
+{
+    CachedResource* resource = MemoryCache::singleton().resourceForRequest(request.resourceRequest(), document().page()->sessionID());
+    if (!resource || resource->stillNeedsLoad() || resource->isPreloaded())
+        return false;
+
+    if (!crossOriginAttribute.isNull() && !document().securityOrigin().isSameOriginAs(*resource->origin()))
+        return false;
+
+    if (resource->options().credentials == FetchOptions::Credentials::SameOrigin && (crossOriginAttribute.isNull() || equalLettersIgnoringASCIICase(crossOriginAttribute, "use-credentials"_s)))
+        return false;
+
+    return true;
+}
+
 void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
 {
     // If we're not making renderers for the page, then don't load images. We don't want to slow
@@ -247,7 +264,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
 #endif
             if (m_lazyImageLoadState == LazyImageLoadState::None && isImageElement) {
                 auto& imageElement = downcast<HTMLImageElement>(element());
-                if (imageElement.isLazyLoadable() && document.settings().lazyImageLoadingEnabled()) {
+                if (imageElement.isLazyLoadable() && document.settings().lazyImageLoadingEnabled() && !canReuseFromListOfAvailableImages(request, crossOriginAttribute)) {
                     m_lazyImageLoadState = LazyImageLoadState::Deferred;
                     request.setIgnoreForRequestCount(true);
                 }

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -31,6 +31,7 @@
 
 namespace WebCore {
 
+class CachedResourceRequest;
 class DeferredPromise;
 class Document;
 class ImageLoader;
@@ -118,6 +119,8 @@ private:
     void timerFired();
 
     VisibleInViewportState imageVisibleInViewport(const Document&) const override;
+
+    bool canReuseFromListOfAvailableImages(const CachedResourceRequest&, const String& crossOriginAttribute);
 
     Element& m_element;
     CachedResourceHandle<CachedImage> m_image;


### PR DESCRIPTION
#### 0504bec7f8c6dcd89ac67100faa7920fa000967c
<pre>
Implement list of available images matching logic
 <a href="https://bugs.webkit.org/show_bug.cgi?id=243790">https://bugs.webkit.org/show_bug.cgi?id=243790</a>

Reviewed by NOBODY (OOPS!).

Implement list of available images matching logic:
<a href="https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data">https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data</a>:list-of-available-images

This is restricted to lazy loading for now.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-available-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-use-list-of-available-images-expected.txt:
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::canReuseFromListOfAvailableImages):
(WebCore::ImageLoader::updateFromElement):
* Source/WebCore/loader/ImageLoader.h:
</pre>









































<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0504bec7f8c6dcd89ac67100faa7920fa000967c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95514 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149245 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29115 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25531 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78853 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90757 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23519 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73593 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23581 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66590 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26887 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12721 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26806 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13736 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36598 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33015 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->