### PR TITLE
[ews] Refactoring and logging improvements

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -135,18 +135,18 @@ class GitHub(object):
                 json=dict(body=ews_comment),
             )
             if response.status_code // 100 != 2:
-                _log.error("Failed to post comment to PR {}. Unexpected response code from GitHub: {}\n".format(pr_number, response.status_code))
+                _log.error('Failed to post comment to PR {}. Unexpected response code from GitHub: {}\n'.format(pr_number, response.status_code))
                 return -1
             new_comment_id = response.json().get('id')
             comment_url = 'https://github.com/WebKit/WebKit/pull/{}#issuecomment-{}'.format(pr_number, new_comment_id)
-            _log.info('Commented on PR {} for hash: {}, link: {}'.format(pr_number, sha, comment_url))
+            _log.info('Commented on PR {}, link: {}'.format(pr_number, comment_url))
 
             if comment_id == -1 and new_comment_id != -1 and change:
                 change.set_comment_id(new_comment_id)
-                _log.info('PR {}: set new comment id as {} for hash: {}.'.format(pr_number, new_comment_id, sha))
+                _log.info('PR {}: set new comment id as {} for hash: {}.'.format(pr_number, new_comment_id, change.change_id))
             return new_comment_id
         except Exception as e:
-            _log.error("Error in posting comment to PR {}\n".format(pr_number))
+            _log.error('Error in posting comment to PR {}: {}\n'.format(pr_number, e))
         return -1
 
     def update_pr_description_with_status_bubble(self, pr_number, ews_comment, repository_url=None):
@@ -180,7 +180,7 @@ class GitHub(object):
                 _log.error('Failed to update PR {} description. Unexpected response code from GitHub: {}\n'.format(pr_number, response.status_code))
                 return -1
 
-            _log.info('Updated description for PR {}\n'.format(pr_number))
+            _log.info('Updated description for PR {}'.format(pr_number))
             return 0
         except Exception as e:
             _log.error('Error in updating PR description for PR {}: {}\n'.format(pr_number, e))
@@ -208,7 +208,7 @@ class GitHubEWS(GitHub):
     @classmethod
     def generate_updated_pr_description(self, description, ews_comment):
         description = description.split(self.STATUS_BUBBLE_START)[0]
-        return u'{}\n{}\n{}\n{}'.format(description, self.STATUS_BUBBLE_START, ews_comment, self.STATUS_BUBBLE_END)
+        return u'{}{}\n{}\n{}'.format(description, self.STATUS_BUBBLE_START, ews_comment, self.STATUS_BUBBLE_END)
 
     def generate_comment_text_for_change(self, change):
         hash_url = 'https://github.com/WebKit/WebKit/commit/{}'.format(change.change_id)
@@ -246,7 +246,7 @@ class GitHubEWS(GitHub):
             builds = builds[:10]  # Limit number of builds to display in status-bubble hover over message
 
         hover_over_text = ''
-        status = GitHubEWS.ICON_BUILD_WAITING
+        icon = GitHubEWS.ICON_BUILD_WAITING
         if not build:
             if queue in ['merge', 'unsafe-merge']:
                 return u'| '
@@ -256,22 +256,22 @@ class GitHubEWS(GitHub):
             if queue_full_name:
                 url = 'https://{}/#/builders/{}'.format(config.BUILDBOT_SERVER_HOST, queue_full_name)
             hover_over_text = 'Waiting in queue, processing has not started yet'
-            return u'| [{status} {name} ]({url} "{hover_over_text}") '.format(status=status, name=name, url=url, hover_over_text=hover_over_text)
+            return u'| [{icon} {name} ]({url} "{hover_over_text}") '.format(icon=icon, name=name, url=url, hover_over_text=hover_over_text)
 
         url = 'https://{}/#/builders/{}/builds/{}'.format(config.BUILDBOT_SERVER_HOST, build.builder_id, build.number)
 
         if build.result is None:
             hover_over_text = 'Build is in progress'
