### PR TITLE
AX: HTML menu element should map to role=list

### DIFF
--- a/LayoutTests/accessibility/aria-visible-element-roles.html
+++ b/LayoutTests/accessibility/aria-visible-element-roles.html
@@ -36,6 +36,10 @@
         <li hidden aria-hidden="false">Hello world</li>
     </ol>
 
+    <menu hidden aria-hidden="false" id="menu-list">
+        <li hidden aria-hidden="false" id="li-element">Hello world</li>
+    </menu>
+
     <button hidden aria-hidden="false" id="button">Click me</button>
 
     <fieldset>
@@ -188,6 +192,7 @@
         verifyRole("summary");
         verifyRole("output");
         verifyRole("menu-toolbar");
+        verifyRole("menu-list");
         verifyRole("hr");
         verifyRole("time");
 

--- a/LayoutTests/accessibility/aria-visible-element-roles.html
+++ b/LayoutTests/accessibility/aria-visible-element-roles.html
@@ -36,10 +36,6 @@
         <li hidden aria-hidden="false">Hello world</li>
     </ol>
 
-    <menu hidden aria-hidden="false" id="menu-list">
-        <li hidden aria-hidden="false" id="li-element">Hello world</li>
-    </menu>
-
     <button hidden aria-hidden="false" id="button">Click me</button>
 
     <fieldset>
@@ -116,6 +112,10 @@
     <output hidden aria-hidden="false" id="output">Output</output>
 
     <menu hidden aria-hidden="false" type="toolbar" id="menu-toolbar"></menu>
+
+    <menu hidden aria-hidden="false" id="menu-list">
+        <li hidden aria-hidden="false" id="li-element">Hello world</li>
+    </menu>
 
     <hr hidden aria-hidden="false" id="hr"></hr>
 

--- a/LayoutTests/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/accessibility/roles-exposed-expected.txt
@@ -139,6 +139,9 @@ input[type='week']
 math
       AXRole: AXMath
 
+menu
+      AXRole: AXList
+
 nav
       AXRole: AXLandmarkNavigation
 

--- a/LayoutTests/accessibility/roles-exposed.html
+++ b/LayoutTests/accessibility/roles-exposed.html
@@ -218,6 +218,8 @@
 <ul data-platform="atspi,mac" class="ex">
     <li data-platform="atspi,mac" class="ex">X</li>
 </ul>
+
+
 <var data-platform="atspi,mac" class="ex">X</var>
 <!-- skipped <video> -->
 <wbr data-platform="atspi,mac" class="ex">X</wbr>

--- a/LayoutTests/accessibility/roles-exposed.html
+++ b/LayoutTests/accessibility/roles-exposed.html
@@ -142,7 +142,9 @@
   </mtable>
 </math>
 </div>
-<!-- skipped <menu> -->
+<menu data-platform="atspi,mac" class="ex">
+    <li data-platform="atspi,mac" class="ex">X</li>
+</menu>
 <!-- skipped <meta> -->
 <!-- reenable for atspi after http://webkit.org/b/163383 fixed --><meter data-platform="mac" class="ex" value="0.75">X</meter>
 <nav data-platform="atspi,mac" class="ex">X</nav>
@@ -218,8 +220,6 @@
 <ul data-platform="atspi,mac" class="ex">
     <li data-platform="atspi,mac" class="ex">X</li>
 </ul>
-
-
 <var data-platform="atspi,mac" class="ex">X</var>
 <!-- skipped <video> -->
 <wbr data-platform="atspi,mac" class="ex">X</wbr>

