### PR TITLE
[iPad] (Trackpad) scrolling with a trackpad inside `overflow: hidden` should still dispatch `"wheel"`

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -312,6 +312,8 @@ struct PerWebProcessState {
 
     NSUInteger _focusPreservationCount;
     NSUInteger _activeFocusedStateRetainCount;
+
+    RetainPtr<NSArray<NSNumber *>> _scrollViewDefaultAllowedTouchTypes;
 #endif
 }
 

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -449,6 +449,13 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
     return systemContentInset;
 }
 
+- (BOOL)isScrollEnabled
+{
+    if (!self.panGestureRecognizer.allowedTouchTypes.count)
+        return NO;
+    return [super isScrollEnabled];
+}
+
 - (void)setScrollEnabled:(BOOL)value
 {
     _scrollEnabledByClient = value;


### PR DESCRIPTION
#### 8cf5fd7e56b07dddc7ef72cc5b7632a156c1b19b
<pre>
[iPad] (Trackpad) scrolling with a trackpad inside `overflow: hidden` should still dispatch `&quot;wheel&quot;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=244215">https://bugs.webkit.org/show_bug.cgi?id=244215</a>
&lt;rdar://problem/88885351&gt;

Reviewed by Aditya Keerthi.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setupScrollAndContentViews]):
(-[WKWebView _setHasCustomContentView:loadedMIMEType:]):
(-[WKWebView _updateScrollViewForTransaction:]):
(-[WKWebView _scrollView:asynchronouslyHandleScrollEvent:completion:]):
Instead of using `setScrollEnabled:` to disable scrolling (which also disables trackpad interactions),
set the list of `allowedTouchTypes` on the `panGestureRecognizer` to `@[ ]`, which is apparently an
allowed alternative (according to &lt;rdar://23150742&gt;).

* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView isScrollEnabled]): Added.
Also update the value of `scrollEnabled` so that clients will still think that the `WKScrollView` is
not scrollable, even though under the hood it still is (to hopefully avoid compatibility problems).

Canonical link: <a href="https://commits.webkit.org/253709@main">https://commits.webkit.org/253709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d11a6003c7fe7cde824c7bbb2778e1dc03819cb0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30916 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17720 "failed Failed to checkout and rebase branch from PR 3548") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95666 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149420 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29278 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78994 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90899 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23644 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23678 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/90438 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78639 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/17720 "failed Failed to checkout and rebase branch from PR 3548") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66683 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27038 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/17720 "failed Failed to checkout and rebase branch from PR 3548") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/85937 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26960 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/17720 "failed Failed to checkout and rebase branch from PR 3548") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2629 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28644 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28588 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/17720 "failed Failed to checkout and rebase branch from PR 3548") | | 
<!--EWS-Status-Bubble-End-->