-            status = GitHubEWS.ICON_BUILD_ONGOING
+            icon = GitHubEWS.ICON_BUILD_ONGOING
         elif build.result == Buildbot.SUCCESS:
             if is_parent_build:
-                status = GitHubEWS.ICON_BUILD_WAITING
+                icon = GitHubEWS.ICON_BUILD_WAITING
                 hover_over_text = 'Waiting to run tests'
                 queue_full_name = Buildbot.queue_name_by_shortname_mapping.get(queue)
                 if queue_full_name:
                     url = 'https://{}/#/builders/{}'.format(config.BUILDBOT_SERVER_HOST, queue_full_name)
             else:
-                status = GitHubEWS.ICON_BUILD_PASS
+                icon = GitHubEWS.ICON_BUILD_PASS
                 if is_builder_queue and is_tester_queue:
                     hover_over_text = 'Built successfully and passed tests'
                 elif is_builder_queue:
@@ -284,16 +284,16 @@ class GitHubEWS(GitHub):
                 else:
                     hover_over_text = 'Pass'
         elif build.result == Buildbot.WARNINGS:
-            status = GitHubEWS.ICON_BUILD_PASS
+            icon = GitHubEWS.ICON_BUILD_PASS
         elif build.result == Buildbot.FAILURE:
-            status = GitHubEWS.ICON_BUILD_FAIL
+            icon = GitHubEWS.ICON_BUILD_FAIL
             hover_over_text = build.state_string
         elif build.result == Buildbot.CANCELLED:
-            status = GitHubEWS.ICON_EMPTY_SPACE
+            icon = GitHubEWS.ICON_EMPTY_SPACE
             name = u'~~{}~~'.format(name)
             hover_over_text = 'Build was cancelled'
         elif build.result == Buildbot.SKIPPED:
-            status = GitHubEWS.ICON_EMPTY_SPACE
+            icon = GitHubEWS.ICON_EMPTY_SPACE
             if re.search(r'Pull request .* doesn\'t have relevant changes', build.state_string):
                 return u'| '
             name = u'~~{}~~'.format(name)
@@ -304,15 +304,15 @@ class GitHubEWS(GitHub):
                 hover_over_text += ' Commit was outdated when EWS attempted to process it.'
         elif build.result == Buildbot.RETRY:
             hover_over_text = 'Build is being retried'
-            status = GitHubEWS.ICON_BUILD_ONGOING
+            icon = GitHubEWS.ICON_BUILD_ONGOING
         elif build.result == Buildbot.EXCEPTION:
             hover_over_text = 'An unexpected error occured'
-            status = GitHubEWS.ICON_BUILD_ERROR
+            icon = GitHubEWS.ICON_BUILD_ERROR
         else:
-            status = GitHubEWS.ICON_BUILD_ERROR
+            icon = GitHubEWS.ICON_BUILD_ERROR
             hover_over_text = 'An unexpected error occured'
 
-        return u'| [{status} {name}]({url} "{hover_over_text}") '.format(status=status, name=name, url=url, hover_over_text=hover_over_text)
+        return u'| [{icon} {name}]({url} "{hover_over_text}") '.format(icon=icon, name=name, url=url, hover_over_text=hover_over_text)
 
     @classmethod
     def add_or_update_comment_for_change_id(self, sha, pr_id, pr_project=None, allow_new_comment=False):
@@ -336,7 +336,7 @@ class GitHubEWS(GitHub):
             if not allow_new_comment:
                 # FIXME: improve this logic to use locking instead
                 return -1
-            _log.info('Adding comment for hash: {}, pr_id: {}, pr_id from db: {}.'.format(sha, pr_id, change.pr_id))
+            _log.info('Adding comment for hash: {}, PR: {}'.format(sha, pr_id))
             new_comment_id = gh.update_or_leave_comment_on_pr(pr_id, comment_text, change=change)
             obsolete_changes = Change.mark_old_changes_as_obsolete(pr_id, sha)
             for obsolete_change in obsolete_changes:

--- a/Tools/CISupport/ews-app/ews/views/results.py
+++ b/Tools/CISupport/ews-app/ews/views/results.py
@@ -60,16 +60,16 @@ class Results(View):
 
     def build_event(self, data):
         if not self.is_valid_result(data):
-            return HttpResponse("Incomplete data.")
+            return HttpResponse('Incomplete data.')
 
         change_id = data['change_id']
         pr_id = data.get('pr_id', None) or -1
         pr_project = data.get('pr_project', '') or ''
 
-        _log.info('Build {} event received, change_id: {}, type: {} for build_id: {} of type: {}, pr_id: {}, pr_project: {}'.format(data['status'], change_id, type(change_id), data['build_id'], type(data['build_id']), data.get('pr_id', -1), data.get('pr_project', '')))
+        _log.info('Build {}, change_id: {}, build_id: {}, pr_id: {}, pr_project: {}'.format(data['status'], change_id, data['build_id'], pr_id, pr_project))
         if not change_id:
             _log.error('change_id missing: {}'.format(change_id))
-            return HttpResponse("Invalid change id: {}.".format(change_id))
+            return HttpResponse('Invalid change id: {}.'.format(change_id))
 
         rc = Build.save_build(change_id=change_id, hostname=data['hostname'], build_id=data['build_id'], builder_id=data['builder_id'], builder_name=data['builder_name'],
                    builder_display_name=data['builder_display_name'], number=data['number'], result=data['result'],
@@ -78,21 +78,21 @@ class Results(View):
             # For PR builds leave comment on PR
             allow_new_comment = (data['status'] == 'started' and data['builder_display_name'] in ['services', 'ios-wk2'])
             GitHubEWS.add_or_update_comment_for_change_id(change_id, pr_id, pr_project, allow_new_comment)
-        return HttpResponse("Saved data for change: {}.\n".format(change_id))
+        return HttpResponse('Saved data for change: {}.\n'.format(change_id))
 
     def step_event(self, data):
-        _log.info('Step event received')
         if not self.is_valid_result(data):
             _log.warn('Incomplete step event data')
-            return HttpResponse("Incomplete data.")
+            return HttpResponse('Incomplete data.')
+        _log.info('Step event received, step-id: {}'.format(data['step_id'])
 
         Step.save_step(hostname=data['hostname'], step_id=data['step_id'], build_id=data['build_id'], result=data['result'],
                    state_string=data['state_string'], started_at=data['started_at'], complete_at=data['complete_at'])
-        return HttpResponse("Saved data for step: {}.\n".format(data['step_id']))
+        return HttpResponse('Saved data for step: {}.\n'.format(data['step_id']))
 
     def is_valid_result(self, data):
         if data['type'] not in [u'ews-build', u'ews-step']:
-            _log.error("Invalid data type: {}".format(data['type']))
+            _log.error('Invalid data type: {}'.format(data['type']))
             return False
 
         required_keys = {u'ews-build': ['hostname', 'change_id', 'build_id', 'builder_id', 'builder_name', 'builder_display_name',


### PR DESCRIPTION
#### 2ca89e6c99990625f2545012c1db4bd66acf4dcb
<pre>
[ews] Refactoring and logging improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=244265">https://bugs.webkit.org/show_bug.cgi?id=244265</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHub.update_or_leave_comment_on_pr):
(GitHub.update_pr_description_with_status_bubble):
(GitHubEWS.generate_updated_pr_description):
(GitHubEWS.github_status_for_queue):
(GitHubEWS.add_or_update_comment_for_change_id):
* Tools/CISupport/ews-app/ews/views/results.py:
(Results.build_event):
(Results.step_event):
(Results.is_valid_result):

Canonical link: <a href="https://commits.webkit.org/253698@main">https://commits.webkit.org/253698@main</a>
</pre>














<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc205d39113e6ca0e6814b40e0550233b9d71dff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86846 "failed 1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30929 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/95677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/149432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29290 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/90910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92462 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27049 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26972 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28656 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1031 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28600 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->