--- a/LayoutTests/platform/glib/accessibility/aria-visible-element-roles-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/aria-visible-element-roles-expected.txt
@@ -180,6 +180,10 @@ This test ensures ARIA visible elements (e.g. those with both `hidden` and `aria
     AXRole: AXToolbar
     computedRoleString: toolbar
 
+<menu hidden="" aria-hidden="false" id="menu-list"></menu>
+    AXRole: AXList
+    computedRoleString: list
+
 <hr hidden="" aria-hidden="false" id="hr">
     AXRole: AXSeparator
     computedRoleString: separator

--- a/LayoutTests/platform/gtk/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/gtk/accessibility/roles-exposed-expected.txt
@@ -223,6 +223,12 @@ mark
 math
       AXRole: AXMath
 
+menu
+      AXRole: AXList
+
+li
+      AXRole: AXListItem
+
 merror
       AXRole: AXGroup
 

--- a/LayoutTests/platform/mac-wk1/accessibility/aria-visible-element-roles-expected.txt
+++ b/LayoutTests/platform/mac-wk1/accessibility/aria-visible-element-roles-expected.txt
@@ -202,6 +202,10 @@ This test ensures ARIA visible elements (e.g. those with both `hidden` and `aria
     AXRole: AXToolbar
     computedRoleString: toolbar
 
+<menu hidden="" aria-hidden="false" id="menu-list"></menu>
+    AXRole: AXList
+    computedRoleString: list
+
 <hr hidden="" aria-hidden="false" id="hr">
     AXRole: AXSplitter
     computedRoleString: separator

--- a/LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt
@@ -332,11 +332,6 @@ math
       AXSubrole: AXDocumentMath
       AXRoleDescription: math
 
-menu
-      AXRole: AXList
-      AXSubrole: AXContentList
-      AXRoleDescription: content list
-
 merror
       AXRole: AXGroup
       AXSubrole: AXMathRow
@@ -504,6 +499,16 @@ meter
       AXRole: AXLevelIndicator
       AXSubrole: AXMeter
       AXRoleDescription: level indicator
+
+menu
+      AXRole: AXList
+      AXSubrole: AXContentList
+      AXRoleDescription: content list
+
+li
+      AXRole: AXGroup
+      AXSubrole:
+      AXRoleDescription: group
 
 nav
       AXRole: AXGroup

--- a/LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt
@@ -332,6 +332,16 @@ math
       AXSubrole: AXDocumentMath
       AXRoleDescription: math
 
+menu
+      AXRole: AXList
+      AXSubrole: AXContentList
+      AXRoleDescription: content list
+
+li
+      AXRole: AXGroup
+      AXSubrole:
+      AXRoleDescription: group
+
 merror
       AXRole: AXGroup
       AXSubrole: AXMathRow
@@ -499,16 +509,6 @@ meter
       AXRole: AXLevelIndicator
       AXSubrole: AXMeter
       AXRoleDescription: level indicator
-
-menu
-      AXRole: AXList
-      AXSubrole: AXContentList
-      AXRoleDescription: content list
-
-li
-      AXRole: AXGroup
-      AXSubrole:
-      AXRoleDescription: group
 
 nav
       AXRole: AXGroup

--- a/LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt
@@ -332,6 +332,11 @@ math
       AXSubrole: AXDocumentMath
       AXRoleDescription: math
 
+menu
+      AXRole: AXList
+      AXSubrole: AXContentList
+      AXRoleDescription: content list
+
 merror
       AXRole: AXGroup
       AXSubrole: AXMathRow

--- a/LayoutTests/platform/mac-wk2/accessibility/aria-visible-element-roles-expected.txt
+++ b/LayoutTests/platform/mac-wk2/accessibility/aria-visible-element-roles-expected.txt
@@ -120,6 +120,10 @@ This test ensures ARIA visible elements (e.g. those with both `hidden` and `aria
     AXRole: AXList
     computedRoleString: list
 
+<menu hidden="" aria-hidden="false" id="menu-list"></menu>
+    AXRole: AXList
+    computedRoleString: list
+
 <figure hidden="" aria-hidden="false" id="figure"></figure>
     AXRole: AXGroup
     computedRoleString: figure

--- a/LayoutTests/platform/mac-wk2/accessibility/aria-visible-element-roles-expected.txt
+++ b/LayoutTests/platform/mac-wk2/accessibility/aria-visible-element-roles-expected.txt
@@ -120,10 +120,6 @@ This test ensures ARIA visible elements (e.g. those with both `hidden` and `aria
     AXRole: AXList
     computedRoleString: list
 
-<menu hidden="" aria-hidden="false" id="menu-list"></menu>
-    AXRole: AXList
-    computedRoleString: list
-
 <figure hidden="" aria-hidden="false" id="figure"></figure>
     AXRole: AXGroup
     computedRoleString: figure
@@ -205,6 +201,10 @@ This test ensures ARIA visible elements (e.g. those with both `hidden` and `aria
 <menu hidden="" aria-hidden="false" type="toolbar" id="menu-toolbar"></menu>
     AXRole: AXToolbar
     computedRoleString: toolbar
+
+<menu hidden="" aria-hidden="false" id="menu-list"></menu>
+    AXRole: AXList
+    computedRoleString: list
 
 <hr hidden="" aria-hidden="false" id="hr">
     AXRole: AXSplitter

--- a/LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
@@ -332,11 +332,6 @@ math
       AXSubrole: AXDocumentMath
       AXRoleDescription: math
 
-menu
-      AXRole: AXList
-      AXSubrole: AXContentList
-      AXRoleDescription: content list
-
 merror
       AXRole: AXGroup
       AXSubrole: AXMathRow
@@ -504,6 +499,16 @@ meter
       AXRole: AXLevelIndicator
       AXSubrole: AXMeter
       AXRoleDescription: level indicator
+
+menu
+      AXRole: AXList
+      AXSubrole: AXContentList
+      AXRoleDescription: content list
+
+li
+      AXRole: AXGroup
+      AXSubrole:
+      AXRoleDescription: group
 
 nav
       AXRole: AXGroup

--- a/LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
@@ -332,6 +332,16 @@ math
       AXSubrole: AXDocumentMath
       AXRoleDescription: math
 
+menu
+      AXRole: AXList
+      AXSubrole: AXContentList
+      AXRoleDescription: content list
+
+li
+      AXRole: AXGroup
+      AXSubrole:
+      AXRoleDescription: group
+
 merror
       AXRole: AXGroup
       AXSubrole: AXMathRow
@@ -499,16 +509,6 @@ meter
       AXRole: AXLevelIndicator
       AXSubrole: AXMeter
       AXRoleDescription: level indicator
-
-menu
-      AXRole: AXList
-      AXSubrole: AXContentList
-      AXRoleDescription: content list
-
-li
-      AXRole: AXGroup
-      AXSubrole:
-      AXRoleDescription: group
 
 nav
       AXRole: AXGroup

--- a/LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
@@ -332,6 +332,11 @@ math
       AXSubrole: AXDocumentMath
       AXRoleDescription: math
 
+menu
+      AXRole: AXList
+      AXSubrole: AXContentList
+      AXRoleDescription: content list
+
 merror
       AXRole: AXGroup
       AXSubrole: AXMathRow

--- a/LayoutTests/platform/win/accessibility/aria-visible-element-roles-expected.txt
+++ b/LayoutTests/platform/win/accessibility/aria-visible-element-roles-expected.txt
@@ -147,6 +147,9 @@ This test ensures ARIA visible elements (e.g. those with both `hidden` and `aria
 <menu hidden="" aria-hidden="false" type="toolbar" id="menu-toolbar"></menu>
     AXRole: tool bar
 
+<menu hidden="" aria-hidden="false" id="menu-list"></menu>
+    AXRole: AXList
+
 <hr hidden="" aria-hidden="false" id="hr">
     AXRole: separator
 

--- a/LayoutTests/platform/win/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/win/accessibility/roles-exposed-expected.txt
@@ -364,11 +364,6 @@ math
       AXSubrole: AXDocumentMath
       AXRoleDescription: math
 
-menu
-      AXRole: AXList
-      AXSubrole: AXContentList
-      AXRoleDescription: content list
-
 merror
       AXRole: AXGroup
       AXSubrole: AXMathRow
@@ -538,6 +533,16 @@ meter
       AXRole: AXProgressIndicator
       AXSubrole:
       AXRoleDescription: progress indicator
+
+menu
+      AXRole: AXList
+      AXSubrole: AXContentList
+      AXRoleDescription: content list
+
+li
+      AXRole: AXGroup
+      AXSubrole:
+      AXRoleDescription: group
 
 nav
       AXRole: AXGroup

--- a/LayoutTests/platform/win/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/win/accessibility/roles-exposed-expected.txt
@@ -364,6 +364,16 @@ math
       AXSubrole: AXDocumentMath
       AXRoleDescription: math
 
+menu
+      AXRole: AXList
+      AXSubrole: AXContentList
+      AXRoleDescription: content list
+
+li
+      AXRole: AXGroup
+      AXSubrole:
+      AXRoleDescription: group
+
 merror
       AXRole: AXGroup
       AXSubrole: AXMathRow
@@ -533,16 +543,6 @@ meter
       AXRole: AXProgressIndicator
       AXSubrole:
       AXRoleDescription: progress indicator
-
-menu
-      AXRole: AXList
-      AXSubrole: AXContentList
-      AXRoleDescription: content list
-
-li
-      AXRole: AXGroup
-      AXSubrole:
-      AXRoleDescription: group
 
 nav
       AXRole: AXGroup

--- a/LayoutTests/platform/win/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/win/accessibility/roles-exposed-expected.txt
@@ -364,6 +364,11 @@ math
       AXSubrole: AXDocumentMath
       AXRoleDescription: math
 
+menu
+      AXRole: AXList
+      AXSubrole: AXContentList
+      AXRoleDescription: content list
+
 merror
       AXRole: AXGroup
       AXSubrole: AXMathRow

--- a/LayoutTests/platform/wpe/accessibility/aria-visible-element-roles-expected.txt
+++ b/LayoutTests/platform/wpe/accessibility/aria-visible-element-roles-expected.txt
@@ -179,6 +179,10 @@ This test ensures ARIA visible elements (e.g. those with both `hidden` and `aria
     AXRole: AXToolbar
     computedRoleString: toolbar
 
+<menu hidden="" aria-hidden="false" id="menu-list"></menu>
+    AXRole: AXList
+    computedRoleString: list
+    
 <hr hidden="" aria-hidden="false" id="hr">
     AXRole: AXSeparator
     computedRoleString: separator

--- a/LayoutTests/platform/wpe/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/wpe/accessibility/roles-exposed-expected.txt
@@ -223,6 +223,12 @@ mark
 math
       AXRole: AXMath
 
+menu
+      AXRole: AXList
+
+li
+      AXRole: AXListItem
+
 merror
       AXRole: AXGroup
 
@@ -321,12 +327,6 @@ mtr
 
 mtd
       AXRole: AXCell
-
-menu
-      AXRole: AXList
-
-li
-      AXRole: AXListItem
 
 nav
       AXRole: AXLandmarkNavigation

--- a/LayoutTests/platform/wpe/accessibility/roles-exposed-expected.txt
+++ b/LayoutTests/platform/wpe/accessibility/roles-exposed-expected.txt
@@ -322,6 +322,12 @@ mtr
 mtd
       AXRole: AXCell
 
+menu
+      AXRole: AXList
+
+li
+      AXRole: AXListItem
+
 nav
       AXRole: AXLandmarkNavigation
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -418,7 +418,8 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
         return AccessibilityRole::Footer;
     }
 
-    // menu tags with toolbar type should have Toolbar role and menu tags without toolbar should have role list
+    // Per the HTML AAM, <menu> is mapped to list role but we keep backward compatibility for the obsolete type="toolbar".
+    // See https://html.spec.whatwg.org/multipage/obsolete.html#attr-menu-type
     if (node()->hasTagName(menuTag)) {
         if (equalLettersIgnoringASCIICase(getAttribute(typeAttr), "toolbar"_s))
             return AccessibilityRole::Toolbar;

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -418,11 +418,12 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
         return AccessibilityRole::Footer;
     }
 
-    // menu tags with toolbar type should have Toolbar role.
-    if (node()->hasTagName(menuTag) && equalLettersIgnoringASCIICase(getAttribute(typeAttr), "toolbar"_s))
-        return AccessibilityRole::Toolbar;
-    if (node()->hasTagName(menuTag) && !equalLettersIgnoringASCIICase(getAttribute(typeAttr), "toolbar"_s))
+    // menu tags with toolbar type should have Toolbar role and menu tags without toolbar should have role list
+    if (node()->hasTagName(menuTag)) {
+        if (equalLettersIgnoringASCIICase(getAttribute(typeAttr), "toolbar"_s))
+            return AccessibilityRole::Toolbar;
         return AccessibilityRole::List;
+    }
     if (node()->hasTagName(timeTag))
         return AccessibilityRole::Time;
     if (node()->hasTagName(hrTag))

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -419,12 +419,11 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
     }
 
     // menu tags with toolbar type should have Toolbar role.
-    if (node()->hasTagName(menuTag) && equalLettersIgnoringASCIICase(getAttribute(typeAttr), "toolbar"_s)) {
+    if (node()->hasTagName(menuTag) && equalLettersIgnoringASCIICase(getAttribute(typeAttr), "toolbar"_s)) 
         return AccessibilityRole::Toolbar;
-    } else 
+    if (node()->hasTagName(menuTag))
         return AccessibilityRole::List;
     
-        
     if (node()->hasTagName(timeTag))
         return AccessibilityRole::Time;
     if (node()->hasTagName(hrTag))

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -419,8 +419,12 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
     }
 
     // menu tags with toolbar type should have Toolbar role.
-    if (node()->hasTagName(menuTag) && equalLettersIgnoringASCIICase(getAttribute(typeAttr), "toolbar"_s))
+    if (node()->hasTagName(menuTag) && equalLettersIgnoringASCIICase(getAttribute(typeAttr), "toolbar"_s)) {
         return AccessibilityRole::Toolbar;
+    } else 
+        return AccessibilityRole::List;
+    
+        
     if (node()->hasTagName(timeTag))
         return AccessibilityRole::Time;
     if (node()->hasTagName(hrTag))

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -419,11 +419,10 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
     }
 
     // menu tags with toolbar type should have Toolbar role.
-    if (node()->hasTagName(menuTag) && equalLettersIgnoringASCIICase(getAttribute(typeAttr), "toolbar"_s)) 
+    if (node()->hasTagName(menuTag) && equalLettersIgnoringASCIICase(getAttribute(typeAttr), "toolbar"_s))
         return AccessibilityRole::Toolbar;
-    if (node()->hasTagName(menuTag))
+    if (node()->hasTagName(menuTag) && !equalLettersIgnoringASCIICase(getAttribute(typeAttr), "toolbar"_s))
         return AccessibilityRole::List;
-    
     if (node()->hasTagName(timeTag))
         return AccessibilityRole::Time;
     if (node()->hasTagName(hrTag))


### PR DESCRIPTION
#### f816c098797e3849e3871f03c30de2a850c59168
<pre>
2022-09-05 SirriCelles &lt;sirricelles@gmail.com&gt;

    AX: HTML menu element should map to role=list
    https://bugs.webkit.org/show_bug.cgi?id=201581
</pre>
----------------------------------------------------------------------
#### 2d2c29446b11ee9e8e0ff4e8ba64dd761a053d43
<pre>
2022-09-02 SirriCelles &lt;sirricelles@gmail.com&gt;
    update LayoutTests

    Tests:
    * LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt
    * LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
    * LayoutTests/platform/win/accessibility/roles-exposed-expected.txt
    * LayoutTests/platform/wpe/accessibility/roles-exposed-expected.txt
</pre>
----------------------------------------------------------------------
#### f9011a0dcb12f958e55f15c4f2c162b63df54667
<pre>
2022-09-02 SirriCelles &lt;sirricelles@gmail.com&gt;

    Test:
       LayoutTests/platform/glib/accessibility/aria-visible-element-roles-expected.txt
       LayoutTests/platform/win/accessibility/roles-exposed-expected.txt
       LayoutTests/platform/wpe/accessibility/aria-visible-element-roles-expected.txt
       LayoutTests/platform/wpe/accessibility/roles-exposed-expected.txt
</pre>
----------------------------------------------------------------------
#### eb21d127add74ea6d55b63c83370c49121929e41
<pre>
2022-09-02 SirriCelles &lt;sirricelles@gmail.com&gt;

Tests: LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt
         LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
</pre>
----------------------------------------------------------------------
#### a5792c113dc2621404e7600250ac4a3e12e1ebea
<pre>
2022-09-1 SirriCelles &lt;sirricelles@gmail.com&gt;

    AX: HTML menu element should map to role=list
    <a href="https://bugs.webkit.org/show_bug.cgi?id=201581">https://bugs.webkit.org/show_bug.cgi?id=201581</a>

    This patch modifies Source/WebCore/accessibility/AccessibilityNodeObject.cpp file.
    Modified check that returns AccessibilityRole::Toolbar for menu element with attribute=&quot;toolbar&quot; and AccessibilityRole::rolelist
    for the menu element. Per the HTML AAM, &lt;menu&gt; is mapped to list role but we keep backward compatibility for the obsolete type=&quot;toolbar&quot;.

    Tests:  LayoutTests/accessibility/roles-exposed.html

    *LayoutTests/accessibility/roles-exposed-expected.txt
        *LayoutTests/accessibility/roles-exposed.html
        *LayoutTests/platform/mac-wk1/accessibility/aria-visible-element-roles-expected.txt
        *LayoutTests/platform/mac-wk1/accessibility/roles-exposed-expected.txt
        *LayoutTests/platform/mac-wk2/accessibility/roles-exposed-expected.txt
        *LayoutTests/platform/win/accessibility/aria-visible-element-roles-expected.txt
        *LayoutTests/platform/win/accessibility/roles-exposed-expected.txt
    *Source/WebCore/accessibility/AccessibilityNodeObject.cpp
</pre>
----------------------------------------------------------------------
#### 7d9f43b71ceb14a0dbe913a0919015a6cd2e6132
<pre>
2022-08-23 SirriCelles &lt;sirricelles@gmail.com&gt;

    AX: HTML menu element should map to role=list
    <a href="https://bugs.webkit.org/show_bug.cgi?id=201581">https://bugs.webkit.org/show_bug.cgi?id=201581</a>

    This patch modifies Source/WebCore/accessibility/AccessibilityNodeObject.cpp file.
    Modified check that returns AccessibilityRole::Toolbar for menu element with attribute=&quot;toolbar&quot; and AccessibilityRole::rolelist
    for the menu element. Restructure check
</pre>
----------------------------------------------------------------------
#### 7a48c965b49e17cd90c7976b6f90cf794a5f9c9e
<pre>
2022-08-23 SirriCelles &lt;sirricelles@gmail.com&gt;

    AX: HTML menu element should map to role=list
    <a href="https://bugs.webkit.org/show_bug.cgi?id=201581">https://bugs.webkit.org/show_bug.cgi?id=201581</a>

    This patch modifies Source/WebCore/accessibility/AccessibilityNodeObject.cpp file.
    Modified check that returns AccessibilityRole::Toolbar for menu element with attribute=&quot;toolbar&quot; and AccessibilityRole::rolelist
    for the menu element.
</pre>
----------------------------------------------------------------------
#### 3f22c0338e8af6f2634d6ac092f821d5fff09a30
<pre>
2022-08-23 SirriCelles &lt;sirricelles@gmail.com&gt;

    AX: HTML menu element should map to role=list
    <a href="https://bugs.webkit.org/show_bug.cgi?id=201581">https://bugs.webkit.org/show_bug.cgi?id=201581</a>

    This patch modifies Source/WebCore/accessibility/AccessibilityNodeObject.cpp file.
    <a href="https://github.com/WebKit/WebKit/blob/main/Source/WebCore/accessibility/AccessibilityNodeObject.cpp#L422.">https://github.com/WebKit/WebKit/blob/main/Source/WebCore/accessibility/AccessibilityNodeObject.cpp#L422.</a>
    It adds check that returns AccessibilityRole::Toolbar for menu element with attribute=&quot;toolbar&quot; and AccessibilityRole::rolelist
    for the menu element.

    Test: LayoutTests/accessibility/aria-visible-element-roles.html

    *  Source/WebCore/accessibility/AccessibilityNodeObject.cpp
    *  LayoutTests/accessibility/aria-visible-element-roles.html
    *  LayoutTests/platform/mac-wk2/accessibility/aria-visible-element-roles-expected.txt
</pre>
----------------------------------------------------------------------
#### 988c8c64467f0f0d80eb9c7a997263673f316562
<pre>
2022-08-23 SirriCelles &lt;sirricelles@gmail.com&gt;

    AX: HTML menu element should map to role=list
    <a href="https://bugs.webkit.org/show_bug.cgi?id=201581">https://bugs.webkit.org/show_bug.cgi?id=201581</a>

    This patch modifies Source/WebCore/accessibility/AccessibilityNodeObject.cpp file.
    <a href="https://github.com/WebKit/WebKit/blob/main/Source/WebCore/accessibility/AccessibilityNodeObject.cpp#L422.">https://github.com/WebKit/WebKit/blob/main/Source/WebCore/accessibility/AccessibilityNodeObject.cpp#L422.</a>
    It adds check that returns AccessibilityRole::Toolbar for menu element with attribute=&quot;toolbar&quot; and AccessibilityRole::rolelist
    for the menu element.

    Test: LayoutTests/accessibility/aria-visible-element-roles.html
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f816c098797e3849e3871f03c30de2a850c59168

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97497 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152963 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31177 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26858 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80498 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92153 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24840 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75105 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24813 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67779 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28761 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13839 "Found 1 new test failure: accessibility/roles-exposed.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28762 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14847 "Found 1 new test failure: accessibility/roles-exposed.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37756 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33985 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->