### PR TITLE
REGRESSION (253593@main): [ macOS ] inspector/canvas/updateShader-webgl.html is a consistent failure

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1474,6 +1474,9 @@ webkit.org/b/229052 webgl/1.0.x/conformance/textures/misc/texture-corner-case-vi
 webgl/webgl-via-metal-flag-on.html [ Skip ]
 webgl/webgl-via-metal-flag-off.html [ Skip ]
 
+# Remove after ANGLE is the default backend.
+inspector/canvas/updateShader-webgl.html [ Failure ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebGL-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2220,7 +2220,7 @@ webkit.org/b/230862 [ BigSur ] imported/w3c/web-platform-tests/resource-timing/s
 
 webkit.org/b/230984 [ BigSur Debug arm64 ] streams/readableStream-then.html [ Pass Crash ]
 
-webkit.org/b/244159 inspector/canvas/updateShader-webgl.html [ Pass Failure ]
+webkit.org/b/231757 [ BigSur ] inspector/canvas/updateShader-webgl.html [ Pass Failure ]
 
 webkit.org/b/237840 [ Monterey ] webgl/2.0.0/conformance2/glsl3/bool-type-cast-bug-uint-ivec-uvec.html [ Pass Crash ]
 

--- a/Source/WebCore/inspector/InspectorShaderProgram.cpp
+++ b/Source/WebCore/inspector/InspectorShaderProgram.cpp
@@ -29,16 +29,16 @@
 #if ENABLE(WEBGL)
 
 #include "InspectorCanvas.h"
-#include <JavaScriptCore/IdentifiersFactory.h>
-#include <variant>
-#include <wtf/Ref.h>
-#include <wtf/text/WTFString.h>
 
 #if ENABLE(WEBGL)
+#include "JSExecState.h"
 #include "WebGLProgram.h"
 #include "WebGLRenderingContextBase.h"
 #include "WebGLSampler.h"
 #include "WebGLShader.h"
+#include <JavaScriptCore/IdentifiersFactory.h>
+#include <JavaScriptCore/ScriptCallStack.h>
+#include <JavaScriptCore/ScriptCallStackFactory.h>
 #endif
 
 namespace WebCore {
@@ -124,9 +124,19 @@ bool InspectorShaderProgram::updateShader(Inspector::Protocol::Canvas::ShaderTyp
                         contextWebGLBase.shaderSource(*shader, source);
                         contextWebGLBase.compileShader(*shader);
                         auto compileStatus = contextWebGLBase.getShaderParameter(*shader, GraphicsContextGL::COMPILE_STATUS);
-                        if (std::holds_alternative<bool>(compileStatus) && std::get<bool>(compileStatus))
-                            contextWebGLBase.linkProgramWithoutInvalidatingAttribLocations(&program);
-                        return true;
+                        if (std::holds_alternative<bool>(compileStatus)) {
+                            if (std::get<bool>(compileStatus))
+                                contextWebGLBase.linkProgramWithoutInvalidatingAttribLocations(&program);
+                            else {
+                                auto errors = contextWebGLBase.getShaderInfoLog(*shader);
+                                auto* scriptContext = m_canvas.scriptExecutionContext();
+                                for (auto error : StringView(errors).split('\n')) {
+                                    auto message = makeString("WebGL: "_s, error);
+                                    scriptContext->addConsoleMessage(makeUnique<ConsoleMessage>(MessageSource::Rendering, MessageType::Log, MessageLevel::Error, message));
+                                }
+                            }
+                            return true;
+                        }
                     }
                 }
             }

--- a/Source/WebCore/inspector/InspectorShaderProgram.h
+++ b/Source/WebCore/inspector/InspectorShaderProgram.h
@@ -30,7 +30,9 @@
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <variant>
 #include <wtf/Forward.h>
+#include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 


### PR DESCRIPTION
#### c984b72df669166a4d5def7ceaf8cb7bafb772c3
<pre>
REGRESSION (253593@main): [ macOS ] inspector/canvas/updateShader-webgl.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244159">https://bugs.webkit.org/show_bug.cgi?id=244159</a>
rdar://problem/98926428

Reviewed by Devin Rousso.

Shader compilation status cannot be queried after invoking the compilation,
because this will block otherwise asynchronous method. This means we cannot
print the ad hoc console message on all compile failures. The commit
253593@main removed the message for all WebGL shader compiles.

Add the error message back when user edits the shader with inspector.

* LayoutTests/inspector/canvas/updateShader-webgl-expected.txt:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253902@main">https://commits.webkit.org/253902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fe5a3ecf495313a25e08523fb57ffed35b03e20

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96655 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150038 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29881 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26065 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79546 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91426 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93045 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74213 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23979 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66997 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27591 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13167 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27545 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14183 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2742 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37046 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29160 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33461 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->