### PR TITLE
IntersectionObserver intersectionRatio < 1 observed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/intersection-ratio-with-fractional-bounds-in-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/intersection-ratio-with-fractional-bounds-in-iframe-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS intersectionRatio in iframe should be 1 for totally visible target with fractional bounds
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/intersection-ratio-with-fractional-bounds-in-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/intersection-ratio-with-fractional-bounds-in-iframe.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+        }
+        .iframe-container {
+            width: 100%;
+            border: 0;
+            height: 200px;
+        }
+    </style>
+</head>
+<body">
+<script>
+    const asyncTest = async_test("intersectionRatio in iframe should be 1 for totally visible target with fractional bounds");
+    const onIframeObserved = (event) => {
+        const ratio = event.detail.intersectionRatio;
+        asyncTest.step(() => {
+            assert_equals(ratio, 1);
+        });
+        asyncTest.done();
+    };
+    window.document.addEventListener("iframeObserved", onIframeObserved, false);
+</script>
+    <iframe class="iframe-container" src="./resources/intersection-ratio-with-fractional-bounds-in-iframe-content.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/intersection-ratio-with-fractional-bounds-in-iframe-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/intersection-ratio-with-fractional-bounds-in-iframe-content.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {
+            margin: 0;
+            height: 100%;
+        }
+        .app {
+            display: flex;
+            width: 100%;
+        }
+        .sidebar {
+            width: 31.1%;
+            margin: 0;
+            background: rgb(231, 249, 139);
+        }
+        section {
+            width: 68.9%;
+            background-color: rgb(119, 219, 172);
+            border: dashed red 3px;
+        }
+        p {
+            margin-top: 0;
+        }
+    </style>
+</head>
+<body>
+    <div class=app>
+        <div class="sidebar"></div>
+        <section id=target>
+            <h2>Observer target</h2>
+            <p><strong>Intersection ratio:</strong> <span id=ratio></span></p>
+        </section>
+    </div>
+
+    <script>
+        const onIntersection = entries => {
+            const ratio = entries[0].intersectionRatio;
+            const eventData = { intersectionRatio: ratio };
+            document.getElementById("ratio").innerText = ratio.toFixed(5);
+            const event = new CustomEvent("iframeObserved", {detail: eventData});
+            parent.document.dispatchEvent(event);
+        };
+        const observer = new IntersectionObserver(onIntersection, {threshold: 1});
+        setTimeout(() => {observer.observe(document.getElementById("target"))}, 0);
+    </script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8084,10 +8084,11 @@ static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const Lay
     if (!intersects)
         return std::nullopt;
 
-    LayoutRect rectInFrameViewSpace(renderer->view().frameView().contentsToView(snappedIntRect(*rectInFrameAbsoluteSpace)));
     auto* ownerRenderer = renderer->frame().ownerRenderer();
     if (!ownerRenderer)
         return std::nullopt;
+    
+    LayoutRect rectInFrameViewSpace { renderer->view().frameView().contentsToView(*rectInFrameAbsoluteSpace) };
 
     rectInFrameViewSpace.moveBy(ownerRenderer->contentBoxLocation());
     return computeClippedRectInRootContentsSpace(rectInFrameViewSpace, ownerRenderer);


### PR DESCRIPTION
#### b5701774e49ff045c17f405df13ad7d6edfd1f41
<pre>
IntersectionObserver intersectionRatio &lt; 1 observed
<a href="https://bugs.webkit.org/show_bug.cgi?id=243573">https://bugs.webkit.org/show_bug.cgi?id=243573</a>
&lt;rdar://98541023&gt;

Reviewed by Simon Fraser.

* Source/WebCore/dom/Document.cpp:
(WebCore::computeClippedRectInRootContentsSpace):
We call `computeClippedRectInRootContentsSpace` recursively until the renderer’s frame
 is the main frame. If we are not yet in the main frame, we use `contentsToView` to adjust
the target rect to the origin’s view scrolling position. Before this patch we were snapping
the target rect before passing it.

The patch removes the snapping, forcing the use of FloatRect overload of contentsToView
to avoid inaccurate calculation of intersection ratio when the target is not directly in the
main frame.

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/intersection-ratio-with-fractional-bounds-in-iframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/intersection-ratio-with-fractional-bounds-in-iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/intersection-ratio-with-fractional-bounds-in-iframe-content.html: Added.

Canonical link: <a href="https://commits.webkit.org/254244@main">https://commits.webkit.org/254244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27cc2269a8371065999ee866fb479b39a2d70577

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97567 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153040 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31325 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26972 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92225 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24914 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75234 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24889 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67853 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28937 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28928 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14937 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2985 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37853 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34050 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->