### PR TITLE
[WPE] Gardening -- baseline updates

### DIFF
--- a/LayoutTests/platform/wpe/accessibility/aria-description-expected.txt
+++ b/LayoutTests/platform/wpe/accessibility/aria-description-expected.txt
@@ -1,0 +1,8 @@
+This test ensures that aria-description maps to appropriate attributes.
+
+Custom content: null
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+button

--- a/LayoutTests/platform/wpe/accessibility/aria-visible-element-roles-expected.txt
+++ b/LayoutTests/platform/wpe/accessibility/aria-visible-element-roles-expected.txt
@@ -1,0 +1,196 @@
+This test ensures ARIA visible elements (e.g. those with both `hidden` and `aria-hidden='false'` attributes) have the correct role.
+
+<a href="https://apple.com" id="link" hidden="" aria-hidden="false"></a>
+    AXRole: AXLink
+    computedRoleString: link
+
+<select id="select" name="pets" hidden="" aria-hidden="false"></select>
+    AXRole: AXComboBox
+    computedRoleString: button
+
+<select id="select-multiple" multiple="" name="pets-multiple" hidden="" aria-hidden="false"></select>
+    AXRole: AXListBox
+    computedRoleString: listbox
+
+<textarea id="textarea" rows="5" cols="33" hidden="" aria-hidden="false"></textarea>
+    AXRole: AXTextField
+    computedRoleString: textbox
+
+<img id="img-with-map" src="resources/cake.png" width="145" height="126" usemap="#map" aria-label="Label" hidden="" aria-hidden="false">
+    AXRole: AXImageMap
+
+<li hidden="" aria-hidden="false" id="li-element"></li>
+    AXRole: AXListItem
+    computedRoleString: listitem
+
+<button hidden="" aria-hidden="false" id="button"></button>
+    AXRole: AXButton
+    computedRoleString: button
+
+<legend hidden="" aria-hidden="false" id="legend"></legend>
+    AXRole: AXLabel
+
+<canvas hidden="" aria-hidden="false" id="canvas-without-fallback-content"></canvas>
+    AXRole: AXCanvas
+
+<canvas hidden="" aria-hidden="false" id="canvas-with-fallback-content"></canvas>
+    AXRole: AXCanvas
+
+<input hidden="" aria-hidden="false" id="file-upload-button" type="file">
+    AXRole: AXButton
+    computedRoleString: button
+
+<input hidden="" aria-hidden="false" id="checkbox" type="checkbox">
+    AXRole: AXCheckBox
+    computedRoleString: checkbox
+
+<input hidden="" aria-hidden="false" type="radio" id="radio-button" name="monster">
+    AXRole: AXRadioButton
+    computedRoleString: radio
+
+<input hidden="" aria-hidden="false" id="text-button" type="submit">
+    AXRole: AXButton
+    computedRoleString: button
+
+<input hidden="" aria-hidden="false" id="text-button-with-pressed" aria-pressed="false" type="submit">
+    AXRole: AXToggleButton
+    computedRoleString: button
+
+<input hidden="" aria-hidden="false" id="date-input" type="date">
+    AXRole: AXTextField
+
+<input hidden="" aria-hidden="false" id="color-input" type="color">
+    AXRole: AXTextField
+
+<input hidden="" aria-hidden="false" id="range-input" type="range">
+    AXRole: AXSlider
+    computedRoleString: slider
+
+<input hidden="" aria-hidden="false" id="search-input" type="search">
+    AXRole: AXTextField
+    computedRoleString: searchbox
+
+<h2 hidden="" aria-hidden="false" id="h2"></h2>
+    AXRole: AXHeading
+    computedRoleString: heading
+
+<del hidden="" aria-hidden="false" id="del"></del>
+    AXRole: AXDeletion
+    computedRoleString: deletion
+
+<ins hidden="" aria-hidden="false" id="ins"></ins>
+    AXRole: AXInsertion
+    computedRoleString: insertion
+
+<sub hidden="" aria-hidden="false" id="sub"></sub>
+    AXRole: AXSubscript
+    computedRoleString: subscript
+
+<sup hidden="" aria-hidden="false" id="sup"></sup>
+    AXRole: AXSuperscript
+    computedRoleString: superscript
+
+<code hidden="" aria-hidden="false" id="code"></code>
+    AXRole: AXSection
+
+<dt hidden="" aria-hidden="false" id="dt"></dt>
+    AXRole: AXDescriptionTerm
+
+<dd hidden="" aria-hidden="false" id="dd"></dd>
+    AXRole: AXDescriptionValue
+
+<dl hidden="" aria-hidden="false" id="dl"></dl>
+    AXRole: AXDescriptionList
+
+<ol hidden="" aria-hidden="false" id="ol"></ol>
+    AXRole: AXList
+    computedRoleString: list
+
+<ul hidden="" aria-hidden="false" id="ul"></ul>
+    AXRole: AXList
+    computedRoleString: list
+
+<figure hidden="" aria-hidden="false" id="figure"></figure>
+    AXRole: AXGroup
+    computedRoleString: figure
+
+<p hidden="" aria-hidden="false" id="p"></p>
+    AXRole: AXParagraph
+    computedRoleString: paragraph
+
+<label hidden="" aria-hidden="false" id="label"></label>
+    AXRole: AXLabel
+
+<dfn hidden="" aria-hidden="false" id="dfn"></dfn>
+    AXRole: AXDefinition
+    computedRoleString: definition
+
+<div hidden="" aria-hidden="false" id="div"></div>
+    AXRole: AXSection
+
+<form hidden="" aria-hidden="false" id="form"></form>
+    AXRole: AXForm
+    computedRoleString: form
+
+<article hidden="" aria-hidden="false" id="article"></article>
+    AXRole: AXArticle
+    computedRoleString: article
+
+<main hidden="" aria-hidden="false" id="main"></main>
+    AXRole: AXLandmarkMain
+    computedRoleString: main
+
+<nav hidden="" aria-hidden="false" id="nav"></nav>
+    AXRole: AXLandmarkNavigation
+    computedRoleString: navigation
+
+<aside hidden="" aria-hidden="false" id="aside"></aside>
+    AXRole: AXLandmarkComplementary
+    computedRoleString: complementary
+
+<section hidden="" aria-hidden="false" id="section-with-name" aria-label="Section name"></section>
+    AXRole: AXLandmarkRegion
+    computedRoleString: region
+
+<section hidden="" aria-hidden="false" id="section-without-name"></section>
+    AXRole: AXSection
+
+<blockquote hidden="" aria-hidden="false" id="blockquote"></blockquote>
+    AXRole: AXBlockquote
+    computedRoleString: blockquote
+
+<mark hidden="" aria-hidden="false" id="mark"></mark>
+
+
+<pre hidden="" aria-hidden="false" id="pre"></pre>
+    AXRole: AXSection
+
+<details hidden="" aria-hidden="false" id="details"></details>
+    AXRole: AXUnknown
+
+<summary hidden="" aria-hidden="false" id="summary"></summary>
+    AXRole: AXUnknown
+
+<output hidden="" aria-hidden="false" id="output"></output>
+    AXRole: AXStatusBar
+    computedRoleString: status
+
+<menu hidden="" aria-hidden="false" type="toolbar" id="menu-toolbar"></menu>
+    AXRole: AXToolbar
+    computedRoleString: toolbar
+
+<hr hidden="" aria-hidden="false" id="hr">
+    AXRole: AXSeparator
+    computedRoleString: separator
+
+<time hidden="" aria-hidden="false" id="time"></time>
+    AXRole: AXStatic
+    computedRoleString: time
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+

--- a/LayoutTests/platform/wpe/accessibility/node-only-object-element-rect-expected.txt
+++ b/LayoutTests/platform/wpe/accessibility/node-only-object-element-rect-expected.txt
@@ -1,0 +1,12 @@
+This test ensures we calculate the frame correctly for objects that don't have a renderer (like display: contents elements).
+
+#toolbar: {width: 784, height: 27}
+#group: {width: 41, height: 27}
+#button: {width: 784, height: 10}
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Foo
+Foo
+Foo

