### PR TITLE
REGRESSION(253529@main): [ iOS ] 2X imported/w3c/web-platform-tests/mediacapture-record/(Layout Tests) are almost constant failures

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -1961,9 +1961,6 @@ webkit.org/b/216292 [ Release ] imported/w3c/web-platform-tests/css/css-flexbox/
 
 webkit.org/b/186045 imported/w3c/web-platform-tests/css/css-values/vh_not_refreshing_on_chrome.html [ Skip ]
 
-webkit.org/b/217263 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-no-sink.https.html [ Slow ]
-webkit.org/b/217263 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html [ Slow ]
-
 webkit.org/b/196403 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-stop.html [ Pass Failure Slow ]
 
 webkit.org/b/217641 [ Debug ] imported/w3c/web-platform-tests/xhr/event-timeout.any.worker.html [ Pass Failure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3724,3 +3724,6 @@ webkit.org/b/244065 fast/forms/auto-fill-button/hide-auto-fill-button-when-input
 
 webkit.org/b/244134 animations/no-style-recalc-during-accelerated-animation.html [ Pass Failure ]
 webkit.org/b/244134 animations/steps-transform-rendering-updates.html [ Pass Failure ]
+
+webkit.org/b/244208 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-no-sink.https.html [ Pass Failure Slow ]
+webkit.org/b/244208 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html [ Pass Failure Slow ]

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -103,11 +103,11 @@ void HTMLDetailsElement::didAddUserAgentShadowRoot(ShadowRoot& root)
 {
     auto summarySlot = HTMLSlotElement::create(slotTag, document());
     summarySlot->setAttributeWithoutSynchronization(nameAttr, summarySlotName());
-    m_summarySlot = summarySlot.ptr();
+    m_summarySlot = summarySlot.get();
 
     auto defaultSummary = HTMLSummaryElement::create(summaryTag, document());
     defaultSummary->appendChild(Text::create(document(), defaultDetailsSummaryText()));
-    m_defaultSummary = defaultSummary.ptr();
+    m_defaultSummary = defaultSummary.get();
 
     summarySlot->appendChild(defaultSummary);
     root.appendChild(summarySlot);
@@ -127,7 +127,7 @@ bool HTMLDetailsElement::isActiveSummary(const HTMLSummaryElement& summary) cons
     RefPtr slot = shadowRoot()->findAssignedSlot(summary);
     if (!slot)
         return false;
-    return slot == m_summarySlot;
+    return slot == m_summarySlot.get();
 }
 
 void HTMLDetailsElement::parseAttribute(const QualifiedName& name, const AtomString& value)

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -48,8 +48,8 @@ private:
     bool isInteractiveContent() const final { return true; }
 
     bool m_isOpen { false };
-    HTMLSlotElement* m_summarySlot { nullptr };
-    HTMLSummaryElement* m_defaultSummary { nullptr };
+    WeakPtr<HTMLSlotElement> m_summarySlot;
+    WeakPtr<HTMLSummaryElement> m_defaultSummary;
     RefPtr<HTMLSlotElement> m_defaultSlot;
     bool m_isToggleEventTaskQueued { false };
 };


### PR DESCRIPTION
#### 8a70a07f345416cc6e643573d82a08598e13be76
<pre>
REGRESSION(253529@main): [ iOS ] 2X imported/w3c/web-platform-tests/mediacapture-record/(Layout Tests) are almost constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=244208">https://bugs.webkit.org/show_bug.cgi?id=244208</a>
rdar://problem/98987676

Reviewed by NOBODY (OOPS!).

When trying to convert with not enough data, the converter is blocked and does not process any future audio data.
This happened when flushing at the end and 253529@main made it happen when flushing to request data.
To workaround this, we no longer flush audio data but we make sure to let the compressor do its job.
At most 100 ms audio data might not get flushed. A follow-up should fix this.

Enable tests in mac since the underlying issue was solved a long time ago.

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm:
(WebCore::AudioSampleBufferCompressor::flushInternal):
</pre>