### PR TITLE
[GStreamer][WebRTC] Minor improvements in incoming media sources

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
@@ -25,12 +25,18 @@
 #include "GStreamerAudioData.h"
 #include "GStreamerAudioStreamDescription.h"
 
+GST_DEBUG_CATEGORY_EXTERN(webkit_webrtc_endpoint_debug);
+#define GST_CAT_DEFAULT webkit_webrtc_endpoint_debug
+
 namespace WebCore {
 
 RealtimeIncomingAudioSourceGStreamer::RealtimeIncomingAudioSourceGStreamer(AtomString&& audioTrackId)
     : RealtimeMediaSource(RealtimeMediaSource::Type::Audio, WTFMove(audioTrackId))
     , RealtimeIncomingSourceGStreamer()
 {
+    static Atomic<uint64_t> sourceCounter = 0;
+    gst_element_set_name(bin(), makeString("incoming-audio-source-", sourceCounter.exchangeAdd(1)).ascii().data());
+    GST_DEBUG_OBJECT(bin(), "New incoming audio source created");
     start();
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
@@ -42,9 +42,6 @@ RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer()
     gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_valve.get(), queue, m_tee.get(), nullptr);
 
     gst_element_link_many(m_valve.get(), queue, m_tee.get(), nullptr);
-    gst_element_sync_state_with_parent(m_valve.get());
-    gst_element_sync_state_with_parent(queue);
-    gst_element_sync_state_with_parent(m_tee.get());
 
     auto sinkPad = adoptGRef(gst_element_get_static_pad(m_valve.get(), "sink"));
     gst_element_add_pad(m_bin.get(), gst_ghost_pad_new("sink", sinkPad.get()));
@@ -52,19 +49,21 @@ RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer()
 
 void RealtimeIncomingSourceGStreamer::closeValve() const
 {
+    GST_DEBUG_OBJECT(m_bin.get(), "Closing valve");
     if (m_valve)
         g_object_set(m_valve.get(), "drop", true, nullptr);
 }
 
 void RealtimeIncomingSourceGStreamer::openValve() const
 {
+    GST_DEBUG_OBJECT(m_bin.get(), "Opening valve");
     if (m_valve)
         g_object_set(m_valve.get(), "drop", false, nullptr);
 }
 
 void RealtimeIncomingSourceGStreamer::registerClient()
 {
-    GST_DEBUG("Registering new client");
+    GST_DEBUG_OBJECT(m_bin.get(), "Registering new client");
     auto* queue = gst_element_factory_make("queue", nullptr);
     auto* sink = makeGStreamerElement("appsink", nullptr);
     g_object_set(sink, "enable-last-sample", FALSE, "emit-signals", TRUE, "max-buffers", 1, nullptr);
@@ -85,10 +84,7 @@ void RealtimeIncomingSourceGStreamer::registerClient()
     gst_element_sync_state_with_parent(queue);
     gst_element_sync_state_with_parent(sink);
 
-#ifndef GST_DISABLE_GST_DEBUG
-    auto dotFileName = makeString(GST_OBJECT_NAME(m_bin.get()), ".incoming");
-    GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(m_bin.get()), GST_DEBUG_GRAPH_SHOW_ALL, dotFileName.utf8().data());
-#endif
+    GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(m_bin.get()), GST_DEBUG_GRAPH_SHOW_ALL, GST_OBJECT_NAME(m_bin.get()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
@@ -27,12 +27,19 @@
 #include "VideoFrameMetadataGStreamer.h"
 #include <gst/rtp/rtp.h>
 
+GST_DEBUG_CATEGORY_EXTERN(webkit_webrtc_endpoint_debug);
+#define GST_CAT_DEFAULT webkit_webrtc_endpoint_debug
+
 namespace WebCore {
 
 RealtimeIncomingVideoSourceGStreamer::RealtimeIncomingVideoSourceGStreamer(AtomString&& videoTrackId)
     : RealtimeMediaSource(RealtimeMediaSource::Type::Video, WTFMove(videoTrackId))
     , RealtimeIncomingSourceGStreamer()
 {
+    static Atomic<uint64_t> sourceCounter = 0;
+    gst_element_set_name(bin(), makeString("incoming-video-source-", sourceCounter.exchangeAdd(1)).ascii().data());
+    GST_DEBUG_OBJECT(bin(), "New incoming video source created");
+
     RealtimeMediaSourceSupportedConstraints constraints;
     constraints.setSupportsWidth(true);
     constraints.setSupportsHeight(true);
@@ -60,11 +67,13 @@ RealtimeIncomingVideoSourceGStreamer::RealtimeIncomingVideoSourceGStreamer(AtomS
 
 void RealtimeIncomingVideoSourceGStreamer::startProducingData()
 {
+    GST_DEBUG_OBJECT(bin(), "Starting data flow");
     openValve();
 }
 
 void RealtimeIncomingVideoSourceGStreamer::stopProducingData()
 {
+    GST_DEBUG_OBJECT(bin(), "Stopping data flow");
     closeValve();
 }
 


### PR DESCRIPTION
#### b352c717fc680c07163031f40a638417cb7f504e
<pre>
[GStreamer][WebRTC] Minor improvements in incoming media sources
<a href="https://bugs.webkit.org/show_bug.cgi?id=244213">https://bugs.webkit.org/show_bug.cgi?id=244213</a>

Reviewed by Alicia Boya Garcia.

The associated GStreamer bins are now properly named to ease debugging when multiple PeerConnections
are created in the same WebProcess, for instance.

* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp:
(WebCore::RealtimeIncomingAudioSourceGStreamer::RealtimeIncomingAudioSourceGStreamer):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp:
(WebCore::RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer):
(WebCore::RealtimeIncomingSourceGStreamer::closeValve const):
(WebCore::RealtimeIncomingSourceGStreamer::openValve const):
(WebCore::RealtimeIncomingSourceGStreamer::registerClient):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp:
(WebCore::RealtimeIncomingVideoSourceGStreamer::RealtimeIncomingVideoSourceGStreamer):
(WebCore::RealtimeIncomingVideoSourceGStreamer::startProducingData):
(WebCore::RealtimeIncomingVideoSourceGStreamer::stopProducingData):

Canonical link: <a href="https://commits.webkit.org/253679@main">https://commits.webkit.org/253679@main</a>
</pre>











<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb11ec4b53a6e11afc1cead164d629d9d4e44a8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86780 "failed Failed to checkout and rebase branch from PR 3545") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30839 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95612 "failed Failed to checkout and rebase branch from PR 3545") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149361 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29223 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90848 "Built successfully") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92396 "failed Failed to checkout and rebase branch from PR 3545") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23597 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/78944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78598 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78702 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26985 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72351 "failed Failed to checkout and rebase branch from PR 3545") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26908 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/38/builds/72351 "failed Failed to checkout and rebase branch from PR 3545") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2614 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28591 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75135 "failed Failed to checkout and rebase branch from PR 3545") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28535 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/37/builds/75135 "failed Failed to checkout and rebase branch from PR 3545") | 
<!--EWS-Status-Bubble-End-->