### PR TITLE
Reland "[Wasm-GC] Add support for recursion groups"

### DIFF
--- a/JSTests/wasm/gc/rec.js
+++ b/JSTests/wasm/gc/rec.js
@@ -1,0 +1,235 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+function testRecDeclaration() {
+  instantiate(`
+    (module
+      (rec (type (func)) (type (struct)))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec (type (func)) (type (struct)))
+      (func (type 0))
+    )
+  `);
+
+  assert.throws(
+    () => compile(`
+      (module
+        (rec (type (struct)) (type (func)))
+        (func (type 0))
+      )
+    `),
+    WebAssembly.CompileError,
+    "type signature was not a function signature"
+  );
+
+  instantiate(`
+    (module
+      (rec
+        (type (func (result (ref 1))))
+        (type (func (result (ref 0)))))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec
+        (type (func))
+        (type (func (result (ref 0)))))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec (type (func)) (type (struct)))
+      (rec (type (func)) (type (struct)))
+      (elem declare funcref (ref.func 0))
+      (func (type 0))
+      (func (result (ref 2)) (ref.func 0))
+    )
+  `);
+
+  {
+    let m1 = instantiate(`
+      (module
+        (rec (type (func)) (type (struct)))
+        (func (export "f") (type 0))
+      )
+    `);
+    instantiate(`
+      (module
+        (rec (type (func)) (type (struct)))
+        (func (import "m" "f") (type 0))
+        (start 0)
+      )
+    `, { m: { f: m1.exports.f } });
+  }
+
+  {
+    let m1 = instantiate(`
+      (module
+        (rec (type (func)) (type (struct)))
+        (func (export "f") (type 0))
+      )
+    `);
+    assert.throws(
+      () => instantiate(`
+        (module
+          (rec (type (struct)) (type (func)))
+          (func (import "m" "f") (type 1))
+          (start 0)
+        )
+      `, { m: { f: m1.exports.f } }),
+      WebAssembly.LinkError,
+      "imported function m:f signature doesn't match the provided WebAssembly function's signature"
+    );
+  }
+
+  {
+    let m1 = instantiate(`
+      (module
+        (rec (type (func)) (type (struct)))
+        (elem declare funcref (ref.func 0))
+        (func)
+        (func (export "f") (result (ref 0)) (ref.func 0))
+      )
+    `);
+    assert.throws(
+      () => instantiate(`
+        (module
+          (rec (type (struct)) (type (func)))
+          (func (import "m" "f") (type 1))
+        )
+      `, { m: { f: m1.exports.f } }),
+      WebAssembly.LinkError,
+      "imported function m:f signature doesn't match the provided WebAssembly function's signature"
+    );
+  }
+
+  assert.throws(
+    () => compile(`
+      (module
+        (rec (type (func)) (type (struct)))
+        (rec (type (struct)) (type (func)))
+        (global (ref 0) (ref.func 0))
+        (func (type 3))
+      )
+    `),
+    WebAssembly.CompileError,
+    "Global init_expr opcode of type Ref doesn't match global's type Ref"
+  );
+
+  instantiate(`
+    (module
+      (rec (type (func (result (ref 1))))
+           (type (func (result (ref 0)))))
+      (elem declare funcref (ref.func 0))
+      (elem declare funcref (ref.func 1))
+      (func (type 0) (ref.func 1))
+      (func (type 1) (ref.func 0))
+    )
+  `);
+
+  assert.throws(
+    () => compile(`
+      (module
+        (rec (type (func (result (ref 1))))
+             (type (func (result (ref 0)))))
+        (elem declare funcref (ref.func 0))
+        (elem declare funcref (ref.func 1))
+        (func (type 0) (ref.func 1))
+        (func (type 1) (ref.func 1))
+      )
+    `),
+    WebAssembly.CompileError,
+    "control flow returns with unexpected type. Ref is not a Ref, in function at index 1"
+  );
+
+  instantiate(`
+    (module
+      (rec (type (func (param i32))) (type (struct)))
+      (elem declare funcref (ref.func 0))
+      (func (type 0))
+      (func (call_ref (i32.const 42) (ref.func 0)))
+      (start 1)
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec (type (func (result i32))) (type (struct)))
+      (rec (type (struct)) (type (func (result i32))))
+      (func (type 0)
+        (block (type 3)
+          (i32.const 42)))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec (type (func (result i32))) (type (struct)))
+      (rec (type (struct)) (type (func (result i32))))
+      (func (type 0)
+        (loop (type 3)
+          (i32.const 42)))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec (type (func (result i32))) (type (struct)))
+      (rec (type (struct)) (type (func (result i32))))
+      (func (type 0)
+        (i32.const 1)
+        (if (type 3) (then (i32.const 42)) (else (i32.const 43))))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec (type (func)) (type (struct)))
+      (table 5 funcref)
+      (elem (offset (i32.const 0)) funcref (ref.func 0))
+      (func (type 0))
+      (func (call_indirect (type 0) (i32.const 0)))
+      (start 1)
+    )
+  `);
+
+  // Ensure implicit rec groups are accounted for, and treated
+  // correctly with regards to equality.
+  instantiate(`
+    (module
+      (type $a (struct (field i32)))
+      (rec (type $b (struct (field i32))))
+      (type $c (struct (field i32)))
+
+      (func (result (ref null $a)) (ref.null $b))
+      (func (result (ref null $a)) (ref.null $c))
+      (func (result (ref null $b)) (ref.null $a))
+      (func (result (ref null $b)) (ref.null $c))
+      (func (result (ref null $c)) (ref.null $a))
+      (func (result (ref null $c)) (ref.null $b)))
+  `);
+
+  // This is the same test as above, but using a particular binary encoding.
+  // The encoding for this test specifically uses both shorthand and the full
+  // rec form to test the equivalence of the two.
+  new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x9e\x80\x80\x80\x00\x06\x5f\x01\x7f\x00\x4f\x01\x5f\x01\x7f\x00\x5f\x01\x7f\x00\x60\x00\x01\x6c\x00\x60\x00\x01\x6c\x01\x60\x00\x01\x6c\x02\x03\x87\x80\x80\x80\x00\x06\x03\x03\x04\x04\x05\x05\x0a\xb7\x80\x80\x80\x00\x06\x84\x80\x80\x80\x00\x00\xd0\x01\x0b\x84\x80\x80\x80\x00\x00\xd0\x02\x0b\x84\x80\x80\x80\x00\x00\xd0\x00\x0b\x84\x80\x80\x80\x00\x00\xd0\x02\x0b\x84\x80\x80\x80\x00\x00\xd0\x00\x0b\x84\x80\x80\x80\x00\x00\xd0\x01\x0b"));
+}
+
+testRecDeclaration();

