### PR TITLE
Remove hspace and vspace attributes from input

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/unmapped-attributes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/unmapped-attributes-expected.txt
@@ -54,12 +54,11 @@ PASS <input width> should not be mapped to style width in CSS1Compat mode
 PASS <input width> should not be mapped to style width in BackCompat mode
 PASS <input height> should not be mapped to style height in CSS1Compat mode
 PASS <input height> should not be mapped to style height in BackCompat mode
-FAIL <input hspace> should not be mapped to style marginLeft in CSS1Compat mode assert_equals: expected "0px" but got "200px"
-FAIL <input hspace> should not be mapped to style marginLeft in BackCompat mode assert_equals: expected "0px" but got "200px"
-FAIL <input hspace> should not be mapped to style marginRight in CSS1Compat mode assert_equals: expected "0px" but got "200px"
-FAIL <input hspace> should not be mapped to style marginRight in BackCompat mode assert_equals: expected "0px" but got "200px"
-FAIL <input vspace> should not be mapped to style marginTop in CSS1Compat mode assert_equals: expected "0px" but got "200px"
-FAIL <input vspace> should not be mapped to style marginTop in BackCompat mode assert_equals: expected "0px" but got "200px"
-FAIL <input vspace> should not be mapped to style marginBottom in CSS1Compat mode assert_equals: expected "0px" but got "200px"
-FAIL <input vspace> should not be mapped to style marginBottom in BackCompat mode assert_equals: expected "0px" but got "200px"
-
+PASS <input hspace> should not be mapped to style marginLeft in CSS1Compat mode
+PASS <input hspace> should not be mapped to style marginLeft in BackCompat mode
+PASS <input hspace> should not be mapped to style marginRight in CSS1Compat mode
+PASS <input hspace> should not be mapped to style marginRight in BackCompat mode
+PASS <input vspace> should not be mapped to style marginTop in CSS1Compat mode
+PASS <input vspace> should not be mapped to style marginTop in BackCompat mode
+PASS <input vspace> should not be mapped to style marginBottom in CSS1Compat mode
+PASS <input vspace> should not be mapped to style marginBottom in BackCompat mode

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -677,13 +677,7 @@ bool HTMLInputElement::hasPresentationalHintsForAttribute(const QualifiedName& n
 
 void HTMLInputElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    if (name == vspaceAttr) {
-        addHTMLLengthToStyle(style, CSSPropertyMarginTop, value);
-        addHTMLLengthToStyle(style, CSSPropertyMarginBottom, value);
-    } else if (name == hspaceAttr) {
-        addHTMLLengthToStyle(style, CSSPropertyMarginLeft, value);
-        addHTMLLengthToStyle(style, CSSPropertyMarginRight, value);
-    } else if (name == alignAttr) {
+    if (name == alignAttr) {
         if (m_inputType->shouldRespectAlignAttribute())
             applyAlignmentAttributeToStyle(value, style);
     } else if (name == widthAttr) {


### PR DESCRIPTION
<pre>

Remove hspace and vspace attributes from input

<a href="https://bugs.webkit.org/show_bug.cgi?id=244279">https://bugs.webkit.org/show_bug.cgi?id=244279</a>

Reviewed by NOBODY (OOPS!).

Aligning with Gecko and Web-spec behavior by removing support for 'hspace' and 'vspace' from input element.

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/unmapped-attributes-expected.txt: Updated based on new expectations.
* Source/WebCore/html/HTMLInputElement.cpp
(HTMLInputElement::collectPresentationalHintsForAttribute): Removed 'hspace' and 'vspace' attributes on input to match with Gecko and web-specifications.

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce7251150eee6e9ed169036f29705ef8646b3cb8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95707 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149465 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29323 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25666 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79027 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90934 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92494 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23677 "Found 4 new test failures: fast/forms/005.html, imported/w3c/web-platform-tests/html/rendering/dimension-attributes.html, imported/w3c/web-platform-tests/html/rendering/unmapped-attributes.html, tables/mozilla/bugs/bug24200.html") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73741 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23706 "Found 3 new test failures: imported/w3c/web-platform-tests/html/rendering/dimension-attributes.html, imported/w3c/web-platform-tests/html/rendering/unmapped-attributes.html, tables/mozilla/bugs/bug24200.html") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66711 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27076 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12813 "Found 4 new test failures: fast/forms/005.html, imported/w3c/web-platform-tests/html/rendering/dimension-attributes.html, imported/w3c/web-platform-tests/html/rendering/unmapped-attributes.html, tables/mozilla/bugs/bug24200.html") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27009 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13827 "Found 4 new test failures: fast/forms/005.html, imported/w3c/web-platform-tests/html/rendering/dimension-attributes.html, imported/w3c/web-platform-tests/html/rendering/unmapped-attributes.html, tables/mozilla/bugs/bug24200.html") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28688 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36691 "Found 4 new test failures: fast/forms/005.html, imported/w3c/web-platform-tests/html/rendering/dimension-attributes.html, imported/w3c/web-platform-tests/html/rendering/unmapped-attributes.html, tables/mozilla/bugs/bug24200.html") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33106 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->