### PR TITLE
Deploy smart pointers in EventPath

### DIFF
--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -137,10 +137,15 @@ void Event::setCurrentTarget(EventTarget* currentTarget, std::optional<bool> isI
     m_currentTargetIsInShadowTree = isInShadowTree ? *isInShadowTree : (is<Node>(currentTarget) && downcast<Node>(*currentTarget).isInShadowTree());
 }
 
-Vector<EventTarget*> Event::composedPath() const
+void Event::setEventPath(const EventPath& path)
+{
+    m_eventPath = &path;
+}
+
+Vector<Ref<EventTarget>> Event::composedPath() const
 {
     if (!m_eventPath)
-        return Vector<EventTarget*>();
+        return Vector<Ref<EventTarget>>();
     return m_eventPath->computePathUnclosedToTarget(*m_currentTarget);
 }
 

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -29,6 +29,7 @@
 #include "EventOptions.h"
 #include "ExceptionOr.h"
 #include "ScriptWrappable.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/AtomString.h>
@@ -88,8 +89,8 @@ public:
     DOMHighResTimeStamp timeStampForBindings(ScriptExecutionContext&) const;
     MonotonicTime timeStamp() const { return m_createTime; }
 
-    void setEventPath(const EventPath& path) { m_eventPath = &path; }
-    Vector<EventTarget*> composedPath() const;
+    void setEventPath(const EventPath&);
+    Vector<Ref<EventTarget>> composedPath() const;
 
     void stopPropagation() { m_propagationStopped = true; }
     void stopImmediatePropagation() { m_immediatePropagationStopped = true; }
@@ -182,7 +183,7 @@ private:
     AtomString m_type;
 
     RefPtr<EventTarget> m_currentTarget;
-    const EventPath* m_eventPath { nullptr };
+    CheckedPtr<const EventPath> m_eventPath;
     RefPtr<EventTarget> m_target;
     MonotonicTime m_createTime;
 

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -73,8 +73,8 @@ private:
 
     void checkConsistency(Node& currentTarget);
 
-    Node& m_relatedNode;
-    Node* m_retargetedRelatedNode;
+    Ref<Node> m_relatedNode;
+    RefPtr<Node> m_retargetedRelatedNode;
     Vector<TreeScope*, 8> m_ancestorTreeScopes;
     unsigned m_lowestCommonAncestorIndex { 0 };
     bool m_hasDifferentTreeRoot { false };
@@ -105,14 +105,14 @@ void EventPath::buildPath(Node& originalTarget, Event& event)
         return EventContext::Type::Normal;
     }();
 
-    Node* node = nodeOrHostIfPseudoElement(&originalTarget);
-    Node* target = node ? eventTargetRespectingTargetRules(*node) : nullptr;
+    RefPtr node = nodeOrHostIfPseudoElement(&originalTarget);
+    RefPtr target = node ? eventTargetRespectingTargetRules(*node) : nullptr;
     int closedShadowDepth = 0;
     // Depths are used to decided which nodes are excluded in event.composedPath when the tree is mutated during event dispatching.
     // They could be negative for nodes outside the shadow tree of the target node.
     while (node) {
         while (node) {
-            m_path.append(EventContext { contextType, *node, eventTargetRespectingTargetRules(*node), target, closedShadowDepth });
+            m_path.append(EventContext { contextType, *node, eventTargetRespectingTargetRules(*node), target.get(), closedShadowDepth });
 
             if (is<ShadowRoot>(*node))
                 break;
@@ -124,13 +124,13 @@ void EventPath::buildPath(Node& originalTarget, Event& event)
                     ASSERT(target);
                     if (target) {
                         if (auto* window = downcast<Document>(*node).domWindow())
-                            m_path.append(EventContext { EventContext::Type::Window, node, window, target, closedShadowDepth });
+                            m_path.append(EventContext { EventContext::Type::Window, node.get(), window, target.get(), closedShadowDepth });
                     }
                 }
                 return;
             }
 
