### PR TITLE
[Modern Media Controls] [iOS] media documents in an `<iframe>` don't autosize until the user taps to play

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/media-document-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-document-controller.js
@@ -34,8 +34,6 @@ class MediaDocumentController
         mediaController.controls.shouldUseAudioLayout = true;
         mediaController.controls.timeControl.loading = true;
 
-        this._hasDeterminedMediaType = false;
-
         const media = mediaController.media;
         media.classList.add("media-document");
         media.classList.add("audio");
@@ -47,18 +45,12 @@ class MediaDocumentController
             deviceType = "linux";
 
         media.classList.add(deviceType);
-
-        media.addEventListener("error", this);
-        media.addEventListener("play", this);
     }
 
     // Public
 
     layout()
     {
-        if (!this._hasDeterminedMediaType)
-            return;
-
         scheduler.scheduleLayout(() => {
             const media = this.mediaController.media;
             const isInvalid = media.error !== null && media.played.length === 0;
@@ -69,18 +61,6 @@ class MediaDocumentController
             classList.toggle("video", useVideoLayout);
             classList.toggle("audio", !useVideoLayout);
         });
-    }
-
-    // Protected
-
-    handleEvent(event)
-    {
-        event.currentTarget.removeEventListener(event.type, this);
-
-        if (event.type === "play" || event.type === "error") {
-            this._hasDeterminedMediaType = true;
-            this.layout();
-        }
     }
 
 }


### PR DESCRIPTION
#### 1c1d283d5d189ead139b6374017eb3f5b64869c6
<pre>
[Modern Media Controls] [iOS] media documents in an `&lt;iframe&gt;` don&apos;t autosize until the user taps to play
<a href="https://bugs.webkit.org/show_bug.cgi?id=244220">https://bugs.webkit.org/show_bug.cgi?id=244220</a>
&lt;rdar://problem/98636512&gt;

Reviewed by Jer Noble.

Media documents default to showing audio controls until the type of media is able to be determined.
Previously, this would only happen on `&quot;error&quot;` or `&quot;play&quot;`, which really ended up requiring the
user to tap on the `&lt;video&gt;` before the media document would recognize it as video media (type).

* Source/WebCore/Modules/modern-media-controls/media/media-document-controller.js:
(MediaDocumentController):
(MediaDocumentController.prototype.layout):
(MediaDocumentController.prototype.handleEvent): Deleted.
`AudioSupport` already handles listening for `&quot;loadedmetadata&quot;` and `&quot;error&quot;` (as well as changes to
`HTMLMediaElement.prototype.videoTracks`), so entirely rely on that for updating CSS instead of also
having separate event listeners for `&quot;error&quot;` and `&quot;play&quot;`. With this, media documents with a video
media (type) will present `&lt;video&gt;` controls without the user having to tap to play.

Canonical link: <a href="https://commits.webkit.org/253726@main">https://commits.webkit.org/253726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19529e316d45789c39b16a6aae3da40f0f580098

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95577 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149321 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29185 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25574 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90814 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23566 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73642 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23621 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66628 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26949 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12749 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26872 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13763 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2643 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36627 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33042 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->