### PR TITLE
Implement wheel WPT actions in WebKit's vendor JS

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6035,6 +6035,15 @@ imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of
 
 webkit.org/b/233267 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_window_open_download_block_downloads.tentative.html [ Pass Failure ]
 
+# These are timeouts after adding wheel actions in WPT vendor JS: webkit.org/b/243272
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/ [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/forms/the-label-element/proxy-modifier-click-to-associated-element.tentative.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel.html [ Skip ]
+imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-scrolling.html [ Skip ]
+imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-basic.html [ Skip ]
+imported/w3c/web-platform-tests/uievents/order-of-events/focus-events/focus-management-expectations.html [ Skip ]
+imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-keyboard.html [ Skip ]
+
 # Flaky because of network ordering
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset.html [ Pass Failure ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/cors-crossorigin-requests.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL Wheel-scroll triggers snap to target position immediately. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: action"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Wheel-scroll triggers snap to target position immediately. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-expected.txt
@@ -2,5 +2,5 @@ Header 1Footer 1
 Header 2Footer 2
 
 FAIL Keyboard scrolling with vertical snap-area overflow assert_equals: End boundary of snap-area is valid snap target expected 39 but got 449
-FAIL Mouse-wheel scrolling with vertical snap-area overflow promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: action"
+FAIL Mouse-wheel scrolling with vertical snap-area overflow assert_equals: Wheel-scroll moved scroll position expected 50 but got 510
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/selection-target-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/selection-target-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Test scrolling into view when typing promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: action"
+FAIL Test scrolling into view when typing promise_test: Unhandled rejection with value: object "Error: Unknown source type "key"."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end-expected.txt
@@ -1,13 +1,3 @@
-CONSOLE MESSAGE: ReferenceError: Can't find variable: action
-CSSScrollSnap
 
-Tests that the window can snap at user scroll end.
-
-Scroll the page vertically and horizontally. Keep scrolling until background has turned yellow.
-Press the button "Done"
-
-
-Harness Error (FAIL), message = ReferenceError: Can't find variable: action
-
-NOTRUN Tests that window should snap at user scroll end.
+PASS Tests that window should snap at user scroll end.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/active-onblur-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/active-onblur-expected.txt
@@ -1,4 +1,4 @@
 button one button two
 
-FAIL Buttons should clear :active when the user tabs away from them while holding spacebar. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: action"
+FAIL Buttons should clear :active when the user tabs away from them while holding spacebar. promise_test: Unhandled rejection with value: object "Error: Unknown source type "key"."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/checkable-active-onblur-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/checkable-active-onblur-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL Checkboxes should clear :active when the user tabs away from them while holding spacebar. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: action"
-FAIL Radios should clear :active when the user tabs away from them while holding spacebar. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: action"
+FAIL Checkboxes should clear :active when the user tabs away from them while holding spacebar. promise_test: Unhandled rejection with value: object "Error: Unknown source type "key"."
+FAIL Radios should clear :active when the user tabs away from them while holding spacebar. promise_test: Unhandled rejection with value: object "Error: Unknown source type "key"."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-canceling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-canceling-expected.txt
@@ -1,5 +1,5 @@
 You can't Escape when this textbox has focus:
 You can Escape even if this textbox has focus:
 
-FAIL Modal dialogs should close when the escape key is pressed. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: action"
+FAIL Modal dialogs should close when the escape key is pressed. promise_test: Unhandled rejection with value: object "Error: Unknown source type "key"."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-uneditable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-uneditable-expected.txt
@@ -1,4 +1,4 @@
 I'm not editable while the dialog is showing. I'm editable.
 
-FAIL Test that inert nodes cannot be edited. The test passes if the only text you can edit is in the dialog. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: action"
+FAIL Test that inert nodes cannot be edited. The test passes if the only text you can edit is in the dialog. promise_test: Unhandled rejection with value: object "Error: Unknown source type "key"."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/compat/pointerevent_mouseevent_key_pressed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/compat/pointerevent_mouseevent_key_pressed-expected.txt
@@ -1,9 +1,9 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: ReferenceError: Can't find variable: action
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unknown source type "key".
 Test Description: Tests that the mouse events with some keys pressed.
 Press Alt, Control, Meta, Shift keys and move the mouse
 
 
-Harness Error (FAIL), message = Unhandled rejection: Can't find variable: action
+Harness Error (FAIL), message = Unhandled rejection: Unknown source type "key".
 
 FAIL Tests that the mouse events with some keys pressed. assert_true: Timed out waiting for pointermove expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-keyboard-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-keyboard-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: ReferenceError: Can't find variable: action
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unknown source type "key".
 Pointer Events touch-action attribute support
 
 Test Description: Press DOWN ARROW key. Wait for description update. Expected: pan enabled
@@ -72,7 +72,7 @@ Lorem ipsum dolor sit amet...
 touch-action: none
 
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: action
+Harness Error (FAIL), message = Unhandled rejection: Unknown source type "key".
 
 NOTRUN touch-action attribute test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/accesskey.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/accesskey.tentative-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL button element with accesskey in the shadow tree of open mode promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: action"
-FAIL button element with accesskey in the shadow tree of closed mode promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: action"
+FAIL button element with accesskey in the shadow tree of open mode promise_test: Unhandled rejection with value: object "Error: Unknown source type "key"."
+FAIL button element with accesskey in the shadow tree of closed mode promise_test: Unhandled rejection with value: object "Error: Unknown source type "key"."
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1913,6 +1913,11 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/js
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.worker.html [ Pass Failure ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.html [ Pass Failure ]
 
+# These timeout after implementing wheel actions: webkit.org/b/243272
+imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary.html [ Skip ]
+
 # fails even with specific expectation.
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048.html [ Pass Failure ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3753,7 +3753,13 @@ webkit.org/b/244619 editing/selection/ios/tap-to-set-selection-in-editable-web-v
 
 webkit.org/b/244740 http/wpt/cross-origin-opener-policy/non-secure-to-secure-context-navigation.https.html [ Pass Failure ]
 
+# These timeout after implementing wheel actions: webkit.org/b/243272
+imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html [ Skip ]
+
 # These tests have similar harness errors and timeouts. See webkit.org/b/244900
 [ Debug ] imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-1.html [ Pass Timeout Failure ]
 [ Debug ] imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-2.html [ Pass Timeout Failure ]
 [ Debug ] imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-3.html [ Pass Timeout Failure ]
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior-expected.txt
@@ -8,5 +8,5 @@ Repeat the same scrolls as in step 1 and then tap on DONE.
 Repeat the same scrolls as in step 1 and then tap on DONE.
 Make two separate scrolls on GREEN, in this order: scroll UP (or drag down), then scroll LEFT (or drag right). Scroll (or drag) until nothing is scrolling. Then tap on DONE.
 
-PASS overscroll-behavior prevents scroll-propagation in the area and direction as specified
+FAIL overscroll-behavior prevents scroll-propagation in the area and direction as specified assert_equals: expected 100 but got 0
 


### PR DESCRIPTION
#### c84e12023b1fdceb3db72041895d5e5160ad7acf
<pre>
Implement wheel WPT actions in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=243272">https://bugs.webkit.org/show_bug.cgi?id=243272</a>
&lt;rdar://97691874&gt;

Reviewed by NOBODY (OOPS!).

WIP patch from Tim Nguyen. Implement wheel actions in WebKitTestRunner.

* LayoutTests/imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js:
(async dispatchWheelActions):
(async let):
(window.test_driver_internal.action_sequence):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c84e12023b1fdceb3db72041895d5e5160ad7acf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101276 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161338 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/732 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29427 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97624 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/452 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78252 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27404 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70443 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35691 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16059 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33458 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17153 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39928 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36270 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->