-            if (auto* shadowRootOfParent = parent->shadowRoot(); UNLIKELY(shadowRootOfParent)) {
+            if (RefPtr shadowRootOfParent = parent->shadowRoot(); UNLIKELY(shadowRootOfParent)) {
                 if (auto* assignedSlot = shadowRootOfParent->findAssignedSlot(*node)) {
                     if (shadowRootOfParent->mode() != ShadowRootMode::Open)
                         closedShadowDepth++;
@@ -235,9 +235,9 @@ void EventPath::retargetTouchLists(const TouchEvent& event)
 // Any node whose depth computed in EventPath::buildPath is greater than the context object is excluded.
 // Because we can exit out of a closed shadow tree and re-enter another closed shadow tree via a slot,
 // we decrease the *allowed depth* whenever we moved to a "shallower" (closer-to-document) tree.
-Vector<EventTarget*> EventPath::computePathUnclosedToTarget(const EventTarget& target) const
+Vector<Ref<EventTarget>> EventPath::computePathUnclosedToTarget(const EventTarget& target) const
 {
-    Vector<EventTarget*> path;
+    Vector<Ref<EventTarget>> path;
     auto pathSize = m_path.size();
     RELEASE_ASSERT(pathSize);
     path.reserveInitialCapacity(pathSize);
@@ -256,7 +256,7 @@ Vector<EventTarget*> EventPath::computePathUnclosedToTarget(const EventTarget& t
         bool movedOutOfShadowTree = depth < currentDepthAllowed;
         if (movedOutOfShadowTree)
             currentDepthAllowed = depth;
-        path.uncheckedAppend(currentContext.currentTarget());
+        path.uncheckedAppend(*currentContext.currentTarget());
     };
 
     auto currentDepthAllowed = currentTargetDepth;
@@ -295,8 +295,8 @@ RelatedNodeRetargeter::RelatedNodeRetargeter(Node& relatedNode, Node& target)
     , m_retargetedRelatedNode(&relatedNode)
 {
     auto& targetTreeScope = target.treeScope();
-    TreeScope* currentTreeScope = &m_relatedNode.treeScope();
-    if (LIKELY(currentTreeScope == &targetTreeScope && target.isConnected() && m_relatedNode.isConnected()))
+    TreeScope* currentTreeScope = &m_relatedNode->treeScope();
+    if (LIKELY(currentTreeScope == &targetTreeScope && target.isConnected() && m_relatedNode->isConnected()))
         return;
 
     if (&currentTreeScope->documentScope() != &targetTreeScope.documentScope()
@@ -347,7 +347,7 @@ RelatedNodeRetargeter::RelatedNodeRetargeter(Node& relatedNode, Node& target)
 inline Node* RelatedNodeRetargeter::currentNode(Node& currentTarget)
 {
     checkConsistency(currentTarget);
-    return m_retargetedRelatedNode;
+    return m_retargetedRelatedNode.get();
 }
 
 void RelatedNodeRetargeter::moveToNewTreeScope(TreeScope* previousTreeScope, TreeScope& newTreeScope)
@@ -374,7 +374,7 @@ void RelatedNodeRetargeter::moveToNewTreeScope(TreeScope* previousTreeScope, Tre
                 ASSERT(&newTreeScope == &m_retargetedRelatedNode->treeScope());
             }
         } else
-            ASSERT(m_retargetedRelatedNode == &m_relatedNode);
+            ASSERT(m_retargetedRelatedNode == m_relatedNode.ptr());
     } else {
         ASSERT(previousTreeScope->parentTreeScope() == &newTreeScope);
         m_lowestCommonAncestorIndex++;
@@ -387,7 +387,7 @@ void RelatedNodeRetargeter::moveToNewTreeScope(TreeScope* previousTreeScope, Tre
 inline Node* RelatedNodeRetargeter::nodeInLowestCommonAncestor()
 {
     if (!m_lowestCommonAncestorIndex)
-        return &m_relatedNode;
+        return m_relatedNode.ptr();
     auto& rootNode = m_ancestorTreeScopes[m_lowestCommonAncestorIndex - 1]->rootNode();
     return downcast<ShadowRoot>(rootNode).host();
 }
@@ -395,7 +395,7 @@ inline Node* RelatedNodeRetargeter::nodeInLowestCommonAncestor()
 void RelatedNodeRetargeter::collectTreeScopes()
 {
     ASSERT(m_ancestorTreeScopes.isEmpty());
-    for (TreeScope* currentTreeScope = &m_relatedNode.treeScope(); currentTreeScope; currentTreeScope = currentTreeScope->parentTreeScope())
+    for (TreeScope* currentTreeScope = &m_relatedNode->treeScope(); currentTreeScope; currentTreeScope = currentTreeScope->parentTreeScope())
         m_ancestorTreeScopes.append(currentTreeScope);
     ASSERT_WITH_SECURITY_IMPLICATION(!m_ancestorTreeScopes.isEmpty());
 }
@@ -413,7 +413,7 @@ void RelatedNodeRetargeter::checkConsistency(Node& currentTarget)
     if (!m_retargetedRelatedNode)
         return;
     ASSERT(!currentTarget.isClosedShadowHidden(*m_retargetedRelatedNode));
-    ASSERT(m_retargetedRelatedNode == currentTarget.treeScope().retargetToScope(m_relatedNode).ptr());
+    ASSERT(m_retargetedRelatedNode == currentTarget.treeScope().retargetToScope(m_relatedNode.get()).ptr());
 }
 
 #endif // ASSERT_ENABLED

--- a/Source/WebCore/dom/EventPath.h
+++ b/Source/WebCore/dom/EventPath.h
@@ -24,6 +24,7 @@
 #include "PseudoElement.h"
 #include "SVGElement.h"
 #include "SVGUseElement.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 
@@ -31,7 +32,7 @@ namespace WebCore {
 
 class Touch;
 
-class EventPath {
+class EventPath : public CanMakeCheckedPtr {
 public:
     EventPath(Node& origin, Event&);
     explicit EventPath(const Vector<EventTarget*>&);
@@ -41,7 +42,7 @@ public:
     const EventContext& contextAt(size_t i) const { return m_path[i]; }
     EventContext& contextAt(size_t i) { return m_path[i]; }
 
-    Vector<EventTarget*> computePathUnclosedToTarget(const EventTarget&) const;
+    Vector<Ref<EventTarget>> computePathUnclosedToTarget(const EventTarget&) const;
 
     static Node* eventTargetRespectingTargetRules(Node&);
 


### PR DESCRIPTION
#### 02c9408f825d7c4fe7408aca6dfc01d80eabd803
<pre>
Deploy smart pointers in EventPath
<a href="https://bugs.webkit.org/show_bug.cgi?id=244275">https://bugs.webkit.org/show_bug.cgi?id=244275</a>

Reviewed by Darin Adler.

Use more smart pointers in EventPath and related code.

* Source/WebCore/dom/Event.cpp:
(WebCore::Event::setEventPath): Moved from the header file.
(WebCore::Event::composedPath const):

* Source/WebCore/dom/Event.h:
(WebCore::Event::setEventPath): Removed.

* Source/WebCore/dom/EventPath.cpp:
(WebCore::EventPath::buildPath):
(WebCore::EventPath::computePathUnclosedToTarget const):
(WebCore::RelatedNodeRetargeter::RelatedNodeRetargeter):
(WebCore::RelatedNodeRetargeter::currentNode):
(WebCore::RelatedNodeRetargeter::moveToNewTreeScope):
(WebCore::RelatedNodeRetargeter::nodeInLowestCommonAncestor):
(WebCore::RelatedNodeRetargeter::collectTreeScopes):
(WebCore::RelatedNodeRetargeter::checkConsistency):
* Source/WebCore/dom/EventPath.h:

Canonical link: <a href="https://commits.webkit.org/253717@main">https://commits.webkit.org/253717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e7edfa909a9b289acea4880c46f1efd5767ad70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17748 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95702 "Hash 3e7edfa9 for PR 3596 does not build") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149457 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29317 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79022 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90929 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23676 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73736 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23697 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66702 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27071 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12807 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27004 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13821 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36686 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1039 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28627 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33100 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->