### PR TITLE
Add API to include backgrounds when printing

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -2037,7 +2037,7 @@ ShouldPrintBackgrounds:
       "PLATFORM(IOS_FAMILY)": true
       default: false
     WebKit:
-      "PLATFORM(IOS_FAMILY)": true
+      "PLATFORM(IOS_FAMILY)": WebKit::defaultShouldPrintBackgrounds()
       default: false
     WebCore:
       default: false

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -40,6 +40,7 @@ enum class SDKAlignedBehavior {
     ConvertsInvalidURLsToBlank,
     DataURLFragmentRemoval,
     DecidesPolicyBeforeLoadingQuickLookPreview,
+    DefaultsToExcludingBackgroundsWhenPrinting,
     DefaultsToPassiveTouchListenersOnDocument,
     DefaultsToPassiveWheelListenersOnDocument,
     DisallowsSettingAnyXHRHeaderFromFileURLs,

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -54,6 +54,12 @@ bool defaultCSSOMViewScrollingAPIEnabled()
     return !result;
 }
 
+bool defaultShouldPrintBackgrounds()
+{
+    static bool result = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DefaultsToExcludingBackgroundsWhenPrinting);
+    return result;
+}
+
 #if !USE(APPLE_INTERNAL_SDK)
 bool defaultAlternateFormControlDesignEnabled()
 {

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -38,6 +38,7 @@ namespace WebKit {
 #if PLATFORM(IOS_FAMILY)
 bool defaultPassiveTouchListenersAsDefaultOnDocument();
 bool defaultCSSOMViewScrollingAPIEnabled();
+bool defaultShouldPrintBackgrounds();
 bool defaultAlternateFormControlDesignEnabled();
 #if ENABLE(TEXT_AUTOSIZING)
 bool defaultTextAutosizingUsesIdempotentMode();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.h
@@ -51,6 +51,11 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
  */
 @property (nonatomic, getter=isFraudulentWebsiteWarningEnabled) BOOL fraudulentWebsiteWarningEnabled WK_API_AVAILABLE(macos(10.15), ios(13.0));
 
+/*! @abstract A Boolean value indicating whether the web view should include backgrounds when printing.
+ @discussion The default value is `NO`.
+ */
+@property (nonatomic) BOOL shouldPrintBackgrounds WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 #if !TARGET_OS_IPHONE
 /*!
  @property tabFocusesLinks

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -74,6 +74,8 @@
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [coder encodeBool:self.javaScriptEnabled forKey:@"javaScriptEnabled"];
 ALLOW_DEPRECATED_DECLARATIONS_END
+    
+    [coder encodeBool:self.shouldPrintBackgrounds forKey:@"shouldPrintBackgrounds"];
 
 #if PLATFORM(MAC)
     [coder encodeBool:self.tabFocusesLinks forKey:@"tabFocusesLinks"];
@@ -92,6 +94,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     self.javaScriptEnabled = [coder decodeBoolForKey:@"javaScriptEnabled"];
 ALLOW_DEPRECATED_DECLARATIONS_END
+    
+    self.shouldPrintBackgrounds = [coder decodeBoolForKey:@"shouldPrintBackgrounds"];
 
 #if PLATFORM(MAC)
     self.tabFocusesLinks = [coder decodeBoolForKey:@"tabFocusesLinks"];
@@ -135,6 +139,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)setJavaScriptCanOpenWindowsAutomatically:(BOOL)javaScriptCanOpenWindowsAutomatically
 {
     _preferences->setJavaScriptCanOpenWindowsAutomatically(javaScriptCanOpenWindowsAutomatically);
+}
+
+- (void)setShouldPrintBackgrounds:(BOOL)enabled
+{
+    _preferences->setShouldPrintBackgrounds(enabled);
+}
+
+- (BOOL)shouldPrintBackgrounds
+{
+    return _preferences->shouldPrintBackgrounds();
 }
 
 - (BOOL)isTextInteractionEnabled
@@ -1019,12 +1033,12 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 
 - (void)_setShouldPrintBackgrounds:(BOOL)enabled
 {
-    _preferences->setShouldPrintBackgrounds(enabled);
+    self.shouldPrintBackgrounds = enabled;
 }
 
 - (BOOL)_shouldPrintBackgrounds
 {
-    return _preferences->shouldPrintBackgrounds();
+    return self.shouldPrintBackgrounds;
 }
 
 - (void)_setWebSecurityEnabled:(BOOL)enabled

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -471,8 +471,9 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
 
     pageConfiguration->preferences()->setShouldRespectImageOrientation(!![_configuration _respectsImageOrientation]);
 #if !PLATFORM(MAC)
-    // FIXME: Expose WKPreferences._shouldPrintBackgrounds on iOS, adopt it in all iOS clients, and remove this and WKWebViewConfiguration._printsBackgrounds.
-    pageConfiguration->preferences()->setShouldPrintBackgrounds(!![_configuration _printsBackgrounds]);
+    // FIXME: rdar://99156546. Remove this and WKWebViewConfiguration._printsBackgrounds once all iOS clients adopt the new API.
+    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DefaultsToExcludingBackgroundsWhenPrinting))
+        pageConfiguration->preferences()->setShouldPrintBackgrounds(!![_configuration _printsBackgrounds]);
 #endif
     pageConfiguration->preferences()->setIncrementalRenderingSuppressionTimeout([_configuration _incrementalRenderingSuppressionTimeout]);
     pageConfiguration->preferences()->setJavaScriptMarkupEnabled(!![_configuration _allowsJavaScriptMarkup]);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -129,7 +129,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     std::optional<RetainPtr<NSString>> _applicationNameForUserAgent;
     NSTimeInterval _incrementalRenderingSuppressionTimeout;
     BOOL _respectsImageOrientation;
-    BOOL _printsBackgrounds;
     BOOL _allowsJavaScriptMarkup;
     BOOL _convertsPositionStyleOnCopy;
     BOOL _allowsMetaRefresh;
@@ -221,11 +220,9 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
 
 #if PLATFORM(IOS_FAMILY)
     _respectsImageOrientation = YES;
-    _printsBackgrounds = YES;
 #endif
 
 #if PLATFORM(MAC)
-    _printsBackgrounds = NO;
     _respectsImageOrientation = NO;
     _showsURLsInToolTips = NO;
     _serviceControlsEnabled = NO;
@@ -395,7 +392,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     configuration->_applicationNameForUserAgent = self->_applicationNameForUserAgent;
 
     configuration->_respectsImageOrientation = self->_respectsImageOrientation;
-    configuration->_printsBackgrounds = self->_printsBackgrounds;
     configuration->_incrementalRenderingSuppressionTimeout = self->_incrementalRenderingSuppressionTimeout;
     configuration->_allowsJavaScriptMarkup = self->_allowsJavaScriptMarkup;
     configuration->_convertsPositionStyleOnCopy = self->_convertsPositionStyleOnCopy;
@@ -659,12 +655,12 @@ static NSString *defaultApplicationNameForUserAgent()
 
 - (BOOL)_printsBackgrounds
 {
-    return _printsBackgrounds;
+    return self.preferences.shouldPrintBackgrounds;
 }
 
 - (void)_setPrintsBackgrounds:(BOOL)printsBackgrounds
 {
-    _printsBackgrounds = printsBackgrounds;
+    self.preferences.shouldPrintBackgrounds = printsBackgrounds;
 }
 
 - (NSTimeInterval)_incrementalRenderingSuppressionTimeout

--- a/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
@@ -44,8 +44,8 @@
 #define WebKitUsesEncodingDetectorPreferenceKey @"WebKitUsesEncodingDetector"
 #define WebKitUserStyleSheetEnabledPreferenceKey @"WebKitUserStyleSheetEnabledPreferenceKey"
 #define WebKitUserStyleSheetLocationPreferenceKey @"WebKitUserStyleSheetLocationPreferenceKey"
-#if !TARGET_OS_IPHONE
 #define WebKitShouldPrintBackgroundsPreferenceKey @"WebKitShouldPrintBackgroundsPreferenceKey"
+#if !TARGET_OS_IPHONE
 #define WebKitTextAreasAreResizablePreferenceKey @"WebKitTextAreasAreResizable"
 #endif
 #define WebKitShrinksStandaloneImagesToFitPreferenceKey @"WebKitShrinksStandaloneImagesToFit"

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.h
@@ -209,12 +209,10 @@ WEBKIT_CLASS_DEPRECATED_MAC(10_3, 10_14)
 */
 @property (nonatomic) BOOL autosaves;
 
-#if !TARGET_OS_IPHONE
 /*!
     @property shouldPrintBackgrounds
 */
 @property (nonatomic) BOOL shouldPrintBackgrounds;
-#endif
 
 /*!
     @property privateBrowsingEnabled:

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -847,7 +847,6 @@ public:
 }
 #endif // PLATFORM(IOS_FAMILY)
 
-#if !PLATFORM(IOS_FAMILY)
 - (BOOL)shouldPrintBackgrounds
 {
     return [self _boolValueForKey: WebKitShouldPrintBackgroundsPreferenceKey];
@@ -857,7 +856,6 @@ public:
 {
     [self _setBoolValue: flag forKey: WebKitShouldPrintBackgroundsPreferenceKey];
 }
-#endif
 
 - (BOOL)isJavaScriptEnabled
 {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPreferences.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPreferences.cpp
@@ -81,6 +81,7 @@ TEST(WebKit, WKPreferencesDefaults)
     EXPECT_TRUE(WKPreferencesGetLocalStorageEnabled(preference));
     EXPECT_FALSE(WKPreferencesGetFrameFlatteningEnabled(preference));
     EXPECT_TRUE(WKPreferencesGetPluginsEnabled(preference));
+    EXPECT_FALSE(WKPreferencesGetShouldPrintBackgrounds(preference));
     EXPECT_TRUE(WKPreferencesGetJavaScriptCanOpenWindowsAutomatically(preference));
     EXPECT_TRUE(WKPreferencesGetHyperlinkAuditingEnabled(preference));
     EXPECT_WK_STREQ(expectedStandardFontFamily, adoptWK(WKPreferencesCopyStandardFontFamily(preference)));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Coding.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Coding.mm
@@ -49,6 +49,7 @@ TEST(Coding, WKPreferences)
     // Change all defaults to something else.
     [a setMinimumFontSize:10];
     [a setJavaScriptEnabled:NO];
+    [a setShouldPrintBackgrounds:YES];
 #if PLATFORM(IOS_FAMILY)
     [a setJavaScriptCanOpenWindowsAutomatically:YES];
 #else
@@ -62,6 +63,7 @@ TEST(Coding, WKPreferences)
     EXPECT_EQ([a minimumFontSize], [b minimumFontSize]);
     EXPECT_EQ([a javaScriptEnabled], [b javaScriptEnabled]);
     EXPECT_EQ([a javaScriptCanOpenWindowsAutomatically], [b javaScriptCanOpenWindowsAutomatically]);
+    EXPECT_EQ([a shouldPrintBackgrounds], [b shouldPrintBackgrounds]);
 
 #if PLATFORM(MAC)
     EXPECT_EQ([a plugInsEnabled], [b plugInsEnabled]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Copying.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Copying.mm
@@ -33,6 +33,7 @@ TEST(Copying, WKPreferences)
     RetainPtr<WKPreferences> a = adoptNS([[WKPreferences alloc] init]);
     [a setMinimumFontSize:10];
     [a setJavaScriptEnabled:NO];
+    [a setShouldPrintBackgrounds:YES];
 #if PLATFORM(IOS_FAMILY)
     [a setJavaScriptCanOpenWindowsAutomatically:YES];
 #else
@@ -46,6 +47,7 @@ TEST(Copying, WKPreferences)
     EXPECT_EQ([a minimumFontSize], [b minimumFontSize]);
     EXPECT_EQ([a javaScriptEnabled], [b javaScriptEnabled]);
     EXPECT_EQ([a javaScriptCanOpenWindowsAutomatically], [b javaScriptCanOpenWindowsAutomatically]);
+    EXPECT_EQ([a shouldPrintBackgrounds], [b shouldPrintBackgrounds]);
 #if PLATFORM(MAC)
     EXPECT_EQ([a javaEnabled], [b javaEnabled]);
     EXPECT_EQ([a plugInsEnabled], NO);
@@ -55,6 +57,7 @@ TEST(Copying, WKPreferences)
     // Change all defaults on the copied instance.
     [b setMinimumFontSize:13];
     [b setJavaScriptEnabled:YES];
+    [b setShouldPrintBackgrounds:NO];
 #if PLATFORM(IOS_FAMILY)
     [b setJavaScriptCanOpenWindowsAutomatically:NO];
 #else
@@ -67,6 +70,7 @@ TEST(Copying, WKPreferences)
     EXPECT_NE([a minimumFontSize], [b minimumFontSize]);
     EXPECT_NE([a javaScriptEnabled], [b javaScriptEnabled]);
     EXPECT_NE([a javaScriptCanOpenWindowsAutomatically], [b javaScriptCanOpenWindowsAutomatically]);
+    EXPECT_NE([a shouldPrintBackgrounds], [b shouldPrintBackgrounds]);
 #if PLATFORM(MAC)
     EXPECT_EQ([a plugInsEnabled], [b plugInsEnabled]);
     EXPECT_NE([a tabFocusesLinks], [b tabFocusesLinks]);


### PR DESCRIPTION
#### eee10982d72fa04055ce4c123a17d77e36e71946
<pre>
Add API to include backgrounds when printing
<a href="https://bugs.webkit.org/show_bug.cgi?id=244270">https://bugs.webkit.org/show_bug.cgi?id=244270</a>
rdar://90055962

Reviewed by Tim Horton and Aditya Keerthi.

Adds an API to allow for customization of if backgrounds should be included
when printing or not.

Also changes the default value of this option to `NO` on iOS, for consistency
with macOS. We are using a linked-on-or-after check to avoid breakage.

* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences encodeWithCoder:]):
(-[WKPreferences initWithCoder:]):
(-[WKPreferences setShouldPrintBackgrounds:]):
(-[WKPreferences shouldPrintBackgrounds]):
(-[WKPreferences _setShouldPrintBackgrounds:]):
(-[WKPreferences _shouldPrintBackgrounds]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setupPageConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration init]):
(-[WKWebViewConfiguration copyWithZone:]):
(-[WKWebViewConfiguration _printsBackgrounds]):
(-[WKWebViewConfiguration _setPrintsBackgrounds:]):
* Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebPreferences.h:
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(-[WebPreferences setShouldPrintBackgrounds:]):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKPreferences.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKit/backgroundcolor.html: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Copying.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewPrintFormatter.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/253952@main">https://commits.webkit.org/253952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b53a87e1044910ab762c04152cee917890d3526

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96748 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150475 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29974 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26143 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79640 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91509 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24221 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74302 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24048 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67066 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79358 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27682 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13227 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73040 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27635 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14243 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26002 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2778 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37116 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75868 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33521 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16819 "Passed tests") | 
<!--EWS-Status-Bubble-End-->