--- a/JSTests/wasm/wasm.json
+++ b/JSTests/wasm/wasm.json
@@ -18,6 +18,7 @@
         "i31ref":    { "type": "varint7", "value":  -22, "b3type": "B3::Void" },
         "func":      { "type": "varint7", "value":  -32, "b3type": "B3::Void" },
         "struct":    { "type": "varint7", "value":  -33, "b3type": "B3::Void" },
+        "rec":       { "type": "varint7", "value":  -49, "b3type": "B3::Void" },
         "void":      { "type": "varint7", "value":  -64, "b3type": "B3::Void" }
     },
     "value_type": ["i32", "i64", "f32", "f64", "externref", "funcref"],

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -3066,9 +3066,10 @@ auto B3IRGenerator::addCall(uint32_t functionIndex, const TypeDefinition& signat
     return { };
 }
 
-auto B3IRGenerator::addCallIndirect(unsigned tableIndex, const TypeDefinition& signature, Vector<ExpressionType>& args, ResultList& results) -> PartialResult
+auto B3IRGenerator::addCallIndirect(unsigned tableIndex, const TypeDefinition& originalSignature, Vector<ExpressionType>& args, ResultList& results) -> PartialResult
 {
     Value* calleeIndex = get(args.takeLast());
+    const TypeDefinition& signature = originalSignature.expand();
     ASSERT(signature.as<FunctionSignature>()->argumentCount() == args.size());
 
     m_makesCalls = true;
@@ -3127,7 +3128,7 @@ auto B3IRGenerator::addCallIndirect(unsigned tableIndex, const TypeDefinition& s
 
         // Check the signature matches the value we expect.
         {
-            Value* expectedSignatureIndex = m_currentBlock->appendNew<Const64Value>(m_proc, origin(), TypeInformation::get(signature));
+            Value* expectedSignatureIndex = m_currentBlock->appendNew<Const64Value>(m_proc, origin(), TypeInformation::get(originalSignature));
             CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
                 m_currentBlock->appendNew<Value>(m_proc, NotEqual, origin(), calleeSignatureIndex, expectedSignatureIndex));
 
@@ -3148,9 +3149,10 @@ auto B3IRGenerator::addCallIndirect(unsigned tableIndex, const TypeDefinition& s
     return emitIndirectCall(calleeInstance, calleeCode, signature, args, results);
 }
 
-auto B3IRGenerator::addCallRef(const TypeDefinition& signature, Vector<ExpressionType>& args, ResultList& results) -> PartialResult
+auto B3IRGenerator::addCallRef(const TypeDefinition& originalSignature, Vector<ExpressionType>& args, ResultList& results) -> PartialResult
 {
     Value* callee = get(args.takeLast());
+    const TypeDefinition& signature = originalSignature.expand();
     ASSERT(signature.as<FunctionSignature>()->argumentCount() == args.size());
     m_makesCalls = true;
 

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -137,7 +137,7 @@ void BBQPlan::work(CompilationEffort effort)
 
     size_t functionIndexSpace = m_functionIndex + m_moduleInformation->importFunctionCount();
     TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[m_functionIndex];
-    const TypeDefinition& signature = TypeInformation::get(typeIndex);
+    const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
     function->entrypoint.compilation = makeUnique<Compilation>(
         FINALIZE_WASM_CODE_FOR_MODE(CompilationMode::BBQMode, linkBuffer, JITCompilationPtrTag, "WebAssembly BBQ function[%i] %s name %s", m_functionIndex, signature.toString().ascii().data(), makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace))).ascii().data()),
         WTFMove(context.wasmEntrypointByproducts));