--- a/LayoutTests/platform/wpe/css1/box_properties/margin_right-expected.txt
+++ b/LayoutTests/platform/wpe/css1/box_properties/margin_right-expected.txt
@@ -39,18 +39,18 @@ layer at (0,0) size 785x1005
           text run at (400,18) width 177: "width of the parent element."
       RenderBlock {UL} at (0,343) size 744x90 [bgcolor=#808080]
         RenderListItem {LI} at (40,0) size 704x18
-          RenderListMarker at (-13,0) size 7x17: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderText {#text} at (4,0) size 700x17
             text run at (4,0) width 700: "The right margin on this unordered list has been set to 25 pixels, and the background color has been set to gray."
         RenderListItem {LI} at (40,18) size 679x54 [bgcolor=#FFFFFF]
-          RenderListMarker at (6,0) size 7x17: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderText {#text} at (23,0) size 677x53
             text run at (23,0) width 656: "Another list item might not be such a bad idea, either, considering that such things do need to be double-"
             text run at (2,18) width 60: "checked. "
             text run at (62,18) width 617: "This list item has its right margin also set to 25 pixels, which should combine with the list's margin"
             text run at (199,36) width 480: "to make 50 pixels of margin, and its background-color has been set to white."
         RenderListItem {LI} at (40,72) size 704x18
-          RenderListMarker at (508,0) size 7x17: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderText {#text} at (525,0) size 179x17
             text run at (525,0) width 179: "This is an unclassed list item"
       RenderBlock {P} at (0,449) size 769x18 [bgcolor=#C0C0C0]
@@ -93,19 +93,19 @@ layer at (0,0) size 785x1005
                   text run at (384,18) width 177: "width of the parent element."
               RenderBlock {UL} at (4,192) size 722x108 [bgcolor=#808080]
                 RenderListItem {LI} at (40,0) size 682x36
-                  RenderListMarker at (1,0) size 7x17: bullet
+                  RenderListMarker at (-17,0) size 7x17: bullet
                   RenderText {#text} at (18,0) size 664x35
                     text run at (18,0) width 664: "The right margin on this unordered list has been set to 25 pixels, and the background color has been set to"
                     text run at (650,18) width 32: "gray."
                 RenderListItem {LI} at (40,36) size 657x54 [bgcolor=#FFFFFF]
-                  RenderListMarker at (-16,0) size 7x17: bullet
+                  RenderListMarker at (-17,0) size 7x17: bullet
                   RenderText {#text} at (1,0) size 656x53
                     text run at (1,0) width 656: "Another list item might not be such a bad idea, either, considering that such things do need to be double-"
                     text run at (28,18) width 60: "checked. "
                     text run at (88,18) width 569: "This list item has its right margin also set to 25 pixels, which should combine with the list's"
                     text run at (129,36) width 528: "margin to make 50 pixels of margin, and its background-color has been set to white."
                 RenderListItem {LI} at (40,90) size 682x18
-                  RenderListMarker at (486,0) size 7x17: bullet
+                  RenderListMarker at (-17,0) size 7x17: bullet
                   RenderText {#text} at (503,0) size 179x17
                     text run at (503,0) width 179: "This is an unclassed list item"
               RenderBlock {P} at (4,316) size 747x18 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/wpe/css1/box_properties/padding_right-expected.txt
+++ b/LayoutTests/platform/wpe/css1/box_properties/padding_right-expected.txt
@@ -54,12 +54,12 @@ layer at (0,0) size 785x1153
           text run at (79,36) width 498: "The text has been right-aligned in order to make the right padding easier to see."
       RenderBlock {UL} at (0,469) size 769x72 [bgcolor=#808080]
         RenderListItem {LI} at (40,0) size 704x36
-          RenderListMarker at (-10,0) size 7x17: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderText {#text} at (7,0) size 697x35
             text run at (7,0) width 697: "The right padding on this unordered list has been set to 25 pixels, which will require some extra text in order to"
             text run at (679,18) width 25: "test."
         RenderListItem {LI} at (40,36) size 704x36 [bgcolor=#FFFFFF]
-          RenderListMarker at (2,0) size 7x17: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderText {#text} at (19,0) size 660x35
             text run at (19,0) width 660: "This list item has a right padding of 25 pixels, which will appear to the left of the gray padding of the UL"
             text run at (626,18) width 53: "element."
@@ -116,12 +116,12 @@ layer at (0,0) size 785x1153
                   text run at (480,54) width 81: "easier to see."
               RenderBlock {UL} at (4,336) size 747x72 [bgcolor=#808080]
                 RenderListItem {LI} at (40,0) size 682x36
-                  RenderListMarker at (-16,0) size 7x17: bullet
+                  RenderListMarker at (-17,0) size 7x17: bullet
                   RenderText {#text} at (1,0) size 681x35
                     text run at (1,0) width 681: "The right padding on this unordered list has been set to 25 pixels, which will require some extra text in order"
                     text run at (641,18) width 41: "to test."
                 RenderListItem {LI} at (40,36) size 682x36 [bgcolor=#FFFFFF]
-                  RenderListMarker at (6,0) size 7x17: bullet
+                  RenderListMarker at (-17,0) size 7x17: bullet
                   RenderText {#text} at (23,0) size 634x35
                     text run at (23,0) width 634: "This list item has a right padding of 25 pixels, which will appear to the left of the gray padding of the"
                     text run at (578,18) width 79: "UL element."

--- a/LayoutTests/platform/wpe/css1/box_properties/width-expected.txt
+++ b/LayoutTests/platform/wpe/css1/box_properties/width-expected.txt
@@ -59,7 +59,7 @@ layer at (0,0) size 785x1342
                 RenderText {#text} at (0,0) size 287x17
                   text run at (0,0) width 287: "The square above should be fifty pixels wide."
               RenderBlock (anonymous) at (4,104) size 363x181
-                RenderImage {IMG} at (0,0) size 182x181
+                RenderImage {IMG} at (0,0) size 182x182
                 RenderText {#text} at (0,0) size 0x0
               RenderBlock {P} at (4,301) size 363x36
                 RenderText {#text} at (0,0) size 348x35

--- a/LayoutTests/platform/wpe/css1/formatting_model/replaced_elements-expected.txt
+++ b/LayoutTests/platform/wpe/css1/formatting_model/replaced_elements-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2341
+layer at (0,0) size 785x2339
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2341
-  RenderBlock {HTML} at (0,0) size 785x2341
-    RenderBody {BODY} at (8,8) size 769x2325 [bgcolor=#CCCCCC]
+layer at (0,0) size 785x2339
+  RenderBlock {HTML} at (0,0) size 785x2339
+    RenderBody {BODY} at (8,8) size 769x2323 [bgcolor=#CCCCCC]
       RenderBlock {P} at (0,0) size 769x18
         RenderText {#text} at (0,0) size 355x17
           text run at (0,0) width 355: "The style declarations which apply to the text below are:"
@@ -38,29 +38,29 @@ layer at (0,0) size 785x2341
         RenderText {#text} at (0,0) size 400x17
           text run at (0,0) width 400: "The above image should be a 15px square aligned at the center."
       RenderImage {IMG} at (192,350) size 385x385
-      RenderBlock {P} at (0,751) size 769x36
+      RenderBlock {P} at (0,750) size 769x37
         RenderText {#text} at (0,0) size 766x35
           text run at (0,0) width 766: "The above image should be a square resized so its width is 50% of the its parent element, and centered horizontally within"
           text run at (0,18) width 123: "the parent element: "
           text run at (123,18) width 395: "the document body in the first half, and the table in the second."
-      RenderImage {IMG} at (384,803) size 385x385
-      RenderBlock {P} at (0,1204) size 769x36
+      RenderImage {IMG} at (384,802) size 385x385
+      RenderBlock {P} at (0,1203) size 769x36
         RenderText {#text} at (0,0) size 758x35
           text run at (0,0) width 758: "The above image should be a square resized so its width is 50% of its parent element, and aligned at the right edge of the"
           text run at (0,18) width 100: "parent element: "
           text run at (100,18) width 395: "the document body in the first half, and the table in the second."
-      RenderTable {TABLE} at (0,1256) size 769x1069 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 767x1067
+      RenderTable {TABLE} at (0,1255) size 769x1068 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 767x1066
           RenderTableRow {TR} at (0,0) size 767x26
             RenderTableCell {TD} at (0,0) size 767x26 [bgcolor=#C0C0C0] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=2]
               RenderInline {STRONG} at (0,0) size 163x17
                 RenderText {#text} at (4,4) size 163x17
                   text run at (4,4) width 163: "TABLE Testing Section"
-          RenderTableRow {TR} at (0,26) size 767x1041
-            RenderTableCell {TD} at (0,533) size 12x27 [bgcolor=#C0C0C0] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (4,3) size 4x19
+          RenderTableRow {TR} at (0,26) size 767x1040
+            RenderTableCell {TD} at (0,533) size 12x26 [bgcolor=#C0C0C0] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (4,4) size 4x17
                 text run at (4,4) width 4: " "
-            RenderTableCell {TD} at (12,26) size 755x1041 [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (12,26) size 755x1040 [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
               RenderBlock {P} at (4,4) size 747x19
                 RenderImage {IMG} at (0,0) size 15x15
                 RenderText {#text} at (15,1) size 434x17
@@ -74,13 +74,13 @@ layer at (0,0) size 785x2341
                 RenderText {#text} at (0,0) size 400x17
                   text run at (0,0) width 400: "The above image should be a 15px square aligned at the center."
               RenderImage {IMG} at (190,169) size 375x374
-              RenderBlock {P} at (4,559) size 747x36
+              RenderBlock {P} at (4,558) size 747x37
                 RenderText {#text} at (0,0) size 722x35
                   text run at (0,0) width 722: "The above image should be a square resized so its width is 50% of the its parent element, and centered horizontally"
                   text run at (0,18) width 167: "within the parent element: "
                   text run at (167,18) width 395: "the document body in the first half, and the table in the second."
-              RenderImage {IMG} at (377,611) size 374x374
-              RenderBlock {P} at (4,1001) size 747x36
+              RenderImage {IMG} at (377,610) size 374x374
+              RenderBlock {P} at (4,1000) size 747x36
                 RenderText {#text} at (0,0) size 735x35
                   text run at (0,0) width 735: "The above image should be a square resized so its width is 50% of its parent element, and aligned at the right edge of"
                   text run at (0,18) width 123: "the parent element: "

--- a/LayoutTests/platform/wpe/css1/text_properties/vertical_align-expected.txt
+++ b/LayoutTests/platform/wpe/css1/text_properties/vertical_align-expected.txt
@@ -173,25 +173,25 @@ layer at (0,0) size 785x4408
         RenderText {#text} at (80,122) size 101x21
           text run at (80,122) width 101: " all of which "
         RenderImage {IMG} at (181,122) size 20x65
-        RenderText {#text} at (201,122) size 5x21
-          text run at (201,122) width 5: " "
-        RenderInline {SPAN} at (0,0) size 262x41
-          RenderText {#text} at (206,106) size 262x41
-            text run at (206,106) width 262: "should be aligned"
-        RenderText {#text} at (468,122) size 5x21
-          text run at (468,122) width 5: " "
-        RenderImage {IMG} at (473,122) size 11x35
-        RenderText {#text} at (484,122) size 123x21
-          text run at (484,122) width 123: " with the top of "
-        RenderImage {IMG} at (607,122) size 9x30
-        RenderText {#text} at (616,122) size 5x21
-          text run at (616,122) width 5: " "
-        RenderInline {SPAN} at (0,0) size 733x142
-          RenderText {#text} at (621,114) size 19x31
-            text run at (621,114) width 19: "a "
-          RenderInline {SPAN} at (0,0) size 733x188
-            RenderText {#text} at (640,77) size 733x188
-              text run at (640,77) width 93: "14-"
+        RenderText {#text} at (200,122) size 6x21
+          text run at (200,122) width 6: " "
+        RenderInline {SPAN} at (0,0) size 263x41
+          RenderText {#text} at (205,106) size 263x41
+            text run at (205,106) width 263: "should be aligned"
+        RenderText {#text} at (467,122) size 6x21
+          text run at (467,122) width 6: " "
+        RenderImage {IMG} at (472,122) size 11x35
+        RenderText {#text} at (483,122) size 123x21
+          text run at (483,122) width 123: " with the top of "
+        RenderImage {IMG} at (606,122) size 9x30
+        RenderText {#text} at (615,122) size 5x21
+          text run at (615,122) width 5: " "
+        RenderInline {SPAN} at (0,0) size 732x142
+          RenderText {#text} at (620,114) size 19x31
+            text run at (620,114) width 19: "a "
+          RenderInline {SPAN} at (0,0) size 732x188
+            RenderText {#text} at (639,77) size 732x188
+              text run at (639,77) width 93: "14-"
               text run at (0,188) width 143: "point"
           RenderText {#text} at (143,225) size 144x31
             text run at (143,225) width 144: " text element"
@@ -206,14 +206,14 @@ layer at (0,0) size 785x4408
         RenderText {#text} at (501,233) size 5x21
           text run at (501,233) width 5: " "
         RenderImage {IMG} at (506,233) size 5x15
-        RenderText {#text} at (511,233) size 5x21
-          text run at (511,233) width 5: " "
-        RenderInline {BIG} at (0,0) size 156x24
-          RenderText {#text} at (516,231) size 156x24
-            text run at (516,231) width 156: "the images appear."
-        RenderText {#text} at (672,233) size 5x21
-          text run at (672,233) width 5: " "
-        RenderImage {IMG} at (677,233) size 27x90
+        RenderText {#text} at (510,233) size 6x21
+          text run at (510,233) width 6: " "
+        RenderInline {BIG} at (0,0) size 157x24
+          RenderText {#text} at (515,231) size 157x24
+            text run at (515,231) width 157: "the images appear."
+        RenderText {#text} at (671,233) size 6x21
+          text run at (671,233) width 6: " "
+        RenderImage {IMG} at (676,233) size 28x90
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,1784) size 769x37
         RenderText {#text} at (0,0) size 749x35
@@ -246,27 +246,27 @@ layer at (0,0) size 785x4408
           text run at (696,23) width 36: " all of"
           text run at (0,98) width 43: "which "
         RenderImage {IMG} at (43,76) size 20x66
-        RenderText {#text} at (63,98) size 119x18
-          text run at (63,98) width 119: " should be aligned "
-        RenderImage {IMG} at (182,91) size 11x36
-        RenderText {#text} at (193,98) size 4x18
-          text run at (193,98) width 4: " "
+        RenderText {#text} at (62,98) size 120x18
+          text run at (62,98) width 120: " should be aligned "
+        RenderImage {IMG} at (181,91) size 11x36
+        RenderText {#text} at (192,98) size 4x18
+          text run at (192,98) width 4: " "
         RenderInline {SPAN} at (0,0) size 236x37
-          RenderText {#text} at (197,83) size 236x37
-            text run at (197,83) width 236: "with the middle of"
-        RenderText {#text} at (433,98) size 4x18
-          text run at (433,98) width 4: " "
-        RenderImage {IMG} at (437,83) size 15x51
-        RenderText {#text} at (452,98) size 4x18
-          text run at (452,98) width 4: " "
-        RenderInline {SPAN} at (0,0) size 720x105
-          RenderText {#text} at (456,91) size 17x27
-            text run at (456,91) width 17: "a "
+          RenderText {#text} at (196,83) size 236x37
+            text run at (196,83) width 236: "with the middle of"
+        RenderText {#text} at (432,98) size 4x18
+          text run at (432,98) width 4: " "
+        RenderImage {IMG} at (436,83) size 15x51
+        RenderText {#text} at (451,98) size 4x18
+          text run at (451,98) width 4: " "
+        RenderInline {SPAN} at (0,0) size 719x105
+          RenderText {#text} at (455,91) size 17x27
+            text run at (455,91) width 17: "a "
           RenderInline {SPAN} at (0,0) size 204x67
-            RenderText {#text} at (473,59) size 204x67
-              text run at (473,59) width 204: "14-point"
-          RenderText {#text} at (677,91) size 720x105
-            text run at (677,91) width 43: " text"
+            RenderText {#text} at (472,59) size 204x67
+              text run at (472,59) width 204: "14-point"
+          RenderText {#text} at (676,91) size 719x105
+            text run at (676,91) width 43: " text"
             text run at (0,169) width 78: "element"
         RenderText {#text} at (78,176) size 4x18
           text run at (78,176) width 4: " "
@@ -279,14 +279,14 @@ layer at (0,0) size 785x4408
         RenderText {#text} at (290,176) size 4x18
           text run at (290,176) width 4: " "
         RenderImage {IMG} at (294,179) size 5x16
-        RenderText {#text} at (299,176) size 4x18
-          text run at (299,176) width 4: " "
-        RenderInline {BIG} at (0,0) size 156x25
-          RenderText {#text} at (303,171) size 156x25
-            text run at (303,171) width 156: "the images appear."
-        RenderText {#text} at (459,176) size 4x18
-          text run at (459,176) width 4: " "
-        RenderImage {IMG} at (463,141) size 27x91
+        RenderText {#text} at (298,176) size 5x18
+          text run at (298,176) width 5: " "
+        RenderInline {BIG} at (0,0) size 157x25
+          RenderText {#text} at (302,171) size 157x25
+            text run at (302,171) width 157: "the images appear."
+        RenderText {#text} at (458,176) size 5x18
+          text run at (458,176) width 5: " "
+        RenderImage {IMG} at (462,141) size 28x91
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,2083) size 769x37
         RenderText {#text} at (0,0) size 733x35
@@ -341,35 +341,35 @@ layer at (0,0) size 785x4408
         RenderText {#text} at (146,47) size 4x17
           text run at (146,47) width 4: " "
         RenderImage {IMG} at (150,47) size 20x65
-        RenderText {#text} at (170,47) size 4x17
-          text run at (170,47) width 4: " "
-        RenderInline {SPAN} at (0,0) size 111x17
-          RenderText {#text} at (174,47) size 111x17
-            text run at (174,47) width 111: "should be aligned"
-        RenderText {#text} at (285,47) size 4x17
-          text run at (285,47) width 4: " "
-        RenderImage {IMG} at (289,47) size 11x35
-        RenderText {#text} at (300,47) size 4x17
-          text run at (300,47) width 4: " "
+        RenderText {#text} at (169,47) size 5x17
+          text run at (169,47) width 5: " "
+        RenderInline {SPAN} at (0,0) size 112x17
+          RenderText {#text} at (173,47) size 112x17
+            text run at (173,47) width 112: "should be aligned"
+        RenderText {#text} at (284,47) size 5x17
+          text run at (284,47) width 5: " "
+        RenderImage {IMG} at (288,47) size 11x35
+        RenderText {#text} at (299,47) size 4x17
+          text run at (299,47) width 4: " "
         RenderInline {SPAN} at (0,0) size 188x36
-          RenderText {#text} at (304,47) size 188x36
-            text run at (304,47) width 188: "with the top of"
-        RenderText {#text} at (492,47) size 4x17
-          text run at (492,47) width 4: " "
-        RenderImage {IMG} at (496,47) size 15x50
-        RenderText {#text} at (511,47) size 4x17
-          text run at (511,47) width 4: " "
+          RenderText {#text} at (303,47) size 188x36
+            text run at (303,47) width 188: "with the top of"
+        RenderText {#text} at (491,47) size 4x17
+          text run at (491,47) width 4: " "
+        RenderImage {IMG} at (495,47) size 15x50
+        RenderText {#text} at (510,47) size 4x17
+          text run at (510,47) width 4: " "
         RenderInline {SPAN} at (0,0) size 128x17
-          RenderText {#text} at (515,47) size 128x17
-            text run at (515,47) width 128: "the tallest element in"
-        RenderText {#text} at (643,47) size 4x17
-          text run at (643,47) width 4: " "
-        RenderImage {IMG} at (647,47) size 5x15
-        RenderText {#text} at (652,47) size 4x17
-          text run at (652,47) width 4: " "
-        RenderInline {BIG} at (0,0) size 744x89
-          RenderText {#text} at (656,47) size 744x89
-            text run at (656,47) width 88: "whichever"
+          RenderText {#text} at (514,47) size 128x17
+            text run at (514,47) width 128: "the tallest element in"
+        RenderText {#text} at (642,47) size 4x17
+          text run at (642,47) width 4: " "
+        RenderImage {IMG} at (646,47) size 5x15
+        RenderText {#text} at (650,47) size 5x17
+          text run at (650,47) width 5: " "
+        RenderInline {BIG} at (0,0) size 743x89
+          RenderText {#text} at (654,47) size 743x89
+            text run at (654,47) width 89: "whichever"
             text run at (0,112) width 208: "line the elements appear."
         RenderText {#text} at (208,112) size 4x17
           text run at (208,112) width 4: " "
@@ -517,25 +517,25 @@ layer at (0,0) size 785x4408
                 RenderText {#text} at (80,122) size 101x21
                   text run at (80,122) width 101: " all of which "
                 RenderImage {IMG} at (181,122) size 20x65
-                RenderText {#text} at (201,122) size 5x21
-                  text run at (201,122) width 5: " "
-                RenderInline {SPAN} at (0,0) size 262x41
-                  RenderText {#text} at (206,106) size 262x41
-                    text run at (206,106) width 262: "should be aligned"
-                RenderText {#text} at (468,122) size 5x21
-                  text run at (468,122) width 5: " "
-                RenderImage {IMG} at (473,122) size 11x35
-                RenderText {#text} at (484,122) size 123x21
-                  text run at (484,122) width 123: " with the top of "
-                RenderImage {IMG} at (607,122) size 9x30
-                RenderText {#text} at (616,122) size 5x21
-                  text run at (616,122) width 5: " "
-                RenderInline {SPAN} at (0,0) size 733x142
-                  RenderText {#text} at (621,114) size 19x31
-                    text run at (621,114) width 19: "a "
-                  RenderInline {SPAN} at (0,0) size 733x188
-                    RenderText {#text} at (640,77) size 733x188
-                      text run at (640,77) width 93: "14-"
+                RenderText {#text} at (200,122) size 6x21
+                  text run at (200,122) width 6: " "
+                RenderInline {SPAN} at (0,0) size 263x41
+                  RenderText {#text} at (205,106) size 263x41
+                    text run at (205,106) width 263: "should be aligned"
+                RenderText {#text} at (467,122) size 6x21
+                  text run at (467,122) width 6: " "
+                RenderImage {IMG} at (472,122) size 11x35
+                RenderText {#text} at (483,122) size 123x21
+                  text run at (483,122) width 123: " with the top of "
+                RenderImage {IMG} at (606,122) size 9x30
+                RenderText {#text} at (615,122) size 5x21
+                  text run at (615,122) width 5: " "
+                RenderInline {SPAN} at (0,0) size 732x142
+                  RenderText {#text} at (620,114) size 19x31
+                    text run at (620,114) width 19: "a "
+                  RenderInline {SPAN} at (0,0) size 732x188
+                    RenderText {#text} at (639,77) size 732x188
+                      text run at (639,77) width 93: "14-"
                       text run at (0,188) width 143: "point"
                   RenderText {#text} at (143,225) size 144x31
                     text run at (143,225) width 144: " text element"
@@ -550,14 +550,14 @@ layer at (0,0) size 785x4408
                 RenderText {#text} at (501,233) size 5x21
                   text run at (501,233) width 5: " "
                 RenderImage {IMG} at (506,233) size 5x15
-                RenderText {#text} at (511,233) size 5x21
-                  text run at (511,233) width 5: " "
-                RenderInline {BIG} at (0,0) size 156x24
-                  RenderText {#text} at (516,231) size 156x24
-                    text run at (516,231) width 156: "the images appear."
-                RenderText {#text} at (672,233) size 5x21
-                  text run at (672,233) width 5: " "
-                RenderImage {IMG} at (677,233) size 27x90
+                RenderText {#text} at (510,233) size 6x21
+                  text run at (510,233) width 6: " "
+                RenderInline {BIG} at (0,0) size 157x24
+                  RenderText {#text} at (515,231) size 157x24
+                    text run at (515,231) width 157: "the images appear."
+                RenderText {#text} at (671,233) size 6x21
+                  text run at (671,233) width 6: " "
+                RenderImage {IMG} at (676,233) size 28x90
                 RenderText {#text} at (0,0) size 0x0
               RenderBlock {P} at (4,1453) size 747x37
                 RenderText {#text} at (0,0) size 730x35
@@ -590,27 +590,27 @@ layer at (0,0) size 785x4408
                   text run at (696,23) width 36: " all of"
                   text run at (0,98) width 43: "which "
                 RenderImage {IMG} at (43,76) size 20x66
-                RenderText {#text} at (63,98) size 119x18
-                  text run at (63,98) width 119: " should be aligned "
-                RenderImage {IMG} at (182,91) size 11x36
-                RenderText {#text} at (193,98) size 4x18
-                  text run at (193,98) width 4: " "
+                RenderText {#text} at (62,98) size 120x18
+                  text run at (62,98) width 120: " should be aligned "
+                RenderImage {IMG} at (181,91) size 11x36
+                RenderText {#text} at (192,98) size 4x18
+                  text run at (192,98) width 4: " "
                 RenderInline {SPAN} at (0,0) size 236x37
-                  RenderText {#text} at (197,83) size 236x37
-                    text run at (197,83) width 236: "with the middle of"
-                RenderText {#text} at (433,98) size 4x18
-                  text run at (433,98) width 4: " "
-                RenderImage {IMG} at (437,83) size 15x51
-                RenderText {#text} at (452,98) size 4x18
-                  text run at (452,98) width 4: " "
-                RenderInline {SPAN} at (0,0) size 720x105
-                  RenderText {#text} at (456,91) size 17x27
-                    text run at (456,91) width 17: "a "
+                  RenderText {#text} at (196,83) size 236x37
+                    text run at (196,83) width 236: "with the middle of"
+                RenderText {#text} at (432,98) size 4x18
+                  text run at (432,98) width 4: " "
+                RenderImage {IMG} at (436,83) size 15x51
+                RenderText {#text} at (451,98) size 4x18
+                  text run at (451,98) width 4: " "
+                RenderInline {SPAN} at (0,0) size 719x105
+                  RenderText {#text} at (455,91) size 17x27
+                    text run at (455,91) width 17: "a "
                   RenderInline {SPAN} at (0,0) size 204x67
-                    RenderText {#text} at (473,59) size 204x67
-                      text run at (473,59) width 204: "14-point"
-                  RenderText {#text} at (677,91) size 720x105
-                    text run at (677,91) width 43: " text"
+                    RenderText {#text} at (472,59) size 204x67
+                      text run at (472,59) width 204: "14-point"
+                  RenderText {#text} at (676,91) size 719x105
+                    text run at (676,91) width 43: " text"
                     text run at (0,169) width 78: "element"
                 RenderText {#text} at (78,176) size 4x18
                   text run at (78,176) width 4: " "
@@ -623,14 +623,14 @@ layer at (0,0) size 785x4408
                 RenderText {#text} at (290,176) size 4x18
                   text run at (290,176) width 4: " "
                 RenderImage {IMG} at (294,179) size 5x16
-                RenderText {#text} at (299,176) size 4x18
-                  text run at (299,176) width 4: " "
-                RenderInline {BIG} at (0,0) size 156x25
-                  RenderText {#text} at (303,171) size 156x25
-                    text run at (303,171) width 156: "the images appear."
-                RenderText {#text} at (459,176) size 4x18
-                  text run at (459,176) width 4: " "
-                RenderImage {IMG} at (463,141) size 27x91
+                RenderText {#text} at (298,176) size 5x18
+                  text run at (298,176) width 5: " "
+                RenderInline {BIG} at (0,0) size 157x25
+                  RenderText {#text} at (302,171) size 157x25
+                    text run at (302,171) width 157: "the images appear."
+                RenderText {#text} at (458,176) size 5x18
+                  text run at (458,176) width 5: " "
+                RenderImage {IMG} at (462,141) size 28x91
                 RenderText {#text} at (0,0) size 0x0
               RenderBlock {P} at (4,1752) size 747x37
                 RenderText {#text} at (0,0) size 733x35
@@ -685,35 +685,35 @@ layer at (0,0) size 785x4408
                 RenderText {#text} at (146,47) size 4x17
                   text run at (146,47) width 4: " "
                 RenderImage {IMG} at (150,47) size 20x65
-                RenderText {#text} at (170,47) size 4x17
-                  text run at (170,47) width 4: " "
-                RenderInline {SPAN} at (0,0) size 111x17
-                  RenderText {#text} at (174,47) size 111x17
-                    text run at (174,47) width 111: "should be aligned"
-                RenderText {#text} at (285,47) size 4x17
-                  text run at (285,47) width 4: " "
-                RenderImage {IMG} at (289,47) size 11x35
-                RenderText {#text} at (300,47) size 4x17
-                  text run at (300,47) width 4: " "
+                RenderText {#text} at (169,47) size 5x17
+                  text run at (169,47) width 5: " "
+                RenderInline {SPAN} at (0,0) size 112x17
+                  RenderText {#text} at (173,47) size 112x17
+                    text run at (173,47) width 112: "should be aligned"
+                RenderText {#text} at (284,47) size 5x17
+                  text run at (284,47) width 5: " "
+                RenderImage {IMG} at (288,47) size 11x35
+                RenderText {#text} at (299,47) size 4x17
+                  text run at (299,47) width 4: " "
                 RenderInline {SPAN} at (0,0) size 188x36
-                  RenderText {#text} at (304,47) size 188x36
-                    text run at (304,47) width 188: "with the top of"
-                RenderText {#text} at (492,47) size 4x17
-                  text run at (492,47) width 4: " "
-                RenderImage {IMG} at (496,47) size 15x50
-                RenderText {#text} at (511,47) size 4x17
-                  text run at (511,47) width 4: " "
+                  RenderText {#text} at (303,47) size 188x36
+                    text run at (303,47) width 188: "with the top of"
+                RenderText {#text} at (491,47) size 4x17
+                  text run at (491,47) width 4: " "
+                RenderImage {IMG} at (495,47) size 15x50
+                RenderText {#text} at (510,47) size 4x17
+                  text run at (510,47) width 4: " "
                 RenderInline {SPAN} at (0,0) size 128x17
-                  RenderText {#text} at (515,47) size 128x17
-                    text run at (515,47) width 128: "the tallest element in"
-                RenderText {#text} at (643,47) size 4x17
-                  text run at (643,47) width 4: " "
-                RenderImage {IMG} at (647,47) size 5x15
-                RenderText {#text} at (652,47) size 4x17
-                  text run at (652,47) width 4: " "
-                RenderInline {BIG} at (0,0) size 744x89
-                  RenderText {#text} at (656,47) size 744x89
-                    text run at (656,47) width 88: "whichever"
+                  RenderText {#text} at (514,47) size 128x17
+                    text run at (514,47) width 128: "the tallest element in"
+                RenderText {#text} at (642,47) size 4x17
+                  text run at (642,47) width 4: " "
+                RenderImage {IMG} at (646,47) size 5x15
+                RenderText {#text} at (650,47) size 5x17
+                  text run at (650,47) width 5: " "
+                RenderInline {BIG} at (0,0) size 743x89
+                  RenderText {#text} at (654,47) size 743x89
+                    text run at (654,47) width 89: "whichever"
                     text run at (0,112) width 208: "line the elements appear."
                 RenderText {#text} at (208,112) size 4x17
                   text run at (208,112) width 4: " "

--- a/LayoutTests/platform/wpe/css2.1/20110323/replaced-elements-001-expected.txt
+++ b/LayoutTests/platform/wpe/css2.1/20110323/replaced-elements-001-expected.txt
@@ -1,19 +1,19 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x176
-  RenderBlock {HTML} at (0,0) size 800x176
-    RenderBody {BODY} at (8,16) size 784x144
+layer at (0,0) size 800x172
+  RenderBlock {HTML} at (0,0) size 800x172
+    RenderBody {BODY} at (8,16) size 784x140
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 598x17
           text run at (0,0) width 598: "Below, there should be 2 orange boxes horizontally centered within their respective green bars."
-      RenderBlock {DIV} at (16,34) size 752x47 [bgcolor=#008000]
+      RenderBlock {DIV} at (16,34) size 752x45 [bgcolor=#008000]
         RenderBlock (anonymous) at (0,0) size 752x18
           RenderText {#text} at (0,0) size 36x17
             text run at (0,0) width 36: "         "
-        RenderButton {INPUT} at (368,20) size 16x27 [color=#000000CC] [bgcolor=#FFA500] [border: (2px outset #C0C0C0)]
-      RenderBlock {FORM} at (0,97) size 784x47
-        RenderBlock {DIV} at (16,0) size 752x47 [bgcolor=#008000]
+        RenderButton {INPUT} at (368,18) size 16x27 [color=#000000CC] [bgcolor=#FFA500] [border: (2px outset #C0C0C0)]
+      RenderBlock {FORM} at (0,95) size 784x45
+        RenderBlock {DIV} at (16,0) size 752x45 [bgcolor=#008000]
           RenderBlock (anonymous) at (0,0) size 752x18
             RenderText {#text} at (0,0) size 36x17
               text run at (0,0) width 36: "         "
-          RenderButton {INPUT} at (368,20) size 16x27 [color=#000000CC] [bgcolor=#FFA500] [border: (2px outset #C0C0C0)]
+          RenderButton {INPUT} at (368,18) size 16x27 [color=#000000CC] [bgcolor=#FFA500] [border: (2px outset #C0C0C0)]

--- a/LayoutTests/platform/wpe/css2.1/t100801-c544-valgn-03-d-agi-expected.txt
+++ b/LayoutTests/platform/wpe/css2.1/t100801-c544-valgn-03-d-agi-expected.txt
@@ -1,0 +1,81 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x319
+  RenderBlock {HTML} at (0,0) size 800x319
+    RenderBody {BODY} at (8,16) size 784x288
+      RenderBlock {P} at (0,0) size 784x36
+        RenderText {#text} at (0,0) size 750x35
+          text run at (0,0) width 387: "Change your window size. However the lines wrap, the blue "
+          text run at (387,0) width 363: "rectanglues should always have their middles on the same"
+          text run at (0,18) width 83: "alignment as "
+          text run at (83,18) width 204: "other blue rectangles on the line."
+      RenderBlock {P} at (15,52) size 754x236 [color=#0000FF] [bgcolor=#FFFFFF] [border: (1px solid #C0C0C0)]
+        RenderText {#text} at (8,35) size 61x16
+          text run at (8,35) width 61: "\x{C9}\x{C9}\x{C9} "
+        RenderImage {IMG} at (68,26) size 31x31
+        RenderText {#text} at (98,35) size 16x16
+          text run at (98,35) width 16: " "
+        RenderInline {SPAN} at (0,0) size 115x39 [color=#C0C0C0]
+          RenderText {#text} at (113,17) size 115x39
+            text run at (113,17) width 115: "xxx"
+        RenderText {#text} at (227,35) size 16x16
+          text run at (227,35) width 16: " "
+        RenderImage {IMG} at (242,16) size 51x51
+        RenderText {#text} at (292,35) size 76x16
+          text run at (292,35) width 16: " "
+          text run at (307,35) width 61: "\x{C9}\x{C9}\x{C9} "
+        RenderImage {IMG} at (367,36) size 11x11
+        RenderText {#text} at (377,35) size 16x16
+          text run at (377,35) width 16: " "
+        RenderInline {SMALL} at (0,0) size 31x11 [color=#C0C0C0]
+          RenderText {#text} at (392,39) size 31x11
+            text run at (392,39) width 31: "xxx"
+        RenderText {#text} at (422,35) size 16x16
+          text run at (422,35) width 16: " "
+        RenderImage {IMG} at (437,31) size 21x21
+        RenderText {#text} at (457,35) size 76x16
+          text run at (457,35) width 16: " "
+          text run at (472,35) width 61: "\x{C9}\x{C9}\x{C9} "
+        RenderImage {IMG} at (532,8) size 66x66
+        RenderText {#text} at (597,35) size 76x16
+          text run at (597,35) width 16: " "
+          text run at (612,35) width 61: "\x{C9}\x{C9}\x{C9} "
+        RenderImage {IMG} at (672,23) size 36x36
+        RenderText {#text} at (0,0) size 0x0
+        RenderInline {SPAN} at (0,0) size 91x31 [color=#C0C0C0]
+          RenderText {#text} at (8,94) size 91x31
+            text run at (8,94) width 91: "xxx"
+        RenderText {#text} at (98,106) size 16x16
+          text run at (98,106) width 16: " "
+        RenderImage {IMG} at (113,87) size 51x51
+        RenderText {#text} at (163,106) size 16x16
+          text run at (163,106) width 16: " "
+        RenderInline {SPAN} at (0,0) size 353x24 [color=#C0C0C0]
+          RenderText {#text} at (178,100) size 93x24
+            text run at (178,100) width 93: "xxx "
+          RenderInline {SPAN} at (0,0) size 169x57
+            RenderText {#text} at (270,73) size 169x57
+              text run at (270,73) width 169: "xxx"
+          RenderText {#text} at (438,100) size 93x24
+            text run at (438,100) width 93: " xxx"
+        RenderText {#text} at (530,106) size 16x16
+          text run at (530,106) width 16: " "
+        RenderImage {IMG} at (545,87) size 51x51
+        RenderText {#text} at (595,106) size 16x16
+          text run at (595,106) width 16: " "
+        RenderInline {SMALL} at (0,0) size 31x11 [color=#C0C0C0]
+          RenderText {#text} at (610,110) size 31x11
+            text run at (610,110) width 31: "xxx"
+        RenderText {#text} at (640,106) size 16x16
+          text run at (640,106) width 16: " "
+        RenderImage {IMG} at (655,104) size 16x16
+        RenderText {#text} at (670,106) size 16x16
+          text run at (670,106) width 16: " "
+        RenderInline {BIG} at (0,0) size 61x21 [color=#C0C0C0]
+          RenderText {#text} at (685,102) size 61x21
+            text run at (685,102) width 61: "xxx"
+        RenderText {#text} at (0,0) size 0x0
+        RenderImage {IMG} at (8,137) size 91x91
+        RenderText {#text} at (98,176) size 61x16
+          text run at (98,176) width 16: " "
+          text run at (113,176) width 46: "\x{C9}\x{C9}\x{C9}"

--- a/LayoutTests/platform/wpe/css2.1/t1202-counter-09-b-expected.txt
+++ b/LayoutTests/platform/wpe/css2.1/t1202-counter-09-b-expected.txt
@@ -1,252 +1,252 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x95
-  RenderBlock {HTML} at (0,0) size 800x95
-    RenderBody {BODY} at (8,16) size 784x71
+layer at (0,0) size 800x96
+  RenderBlock {HTML} at (0,0) size 800x96
+    RenderBody {BODY} at (8,16) size 784x72
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 292x17
           text run at (0,0) width 292: "The following two lines should look the same:"
-      RenderBlock {DIV} at (0,34) size 784x18
+      RenderBlock {DIV} at (0,34) size 784x19
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (0,0) size 8x17
-              text run at (0,0) width 8: "\x{10D0}"
-        RenderText {#text} at (8,0) size 4x17
-          text run at (8,0) width 4: " "
+            RenderCounter at (0,1) size 8x17
+              text run at (0,1) width 8: "\x{10D0}"
+        RenderText {#text} at (8,1) size 4x17
+          text run at (8,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (12,0) size 8x17
-              text run at (12,0) width 8: "\x{10D1}"
-        RenderText {#text} at (20,0) size 4x17
-          text run at (20,0) width 4: " "
+            RenderCounter at (12,1) size 8x17
+              text run at (12,1) width 8: "\x{10D1}"
+        RenderText {#text} at (20,1) size 4x17
+          text run at (20,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 9x17
           RenderInline (generated) at (0,0) size 9x17
-            RenderCounter at (24,0) size 9x17
-              text run at (24,0) width 9: "\x{10D2}"
-        RenderText {#text} at (33,0) size 4x17
-          text run at (33,0) width 4: " "
+            RenderCounter at (24,1) size 9x17
+              text run at (24,1) width 9: "\x{10D2}"
+        RenderText {#text} at (33,1) size 4x17
+          text run at (33,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 13x17
           RenderInline (generated) at (0,0) size 13x17
-            RenderCounter at (37,0) size 13x17
-              text run at (37,0) width 13: "\x{10D3}"
-        RenderText {#text} at (50,0) size 4x17
-          text run at (50,0) width 4: " "
+            RenderCounter at (37,1) size 13x17
+              text run at (37,1) width 13: "\x{10D3}"
+        RenderText {#text} at (50,1) size 4x17
+          text run at (50,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (54,0) size 8x17
-              text run at (54,0) width 8: "\x{10D4}"
-        RenderText {#text} at (62,0) size 4x17
-          text run at (62,0) width 4: " "
+            RenderCounter at (54,1) size 8x17
+              text run at (54,1) width 8: "\x{10D4}"
+        RenderText {#text} at (62,1) size 4x17
+          text run at (62,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (66,0) size 8x17
-              text run at (66,0) width 8: "\x{10D5}"
-        RenderText {#text} at (74,0) size 4x17
-          text run at (74,0) width 4: " "
+            RenderCounter at (66,1) size 8x17
+              text run at (66,1) width 8: "\x{10D5}"
+        RenderText {#text} at (74,1) size 4x17
+          text run at (74,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (78,0) size 8x17
-              text run at (78,0) width 8: "\x{10D6}"
-        RenderText {#text} at (86,0) size 4x17
-          text run at (86,0) width 4: " "
+            RenderCounter at (78,1) size 8x17
+              text run at (78,1) width 8: "\x{10D6}"
+        RenderText {#text} at (86,1) size 4x17
+          text run at (86,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 9x17
           RenderInline (generated) at (0,0) size 9x17
-            RenderCounter at (90,0) size 9x17
-              text run at (90,0) width 9: "\x{10F1}"
-        RenderText {#text} at (99,0) size 4x17
-          text run at (99,0) width 4: " "
+            RenderCounter at (90,1) size 9x17
+              text run at (90,1) width 9: "\x{10F1}"
+        RenderText {#text} at (99,1) size 4x17
+          text run at (99,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 13x17
           RenderInline (generated) at (0,0) size 13x17
-            RenderCounter at (103,0) size 13x17
-              text run at (103,0) width 13: "\x{10D7}"
-        RenderText {#text} at (116,0) size 4x17
-          text run at (116,0) width 4: " "
+            RenderCounter at (103,1) size 13x17
+              text run at (103,1) width 13: "\x{10D7}"
+        RenderText {#text} at (116,1) size 4x17
+          text run at (116,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (120,0) size 8x17
-              text run at (120,0) width 8: "\x{10D8}"
-        RenderText {#text} at (128,0) size 4x17
-          text run at (128,0) width 4: " "
+            RenderCounter at (120,1) size 8x17
+              text run at (120,1) width 8: "\x{10D8}"
+        RenderText {#text} at (128,1) size 4x17
+          text run at (128,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 16x17
           RenderInline (generated) at (0,0) size 16x17
-            RenderCounter at (132,0) size 16x17
-              text run at (132,0) width 16: "\x{10D8}\x{10D0}"
-        RenderText {#text} at (148,0) size 4x17
-          text run at (148,0) width 4: " "
+            RenderCounter at (132,1) size 16x17
+              text run at (132,1) width 16: "\x{10D8}\x{10D0}"
+        RenderText {#text} at (148,1) size 4x17
+          text run at (148,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 16x17
           RenderInline (generated) at (0,0) size 16x17
-            RenderCounter at (152,0) size 16x17
-              text run at (152,0) width 16: "\x{10D8}\x{10D1}"
-        RenderText {#text} at (168,0) size 4x17
-          text run at (168,0) width 4: " "
+            RenderCounter at (152,1) size 16x17
+              text run at (152,1) width 16: "\x{10D8}\x{10D1}"
+        RenderText {#text} at (168,1) size 4x17
+          text run at (168,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (172,0) size 8x17
-              text run at (172,0) width 8: "\x{10D9}"
-        RenderText {#text} at (180,0) size 4x17
-          text run at (180,0) width 4: " "
+            RenderCounter at (172,1) size 8x17
+              text run at (172,1) width 8: "\x{10D9}"
+        RenderText {#text} at (180,1) size 4x17
+          text run at (180,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 17x17
           RenderInline (generated) at (0,0) size 17x17
-            RenderCounter at (184,0) size 17x17
-              text run at (184,0) width 17: "\x{10DA}"
-        RenderText {#text} at (201,0) size 4x17
-          text run at (201,0) width 4: " "
+            RenderCounter at (184,1) size 17x17
+              text run at (184,1) width 17: "\x{10DA}"
+        RenderText {#text} at (201,1) size 4x17
+          text run at (201,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (205,0) size 8x17
-              text run at (205,0) width 8: "\x{10DB}"
-        RenderText {#text} at (213,0) size 4x17
-          text run at (213,0) width 4: " "
+            RenderCounter at (205,1) size 8x17
+              text run at (205,1) width 8: "\x{10DB}"
+        RenderText {#text} at (213,1) size 4x17
+          text run at (213,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (217,0) size 8x17
-              text run at (217,0) width 8: "\x{10DC}"
-        RenderText {#text} at (225,0) size 4x17
-          text run at (225,0) width 4: " "
+            RenderCounter at (217,1) size 8x17
+              text run at (217,1) width 8: "\x{10DC}"
+        RenderText {#text} at (225,1) size 4x17
+          text run at (225,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (229,0) size 8x17
-              text run at (229,0) width 8: "\x{10F2}"
-        RenderText {#text} at (237,0) size 4x17
-          text run at (237,0) width 4: " "
+            RenderCounter at (229,1) size 8x17
+              text run at (229,1) width 8: "\x{10F2}"
+        RenderText {#text} at (237,1) size 4x17
+          text run at (237,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 13x17
           RenderInline (generated) at (0,0) size 13x17
-            RenderCounter at (241,0) size 13x17
-              text run at (241,0) width 13: "\x{10DD}"
-        RenderText {#text} at (254,0) size 4x17
-          text run at (254,0) width 4: " "
+            RenderCounter at (241,1) size 13x17
+              text run at (241,1) width 13: "\x{10DD}"
+        RenderText {#text} at (254,1) size 4x17
+          text run at (254,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (258,0) size 8x17
-              text run at (258,0) width 8: "\x{10DE}"
-        RenderText {#text} at (266,0) size 4x17
-          text run at (266,0) width 4: " "
+            RenderCounter at (258,1) size 8x17
+              text run at (258,1) width 8: "\x{10DE}"
+        RenderText {#text} at (266,1) size 4x17
+          text run at (266,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (270,0) size 8x17
-              text run at (270,0) width 8: "\x{10DF}"
-        RenderText {#text} at (278,0) size 4x17
-          text run at (278,0) width 4: " "
+            RenderCounter at (270,1) size 8x17
+              text run at (270,1) width 8: "\x{10DF}"
+        RenderText {#text} at (278,1) size 4x17
+          text run at (278,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 13x17
           RenderInline (generated) at (0,0) size 13x17
-            RenderCounter at (282,0) size 13x17
-              text run at (282,0) width 13: "\x{10E0}"
-        RenderText {#text} at (295,0) size 4x17
-          text run at (295,0) width 4: " "
+            RenderCounter at (282,1) size 13x17
+              text run at (282,1) width 13: "\x{10E0}"
+        RenderText {#text} at (295,1) size 4x17
+          text run at (295,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (299,0) size 8x17
-              text run at (299,0) width 8: "\x{10E1}"
-        RenderText {#text} at (307,0) size 4x17
-          text run at (307,0) width 4: " "
+            RenderCounter at (299,1) size 8x17
+              text run at (299,1) width 8: "\x{10E1}"
+        RenderText {#text} at (307,1) size 4x17
+          text run at (307,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 11x17
           RenderInline (generated) at (0,0) size 11x17
-            RenderCounter at (311,0) size 11x17
-              text run at (311,0) width 11: "\x{10E2}"
-        RenderText {#text} at (322,0) size 4x17
-          text run at (322,0) width 4: " "
+            RenderCounter at (311,1) size 11x17
+              text run at (311,1) width 11: "\x{10E2}"
+        RenderText {#text} at (322,1) size 4x17
+          text run at (322,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (326,0) size 8x17
-              text run at (326,0) width 8: "\x{10F3}"
-        RenderText {#text} at (334,0) size 4x17
-          text run at (334,0) width 4: " "
+            RenderCounter at (326,1) size 8x17
+              text run at (326,1) width 8: "\x{10F3}"
+        RenderText {#text} at (334,1) size 4x17
+          text run at (334,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 13x17
           RenderInline (generated) at (0,0) size 13x17
-            RenderCounter at (338,0) size 13x17
-              text run at (338,0) width 13: "\x{10E4}"
-        RenderText {#text} at (351,0) size 4x17
-          text run at (351,0) width 4: " "
+            RenderCounter at (338,1) size 13x17
+              text run at (338,1) width 13: "\x{10E4}"
+        RenderText {#text} at (351,1) size 4x17
+          text run at (351,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (355,0) size 8x17
-              text run at (355,0) width 8: "\x{10E5}"
-        RenderText {#text} at (363,0) size 4x17
-          text run at (363,0) width 4: " "
+            RenderCounter at (355,1) size 8x17
+              text run at (355,1) width 8: "\x{10E5}"
+        RenderText {#text} at (363,1) size 4x17
+          text run at (363,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 13x17
           RenderInline (generated) at (0,0) size 13x17
-            RenderCounter at (367,0) size 13x17
-              text run at (367,0) width 13: "\x{10E6}"
-        RenderText {#text} at (380,0) size 4x17
-          text run at (380,0) width 4: " "
+            RenderCounter at (367,1) size 13x17
+              text run at (367,1) width 13: "\x{10E6}"
+        RenderText {#text} at (380,1) size 4x17
+          text run at (380,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (384,0) size 8x17
-              text run at (384,0) width 8: "\x{10E7}"
-        RenderText {#text} at (392,0) size 4x17
-          text run at (392,0) width 4: " "
+            RenderCounter at (384,1) size 8x17
+              text run at (384,1) width 8: "\x{10E7}"
+        RenderText {#text} at (392,1) size 4x17
+          text run at (392,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (396,0) size 8x17
-              text run at (396,0) width 8: "\x{10E8}"
-        RenderText {#text} at (404,0) size 4x17
-          text run at (404,0) width 4: " "
+            RenderCounter at (396,1) size 8x17
+              text run at (396,1) width 8: "\x{10E8}"
+        RenderText {#text} at (404,1) size 4x17
+          text run at (404,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (408,0) size 8x17
-              text run at (408,0) width 8: "\x{10E9}"
-        RenderText {#text} at (416,0) size 4x17
-          text run at (416,0) width 4: " "
+            RenderCounter at (408,1) size 8x17
+              text run at (408,1) width 8: "\x{10E9}"
+        RenderText {#text} at (416,1) size 4x17
+          text run at (416,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 9x17
           RenderInline (generated) at (0,0) size 9x17
-            RenderCounter at (420,0) size 9x17
-              text run at (420,0) width 9: "\x{10EA}"
-        RenderText {#text} at (429,0) size 4x17
-          text run at (429,0) width 4: " "
+            RenderCounter at (420,1) size 9x17
+              text run at (420,1) width 9: "\x{10EA}"
+        RenderText {#text} at (429,1) size 4x17
+          text run at (429,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (433,0) size 8x17
-              text run at (433,0) width 8: "\x{10EB}"
-        RenderText {#text} at (441,0) size 4x17
-          text run at (441,0) width 4: " "
+            RenderCounter at (433,1) size 8x17
+              text run at (433,1) width 8: "\x{10EB}"
+        RenderText {#text} at (441,1) size 4x17
+          text run at (441,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (445,0) size 8x17
-              text run at (445,0) width 8: "\x{10EC}"
-        RenderText {#text} at (453,0) size 4x17
-          text run at (453,0) width 4: " "
+            RenderCounter at (445,1) size 8x17
+              text run at (445,1) width 8: "\x{10EC}"
+        RenderText {#text} at (453,1) size 4x17
+          text run at (453,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (457,0) size 8x17
-              text run at (457,0) width 8: "\x{10ED}"
-        RenderText {#text} at (465,0) size 4x17
-          text run at (465,0) width 4: " "
+            RenderCounter at (457,1) size 8x17
+              text run at (457,1) width 8: "\x{10ED}"
+        RenderText {#text} at (465,1) size 4x17
+          text run at (465,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (469,0) size 8x17
-              text run at (469,0) width 8: "\x{10EE}"
-        RenderText {#text} at (477,0) size 4x17
-          text run at (477,0) width 4: " "
+            RenderCounter at (469,1) size 8x17
+              text run at (469,1) width 8: "\x{10EE}"
+        RenderText {#text} at (477,1) size 4x17
+          text run at (477,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (481,0) size 8x17
-              text run at (481,0) width 8: "\x{10F4}"
-        RenderText {#text} at (489,0) size 4x17
-          text run at (489,0) width 4: " "
+            RenderCounter at (481,1) size 8x17
+              text run at (481,1) width 8: "\x{10F4}"
+        RenderText {#text} at (489,1) size 4x17
+          text run at (489,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (493,0) size 8x17
-              text run at (493,0) width 8: "\x{10EF}"
-        RenderText {#text} at (501,0) size 4x17
-          text run at (501,0) width 4: " "
+            RenderCounter at (493,1) size 8x17
+              text run at (493,1) width 8: "\x{10EF}"
+        RenderText {#text} at (501,1) size 4x17
+          text run at (501,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 8x17
           RenderInline (generated) at (0,0) size 8x17
-            RenderCounter at (505,0) size 8x17
-              text run at (505,0) width 8: "\x{10F0}"
-        RenderText {#text} at (513,0) size 4x17
-          text run at (513,0) width 4: " "
+            RenderCounter at (505,1) size 8x17
+              text run at (505,1) width 8: "\x{10F0}"
+        RenderText {#text} at (513,1) size 4x17
+          text run at (513,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 9x17
           RenderInline (generated) at (0,0) size 9x17
-            RenderCounter at (517,0) size 9x17
-              text run at (517,0) width 9: "\x{10F5}"
-        RenderText {#text} at (526,0) size 4x17
-          text run at (526,0) width 4: " "
+            RenderCounter at (517,1) size 9x17
+              text run at (517,1) width 9: "\x{10F5}"
+        RenderText {#text} at (526,1) size 4x17
+          text run at (526,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 46x17
           RenderInline (generated) at (0,0) size 46x17
-            RenderCounter at (530,0) size 46x17
-              text run at (530,0) width 46: "\x{10F5}\x{10F0}\x{10E8}\x{10DF}\x{10D7}"
+            RenderCounter at (530,1) size 46x17
+              text run at (530,1) width 46: "\x{10F5}\x{10F0}\x{10E8}\x{10DF}\x{10D7}"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,52) size 784x19
+      RenderBlock {DIV} at (0,53) size 784x19
         RenderText {#text} at (0,1) size 576x17
           text run at (0,1) width 12: "\x{10D0} "
           text run at (12,1) width 12: "\x{10D1} "

--- a/LayoutTests/platform/wpe/css2.1/t1202-counters-09-b-expected.txt
+++ b/LayoutTests/platform/wpe/css2.1/t1202-counters-09-b-expected.txt
@@ -1,252 +1,252 @@
 layer at (0,0) size 1064x585
   RenderView at (0,0) size 800x585
-layer at (0,0) size 800x95
-  RenderBlock {HTML} at (0,0) size 800x95
-    RenderBody {BODY} at (8,16) size 784x71
+layer at (0,0) size 800x96
+  RenderBlock {HTML} at (0,0) size 800x96
+    RenderBody {BODY} at (8,16) size 784x72
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 292x17
           text run at (0,0) width 292: "The following two lines should look the same:"
-      RenderBlock {DIV} at (0,34) size 784x18
+      RenderBlock {DIV} at (0,34) size 784x19
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (0,0) size 20x17
-              text run at (0,0) width 20: "\x{10D0}.\x{10D0}"
-        RenderText {#text} at (20,0) size 4x17
-          text run at (20,0) width 4: " "
+            RenderCounter at (0,1) size 20x17
+              text run at (0,1) width 20: "\x{10D0}.\x{10D0}"
+        RenderText {#text} at (20,1) size 4x17
+          text run at (20,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (24,0) size 20x17
-              text run at (24,0) width 20: "\x{10D0}.\x{10D1}"
-        RenderText {#text} at (44,0) size 4x17
-          text run at (44,0) width 4: " "
+            RenderCounter at (24,1) size 20x17
+              text run at (24,1) width 20: "\x{10D0}.\x{10D1}"
+        RenderText {#text} at (44,1) size 4x17
+          text run at (44,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 21x17
           RenderInline (generated) at (0,0) size 21x17
-            RenderCounter at (48,0) size 21x17
-              text run at (48,0) width 21: "\x{10D0}.\x{10D2}"
-        RenderText {#text} at (69,0) size 4x17
-          text run at (69,0) width 4: " "
+            RenderCounter at (48,1) size 21x17
+              text run at (48,1) width 21: "\x{10D0}.\x{10D2}"
+        RenderText {#text} at (69,1) size 4x17
+          text run at (69,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 25x17
           RenderInline (generated) at (0,0) size 25x17
-            RenderCounter at (73,0) size 25x17
-              text run at (73,0) width 25: "\x{10D0}.\x{10D3}"
-        RenderText {#text} at (98,0) size 4x17
-          text run at (98,0) width 4: " "
+            RenderCounter at (73,1) size 25x17
+              text run at (73,1) width 25: "\x{10D0}.\x{10D3}"
+        RenderText {#text} at (98,1) size 4x17
+          text run at (98,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (102,0) size 20x17
-              text run at (102,0) width 20: "\x{10D0}.\x{10D4}"
-        RenderText {#text} at (122,0) size 4x17
-          text run at (122,0) width 4: " "
+            RenderCounter at (102,1) size 20x17
+              text run at (102,1) width 20: "\x{10D0}.\x{10D4}"
+        RenderText {#text} at (122,1) size 4x17
+          text run at (122,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (126,0) size 20x17
-              text run at (126,0) width 20: "\x{10D0}.\x{10D5}"
-        RenderText {#text} at (146,0) size 4x17
-          text run at (146,0) width 4: " "
+            RenderCounter at (126,1) size 20x17
+              text run at (126,1) width 20: "\x{10D0}.\x{10D5}"
+        RenderText {#text} at (146,1) size 4x17
+          text run at (146,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (150,0) size 20x17
-              text run at (150,0) width 20: "\x{10D0}.\x{10D6}"
-        RenderText {#text} at (170,0) size 4x17
-          text run at (170,0) width 4: " "
+            RenderCounter at (150,1) size 20x17
+              text run at (150,1) width 20: "\x{10D0}.\x{10D6}"
+        RenderText {#text} at (170,1) size 4x17
+          text run at (170,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 21x17
           RenderInline (generated) at (0,0) size 21x17
-            RenderCounter at (174,0) size 21x17
-              text run at (174,0) width 21: "\x{10D0}.\x{10F1}"
-        RenderText {#text} at (195,0) size 4x17
-          text run at (195,0) width 4: " "
+            RenderCounter at (174,1) size 21x17
+              text run at (174,1) width 21: "\x{10D0}.\x{10F1}"
+        RenderText {#text} at (195,1) size 4x17
+          text run at (195,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 25x17
           RenderInline (generated) at (0,0) size 25x17
-            RenderCounter at (199,0) size 25x17
-              text run at (199,0) width 25: "\x{10D0}.\x{10D7}"
-        RenderText {#text} at (224,0) size 4x17
-          text run at (224,0) width 4: " "
+            RenderCounter at (199,1) size 25x17
+              text run at (199,1) width 25: "\x{10D0}.\x{10D7}"
+        RenderText {#text} at (224,1) size 4x17
+          text run at (224,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (228,0) size 20x17
-              text run at (228,0) width 20: "\x{10D0}.\x{10D8}"
-        RenderText {#text} at (248,0) size 4x17
-          text run at (248,0) width 4: " "
+            RenderCounter at (228,1) size 20x17
+              text run at (228,1) width 20: "\x{10D0}.\x{10D8}"
+        RenderText {#text} at (248,1) size 4x17
+          text run at (248,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 28x17
           RenderInline (generated) at (0,0) size 28x17
-            RenderCounter at (252,0) size 28x17
-              text run at (252,0) width 28: "\x{10D0}.\x{10D8}\x{10D0}"
-        RenderText {#text} at (280,0) size 4x17
-          text run at (280,0) width 4: " "
+            RenderCounter at (252,1) size 28x17
+              text run at (252,1) width 28: "\x{10D0}.\x{10D8}\x{10D0}"
+        RenderText {#text} at (280,1) size 4x17
+          text run at (280,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 28x17
           RenderInline (generated) at (0,0) size 28x17
-            RenderCounter at (284,0) size 28x17
-              text run at (284,0) width 28: "\x{10D0}.\x{10D8}\x{10D1}"
-        RenderText {#text} at (312,0) size 4x17
-          text run at (312,0) width 4: " "
+            RenderCounter at (284,1) size 28x17
+              text run at (284,1) width 28: "\x{10D0}.\x{10D8}\x{10D1}"
+        RenderText {#text} at (312,1) size 4x17
+          text run at (312,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (316,0) size 20x17
-              text run at (316,0) width 20: "\x{10D0}.\x{10D9}"
-        RenderText {#text} at (336,0) size 4x17
-          text run at (336,0) width 4: " "
+            RenderCounter at (316,1) size 20x17
+              text run at (316,1) width 20: "\x{10D0}.\x{10D9}"
+        RenderText {#text} at (336,1) size 4x17
+          text run at (336,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 29x17
           RenderInline (generated) at (0,0) size 29x17
-            RenderCounter at (340,0) size 29x17
-              text run at (340,0) width 29: "\x{10D0}.\x{10DA}"
-        RenderText {#text} at (369,0) size 4x17
-          text run at (369,0) width 4: " "
+            RenderCounter at (340,1) size 29x17
+              text run at (340,1) width 29: "\x{10D0}.\x{10DA}"
+        RenderText {#text} at (369,1) size 4x17
+          text run at (369,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (373,0) size 20x17
-              text run at (373,0) width 20: "\x{10D0}.\x{10DB}"
-        RenderText {#text} at (393,0) size 4x17
-          text run at (393,0) width 4: " "
+            RenderCounter at (373,1) size 20x17
+              text run at (373,1) width 20: "\x{10D0}.\x{10DB}"
+        RenderText {#text} at (393,1) size 4x17
+          text run at (393,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (397,0) size 20x17
-              text run at (397,0) width 20: "\x{10D0}.\x{10DC}"
-        RenderText {#text} at (417,0) size 4x17
-          text run at (417,0) width 4: " "
+            RenderCounter at (397,1) size 20x17
+              text run at (397,1) width 20: "\x{10D0}.\x{10DC}"
+        RenderText {#text} at (417,1) size 4x17
+          text run at (417,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (421,0) size 20x17
-              text run at (421,0) width 20: "\x{10D0}.\x{10F2}"
-        RenderText {#text} at (441,0) size 4x17
-          text run at (441,0) width 4: " "
+            RenderCounter at (421,1) size 20x17
+              text run at (421,1) width 20: "\x{10D0}.\x{10F2}"
+        RenderText {#text} at (441,1) size 4x17
+          text run at (441,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 25x17
           RenderInline (generated) at (0,0) size 25x17
-            RenderCounter at (445,0) size 25x17
-              text run at (445,0) width 25: "\x{10D0}.\x{10DD}"
-        RenderText {#text} at (470,0) size 4x17
-          text run at (470,0) width 4: " "
+            RenderCounter at (445,1) size 25x17
+              text run at (445,1) width 25: "\x{10D0}.\x{10DD}"
+        RenderText {#text} at (470,1) size 4x17
+          text run at (470,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (474,0) size 20x17
-              text run at (474,0) width 20: "\x{10D0}.\x{10DE}"
-        RenderText {#text} at (494,0) size 4x17
-          text run at (494,0) width 4: " "
+            RenderCounter at (474,1) size 20x17
+              text run at (474,1) width 20: "\x{10D0}.\x{10DE}"
+        RenderText {#text} at (494,1) size 4x17
+          text run at (494,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (498,0) size 20x17
-              text run at (498,0) width 20: "\x{10D0}.\x{10DF}"
-        RenderText {#text} at (518,0) size 4x17
-          text run at (518,0) width 4: " "
+            RenderCounter at (498,1) size 20x17
+              text run at (498,1) width 20: "\x{10D0}.\x{10DF}"
+        RenderText {#text} at (518,1) size 4x17
+          text run at (518,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 25x17
           RenderInline (generated) at (0,0) size 25x17
-            RenderCounter at (522,0) size 25x17
-              text run at (522,0) width 25: "\x{10D0}.\x{10E0}"
-        RenderText {#text} at (547,0) size 4x17
-          text run at (547,0) width 4: " "
+            RenderCounter at (522,1) size 25x17
+              text run at (522,1) width 25: "\x{10D0}.\x{10E0}"
+        RenderText {#text} at (547,1) size 4x17
+          text run at (547,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (551,0) size 20x17
-              text run at (551,0) width 20: "\x{10D0}.\x{10E1}"
-        RenderText {#text} at (571,0) size 4x17
-          text run at (571,0) width 4: " "
+            RenderCounter at (551,1) size 20x17
+              text run at (551,1) width 20: "\x{10D0}.\x{10E1}"
+        RenderText {#text} at (571,1) size 4x17
+          text run at (571,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 23x17
           RenderInline (generated) at (0,0) size 23x17
-            RenderCounter at (575,0) size 23x17
-              text run at (575,0) width 23: "\x{10D0}.\x{10E2}"
-        RenderText {#text} at (598,0) size 4x17
-          text run at (598,0) width 4: " "
+            RenderCounter at (575,1) size 23x17
+              text run at (575,1) width 23: "\x{10D0}.\x{10E2}"
+        RenderText {#text} at (598,1) size 4x17
+          text run at (598,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (602,0) size 20x17
-              text run at (602,0) width 20: "\x{10D0}.\x{10F3}"
-        RenderText {#text} at (622,0) size 4x17
-          text run at (622,0) width 4: " "
+            RenderCounter at (602,1) size 20x17
+              text run at (602,1) width 20: "\x{10D0}.\x{10F3}"
+        RenderText {#text} at (622,1) size 4x17
+          text run at (622,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 25x17
           RenderInline (generated) at (0,0) size 25x17
-            RenderCounter at (626,0) size 25x17
-              text run at (626,0) width 25: "\x{10D0}.\x{10E4}"
-        RenderText {#text} at (651,0) size 4x17
-          text run at (651,0) width 4: " "
+            RenderCounter at (626,1) size 25x17
+              text run at (626,1) width 25: "\x{10D0}.\x{10E4}"
+        RenderText {#text} at (651,1) size 4x17
+          text run at (651,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (655,0) size 20x17
-              text run at (655,0) width 20: "\x{10D0}.\x{10E5}"
-        RenderText {#text} at (675,0) size 4x17
-          text run at (675,0) width 4: " "
+            RenderCounter at (655,1) size 20x17
+              text run at (655,1) width 20: "\x{10D0}.\x{10E5}"
+        RenderText {#text} at (675,1) size 4x17
+          text run at (675,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 25x17
           RenderInline (generated) at (0,0) size 25x17
-            RenderCounter at (679,0) size 25x17
-              text run at (679,0) width 25: "\x{10D0}.\x{10E6}"
-        RenderText {#text} at (704,0) size 4x17
-          text run at (704,0) width 4: " "
+            RenderCounter at (679,1) size 25x17
+              text run at (679,1) width 25: "\x{10D0}.\x{10E6}"
+        RenderText {#text} at (704,1) size 4x17
+          text run at (704,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (708,0) size 20x17
-              text run at (708,0) width 20: "\x{10D0}.\x{10E7}"
-        RenderText {#text} at (728,0) size 4x17
-          text run at (728,0) width 4: " "
+            RenderCounter at (708,1) size 20x17
+              text run at (708,1) width 20: "\x{10D0}.\x{10E7}"
+        RenderText {#text} at (728,1) size 4x17
+          text run at (728,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (732,0) size 20x17
-              text run at (732,0) width 20: "\x{10D0}.\x{10E8}"
-        RenderText {#text} at (752,0) size 4x17
-          text run at (752,0) width 4: " "
+            RenderCounter at (732,1) size 20x17
+              text run at (732,1) width 20: "\x{10D0}.\x{10E8}"
+        RenderText {#text} at (752,1) size 4x17
+          text run at (752,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (756,0) size 20x17
-              text run at (756,0) width 20: "\x{10D0}.\x{10E9}"
-        RenderText {#text} at (776,0) size 4x17
-          text run at (776,0) width 4: " "
+            RenderCounter at (756,1) size 20x17
+              text run at (756,1) width 20: "\x{10D0}.\x{10E9}"
+        RenderText {#text} at (776,1) size 4x17
+          text run at (776,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 21x17
           RenderInline (generated) at (0,0) size 21x17
-            RenderCounter at (780,0) size 21x17
-              text run at (780,0) width 21: "\x{10D0}.\x{10EA}"
-        RenderText {#text} at (801,0) size 4x17
-          text run at (801,0) width 4: " "
+            RenderCounter at (780,1) size 21x17
+              text run at (780,1) width 21: "\x{10D0}.\x{10EA}"
+        RenderText {#text} at (801,1) size 4x17
+          text run at (801,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (805,0) size 20x17
-              text run at (805,0) width 20: "\x{10D0}.\x{10EB}"
-        RenderText {#text} at (825,0) size 4x17
-          text run at (825,0) width 4: " "
+            RenderCounter at (805,1) size 20x17
+              text run at (805,1) width 20: "\x{10D0}.\x{10EB}"
+        RenderText {#text} at (825,1) size 4x17
+          text run at (825,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (829,0) size 20x17
-              text run at (829,0) width 20: "\x{10D0}.\x{10EC}"
-        RenderText {#text} at (849,0) size 4x17
-          text run at (849,0) width 4: " "
+            RenderCounter at (829,1) size 20x17
+              text run at (829,1) width 20: "\x{10D0}.\x{10EC}"
+        RenderText {#text} at (849,1) size 4x17
+          text run at (849,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (853,0) size 20x17
-              text run at (853,0) width 20: "\x{10D0}.\x{10ED}"
-        RenderText {#text} at (873,0) size 4x17
-          text run at (873,0) width 4: " "
+            RenderCounter at (853,1) size 20x17
+              text run at (853,1) width 20: "\x{10D0}.\x{10ED}"
+        RenderText {#text} at (873,1) size 4x17
+          text run at (873,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (877,0) size 20x17
-              text run at (877,0) width 20: "\x{10D0}.\x{10EE}"
-        RenderText {#text} at (897,0) size 4x17
-          text run at (897,0) width 4: " "
+            RenderCounter at (877,1) size 20x17
+              text run at (877,1) width 20: "\x{10D0}.\x{10EE}"
+        RenderText {#text} at (897,1) size 4x17
+          text run at (897,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (901,0) size 20x17
-              text run at (901,0) width 20: "\x{10D0}.\x{10F4}"
-        RenderText {#text} at (921,0) size 4x17
-          text run at (921,0) width 4: " "
+            RenderCounter at (901,1) size 20x17
+              text run at (901,1) width 20: "\x{10D0}.\x{10F4}"
+        RenderText {#text} at (921,1) size 4x17
+          text run at (921,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (925,0) size 20x17
-              text run at (925,0) width 20: "\x{10D0}.\x{10EF}"
-        RenderText {#text} at (945,0) size 4x17
-          text run at (945,0) width 4: " "
+            RenderCounter at (925,1) size 20x17
+              text run at (925,1) width 20: "\x{10D0}.\x{10EF}"
+        RenderText {#text} at (945,1) size 4x17
+          text run at (945,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 20x17
           RenderInline (generated) at (0,0) size 20x17
-            RenderCounter at (949,0) size 20x17
-              text run at (949,0) width 20: "\x{10D0}.\x{10F0}"
-        RenderText {#text} at (969,0) size 4x17
-          text run at (969,0) width 4: " "
+            RenderCounter at (949,1) size 20x17
+              text run at (949,1) width 20: "\x{10D0}.\x{10F0}"
+        RenderText {#text} at (969,1) size 4x17
+          text run at (969,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 21x17
           RenderInline (generated) at (0,0) size 21x17
-            RenderCounter at (973,0) size 21x17
-              text run at (973,0) width 21: "\x{10D0}.\x{10F5}"
-        RenderText {#text} at (994,0) size 4x17
-          text run at (994,0) width 4: " "
+            RenderCounter at (973,1) size 21x17
+              text run at (973,1) width 21: "\x{10D0}.\x{10F5}"
+        RenderText {#text} at (994,1) size 4x17
+          text run at (994,1) width 4: " "
         RenderInline {SPAN} at (0,0) size 58x17
           RenderInline (generated) at (0,0) size 58x17
-            RenderCounter at (998,0) size 58x17
-              text run at (998,0) width 58: "\x{10D0}.\x{10F5}\x{10F0}\x{10E8}\x{10DF}\x{10D7}"
+            RenderCounter at (998,1) size 58x17
+              text run at (998,1) width 58: "\x{10D0}.\x{10F5}\x{10F0}\x{10E8}\x{10DF}\x{10D7}"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,52) size 784x19
+      RenderBlock {DIV} at (0,53) size 784x19
         RenderText {#text} at (0,1) size 1056x17
           text run at (0,1) width 24: "\x{10D0}.\x{10D0} "
           text run at (24,1) width 24: "\x{10D0}.\x{10D1} "

--- a/LayoutTests/platform/wpe/css2.1/t120401-scope-04-d-expected.txt
+++ b/LayoutTests/platform/wpe/css2.1/t120401-scope-04-d-expected.txt
@@ -1,0 +1,42 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x94
+  RenderBlock {HTML} at (0,0) size 800x94
+    RenderBody {BODY} at (8,16) size 784x70
+      RenderBlock {P} at (0,0) size 784x18
+        RenderText {#text} at (0,0) size 245x17
+          text run at (0,0) width 245: "The next two lines should be the same:"
+      RenderBlock {DIV} at (0,34) size 784x18
+        RenderInline {SPAN} at (0,0) size 0x17
+        RenderInline {SPAN} at (0,0) size 12x17
+          RenderInline (generated) at (0,0) size 12x17
+            RenderCounter at (0,0) size 8x17
+              text run at (0,0) width 8: "1"
+            RenderText at (8,0) size 4x17
+              text run at (8,0) width 4: " "
+        RenderInline {SPAN} at (0,0) size 0x17
+        RenderInline {SPAN} at (0,0) size 12x17
+          RenderInline (generated) at (0,0) size 12x17
+            RenderCounter at (12,0) size 8x17
+              text run at (12,0) width 8: "1"
+            RenderText at (20,0) size 4x17
+              text run at (20,0) width 4: " "
+        RenderInline {SPAN} at (0,0) size 55x17
+          RenderInline (generated) at (0,0) size 11x17
+            RenderText at (24,0) size 11x17
+              text run at (24,0) width 11: "R"
+          RenderInline {SPAN} at (0,0) size 24x17
+            RenderInline (generated) at (0,0) size 24x17
+              RenderCounter at (35,0) size 20x17
+                text run at (35,0) width 20: "1.1"
+              RenderText at (55,0) size 4x17
+                text run at (55,0) width 4: " "
+          RenderInline {SPAN} at (0,0) size 0x17
+          RenderInline {SPAN} at (0,0) size 20x17
+            RenderInline (generated) at (0,0) size 20x17
+              RenderCounter at (59,0) size 20x17
+                text run at (59,0) width 20: "1.1"
+              RenderText at (0,0) size 0x0
+      RenderBlock {DIV} at (0,52) size 784x18
+        RenderText {#text} at (0,0) size 79x17
+          text run at (0,0) width 79: "1 1 R1.1 1.1"

--- a/LayoutTests/platform/wpe/css2.1/t120403-content-none-00-c-expected.txt
+++ b/LayoutTests/platform/wpe/css2.1/t120403-content-none-00-c-expected.txt
@@ -1,0 +1,17 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x94
+  RenderBlock {HTML} at (0,0) size 800x94
+    RenderBody {BODY} at (8,16) size 784x70
+      RenderBlock {P} at (0,0) size 784x18
+        RenderText {#text} at (0,0) size 216x17
+          text run at (0,0) width 216: "The following should be identical:"
+      RenderBlock {DIV} at (0,34) size 784x18
+        RenderInline {SPAN} at (0,0) size 0x17
+        RenderInline {SPAN} at (0,0) size 8x17
+          RenderInline (generated) at (0,0) size 8x17
+            RenderCounter at (0,0) size 8x17
+              text run at (0,0) width 8: "0"
+      RenderBlock {DIV} at (0,52) size 784x18
+        RenderText {#text} at (0,0) size 8x17
+          text run at (0,0) width 8: "0"

--- a/LayoutTests/platform/wpe/css2.1/t120403-visibility-00-c-expected.txt
+++ b/LayoutTests/platform/wpe/css2.1/t120403-visibility-00-c-expected.txt
@@ -1,0 +1,17 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x94
+  RenderBlock {HTML} at (0,0) size 800x94
+    RenderBody {BODY} at (8,16) size 784x70
+      RenderBlock {P} at (0,0) size 784x18
+        RenderText {#text} at (0,0) size 216x17
+          text run at (0,0) width 216: "The following should be identical:"
+      RenderBlock {DIV} at (0,34) size 784x18
+        RenderInline {SPAN} at (0,0) size 0x17
+        RenderInline {SPAN} at (0,0) size 8x17
+          RenderInline (generated) at (0,0) size 8x17
+            RenderCounter at (0,0) size 8x17
+              text run at (0,0) width 8: "1"
+      RenderBlock {DIV} at (0,52) size 784x18
+        RenderText {#text} at (0,0) size 8x17
+          text run at (0,0) width 8: "1"

--- a/LayoutTests/platform/wpe/css3/flexbox/button-expected.txt
+++ b/LayoutTests/platform/wpe/css3/flexbox/button-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x258
-  RenderBlock {HTML} at (0,0) size 800x258
-    RenderBody {BODY} at (8,8) size 784x242
+layer at (0,0) size 800x246
+  RenderBlock {HTML} at (0,0) size 800x246
+    RenderBody {BODY} at (8,8) size 784x230
       RenderBlock (anonymous) at (0,0) size 784x36
         RenderText {#text} at (0,0) size 765x35
           text run at (0,0) width 403: "Test for empty buttons, which inherit from RenderFlexibleBox. "
@@ -14,22 +14,22 @@ layer at (0,0) size 800x258
         RenderText {#text} at (563,18) size 4x17
           text run at (563,18) width 4: "."
       RenderBlock {HR} at (0,44) size 784x2 [border: (1px inset #000000)]
-      RenderBlock (anonymous) at (0,54) size 784x70
+      RenderBlock (anonymous) at (0,54) size 784x64
         RenderText {#text} at (0,0) size 79x17
           text run at (0,0) width 79: "Simple case."
         RenderBR {BR} at (79,0) size 0x17
-        RenderButton {BUTTON} at (2,28) size 16x9 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
-        RenderBR {BR} at (20,18) size 0x17
-        RenderButton {INPUT} at (2,41) size 16x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
-        RenderBR {BR} at (20,49) size 0x17
-      RenderBlock {HR} at (0,132) size 784x2 [border: (1px inset #000000)]
-      RenderBlock (anonymous) at (0,142) size 784x100
+        RenderButton {BUTTON} at (0,28) size 16x9 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderBR {BR} at (16,18) size 0x17
+        RenderButton {INPUT} at (0,37) size 16x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderBR {BR} at (16,45) size 0x17
+      RenderBlock {HR} at (0,126) size 784x2 [border: (1px inset #000000)]
+      RenderBlock (anonymous) at (0,136) size 784x94
         RenderText {#text} at (0,0) size 778x17
           text run at (0,0) width 778: "Empty <button> and <input type=button> with overflow: scroll;. The presence of the scrollbar should not shrink the button."
         RenderBR {BR} at (778,0) size 0x17
-        RenderBR {BR} at (35,18) size 0x17
-        RenderBR {BR} at (35,64) size 0x17
-layer at (10,178) size 31x24 clip at (12,180) size 12x5
-  RenderButton {BUTTON} at (2,28) size 31x24 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
-layer at (10,206) size 31x42 clip at (12,208) size 12x23
-  RenderButton {INPUT} at (2,56) size 31x42 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderBR {BR} at (31,18) size 0x17
+        RenderBR {BR} at (31,60) size 0x17
+layer at (8,172) size 31x24 clip at (10,174) size 12x5
+  RenderButton {BUTTON} at (0,28) size 31x24 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+layer at (8,196) size 31x42 clip at (10,198) size 12x23
+  RenderButton {INPUT} at (0,52) size 31x42 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]

--- a/LayoutTests/platform/wpe/printing/print-with-media-query-destory-expected.txt
+++ b/LayoutTests/platform/wpe/printing/print-with-media-query-destory-expected.txt
@@ -1,0 +1,2 @@
+Pass if no crash or assert
+

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll-expected.txt
@@ -11,7 +11,7 @@
   (layout viewport at (0,0) size 785x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,421))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 2
     (Overflow scrolling node
       (scrollable area size 295 295)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/absolute-in-nested-sc-scrollers-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/absolute-in-nested-sc-scrollers-expected.txt
@@ -10,7 +10,7 @@
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Overflow scrolling node
       (scrollable area size 285 285)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/absolute-inside-stacking-in-scroller-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/absolute-inside-stacking-in-scroller-expected.txt
@@ -10,7 +10,7 @@
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 2
     (Overflow scrolling node
       (scrollable area size 205 155)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/clipped-layer-in-overflow-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/clipped-layer-in-overflow-expected.txt
@@ -10,7 +10,7 @@
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 2
     (Overflow scrolling node
       (scroll position 0 50)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/clipped-layer-in-overflow-nested-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/clipped-layer-in-overflow-nested-expected.txt
@@ -10,7 +10,7 @@
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 3
     (Overflow scrolling node
       (scroll position 0 50)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/composited-in-absolute-in-overflow-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/composited-in-absolute-in-overflow-expected.txt
@@ -10,7 +10,7 @@
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Overflow scrolling node
       (scrollable area size 285 285)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/composited-in-absolute-in-stacking-context-overflow-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/composited-in-absolute-in-stacking-context-overflow-expected.txt
@@ -10,7 +10,7 @@
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Overflow scrolling node
       (scrollable area size 285 285)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/coordinated-frame-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/coordinated-frame-expected.txt
@@ -11,7 +11,7 @@
   (layout viewport at (0,0) size 785x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,416))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Frame hosting node
       (children 1
@@ -27,7 +27,7 @@
           (layout viewport at (0,0) size 485x300)
           (min layout viewport origin (0,0))
           (max layout viewport origin (0,120))
-          (behavior for fixed 0)
+          (behavior for fixed 1)
           (children 2
             (Overflow scrolling node
               (scrollable area size 385 285)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/coordinated-frame-gain-scrolling-ancestor-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/coordinated-frame-gain-scrolling-ancestor-expected.txt
@@ -11,7 +11,7 @@
   (layout viewport at (0,0) size 785x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,416))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Fixed node
       (anchor edges: AnchorEdgeLeft AnchorEdgeTop)
@@ -31,7 +31,7 @@
               (layout viewport at (0,0) size 500x300)
               (min layout viewport origin (0,0))
               (max layout viewport origin (0,120))
-              (behavior for fixed 0)
+              (behavior for fixed 1)
               (children 2
                 (Overflow scrolling node
                   (scrollable area size 385 285)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/coordinated-frame-in-fixed-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/coordinated-frame-in-fixed-expected.txt
@@ -11,7 +11,7 @@
   (layout viewport at (0,0) size 785x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,416))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Fixed node
       (anchor edges: AnchorEdgeLeft AnchorEdgeTop)
@@ -32,7 +32,7 @@
               (layout viewport at (0,0) size 485x300)
               (min layout viewport origin (0,0))
               (max layout viewport origin (0,120))
-              (behavior for fixed 0)
+              (behavior for fixed 1)
               (children 2
                 (Overflow scrolling node
                   (scrollable area size 385 285)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/coordinated-frame-lose-scrolling-ancestor-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/coordinated-frame-lose-scrolling-ancestor-expected.txt
@@ -11,7 +11,7 @@
   (layout viewport at (0,0) size 785x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,416))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Frame hosting node
       (children 1
@@ -26,7 +26,7 @@
           (layout viewport at (0,0) size 500x300)
           (min layout viewport origin (0,0))
           (max layout viewport origin (0,120))
-          (behavior for fixed 0)
+          (behavior for fixed 1)
           (children 2
             (Overflow scrolling node
               (scrollable area size 385 285)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/fixed-inside-frame-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/fixed-inside-frame-expected.txt
@@ -12,7 +12,7 @@
   (layout viewport at (0,0) size 785x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,57))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Frame hosting node
       (children 1
@@ -31,7 +31,7 @@
           (layout viewport at (0,120) size 465x400)
           (min layout viewport origin (0,0))
           (max layout viewport origin (0,616))
-          (behavior for fixed 0)
+          (behavior for fixed 1)
           (children 1
             (Fixed node
               (anchor edges: AnchorEdgeLeft AnchorEdgeTop)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/gain-scrolling-node-parent-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/gain-scrolling-node-parent-expected.txt
@@ -13,7 +13,7 @@ Inner scrolling content
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Overflow scrolling node
       (scrollable area size 405 305)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/lose-scrolling-node-parent-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/lose-scrolling-node-parent-expected.txt
@@ -13,7 +13,7 @@ Inner scrolling content
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Overflow scrolling node
       (scrollable area size 405 305)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/nested-absolute-in-absolute-overflow-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/nested-absolute-in-absolute-overflow-expected.txt
@@ -12,7 +12,7 @@ abs
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 5
     (Overflow scrolling node
       (scrollable area size 285 285)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/nested-absolute-in-overflow-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/nested-absolute-in-overflow-expected.txt
@@ -11,7 +11,7 @@ abs abs
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Overflow scrolling node
       (scrollable area size 285 285)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/nested-absolute-in-relative-in-overflow-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/nested-absolute-in-relative-in-overflow-expected.txt
@@ -12,7 +12,7 @@ abs
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 7
     (Overflow scrolling node
       (scrollable area size 285 285)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/nested-absolute-in-sc-overflow-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/nested-absolute-in-sc-overflow-expected.txt
@@ -12,7 +12,7 @@ abs
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Overflow scrolling node
       (scrollable area size 285 285)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/overflow-in-fixed-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/overflow-in-fixed-expected.txt
@@ -11,7 +11,7 @@ Scrolling content
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Fixed node
       (anchor edges: AnchorEdgeLeft AnchorEdgeTop)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/positioned-nodes-complex-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/positioned-nodes-complex-expected.txt
@@ -25,7 +25,7 @@ Stacking
   (layout viewport at (0,0) size 785x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,229))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 19
     (Overflow scrolling node
       (scrollable area size 205 155)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/positioned-nodes-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/positioned-nodes-expected.txt
@@ -16,7 +16,7 @@ Scrolling content
   (layout viewport at (0,0) size 785x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,141))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 5
     (Overflow scrolling node
       (scrollable area size 205 155)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/remove-coordinated-frame-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/remove-coordinated-frame-expected.txt
@@ -11,7 +11,7 @@
   (layout viewport at (0,0) size 785x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,416))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Fixed node
       (anchor edges: AnchorEdgeLeft AnchorEdgeTop)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/remove-scrolling-role-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/remove-scrolling-role-expected.txt
@@ -11,7 +11,7 @@
   (layout viewport at (0,0) size 785x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,1913))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Overflow scrolling node
       (scrollable area size 285 400)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/reparent-across-compositing-layers-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/reparent-across-compositing-layers-expected.txt
@@ -13,7 +13,7 @@ Inner scrolling content
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Overflow scrolling node
       (scrollable area size 425 325)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/reparent-with-layer-removal-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/reparent-with-layer-removal-expected.txt
@@ -14,7 +14,7 @@ Inner scrolling content
   (layout viewport at (0,0) size 785x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,441))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Overflow scrolling node
       (scrollable area size 425 325)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/scrolling-tree-includes-frame-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/scrolling-tree-includes-frame-expected.txt
@@ -11,7 +11,7 @@
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Frame hosting node
       (children 1
@@ -28,7 +28,7 @@
           (layout viewport at (0,0) size 85x185)
           (min layout viewport origin (0,0))
           (max layout viewport origin (223,231))
-          (behavior for fixed 0)
+          (behavior for fixed 1)
         )
       )
     )

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/scrolling-tree-is-z-order-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/scrolling-tree-is-z-order-expected.txt
@@ -11,7 +11,7 @@ FirstSecondThird
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 3
     (Fixed node
       (anchor edges: AnchorEdgeLeft AnchorEdgeTop)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/sibling-node-order-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/sibling-node-order-expected.txt
@@ -12,7 +12,7 @@ Bottom
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 2
     (Fixed node
       (anchor edges: AnchorEdgeLeft AnchorEdgeTop)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/sticky-in-overflow-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/sticky-in-overflow-expected.txt
@@ -11,7 +11,7 @@ Sticky content
   (layout viewport at (0,0) size 800x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 2
     (Overflow scrolling node
       (scrollable area size 385 285)

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/sticky-in-overflow-stale-constraints-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/sticky-in-overflow-stale-constraints-expected.txt
@@ -1,3 +1,4 @@
+Hello
 
 (Frame scrolling node
   (scrollable area size 800 600)
@@ -13,8 +14,11 @@
   (behavior for fixed 1)
   (children 2
     (Overflow scrolling node
-      (scrollable area size 285 285)
-      (contents size 285 464)
+      (scroll position 0 380)
+      (scrollable area size 285 500)
+      (contents size 285 1400)
+      (requested scroll position 0 380)
+      (requested scroll position represents programmatic scroll 1)
       (scrollable area parameters
         (horizontal scroll elasticity 1)
         (vertical scroll elasticity 1)
@@ -23,20 +27,20 @@
         (allows vertical scrolling 1))
     )
     (Overflow scroll proxy node
-      (related overflow scrolling node scroll position (0,0))
+      (related overflow scrolling node scroll position (0,380))
       (children 1
-        (Overflow scrolling node
-          (scrollable area size 185 185)
-          (contents size 185 520)
-          (scrollable area parameters
-            (horizontal scroll elasticity 1)
-            (vertical scroll elasticity 1)
-            (horizontal scrollbar mode 0)
-            (vertical scrollbar mode 0)
-            (allows vertical scrolling 1))
+        (Sticky node
+          (anchor edges: AnchorEdgeTop )
+          (top offset 0.00)
+          (containing block rect at (0,0) size 285x1400)
+          (sticky box rect at (0,400) size 285x200)
+          (constraining rect at (0,380) size 285x500)
+          (sticky offset at last layout width=0 height=0)
+          (layer position at last layout (0,400))
         )
       )
     )
   )
 )
+
 

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/toggle-coordinated-frame-scrolling-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/toggle-coordinated-frame-scrolling-expected.txt
@@ -14,7 +14,7 @@ Scrolling tree on non-scrollable
   (layout viewport at (0,0) size 785x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,40))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Frame hosting node
       (children 1
@@ -29,7 +29,7 @@ Scrolling tree on non-scrollable
           (layout viewport at (0,0) size 600x500)
           (min layout viewport origin (0,0))
           (max layout viewport origin (0,0))
-          (behavior for fixed 0)
+          (behavior for fixed 1)
           (children 1
             (Frame hosting node
               (children 1
@@ -45,7 +45,7 @@ Scrolling tree on non-scrollable
                   (layout viewport at (0,0) size 485x400)
                   (min layout viewport origin (0,0))
                   (max layout viewport origin (0,624))
-                  (behavior for fixed 0)
+                  (behavior for fixed 1)
                 )
               )
             )
@@ -71,7 +71,7 @@ Scrolling tree on scrollable
   (layout viewport at (0,0) size 785x600)
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,40))
-  (behavior for fixed 0)
+  (behavior for fixed 1)
   (children 1
     (Frame hosting node
       (children 1
@@ -87,7 +87,7 @@ Scrolling tree on scrollable
           (layout viewport at (0,0) size 585x500)
           (min layout viewport origin (0,0))
           (max layout viewport origin (0,524))
-          (behavior for fixed 0)
+          (behavior for fixed 1)
           (children 1
             (Frame hosting node
               (children 1
@@ -103,7 +103,7 @@ Scrolling tree on scrollable
                   (layout viewport at (0,0) size 485x400)
                   (min layout viewport origin (0,0))
                   (max layout viewport origin (0,624))
-                  (behavior for fixed 0)
+                  (behavior for fixed 1)
                 )
               )
             )

--- a/LayoutTests/platform/wpe/svg/custom/inline-svg-in-xhtml-expected.txt
+++ b/LayoutTests/platform/wpe/svg/custom/inline-svg-in-xhtml-expected.txt
@@ -12,23 +12,23 @@ layer at (49,39) size 720x540
     RenderSVGEllipse {circle} at (193,93) size 432x432 [fill={[type=LINEAR-GRADIENT] [id="gradient"]}] [cx=50.00] [cy=50.00] [r=30.00]
 layer at (48,38) size 722x542 layerType: foreground only
   RenderBody {body} at (48,38) size 722x542 [border: (1px solid #000000)]
-    RenderBlock {form} at (1,1) size 720x143
-      RenderFieldSet {fieldset} at (2,0) size 716x143 [border: (2px groove #C0C0C0)]
+    RenderBlock {form} at (1,1) size 720x135
+      RenderFieldSet {fieldset} at (2,0) size 716x135 [border: (2px groove #C0C0C0)]
         RenderBlock {legend} at (14,0) size 88x18
           RenderText {#text} at (2,0) size 84x17
             text run at (2,0) width 84: "HTML Form"
-        RenderBlock {p} at (14,39) size 688x29
+        RenderBlock {p} at (14,39) size 688x25
           RenderInline {label} at (0,0) size 107x17
-            RenderText {#text} at (0,5) size 107x17
-              text run at (0,5) width 107: "Enter something:"
-          RenderText {#text} at (107,5) size 4x17
-            text run at (107,5) width 4: " "
-          RenderTextControl {input} at (113,2) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+            RenderText {#text} at (0,3) size 107x17
+              text run at (0,3) width 107: "Enter something:"
+          RenderText {#text} at (107,3) size 4x17
+            text run at (107,3) width 4: " "
+          RenderTextControl {input} at (111,0) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderText {#text} at (0,0) size 0x0
-        RenderBlock {p} at (14,83) size 688x32
-          RenderButton {button} at (2,2) size 74x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderBlock {p} at (14,79) size 688x28
+          RenderButton {button} at (0,0) size 74x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 58x18
               RenderText {#text} at (0,0) size 58x17
                 text run at (0,0) width 58: "Activate!"
-layer at (181,84) size 167x18
+layer at (179,82) size 167x18
   RenderBlock {div} at (3,3) size 167x18

--- a/LayoutTests/platform/wpe/svg/hixie/mixed/003-expected.txt
+++ b/LayoutTests/platform/wpe/svg/hixie/mixed/003-expected.txt
@@ -1,19 +1,19 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x306
-  RenderBlock {html} at (0,0) size 800x306
-    RenderBody {body} at (8,16) size 784x282
-      RenderBlock {p} at (0,0) size 784x28
-        RenderTextControl {input} at (2,2) size 413x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-      RenderBlock {p} at (0,44) size 784x18
+layer at (0,0) size 800x302
+  RenderBlock {html} at (0,0) size 800x302
+    RenderBody {body} at (8,16) size 784x278
+      RenderBlock {p} at (0,0) size 784x24
+        RenderTextControl {input} at (0,0) size 413x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderBlock {p} at (0,40) size 784x18
         RenderText {#text} at (0,0) size 463x17
           text run at (0,0) width 463: "It should say \"PASSED\" above and there should be a green circle below."
-      RenderBlock (anonymous) at (0,78) size 784x204
-        RenderSVGRoot {svg} at (8,94) size 100x100
-          RenderSVGEllipse {circle} at (8,94) size 100x100 [fill={[type=SOLID] [color=#008000]}] [cx=50.00] [cy=50.00] [r=50.00]
+      RenderBlock (anonymous) at (0,74) size 784x204
+        RenderSVGRoot {svg} at (8,90) size 100x100
+          RenderSVGEllipse {circle} at (8,90) size 100x100 [fill={[type=SOLID] [color=#008000]}] [cx=50.00] [cy=50.00] [r=50.00]
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-layer at (13,21) size 407x18
+layer at (11,19) size 407x18
   RenderBlock {div} at (3,3) size 407x18
     RenderText {#text} at (0,0) size 147x17
       text run at (0,0) width 147: "This test has PASSED."

--- a/LayoutTests/platform/wpe/svg/wicd/rightsizing-grid-expected.txt
+++ b/LayoutTests/platform/wpe/svg/wicd/rightsizing-grid-expected.txt
@@ -1,9 +1,9 @@
-layer at (0,0) size 785x1435
+layer at (0,0) size 785x1359
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1435
-  RenderBlock {html} at (0,0) size 785x1436
+layer at (0,0) size 785x1359
+  RenderBlock {html} at (0,0) size 785x1360
     RenderBody {body} at (8,8) size 769x0
-      RenderBlock (floating) {div} at (0,0) size 769x1428
+      RenderBlock (floating) {div} at (0,0) size 769x1352
         RenderBlock {h1} at (0,21) size 769x38
           RenderText {#text} at (0,0) size 444x36
             text run at (0,0) width 444: "SVG grid with percentage width"
@@ -11,7 +11,7 @@ layer at (0,0) size 785x1435
           RenderText {#text} at (0,0) size 149x17
             text run at (0,0) width 149: "WICD Core 1.0 #20-3"
         RenderBlock {p} at (0,119) size 769x0
-          RenderEmbeddedObject {object} at (0,0) size 385x128
+          RenderEmbeddedObject {object} at (0,0) size 385x129
             layer at (0,0) size 385x128
               RenderView at (0,0) size 385x128
             layer at (0,0) size 385x128
@@ -24,7 +24,7 @@ layer at (0,0) size 785x1435
                 RenderSVGText {text} at (52,9) size 16x23 contains 1 chunk(s)
                   RenderSVGInlineText {#text} at (0,0) size 15x23
                     chunk 1 (middle anchor) text run 1 at (52.81,27.00) startOffset 0 endOffset 1 width 14.38: "A"
-          RenderEmbeddedObject {object} at (384,0) size 385x128
+          RenderEmbeddedObject {object} at (384,0) size 385x129
             layer at (0,0) size 385x128
               RenderView at (0,0) size 385x128
             layer at (0,0) size 385x128
@@ -70,8 +70,8 @@ layer at (0,0) size 785x1435
                   RenderSVGText {text} at (53,109) size 14x23 contains 1 chunk(s)
                     RenderSVGInlineText {#text} at (0,0) size 13x23
                       chunk 1 (middle anchor) text run 1 at (53.91,127.00) startOffset 0 endOffset 1 width 12.19: "E"
-          RenderBlock (floating) {div} at (256,128) size 257x448
-            RenderEmbeddedObject {object} at (0,0) size 257x256
+          RenderBlock (floating) {div} at (256,128) size 257x449
+            RenderEmbeddedObject {object} at (0,0) size 257x257
               layer at (0,0) size 256x256
                 RenderView at (0,0) size 256x256
               layer at (0,0) size 256x256
@@ -85,7 +85,7 @@ layer at (0,0) size 785x1435
                     RenderSVGInlineText {#text} at (0,0) size 15x23
                       chunk 1 (middle anchor) text run 1 at (32.81,47.00) startOffset 0 endOffset 1 width 14.38: "K"
             RenderBR {br} at (256,0) size 1x17
-            RenderEmbeddedObject {object} at (0,256) size 257x192
+            RenderEmbeddedObject {object} at (0,256) size 257x193
               layer at (0,0) size 256x192
                 RenderView at (0,0) size 256x192
               layer at (0,0) size 256x192
@@ -98,8 +98,8 @@ layer at (0,0) size 785x1435
                   RenderSVGText {text} at (36,19) size 8x23 contains 1 chunk(s)
                     RenderSVGInlineText {#text} at (0,0) size 8x23
                       chunk 1 (middle anchor) text run 1 at (36.09,37.00) startOffset 0 endOffset 1 width 7.81: "J"
-          RenderBlock (floating) {div} at (512,128) size 257x448
-            RenderEmbeddedObject {object} at (0,0) size 257x256
+          RenderBlock (floating) {div} at (512,128) size 257x449
+            RenderEmbeddedObject {object} at (0,0) size 257x257
               layer at (0,0) size 256x256
                 RenderView at (0,0) size 256x256
               layer at (0,0) size 256x256
@@ -128,7 +128,7 @@ layer at (0,0) size 785x1435
                     RenderSVGText {text} at (52,49) size 16x23 contains 1 chunk(s)
                       RenderSVGInlineText {#text} at (0,0) size 15x23
                         chunk 1 (middle anchor) text run 1 at (52.81,67.00) startOffset 0 endOffset 1 width 14.38: "O"
-            RenderEmbeddedObject {object} at (0,256) size 257x192
+            RenderEmbeddedObject {object} at (0,256) size 257x193
               layer at (0,0) size 256x192
                 RenderView at (0,0) size 256x192
               layer at (0,0) size 256x192
@@ -141,7 +141,7 @@ layer at (0,0) size 785x1435
                   RenderSVGText {text} at (32,19) size 16x23 contains 1 chunk(s)
                     RenderSVGInlineText {#text} at (0,0) size 15x23
                       chunk 1 (middle anchor) text run 1 at (32.81,37.00) startOffset 0 endOffset 1 width 14.38: "Q"
-          RenderEmbeddedObject {object} at (256,576) size 385x128
+          RenderEmbeddedObject {object} at (0,576) size 385x129
             layer at (0,0) size 385x128
               RenderView at (0,0) size 385x128
             layer at (0,0) size 385x128
@@ -154,7 +154,7 @@ layer at (0,0) size 785x1435
                 RenderSVGText {text} at (54,9) size 12x23 contains 1 chunk(s)
                   RenderSVGInlineText {#text} at (0,0) size 12x23
                     chunk 1 (middle anchor) text run 1 at (54.38,27.00) startOffset 0 endOffset 1 width 11.25: "F"
-          RenderEmbeddedObject {object} at (0,704) size 385x128
+          RenderEmbeddedObject {object} at (384,576) size 385x129
             layer at (0,0) size 385x128
               RenderView at (0,0) size 385x128
             layer at (0,0) size 385x128
@@ -167,8 +167,8 @@ layer at (0,0) size 785x1435
                 RenderSVGText {text} at (56,9) size 8x23 contains 1 chunk(s)
                   RenderSVGInlineText {#text} at (0,0) size 7x23
                     chunk 1 (middle anchor) text run 1 at (56.72,27.00) startOffset 0 endOffset 1 width 6.56: "I"
-          RenderBlock (floating) {div} at (384,704) size 385x192
-            RenderEmbeddedObject {object} at (0,0) size 97x192
+          RenderBlock (floating) {div} at (0,704) size 385x193
+            RenderEmbeddedObject {object} at (0,0) size 97x193
               layer at (0,0) size 96x192
                 RenderView at (0,0) size 96x192
               layer at (0,0) size 96x192
@@ -178,7 +178,7 @@ layer at (0,0) size 785x1435
                       RenderSVGGradientStop {stop} [offset=0.00] [color=#FFFFFF]
                       RenderSVGGradientStop {stop} [offset=1.00] [color=#FFEEAA]
                   RenderSVGRect {rect} at (0,0) size 96x192 [stroke={[type=SOLID] [color=#FFCC33] [stroke width=2.00]}] [fill={[type=LINEAR-GRADIENT] [id="surface"]}] [x=1.00] [y=1.00] [width=28.00] [height=58.00]
-            RenderEmbeddedObject {object} at (96,0) size 289x192
+            RenderEmbeddedObject {object} at (96,0) size 289x193
               layer at (0,0) size 288x192
                 RenderView at (0,0) size 288x192
               layer at (0,0) size 288x192
@@ -191,8 +191,8 @@ layer at (0,0) size 785x1435
                   RenderSVGText {text} at (37,19) size 16x23 contains 1 chunk(s)
                     RenderSVGInlineText {#text} at (0,0) size 15x23
                       chunk 1 (middle anchor) text run 1 at (37.81,37.00) startOffset 0 endOffset 1 width 14.38: "G"
-          RenderBlock (floating) {div} at (0,896) size 385x192
-            RenderEmbeddedObject {object} at (0,0) size 193x192
+          RenderBlock (floating) {div} at (384,704) size 385x193
+            RenderEmbeddedObject {object} at (0,0) size 193x193
               layer at (0,0) size 192x192
                 RenderView at (0,0) size 192x192
               layer at (0,0) size 192x192
@@ -205,7 +205,7 @@ layer at (0,0) size 785x1435
                   RenderSVGText {text} at (22,19) size 16x23 contains 1 chunk(s)
                     RenderSVGInlineText {#text} at (0,0) size 15x23
                       chunk 1 (middle anchor) text run 1 at (22.81,37.00) startOffset 0 endOffset 1 width 14.38: "H"
-            RenderEmbeddedObject {object} at (192,0) size 193x192
+            RenderEmbeddedObject {object} at (192,0) size 193x193
               layer at (0,0) size 192x192
                 RenderView at (0,0) size 192x192
               layer at (0,0) size 192x192
@@ -218,7 +218,7 @@ layer at (0,0) size 785x1435
                   RenderSVGText {text} at (23,19) size 14x23 contains 1 chunk(s)
                     RenderSVGInlineText {#text} at (0,0) size 14x23
                       chunk 1 (middle anchor) text run 1 at (23.28,37.00) startOffset 0 endOffset 1 width 13.44: "R"
-          RenderEmbeddedObject {object} at (384,896) size 193x128
+          RenderEmbeddedObject {object} at (0,896) size 193x129
             layer at (0,0) size 192x128
               RenderView at (0,0) size 192x128
             layer at (0,0) size 192x128
@@ -228,7 +228,7 @@ layer at (0,0) size 785x1435
                     RenderSVGGradientStop {stop} [offset=0.00] [color=#FFFFFF]
                     RenderSVGGradientStop {stop} [offset=1.00] [color=#FFEEAA]
                 RenderSVGEllipse {ellipse} at (0,0) size 192x128 [stroke={[type=SOLID] [color=#FFCC33] [stroke width=2.00]}] [fill={[type=LINEAR-GRADIENT] [id="surface"]}] [cx=30.00] [cy=20.00] [rx=29.00] [ry=19.00]
-          RenderEmbeddedObject {object} at (576,896) size 193x128
+          RenderEmbeddedObject {object} at (192,896) size 193x129
             layer at (0,0) size 192x128
               RenderView at (0,0) size 192x128
             layer at (0,0) size 192x128
@@ -238,8 +238,8 @@ layer at (0,0) size 785x1435
                     RenderSVGGradientStop {stop} [offset=0.00] [color=#FFFFFF]
                     RenderSVGGradientStop {stop} [offset=1.00] [color=#FFEEAA]
                 RenderSVGEllipse {ellipse} at (0,0) size 192x128 [stroke={[type=SOLID] [color=#FFCC33] [stroke width=2.00]}] [fill={[type=LINEAR-GRADIENT] [id="surface"]}] [cx=30.00] [cy=20.00] [rx=29.00] [ry=19.00]
-          RenderBlock (floating) {div} at (384,1024) size 385x128
-            RenderEmbeddedObject {object} at (0,0) size 289x128
+          RenderBlock (floating) {div} at (384,896) size 385x129
+            RenderEmbeddedObject {object} at (0,0) size 289x129
               layer at (0,0) size 288x128
                 RenderView at (0,0) size 288x128
               layer at (0,0) size 288x128
@@ -252,7 +252,7 @@ layer at (0,0) size 785x1435
                   RenderSVGText {text} at (39,9) size 12x23 contains 1 chunk(s)
                     RenderSVGInlineText {#text} at (0,0) size 12x23
                       chunk 1 (middle anchor) text run 1 at (39.38,27.00) startOffset 0 endOffset 1 width 11.25: "S"
-            RenderEmbeddedObject {object} at (288,0) size 97x128
+            RenderEmbeddedObject {object} at (288,0) size 97x129
               layer at (0,0) size 96x128
                 RenderView at (0,0) size 96x128
               layer at (0,0) size 96x128
@@ -265,40 +265,36 @@ layer at (0,0) size 785x1435
                   RenderSVGText {text} at (8,9) size 14x23 contains 1 chunk(s)
                     RenderSVGInlineText {#text} at (0,0) size 13x23
                       chunk 1 (middle anchor) text run 1 at (8.91,27.00) startOffset 0 endOffset 1 width 12.19: "T"
-        RenderBlock {p} at (0,119) size 769x595 [color=#FFFFFF]
+        RenderBlock {p} at (0,119) size 769x1043 [color=#FFFFFF]
           RenderBR {br} at (769,0) size 0x17
-          RenderText {#text} at (640,576) size 9x17
-            text run at (640,576) width 9: ".."
-        RenderBlock {p} at (0,729) size 769x579
-          RenderText {#text} at (640,0) size 768x577
-            text run at (640,0) width 122: "Above, you should"
-            text run at (640,18) width 98: "see a grid of 17"
-            text run at (640,36) width 128: "SVG child elements"
-            text run at (640,54) width 116: "sticked together to"
-            text run at (640,72) width 121: "build one rectangle"
-            text run at (0,542) width 33: "grid. "
-            text run at (33,542) width 718: "You should be able to resize your browser window and the grid rendering should adjust to it. The outcome should"
-            text run at (0,560) width 239: "look like in these sample screenshots: "
+          RenderText {#text} at (0,1024) size 8x17
+            text run at (0,1024) width 8: ".."
+        RenderBlock {p} at (0,1177) size 769x55
+          RenderText {#text} at (0,0) size 756x53
+            text run at (0,0) width 633: "Above, you should see a grid of 17 SVG child elements sticked together to build one rectangle grid. "
+            text run at (633,0) width 123: "You should be able"
+            text run at (0,18) width 750: "to resize your browser window and the grid rendering should adjust to it. The outcome should look like in these sample"
+            text run at (0,36) width 80: "screenshots: "
           RenderInline {a} at (0,0) size 33x17 [color=#0000EE]
-            RenderText {#text} at (239,560) size 33x17
-              text run at (239,560) width 33: "small"
-          RenderText {#text} at (272,560) size 8x17
-            text run at (272,560) width 8: ", "
+            RenderText {#text} at (80,36) size 33x17
+              text run at (80,36) width 33: "small"
+          RenderText {#text} at (113,36) size 8x17
+            text run at (113,36) width 8: ", "
           RenderInline {a} at (0,0) size 40x17 [color=#0000EE]
-            RenderText {#text} at (280,560) size 40x17
-              text run at (280,560) width 40: "bigger"
-          RenderText {#text} at (320,560) size 31x17
-            text run at (320,560) width 31: " and "
+            RenderText {#text} at (121,36) size 40x17
+              text run at (121,36) width 40: "bigger"
+          RenderText {#text} at (161,36) size 31x17
+            text run at (161,36) width 31: " and "
           RenderInline {a} at (0,0) size 20x17 [color=#0000EE]
-            RenderText {#text} at (351,560) size 20x17
-              text run at (351,560) width 20: "big"
-          RenderText {#text} at (371,560) size 4x17
-            text run at (371,560) width 4: "."
-        RenderBlock {p} at (0,1323) size 769x37
+            RenderText {#text} at (192,36) size 20x17
+              text run at (192,36) width 20: "big"
+          RenderText {#text} at (212,36) size 4x17
+            text run at (212,36) width 4: "."
+        RenderBlock {p} at (0,1247) size 769x37
           RenderText {#text} at (0,0) size 750x35
             text run at (0,0) width 750: "The test is successful, if all SVG elements resize exacly dependend on the width of the browser window, but keep their"
             text run at (0,18) width 622: "aspect ratio and relative position. The complete grid should always show a perfect rectangle object."
-        RenderBlock {p} at (0,1375) size 769x37
+        RenderBlock {p} at (0,1299) size 769x37
           RenderBR {br} at (0,0) size 0x17
           RenderInline {a} at (0,0) size 33x17 [color=#0000EE]
             RenderText {#text} at (0,18) size 33x17

--- a/LayoutTests/platform/wpe/svg/wicd/test-rightsizing-b-expected.txt
+++ b/LayoutTests/platform/wpe/svg/wicd/test-rightsizing-b-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 785x848
           RenderText {#text} at (0,0) size 138x16
             text run at (0,0) width 138: "WICD Core 1.0 #20-2"
         RenderBlock (anonymous) at (0,66) size 738x300
-          RenderEmbeddedObject {object} at (0,0) size 296x295 [bgcolor=#FF0000]
+          RenderEmbeddedObject {object} at (0,0) size 296x296 [bgcolor=#FF0000]
             layer at (0,0) size 295x295
               RenderView at (0,0) size 295x295
             layer at (0,0) size 295x295
@@ -75,7 +75,7 @@ layer at (0,0) size 785x848
           RenderText {#text} at (0,48) size 373x15
             text run at (0,48) width 373: "Beyond there is the same, only with PNG images instead of SVG."
         RenderBlock (anonymous) at (0,437) size 738x300
-          RenderImage {object} at (0,0) size 296x295 [bgcolor=#FF0000]
+          RenderImage {object} at (0,0) size 296x296 [bgcolor=#FF0000]
           RenderText {#text} at (295,281) size 5x17
             text run at (295,281) width 5: " "
           RenderImage {object} at (299,147) size 148x148 [bgcolor=#FF0000]

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug1188-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug1188-expected.txt
@@ -12,61 +12,61 @@ layer at (0,0) size 800x600
                 RenderImage {IMG} at (7,1) size 580x42
                 RenderText {#text} at (0,0) size 0x0
             RenderTableRow {TR} at (0,48) size 600x55
-              RenderTableCell {TD} at (2,49) size 595x53 [bgcolor=#99CCCC] [r=1 c=0 rs=1 cs=3]
+              RenderTableCell {TD} at (2,51) size 595x49 [bgcolor=#99CCCC] [r=1 c=0 rs=1 cs=3]
                 RenderInline {FONT} at (0,0) size 128x16
                   RenderInline {B} at (0,0) size 128x16
-                    RenderText {#text} at (24,10) size 128x17
-                      text run at (24,11) width 128: "Search the Web with"
-                RenderText {#text} at (151,8) size 5x19
-                  text run at (151,9) width 5: " "
-                RenderMenuList {SELECT} at (157,3) size 87x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+                    RenderText {#text} at (30,8) size 128x17
+                      text run at (30,9) width 128: "Search the Web with"
+                RenderText {#text} at (157,6) size 5x19
+                  text run at (157,7) width 5: " "
+                RenderMenuList {SELECT} at (161,1) size 87x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
                   RenderBlock (anonymous) at (1,1) size 84x28
                     RenderText at (5,5) size 58x17
                       text run at (5,5) width 58: "Netscape"
-                RenderTextControl {INPUT} at (247,6) size 254x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-                RenderText {#text} at (502,8) size 5x19
-                  text run at (502,9) width 5: " "
-                RenderButton {INPUT} at (508,5) size 60x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+                RenderTextControl {INPUT} at (247,4) size 254x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                RenderText {#text} at (500,6) size 5x19
+                  text run at (500,7) width 5: " "
+                RenderButton {INPUT} at (504,3) size 60x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,4) size 43x18
                     RenderText at (0,0) size 43x17
                       text run at (0,0) width 43: "Search"
-                RenderBR {BR} at (569,8) size 1x19
+                RenderBR {BR} at (563,6) size 1x19
                 RenderInline {SMALL} at (0,0) size 561x16
                   RenderInline {A} at (0,0) size 99x16 [color=#0000EE]
-                    RenderText {#text} at (17,34) size 99x17
-                      text run at (17,35) width 99: "Classifieds< /A>   "
+                    RenderText {#text} at (17,30) size 99x17
+                      text run at (17,31) width 99: "Classifieds< /A>   "
                   RenderInline {A} at (0,0) size 59x16 [color=#0000EE]
-                    RenderText {#text} at (115,34) size 59x17
-                      text run at (115,35) width 23: "Net "
-                      text run at (137,35) width 37: "Search"
-                  RenderText {#text} at (173,34) size 10x17
-                    text run at (173,35) width 10: "   "
+                    RenderText {#text} at (115,30) size 59x17
+                      text run at (115,31) width 23: "Net "
+                      text run at (137,31) width 37: "Search"
+                  RenderText {#text} at (173,30) size 10x17
+                    text run at (173,31) width 10: "   "
                   RenderInline {A} at (0,0) size 83x16 [color=#0000EE]
-                    RenderText {#text} at (182,34) size 83x17
-                      text run at (182,35) width 57: "Find Web "
-                      text run at (238,35) width 27: "Sites"
-                  RenderText {#text} at (264,34) size 10x17
-                    text run at (264,35) width 4: " "
-                    text run at (267,35) width 7: "  "
+                    RenderText {#text} at (182,30) size 83x17
+                      text run at (182,31) width 57: "Find Web "
+                      text run at (238,31) width 27: "Sites"
+                  RenderText {#text} at (264,30) size 10x17
+                    text run at (264,31) width 4: " "
+                    text run at (267,31) width 7: "  "
                   RenderInline {A} at (0,0) size 67x16 [color=#0000EE]
-                    RenderText {#text} at (273,34) size 67x17
-                      text run at (273,35) width 40: "What's "
-                      text run at (312,35) width 28: "Cool"
-                  RenderText {#text} at (339,34) size 10x17
-                    text run at (339,35) width 10: "   "
+                    RenderText {#text} at (273,30) size 67x17
+                      text run at (273,31) width 40: "What's "
+                      text run at (312,31) width 28: "Cool"
+                  RenderText {#text} at (339,30) size 10x17
+                    text run at (339,31) width 10: "   "
                   RenderInline {A} at (0,0) size 64x16 [color=#0000EE]
-                    RenderText {#text} at (348,34) size 64x17
-                      text run at (348,35) width 64: "What's New"
-                  RenderText {#text} at (411,34) size 10x17
-                    text run at (411,35) width 10: "   "
+                    RenderText {#text} at (348,30) size 64x17
+                      text run at (348,31) width 64: "What's New"
+                  RenderText {#text} at (411,30) size 10x17
+                    text run at (411,31) width 10: "   "
                   RenderInline {A} at (0,0) size 76x16 [color=#0000EE]
-                    RenderText {#text} at (420,34) size 76x17
-                      text run at (420,35) width 76: "People Finder"
-                  RenderText {#text} at (495,34) size 10x17
-                    text run at (495,35) width 10: "   "
+                    RenderText {#text} at (420,30) size 76x17
+                      text run at (420,31) width 76: "People Finder"
+                  RenderText {#text} at (495,30) size 10x17
+                    text run at (495,31) width 10: "   "
                   RenderInline {A} at (0,0) size 74x16 [color=#0000EE]
-                    RenderText {#text} at (504,34) size 74x17
-                      text run at (504,35) width 74: "Yellow Pages"
+                    RenderText {#text} at (504,30) size 74x17
+                      text run at (504,31) width 74: "Yellow Pages"
                   RenderText {#text} at (0,0) size 0x0
                 RenderText {#text} at (0,0) size 0x0
             RenderTableRow {TR} at (0,105) size 600x48

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug12384-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug12384-expected.txt
@@ -1,26 +1,26 @@
-layer at (0,0) size 809x585
-  RenderView at (0,0) size 800x585
-layer at (0,0) size 800x585
-  RenderBlock {HTML} at (0,0) size 800x585
-    RenderBody {BODY} at (8,8) size 784x561
-      RenderBlock {FORM} at (0,0) size 784x32
-        RenderTable {TABLE} at (0,0) size 801x32 [bgcolor=#FFE030] [border: (1px outset #808080)]
-          RenderTableSection {TBODY} at (1,1) size 799x30
-            RenderTableRow {TR} at (0,0) size 799x30
-              RenderTableCell {TD} at (0,0) size 799x30 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                RenderInline {NOBR} at (0,0) size 797x17
-                  RenderTextControl {INPUT} at (3,3) size 253x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-                  RenderText {#text} at (258,6) size 13x17
-                    text run at (258,6) width 13: " - "
-                  RenderTextControl {INPUT} at (273,3) size 253x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-                  RenderText {#text} at (528,6) size 13x17
-                    text run at (528,6) width 13: " - "
-                  RenderTextControl {INPUT} at (543,3) size 253x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x576
+      RenderBlock {FORM} at (0,0) size 784x28
+        RenderTable {TABLE} at (0,0) size 789x28 [bgcolor=#FFE030] [border: (1px outset #808080)]
+          RenderTableSection {TBODY} at (1,1) size 787x26
+            RenderTableRow {TR} at (0,0) size 787x26
+              RenderTableCell {TD} at (0,0) size 787x26 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                RenderInline {NOBR} at (0,0) size 785x17
+                  RenderTextControl {INPUT} at (1,1) size 253x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                  RenderText {#text} at (254,4) size 13x17
+                    text run at (254,4) width 13: " - "
+                  RenderTextControl {INPUT} at (267,1) size 253x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                  RenderText {#text} at (520,4) size 13x17
+                    text run at (520,4) width 13: " - "
+                  RenderTextControl {INPUT} at (533,1) size 253x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                 RenderText {#text} at (0,0) size 0x0
-            RenderTableRow {TR} at (0,30) size 799x0
-layer at (15,15) size 247x18
+            RenderTableRow {TR} at (0,26) size 787x0
+layer at (13,13) size 247x18
   RenderBlock {DIV} at (3,3) size 247x18
-layer at (285,15) size 247x18
+layer at (279,13) size 247x18
   RenderBlock {DIV} at (3,3) size 247x18
-layer at (555,15) size 247x18
+layer at (545,13) size 247x18
   RenderBlock {DIV} at (3,3) size 247x18

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug1318-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug1318-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 784x147
-        RenderTableSection {TBODY} at (0,0) size 784x147
+      RenderTable {TABLE} at (0,0) size 784x143
+        RenderTableSection {TBODY} at (0,0) size 784x143
           RenderTableRow {TR} at (0,0) size 784x74
             RenderTableCell {TD} at (0,0) size 785x74 [r=0 c=0 rs=1 cs=4]
               RenderBR {BR} at (392,1) size 1x17
@@ -18,31 +18,31 @@ layer at (0,0) size 800x600
                 RenderBR {BR} at (392,55) size 1x17
               RenderText {#text} at (0,0) size 0x0
           RenderTableRow {TR} at (0,74) size 784x20
-            RenderTableCell {TD} at (0,75) size 548x18 [r=1 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,75) size 558x18 [r=1 c=0 rs=1 cs=1]
               RenderInline {FONT} at (0,0) size 141x16
-                RenderText {#text} at (406,0) size 141x17
-                  text run at (406,1) width 141: "I agree with the program"
+                RenderText {#text} at (416,0) size 141x17
+                  text run at (416,1) width 141: "I agree with the program"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (547,74) size 64x20 [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (557,74) size 66x20 [r=1 c=1 rs=1 cs=1]
               RenderBlock {INPUT} at (3,4) size 12x12
           RenderTableRow {TR} at (0,94) size 784x20
-            RenderTableCell {TD} at (0,95) size 548x18 [r=2 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,95) size 558x18 [r=2 c=0 rs=1 cs=1]
               RenderInline {FONT} at (0,0) size 154x16
-                RenderText {#text} at (393,0) size 154x17
-                  text run at (393,1) width 154: "I think vouchers are wrong"
+                RenderText {#text} at (403,0) size 154x17
+                  text run at (403,1) width 154: "I think vouchers are wrong"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (547,94) size 64x20 [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (557,94) size 66x20 [r=2 c=1 rs=1 cs=1]
               RenderBlock {INPUT} at (3,4) size 12x12
-          RenderTableRow {TR} at (0,114) size 784x33
-            RenderTableCell {TD} at (0,122) size 611x17 [r=3 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,114) size 784x29
+            RenderTableCell {TD} at (0,120) size 623x17 [r=3 c=0 rs=1 cs=2]
               RenderInline {A} at (0,0) size 77x17 [color=#0000EE]
                 RenderInline {FONT} at (0,0) size 77x15
-                  RenderText {#text} at (267,1) size 77x15
-                    text run at (267,1) width 77: "View Results"
+                  RenderText {#text} at (273,1) size 77x15
+                    text run at (273,1) width 77: "View Results"
               RenderInline {FONT} at (0,0) size 0x15
                 RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (610,114) size 175x33 [r=3 c=2 rs=1 cs=2]
-              RenderButton {INPUT} at (65,3) size 44x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+            RenderTableCell {TD} at (622,114) size 163x29 [r=3 c=2 rs=1 cs=2]
+              RenderButton {INPUT} at (59,1) size 44x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (8,4) size 27x18
                   RenderText at (0,0) size 27x17
                     text run at (0,0) width 27: "vote"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug138725-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug138725-expected.txt
@@ -3,32 +3,32 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 179x65
-        RenderTableSection {TBODY} at (0,0) size 179x65
-          RenderTableRow {TR} at (0,2) size 179x61
-            RenderTableCell {TD} at (2,2) size 175x61 [r=0 c=0 rs=1 cs=1]
-              RenderBlock (anonymous) at (1,1) size 173x0
+      RenderTable {TABLE} at (0,0) size 175x61
+        RenderTableSection {TBODY} at (0,0) size 175x61
+          RenderTableRow {TR} at (0,2) size 175x57
+            RenderTableCell {TD} at (2,2) size 171x57 [r=0 c=0 rs=1 cs=1]
+              RenderBlock (anonymous) at (1,1) size 169x0
                 RenderInline {SPAN} at (0,0) size 0x0
                   RenderText {#text} at (0,0) size 0x0
                   RenderInline {SPAN} at (0,0) size 0x0
                     RenderText {#text} at (0,0) size 0x0
                     RenderText {#text} at (0,0) size 0x0
-              RenderBlock (anonymous) at (1,1) size 173x59
-                RenderTable {TABLE} at (0,0) size 173x59
-                  RenderTableSection {TBODY} at (0,0) size 173x59
-                    RenderTableRow {TR} at (0,2) size 173x55
-                      RenderTableCell {TD} at (2,2) size 169x55 [r=0 c=0 rs=1 cs=1]
-                        RenderTable {TABLE} at (1,1) size 167x53
-                          RenderTableSection {TBODY} at (0,0) size 167x53
-                            RenderTableRow {TR} at (0,2) size 167x49
-                              RenderTableCell {TD} at (2,2) size 163x49 [r=0 c=0 rs=1 cs=1]
-                                RenderBlock {FORM} at (1,1) size 161x31
-                                  RenderButton {INPUT} at (2,2) size 157x27 [color=#2E3436] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+              RenderBlock (anonymous) at (1,1) size 169x55
+                RenderTable {TABLE} at (0,0) size 169x55
+                  RenderTableSection {TBODY} at (0,0) size 169x55
+                    RenderTableRow {TR} at (0,2) size 169x51
+                      RenderTableCell {TD} at (2,2) size 165x51 [r=0 c=0 rs=1 cs=1]
+                        RenderTable {TABLE} at (1,1) size 163x49
+                          RenderTableSection {TBODY} at (0,0) size 163x49
+                            RenderTableRow {TR} at (0,2) size 163x45
+                              RenderTableCell {TD} at (2,2) size 159x45 [r=0 c=0 rs=1 cs=1]
+                                RenderBlock {FORM} at (1,1) size 157x27
+                                  RenderButton {INPUT} at (0,0) size 157x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                                     RenderBlock (anonymous) at (8,4) size 141x18
                                       RenderText at (0,0) size 141x17
                                         text run at (0,0) width 141: "ApplyForThisPosition"
                                   RenderText {#text} at (0,0) size 0x0
-              RenderBlock (anonymous) at (1,60) size 173x0
+              RenderBlock (anonymous) at (1,56) size 169x0
                 RenderInline {SPAN} at (0,0) size 0x0
                   RenderInline {SPAN} at (0,0) size 0x0
                   RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug1430-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug1430-expected.txt
@@ -40,7 +40,7 @@ layer at (0,0) size 800x600
                               RenderImage {IMG} at (1,45) size 4x1
                               RenderImage {IMG} at (5,6) size 436x35
                               RenderText {#text} at (0,0) size 0x0
-                              RenderInline {MAP} at (0,0) size 0x0
+                              RenderInline {MAP} at (0,0) size 0x17
                                 RenderText {#text} at (0,0) size 0x0
                                 RenderText {#text} at (0,0) size 0x0
                                 RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug14929-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug14929-expected.txt
@@ -28,7 +28,7 @@ layer at (0,0) size 800x600
           RenderTableSection {TBODY} at (1,1) size 638x50
             RenderTableRow {TR} at (0,2) size 638x22
               RenderTableCell {TD} at (2,2) size 635x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=2]
-                RenderImage {IMG} at (2,2) size 190x18
+                RenderImage {IMG} at (2,2) size 190x19
             RenderTableRow {TR} at (0,26) size 638x22
               RenderTableCell {TD} at (2,26) size 127x22 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 58x17

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug18359-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug18359-expected.txt
@@ -7,38 +7,38 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 365x26
           text run at (0,0) width 365: "SeaMonkey XPInstall Trigger Page"
       RenderBlock {HR} at (0,46) size 784x3 [border: (1px inset #000000)]
-      RenderBlock {FORM} at (0,56) size 784x76
-        RenderTable {TABLE} at (0,0) size 754x75
-          RenderTableSection {TBODY} at (0,0) size 754x75
-            RenderTableRow {TR} at (0,2) size 754x33
-              RenderTableCell {TD} at (2,8) size 107x21 [r=0 c=0 rs=1 cs=1]
+      RenderBlock {FORM} at (0,56) size 784x68
+        RenderTable {TABLE} at (0,0) size 746x67
+          RenderTableSection {TBODY} at (0,0) size 746x67
+            RenderTableRow {TR} at (0,2) size 746x29
+              RenderTableCell {TD} at (2,6) size 107x21 [r=0 c=0 rs=1 cs=1]
                 RenderInline {B} at (0,0) size 96x18
                   RenderText {#text} at (1,0) size 96x19
                     text run at (1,1) width 96: "Trigger URL:"
-              RenderTableCell {TD} at (111,3) size 539x31 [r=0 c=1 rs=1 cs=1]
-                RenderTextControl {INPUT} at (3,3) size 533x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-              RenderTableCell {TD} at (652,2) size 100x33 [r=0 c=2 rs=1 cs=1]
-                RenderButton {INPUT} at (3,3) size 63x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+              RenderTableCell {TD} at (111,3) size 535x27 [r=0 c=1 rs=1 cs=1]
+                RenderTextControl {INPUT} at (1,1) size 533x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+              RenderTableCell {TD} at (648,2) size 96x29 [r=0 c=2 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 63x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,4) size 47x18
                     RenderText at (0,0) size 47x17
                       text run at (0,0) width 47: "Trigger"
-            RenderTableRow {TR} at (0,37) size 754x36
-              RenderTableCell {TD} at (2,45) size 107x20 [r=1 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,33) size 746x32
+              RenderTableCell {TD} at (2,39) size 107x20 [r=1 c=0 rs=1 cs=1]
                 RenderInline {B} at (0,0) size 105x17
                   RenderText {#text} at (1,1) size 105x17
                     text run at (1,1) width 105: "Run Test Case:"
-              RenderTableCell {TD} at (111,37) size 539x36 [r=1 c=1 rs=1 cs=1]
-                RenderMenuList {SELECT} at (3,3) size 303x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+              RenderTableCell {TD} at (111,33) size 535x32 [r=1 c=1 rs=1 cs=1]
+                RenderMenuList {SELECT} at (1,1) size 303x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
                   RenderBlock (anonymous) at (1,1) size 301x28
                     RenderText at (5,5) size 84x17
                       text run at (5,5) width 84: "a_abortinstall"
                 RenderText {#text} at (0,0) size 0x0
-              RenderTableCell {TD} at (652,38) size 100x34 [r=1 c=2 rs=1 cs=1]
-                RenderButton {INPUT} at (3,3) size 94x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+              RenderTableCell {TD} at (648,34) size 96x30 [r=1 c=2 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 94x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,4) size 78x18
                     RenderText at (0,0) size 78x17
                       text run at (0,0) width 78: "Trigger case"
-layer at (125,74) size 527x18
+layer at (123,72) size 527x18
   RenderBlock {DIV} at (3,3) size 527x18
     RenderText {#text} at (0,0) size 110x17
       text run at (0,0) width 110: "http://jimbob/jars/"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug194024-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug194024-expected.txt
@@ -1,146 +1,146 @@
-layer at (0,0) size 785x632
-  RenderView at (0,0) size 785x600
-layer at (0,0) size 785x632
-  RenderBlock {HTML} at (0,0) size 785x632
-    RenderBody {BODY} at (8,8) size 769x616
-      RenderBlock (anonymous) at (0,0) size 769x18
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 285x17
           text run at (0,0) width 285: "border=\"0\" cellspacing=\"0\" cellpadding=\"0\""
-      RenderTable {TABLE} at (0,18) size 769x46 [bgcolor=#DDDD33]
-        RenderTableSection {TBODY} at (0,0) size 769x46
-          RenderTableRow {TR} at (0,0) size 769x46
-            RenderTableCell {TD} at (0,23) size 12x0 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (12,0) size 745x46 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (757,23) size 12x0 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,64) size 769x18
+      RenderTable {TABLE} at (0,18) size 784x42 [bgcolor=#DDDD33]
+        RenderTableSection {TBODY} at (0,0) size 784x42
+          RenderTableRow {TR} at (0,0) size 784x42
+            RenderTableCell {TD} at (0,21) size 12x0 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (12,0) size 760x42 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (772,21) size 12x0 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,60) size 784x18
         RenderText {#text} at (0,0) size 209x17
           text run at (0,0) width 209: "cellspacing=\"0\" cellpadding=\"0\""
-      RenderTable {TABLE} at (0,82) size 769x46 [bgcolor=#CCCCFF]
-        RenderTableSection {TBODY} at (0,0) size 769x46
-          RenderTableRow {TR} at (0,0) size 769x46
-            RenderTableCell {TD} at (0,23) size 12x0 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (12,0) size 745x46 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (757,23) size 12x0 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,128) size 769x18
+      RenderTable {TABLE} at (0,78) size 784x42 [bgcolor=#CCCCFF]
+        RenderTableSection {TBODY} at (0,0) size 784x42
+          RenderTableRow {TR} at (0,0) size 784x42
+            RenderTableCell {TD} at (0,21) size 12x0 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (12,0) size 760x42 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (772,21) size 12x0 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,120) size 784x18
         RenderText {#text} at (0,0) size 104x17
           text run at (0,0) width 104: "cellpadding=\"0\""
-      RenderTable {TABLE} at (0,146) size 769x50 [bgcolor=#FF9999]
-        RenderTableSection {TBODY} at (0,0) size 769x50
-          RenderTableRow {TR} at (0,2) size 769x46
-            RenderTableCell {TD} at (2,25) size 12x0 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (16,2) size 737x46 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (755,25) size 12x0 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,196) size 769x18
+      RenderTable {TABLE} at (0,138) size 784x46 [bgcolor=#FF9999]
+        RenderTableSection {TBODY} at (0,0) size 784x46
+          RenderTableRow {TR} at (0,2) size 784x42
+            RenderTableCell {TD} at (2,23) size 12x0 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (16,2) size 752x42 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (770,23) size 12x0 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,184) size 784x18
         RenderText {#text} at (0,0) size 180x17
           text run at (0,0) width 180: "border=\"0\" cellpadding=\"0\""
-      RenderTable {TABLE} at (0,214) size 769x50 [bgcolor=#AAEEBB]
-        RenderTableSection {TBODY} at (0,0) size 769x50
-          RenderTableRow {TR} at (0,2) size 769x46
-            RenderTableCell {TD} at (2,25) size 12x0 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (16,2) size 737x46 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (755,25) size 12x0 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,264) size 769x18
+      RenderTable {TABLE} at (0,202) size 784x46 [bgcolor=#AAEEBB]
+        RenderTableSection {TBODY} at (0,0) size 784x46
+          RenderTableRow {TR} at (0,2) size 784x42
+            RenderTableCell {TD} at (2,23) size 12x0 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (16,2) size 752x42 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (770,23) size 12x0 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,248) size 784x18
         RenderInline {FONT} at (0,0) size 29x17 [color=#0000FF]
           RenderText {#text} at (0,0) size 29x17
             text run at (0,0) width 29: "right"
         RenderText {#text} at (29,0) size 76x17
           text run at (29,0) width 76: " border=\"0\""
-      RenderTable {TABLE} at (0,282) size 769x52 [bgcolor=#FFCCEE]
-        RenderTableSection {TBODY} at (0,0) size 769x52
-          RenderTableRow {TR} at (0,2) size 769x48
-            RenderTableCell {TD} at (2,25) size 14x2 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (18,2) size 733x48 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (753,25) size 14x2 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,334) size 769x18
+      RenderTable {TABLE} at (0,266) size 784x48 [bgcolor=#FFCCEE]
+        RenderTableSection {TBODY} at (0,0) size 784x48
+          RenderTableRow {TR} at (0,2) size 784x44
+            RenderTableCell {TD} at (2,23) size 14x2 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (18,2) size 748x44 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (768,23) size 14x2 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,314) size 784x18
         RenderInline {FONT} at (0,0) size 29x17 [color=#0000FF]
           RenderText {#text} at (0,0) size 29x17
             text run at (0,0) width 29: "right"
         RenderText {#text} at (29,0) size 108x17
           text run at (29,0) width 108: " cellpadding=\"1\""
-      RenderTable {TABLE} at (0,352) size 769x52 [bgcolor=#66DDFF]
-        RenderTableSection {TBODY} at (0,0) size 769x52
-          RenderTableRow {TR} at (0,2) size 769x48
-            RenderTableCell {TD} at (2,25) size 14x2 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (18,2) size 733x48 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (753,25) size 14x2 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,404) size 769x18
+      RenderTable {TABLE} at (0,332) size 784x48 [bgcolor=#66DDFF]
+        RenderTableSection {TBODY} at (0,0) size 784x48
+          RenderTableRow {TR} at (0,2) size 784x44
+            RenderTableCell {TD} at (2,23) size 14x2 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (18,2) size 748x44 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (768,23) size 14x2 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,380) size 784x18
         RenderInline {FONT} at (0,0) size 29x17 [color=#0000FF]
           RenderText {#text} at (0,0) size 29x17
             text run at (0,0) width 29: "right"
         RenderText {#text} at (29,0) size 289x17
           text run at (29,0) width 289: " border=\"1\" cellspacing=\"0\" cellpadding=\"0\""
-      RenderTable {TABLE} at (0,422) size 769x50 [bgcolor=#EEEEEE] [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 767x48
-          RenderTableRow {TR} at (0,0) size 767x48
-            RenderTableCell {TD} at (0,23) size 14x2 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (14,0) size 739x48 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (753,23) size 14x2 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,472) size 769x18
+      RenderTable {TABLE} at (0,398) size 784x46 [bgcolor=#EEEEEE] [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 782x44
+          RenderTableRow {TR} at (0,0) size 782x44
+            RenderTableCell {TD} at (0,21) size 14x2 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (14,0) size 754x44 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (768,21) size 14x2 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,444) size 784x18
         RenderInline {FONT} at (0,0) size 29x17 [color=#0000FF]
           RenderText {#text} at (0,0) size 29x17
             text run at (0,0) width 29: "right"
         RenderText {#text} at (29,0) size 181x17
           text run at (29,0) width 181: " border=\"1\" cellspacing=\"0\""
-      RenderTable {TABLE} at (0,490) size 769x52 [bgcolor=#FFCC66] [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 767x50
-          RenderTableRow {TR} at (0,0) size 767x50
-            RenderTableCell {TD} at (0,23) size 16x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (16,0) size 735x50 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (751,23) size 16x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,542) size 769x18
+      RenderTable {TABLE} at (0,462) size 784x48 [bgcolor=#FFCC66] [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 782x46
+          RenderTableRow {TR} at (0,0) size 782x46
+            RenderTableCell {TD} at (0,21) size 16x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (16,0) size 750x46 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (766,21) size 16x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,510) size 784x18
         RenderInline {FONT} at (0,0) size 29x17 [color=#0000FF]
           RenderText {#text} at (0,0) size 29x17
             text run at (0,0) width 29: "right"
         RenderText {#text} at (29,0) size 76x17
           text run at (29,0) width 76: " border=\"1\""
-      RenderTable {TABLE} at (0,560) size 769x56 [bgcolor=#CCFF33] [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 767x54
-          RenderTableRow {TR} at (0,2) size 767x50
-            RenderTableCell {TD} at (2,25) size 16x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (20,2) size 727x50 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (749,25) size 16x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
-layer at (20,28) size 745x42 clip at (21,29) size 743x40
-  RenderTextControl {TEXTAREA} at (0,2) size 745x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 739x18
+      RenderTable {TABLE} at (0,528) size 784x52 [bgcolor=#CCFF33] [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 782x50
+          RenderTableRow {TR} at (0,2) size 782x46
+            RenderTableCell {TD} at (2,23) size 16x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (20,2) size 742x46 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (764,23) size 16x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
+layer at (20,26) size 760x42 clip at (21,27) size 758x40
+  RenderTextControl {TEXTAREA} at (0,0) size 760x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 754x18
       RenderText {#text} at (0,0) size 21x17
         text run at (0,0) width 21: "test"
-layer at (20,92) size 745x42 clip at (21,93) size 743x40
-  RenderTextControl {TEXTAREA} at (0,2) size 745x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 739x18
+layer at (20,86) size 760x42 clip at (21,87) size 758x40
+  RenderTextControl {TEXTAREA} at (0,0) size 760x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 754x18
       RenderText {#text} at (0,0) size 21x17
         text run at (0,0) width 21: "test"
-layer at (24,158) size 737x42 clip at (25,159) size 735x40
-  RenderTextControl {TEXTAREA} at (0,2) size 737x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 731x18
+layer at (24,148) size 752x42 clip at (25,149) size 750x40
+  RenderTextControl {TEXTAREA} at (0,0) size 752x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 746x18
       RenderText {#text} at (0,0) size 21x17
         text run at (0,0) width 21: "test"
-layer at (24,226) size 737x42 clip at (25,227) size 735x40
-  RenderTextControl {TEXTAREA} at (0,2) size 737x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 731x18
+layer at (24,212) size 752x42 clip at (25,213) size 750x40
+  RenderTextControl {TEXTAREA} at (0,0) size 752x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 746x18
       RenderText {#text} at (0,0) size 21x17
         text run at (0,0) width 21: "test"
-layer at (27,295) size 731x42 clip at (28,296) size 729x40
-  RenderTextControl {TEXTAREA} at (1,3) size 731x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 725x18
+layer at (27,277) size 746x42 clip at (28,278) size 744x40
+  RenderTextControl {TEXTAREA} at (1,1) size 746x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 740x18
       RenderText {#text} at (0,0) size 21x17
         text run at (0,0) width 21: "test"
-layer at (27,365) size 731x42 clip at (28,366) size 729x40
-  RenderTextControl {TEXTAREA} at (1,3) size 731x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 725x18
+layer at (27,343) size 746x42 clip at (28,344) size 744x40
+  RenderTextControl {TEXTAREA} at (1,1) size 746x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 740x18
       RenderText {#text} at (0,0) size 21x17
         text run at (0,0) width 21: "test"
-layer at (24,434) size 737x42 clip at (25,435) size 735x40
-  RenderTextControl {TEXTAREA} at (1,3) size 737x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 731x18
+layer at (24,408) size 752x42 clip at (25,409) size 750x40
+  RenderTextControl {TEXTAREA} at (1,1) size 752x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 746x18
       RenderText {#text} at (0,0) size 21x17
         text run at (0,0) width 21: "test"
-layer at (27,503) size 731x42 clip at (28,504) size 729x40
-  RenderTextControl {TEXTAREA} at (2,4) size 731x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 725x18
+layer at (27,473) size 746x42 clip at (28,474) size 744x40
+  RenderTextControl {TEXTAREA} at (2,2) size 746x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 740x18
       RenderText {#text} at (0,0) size 21x17
         text run at (0,0) width 21: "test"
-layer at (31,575) size 723x42 clip at (32,576) size 721x40
-  RenderTextControl {TEXTAREA} at (2,4) size 723x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 717x18
+layer at (31,541) size 738x42 clip at (32,542) size 736x40
+  RenderTextControl {TEXTAREA} at (2,2) size 738x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 732x18
       RenderText {#text} at (0,0) size 21x17
         text run at (0,0) width 21: "test"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug24200-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug24200-expected.txt
@@ -3,40 +3,40 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {CENTER} at (0,0) size 784x202
-        RenderTable {TABLE} at (74,0) size 636x202 [border: (1px solid #FF0000)]
-          RenderTableSection {TBODY} at (1,1) size 632x199
-            RenderTableRow {TR} at (0,0) size 632x22
-              RenderTableCell {TD} at (0,0) size 632x22 [border: (2px solid #FF0000)] [r=0 c=0 rs=1 cs=2]
+      RenderBlock {CENTER} at (0,0) size 784x200
+        RenderTable {TABLE} at (76,0) size 632x200 [border: (1px solid #FF0000)]
+          RenderTableSection {TBODY} at (1,1) size 628x197
+            RenderTableRow {TR} at (0,0) size 628x22
+              RenderTableCell {TD} at (0,0) size 628x22 [border: (2px solid #FF0000)] [r=0 c=0 rs=1 cs=2]
                 RenderText {#text} at (3,3) size 177x17
                   text run at (3,3) width 177: "parent table, 1st row, 1st col"
-            RenderTableRow {TR} at (0,22) size 632x177
-              RenderTableCell {TD} at (0,22) size 147x177 [border: (1px solid #FF0000)] [r=1 c=0 rs=1 cs=1]
-                RenderBlock {FORM} at (3,2) size 143x157
-                  RenderTable {TABLE} at (0,0) size 143x157 [border: (1px solid #00FF00)]
-                    RenderTableSection {TBODY} at (1,1) size 140x154
-                      RenderTableRow {TR} at (0,0) size 140x22
-                        RenderTableCell {TD} at (0,0) size 140x22 [border: (2px solid #00FF00)] [r=0 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,22) size 628x175
+              RenderTableCell {TD} at (0,22) size 143x175 [border: (1px solid #FF0000)] [r=1 c=0 rs=1 cs=1]
+                RenderBlock {FORM} at (3,2) size 139x155
+                  RenderTable {TABLE} at (0,0) size 139x155 [border: (1px solid #00FF00)]
+                    RenderTableSection {TBODY} at (1,1) size 136x152
+                      RenderTableRow {TR} at (0,0) size 136x22
+                        RenderTableCell {TD} at (0,0) size 136x22 [border: (2px solid #00FF00)] [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,3) size 23x17
                             text run at (3,3) width 23: "text"
-                      RenderTableRow {TR} at (0,22) size 140x39
-                        RenderTableCell {TD} at (0,22) size 140x39 [border: (1px solid #00FF00)] [r=1 c=0 rs=1 cs=1]
-                          RenderTable {TABLE} at (3,2) size 135x36 [border: (1px solid #FFFF00)]
-                            RenderTableSection {TBODY} at (1,1) size 132x33
-                              RenderTableRow {TR} at (0,0) size 132x33
-                                RenderTableCell {TD} at (0,0) size 109x33 [border: (2px solid #FFFF00)] [r=0 c=0 rs=1 cs=1]
-                                  RenderTextControl {INPUT} at (5,5) size 101x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                      RenderTableRow {TR} at (0,22) size 136x37
+                        RenderTableCell {TD} at (0,22) size 136x37 [border: (1px solid #00FF00)] [r=1 c=0 rs=1 cs=1]
+                          RenderTable {TABLE} at (3,2) size 131x34 [border: (1px solid #FFFF00)]
+                            RenderTableSection {TBODY} at (1,1) size 128x31
+                              RenderTableRow {TR} at (0,0) size 128x31
+                                RenderTableCell {TD} at (0,1) size 105x29 [border: (2px solid #FFFF00)] [r=0 c=0 rs=1 cs=1]
+                                  RenderTextControl {INPUT} at (3,3) size 101x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                                   RenderText {#text} at (0,0) size 0x0
-                                RenderTableCell {TD} at (109,1) size 23x31 [border: (2px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
+                                RenderTableCell {TD} at (105,0) size 23x31 [border: (2px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
                                   RenderImage {INPUT} at (2,7) size 19x18
                                   RenderText {#text} at (0,0) size 0x0
-                      RenderTableRow {TR} at (0,61) size 140x21
-                        RenderTableCell {TD} at (0,61) size 140x21 [border: (1px solid #00FF00)] [r=2 c=0 rs=1 cs=1]
+                      RenderTableRow {TR} at (0,59) size 136x21
+                        RenderTableCell {TD} at (0,59) size 136x21 [border: (1px solid #00FF00)] [r=2 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 23x17
                             text run at (3,2) width 23: "text"
-                      RenderTableRow {TR} at (0,82) size 140x50
-                        RenderTableCell {TD} at (0,82) size 140x50 [border: (1px solid #00FF00)] [r=3 c=0 rs=1 cs=1]
-                          RenderBlock (anonymous) at (3,2) size 135x0
+                      RenderTableRow {TR} at (0,80) size 136x50
+                        RenderTableCell {TD} at (0,80) size 136x50 [border: (1px solid #00FF00)] [r=3 c=0 rs=1 cs=1]
+                          RenderBlock (anonymous) at (3,2) size 131x0
                             RenderInline {FONT} at (0,0) size 0x0
                           RenderTable {TABLE} at (3,2) size 131x47 [border: (1px solid #FF00FF)]
                             RenderTableSection {TBODY} at (1,1) size 128x44
@@ -48,16 +48,16 @@ layer at (0,0) size 800x600
                                 RenderTableCell {TD} at (0,22) size 128x22 [border: (1px solid #FF00FF)] [r=1 c=0 rs=1 cs=1]
                                   RenderText {#text} at (3,2) size 52x17
                                     text run at (3,2) width 52: "problem"
-                      RenderTableRow {TR} at (0,132) size 140x22
-                        RenderTableCell {TD} at (0,132) size 140x22 [border: (1px solid #00FF00)] [r=4 c=0 rs=1 cs=1]
+                      RenderTableRow {TR} at (0,130) size 136x22
+                        RenderTableCell {TD} at (0,130) size 136x22 [border: (1px solid #00FF00)] [r=4 c=0 rs=1 cs=1]
                           RenderText {#text} at (3,2) size 23x17
                             text run at (3,2) width 23: "text"
-              RenderTableCell {TD} at (147,22) size 485x30 [border: (1px solid #FF0000)] [r=1 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (143,22) size 485x30 [border: (1px solid #FF0000)] [r=1 c=1 rs=1 cs=1]
                 RenderTable {TABLE} at (2,2) size 481x26 [border: (1px solid #0000FF)]
                   RenderTableSection {TBODY} at (1,1) size 478x23
                     RenderTableRow {TR} at (0,0) size 478x23
                       RenderTableCell {TD} at (0,0) size 478x23 [border: (2px solid #0000FF)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (3,3) size 47x17
                           text run at (3,3) width 47: "overlap"
-layer at (100,67) size 95x18
+layer at (100,66) size 95x18
   RenderBlock {DIV} at (3,3) size 95x18

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug2479-2-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug2479-2-expected.txt
@@ -41,79 +41,79 @@ layer at (0,0) size 800x548
               text run at (0,39) width 222: "table-row/table-cell problem as "
               text run at (222,39) width 48: "above."
           RenderBlock {P} at (0,64) size 568x62
-            RenderTable {SPAN} at (0,2) size 160x60
-              RenderTableSection (anonymous) at (0,0) size 160x60
-                RenderTableRow {SPAN} at (0,0) size 160x28
-                  RenderTableCell (anonymous) at (0,0) size 160x28 [r=0 c=0 rs=1 cs=1]
+            RenderTable {SPAN} at (0,2) size 141x60
+              RenderTableSection (anonymous) at (0,0) size 141x60
+                RenderTableRow {SPAN} at (0,0) size 141x28
+                  RenderTableCell (anonymous) at (0,0) size 141x28 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (0,6) size 137x16
                       text run at (0,6) width 137: "First Name (required)"
-                RenderTableRow (anonymous) at (0,28) size 160x32
-                  RenderTableCell (anonymous) at (0,28) size 160x32 [r=1 c=0 rs=1 cs=1]
-                    RenderTextControl {INPUT} at (2,4) size 156x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-            RenderText {#text} at (160,7) size 4x17
-              text run at (160,7) width 4: " "
-            RenderTable {SPAN} at (164,2) size 160x60
-              RenderTableSection (anonymous) at (0,0) size 160x60
-                RenderTableRow {SPAN} at (0,0) size 160x28
-                  RenderTableCell (anonymous) at (0,0) size 160x28 [r=0 c=0 rs=1 cs=1]
+                RenderTableRow (anonymous) at (0,28) size 141x32
+                  RenderTableCell (anonymous) at (0,28) size 141x32 [r=1 c=0 rs=1 cs=1]
+                    RenderTextControl {INPUT} at (0,4) size 141x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+            RenderText {#text} at (141,7) size 4x17
+              text run at (141,7) width 4: " "
+            RenderTable {SPAN} at (145,2) size 141x60
+              RenderTableSection (anonymous) at (0,0) size 141x60
+                RenderTableRow {SPAN} at (0,0) size 141x28
+                  RenderTableCell (anonymous) at (0,0) size 141x28 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (0,6) size 136x16
                       text run at (0,6) width 136: "Last Name (required)"
-                RenderTableRow (anonymous) at (0,28) size 160x32
-                  RenderTableCell (anonymous) at (0,28) size 160x32 [r=1 c=0 rs=1 cs=1]
-                    RenderTextControl {INPUT} at (2,4) size 156x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                RenderTableRow (anonymous) at (0,28) size 141x32
+                  RenderTableCell (anonymous) at (0,28) size 141x32 [r=1 c=0 rs=1 cs=1]
+                    RenderTextControl {INPUT} at (0,4) size 141x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
             RenderText {#text} at (0,0) size 0x0
           RenderBlock {P} at (0,126) size 568x62
-            RenderTable {SPAN} at (0,2) size 376x60
-              RenderTableSection (anonymous) at (0,0) size 376x60
-                RenderTableRow {SPAN} at (0,0) size 376x28
-                  RenderTableCell (anonymous) at (0,0) size 376x28 [r=0 c=0 rs=1 cs=1]
+            RenderTable {SPAN} at (0,2) size 333x60
+              RenderTableSection (anonymous) at (0,0) size 333x60
+                RenderTableRow {SPAN} at (0,0) size 333x28
+                  RenderTableCell (anonymous) at (0,0) size 333x28 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (0,6) size 91x16
                       text run at (0,6) width 91: "Email Address"
-                RenderTableRow (anonymous) at (0,28) size 376x32
-                  RenderTableCell (anonymous) at (0,28) size 376x32 [r=1 c=0 rs=1 cs=1]
-                    RenderTextControl {INPUT} at (2,4) size 372x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                RenderTableRow (anonymous) at (0,28) size 333x32
+                  RenderTableCell (anonymous) at (0,28) size 333x32 [r=1 c=0 rs=1 cs=1]
+                    RenderTextControl {INPUT} at (0,4) size 333x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
             RenderText {#text} at (0,0) size 0x0
           RenderBlock {P} at (0,188) size 568x62
-            RenderTable {SPAN} at (0,2) size 160x60
-              RenderTableSection (anonymous) at (0,0) size 160x60
-                RenderTableRow {SPAN} at (0,0) size 160x28
-                  RenderTableCell (anonymous) at (0,0) size 160x28 [r=0 c=0 rs=1 cs=1]
+            RenderTable {SPAN} at (0,2) size 141x60
+              RenderTableSection (anonymous) at (0,0) size 141x60
+                RenderTableRow {SPAN} at (0,0) size 141x28
+                  RenderTableCell (anonymous) at (0,0) size 141x28 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (0,6) size 103x16
                       text run at (0,6) width 103: "Company Name"
-                RenderTableRow (anonymous) at (0,28) size 160x32
-                  RenderTableCell (anonymous) at (0,28) size 160x32 [r=1 c=0 rs=1 cs=1]
-                    RenderTextControl {INPUT} at (2,4) size 156x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-            RenderText {#text} at (160,7) size 4x17
-              text run at (160,7) width 4: " "
-            RenderTable {SPAN} at (164,2) size 160x60
-              RenderTableSection (anonymous) at (0,0) size 160x60
-                RenderTableRow {SPAN} at (0,0) size 160x28
-                  RenderTableCell (anonymous) at (0,0) size 160x28 [r=0 c=0 rs=1 cs=1]
+                RenderTableRow (anonymous) at (0,28) size 141x32
+                  RenderTableCell (anonymous) at (0,28) size 141x32 [r=1 c=0 rs=1 cs=1]
+                    RenderTextControl {INPUT} at (0,4) size 141x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+            RenderText {#text} at (141,7) size 4x17
+              text run at (141,7) width 4: " "
+            RenderTable {SPAN} at (145,2) size 141x60
+              RenderTableSection (anonymous) at (0,0) size 141x60
+                RenderTableRow {SPAN} at (0,0) size 141x28
+                  RenderTableCell (anonymous) at (0,0) size 141x28 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (0,6) size 27x16
                       text run at (0,6) width 27: "Title"
-                RenderTableRow (anonymous) at (0,28) size 160x32
-                  RenderTableCell (anonymous) at (0,28) size 160x32 [r=1 c=0 rs=1 cs=1]
-                    RenderTextControl {INPUT} at (2,4) size 156x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                RenderTableRow (anonymous) at (0,28) size 141x32
+                  RenderTableCell (anonymous) at (0,28) size 141x32 [r=1 c=0 rs=1 cs=1]
+                    RenderTextControl {INPUT} at (0,4) size 141x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
             RenderText {#text} at (0,0) size 0x0
           RenderBlock {P} at (0,250) size 568x32
-            RenderButton {INPUT} at (2,3) size 70x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
-              RenderBlock (anonymous) at (8,4) size 54x18
-                RenderText at (0,0) size 54x17
-                  text run at (0,0) width 54: "Submit!"
-            RenderText {#text} at (74,7) size 4x17
-              text run at (74,7) width 4: " "
-            RenderButton {INPUT} at (80,3) size 96x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
-              RenderBlock (anonymous) at (8,4) size 80x18
-                RenderText at (0,0) size 80x17
-                  text run at (0,0) width 80: "Clear Form"
+            RenderButton {INPUT} at (0,3) size 66x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+              RenderBlock (anonymous) at (8,4) size 50x18
+                RenderText at (0,0) size 50x17
+                  text run at (0,0) width 50: "Submit!"
+            RenderText {#text} at (66,7) size 4x17
+              text run at (66,7) width 4: " "
+            RenderButton {INPUT} at (70,3) size 88x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+              RenderBlock (anonymous) at (8,4) size 72x18
+                RenderText at (0,0) size 72x17
+                  text run at (0,0) width 72: "Clear Form"
             RenderText {#text} at (0,0) size 0x0
-layer at (161,284) size 150x18
-  RenderBlock {DIV} at (3,3) size 150x18
-layer at (325,284) size 150x18
-  RenderBlock {DIV} at (3,3) size 150x18
-layer at (161,346) size 366x18
-  RenderBlock {DIV} at (3,3) size 366x18
-layer at (161,408) size 150x18
-  RenderBlock {DIV} at (3,3) size 150x18
-layer at (325,408) size 150x18
-  RenderBlock {DIV} at (3,3) size 150x18
+layer at (159,284) size 135x18
+  RenderBlock {DIV} at (3,3) size 135x18
+layer at (304,284) size 135x18
+  RenderBlock {DIV} at (3,3) size 135x18
+layer at (159,346) size 327x18
+  RenderBlock {DIV} at (3,3) size 327x18
+layer at (159,408) size 135x18
+  RenderBlock {DIV} at (3,3) size 135x18
+layer at (304,408) size 135x18
+  RenderBlock {DIV} at (3,3) size 135x18

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug2479-3-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug2479-3-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x703
+layer at (0,0) size 785x695
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x703
-  RenderBlock {HTML} at (0,0) size 785x703
-    RenderBody {BODY} at (8,21) size 769x666
+layer at (0,0) size 785x695
+  RenderBlock {HTML} at (0,0) size 785x695
+    RenderBody {BODY} at (8,21) size 769x658
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 315x36
           text run at (0,0) width 315: "Generic Table Tests - 1"
@@ -62,29 +62,29 @@ layer at (0,0) size 785x703
       RenderBlock {H2} at (0,399) size 769x28
         RenderText {#text} at (0,0) size 154x26
           text run at (0,0) width 154: "Submit Results"
-      RenderBlock {FORM} at (0,446) size 769x66
-        RenderBlock {P} at (0,0) size 769x65
-          RenderText {#text} at (0,8) size 263x17
-            text run at (0,8) width 263: "How does your browser fare on this test? "
-          RenderMenuList {SELECT} at (265,2) size 279x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderBlock {FORM} at (0,446) size 769x58
+        RenderBlock {P} at (0,0) size 769x57
+          RenderText {#text} at (0,6) size 263x17
+            text run at (0,6) width 263: "How does your browser fare on this test? "
+          RenderMenuList {SELECT} at (263,0) size 279x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock (anonymous) at (1,1) size 277x28
               RenderText at (5,5) size 163x17
                 text run at (5,5) width 163: "The test renders correctly."
-          RenderText {#text} at (546,8) size 4x17
-            text run at (546,8) width 4: " "
-          RenderInline {LABEL} at (0,0) size 620x49
-            RenderText {#text} at (550,8) size 70x17
-              text run at (550,8) width 70: "Comment: "
-            RenderTextControl {INPUT} at (2,37) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-          RenderText {#text} at (177,40) size 4x17
-            text run at (177,40) width 4: " "
-          RenderButton {INPUT} at (183,36) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderText {#text} at (542,6) size 4x17
+            text run at (542,6) width 4: " "
+          RenderInline {LABEL} at (0,0) size 616x45
+            RenderText {#text} at (546,6) size 70x17
+              text run at (546,6) width 70: "Comment: "
+            RenderTextControl {INPUT} at (0,31) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+          RenderText {#text} at (173,34) size 4x17
+            text run at (173,34) width 4: " "
+          RenderButton {INPUT} at (177,30) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 45x18
               RenderText at (0,0) size 45x17
                 text run at (0,0) width 45: "Submit"
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock {HR} at (0,527) size 769x3 [border: (1px inset #000000)]
-      RenderBlock {P} at (0,545) size 769x19
+      RenderBlock {HR} at (0,519) size 769x3 [border: (1px inset #000000)]
+      RenderBlock {P} at (0,537) size 769x19
         RenderText {#text} at (0,0) size 63x17
           text run at (0,0) width 63: "Up to the "
         RenderInline {A} at (0,0) size 73x17 [color=#0000EE]
@@ -92,7 +92,7 @@ layer at (0,0) size 785x703
             text run at (63,0) width 73: "Table Tests"
         RenderText {#text} at (136,0) size 4x17
           text run at (136,0) width 4: "."
-      RenderBlock {P} at (0,579) size 769x19
+      RenderBlock {P} at (0,571) size 769x19
         RenderText {#text} at (0,0) size 63x17
           text run at (0,0) width 63: "Up to the "
         RenderInline {A} at (0,0) size 98x17 [color=#0000EE]
@@ -100,7 +100,7 @@ layer at (0,0) size 785x703
             text run at (63,0) width 98: "Evil Tests Page"
         RenderText {#text} at (161,0) size 4x17
           text run at (161,0) width 4: "."
-      RenderBlock {P} at (0,613) size 769x19
+      RenderBlock {P} at (0,605) size 769x19
         RenderText {#text} at (0,0) size 173x17
           text run at (0,0) width 173: "This page is maintained by "
         RenderInline {A} at (0,0) size 77x17 [color=#0000EE]
@@ -113,8 +113,8 @@ layer at (0,0) size 785x703
             text run at (259,0) width 123: "py8ieh@bath.ac.uk"
         RenderText {#text} at (382,0) size 9x17
           text run at (382,0) width 9: ")."
-      RenderBlock {P} at (0,647) size 769x19
+      RenderBlock {P} at (0,639) size 769x19
         RenderText {#text} at (0,0) size 182x17
           text run at (0,0) width 182: "Last updated in March 1999."
-layer at (13,508) size 167x18
+layer at (11,502) size 167x18
   RenderBlock {DIV} at (3,3) size 167x18

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug2479-4-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug2479-4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2620
+layer at (0,0) size 785x2612
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2620
-  RenderBlock {HTML} at (0,0) size 785x2621
-    RenderBody {BODY} at (8,21) size 769x2584 [bgcolor=#FFFFFF]
+layer at (0,0) size 785x2612
+  RenderBlock {HTML} at (0,0) size 785x2613
+    RenderBody {BODY} at (8,21) size 769x2576 [bgcolor=#FFFFFF]
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 365x36
           text run at (0,0) width 365: "Table Inheritance Tests - 1"
@@ -180,29 +180,29 @@ layer at (0,0) size 785x2620
       RenderBlock {H2} at (0,2264) size 769x28
         RenderText {#text} at (0,0) size 154x26
           text run at (0,0) width 154: "Submit Results"
-      RenderBlock {FORM} at (0,2311) size 769x84
-        RenderBlock {P} at (0,0) size 769x83
+      RenderBlock {FORM} at (0,2311) size 769x76
+        RenderBlock {P} at (0,0) size 769x75
           RenderText {#text} at (0,0) size 259x17
             text run at (0,0) width 259: "How does your browser fare on this test?"
-          RenderMenuList {SELECT} at (2,20) size 549x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderMenuList {SELECT} at (0,18) size 549x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock (anonymous) at (1,1) size 547x28
               RenderText at (5,5) size 521x17
                 text run at (5,5) width 521: "The tests all render identically, and this browser may or may not grok CSS2 tables."
-          RenderText {#text} at (553,26) size 4x17
-            text run at (553,26) width 4: " "
-          RenderInline {LABEL} at (0,0) size 627x49
-            RenderText {#text} at (557,26) size 70x17
-              text run at (557,26) width 70: "Comment: "
-            RenderTextControl {INPUT} at (2,55) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-          RenderText {#text} at (177,58) size 4x17
-            text run at (177,58) width 4: " "
-          RenderButton {INPUT} at (183,54) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderText {#text} at (549,24) size 4x17
+            text run at (549,24) width 4: " "
+          RenderInline {LABEL} at (0,0) size 623x45
+            RenderText {#text} at (553,24) size 70x17
+              text run at (553,24) width 70: "Comment: "
+            RenderTextControl {INPUT} at (0,49) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+          RenderText {#text} at (173,52) size 4x17
+            text run at (173,52) width 4: " "
+          RenderButton {INPUT} at (177,48) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 45x18
               RenderText at (0,0) size 45x17
                 text run at (0,0) width 45: "Submit"
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock {HR} at (0,2410) size 769x3 [border: (1px inset #000000)]
-      RenderBlock {P} at (0,2428) size 769x19
+      RenderBlock {HR} at (0,2402) size 769x3 [border: (1px inset #000000)]
+      RenderBlock {P} at (0,2420) size 769x19
         RenderText {#text} at (0,0) size 63x17
           text run at (0,0) width 63: "Up to the "
         RenderInline {A} at (0,0) size 73x17 [color=#0000EE]
@@ -210,7 +210,7 @@ layer at (0,0) size 785x2620
             text run at (63,0) width 73: "Table Tests"
         RenderText {#text} at (136,0) size 4x17
           text run at (136,0) width 4: "."
-      RenderBlock {P} at (0,2462) size 769x19
+      RenderBlock {P} at (0,2454) size 769x19
         RenderText {#text} at (0,0) size 63x17
           text run at (0,0) width 63: "Up to the "
         RenderInline {A} at (0,0) size 98x17 [color=#0000EE]
@@ -218,13 +218,13 @@ layer at (0,0) size 785x2620
             text run at (63,0) width 98: "Evil Tests Page"
         RenderText {#text} at (161,0) size 4x17
           text run at (161,0) width 4: "."
-      RenderBlock {P} at (0,2496) size 769x19
+      RenderBlock {P} at (0,2488) size 769x19
         RenderText {#text} at (0,0) size 61x17
           text run at (0,0) width 61: "Bugzilla: "
         RenderInline {A} at (0,0) size 63x17 [color=#0000EE]
           RenderText {#text} at (61,0) size 63x17
             text run at (61,0) width 63: "Bug 1044"
-      RenderBlock {P} at (0,2530) size 769x19
+      RenderBlock {P} at (0,2522) size 769x19
         RenderText {#text} at (0,0) size 173x17
           text run at (0,0) width 173: "This page is maintained by "
         RenderInline {A} at (0,0) size 77x17 [color=#0000EE]
@@ -237,8 +237,8 @@ layer at (0,0) size 785x2620
             text run at (259,0) width 123: "py8ieh@bath.ac.uk"
         RenderText {#text} at (382,0) size 9x17
           text run at (382,0) width 9: ")."
-      RenderBlock {P} at (0,2564) size 769x19
+      RenderBlock {P} at (0,2556) size 769x19
         RenderText {#text} at (0,0) size 182x17
           text run at (0,0) width 182: "Last updated in March 1999."
-layer at (13,2391) size 167x18
+layer at (11,2385) size 167x18
   RenderBlock {DIV} at (3,3) size 167x18

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug26178-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug26178-expected.txt
@@ -14,8 +14,8 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (2,0) size 61x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 57x17
                 text run at (1,1) width 57: "First row"
-      RenderBlock {FORM} at (0,46) size 784x31
-        RenderButton {INPUT} at (2,2) size 50x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+      RenderBlock {FORM} at (0,46) size 784x27
+        RenderButton {INPUT} at (0,0) size 50x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 34x18
             RenderText at (0,0) size 34x17
               text run at (0,0) width 34: "insert"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug28928-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug28928-expected.txt
@@ -6,47 +6,47 @@ layer at (0,0) size 800x600
       RenderBlock {H3} at (0,0) size 784x22
         RenderText {#text} at (0,0) size 200x21
           text run at (0,0) width 200: "With long hidden values"
-      RenderTable {TABLE} at (0,40) size 196x76 [border: (1px solid #FF0000)]
-        RenderTableSection {TBODY} at (1,1) size 194x73
-          RenderTableRow {TR} at (0,2) size 194x67
-            RenderTableCell {TD} at (2,2) size 190x67 [r=0 c=0 rs=1 cs=1]
-              RenderBlock {FORM} at (1,1) size 188x49
-                RenderTextControl {INPUT} at (2,3) size 117x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-                RenderText {#text} at (121,6) size 4x17
-                  text run at (121,6) width 4: " "
-                RenderButton {INPUT} at (127,2) size 44x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+      RenderTable {TABLE} at (0,40) size 196x72 [border: (1px solid #FF0000)]
+        RenderTableSection {TBODY} at (1,1) size 194x69
+          RenderTableRow {TR} at (0,2) size 194x63
+            RenderTableCell {TD} at (2,2) size 190x63 [r=0 c=0 rs=1 cs=1]
+              RenderBlock {FORM} at (1,1) size 188x45
+                RenderTextControl {INPUT} at (0,1) size 117x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                RenderText {#text} at (117,4) size 4x17
+                  text run at (117,4) width 4: " "
+                RenderButton {INPUT} at (121,0) size 44x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,4) size 28x18
                     RenderText at (0,0) size 28x17
                       text run at (0,0) width 28: " Go "
-                RenderText {#text} at (173,6) size 4x17
-                  text run at (173,6) width 4: " "
-                RenderBR {BR} at (177,6) size 0x17
-                RenderText {#text} at (0,31) size 188x17
-                  text run at (0,31) width 188: "Enter City Name or Zip Code"
-          RenderTableRow {TR} at (0,71) size 194x0
-      RenderBlock {HR} at (0,123) size 784x3 [border: (1px inset #000000)]
-      RenderBlock {H3} at (0,144) size 784x23
+                RenderText {#text} at (165,4) size 4x17
+                  text run at (165,4) width 4: " "
+                RenderBR {BR} at (169,4) size 0x17
+                RenderText {#text} at (0,27) size 188x17
+                  text run at (0,27) width 188: "Enter City Name or Zip Code"
+          RenderTableRow {TR} at (0,67) size 194x0
+      RenderBlock {HR} at (0,119) size 784x3 [border: (1px inset #000000)]
+      RenderBlock {H3} at (0,140) size 784x23
         RenderText {#text} at (0,0) size 206x21
           text run at (0,0) width 206: "With short hidden values"
-      RenderTable {TABLE} at (0,185) size 196x76 [border: (1px solid #FF0000)]
-        RenderTableSection {TBODY} at (1,1) size 194x73
-          RenderTableRow {TR} at (0,2) size 194x67
-            RenderTableCell {TD} at (2,2) size 190x67 [r=0 c=0 rs=1 cs=1]
-              RenderBlock {FORM} at (1,1) size 188x49
-                RenderTextControl {INPUT} at (2,3) size 117x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-                RenderText {#text} at (121,6) size 4x17
-                  text run at (121,6) width 4: " "
-                RenderButton {INPUT} at (127,2) size 44x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+      RenderTable {TABLE} at (0,181) size 196x72 [border: (1px solid #FF0000)]
+        RenderTableSection {TBODY} at (1,1) size 194x69
+          RenderTableRow {TR} at (0,2) size 194x63
+            RenderTableCell {TD} at (2,2) size 190x63 [r=0 c=0 rs=1 cs=1]
+              RenderBlock {FORM} at (1,1) size 188x45
+                RenderTextControl {INPUT} at (0,1) size 117x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                RenderText {#text} at (117,4) size 4x17
+                  text run at (117,4) width 4: " "
+                RenderButton {INPUT} at (121,0) size 44x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,4) size 28x18
                     RenderText at (0,0) size 28x17
                       text run at (0,0) width 28: " Go "
-                RenderText {#text} at (173,6) size 4x17
-                  text run at (173,6) width 4: " "
-                RenderBR {BR} at (177,6) size 0x17
-                RenderText {#text} at (0,31) size 188x17
-                  text run at (0,31) width 188: "Enter City Name or Zip Code"
-          RenderTableRow {TR} at (0,71) size 194x0
-layer at (17,59) size 111x18
+                RenderText {#text} at (165,4) size 4x17
+                  text run at (165,4) width 4: " "
+                RenderBR {BR} at (169,4) size 0x17
+                RenderText {#text} at (0,27) size 188x17
+                  text run at (0,27) width 188: "Enter City Name or Zip Code"
+          RenderTableRow {TR} at (0,67) size 194x0
+layer at (15,57) size 111x18
   RenderBlock {DIV} at (3,3) size 111x18
-layer at (17,203) size 111x18
+layer at (15,197) size 111x18
   RenderBlock {DIV} at (3,3) size 111x18

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug29326-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug29326-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (192,0) size 400x60 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 398x58
-          RenderTableRow {TR} at (0,2) size 398x54
-            RenderTableCell {TD} at (2,2) size 394x54 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderBlock {FORM} at (2,2) size 390x34
-                RenderMenuList {SELECT} at (2,2) size 55x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderTable {TABLE} at (192,0) size 400x56 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 398x54
+          RenderTableRow {TR} at (0,2) size 398x50
+            RenderTableCell {TD} at (2,2) size 394x50 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderBlock {FORM} at (2,2) size 390x30
+                RenderMenuList {SELECT} at (0,0) size 55x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
                   RenderBlock (anonymous) at (1,1) size 53x28
                     RenderText at (5,5) size 27x17
                       text run at (5,5) width 27: "Test"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug30559-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug30559-expected.txt
@@ -7,17 +7,17 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 712x17
           text run at (0,0) width 712: "The bug causes the nested table containing the textarea to be positioned away from the left edge of the outer table"
         RenderBR {BR} at (712,0) size 0x17
-      RenderTable {TABLE} at (242,18) size 300x66 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 298x64
-          RenderTableRow {TR} at (0,2) size 298x60
-            RenderTableCell {TD} at (2,2) size 294x60 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderTable {TABLE} at (2,2) size 75x56 [border: (1px outset #808080)]
-                RenderTableSection {TBODY} at (1,1) size 73x54
-                  RenderTableRow {TR} at (0,2) size 73x50
-                    RenderTableCell {TD} at (2,2) size 69x50 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (242,18) size 300x62 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 298x60
+          RenderTableRow {TR} at (0,2) size 298x56
+            RenderTableCell {TD} at (2,2) size 294x56 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {TABLE} at (2,2) size 71x52 [border: (1px outset #808080)]
+                RenderTableSection {TBODY} at (1,1) size 69x50
+                  RenderTableRow {TR} at (0,2) size 69x46
+                    RenderTableCell {TD} at (2,2) size 65x46 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (0,0) size 0x0
-layer at (262,38) size 61x42 clip at (263,39) size 59x40
-  RenderTextControl {TEXTAREA} at (4,4) size 61x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (260,36) size 61x42 clip at (261,37) size 59x40
+  RenderTextControl {TEXTAREA} at (2,2) size 61x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 55x18
       RenderText {#text} at (0,0) size 20x17
         text run at (0,0) width 20: "bar"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug33855-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug33855-expected.txt
@@ -3,35 +3,35 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576 [bgcolor=#FFFFFF]
-      RenderBlock {FORM} at (0,0) size 784x40
-        RenderTable {TABLE} at (0,0) size 784x40
-          RenderTableSection {TBODY} at (0,0) size 784x40
-            RenderTableRow {TR} at (0,2) size 784x36 [bgcolor=#FFFFFF]
-              RenderTableCell {TD} at (2,5) size 79x33 [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (3,3) size 73x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+      RenderBlock {FORM} at (0,0) size 784x36
+        RenderTable {TABLE} at (0,0) size 784x36
+          RenderTableSection {TBODY} at (0,0) size 784x36
+            RenderTableRow {TR} at (0,2) size 784x32 [bgcolor=#FFFFFF]
+              RenderTableCell {TD} at (2,5) size 75x29 [r=0 c=0 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 73x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,4) size 57x18
                     RenderText at (0,0) size 57x17
                       text run at (0,0) width 57: "Select all"
-              RenderTableCell {TD} at (83,5) size 63x33 [r=0 c=1 rs=1 cs=1]
-                RenderButton {INPUT} at (3,3) size 57x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+              RenderTableCell {TD} at (79,5) size 59x29 [r=0 c=1 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 57x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,4) size 41x18
                     RenderText at (0,0) size 41x17
                       text run at (0,0) width 41: "Delete"
-              RenderTableCell {TD} at (148,5) size 98x33 [r=0 c=2 rs=1 cs=1]
-                RenderButton {INPUT} at (3,3) size 92x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+              RenderTableCell {TD} at (140,5) size 94x29 [r=0 c=2 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 92x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,4) size 76x18
                     RenderText at (0,0) size 76x17
                       text run at (0,0) width 76: "Empty trash"
-              RenderTableCell {TD} at (248,18) size 324x20 [r=0 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (236,14) size 344x20 [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 4x17
                   text run at (1,1) width 4: " "
-              RenderTableCell {TD} at (574,5) size 79x33 [r=0 c=4 rs=1 cs=1]
-                RenderButton {INPUT} at (3,3) size 73x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+              RenderTableCell {TD} at (582,5) size 75x29 [r=0 c=4 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 73x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,4) size 57x18
                     RenderText at (0,0) size 57x17
                       text run at (0,0) width 57: "Move to:"
-              RenderTableCell {TD} at (655,2) size 127x36 [r=0 c=5 rs=1 cs=1]
-                RenderMenuList {SELECT} at (3,3) size 121x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+              RenderTableCell {TD} at (659,2) size 123x32 [r=0 c=5 rs=1 cs=1]
+                RenderMenuList {SELECT} at (1,1) size 121x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
                   RenderBlock (anonymous) at (1,1) size 119x28
                     RenderText at (5,5) size 93x17
                       text run at (5,5) width 93: "Choose folder "

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug39209-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug39209-expected.txt
@@ -3,24 +3,24 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 431x91 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 429x89
-          RenderTableRow {TR} at (0,2) size 429x61
-            RenderTableCell {TD} at (2,21) size 128x23 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (0,0) size 431x87 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 429x85
+          RenderTableRow {TR} at (0,2) size 429x57
+            RenderTableCell {TD} at (2,19) size 132x23 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,1) size 30x19
                 text run at (2,2) width 30: "Blah"
-            RenderTableCell {TD} at (131,2) size 297x61 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-              RenderTable {TABLE} at (110,2) size 76x57 [border: (1px outset #808080)]
-                RenderTableSection {TBODY} at (1,1) size 73x55
-                  RenderTableRow {TR} at (0,2) size 73x51
-                    RenderTableCell {TD} at (2,2) size 69x51 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                      RenderBlock {FORM} at (2,2) size 65x31
-                        RenderButton {INPUT} at (2,2) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+            RenderTableCell {TD} at (135,2) size 293x57 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+              RenderTable {TABLE} at (110,2) size 72x53 [border: (1px outset #808080)]
+                RenderTableSection {TBODY} at (1,1) size 69x51
+                  RenderTableRow {TR} at (0,2) size 69x47
+                    RenderTableCell {TD} at (2,2) size 65x47 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                      RenderBlock {FORM} at (2,2) size 61x27
+                        RenderButton {INPUT} at (0,0) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                           RenderBlock (anonymous) at (8,4) size 45x18
                             RenderText at (0,0) size 45x17
                               text run at (0,0) width 45: "Submit"
                         RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,65) size 429x22
-            RenderTableCell {TD} at (2,65) size 426x22 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,61) size 429x22
+            RenderTableCell {TD} at (2,61) size 426x22 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 421x17
                 text run at (2,2) width 421: "This line is only here to separate the two columns in the row above"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug4382-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug4382-expected.txt
@@ -7,29 +7,29 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 260x17
           text run at (0,0) width 260: "The select should not contain blank items"
         RenderBR {BR} at (260,0) size 0x17
-      RenderBlock {FORM} at (0,18) size 784x34
+      RenderBlock {FORM} at (0,18) size 784x30
         RenderInline {B} at (0,0) size 47x17
-          RenderText {#text} at (0,8) size 47x17
-            text run at (0,8) width 47: "Search"
-        RenderText {#text} at (47,8) size 4x17
-          text run at (47,8) width 4: " "
-        RenderTextControl {INPUT} at (53,5) size 157x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-        RenderText {#text} at (212,8) size 4x17
-          text run at (212,8) width 4: " "
-        RenderMenuList {SELECT} at (218,2) size 82x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+          RenderText {#text} at (0,6) size 47x17
+            text run at (0,6) width 47: "Search"
+        RenderText {#text} at (47,6) size 4x17
+          text run at (47,6) width 4: " "
+        RenderTextControl {INPUT} at (51,3) size 157x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderText {#text} at (208,6) size 4x17
+          text run at (208,6) width 4: " "
+        RenderMenuList {SELECT} at (212,0) size 82x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
           RenderBlock (anonymous) at (1,1) size 80x28
             RenderText at (5,5) size 40x17
               text run at (5,5) width 40: "Excite"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,68) size 784x36
+      RenderBlock (anonymous) at (0,64) size 784x36
         RenderBR {BR} at (0,0) size 0x17
         RenderText {#text} at (0,18) size 260x17
           text run at (0,18) width 260: "The select should not contain blank items"
         RenderBR {BR} at (260,18) size 0x17
-      RenderBlock {FORM} at (0,104) size 784x34
-        RenderMenuList {SELECT} at (2,2) size 256x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderBlock {FORM} at (0,100) size 784x30
+        RenderMenuList {SELECT} at (0,0) size 256x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
           RenderBlock (anonymous) at (1,1) size 254x28
             RenderText at (5,5) size 73x17
               text run at (5,5) width 73: "Quick Link"
-layer at (64,34) size 151x18
+layer at (62,32) size 151x18
   RenderBlock {DIV} at (3,3) size 151x18

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug4429-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug4429-expected.txt
@@ -3,15 +3,15 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {FORM} at (0,0) size 784x59
+      RenderBlock {FORM} at (0,0) size 784x55
         RenderTable {TABLE} at (0,0) size 31x28 [border: (1px outset #808080)]
           RenderTableSection {TBODY} at (1,1) size 29x26
             RenderTableRow {TR} at (0,2) size 29x22
               RenderTableCell {TD} at (2,2) size 25x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 21x17
                   text run at (2,2) width 21: "foo"
-        RenderBlock (anonymous) at (0,28) size 784x31
-          RenderButton {INPUT} at (2,2) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderBlock (anonymous) at (0,28) size 784x27
+          RenderButton {INPUT} at (0,0) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 45x18
               RenderText at (0,0) size 45x17
                 text run at (0,0) width 45: "Submit"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug44505-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug44505-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x628
+layer at (0,0) size 785x620
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x628
-  RenderBlock {HTML} at (0,0) size 785x628
-    RenderBody {BODY} at (8,8) size 769x612 [bgcolor=#FFFFFF]
+layer at (0,0) size 785x620
+  RenderBlock {HTML} at (0,0) size 785x620
+    RenderBody {BODY} at (8,8) size 769x604 [bgcolor=#FFFFFF]
       RenderTable {TABLE} at (0,0) size 308x52 [border: (1px outset #808080)]
         RenderTableCol {COLGROUP} at (0,0) size 0x0
           RenderTableCol {COL} at (0,0) size 0x0
@@ -25,19 +25,19 @@ layer at (0,0) size 785x628
         RenderTableSection {TBODY} at (1,1) size 298x50
           RenderTableRow {TR} at (0,2) size 298x22
           RenderTableRow {TR} at (0,26) size 298x22
-      RenderTable {TABLE} at (0,208) size 300x65 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 298x63
-          RenderTableRow {TR} at (0,2) size 298x35
-          RenderTableRow {TR} at (0,39) size 298x22
-      RenderTable {TABLE} at (0,273) size 300x65 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 298x63
-          RenderTableRow {TR} at (0,2) size 298x35
-          RenderTableRow {TR} at (0,39) size 298x22
-      RenderTable {TABLE} at (0,338) size 300x94 [border: (1px outset #808080)]
+      RenderTable {TABLE} at (0,208) size 300x61 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 298x59
+          RenderTableRow {TR} at (0,2) size 298x31
+          RenderTableRow {TR} at (0,35) size 298x22
+      RenderTable {TABLE} at (0,269) size 300x61 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 298x59
+          RenderTableRow {TR} at (0,2) size 298x31
+          RenderTableRow {TR} at (0,35) size 298x22
+      RenderTable {TABLE} at (0,330) size 300x94 [border: (1px outset #808080)]
         RenderTableSection {TBODY} at (1,1) size 298x92
           RenderTableRow {TR} at (0,2) size 298x46
           RenderTableRow {TR} at (0,50) size 298x40
-      RenderTable {TABLE} at (0,522) size 300x90 [border: (1px outset #808080)]
+      RenderTable {TABLE} at (0,514) size 300x90 [border: (1px outset #808080)]
         RenderTableSection {TBODY} at (1,1) size 298x88
           RenderTableRow {TR} at (0,2) size 298x60
           RenderTableRow {TR} at (0,64) size 298x22
@@ -105,97 +105,97 @@ layer at (167,191) size 138x22 clip at (168,192) size 136x20
   RenderTableCell {TD} at (158,26) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x17
       text run at (2,2) width 4: " "
-layer at (11,219) size 154x35 clip at (12,220) size 152x33 scrollWidth 201
-  RenderTableCell {TD} at (2,2) size 154x35 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-    RenderBlock {FORM} at (2,2) size 150x31
-      RenderButton {BUTTON} at (0,2) size 200x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+layer at (11,219) size 154x31 clip at (12,220) size 152x29 scrollWidth 201
+  RenderTableCell {TD} at (2,2) size 154x31 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+    RenderBlock {FORM} at (2,2) size 150x27
+      RenderButton {BUTTON} at (0,0) size 200x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,4) size 184x18
           RenderText {#text} at (72,0) size 40x17
             text run at (72,0) width 40: "button"
-layer at (167,219) size 138x35 clip at (168,220) size 136x33
-  RenderTableCell {TD} at (158,8) size 138x23 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+layer at (167,219) size 138x31 clip at (168,220) size 136x29
+  RenderTableCell {TD} at (158,6) size 138x23 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
     RenderText {#text} at (2,1) size 4x19
       text run at (2,2) width 4: " "
-layer at (11,256) size 154x22 clip at (12,257) size 152x20
-  RenderTableCell {TD} at (2,39) size 154x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
+layer at (11,252) size 154x22 clip at (12,253) size 152x20
+  RenderTableCell {TD} at (2,35) size 154x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x17
       text run at (2,2) width 4: " "
-layer at (167,256) size 138x22 clip at (168,257) size 136x20
-  RenderTableCell {TD} at (158,39) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
+layer at (167,252) size 138x22 clip at (168,253) size 136x20
+  RenderTableCell {TD} at (158,35) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x17
       text run at (2,2) width 4: " "
-layer at (11,284) size 281x35 clip at (12,285) size 279x33
-  RenderTableCell {TD} at (2,2) size 281x35 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-    RenderBlock {FORM} at (2,2) size 277x31
-      RenderButton {BUTTON} at (0,2) size 200x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+layer at (11,280) size 281x31 clip at (12,281) size 279x29
+  RenderTableCell {TD} at (2,2) size 281x31 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+    RenderBlock {FORM} at (2,2) size 277x27
+      RenderButton {BUTTON} at (0,0) size 200x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,4) size 184x18
           RenderText {#text} at (72,0) size 40x17
             text run at (72,0) width 40: "button"
-layer at (294,284) size 11x35 clip at (295,285) size 9x33
-  RenderTableCell {TD} at (284,8) size 13x23 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+layer at (294,280) size 11x31 clip at (295,281) size 9x29
+  RenderTableCell {TD} at (284,6) size 13x23 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
     RenderText {#text} at (2,1) size 4x19
       text run at (2,2) width 4: " "
-layer at (11,321) size 281x22 clip at (12,322) size 279x20
-  RenderTableCell {TD} at (2,39) size 281x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
+layer at (11,313) size 281x22 clip at (12,314) size 279x20
+  RenderTableCell {TD} at (2,35) size 281x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x17
       text run at (2,2) width 4: " "
-layer at (294,321) size 11x22 clip at (295,322) size 9x20
-  RenderTableCell {TD} at (284,39) size 13x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
+layer at (294,313) size 11x22 clip at (295,314) size 9x20
+  RenderTableCell {TD} at (284,35) size 13x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x17
       text run at (2,2) width 4: " "
-layer at (11,349) size 172x46 clip at (12,350) size 170x44 scrollWidth 216
+layer at (11,341) size 172x46 clip at (12,342) size 170x44 scrollWidth 216
   RenderTableCell {TD} at (2,2) size 172x46 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
     RenderBlock {DIV} at (11,11) size 206x24 [border: (3px solid #000000)]
       RenderText {#text} at (3,3) size 20x17
         text run at (3,3) width 20: "div"
-layer at (185,349) size 120x46 clip at (186,350) size 118x44
+layer at (185,341) size 120x46 clip at (186,342) size 118x44
   RenderTableCell {TD} at (176,5) size 120x40 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
     RenderText {#text} at (11,11) size 4x17
       text run at (11,11) width 4: " "
-layer at (11,397) size 172x40 clip at (12,398) size 170x38
+layer at (11,389) size 172x40 clip at (12,390) size 170x38
   RenderTableCell {TD} at (2,50) size 172x40 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (11,11) size 4x17
       text run at (11,11) width 4: " "
-layer at (185,397) size 120x40 clip at (186,398) size 118x38
+layer at (185,389) size 120x40 clip at (186,390) size 118x38
   RenderTableCell {TD} at (176,50) size 120x40 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (11,11) size 4x17
       text run at (11,11) width 4: " "
-layer at (8,440) size 300x90 clip at (9,441) size 298x88
-  RenderTable {TABLE} at (0,432) size 300x90 [border: (1px outset #808080)]
+layer at (8,432) size 300x90 clip at (9,433) size 298x88
+  RenderTable {TABLE} at (0,424) size 300x90 [border: (1px outset #808080)]
     RenderTableSection {TBODY} at (1,1) size 298x88
       RenderTableRow {TR} at (0,2) size 298x60
       RenderTableRow {TR} at (0,64) size 298x22
-layer at (11,443) size 154x60 clip at (12,444) size 152x58 scrollWidth 207
+layer at (11,435) size 154x60 clip at (12,436) size 152x58 scrollWidth 207
   RenderTableCell {TD} at (2,2) size 154x60 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
     RenderBlock {P} at (2,18) size 206x24 [border: (3px solid #000000)]
       RenderText {#text} at (3,3) size 27x17
         text run at (3,3) width 27: "para"
-layer at (167,443) size 138x60 clip at (168,444) size 136x58
+layer at (167,435) size 138x60 clip at (168,436) size 136x58
   RenderTableCell {TD} at (158,21) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x17
       text run at (2,2) width 4: " "
-layer at (11,505) size 154x22 clip at (12,506) size 152x20
+layer at (11,497) size 154x22 clip at (12,498) size 152x20
   RenderTableCell {TD} at (2,64) size 154x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x17
       text run at (2,2) width 4: " "
-layer at (167,505) size 138x22 clip at (168,506) size 136x20
+layer at (167,497) size 138x22 clip at (168,498) size 136x20
   RenderTableCell {TD} at (158,64) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x17
       text run at (2,2) width 4: " "
-layer at (11,533) size 254x60 clip at (12,534) size 252x58
+layer at (11,525) size 254x60 clip at (12,526) size 252x58
   RenderTableCell {TD} at (2,2) size 254x60 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
     RenderBlock {P} at (2,18) size 206x24 [border: (3px solid #000000)]
       RenderText {#text} at (3,3) size 27x17
         text run at (3,3) width 27: "para"
-layer at (267,533) size 38x60 clip at (268,534) size 36x58
+layer at (267,525) size 38x60 clip at (268,526) size 36x58
   RenderTableCell {TD} at (258,21) size 38x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x17
       text run at (2,2) width 4: " "
-layer at (11,595) size 254x22 clip at (12,596) size 252x20
+layer at (11,587) size 254x22 clip at (12,588) size 252x20
   RenderTableCell {TD} at (2,64) size 254x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x17
       text run at (2,2) width 4: " "
-layer at (267,595) size 38x22 clip at (268,596) size 36x20
+layer at (267,587) size 38x22 clip at (268,588) size 36x20
   RenderTableCell {TD} at (258,64) size 38x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x17
       text run at (2,2) width 4: " "

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug4527-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug4527-expected.txt
@@ -6,11 +6,11 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x0
         RenderInline {BASEFONT} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-      RenderTable {TABLE} at (0,0) size 613x98
-        RenderTableSection {TBODY} at (0,0) size 613x98
+      RenderTable {TABLE} at (0,0) size 613x95
+        RenderTableSection {TBODY} at (0,0) size 613x95
           RenderTableRow {TR} at (0,0) size 613x70
-            RenderTableCell {TD} at (0,6) size 126x86 [r=0 c=0 rs=2 cs=1]
-              RenderInline {A} at (0,0) size 126x18 [color=#0000EE]
+            RenderTableCell {TD} at (0,5) size 126x85 [r=0 c=0 rs=2 cs=1]
+              RenderInline {A} at (0,0) size 126x17 [color=#0000EE]
                 RenderImage {IMG} at (0,0) size 126x85
               RenderText {#text} at (0,0) size 0x0
             RenderTableCell {TD} at (126,0) size 488x70 [r=0 c=1 rs=1 cs=3]
@@ -32,18 +32,18 @@ layer at (0,0) size 800x600
               RenderBR {BR} at (487,46) size 0x17
               RenderImage {IMG} at (0,60) size 470x10
               RenderBR {BR} at (470,56) size 0x17
-          RenderTableRow {TR} at (0,70) size 613x28
-            RenderTableCell {TD} at (126,71) size 238x26 [bgcolor=#CCCCCC] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,70) size 613x25
+            RenderTableCell {TD} at (126,70) size 240x25 [bgcolor=#CCCCCC] [r=1 c=1 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 232x25
-            RenderTableCell {TD} at (363,70) size 126x28 [bgcolor=#CCCCCC] [r=1 c=2 rs=1 cs=1]
-              RenderTextControl {INPUT} at (3,2) size 94x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-              RenderImage {INPUT} at (98,6) size 26x18
-            RenderTableCell {TD} at (488,71) size 126x26 [bgcolor=#CCCCCC] [r=1 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (365,70) size 123x25 [bgcolor=#CCCCCC] [r=1 c=2 rs=1 cs=1]
+              RenderTextControl {INPUT} at (1,0) size 94x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+              RenderImage {INPUT} at (94,4) size 26x18
+            RenderTableCell {TD} at (487,70) size 127x25 [bgcolor=#CCCCCC] [r=1 c=3 rs=1 cs=1]
               RenderBlock {INPUT} at (2,4) size 12x12
               RenderImage {IMG} at (16,0) size 40x25
               RenderBlock {INPUT} at (58,4) size 12x12
-              RenderText {#text} at (72,1) size 4x19
+              RenderText {#text} at (72,2) size 4x17
                 text run at (72,2) width 4: " "
               RenderImage {IMG} at (76,0) size 46x25
-layer at (378,83) size 87x18
+layer at (378,82) size 87x18
   RenderBlock {DIV} at (3,3) size 87x18

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug46368-1-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug46368-1-expected.txt
@@ -31,23 +31,23 @@ layer at (0,0) size 800x600
                 text run at (2,2) width 266: "This status update contains information on"
                 text run at (2,20) width 317: "MailNews, XML/DOM, XPToolkit, Architecture,"
                 text run at (2,38) width 201: "Bidi, Necko/Imglib, and more..."
-      RenderBlock (anonymous) at (0,111) size 784x49
+      RenderBlock (anonymous) at (0,111) size 784x45
         RenderBR {BR} at (0,0) size 0x17
-        RenderButton {INPUT} at (2,20) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderButton {INPUT} at (0,18) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 45x18
             RenderText at (0,0) size 45x17
               text run at (0,0) width 45: "Reload"
-        RenderText {#text} at (65,24) size 8x17
-          text run at (65,24) width 8: "  "
-        RenderButton {INPUT} at (75,20) size 98x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderText {#text} at (61,22) size 8x17
+          text run at (61,22) width 8: "  "
+        RenderButton {INPUT} at (69,18) size 98x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 82x18
             RenderText at (0,0) size 82x17
               text run at (0,0) width 82: "Change Font"
-        RenderText {#text} at (175,24) size 8x17
-          text run at (175,24) width 8: "  "
-        RenderTextControl {INPUT} at (185,21) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderText {#text} at (167,22) size 8x17
+          text run at (167,22) width 8: "  "
+        RenderTextControl {INPUT} at (175,19) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderText {#text} at (0,0) size 0x0
-layer at (196,143) size 167x18
+layer at (186,141) size 167x18
   RenderBlock {DIV} at (3,3) size 167x18
     RenderText {#text} at (0,0) size 8x17
       text run at (0,0) width 8: "6"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug46368-2-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug46368-2-expected.txt
@@ -19,23 +19,23 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (308,20) size 472x23 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,1) size 241x19
                 text run at (2,2) width 241: "foo bar foo bar foo bar foo bar foo bar"
-      RenderBlock (anonymous) at (0,65) size 784x49
+      RenderBlock (anonymous) at (0,65) size 784x45
         RenderBR {BR} at (0,0) size 0x17
-        RenderButton {INPUT} at (2,20) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderButton {INPUT} at (0,18) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 45x18
             RenderText at (0,0) size 45x17
               text run at (0,0) width 45: "Reload"
-        RenderText {#text} at (65,24) size 8x17
-          text run at (65,24) width 8: "  "
-        RenderButton {INPUT} at (75,20) size 98x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderText {#text} at (61,22) size 8x17
+          text run at (61,22) width 8: "  "
+        RenderButton {INPUT} at (69,18) size 98x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 82x18
             RenderText at (0,0) size 82x17
               text run at (0,0) width 82: "Change Font"
-        RenderText {#text} at (175,24) size 8x17
-          text run at (175,24) width 8: "  "
-        RenderTextControl {INPUT} at (185,21) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderText {#text} at (167,22) size 8x17
+          text run at (167,22) width 8: "  "
+        RenderTextControl {INPUT} at (175,19) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderText {#text} at (0,0) size 0x0
-layer at (196,97) size 167x18
+layer at (186,95) size 167x18
   RenderBlock {DIV} at (3,3) size 167x18
     RenderText {#text} at (0,0) size 8x17
       text run at (0,0) width 8: "6"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug51037-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug51037-expected.txt
@@ -6,24 +6,24 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 240x17
           text run at (0,0) width 240: "The tables left position should be 250."
-      RenderBlock {P} at (0,34) size 784x28
-        RenderText {#text} at (0,5) size 34x17
-          text run at (0,5) width 34: "Left: "
-        RenderTextControl {INPUT} at (36,2) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-      RenderBlock {P} at (0,78) size 784x28
-        RenderText {#text} at (0,5) size 34x17
-          text run at (0,5) width 34: "Top: "
-        RenderTextControl {INPUT} at (36,2) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-      RenderBlock {P} at (0,122) size 784x31
-        RenderButton {INPUT} at (2,2) size 53x27 [color=#2E3436] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+      RenderBlock {P} at (0,34) size 784x24
+        RenderText {#text} at (0,3) size 34x17
+          text run at (0,3) width 34: "Left: "
+        RenderTextControl {INPUT} at (34,0) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderBlock {P} at (0,74) size 784x24
+        RenderText {#text} at (0,3) size 34x17
+          text run at (0,3) width 34: "Top: "
+        RenderTextControl {INPUT} at (34,0) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderBlock {P} at (0,114) size 784x27
+        RenderButton {INPUT} at (0,0) size 53x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 37x18
             RenderText at (0,0) size 37x17
               text run at (0,0) width 37: "Move"
-layer at (47,47) size 167x18
+layer at (45,45) size 167x18
   RenderBlock {DIV} at (3,3) size 167x18
     RenderText {#text} at (0,0) size 40x17
       text run at (0,0) width 40: "120px"
-layer at (47,91) size 167x18
+layer at (45,85) size 167x18
   RenderBlock {DIV} at (3,3) size 167x18
     RenderText {#text} at (0,0) size 40x17
       text run at (0,0) width 40: "120px"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug51727-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug51727-expected.txt
@@ -1,20 +1,20 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x104
-  RenderBlock {HTML} at (0,0) size 800x104
-    RenderBody {BODY} at (8,8) size 784x88
-      RenderBlock {FORM} at (0,0) size 784x62
-        RenderButton {INPUT} at (2,2) size 188x27 [color=#2E3436] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+layer at (0,0) size 800x96
+  RenderBlock {HTML} at (0,0) size 800x96
+    RenderBody {BODY} at (8,8) size 784x80
+      RenderBlock {FORM} at (0,0) size 784x54
+        RenderButton {INPUT} at (0,0) size 188x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 172x18
             RenderText at (0,0) size 172x17
               text run at (0,0) width 172: "(1) Fill cell with long string"
-        RenderBR {BR} at (192,6) size 0x17
-        RenderButton {INPUT} at (2,33) size 191x27 [color=#2E3436] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderBR {BR} at (188,4) size 0x17
+        RenderButton {INPUT} at (0,27) size 191x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 175x18
             RenderText at (0,0) size 175x17
               text run at (0,0) width 175: "(2) Fill cell with short string"
-        RenderBR {BR} at (195,37) size 0x17
-      RenderTable {TABLE} at (0,62) size 83x26
+        RenderBR {BR} at (191,31) size 0x17
+      RenderTable {TABLE} at (0,54) size 83x26
         RenderTableSection {TBODY} at (0,0) size 83x26
           RenderTableRow {TR} at (0,2) size 83x22
             RenderTableCell {TD} at (2,2) size 79x22 [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug52505-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug52505-expected.txt
@@ -1,18 +1,18 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x128
-  RenderBlock {HTML} at (0,0) size 800x128
-    RenderBody {BODY} at (8,8) size 784x112
-      RenderBlock {FORM} at (0,0) size 784x56
-        RenderButton {INPUT} at (2,0) size 302x27 [color=#2E3436] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+layer at (0,0) size 800x124
+  RenderBlock {HTML} at (0,0) size 800x124
+    RenderBody {BODY} at (8,8) size 784x108
+      RenderBlock {FORM} at (0,0) size 784x54
+        RenderButton {INPUT} at (0,0) size 302x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 286x18
             RenderText at (0,0) size 286x17
               text run at (0,0) width 286: "[Step 1] Set cell width to 60px (nothing seen)"
-        RenderButton {INPUT} at (2,29) size 304x27 [color=#2E3436] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderButton {INPUT} at (0,27) size 304x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 288x18
             RenderText at (0,0) size 288x17
               text run at (0,0) width 288: "[Step 2] Set cell width to 20px (garbage seen)"
-      RenderTable {TABLE} at (0,58) size 34x54
+      RenderTable {TABLE} at (0,54) size 34x54
         RenderTableSection {TBODY} at (0,0) size 34x54
           RenderTableRow {TR} at (0,2) size 34x24
             RenderTableCell {TD} at (2,2) size 14x24 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug52506-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug52506-expected.txt
@@ -1,18 +1,18 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x136
-  RenderBlock {HTML} at (0,0) size 800x136
-    RenderBody {BODY} at (8,8) size 784x120
-      RenderBlock {FORM} at (0,0) size 784x56
-        RenderButton {INPUT} at (2,0) size 211x27 [color=#2E3436] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+layer at (0,0) size 800x132
+  RenderBlock {HTML} at (0,0) size 800x132
+    RenderBody {BODY} at (8,8) size 784x116
+      RenderBlock {FORM} at (0,0) size 784x54
+        RenderButton {INPUT} at (0,0) size 211x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 195x18
             RenderText at (0,0) size 195x17
               text run at (0,0) width 195: "[Step 1] Set cell height to 60px"
-        RenderButton {INPUT} at (2,29) size 211x27 [color=#2E3436] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderButton {INPUT} at (0,27) size 211x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 195x18
             RenderText at (0,0) size 195x17
               text run at (0,0) width 195: "[Step 2] Set cell height to 20px"
-      RenderTable {TABLE} at (0,58) size 42x62
+      RenderTable {TABLE} at (0,54) size 42x62
         RenderTableSection {TBODY} at (0,0) size 42x62
           RenderTableRow {TR} at (0,2) size 42x28
             RenderTableCell {TD} at (2,2) size 18x28 [border: (4px solid #000000)] [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug55545-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug55545-expected.txt
@@ -3,18 +3,18 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 412x40
-        RenderTableSection {TBODY} at (0,0) size 412x40
-          RenderTableRow {TR} at (0,2) size 412x36
-            RenderTableCell {TD} at (2,2) size 408x36 [r=0 c=0 rs=1 cs=1]
-              RenderTable {TABLE} at (1,1) size 406x34
-                RenderTableSection {TBODY} at (0,0) size 406x34
-                  RenderTableRow {TR} at (0,2) size 406x30
-                    RenderTableCell {TH} at (2,7) size 61x20 [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (0,0) size 408x36
+        RenderTableSection {TBODY} at (0,0) size 408x36
+          RenderTableRow {TR} at (0,2) size 408x32
+            RenderTableCell {TD} at (2,2) size 404x32 [r=0 c=0 rs=1 cs=1]
+              RenderTable {TABLE} at (1,1) size 402x30
+                RenderTableSection {TBODY} at (0,0) size 402x30
+                  RenderTableRow {TR} at (0,2) size 402x26
+                    RenderTableCell {TH} at (2,5) size 61x20 [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 59x17
                         text run at (1,1) width 59: "User ID:"
-                    RenderTableCell {TD} at (65,2) size 339x30 [r=0 c=1 rs=1 cs=1]
-                      RenderTextControl {INPUT} at (3,3) size 333x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                    RenderTableCell {TD} at (65,2) size 335x26 [r=0 c=1 rs=1 cs=1]
+                      RenderTextControl {INPUT} at (1,1) size 333x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                       RenderText {#text} at (0,0) size 0x0
-layer at (82,19) size 327x18
+layer at (80,17) size 327x18
   RenderBlock {DIV} at (3,3) size 327x18

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug59354-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug59354-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 462x151 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 460x149
-          RenderTableRow {TR} at (0,0) size 460x149
-            RenderTableCell {TD} at (0,0) size 460x149 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderTable {TABLE} at (1,1) size 458x147 [border: (1px outset #808080)]
-                RenderTableSection {TBODY} at (1,1) size 456x145
+      RenderTable {TABLE} at (0,0) size 462x147 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 460x145
+          RenderTableRow {TR} at (0,0) size 460x145
+            RenderTableCell {TD} at (0,0) size 460x145 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {TABLE} at (1,1) size 458x143 [border: (1px outset #808080)]
+                RenderTableSection {TBODY} at (1,1) size 456x141
                   RenderTableRow {TR} at (0,1) size 456x28
                     RenderTableCell {TD} at (1,1) size 137x28 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (5,5) size 127x17
@@ -28,33 +28,33 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (404,1) size 51x28 [border: (1px inset #808080)] [r=0 c=4 rs=1 cs=1]
                       RenderText {#text} at (5,5) size 41x17
                         text run at (5,5) width 41: "Views"
-                  RenderTableRow {TR} at (0,30) size 456x114
-                    RenderTableCell {TD} at (1,30) size 454x114 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=5]
+                  RenderTableRow {TR} at (0,30) size 456x110
+                    RenderTableCell {TD} at (1,30) size 454x110 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=5]
                       RenderBlock (anonymous) at (5,5) size 444x18
                         RenderBR {BR} at (222,0) size 0x17
-                      RenderTable {TABLE} at (66,23) size 322x86
-                        RenderTableSection {TBODY} at (0,0) size 321x86
-                          RenderTableRow {TR} at (0,2) size 321x82
-                            RenderTableCell {TD} at (2,2) size 317x82 [r=0 c=0 rs=1 cs=1]
-                              RenderBlock {FORM} at (1,1) size 315x64
-                                RenderTable {TABLE} at (0,0) size 315x64 [border: (1px outset #808080)]
-                                  RenderTableSection {TBODY} at (1,1) size 313x62
-                                    RenderTableRow {TR} at (0,0) size 313x62
-                                      RenderTableCell {TD} at (0,0) size 313x62 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                                        RenderBlock (anonymous) at (1,1) size 311x18
-                                          RenderText {#text} at (102,0) size 107x17
-                                            text run at (102,0) width 107: "User Preferences"
-                                        RenderTable {TABLE} at (1,19) size 311x42 [border: (1px outset #808080)]
-                                          RenderTableSection {TBODY} at (1,1) size 309x40
-                                            RenderTableRow {TR} at (0,1) size 309x38
-                                              RenderTableCell {TH} at (1,6) size 119x28 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                      RenderTable {TABLE} at (68,23) size 318x82
+                        RenderTableSection {TBODY} at (0,0) size 317x82
+                          RenderTableRow {TR} at (0,2) size 317x78
+                            RenderTableCell {TD} at (2,2) size 313x78 [r=0 c=0 rs=1 cs=1]
+                              RenderBlock {FORM} at (1,1) size 311x60
+                                RenderTable {TABLE} at (0,0) size 311x60 [border: (1px outset #808080)]
+                                  RenderTableSection {TBODY} at (1,1) size 309x58
+                                    RenderTableRow {TR} at (0,0) size 309x58
+                                      RenderTableCell {TD} at (0,0) size 309x58 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                                        RenderBlock (anonymous) at (1,1) size 307x18
+                                          RenderText {#text} at (100,0) size 107x17
+                                            text run at (100,0) width 107: "User Preferences"
+                                        RenderTable {TABLE} at (1,19) size 307x38 [border: (1px outset #808080)]
+                                          RenderTableSection {TBODY} at (1,1) size 305x36
+                                            RenderTableRow {TR} at (0,1) size 305x34
+                                              RenderTableCell {TH} at (1,4) size 119x28 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                                                 RenderInline {NOBR} at (0,0) size 109x17
                                                   RenderText {#text} at (5,5) size 109x17
                                                     text run at (5,5) width 109: "Email Address :"
-                                              RenderTableCell {TD} at (121,1) size 187x38 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-                                                RenderTextControl {INPUT} at (7,7) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                                              RenderTableCell {TD} at (121,1) size 183x34 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+                                                RenderTextControl {INPUT} at (5,5) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                                                 RenderText {#text} at (0,0) size 0x0
-layer at (216,99) size 167x18 scrollWidth 235
+layer at (216,97) size 167x18 scrollWidth 235
   RenderBlock {DIV} at (3,3) size 167x18
     RenderText {#text} at (0,0) size 234x17
       text run at (0,0) width 234: "simon.king@pipinghotnetworks.com"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug60749-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug60749-expected.txt
@@ -12,14 +12,14 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (68,0) size 304x22 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 106x17
                 text run at (2,2) width 106: "   InspectionText"
-      RenderBlock {FORM} at (0,28) size 784x31
-        RenderButton {INPUT} at (2,2) size 101x27 [color=#2E3436] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+      RenderBlock {FORM} at (0,28) size 784x27
+        RenderButton {INPUT} at (0,0) size 101x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 85x18
             RenderText at (0,0) size 85x17
               text run at (0,0) width 85: "change width"
-        RenderText {#text} at (105,6) size 4x17
-          text run at (105,6) width 4: " "
-        RenderButton {INPUT} at (111,2) size 212x27 [color=#2E3436] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderText {#text} at (101,4) size 4x17
+          text run at (101,4) width 4: " "
+        RenderButton {INPUT} at (105,0) size 212x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 196x18
             RenderText at (0,0) size 196x17
               text run at (0,0) width 196: "change width with table reflow"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug68912-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug68912-expected.txt
@@ -6,10 +6,10 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 468x17
           text run at (0,0) width 468: "This test case creates a TR element then tries to assign to the cells property"
-      RenderBlock {P} at (0,34) size 784x31
-        RenderText {#text} at (0,6) size 41x17
-          text run at (0,6) width 41: "Crash "
-        RenderButton {BUTTON} at (43,2) size 110x27 [color=#2E3436] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+      RenderBlock {P} at (0,34) size 784x27
+        RenderText {#text} at (0,4) size 41x17
+          text run at (0,4) width 41: "Crash "
+        RenderButton {BUTTON} at (41,0) size 110x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 94x18
             RenderText {#text} at (0,0) size 94x17
               text run at (0,0) width 94: "TR.cells = null"

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug7342-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug7342-expected.txt
@@ -16,65 +16,65 @@ layer at (0,0) size 800x600
           RenderTable {TABLE} at (92,0) size 600x136 [bgcolor=#EEEEEE] [border: (1px outset #808080)]
             RenderTableSection {TBODY} at (1,1) size 598x134
               RenderTableRow {TR} at (0,3) size 598x128
-                RenderTableCell {TD} at (3,3) size 123x128 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                  RenderTable {TABLE} at (4,4) size 115x120 [bgcolor=#FFFFFF] [border: (1px outset #808080)]
-                    RenderTableSection {TBODY} at (1,1) size 113x118
-                      RenderTableRow {TR} at (0,2) size 113x28
-                        RenderTableCell {TD} at (2,3) size 109x25 [bgcolor=#CCCCCC] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                RenderTableCell {TD} at (3,3) size 120x128 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                  RenderTable {TABLE} at (4,4) size 112x120 [bgcolor=#FFFFFF] [border: (1px outset #808080)]
+                    RenderTableSection {TBODY} at (1,1) size 110x118
+                      RenderTableRow {TR} at (0,2) size 110x28
+                        RenderTableCell {TD} at (2,3) size 106x25 [bgcolor=#CCCCCC] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                           RenderInline {A} at (0,0) size 61x18 [color=#660099]
                             RenderInline {B} at (0,0) size 61x18
                               RenderText {#text} at (3,2) size 61x19
                                 text run at (3,3) width 61: "Netscape"
                           RenderText {#text} at (0,0) size 0x0
-                      RenderTableRow {TR} at (0,31) size 113x28
-                        RenderTableCell {TD} at (2,33) size 109x25 [bgcolor=#FFFFFF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
+                      RenderTableRow {TR} at (0,31) size 110x28
+                        RenderTableCell {TD} at (2,33) size 106x25 [bgcolor=#FFFFFF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
                           RenderInline {A} at (0,0) size 57x18 [color=#660099]
                             RenderInline {B} at (0,0) size 57x18
                               RenderText {#text} at (3,2) size 57x19
                                 text run at (3,3) width 57: "Infoseek"
                           RenderText {#text} at (0,0) size 0x0
-                      RenderTableRow {TR} at (0,61) size 113x28
-                        RenderTableCell {TD} at (2,62) size 109x25 [bgcolor=#FFFFFF] [border: (1px inset #808080)] [r=2 c=0 rs=1 cs=1]
+                      RenderTableRow {TR} at (0,61) size 110x28
+                        RenderTableCell {TD} at (2,62) size 106x25 [bgcolor=#FFFFFF] [border: (1px inset #808080)] [r=2 c=0 rs=1 cs=1]
                           RenderInline {A} at (0,0) size 78x18 [color=#660099]
                             RenderInline {B} at (0,0) size 78x18
                               RenderText {#text} at (3,2) size 78x19
                                 text run at (3,3) width 78: "LookSmart"
                           RenderText {#text} at (0,0) size 0x0
-                      RenderTableRow {TR} at (0,90) size 113x26
-                        RenderTableCell {TD} at (2,91) size 109x25 [bgcolor=#FFFFFF] [border: (1px inset #808080)] [r=3 c=0 rs=1 cs=1]
+                      RenderTableRow {TR} at (0,90) size 110x26
+                        RenderTableCell {TD} at (2,91) size 106x25 [bgcolor=#FFFFFF] [border: (1px inset #808080)] [r=3 c=0 rs=1 cs=1]
                           RenderInline {A} at (0,0) size 65x18 [color=#660099]
                             RenderInline {B} at (0,0) size 65x18
                               RenderText {#text} at (3,2) size 65x19
                                 text run at (3,3) width 65: "Directory"
                           RenderText {#text} at (0,0) size 0x0
-                RenderTableCell {TD} at (128,21) size 468x92 [bgcolor=#CCCCCC] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-                  RenderTable {TABLE} at (4,4) size 459x83 [border: (1px outset #808080)]
-                    RenderTableSection {TBODY} at (1,1) size 457x81
-                      RenderTableRow {TR} at (0,4) size 457x41
-                        RenderTableCell {TD} at (4,4) size 348x35 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=3]
-                          RenderInline {FONT} at (0,0) size 303x15
+                RenderTableCell {TD} at (125,23) size 471x88 [bgcolor=#CCCCCC] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+                  RenderTable {TABLE} at (4,4) size 462x79 [border: (1px outset #808080)]
+                    RenderTableSection {TBODY} at (1,1) size 460x77
+                      RenderTableRow {TR} at (0,4) size 460x37
+                        RenderTableCell {TD} at (4,4) size 363x34 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=3]
+                          RenderInline {FONT} at (0,0) size 341x15
                             RenderText {#text} at (0,0) size 0x0
-                            RenderTextControl {INPUT} at (7,7) size 299x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                            RenderTextControl {INPUT} at (5,5) size 341x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                             RenderText {#text} at (0,0) size 0x0
                           RenderText {#text} at (0,0) size 0x0
-                        RenderTableCell {TD} at (355,4) size 98x41 [border: (1px inset #808080)] [r=0 c=3 rs=1 cs=1]
-                          RenderButton {INPUT} at (7,7) size 59x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+                        RenderTableCell {TD} at (370,4) size 86x37 [border: (1px inset #808080)] [r=0 c=3 rs=1 cs=1]
+                          RenderButton {INPUT} at (5,5) size 59x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                             RenderBlock (anonymous) at (8,4) size 43x18
                               RenderText at (0,0) size 43x17
                                 text run at (0,0) width 43: "Search"
                           RenderText {#text} at (0,0) size 0x0
-                      RenderTableRow {TR} at (0,49) size 457x28
-                        RenderTableCell {TD} at (4,49) size 114x28 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
+                      RenderTableRow {TR} at (0,45) size 460x28
+                        RenderTableCell {TD} at (4,45) size 119x28 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
                           RenderText {#text} at (5,5) size 26x17
                             text run at (5,5) width 26: "asdf"
-                        RenderTableCell {TD} at (121,49) size 114x28 [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
+                        RenderTableCell {TD} at (126,45) size 119x28 [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
                           RenderText {#text} at (5,5) size 26x17
                             text run at (5,5) width 26: "asdf"
-                        RenderTableCell {TD} at (238,49) size 114x28 [border: (1px inset #808080)] [r=1 c=2 rs=1 cs=1]
+                        RenderTableCell {TD} at (248,45) size 119x28 [border: (1px inset #808080)] [r=1 c=2 rs=1 cs=1]
                           RenderText {#text} at (5,5) size 26x17
                             text run at (5,5) width 26: "asdf"
-                        RenderTableCell {TD} at (355,49) size 98x28 [border: (1px inset #808080)] [r=1 c=3 rs=1 cs=1]
+                        RenderTableCell {TD} at (370,45) size 86x28 [border: (1px inset #808080)] [r=1 c=3 rs=1 cs=1]
                           RenderText {#text} at (5,5) size 26x17
                             text run at (5,5) width 26: "asdf"
-layer at (248,120) size 293x15
-  RenderBlock {DIV} at (3,3) size 293x15
+layer at (244,120) size 335x18
+  RenderBlock {DIV} at (3,3) size 335x18

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug92647-2-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug92647-2-expected.txt
@@ -1,0 +1,16 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderTable {TABLE} at (0,0) size 48x47 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 46x45
+          RenderTableRow {TR} at (0,2) size 46x41
+            RenderTableCell {TD} at (2,2) size 42x41 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {TABLE} at (2,2) size 38x37 [border: (1px outset #808080)]
+                RenderTableSection {TBODY} at (1,1) size 36x35
+                  RenderTableRow {TR} at (0,2) size 36x31
+                    RenderTableCell {TD} at (2,15) size 4x5 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                    RenderTableCell {TD} at (8,2) size 20x31 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+                      RenderButton {INPUT} at (2,2) size 16x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+                    RenderTableCell {TD} at (30,15) size 4x5 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug96334-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug96334-expected.txt
@@ -1,44 +1,45 @@
-layer at (0,0) size 1071x585
+layer at (0,0) size 1067x585
   RenderView at (0,0) size 800x585
 layer at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 800x585
     RenderBody {BODY} at (8,8) size 784x569
-      RenderTable {TABLE} at (0,0) size 1063x146 [border: (2px solid #0000FF)]
-        RenderTableSection {TBODY} at (2,2) size 1059x142
-          RenderTableRow {TR} at (0,2) size 1059x138
-            RenderTableCell {TD} at (2,2) size 279x138 [border: (1px solid #C0C0C0)] [r=0 c=0 rs=1 cs=1]
-              RenderTable {TABLE} at (2,2) size 275x134 [border: (2px solid #008000)]
-                RenderTableSection {TBODY} at (2,2) size 271x130
-                  RenderTableRow {TR} at (0,2) size 271x74
-                    RenderTableCell {TD} at (2,2) size 267x74 [border: (1px solid #C0C0C0)] [r=0 c=0 rs=1 cs=1]
-                      RenderTable {TABLE} at (2,2) size 189x40 [border: (2px solid #FF0000)]
-                        RenderTableSection {TBODY} at (2,2) size 185x36
-                          RenderTableRow {TR} at (0,2) size 185x32
-                            RenderTableCell {TD} at (2,2) size 181x32 [border: (1px solid #C0C0C0)] [r=0 c=0 rs=1 cs=1]
-                              RenderTextControl {INPUT} at (4,4) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderTable {TABLE} at (0,0) size 1059x156 [border: (2px solid #0000FF)]
+        RenderTableSection {TBODY} at (2,2) size 1055x152
+          RenderTableRow {TR} at (0,2) size 1055x148
+            RenderTableCell {TD} at (2,2) size 275x148 [border: (1px solid #C0C0C0)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {TABLE} at (2,2) size 271x144 [border: (2px solid #008000)]
+                RenderTableSection {TBODY} at (2,2) size 267x140
+                  RenderTableRow {TR} at (0,2) size 267x88
+                    RenderTableCell {TD} at (2,2) size 263x88 [border: (1px solid #C0C0C0)] [r=0 c=0 rs=1 cs=1]
+                      RenderTable {TABLE} at (2,2) size 185x36 [border: (2px solid #FF0000)]
+                        RenderTableSection {TBODY} at (2,2) size 181x32
+                          RenderTableRow {TR} at (0,2) size 181x28
+                            RenderTableCell {TD} at (2,2) size 177x28 [border: (1px solid #C0C0C0)] [r=0 c=0 rs=1 cs=1]
+                              RenderTextControl {INPUT} at (2,2) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                               RenderText {#text} at (0,0) size 0x0
-                      RenderTable {TABLE} at (2,42) size 263x30 [border: (2px solid #FF0000)]
-                        RenderTableSection {TBODY} at (2,2) size 259x26
-                          RenderTableRow {TR} at (0,2) size 259x22
-                            RenderTableCell {TD} at (2,2) size 255x22 [border: (1px solid #C0C0C0)] [r=0 c=0 rs=1 cs=1]
-                              RenderText {#text} at (2,2) size 248x17
-                                text run at (2,2) width 248: "THIS TABLE NEEDS TO BE HERE"
-                  RenderTableRow {TR} at (0,78) size 271x50
-                    RenderTableCell {TD} at (2,78) size 267x50 [border: (1px solid #C0C0C0)] [r=1 c=0 rs=1 cs=1]
-                      RenderTable {TABLE} at (2,2) size 263x46 [border: (2px solid #FF0000)]
-                        RenderTableSection {TBODY} at (2,2) size 259x42
-                          RenderTableRow {TR} at (0,2) size 259x38
-                            RenderTableCell {TD} at (2,2) size 255x38 [border: (1px solid #C0C0C0)] [r=0 c=0 rs=1 cs=1]
-                              RenderMenuList {SELECT} at (4,4) size 247x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+                      RenderTable {TABLE} at (2,38) size 259x48 [border: (2px solid #FF0000)]
+                        RenderTableSection {TBODY} at (2,2) size 255x44
+                          RenderTableRow {TR} at (0,2) size 255x40
+                            RenderTableCell {TD} at (2,2) size 251x40 [border: (1px solid #C0C0C0)] [r=0 c=0 rs=1 cs=1]
+                              RenderText {#text} at (2,2) size 201x35
+                                text run at (2,2) width 201: "THIS TABLE NEEDS TO BE"
+                                text run at (2,20) width 43: "HERE"
+                  RenderTableRow {TR} at (0,92) size 267x46
+                    RenderTableCell {TD} at (2,92) size 263x46 [border: (1px solid #C0C0C0)] [r=1 c=0 rs=1 cs=1]
+                      RenderTable {TABLE} at (2,2) size 259x42 [border: (2px solid #FF0000)]
+                        RenderTableSection {TBODY} at (2,2) size 255x38
+                          RenderTableRow {TR} at (0,2) size 255x34
+                            RenderTableCell {TD} at (2,2) size 251x34 [border: (1px solid #C0C0C0)] [r=0 c=0 rs=1 cs=1]
+                              RenderMenuList {SELECT} at (2,2) size 247x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
                                 RenderBlock (anonymous) at (1,1) size 245x28
                                   RenderText at (5,5) size 219x17
                                     text run at (5,5) width 219: "USE THIS JAVASCRIPT HERE"
                               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (283,2) size 774x40 [border: (1px solid #C0C0C0)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (279,2) size 774x40 [border: (1px solid #C0C0C0)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 770x35
                 text run at (2,2) width 770: "KEEPoTHEoTEXToHEREoASoLONGoASoPOSSIBLEooKEEPoTHEoTEXToHEREoASoLONGoASoPOSSIBLE"
                 text run at (2,20) width 618: "THIS SIMULATES THE PROBLEM ON THE WWW.MAPBLAST.COM/ \"CREATE MAP\""
-layer at (31,31) size 167x18 scrollWidth 194
+layer at (29,29) size 167x18 scrollWidth 194
   RenderBlock {DIV} at (3,3) size 167x18
     RenderText {#text} at (0,0) size 193x17
       text run at (0,0) width 193: "THIS NEEDS THIS VALUE"

--- a/LayoutTests/platform/wpe/tables/mozilla/collapsing_borders/bug41262-4-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/collapsing_borders/bug41262-4-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {BLOCKQUOTE} at (40,0) size 704x127
-        RenderBlock {CENTER} at (0,0) size 704x127
+      RenderBlock {BLOCKQUOTE} at (40,0) size 704x123
+        RenderBlock {CENTER} at (0,0) size 704x123
           RenderTable {TABLE} at (298,0) size 108x80 [border: (2px none #808080)]
             RenderTableSection {TBODY} at (2,2) size 103x75
               RenderTableRow {TR} at (0,0) size 103x25
@@ -28,14 +28,14 @@ layer at (0,0) size 800x600
                 RenderTableCell {TD} at (37,50) size 66x25 [border: (3px groove #0000FF)] [r=2 c=1 rs=1 cs=1]
                   RenderText {#text} at (4,4) size 59x17
                     text run at (4,4) width 59: "6:00 a.m."
-          RenderBlock {P} at (0,96) size 704x31
-            RenderButton {INPUT} at (281,2) size 67x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderBlock {P} at (0,96) size 704x27
+            RenderButton {INPUT} at (283,0) size 67x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
               RenderBlock (anonymous) at (8,4) size 51x18
                 RenderText at (0,0) size 51x17
                   text run at (0,0) width 51: "separate"
-            RenderText {#text} at (350,6) size 4x17
-              text run at (350,6) width 4: " "
-            RenderButton {INPUT} at (356,2) size 67x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+            RenderText {#text} at (350,4) size 4x17
+              text run at (350,4) width 4: " "
+            RenderButton {INPUT} at (354,0) size 67x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
               RenderBlock (anonymous) at (8,4) size 51x18
                 RenderText at (0,0) size 51x17
                   text run at (0,0) width 51: "collapse"

--- a/LayoutTests/platform/wpe/tables/mozilla/core/margins-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/core/margins-expected.txt
@@ -6,20 +6,20 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 187x17
           text run at (0,0) width 187: "outer width=400 align=center"
-      RenderTable {TABLE} at (192,18) size 400x60 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 398x58
-          RenderTableRow {TR} at (0,2) size 398x54
-            RenderTableCell {TD} at (2,2) size 394x54 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderBlock {FORM} at (2,2) size 390x34
-                RenderMenuList {SELECT} at (2,2) size 55x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderTable {TABLE} at (192,18) size 400x56 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 398x54
+          RenderTableRow {TR} at (0,2) size 398x50
+            RenderTableCell {TD} at (2,2) size 394x50 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderBlock {FORM} at (2,2) size 390x30
+                RenderMenuList {SELECT} at (0,0) size 55x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
                   RenderBlock (anonymous) at (1,1) size 53x28
                     RenderText at (5,5) size 27x17
                       text run at (5,5) width 27: "Test"
                 RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,78) size 784x18
+      RenderBlock (anonymous) at (0,74) size 784x18
         RenderText {#text} at (0,0) size 296x17
           text run at (0,0) width 296: "outer width=400 inner width=200 align=center"
-      RenderTable {TABLE} at (0,96) size 400x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,92) size 400x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 396x36
           RenderTableRow {TR} at (0,2) size 396x32
             RenderTableCell {TD} at (2,2) size 392x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -29,10 +29,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 194x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 21x17
                         text run at (2,2) width 21: "foo"
-      RenderBlock (anonymous) at (0,136) size 784x18
+      RenderBlock (anonymous) at (0,132) size 784x18
         RenderText {#text} at (0,0) size 181x17
           text run at (0,0) width 181: "outer auto inner align=center"
-      RenderTable {TABLE} at (0,154) size 43x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,150) size 43x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 39x36
           RenderTableRow {TR} at (0,2) size 39x32
             RenderTableCell {TD} at (2,2) size 35x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -42,10 +42,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 25x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 21x17
                         text run at (2,2) width 21: "foo"
-      RenderBlock (anonymous) at (0,194) size 784x18
+      RenderBlock (anonymous) at (0,190) size 784x18
         RenderText {#text} at (0,0) size 215x17
           text run at (0,0) width 215: "outer width=50 inner align=center"
-      RenderTable {TABLE} at (0,212) size 43x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,208) size 43x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 39x36
           RenderTableRow {TR} at (0,2) size 39x32
             RenderTableCell {TD} at (2,2) size 35x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -55,10 +55,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 25x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 21x17
                         text run at (2,2) width 21: "foo"
-      RenderBlock (anonymous) at (0,252) size 784x18
+      RenderBlock (anonymous) at (0,248) size 784x18
         RenderText {#text} at (0,0) size 226x17
           text run at (0,0) width 226: "outer width=50 inner margin-left:50"
-      RenderTable {TABLE} at (0,270) size 93x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,266) size 93x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 89x36
           RenderTableRow {TR} at (0,2) size 89x32
             RenderTableCell {TD} at (2,2) size 85x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -68,10 +68,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 25x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 21x17
                         text run at (2,2) width 21: "foo"
-      RenderBlock (anonymous) at (0,310) size 784x18
+      RenderBlock (anonymous) at (0,306) size 784x18
         RenderText {#text} at (0,0) size 223x17
           text run at (0,0) width 223: "outer width=400 inner align=center"
-      RenderTable {TABLE} at (0,328) size 400x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,324) size 400x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 396x36
           RenderTableRow {TR} at (0,2) size 396x32
             RenderTableCell {TD} at (2,2) size 115x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -84,10 +84,10 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (118,7) size 277x22 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 80x17
                 text run at (2,2) width 80: "x x x x x x x"
-      RenderBlock (anonymous) at (0,368) size 784x18
+      RenderBlock (anonymous) at (0,364) size 784x18
         RenderText {#text} at (0,0) size 223x17
           text run at (0,0) width 223: "outer width=400 inner align=center"
-      RenderTable {TABLE} at (0,386) size 400x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,382) size 400x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 396x36
           RenderTableRow {TR} at (0,2) size 396x32
             RenderTableCell {TD} at (2,2) size 169x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -100,6 +100,6 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (172,7) size 223x22 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 80x17
                 text run at (2,2) width 80: "x x x x x x x"
-      RenderBlock (anonymous) at (0,426) size 784x18
+      RenderBlock (anonymous) at (0,422) size 784x18
         RenderText {#text} at (0,0) size 19x17
           text run at (0,0) width 19: "-->"

--- a/LayoutTests/platform/wpe/tables/mozilla/dom/tableDom-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/dom/tableDom-expected.txt
@@ -3,36 +3,36 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {FORM} at (0,0) size 784x34
-        RenderMenuList {SELECT} at (2,2) size 103x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderBlock {FORM} at (0,0) size 784x30
+        RenderMenuList {SELECT} at (0,0) size 103x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
           RenderBlock (anonymous) at (1,1) size 101x28
             RenderText at (5,5) size 72x17
               text run at (5,5) width 72: "append cell"
-        RenderText {#text} at (107,8) size 52x17
-          text run at (107,8) width 52: "   tbody "
-        RenderTextControl {INPUT} at (161,5) size 53x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-        RenderText {#text} at (216,8) size 41x17
-          text run at (216,8) width 41: "   row "
-        RenderTextControl {INPUT} at (259,5) size 53x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-        RenderText {#text} at (314,8) size 35x17
-          text run at (314,8) width 35: "   col "
-        RenderTextControl {INPUT} at (351,5) size 53x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-        RenderText {#text} at (406,8) size 74x17
-          text run at (406,8) width 74: "   row span "
-        RenderTextControl {INPUT} at (482,5) size 53x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-        RenderText {#text} at (537,8) size 68x17
-          text run at (537,8) width 68: "   col span "
-        RenderTextControl {INPUT} at (607,5) size 53x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-        RenderText {#text} at (662,8) size 20x17
-          text run at (662,8) width 20: "     "
-        RenderButton {INPUT} at (684,4) size 49x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderText {#text} at (103,6) size 52x17
+          text run at (103,6) width 52: "   tbody "
+        RenderTextControl {INPUT} at (155,3) size 53x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderText {#text} at (208,6) size 41x17
+          text run at (208,6) width 41: "   row "
+        RenderTextControl {INPUT} at (249,3) size 53x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderText {#text} at (302,6) size 35x17
+          text run at (302,6) width 35: "   col "
+        RenderTextControl {INPUT} at (337,3) size 53x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderText {#text} at (390,6) size 74x17
+          text run at (390,6) width 74: "   row span "
+        RenderTextControl {INPUT} at (464,3) size 53x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderText {#text} at (517,6) size 68x17
+          text run at (517,6) width 68: "   col span "
+        RenderTextControl {INPUT} at (585,3) size 53x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderText {#text} at (638,6) size 20x17
+          text run at (638,6) width 20: "     "
+        RenderButton {INPUT} at (658,2) size 49x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 33x18
             RenderText at (0,0) size 33x17
               text run at (0,0) width 33: "Do It"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,50) size 784x18
+      RenderBlock (anonymous) at (0,46) size 784x18
         RenderBR {BR} at (0,0) size 0x17
-      RenderTable {TABLE} at (0,68) size 62x52 [bgcolor=#FFA500] [border: (1px outset #808080)]
+      RenderTable {TABLE} at (0,64) size 62x52 [bgcolor=#FFA500] [border: (1px outset #808080)]
         RenderTableSection {TBODY} at (1,1) size 60x50
           RenderTableRow {TR} at (0,2) size 60x22
             RenderTableCell {TD} at (2,2) size 27x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -45,25 +45,25 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (31,26) size 27x22 [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 23x17
                 text run at (2,2) width 23: "c22"
-      RenderBlock (anonymous) at (0,120) size 784x18
+      RenderBlock (anonymous) at (0,116) size 784x18
         RenderBR {BR} at (0,0) size 0x17
-layer at (172,16) size 47x18
+layer at (166,14) size 47x18
   RenderBlock {DIV} at (3,3) size 47x18
     RenderText {#text} at (0,0) size 8x17
       text run at (0,0) width 8: "0"
-layer at (270,16) size 47x18
+layer at (260,14) size 47x18
   RenderBlock {DIV} at (3,3) size 47x18
     RenderText {#text} at (0,0) size 8x17
       text run at (0,0) width 8: "0"
-layer at (362,16) size 47x18
+layer at (348,14) size 47x18
   RenderBlock {DIV} at (3,3) size 47x18
     RenderText {#text} at (0,0) size 8x17
       text run at (0,0) width 8: "0"
-layer at (493,16) size 47x18
+layer at (475,14) size 47x18
   RenderBlock {DIV} at (3,3) size 47x18
     RenderText {#text} at (0,0) size 8x17
       text run at (0,0) width 8: "1"
-layer at (618,16) size 47x18
+layer at (596,14) size 47x18
   RenderBlock {DIV} at (3,3) size 47x18
     RenderText {#text} at (0,0) size 8x17
       text run at (0,0) width 8: "1"

--- a/LayoutTests/platform/wpe/tables/mozilla/other/move_row-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/other/move_row-expected.txt
@@ -29,23 +29,23 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (2,112) size 45x20 [r=5 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 43x17
                 text run at (1,1) width 43: "Row 5"
-      RenderBlock (anonymous) at (0,134) size 784x31
-        RenderTextControl {INPUT} at (2,3) size 21x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-        RenderText {#text} at (25,6) size 4x17
-          text run at (25,6) width 4: " "
-        RenderTextControl {INPUT} at (31,3) size 21x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-        RenderText {#text} at (54,6) size 4x17
-          text run at (54,6) width 4: " "
-        RenderButton {INPUT} at (60,2) size 32x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+      RenderBlock (anonymous) at (0,134) size 784x27
+        RenderTextControl {INPUT} at (0,1) size 21x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderText {#text} at (21,4) size 4x17
+          text run at (21,4) width 4: " "
+        RenderTextControl {INPUT} at (25,1) size 21x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderText {#text} at (46,4) size 4x17
+          text run at (46,4) width 4: " "
+        RenderButton {INPUT} at (50,0) size 32x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 16x18
             RenderText at (0,0) size 16x17
               text run at (0,0) width 16: "go"
         RenderText {#text} at (0,0) size 0x0
-layer at (13,148) size 15x18
+layer at (11,146) size 15x18
   RenderBlock {DIV} at (3,3) size 15x18
     RenderText {#text} at (0,0) size 8x17
       text run at (0,0) width 8: "2"
-layer at (42,148) size 15x18
+layer at (36,146) size 15x18
   RenderBlock {DIV} at (3,3) size 15x18
     RenderText {#text} at (0,0) size 8x17
       text run at (0,0) width 8: "4"

--- a/LayoutTests/platform/wpe/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 600x289 [bgcolor=#FFC0CB]
-        RenderTableSection {TBODY} at (0,0) size 600x289
+      RenderTable {TABLE} at (0,0) size 600x285 [bgcolor=#FFC0CB]
+        RenderTableSection {TBODY} at (0,0) size 600x285
           RenderTableRow {TR} at (0,0) size 600x18
             RenderTableCell {TD} at (0,0) size 601x18 [bgcolor=#FFFF00] [r=0 c=0 rs=1 cs=3]
               RenderText {#text} at (0,0) size 8x17
@@ -17,35 +17,35 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (0,36) size 156x18 [bgcolor=#00FFFF] [r=2 c=0 rs=40 cs=1]
               RenderText {#text} at (0,0) size 8x17
                 text run at (0,0) width 8: "3"
-          RenderTableRow {TR} at (0,36) size 600x37
-            RenderTableCell {TD} at (155,36) size 446x37 [bgcolor=#FFA500] [r=3 c=1 rs=1 cs=1]
-              RenderTable {TABLE} at (0,0) size 440x37
-                RenderTableSection {TBODY} at (0,0) size 440x37
-                  RenderTableRow {TR} at (0,2) size 440x33
-                    RenderTableCell {TD} at (2,2) size 217x33 [r=0 c=0 rs=1 cs=1]
-                      RenderButton {INPUT} at (3,3) size 112x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderTableRow {TR} at (0,36) size 600x33
+            RenderTableCell {TD} at (155,36) size 446x33 [bgcolor=#FFA500] [r=3 c=1 rs=1 cs=1]
+              RenderTable {TABLE} at (0,0) size 440x33
+                RenderTableSection {TBODY} at (0,0) size 440x33
+                  RenderTableRow {TR} at (0,2) size 440x29
+                    RenderTableCell {TD} at (2,2) size 217x29 [r=0 c=0 rs=1 cs=1]
+                      RenderButton {INPUT} at (1,1) size 112x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                         RenderBlock (anonymous) at (8,4) size 96x18
                           RenderText at (0,0) size 96x17
                             text run at (0,0) width 96: "Submit Criteria"
-                    RenderTableCell {TD} at (221,8) size 217x21 [r=0 c=1 rs=1 cs=1]
+                    RenderTableCell {TD} at (221,6) size 217x21 [r=0 c=1 rs=1 cs=1]
                       RenderText {#text} at (1,0) size 8x19
                         text run at (1,1) width 8: "4"
-          RenderTableRow {TR} at (0,73) size 600x18
-            RenderTableCell {TD} at (155,73) size 446x18 [bgcolor=#FF0000] [r=4 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,69) size 600x18
+            RenderTableCell {TD} at (155,69) size 446x18 [bgcolor=#FF0000] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 8x17
                 text run at (0,0) width 8: "5"
-          RenderTableRow {TR} at (0,91) size 600x36
-            RenderTableCell {TD} at (155,91) size 446x36 [bgcolor=#FFFF00] [r=5 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,87) size 600x36
+            RenderTableCell {TD} at (155,87) size 446x36 [bgcolor=#FFFF00] [r=5 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 426x35
                 text run at (0,0) width 257: "If you have entered your feature criteria, "
                 text run at (257,0) width 169: "press the \"Submit Criteria\""
                 text run at (0,18) width 86: "button above."
-          RenderTableRow {TR} at (0,127) size 600x18
-            RenderTableCell {TD} at (155,127) size 446x18 [bgcolor=#D3D3D3] [r=6 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,123) size 600x18
+            RenderTableCell {TD} at (155,123) size 446x18 [bgcolor=#D3D3D3] [r=6 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 8x17
                 text run at (0,0) width 8: "6"
-          RenderTableRow {TR} at (0,145) size 600x54
-            RenderTableCell {TD} at (155,145) size 446x54 [r=7 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,141) size 600x54
+            RenderTableCell {TD} at (155,141) size 446x54 [r=7 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 438x53
                 text run at (0,0) width 262: "If you want to do a radius search instead, "
                 text run at (262,0) width 164: "press the \"Radius Search\""
@@ -53,12 +53,12 @@ layer at (0,0) size 800x600
                 text run at (48,18) width 279: "This will allow you to select a starting point "
                 text run at (327,18) width 111: "and enter a radius"
                 text run at (0,36) width 157: "with new feature criteria."
-          RenderTableRow {TR} at (0,199) size 600x18
-            RenderTableCell {TD} at (155,199) size 446x18 [r=8 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,195) size 600x18
+            RenderTableCell {TD} at (155,195) size 446x18 [r=8 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 4x17
                 text run at (0,0) width 4: " "
-          RenderTableRow {TR} at (0,217) size 600x72
-            RenderTableCell {TD} at (155,217) size 446x72 [r=9 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,213) size 600x72
+            RenderTableCell {TD} at (155,213) size 446x72 [r=9 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 436x71
                 text run at (0,0) width 436: "All information provided is deemed reliable but is not guaranteed and"
                 text run at (0,18) width 65: "should be "

--- a/LayoutTests/platform/wpe/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
@@ -1,16 +1,16 @@
-layer at (0,0) size 785x1325
+layer at (0,0) size 785x1317
   RenderView at (0,0) size 785x600
-layer at (8,8) size 769x1317
-  RenderBlock {HTML} at (8,8) size 769x1317 [bgcolor=#008000] [border: (16px solid #00FF00)]
-    RenderTable at (16,16) size 737x1285
-      RenderTableSection (anonymous) at (0,0) size 737x1285
-        RenderTableRow (anonymous) at (0,0) size 737x1285
-          RenderTableCell {HEAD} at (0,0) size 127x958 [color=#FFFFFF] [bgcolor=#FF0000] [border: (5px solid #FFFFFF)] [r=0 c=0 rs=1 cs=1]
-            RenderBlock {META} at (21,37) size 85x2 [border: (1px dotted #FFFFFF)]
-            RenderBlock {META} at (21,55) size 85x2 [border: (1px dotted #FFFFFF)]
-            RenderBlock {META} at (21,73) size 85x2 [border: (1px dotted #FFFFFF)]
-            RenderBlock {META} at (21,91) size 85x2 [border: (1px dotted #FFFFFF)]
-            RenderBlock {TITLE} at (21,109) size 85x110 [border: (1px dotted #FFFFFF)]
+layer at (8,8) size 769x1309
+  RenderBlock {HTML} at (8,8) size 769x1309 [bgcolor=#008000] [border: (16px solid #00FF00)]
+    RenderTable at (16,16) size 737x1277
+      RenderTableSection (anonymous) at (0,0) size 737x1277
+        RenderTableRow (anonymous) at (0,0) size 737x1277
+          RenderTableCell {HEAD} at (0,0) size 131x940 [color=#FFFFFF] [bgcolor=#FF0000] [border: (5px solid #FFFFFF)] [r=0 c=0 rs=1 cs=1]
+            RenderBlock {META} at (21,37) size 89x2 [border: (1px dotted #FFFFFF)]
+            RenderBlock {META} at (21,55) size 89x2 [border: (1px dotted #FFFFFF)]
+            RenderBlock {META} at (21,73) size 89x2 [border: (1px dotted #FFFFFF)]
+            RenderBlock {META} at (21,91) size 89x2 [border: (1px dotted #FFFFFF)]
+            RenderBlock {TITLE} at (21,109) size 89x110 [border: (1px dotted #FFFFFF)]
               RenderText {#text} at (1,1) size 74x107
                 text run at (1,1) width 67: "Evil Tests:"
                 text run at (1,19) width 66: "Rendering"
@@ -18,8 +18,8 @@ layer at (8,8) size 769x1317
                 text run at (1,55) width 63: "HEAD as"
                 text run at (1,73) width 68: "children of"
                 text run at (1,91) width 67: "HTML - 2"
-            RenderBlock {STYLE} at (21,235) size 85x686 [border: (1px dotted #FFFFFF)]
-              RenderText {#text} at (1,1) size 83x683
+            RenderBlock {STYLE} at (21,235) size 89x668 [border: (1px dotted #FFFFFF)]
+              RenderText {#text} at (1,1) size 87x665
                 text run at (1,1) width 77: "/* Layout */"
                 text run at (1,19) width 58: "HTML {"
                 text run at (1,37) width 49: "display:"
@@ -38,31 +38,30 @@ layer at (8,8) size 769x1317
                 text run at (1,253) width 83: "1em; margin:"
                 text run at (1,271) width 43: "1em; }"
                 text run at (1,289) width 75: "HEAD > *,"
-                text run at (1,307) width 72: "BODY > *"
-                text run at (1,325) width 61: "{ display:"
+                text run at (1,307) width 84: "BODY > * {"
+                text run at (1,325) width 49: "display:"
                 text run at (1,343) width 39: "block;"
                 text run at (1,361) width 73: "border: thin"
                 text run at (1,379) width 43: "dotted;"
                 text run at (1,397) width 79: "margin: 1em"
                 text run at (1,415) width 28: "0; } "
                 text run at (29,415) width 12: "/*"
-                text run at (1,433) width 69: "Formatting"
-                text run at (1,451) width 16: "*/ "
-                text run at (17,451) width 58: "HTML {"
+                text run at (1,433) width 85: "Formatting */"
+                text run at (1,451) width 58: "HTML {"
                 text run at (1,469) width 78: "color: black;"
                 text run at (1,487) width 79: "background:"
                 text run at (1,505) width 51: "green; }"
                 text run at (1,523) width 58: "HEAD {"
                 text run at (1,541) width 79: "color: white;"
                 text run at (1,559) width 79: "background:"
-                text run at (1,577) width 36: "red; }"
-                text run at (1,595) width 59: "BODY {"
-                text run at (1,613) width 36: "color:"
-                text run at (1,631) width 47: "yellow;"
-                text run at (1,649) width 79: "background:"
-                text run at (1,667) width 38: "teal; }"
-          RenderTableCell {BODY} at (127,41) size 610x1244 [color=#FFFF00] [bgcolor=#008080] [border: (5px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
-            RenderBlock {H1} at (21,53) size 568x76 [border: (1px dotted #FFFF00)]
+                text run at (1,577) width 40: "red; } "
+                text run at (41,577) width 47: "BODY"
+                text run at (1,595) width 48: "{ color:"
+                text run at (1,613) width 47: "yellow;"
+                text run at (1,631) width 79: "background:"
+                text run at (1,649) width 38: "teal; }"
+          RenderTableCell {BODY} at (131,41) size 606x1236 [color=#FFFF00] [bgcolor=#008080] [border: (5px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
+            RenderBlock {H1} at (21,53) size 564x76 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 152x36
                 text run at (1,1) width 152: "Rendering "
               RenderInline {CODE} at (0,0) size 64x30
@@ -80,7 +79,7 @@ layer at (8,8) size 769x1317
                   text run at (1,45) width 64: "HTML"
               RenderText {#text} at (65,38) size 43x36
                 text run at (65,38) width 43: " - 2"
-            RenderBlock {P} at (21,161) size 568x38 [border: (1px dotted #FFFF00)]
+            RenderBlock {P} at (21,161) size 564x38 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 383x17
                 text run at (1,1) width 383: "If you have any comments to make regarding this test, e-mail"
               RenderInline {A} at (0,0) size 182x17 [color=#0000EE]
@@ -88,95 +87,94 @@ layer at (8,8) size 769x1317
                   text run at (1,19) width 182: "py8ieh=eviltests@bath.ac.uk"
               RenderText {#text} at (183,19) size 4x17
                 text run at (183,19) width 4: "."
-            RenderBlock {DL} at (21,215) size 568x74 [border: (1px dotted #FFFF00)]
-              RenderBlock {DT} at (1,1) size 566x18
+            RenderBlock {DL} at (21,215) size 564x74 [border: (1px dotted #FFFF00)]
+              RenderBlock {DT} at (1,1) size 562x18
                 RenderText {#text} at (0,0) size 80x17
                   text run at (0,0) width 80: "Prerequisites"
-              RenderBlock {DD} at (41,19) size 526x54
-                RenderText {#text} at (0,0) size 525x35
-                  text run at (0,0) width 525: "Browsers that are subjected to this test should support the the background, padding,"
-                  text run at (0,18) width 401: "margin, border and color properties of CSS, and in addition the "
+              RenderBlock {DD} at (41,19) size 522x54
+                RenderText {#text} at (0,0) size 466x35
+                  text run at (0,0) width 466: "Browsers that are subjected to this test should support the the background,"
+                  text run at (0,18) width 456: "padding, margin, border and color properties of CSS, and in addition the"
                 RenderInline {CODE} at (0,0) size 64x15
-                  RenderText {#text} at (401,21) size 64x15
-                    text run at (401,21) width 64: "overflow"
-                RenderText {#text} at (465,18) size 522x35
-                  text run at (465,18) width 57: " property"
-                  text run at (0,36) width 224: "and fixed position stuff from CSS2."
-            RenderBlock {H2} at (21,313) size 568x29 [border: (1px dotted #FFFF00)]
+                  RenderText {#text} at (0,39) size 64x15
+                    text run at (0,39) width 64: "overflow"
+                RenderText {#text} at (64,36) size 285x17
+                  text run at (64,36) width 285: " property and fixed position stuff from CSS2."
+            RenderBlock {H2} at (21,313) size 564x29 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 495x26
                 text run at (1,1) width 495: "1. Making the BODY and the HEAD into a table"
-            RenderBlock {P} at (21,366) size 568x20 [border: (1px dotted #FFFF00)]
+            RenderBlock {P} at (21,366) size 564x20 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 256x17
                 text run at (1,1) width 256: "This is really evil, but completely valid..."
-            RenderBlock {P} at (21,402) size 568x92 [border: (1px dotted #FFFF00)]
+            RenderBlock {P} at (21,402) size 564x92 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 557x89
                 text run at (1,1) width 557: "This document should have two cells, side by side: one on the left, the other on the right."
                 text run at (1,19) width 548: "The one on the left should be red with white writing and a thick white border. It should"
                 text run at (1,37) width 538: "contain four dotted lines separated by a blank line, followed by a dotted bordered box"
                 text run at (1,55) width 557: "containing the document title, and another dotted bordered box containing the stylesheet,"
                 text run at (1,73) width 118: "also shown below:"
-            RenderBlock {PRE} at (21,510) size 568x17 [border: (1px dotted #FFFF00)]
+            RenderBlock {PRE} at (21,510) size 564x17 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 40x15
                 text run at (1,1) width 40: "  ..."
                 text run at (41,1) width 0: " "
-            RenderBlock {P} at (21,543) size 568x20 [border: (1px dotted #FFFF00)]
+            RenderBlock {P} at (21,543) size 564x20 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 453x17
                 text run at (1,1) width 453: "The dotted borders and lines and the text in the left cell should be white."
-            RenderBlock {P} at (21,579) size 568x38 [border: (1px dotted #FFFF00)]
+            RenderBlock {P} at (21,579) size 564x38 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 522x35
                 text run at (1,1) width 522: "The right cell should be teal, with yellow text. This paragraph you are reading now"
                 text run at (1,19) width 166: "should be in this right cell."
-            RenderBlock {P} at (21,633) size 568x20 [border: (1px dotted #FFFF00)]
+            RenderBlock {P} at (21,633) size 564x20 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 444x17
                 text run at (1,1) width 444: "The width of the two cells is left up to the user agent to decide, I think."
-            RenderBlock {P} at (21,669) size 568x56 [border: (1px dotted #FFFF00)]
-              RenderText {#text} at (1,1) size 563x53
+            RenderBlock {P} at (21,669) size 564x56 [border: (1px dotted #FFFF00)]
+              RenderText {#text} at (1,1) size 547x53
                 text run at (1,1) width 547: "The right cell should look similar to the left cell in formatting -- each box of text should"
-                text run at (1,19) width 563: "have a yellow dotted border, and there should be a blank line between each such box. No"
-                text run at (1,37) width 523: "box should be nested -- the dotted boxes should always be distinct from each other."
-            RenderBlock {P} at (21,741) size 568x38 [border: (1px dotted #FFFF00)]
+                text run at (1,19) width 539: "have a yellow dotted border, and there should be a blank line between each such box."
+                text run at (1,37) width 547: "No box should be nested -- the dotted boxes should always be distinct from each other."
+            RenderBlock {P} at (21,741) size 564x38 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 489x35
                 text run at (1,1) width 489: "The cells should be the same height, and they should have grown vertically to"
                 text run at (1,19) width 144: "accommodate this text."
-            RenderBlock {P} at (21,795) size 568x38 [border: (1px dotted #FFFF00)]
+            RenderBlock {P} at (21,795) size 564x38 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 554x35
                 text run at (1,1) width 534: "Around the whole setup should be two borders, dark green and light green. The cells"
                 text run at (1,19) width 554: "should be separated from each other and from these outer borders by 1em of dark green."
-            RenderBlock {P} at (21,849) size 568x38 [border: (1px dotted #FFFF00)]
+            RenderBlock {P} at (21,849) size 564x38 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 508x35
                 text run at (1,1) width 508: "There should also be some alternate stylesheets set up to allow you to display the"
                 text run at (1,19) width 311: "<META> content. This may help with diagnosis."
-            RenderBlock {H2} at (21,911) size 568x29 [border: (1px dotted #FFFF00)]
+            RenderBlock {H2} at (21,911) size 564x29 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 154x26
                 text run at (1,1) width 154: "Submit Results"
-            RenderBlock {FORM} at (21,964) size 568x117 [border: (1px dotted #FFFF00)]
-              RenderBlock {P} at (1,17) size 566x83
+            RenderBlock {FORM} at (21,964) size 564x109 [border: (1px dotted #FFFF00)]
+              RenderBlock {P} at (1,17) size 562x75
                 RenderText {#text} at (0,0) size 259x17
                   text run at (0,0) width 259: "How does your browser fare on this test?"
-                RenderMenuList {SELECT} at (2,20) size 562x30 [color=#000000] [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+                RenderMenuList {SELECT} at (0,18) size 562x30 [color=#000000] [bgcolor=#FFFFFF] [border: (1px solid #000000)]
                   RenderBlock (anonymous) at (1,1) size 560x28
                     RenderText at (5,5) size 250x17
                       text run at (5,5) width 250: "Document renders exactly as described."
                 RenderText {#text} at (0,0) size 0x0
-                RenderInline {LABEL} at (0,0) size 247x17
-                  RenderText {#text} at (0,58) size 70x17
-                    text run at (0,58) width 70: "Comment: "
-                  RenderTextControl {INPUT} at (72,55) size 173x24 [color=#000000] [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-                RenderText {#text} at (247,58) size 4x17
-                  text run at (247,58) width 4: " "
-                RenderButton {INPUT} at (253,54) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+                RenderInline {LABEL} at (0,0) size 243x17
+                  RenderText {#text} at (0,52) size 70x17
+                    text run at (0,52) width 70: "Comment: "
+                  RenderTextControl {INPUT} at (70,49) size 173x24 [color=#000000] [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                RenderText {#text} at (243,52) size 4x17
+                  text run at (243,52) width 4: " "
+                RenderButton {INPUT} at (247,48) size 61x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,4) size 45x18
                     RenderText at (0,0) size 45x17
                       text run at (0,0) width 45: "Submit"
                 RenderText {#text} at (0,0) size 0x0
-            RenderBlock {HR} at (21,1097) size 568x2 [border: (1px dotted #FFFF00)]
-            RenderBlock {P} at (21,1115) size 568x20 [border: (1px dotted #FFFF00)]
+            RenderBlock {HR} at (21,1089) size 564x2 [border: (1px dotted #FFFF00)]
+            RenderBlock {P} at (21,1107) size 564x20 [border: (1px dotted #FFFF00)]
               RenderInline {A} at (0,0) size 161x17 [color=#0000EE]
                 RenderText {#text} at (1,1) size 161x17
                   text run at (1,1) width 161: "Up to the Evil Tests Page"
               RenderText {#text} at (162,1) size 4x17
                 text run at (162,1) width 4: "."
-            RenderBlock {P} at (21,1151) size 568x20 [border: (1px dotted #FFFF00)]
+            RenderBlock {P} at (21,1143) size 564x20 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 173x17
                 text run at (1,1) width 173: "This page is maintained by "
               RenderInline {A} at (0,0) size 77x17 [color=#0000EE]
@@ -189,8 +187,8 @@ layer at (8,8) size 769x1317
                   text run at (260,1) width 123: "py8ieh@bath.ac.uk"
               RenderText {#text} at (383,1) size 9x17
                 text run at (383,1) width 9: ")."
-            RenderBlock {P} at (21,1187) size 568x20 [border: (1px dotted #FFFF00)]
+            RenderBlock {P} at (21,1179) size 564x20 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 170x17
                 text run at (1,1) width 170: "Last updated in June 1999."
-layer at (248,1104) size 167x18
+layer at (250,1098) size 167x18
   RenderBlock {DIV} at (3,3) size 167x18

--- a/LayoutTests/platform/wpe/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt
@@ -32,14 +32,14 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (2,158) size 42x22 [border: (1px inset #808080)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 37x17
                 text run at (2,2) width 37: "row 3"
-      RenderBlock (anonymous) at (0,240) size 784x31
-        RenderButton {INPUT} at (2,2) size 62x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+      RenderBlock (anonymous) at (0,240) size 784x27
+        RenderButton {INPUT} at (0,0) size 62x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 46x18
             RenderText at (0,0) size 46x17
               text run at (0,0) width 46: "expand"
-        RenderText {#text} at (66,6) size 4x17
-          text run at (66,6) width 4: " "
-        RenderButton {INPUT} at (72,2) size 46x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderText {#text} at (62,4) size 4x17
+          text run at (62,4) width 4: " "
+        RenderButton {INPUT} at (66,0) size 46x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,4) size 30x18
             RenderText at (0,0) size 30x17
               text run at (0,0) width 30: "sizes"

--- a/LayoutTests/platform/wpe/tables/mozilla_expected_failures/bugs/bug92647-1-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla_expected_failures/bugs/bug92647-1-expected.txt
@@ -3,32 +3,32 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {FORM} at (0,0) size 784x92
-        RenderTable {TABLE} at (0,0) size 324x92 [border: (1px outset #808080)]
-          RenderTableSection {TBODY} at (1,1) size 322x90
-            RenderTableRow {TR} at (0,2) size 322x86
-              RenderTableCell {TD} at (2,2) size 318x86 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                RenderTable {TABLE} at (2,2) size 314x82 [border: (2px outset #808080)]
-                  RenderTableSection {TBODY} at (2,2) size 310x78
-                    RenderTableRow {TR} at (0,2) size 310x40
-                      RenderTableCell {TD} at (2,2) size 89x40 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+      RenderBlock {FORM} at (0,0) size 784x88
+        RenderTable {TABLE} at (0,0) size 320x88 [border: (1px outset #808080)]
+          RenderTableSection {TBODY} at (1,1) size 318x86
+            RenderTableRow {TR} at (0,2) size 318x82
+              RenderTableCell {TD} at (2,2) size 314x82 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                RenderTable {TABLE} at (2,2) size 310x78 [border: (2px outset #808080)]
+                  RenderTableSection {TBODY} at (2,2) size 306x74
+                    RenderTableRow {TR} at (0,2) size 306x40
+                      RenderTableCell {TD} at (2,2) size 88x40 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (2,2) size 56x35
                           text run at (2,2) width 53: "Member"
                           text run at (2,20) width 56: "Number:"
-                      RenderTableCell {TD} at (92,6) size 211x32 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-                        RenderTextControl {INPUT} at (4,4) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                      RenderTableCell {TD} at (91,8) size 208x28 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+                        RenderTextControl {INPUT} at (2,2) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                         RenderText {#text} at (0,0) size 0x0
-                    RenderTableRow {TR} at (0,44) size 310x32
-                      RenderTableCell {TD} at (2,49) size 89x22 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
+                    RenderTableRow {TR} at (0,44) size 306x28
+                      RenderTableCell {TD} at (2,47) size 88x22 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
                         RenderText {#text} at (2,2) size 30x17
                           text run at (2,2) width 30: "PIN:"
-                      RenderTableCell {TD} at (92,44) size 211x32 [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
-                        RenderTextControl {INPUT} at (4,4) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+                      RenderTableCell {TD} at (91,44) size 208x28 [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
+                        RenderTextControl {INPUT} at (2,2) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                           RenderFlexibleBox {DIV} at (3,3) size 167x18
                             RenderBlock {DIV} at (0,0) size 167x18
                         RenderText {#text} at (0,0) size 0x0
-                      RenderTableCell {TD} at (304,58) size 5x4 [border: (1px inset #808080)] [r=1 c=2 rs=1 cs=1]
-layer at (115,28) size 167x18
+                      RenderTableCell {TD} at (300,56) size 5x4 [border: (1px inset #808080)] [r=1 c=2 rs=1 cs=1]
+layer at (111,28) size 167x18
   RenderBlock {DIV} at (3,3) size 167x18
-layer at (115,66) size 167x18
+layer at (111,64) size 167x18
   RenderBlock {DIV} at (0,0) size 167x18

--- a/LayoutTests/platform/wpe/tables/mozilla_expected_failures/collapsing_borders/bug41262-5-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla_expected_failures/collapsing_borders/bug41262-5-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {CENTER} at (0,0) size 784x158
+      RenderBlock {CENTER} at (0,0) size 784x150
         RenderTable {TABLE} at (340,0) size 104x80
           RenderTableSection {THEAD} at (0,0) size 104x20
             RenderTableRow {TR} at (0,0) size 104x20
@@ -48,34 +48,34 @@ layer at (0,0) size 800x600
               RenderTableCell {TD} at (65,0) size 39x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,1) size 36x17
                   text run at (2,1) width 36: "11pm"
-        RenderBlock {P} at (0,96) size 784x62
-          RenderButton {BUTTON} at (245,2) size 87x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderBlock {P} at (0,96) size 784x54
+          RenderButton {BUTTON} at (249,0) size 87x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 71x18
               RenderText {#text} at (0,0) size 71x17
                 text run at (0,0) width 24: "No "
                 text run at (24,0) width 47: "borders"
-          RenderButton {BUTTON} at (336,2) size 112x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderButton {BUTTON} at (336,0) size 112x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 96x18
               RenderText {#text} at (0,0) size 96x17
                 text run at (0,0) width 55: "Exterior "
                 text run at (55,0) width 41: "border"
-          RenderButton {BUTTON} at (452,2) size 87x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderButton {BUTTON} at (448,0) size 87x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 71x18
               RenderText {#text} at (0,0) size 71x17
                 text run at (0,0) width 24: "All "
                 text run at (24,0) width 47: "borders"
-          RenderBR {BR} at (541,6) size 0x17
-          RenderButton {BUTTON} at (206,33) size 118x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderBR {BR} at (535,4) size 0x17
+          RenderButton {BUTTON} at (210,27) size 118x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 102x18
               RenderText {#text} at (0,0) size 102x17
                 text run at (0,0) width 55: "Column "
                 text run at (55,0) width 47: "borders"
-          RenderButton {BUTTON} at (328,33) size 114x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderButton {BUTTON} at (328,27) size 114x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 98x18
               RenderText {#text} at (0,0) size 98x17
                 text run at (0,0) width 51: "Groups "
                 text run at (51,0) width 47: "borders"
-          RenderButton {BUTTON} at (446,33) size 132x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderButton {BUTTON} at (442,27) size 132x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 116x18
               RenderText {#text} at (0,0) size 116x17
                 text run at (0,0) width 40: "Table "

--- a/LayoutTests/platform/wpe/tables/mozilla_expected_failures/collapsing_borders/bug41262-6-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla_expected_failures/collapsing_borders/bug41262-6-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {CENTER} at (0,0) size 784x160
+      RenderBlock {CENTER} at (0,0) size 784x152
         RenderTable {TABLE} at (339,0) size 106x82 [border: none]
           RenderTableSection {THEAD} at (0,0) size 105x21
             RenderTableRow {TR} at (0,0) size 105x21
@@ -48,34 +48,34 @@ layer at (0,0) size 800x600
               RenderTableCell {TD} at (66,0) size 39x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,1) size 36x17
                   text run at (2,1) width 36: "11pm"
-        RenderBlock {P} at (0,98) size 784x62
-          RenderButton {BUTTON} at (245,2) size 87x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderBlock {P} at (0,98) size 784x54
+          RenderButton {BUTTON} at (249,0) size 87x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 71x18
               RenderText {#text} at (0,0) size 71x17
                 text run at (0,0) width 24: "No "
                 text run at (24,0) width 47: "borders"
-          RenderButton {BUTTON} at (336,2) size 112x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderButton {BUTTON} at (336,0) size 112x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 96x18
               RenderText {#text} at (0,0) size 96x17
                 text run at (0,0) width 55: "Exterior "
                 text run at (55,0) width 41: "border"
-          RenderButton {BUTTON} at (452,2) size 87x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderButton {BUTTON} at (448,0) size 87x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 71x18
               RenderText {#text} at (0,0) size 71x17
                 text run at (0,0) width 24: "All "
                 text run at (24,0) width 47: "borders"
-          RenderBR {BR} at (541,6) size 0x17
-          RenderButton {BUTTON} at (206,33) size 118x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderBR {BR} at (535,4) size 0x17
+          RenderButton {BUTTON} at (210,27) size 118x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 102x18
               RenderText {#text} at (0,0) size 102x17
                 text run at (0,0) width 55: "Column "
                 text run at (55,0) width 47: "borders"
-          RenderButton {BUTTON} at (328,33) size 114x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderButton {BUTTON} at (328,27) size 114x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 98x18
               RenderText {#text} at (0,0) size 98x17
                 text run at (0,0) width 51: "Groups "
                 text run at (51,0) width 47: "borders"
-          RenderButton {BUTTON} at (446,33) size 132x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+          RenderButton {BUTTON} at (442,27) size 132x27 [color=#000000CC] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,4) size 116x18
               RenderText {#text} at (0,0) size 116x17
                 text run at (0,0) width 40: "Table "

--- a/LayoutTests/platform/wpe/transforms/2d/zoom-menulist-expected.txt
+++ b/LayoutTests/platform/wpe/transforms/2d/zoom-menulist-expected.txt
@@ -6,8 +6,8 @@ layer at (0,0) size 800x600
       RenderBlock {H1} at (0,0) size 784x37
         RenderText {#text} at (0,0) size 272x36
           text run at (0,0) width 272: "Zooming Menu List"
-      RenderBlock (anonymous) at (0,58) size 784x84
-        RenderMenuList {SELECT} at (6,6) size 143x71 [bgcolor=#FFFFFF] [border: (3px solid #000000)]
+      RenderBlock (anonymous) at (0,58) size 784x72
+        RenderMenuList {SELECT} at (0,0) size 143x71 [bgcolor=#FFFFFF] [border: (3px solid #000000)]
           RenderBlock (anonymous) at (3,3) size 137x65
             RenderText at (5,6) size 80x53
               text run at (5,6) width 80: "One"

--- a/LayoutTests/platform/wpe/transforms/3d/general/perspective-non-layer-expected.txt
+++ b/LayoutTests/platform/wpe/transforms/3d/general/perspective-non-layer-expected.txt
@@ -3,14 +3,14 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock (anonymous) at (0,0) size 784x28
-        RenderInline {SPAN} at (0,0) size 177x17
+      RenderBlock (anonymous) at (0,0) size 784x24
+        RenderInline {SPAN} at (0,0) size 173x17
           RenderText {#text} at (0,0) size 0x0
-          RenderTextControl {INPUT} at (2,2) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+          RenderTextControl {INPUT} at (0,0) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,28) size 784x0
+      RenderBlock (anonymous) at (0,24) size 784x0
         RenderBlock {DIV} at (0,0) size 784x0
-      RenderBlock (anonymous) at (0,28) size 784x0
+      RenderBlock (anonymous) at (0,24) size 784x0
         RenderInline {SPAN} at (0,0) size 0x0
-layer at (13,13) size 167x18
+layer at (11,11) size 167x18
   RenderBlock {DIV} at (3,3) size 167x18


### PR DESCRIPTION
#### d9fedce897b5380f09647e7e9ac1a5be5c8a96f4
<pre>
[WPE] Gardening -- baseline updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=244204">https://bugs.webkit.org/show_bug.cgi?id=244204</a>

Unreviewed WPE gardening, further updating of port-specific expected baselines.

* LayoutTests/platform/wpe/accessibility/aria-description-expected.txt: Added.
* LayoutTests/platform/wpe/accessibility/aria-visible-element-roles-expected.txt: Added.
* LayoutTests/platform/wpe/accessibility/node-only-object-element-rect-expected.txt: Added.
* LayoutTests/platform/wpe/css1/box_properties/margin_right-expected.txt:
* LayoutTests/platform/wpe/css1/box_properties/padding_right-expected.txt:
* LayoutTests/platform/wpe/css1/box_properties/width-expected.txt:
* LayoutTests/platform/wpe/css1/formatting_model/replaced_elements-expected.txt:
* LayoutTests/platform/wpe/css1/text_properties/vertical_align-expected.txt:
* LayoutTests/platform/wpe/css2.1/20110323/replaced-elements-001-expected.txt:
* LayoutTests/platform/wpe/css2.1/t100801-c544-valgn-03-d-agi-expected.txt: Added.
* LayoutTests/platform/wpe/css2.1/t1202-counter-09-b-expected.txt:
* LayoutTests/platform/wpe/css2.1/t1202-counters-09-b-expected.txt:
* LayoutTests/platform/wpe/css2.1/t120401-scope-04-d-expected.txt: Added.
* LayoutTests/platform/wpe/css2.1/t120403-content-none-00-c-expected.txt: Added.
* LayoutTests/platform/wpe/css2.1/t120403-visibility-00-c-expected.txt: Added.
* LayoutTests/platform/wpe/css3/flexbox/button-expected.txt:
* LayoutTests/platform/wpe/printing/print-with-media-query-destory-expected.txt: Added.
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/absolute-in-nested-sc-scrollers-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/absolute-inside-stacking-in-scroller-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/clipped-layer-in-overflow-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/clipped-layer-in-overflow-nested-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/composited-in-absolute-in-overflow-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/composited-in-absolute-in-stacking-context-overflow-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/coordinated-frame-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/coordinated-frame-gain-scrolling-ancestor-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/coordinated-frame-in-fixed-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/coordinated-frame-lose-scrolling-ancestor-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/fixed-inside-frame-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/gain-scrolling-node-parent-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/lose-scrolling-node-parent-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/nested-absolute-in-absolute-overflow-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/nested-absolute-in-overflow-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/nested-absolute-in-relative-in-overflow-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/nested-absolute-in-sc-overflow-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/nested-overflow-scroll-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/overflow-in-fixed-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/positioned-nodes-complex-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/positioned-nodes-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/remove-coordinated-frame-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/remove-scrolling-role-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/reparent-across-compositing-layers-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/reparent-with-layer-removal-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/scrolling-tree-includes-frame-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/scrolling-tree-is-z-order-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/sibling-node-order-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/sticky-in-overflow-expected.txt:
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/sticky-in-overflow-stale-constraints-expected.txt: Copied from LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/sticky-in-overflow-expected.txt.
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/toggle-coordinated-frame-scrolling-expected.txt:
* LayoutTests/platform/wpe/svg/custom/inline-svg-in-xhtml-expected.txt:
* LayoutTests/platform/wpe/svg/hixie/mixed/003-expected.txt:
* LayoutTests/platform/wpe/svg/wicd/rightsizing-grid-expected.txt:
* LayoutTests/platform/wpe/svg/wicd/test-rightsizing-b-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug1188-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug12384-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug1318-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug138725-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug1430-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug14929-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug18359-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug194024-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug24200-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug2479-2-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug2479-3-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug2479-4-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug26178-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug28928-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug29326-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug30559-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug33855-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug39209-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug4382-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug4429-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug44505-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug4527-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug46368-1-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug46368-2-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug51037-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug51727-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug52505-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug52506-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug55545-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug59354-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug60749-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug68912-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug7342-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug92647-2-expected.txt: Added.
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug96334-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/collapsing_borders/bug41262-4-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/core/margins-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/dom/tableDom-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/other/move_row-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla_expected_failures/bugs/bug1725-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla_expected_failures/bugs/bug92647-1-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla_expected_failures/collapsing_borders/bug41262-5-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla_expected_failures/collapsing_borders/bug41262-6-expected.txt:
* LayoutTests/platform/wpe/transforms/2d/zoom-menulist-expected.txt:
* LayoutTests/platform/wpe/transforms/3d/general/perspective-non-layer-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253645@main">https://commits.webkit.org/253645@main</a>
</pre>































<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6cce21225513a7b652cb0dee538e483225018ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/86682 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30741 "Built successfully") | [✅ ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95525 "Built successfully") | [✅ ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/149256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29126 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/90767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92298 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/78863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26897 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/26816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28495 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1008 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28439 "Built successfully") | [✅ ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->