### PR TITLE
[GStreamer][WebRTC] Misc clean-ups in stats gathering support

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -338,11 +338,11 @@ static gboolean fillReportCallback(GQuark, const GValue* value, gpointer userDat
         break;
     }
     case GST_WEBRTC_STATS_REMOTE_OUTBOUND_RTP: {
-        GST_FIXME("Remote outbound RTP stats not exposed yet");
+        // FIXME: Remote outbound RTP stats not exposed yet.
         break;
     }
     case GST_WEBRTC_STATS_CSRC:
-        GST_FIXME("Deprecated stats: csrc");
+        // Deprecated stats: csrc.
         break;
     case GST_WEBRTC_STATS_PEER_CONNECTION: {
         RTCStatsReport::PeerConnectionStats stats;
@@ -357,10 +357,10 @@ static gboolean fillReportCallback(GQuark, const GValue* value, gpointer userDat
         break;
     }
     case GST_WEBRTC_STATS_STREAM:
-        GST_FIXME("Deprecated stats: stream");
+        // Deprecated stats: stream.
         break;
     case GST_WEBRTC_STATS_DATA_CHANNEL:
-        GST_FIXME("Missing data-channel stats support");
+        // FIXME: Missing data-channel stats support.
         break;
     case GST_WEBRTC_STATS_LOCAL_CANDIDATE:
     case GST_WEBRTC_STATS_REMOTE_CANDIDATE:
@@ -378,7 +378,7 @@ static gboolean fillReportCallback(GQuark, const GValue* value, gpointer userDat
         }
         break;
     case GST_WEBRTC_STATS_CERTIFICATE:
-        GST_FIXME("Missing certificate stats support");
+        // FIXME: Missing certificate stats support
         break;
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -66,6 +66,10 @@
 #include "WebKitWebSourceGStreamer.h"
 #endif
 
+#if USE(GSTREAMER_WEBRTC)
+#include <gst/webrtc/webrtc-enumtypes.h>
+#endif
+
 GST_DEBUG_CATEGORY(webkit_gst_common_debug);
 #define GST_CAT_DEFAULT webkit_gst_common_debug
 
@@ -647,6 +651,13 @@ static std::optional<RefPtr<JSON::Value>> gstStructureValueToJSON(const GValue* 
 
     if (valueType == G_TYPE_STRING)
         return JSON::Value::create(makeString(g_value_get_string(value)))->asValue();
+
+#if USE(GSTREAMER_WEBRTC)
+    if (valueType == GST_TYPE_WEBRTC_STATS_TYPE) {
+        GUniquePtr<char> statsType(g_enum_to_string(GST_TYPE_WEBRTC_STATS_TYPE, g_value_get_enum(value)));
+        return JSON::Value::create(makeString(statsType.get()))->asValue();
+    }
+#endif
 
     GST_WARNING("Unhandled GValue type: %s", G_VALUE_TYPE_NAME(value));
     return { };


### PR DESCRIPTION
#### dcc38b79c3b0ef2f45489abe43d393c0336ee16b
<pre>
[GStreamer][WebRTC] Misc clean-ups in stats gathering support
<a href="https://bugs.webkit.org/show_bug.cgi?id=244211">https://bugs.webkit.org/show_bug.cgi?id=244211</a>

Reviewed by Alicia Boya Garcia.

The GST_FIXME calls were just adding high-frequence noise in the debug logs. Also the GstStructure
to JSON serializer now understants the WebRTC stats-type enum.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::fillReportCallback):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::gstStructureValueToJSON):

Canonical link: <a href="https://commits.webkit.org/253675@main">https://commits.webkit.org/253675@main</a>
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a12946d536c0d79e100560a73a6a3b93e8a007ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95545 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149280 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29146 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25552 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78882 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90786 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23541 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73618 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23603 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66611 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26917 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12737 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26836 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13751 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2610 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36615 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28459 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33030 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->