@@ -206,7 +206,7 @@ void BBQPlan::compileFunction(uint32_t functionIndex)
     if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->referencedFunctions().contains(functionIndex)) {
         Locker locker { m_lock };
         TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[functionIndex];
-        const TypeDefinition& signature = TypeInformation::get(typeIndex);
+        const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
 
         m_compilationContexts[functionIndex].embedderEntrypointJIT = makeUnique<CCallHelpers>();
         auto embedderToWasmInternalFunction = createJSToWasmWrapper(*m_compilationContexts[functionIndex].embedderEntrypointJIT, signature, &m_unlinkedWasmToWasmCalls[functionIndex], m_moduleInformation.get(), m_mode, functionIndex);

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -265,7 +265,7 @@ public:
 
     LLIntTierUpCounter& tierUpCounter() { return m_tierUpCounter; }
 
-    const FunctionSignature& signature(unsigned index) const
+    const TypeDefinition& signature(unsigned index) const
     {
         return *m_signatures[index];
     }
@@ -304,7 +304,7 @@ private:
     std::unique_ptr<WasmInstructionStream> m_instructions;
     const void* m_instructionsRawPointer { nullptr };
     FixedVector<WasmInstructionStream::Offset> m_jumpTargets;
-    FixedVector<const FunctionSignature*> m_signatures;
+    FixedVector<const TypeDefinition*> m_signatures;
     OutOfLineJumpTargets m_outOfLineJumpTargets;
     LLIntTierUpCounter m_tierUpCounter;
     FixedVector<JumpTable> m_jumpTables;

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -74,6 +74,10 @@ inline bool isValueType(Type type)
     case TypeKind::Ref:
     case TypeKind::RefNull:
         return Options::useWebAssemblyTypedFunctionReferences();
+    // Rec type kinds are used internally to represent `rec.<i>` references
+    // within recursion groups. They are invalid in other contexts.
+    case TypeKind::Rec:
+        return Options::useWebAssemblyGC();
     default:
         break;
     }

--- a/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp
@@ -51,7 +51,7 @@ WasmInstructionStream::Offset FunctionCodeBlockGenerator::outOfLineJumpOffset(Wa
     return m_outOfLineJumpTargets.get(bytecodeOffset);
 }
 
