### PR TITLE
[GStreamer][WebAudio] Misc logging improvements

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
@@ -95,6 +95,7 @@ AudioSourceProviderGStreamer::AudioSourceProviderGStreamer(MediaStreamTrackPriva
     initializeDebugCategory();
     auto pipelineName = makeString("WebAudioProvider_MediaStreamTrack_", source.id());
     m_pipeline = gst_element_factory_make("pipeline", pipelineName.utf8().data());
+    GST_DEBUG_OBJECT(m_pipeline.get(), "MediaStream WebAudio provider created");
     auto src = webkitMediaStreamSrcNew();
     webkitMediaStreamSrcAddTrack(WEBKIT_MEDIA_STREAM_SRC(src), &source, true);
 
@@ -252,7 +253,7 @@ void AudioSourceProviderGStreamer::setClient(AudioSourceProviderClient* newClien
     if (client() == newClient)
         return;
 
-    GST_DEBUG("Setting up client %p (previous: %p)", newClient, client());
+    GST_DEBUG_OBJECT(m_pipeline.get(), "Setting up client %p (previous: %p)", newClient, client());
     bool previousClientWasValid = !!m_client;
     m_client = newClient;
 
@@ -340,7 +341,7 @@ void AudioSourceProviderGStreamer::setClient(AudioSourceProviderClient* newClien
 
 void AudioSourceProviderGStreamer::handleNewDeinterleavePad(GstPad* pad)
 {
-    GST_DEBUG("New pad %" GST_PTR_FORMAT, pad);
+    GST_DEBUG_OBJECT(m_pipeline.get(), "New pad %" GST_PTR_FORMAT, pad);
 
     // A new pad for a planar channel was added in deinterleave. Plug
     // in an appsink so we can pull the data from each


### PR DESCRIPTION
#### 65b0ecd387162580c9bdaecc4b813e2d30339741
<pre>
[GStreamer][WebAudio] Misc logging improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=244212">https://bugs.webkit.org/show_bug.cgi?id=244212</a>

Reviewed by Alicia Boya Garcia.

Associate logs with the corresponding pipeline, which eases debugging when multiple providers are
created from the same WebProcess.

* Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp:
(WebCore::AudioSourceProviderGStreamer::AudioSourceProviderGStreamer):
(WebCore::AudioSourceProviderGStreamer::setClient):
(WebCore::AudioSourceProviderGStreamer::handleNewDeinterleavePad):

Canonical link: <a href="https://commits.webkit.org/253674@main">https://commits.webkit.org/253674@main</a>
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa4ce9560af84c24d9986a50bc76dda0aa85d173

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95546 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149281 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29147 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25553 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90787 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23542 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73619 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23617 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66624 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26918 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12738 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26837 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13752 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2609 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36616 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28460 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33031 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->