### PR TITLE
gamespot.com shows a smaller video when entering full screen

### DIFF
--- a/LayoutTests/compositing/no-compositing-when-fulll-screen-is-present-expected.txt
+++ b/LayoutTests/compositing/no-compositing-when-fulll-screen-is-present-expected.txt
@@ -6,8 +6,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS successfullyParsed is true
 
 TEST COMPLETE
-full screen content
-foobar
+full screen contentfoobar
 foobar
 (GraphicsLayer
   (anchor 0.00 0.00)
@@ -30,8 +29,15 @@ foobar
             )
             (GraphicsLayer
               (bounds 800.00 600.00)
-              (drawsContent 1)
               (backingStoreAttached 1)
+              (children 1
+                (GraphicsLayer
+                  (bounds 800.00 600.00)
+                  (contentsOpaque 1)
+                  (drawsContent 1)
+                  (backingStoreAttached 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/fullscreen/full-screen-layer-dump-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-layer-dump-expected.txt
@@ -19,7 +19,16 @@
             )
             (GraphicsLayer
               (bounds 800.00 600.00)
-              (drawsContent 1)
+              (children 1
+                (GraphicsLayer
+                  (bounds 800.00 600.00)
+                  (contentsOpaque 1)
+                  (contents layer (background color)
+                    (position 0.00 0.00)
+                    (bounds 800.00 600.00)
+                  )
+                )
+              )
             )
           )
         )

--- a/LayoutTests/fullscreen/full-screen-min-max-width-height-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-min-max-width-height-expected.txt
@@ -1,0 +1,17 @@
+Testing with explicit width and height
+EVENT(webkitfullscreenchange)
+EXPECTED (target.clientWidth === document.documentElement.clientWidth == 'true') OK
+EXPECTED (target.clientHeight === document.documentElement.clientHeight == 'true') OK
+EVENT(webkitfullscreenchange)
+Testing with max-width and max-height
+EVENT(webkitfullscreenchange)
+EXPECTED (target.clientWidth === document.documentElement.clientWidth == 'true') OK
+EXPECTED (target.clientHeight === document.documentElement.clientHeight == 'true') OK
+EVENT(webkitfullscreenchange)
+Testing with min-width and min-height
+EVENT(webkitfullscreenchange)
+EXPECTED (target.clientWidth === document.documentElement.clientWidth == 'true') OK
+EXPECTED (target.clientHeight === document.documentElement.clientHeight == 'true') OK
+EVENT(webkitfullscreenchange)
+END OF TEST
+

--- a/LayoutTests/fullscreen/full-screen-min-max-width-height.html
+++ b/LayoutTests/fullscreen/full-screen-min-max-width-height.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<style>
+    .explicit-width-height {
+        height: 400px;
+        width: 400px;
+    }
+
+    .max-width-height {
+        max-height: 400px;
+        max-width: 400px;
+    }
+
+
+    .min-width-height {
+        min-height: 400px;
+        min-width: 400px;
+    }
+</style>
+</head>
+<script src="full-screen-test.js"></script>
+<script>
+window.addEventListener('load', async event => {
+    target = document.getElementById('target');
+
+    consoleWrite('Testing with explicit width and height');
+    target.className = 'explicit-width-height';
+    runWithKeyDown(() => { target.webkitRequestFullscreen(); })
+    await waitFor(document, 'webkitfullscreenchange');
+
+    testExpected('target.clientWidth === document.documentElement.clientWidth', true);
+    testExpected('target.clientHeight === document.documentElement.clientHeight', true);
+
+    runWithKeyDown(() => { document.webkitExitFullscreen(); });
+    await waitFor(document, 'webkitfullscreenchange');
+
+    consoleWrite('Testing with max-width and max-height');
+    target.className = 'max-width-height';
+    runWithKeyDown(() => { target.webkitRequestFullscreen(); })
+    await waitFor(document, 'webkitfullscreenchange');
+
+    testExpected('target.clientWidth === document.documentElement.clientWidth', true);
+    testExpected('target.clientHeight === document.documentElement.clientHeight', true);
+
+    runWithKeyDown(() => { document.webkitExitFullscreen(); });
+    await waitFor(document, 'webkitfullscreenchange');
+
+    consoleWrite('Testing with min-width and min-height');
+    target.className = 'min-width-height';
+    runWithKeyDown(() => { target.webkitRequestFullscreen(); })
+    await waitFor(document, 'webkitfullscreenchange');
+
+    testExpected('target.clientWidth === document.documentElement.clientWidth', true);
+    testExpected('target.clientHeight === document.documentElement.clientHeight', true);
+
+    runWithKeyDown(() => { document.webkitExitFullscreen(); });
+    await waitFor(document, 'webkitfullscreenchange');
+
+    endTest();
+});
+</script>
+<body>
+    <div id="target"></div>
+</body>
+</html>

--- a/LayoutTests/fullscreen/full-screen-test.js
+++ b/LayoutTests/fullscreen/full-screen-test.js
@@ -158,7 +158,7 @@ function waitForEventTestAndEnd(element, eventName, testFuncString)
 {
     waitForEventAndTest(element, eventName, testFuncString, true);
 }
-  
+
 var testEnded = false;
 
 function endTest()

--- a/LayoutTests/fullscreen/fullscreen-user-agent-style-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-user-agent-style-expected.txt
@@ -1,12 +1,12 @@
-EXPECTED (document.defaultView.getComputedStyle(span, null).getPropertyValue('width') == 'auto') OK
-EXPECTED (document.defaultView.getComputedStyle(span, null).getPropertyValue('height') == 'auto') OK
+EXPECTED (document.defaultView.getComputedStyle(span, null).getPropertyValue('bottom') == 'auto') OK
+EXPECTED (document.defaultView.getComputedStyle(span, null).getPropertyValue('right') == 'auto') OK
 RUN(span.webkitRequestFullscreen())
 EVENT(webkitfullscreenchange)
-EXPECTED (document.defaultView.getComputedStyle(span, null).getPropertyValue('width') == '100%') OK
-EXPECTED (document.defaultView.getComputedStyle(span, null).getPropertyValue('height') == '100%') OK
+EXPECTED (document.defaultView.getComputedStyle(span, null).getPropertyValue('bottom') == '0px') OK
+EXPECTED (document.defaultView.getComputedStyle(span, null).getPropertyValue('right') == '0px') OK
 RUN(document.webkitExitFullscreen())
 EVENT(webkitfullscreenchange)
-EXPECTED (document.defaultView.getComputedStyle(span, null).getPropertyValue('width') == 'auto') OK
-EXPECTED (document.defaultView.getComputedStyle(span, null).getPropertyValue('height') == 'auto') OK
+EXPECTED (document.defaultView.getComputedStyle(span, null).getPropertyValue('bottom') == 'auto') OK
+EXPECTED (document.defaultView.getComputedStyle(span, null).getPropertyValue('right') == 'auto') OK
 END OF TEST
 

--- a/LayoutTests/fullscreen/fullscreen-user-agent-style.html
+++ b/LayoutTests/fullscreen/fullscreen-user-agent-style.html
@@ -7,20 +7,20 @@
         window.addEventListener('load', async event => {
             window.span = document.querySelector('span');
 
-            testExpected("document.defaultView.getComputedStyle(span, null).getPropertyValue('width')", "auto");
-            testExpected("document.defaultView.getComputedStyle(span, null).getPropertyValue('height')", "auto");
+            testExpected("document.defaultView.getComputedStyle(span, null).getPropertyValue('bottom')", "auto");
+            testExpected("document.defaultView.getComputedStyle(span, null).getPropertyValue('right')", "auto");
 
             runWithKeyDown(() => { run("span.webkitRequestFullscreen()") });
             await waitFor(span, 'webkitfullscreenchange');
 
-            testExpected("document.defaultView.getComputedStyle(span, null).getPropertyValue('width')", "100%");
-            testExpected("document.defaultView.getComputedStyle(span, null).getPropertyValue('height')", "100%");
+            testExpected("document.defaultView.getComputedStyle(span, null).getPropertyValue('bottom')", "0px");
+            testExpected("document.defaultView.getComputedStyle(span, null).getPropertyValue('right')", "0px");
 
             runWithKeyDown(() => { run("document.webkitExitFullscreen()") });
             await waitFor(span, 'webkitfullscreenchange');
 
-            testExpected("document.defaultView.getComputedStyle(span, null).getPropertyValue('width')", "auto");
-            testExpected("document.defaultView.getComputedStyle(span, null).getPropertyValue('height')", "auto");
+            testExpected("document.defaultView.getComputedStyle(span, null).getPropertyValue('bottom')", "auto");
+            testExpected("document.defaultView.getComputedStyle(span, null).getPropertyValue('right')", "auto");
 
             endTest();
         });

--- a/Source/WebCore/css/fullscreen.css
+++ b/Source/WebCore/css/fullscreen.css
@@ -24,6 +24,23 @@
 
 #if defined(ENABLE_FULLSCREEN_API) && ENABLE_FULLSCREEN_API
 
+:not(:root):-webkit-full-screen {
+  position:fixed !important;
+  top:0 !important; right:0 !important; bottom:0 !important; left:0 !important;
+  margin:0 !important;
+  box-sizing:border-box !important;
+  min-width:0 !important;
+  max-width:none !important;
+  min-height:0 !important;
+  max-height:none !important;
+  width:100% !important;
+  height:100% !important;
+  transform:none !important;
+
+  /* intentionally not !important */
+  object-fit:contain;
+}
+
 :-webkit-full-screen {
     background-color: white;
     z-index: 2147483647 !important;

--- a/Tools/TestWebKitAPI/Tests/mac/FullscreenZoomInitialFrame.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FullscreenZoomInitialFrame.mm
@@ -175,8 +175,8 @@ void FullscreenZoomInitialFrame::runTest(View view)
 
     EXPECT_EQ(300, initialFrame.size.width);
     EXPECT_EQ(300, initialFrame.size.height);
-    EXPECT_EQ(400, finalFrame.size.width);
-    EXPECT_EQ(400, finalFrame.size.height);
+    EXPECT_EQ(view.bounds.size.width, finalFrame.size.width);
+    EXPECT_EQ(view.bounds.size.height, finalFrame.size.height);
 
     isWaitingForPageSignalToContinue = true;
     didGetPageSignalToContinue = false;


### PR DESCRIPTION
#### 5b6026cbed5508f67d6f3305a2e42e47e1a7aad5
<pre>
gamespot.com shows a smaller video when entering full screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=244256">https://bugs.webkit.org/show_bug.cgi?id=244256</a>
&lt;rdar://98754870&gt;

Reviewed by Eric Carlson.

When Gamespot.com videos enter fullscreen, they have a rule with a max-width: property
set on their fullscreen element, that prevents the element from being resized to occupy
the entire screen.

Adopt CSS from the current Fullscreen API specification for the fullscreen element,
including an explicit and !important min, max, and explicit width and height.

* LayoutTests/fullscreen/full-screen-min-max-width-height-expected.txt: Added.
* LayoutTests/fullscreen/full-screen-min-max-width-height.html: Added.
* LayoutTests/fullscreen/full-screen-test.js:
(waitFor):
* Source/WebCore/css/fullscreen.css:

Canonical link: <a href="https://commits.webkit.org/253790@main">https://commits.webkit.org/253790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec52224a5330e0f5fbaf0afa8c72029ae826ecec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31173 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/96060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149667 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29538 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/91113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92702 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73906 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27266 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72635 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27210 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25889 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2677 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28894 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/36806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75439 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28835 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/16702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->