-unsigned FunctionCodeBlockGenerator::addSignature(const FunctionSignature& signature)
+unsigned FunctionCodeBlockGenerator::addSignature(const TypeDefinition& signature)
 {
     unsigned index = m_signatures.size();
     m_signatures.append(&signature);

--- a/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h
@@ -48,7 +48,7 @@ class BytecodeGeneratorBase;
 namespace Wasm {
 
 class LLIntCallee;
-class FunctionSignature;
+class TypeDefinition;
 struct GeneratorTraits;
 
 struct JumpTableEntry {
@@ -116,7 +116,7 @@ public:
 
     HashMap<WasmInstructionStream::Offset, LLIntTierUpCounter::OSREntryData>& tierUpCounter() { return m_tierUpCounter; }
 
-    unsigned addSignature(const FunctionSignature&);
+    unsigned addSignature(const TypeDefinition&);
 
     JumpTable& addJumpTable(size_t numberOfEntries);
     unsigned numberOfJumpTables() const;
@@ -140,7 +140,7 @@ private:
     std::unique_ptr<WasmInstructionStream> m_instructions;
     const void* m_instructionsRawPointer { nullptr };
     Vector<WasmInstructionStream::Offset> m_jumpTargets;
-    Vector<const FunctionSignature*> m_signatures;
+    Vector<const TypeDefinition*> m_signatures;
     OutOfLineJumpTargets m_outOfLineJumpTargets;
     HashMap<WasmInstructionStream::Offset, LLIntTierUpCounter::OSREntryData> m_tierUpCounter;
     Vector<JumpTable> m_jumpTables;

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -48,8 +48,9 @@ enum class CatchKind {
 };
 
 template<typename EnclosingStack, typename NewStack>
-void splitStack(BlockSignature signature, EnclosingStack& enclosingStack, NewStack& newStack)
+void splitStack(BlockSignature originalSignature, EnclosingStack& enclosingStack, NewStack& newStack)
 {
+    BlockSignature signature = &originalSignature->expand();
     newStack.reserveInitialCapacity(signature->as<FunctionSignature>()->argumentCount());
     ASSERT(enclosingStack.size() >= signature->as<FunctionSignature>()->argumentCount());
     unsigned offset = enclosingStack.size() - signature->as<FunctionSignature>()->argumentCount();
@@ -230,7 +231,7 @@ template<typename Context>
 FunctionParser<Context>::FunctionParser(Context& context, const uint8_t* functionStart, size_t functionLength, const TypeDefinition& signature, const ModuleInformation& info)
     : Parser(functionStart, functionLength)
     , m_context(context)
-    , m_signature(signature)
+    , m_signature(signature.expand())
     , m_info(info)
 {
     if (verbose)
@@ -243,6 +244,7 @@ auto FunctionParser<Context>::parse() -> Result
 {
     uint32_t localGroupsCount;
 
+    WASM_PARSER_FAIL_IF(!m_signature.is<FunctionSignature>(), "type signature was not a function signature");
     const auto& signature = *m_signature.as<FunctionSignature>();
     WASM_PARSER_FAIL_IF(!m_context.addArguments(m_signature), "can't add ", signature.argumentCount(), " arguments to Function");
     WASM_PARSER_FAIL_IF(!parseVarUInt32(localGroupsCount), "can't get local groups count");
@@ -1258,7 +1260,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_FAIL_IF_HELPER_FAILS(parseFunctionIndex(functionIndex));
 
         TypeIndex calleeTypeIndex = m_info.typeIndexFromFunctionIndexSpace(functionIndex);
-        const TypeDefinition& typeDefinition = TypeInformation::get(calleeTypeIndex);
+        const TypeDefinition& typeDefinition = TypeInformation::get(calleeTypeIndex).expand();
         const auto& calleeSignature = *typeDefinition.as<FunctionSignature>();
         WASM_PARSER_FAIL_IF(calleeSignature.argumentCount() > m_expressionStack.size(), "call function index ", functionIndex, " has ", calleeSignature.argumentCount(), " arguments, but the expression stack currently holds ", m_expressionStack.size(), " values");
 
@@ -1297,7 +1299,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_PARSER_FAIL_IF(m_info.tables[tableIndex].type() != TableElementType::Funcref, "call_indirect is only valid when a table has type funcref");
 
         const TypeDefinition& typeDefinition = m_info.typeSignatures[signatureIndex].get();
-        const auto& calleeSignature = *typeDefinition.as<FunctionSignature>();
+        const auto& calleeSignature = *typeDefinition.expand().as<FunctionSignature>();
         size_t argumentCount = calleeSignature.argumentCount() + 1; // Add the callee's index.
         WASM_PARSER_FAIL_IF(argumentCount > m_expressionStack.size(), "call_indirect expects ", argumentCount, " arguments, but the expression stack currently holds ", m_expressionStack.size(), " values");
 
@@ -1330,7 +1332,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         const TypeIndex calleeTypeIndex = m_expressionStack.last().type().index;
         const TypeDefinition& typeDefinition = TypeInformation::get(calleeTypeIndex);
-        const auto& calleeSignature = *typeDefinition.as<FunctionSignature>();
+        const auto& calleeSignature = *typeDefinition.expand().as<FunctionSignature>();
         size_t argumentCount = calleeSignature.argumentCount() + 1; // Add the callee's value.
         WASM_PARSER_FAIL_IF(argumentCount > m_expressionStack.size(), "call_ref expects ", argumentCount, " arguments, but the expression stack currently holds ", m_expressionStack.size(), " values");
 
@@ -1359,7 +1361,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignatureAsType;
         WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignatureAsType), "can't get block's signature");
 
-        const FunctionSignature* inlineSignature = inlineSignatureAsType->as<FunctionSignature>();
+        BlockSignature expandedSignature = &inlineSignatureAsType->expand();
+        const FunctionSignature* inlineSignature = expandedSignature->as<FunctionSignature>();
         WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature->argumentCount(), "Too few values on stack for block. Block expects ", inlineSignature->argumentCount(), ", but only ", m_expressionStack.size(), " were present. Block has inlineSignature: ", inlineSignature->toString());
         unsigned offset = m_expressionStack.size() - inlineSignature->argumentCount();
         for (unsigned i = 0; i < inlineSignature->argumentCount(); ++i) {
@@ -1370,7 +1373,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         int64_t oldSize = m_expressionStack.size();
         Stack newStack;
         ControlType block;
-        WASM_TRY_ADD_TO_CONTEXT(addBlock(inlineSignatureAsType, m_expressionStack, block, newStack));
+        WASM_TRY_ADD_TO_CONTEXT(addBlock(expandedSignature, m_expressionStack, block, newStack));
         ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == inlineSignature->argumentCount());
         ASSERT(newStack.size() == inlineSignature->argumentCount());
 
@@ -1383,7 +1386,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignatureAsType;
         WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignatureAsType), "can't get loop's signature");
 
-        const FunctionSignature* inlineSignature = inlineSignatureAsType->as<FunctionSignature>();
+        BlockSignature expandedSignature = &inlineSignatureAsType->expand();
+        const FunctionSignature* inlineSignature = expandedSignature->as<FunctionSignature>();
         WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature->argumentCount(), "Too few values on stack for loop block. Loop expects ", inlineSignature->argumentCount(), ", but only ", m_expressionStack.size(), " were present. Loop has inlineSignature: ", inlineSignature->toString());
         unsigned offset = m_expressionStack.size() - inlineSignature->argumentCount();
         for (unsigned i = 0; i < inlineSignature->argumentCount(); ++i) {
@@ -1394,7 +1398,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         int64_t oldSize = m_expressionStack.size();
         Stack newStack;
         ControlType loop;
-        WASM_TRY_ADD_TO_CONTEXT(addLoop(inlineSignatureAsType, m_expressionStack, loop, newStack, m_loopIndex++));
+        WASM_TRY_ADD_TO_CONTEXT(addLoop(expandedSignature, m_expressionStack, loop, newStack, m_loopIndex++));
         ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == inlineSignature->argumentCount());
         ASSERT(newStack.size() == inlineSignature->argumentCount());
 
@@ -1409,7 +1413,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignatureAsType), "can't get if's signature");
         WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "if condition");
 
-        const FunctionSignature* inlineSignature = inlineSignatureAsType->as<FunctionSignature>();
+        BlockSignature expandedSignature = &inlineSignatureAsType->expand();
+        const FunctionSignature* inlineSignature = expandedSignature->as<FunctionSignature>();
         WASM_VALIDATOR_FAIL_IF(!condition.type().isI32(), "if condition must be i32, got ", condition.type().kind);
         WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature->argumentCount(), "Too few arguments on stack for if block. If expects ", inlineSignature->argumentCount(), ", but only ", m_expressionStack.size(), " were present. If block has signature: ", inlineSignature->toString());
         unsigned offset = m_expressionStack.size() - inlineSignature->argumentCount();
@@ -1419,7 +1424,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         int64_t oldSize = m_expressionStack.size();
         Stack newStack;
         ControlType control;
-        WASM_TRY_ADD_TO_CONTEXT(addIf(condition, inlineSignatureAsType, m_expressionStack, control, newStack));
+        WASM_TRY_ADD_TO_CONTEXT(addIf(condition, expandedSignature, m_expressionStack, control, newStack));
         ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == inlineSignature->argumentCount());
         ASSERT(newStack.size() == inlineSignature->argumentCount());
 
@@ -1446,7 +1451,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignatureAsType;
         WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignatureAsType), "can't get try's signature");
 
-        const FunctionSignature* inlineSignature = inlineSignatureAsType->as<FunctionSignature>();
+        BlockSignature expandedSignature = &inlineSignatureAsType->expand();
+        const FunctionSignature* inlineSignature = expandedSignature->as<FunctionSignature>();
         WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature->argumentCount(), "Too few arguments on stack for try block. Trye expects ", inlineSignature->argumentCount(), ", but only ", m_expressionStack.size(), " were present. Try block has signature: ", inlineSignature->toString());
         unsigned offset = m_expressionStack.size() - inlineSignature->argumentCount();
         for (unsigned i = 0; i < inlineSignature->argumentCount(); ++i)
@@ -1455,7 +1461,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         int64_t oldSize = m_expressionStack.size();
         Stack newStack;
         ControlType control;
-        WASM_TRY_ADD_TO_CONTEXT(addTry(inlineSignatureAsType, m_expressionStack, control, newStack));
+        WASM_TRY_ADD_TO_CONTEXT(addTry(expandedSignature, m_expressionStack, control, newStack));
         ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == inlineSignature->argumentCount());
         ASSERT(newStack.size() == inlineSignature->argumentCount());
 
@@ -1472,7 +1478,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         uint32_t exceptionIndex;
         WASM_FAIL_IF_HELPER_FAILS(parseExceptionIndex(exceptionIndex));
         TypeIndex typeIndex = m_info.typeIndexFromExceptionIndexSpace(exceptionIndex);
-        const TypeDefinition& exceptionSignature = TypeInformation::get(typeIndex);
+        const TypeDefinition& exceptionSignature = TypeInformation::get(typeIndex).expand();
 
         ControlEntry& controlEntry = m_controlStack.last();
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(controlEntry.controlData), "catch block isn't associated to a try");
@@ -1726,7 +1732,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         uint32_t exceptionIndex;
         WASM_FAIL_IF_HELPER_FAILS(parseExceptionIndex(exceptionIndex));
         TypeIndex typeIndex = m_info.typeIndexFromExceptionIndexSpace(exceptionIndex);
-        const TypeDefinition& exceptionSignature = TypeInformation::get(typeIndex);
+        const TypeDefinition& exceptionSignature = TypeInformation::get(typeIndex).expand();
 
         if (m_unreachableBlocks > 1)
             return { };

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -152,7 +152,7 @@ void LLIntPlan::didCompleteCompilation()
     for (uint32_t functionIndex = 0; functionIndex < m_moduleInformation->functions.size(); functionIndex++) {
         if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->referencedFunctions().contains(functionIndex)) {
             TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[functionIndex];
-            const TypeDefinition& signature = TypeInformation::get(typeIndex);
+            const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
             CCallHelpers jit;
             // The LLInt always bounds checks
             MemoryMode mode = MemoryMode::BoundsChecking;

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -45,6 +45,7 @@ constexpr size_t maxExceptions = 100000;
 constexpr size_t maxGlobals = 1000000;
 constexpr size_t maxDataSegments = 100000;
 constexpr size_t maxStructFieldCount = 10000;
+constexpr size_t maxRecursionGroupCount = 10000;
 
 constexpr size_t maxStringSize = 100000;
 constexpr size_t maxModuleSize = 1024 * 1024 * 1024;

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -71,6 +71,7 @@ private:
 
     PartialResult WARN_UNUSED_RETURN parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&);
     PartialResult WARN_UNUSED_RETURN parseStructType(uint32_t position, RefPtr<TypeDefinition>&);
+    PartialResult WARN_UNUSED_RETURN parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition>&);
 
     PartialResult WARN_UNUSED_RETURN validateElementTableIdx(uint32_t);
     PartialResult WARN_UNUSED_RETURN parseI32InitExprForElementSection(std::optional<I32InitExpr>&);

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -500,7 +500,7 @@ inline SlowPathReturnType doWasmCallIndirect(CallFrame* callFrame, Wasm::Instanc
         WASM_THROW(Wasm::ExceptionType::NullTableEntry);
 
     const auto& callSignature = CALLEE()->signature(typeIndex);
-    if (callSignature != Wasm::TypeInformation::getFunctionSignature(function.typeIndex))
+    if (callSignature.index() != function.typeIndex)
         WASM_THROW(Wasm::ExceptionType::BadSignature);
 
     if (targetInstance != instance)
@@ -541,7 +541,7 @@ inline SlowPathReturnType doWasmCallRef(CallFrame* callFrame, Wasm::Instance* ca
     if (calleeInstance != callerInstance)
         calleeInstance->setCachedStackLimit(callerInstance->cachedStackLimit());
 
-    ASSERT(Wasm::TypeInformation::getFunctionSignature(function.typeIndex) == CALLEE()->signature(typeIndex));
+    ASSERT(function.typeIndex == CALLEE()->signature(typeIndex).index());
     UNUSED_PARAM(typeIndex);
     WASM_CALL_RETURN(calleeInstance, function.entrypointLoadLocation->taggedPtr(), WasmEntryPtrTag);
 }

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -44,6 +44,8 @@ namespace Wasm {
 
 using FunctionArgCount = uint32_t;
 using StructFieldCount = uint32_t;
+using RecursionGroupCount = uint32_t;
+using ProjectionIndex = uint32_t;
 
 class FunctionSignature {
 public:
@@ -123,20 +125,93 @@ private:
     StructFieldCount m_fieldCount;
 };
 
+class RecursionGroup {
+public:
+    RecursionGroup(TypeIndex* payload, RecursionGroupCount typeCount)
+        : m_payload(payload)
+        , m_typeCount(typeCount)
+    {
+    }
+
+    RecursionGroupCount typeCount() const { return m_typeCount; }
+    TypeIndex type(RecursionGroupCount i) const { return const_cast<RecursionGroup*>(this)->getType(i); }
+
+    WTF::String toString() const;
+    void dump(WTF::PrintStream& out) const;
+
+    TypeIndex& getType(RecursionGroupCount i) { ASSERT(i < typeCount());; return *storage(i); }
+    TypeIndex* storage(RecursionGroupCount i) { return i + m_payload; }
+    const TypeIndex* storage(RecursionGroupCount i) const { return const_cast<RecursionGroup*>(this)->storage(i); }
+
+private:
+    TypeIndex* m_payload;
+    RecursionGroupCount m_typeCount;
+};
+
+// This class represents a projection into a recursion group. That is, if a recursion
+// group is defined as $r = (rec (type $s ...) (type $t ...)), then a projection accesses
+// the inner types. For example $r.$s or $r.$t, or $r.0 or $r.1 with numeric indices.
+//
+// See https://github.com/WebAssembly/gc/blob/main/proposals/gc/MVP.md#type-contexts
+//
+// We store projections rather than the implied unfolding because the actual type being
+// represented may be recursive and infinite. Projections are unfolded into a concrete type
+// when operations on the type require a specific concrete type.
+class Projection {
+public:
+    Projection(TypeIndex* payload)
+        : m_payload(payload)
+    {
+    }
+
+    TypeIndex recursionGroup() const { return const_cast<Projection*>(this)->getRecursionGroup(); }
+    ProjectionIndex index() const { return const_cast<Projection*>(this)->getIndex(); }
+
+    WTF::String toString() const;
+    void dump(WTF::PrintStream& out) const;
+
+    TypeIndex& getRecursionGroup() { return *storage(0); }
+    ProjectionIndex& getIndex() { return *reinterpret_cast<ProjectionIndex*>(storage(1)); }
+    TypeIndex* storage(uint32_t i) { ASSERT(i <= 1); return i + m_payload; }
+    const TypeIndex* storage(uint32_t i) const { return const_cast<Projection*>(this)->storage(i); }
+
+private:
+    TypeIndex* m_payload;
+};
+static_assert(sizeof(ProjectionIndex) <= sizeof(TypeIndex));
+
+enum class TypeDefinitionKind : uint8_t {
+    FunctionSignature,
+    StructType,
+    RecursionGroup,
+    Projection
+};
+
 class TypeDefinition : public ThreadSafeRefCounted<TypeDefinition> {
     WTF_MAKE_FAST_ALLOCATED;
 
     TypeDefinition() = delete;
     TypeDefinition(const TypeDefinition&) = delete;
 
-    TypeDefinition(FunctionArgCount retCount, FunctionArgCount argCount)
+    TypeDefinition(TypeDefinitionKind kind, FunctionArgCount retCount, FunctionArgCount argCount)
         : m_typeHeader { FunctionSignature { static_cast<Type*>(payload()), argCount, retCount } }
     {
+        RELEASE_ASSERT(kind == TypeDefinitionKind::FunctionSignature);
     }
 
-    TypeDefinition(StructFieldCount fieldCount)
-        : m_typeHeader { StructType { static_cast<StructField*>(payload()), fieldCount } }
+    TypeDefinition(TypeDefinitionKind kind, uint32_t fieldCount)
+        : m_typeHeader { StructType { static_cast<StructField*>(payload()), static_cast<StructFieldCount>(fieldCount) } }
     {
+        if (kind == TypeDefinitionKind::RecursionGroup)
+            m_typeHeader = { RecursionGroup { static_cast<TypeIndex*>(payload()), static_cast<RecursionGroupCount>(fieldCount) } };
+        else
+            RELEASE_ASSERT(kind == TypeDefinitionKind::StructType);
+    }
+
+    TypeDefinition(TypeDefinitionKind kind)
+        : m_typeHeader { Projection { static_cast<TypeIndex*>(payload()) } }
+    {
+        RELEASE_ASSERT(kind == TypeDefinitionKind::Projection);
     }
 
     // Payload starts past end of this object.
@@ -144,6 +219,8 @@ class TypeDefinition : public ThreadSafeRefCounted<TypeDefinition> {
 
     static size_t allocatedFunctionSize(Checked<FunctionArgCount> retCount, Checked<FunctionArgCount> argCount) { return sizeof(TypeDefinition) + (retCount + argCount) * sizeof(Type); }
     static size_t allocatedStructSize(Checked<StructFieldCount> fieldCount) { return sizeof(TypeDefinition) + fieldCount * sizeof(StructField); }
+    static size_t allocatedRecursionGroupSize(Checked<RecursionGroupCount> typeCount) { return sizeof(TypeDefinition) + typeCount * sizeof(TypeIndex); }
+    static size_t allocatedProjectionSize() { return sizeof(TypeDefinition) + 2 * sizeof(TypeIndex); }
 
 public:
     template <typename T>
@@ -162,6 +239,9 @@ public:
     bool operator==(const TypeDefinition& rhs) const { return this == &rhs; }
     unsigned hash() const;
 
+    const TypeDefinition& replacePlaceholders(TypeIndex) const;
+    const TypeDefinition& expand() const;
+
     // Type definitions are uniqued and, for call_indirect, validated at runtime. Tables can create invalid TypeIndex values which cause call_indirect to fail. We use 0 as the invalidIndex so that the codegen can easily test for it and trap, and we add a token invalid entry in TypeInformation.
     static const constexpr TypeIndex invalidIndex = 0;
 
@@ -169,11 +249,17 @@ private:
     friend class TypeInformation;
     friend struct FunctionParameterTypes;
     friend struct StructParameterTypes;
+    friend struct RecursionGroupParameterTypes;
+    friend struct ProjectionParameterTypes;
 
     static RefPtr<TypeDefinition> tryCreateFunctionSignature(FunctionArgCount returnCount, FunctionArgCount argumentCount);
     static RefPtr<TypeDefinition> tryCreateStructType(StructFieldCount);
+    static RefPtr<TypeDefinition> tryCreateRecursionGroup(RecursionGroupCount);
+    static RefPtr<TypeDefinition> tryCreateProjection();
 
-    std::variant<FunctionSignature, StructType> m_typeHeader;
+    static Type substitute(Type, TypeIndex);
+
+    std::variant<FunctionSignature, StructType, RecursionGroup, Projection> m_typeHeader;
     // Payload is stored here.
 };
 
@@ -223,6 +309,8 @@ public:
 
     static RefPtr<TypeDefinition> typeDefinitionForFunction(const Vector<Type, 1>& returnTypes, const Vector<Type>& argumentTypes);
     static RefPtr<TypeDefinition> typeDefinitionForStruct(const Vector<StructField>& fields);
+    static RefPtr<TypeDefinition> typeDefinitionForRecursionGroup(const Vector<TypeIndex>& types);
+    static RefPtr<TypeDefinition> typeDefinitionForProjection(TypeIndex, ProjectionIndex);
     ALWAYS_INLINE const TypeDefinition* thunkFor(Type type) const { return thunkTypes[linearizeType(type.kind)]; }
 
     static const TypeDefinition& get(TypeIndex);

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
@@ -51,7 +51,14 @@ inline const TypeDefinition& TypeInformation::get(TypeIndex index)
 
 inline const FunctionSignature& TypeInformation::getFunctionSignature(TypeIndex index)
 {
-    return *get(index).as<FunctionSignature>();
+    const TypeDefinition& signature = get(index);
+    if (signature.is<Projection>()) {
+        const TypeDefinition& expanded = signature.expand();
+        ASSERT(expanded.is<FunctionSignature>());
+        return *expanded.as<FunctionSignature>();
+    }
+    ASSERT(signature.is<FunctionSignature>());
+    return *signature.as<FunctionSignature>();
 }
 
 inline TypeIndex TypeInformation::get(const TypeDefinition& type)

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -78,7 +78,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
     // It'd be super easy to do so: https://bugs.webkit.org/show_bug.cgi?id=169401
     const auto& wasmCC = wasmCallingConvention();
     const auto& jsCC = jsCallingConvention();
-    const TypeDefinition& typeDefinition = TypeInformation::get(typeIndex);
+    const TypeDefinition& typeDefinition = TypeInformation::get(typeIndex).expand();
     const auto& signature = *typeDefinition.as<FunctionSignature>();
     unsigned argCount = signature.argumentCount();
     JIT jit;
@@ -141,6 +141,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             case TypeKind::Func:
             case TypeKind::Struct:
             case TypeKind::I31ref:
+            case TypeKind::Rec:
                 RELEASE_ASSERT_NOT_REACHED(); // Handled above.
             case TypeKind::RefNull:
             case TypeKind::Ref:
@@ -223,6 +224,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             case TypeKind::Func:
             case TypeKind::Struct:
             case TypeKind::I31ref:
+            case TypeKind::Rec:
                 RELEASE_ASSERT_NOT_REACHED(); // Handled above.
             case TypeKind::RefNull:
             case TypeKind::Ref:

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -483,7 +483,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
 
     for (unsigned index = 0; index < moduleInformation.internalExceptionTypeIndices.size(); ++index) {
         Wasm::TypeIndex typeIndex = moduleInformation.internalExceptionTypeIndices[index];
-        m_instance->instance().setTag(moduleInformation.importExceptionCount() + index, Wasm::Tag::create(Wasm::TypeInformation::get(typeIndex)));
+        m_instance->instance().setTag(moduleInformation.importExceptionCount() + index, Wasm::Tag::create(Wasm::TypeInformation::get(typeIndex).expand()));
     }
 
     unsigned functionImportCount = calleeGroup->functionImportCount();

--- a/Source/JavaScriptCore/wasm/wasm.json
+++ b/Source/JavaScriptCore/wasm/wasm.json
@@ -18,6 +18,7 @@
         "i31ref":    { "type": "varint7", "value":  -22, "b3type": "B3::Void" },
         "func":      { "type": "varint7", "value":  -32, "b3type": "B3::Void" },
         "struct":    { "type": "varint7", "value":  -33, "b3type": "B3::Void" },
+        "rec":       { "type": "varint7", "value":  -49, "b3type": "B3::Void" },
         "void":      { "type": "varint7", "value":  -64, "b3type": "B3::Void" }
     },
     "value_type": ["i32", "i64", "f32", "f64", "externref", "funcref"],


### PR DESCRIPTION
#### 38c77df133317dd0714c025b7d80c8a2dbf9b533
<pre>
Reland &quot;[Wasm-GC] Add support for recursion groups&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=239666">https://bugs.webkit.org/show_bug.cgi?id=239666</a>

Reviewed by Justin Michaud.

Relands support for Wasm GC recursive types. This iteration of the patch
fixes some bugs related to expanding struct types and in handling
signatures passed to `call_ref`.

* JSTests/wasm/gc/rec.js: Added.
(module):
(testRecDeclaration):
* JSTests/wasm/wasm.json:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::AirIRGenerator):
(JSC::Wasm::AirIRGenerator::addCallIndirect):
(JSC::Wasm::AirIRGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addCallIndirect):
(JSC::Wasm::B3IRGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
(JSC::Wasm::BBQPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::isValueType):
* Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp:
(JSC::Wasm::FunctionCodeBlockGenerator::addSignature):
* Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::splitStack):
(JSC::Wasm::FunctionParser&lt;Context&gt;::FunctionParser):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parse):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::callInformationForCaller):
(JSC::Wasm::LLIntGenerator::callInformationForCallee):
(JSC::Wasm::LLIntGenerator::addArguments):
(JSC::Wasm::LLIntGenerator::addCallIndirect):
(JSC::Wasm::LLIntGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmLimits.h:
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::Parser&lt;SuccessType&gt;::Parser):
(JSC::Wasm::Parser&lt;SuccessType&gt;::parseHeapType):
(JSC::Wasm::Parser&lt;SuccessType&gt;::parseValueType):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseType):
(JSC::Wasm::SectionParser::parseElement):
(JSC::Wasm::SectionParser::parseRecursionGroup):
* Source/JavaScriptCore/wasm/WasmSectionParser.h:
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::doWasmCallIndirect):
(JSC::LLInt::doWasmCallRef):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeDefinition::dump const):
(JSC::Wasm::RecursionGroup::toString const):
(JSC::Wasm::RecursionGroup::dump const):
(JSC::Wasm::Projection::toString const):
(JSC::Wasm::Projection::dump const):
(JSC::Wasm::computeRecursionGroupHash):
(JSC::Wasm::computeProjectionHash):
(JSC::Wasm::TypeDefinition::hash const):
(JSC::Wasm::TypeDefinition::tryCreateFunctionSignature):
(JSC::Wasm::TypeDefinition::tryCreateStructType):
(JSC::Wasm::TypeDefinition::tryCreateRecursionGroup):
(JSC::Wasm::TypeDefinition::tryCreateProjection):
(JSC::Wasm::TypeDefinition::substitute):
(JSC::Wasm::TypeDefinition::replacePlaceholders const):
(JSC::Wasm::TypeDefinition::expand const):
(JSC::Wasm::FunctionParameterTypes::equal):
(JSC::Wasm::StructParameterTypes::equal):
(JSC::Wasm::RecursionGroupParameterTypes::hash):
(JSC::Wasm::RecursionGroupParameterTypes::equal):
(JSC::Wasm::RecursionGroupParameterTypes::translate):
(JSC::Wasm::ProjectionParameterTypes::hash):
(JSC::Wasm::ProjectionParameterTypes::equal):
(JSC::Wasm::ProjectionParameterTypes::translate):
(JSC::Wasm::TypeInformation::typeDefinitionForRecursionGroup):
(JSC::Wasm::TypeInformation::typeDefinitionForProjection):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::RecursionGroup::RecursionGroup):
(JSC::Wasm::RecursionGroup::typeCount const):
(JSC::Wasm::RecursionGroup::type const):
(JSC::Wasm::RecursionGroup::getType):
(JSC::Wasm::RecursionGroup::storage):
(JSC::Wasm::RecursionGroup::storage const):
(JSC::Wasm::Projection::Projection):
(JSC::Wasm::Projection::recursionGroup const):
(JSC::Wasm::Projection::index const):
(JSC::Wasm::Projection::getRecursionGroup):
(JSC::Wasm::Projection::getIndex):
(JSC::Wasm::Projection::storage):
(JSC::Wasm::Projection::storage const):
(JSC::Wasm::TypeDefinition::TypeDefinition):
(JSC::Wasm::TypeDefinition::allocatedRecursionGroupSize):
(JSC::Wasm::TypeDefinition::allocatedProjectionSize):
* Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h:
(JSC::Wasm::TypeInformation::getFunctionSignature):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeExports):
* Source/JavaScriptCore/wasm/wasm.json:

Canonical link: <a href="https://commits.webkit.org/253736@main">https://commits.webkit.org/253736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59c078081be072d101c163aa1096c650e125a152

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95709 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149467 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29325 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25668 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79029 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90936 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23680 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73743 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23703 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66708 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78792 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27078 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12816 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72449 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27011 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13830 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25838 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2650 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36693 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75234 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33109 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16639 "Passed tests") | 
<!--EWS-Status-Bubble-End-->