### PR TITLE
HTMLOptionElement::defaultSelected should affect selection state of other option elements

### DIFF
--- a/LayoutTests/fast/forms/select/option-defaultselected-expected.txt
+++ b/LayoutTests/fast/forms/select/option-defaultselected-expected.txt
@@ -1,0 +1,21 @@
+Tests for HTMLOptionElement::defaultSelected
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS option1.defaultSelected is false
+PASS option1.defaultSelected = true; option1.hasAttribute("selected") is true
+PASS option1.selected is true
+PASS option1.selected = false; option1.defaultSelected is true
+PASS option1.defaultSelected = false; option1.hasAttribute("selected") is false
+PASS option1.setAttribute("selected", "no"); option1.defaultSelected is true
+PASS option1.removeAttribute("selected"); option1.defaultSelected is false
+PASS selectionMap(select1) is "100"
+PASS select1[2].defaultSelected = true; selectionMap(select1) is "001"
+PASS select1[1].defaultSelected = true; selectionMap(select1) is "010"
+PASS select1[1].defaultSelected = false; selectionMap(select1) is "010"
+PASS select1[2].selected = true; selectionMap(select1) is "001"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/select/option-defaultselected.html
+++ b/LayoutTests/fast/forms/select/option-defaultselected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script>
+function selectionMap(select) {
+    var result = '';
+    var options = select.options;
+    for (var i = 0; i < options.length; ++i)
+        result += options[i].selected ? '1' : '0';
+    return result;
+}
+
+description('Tests for HTMLOptionElement::defaultSelected');
+
+var option1 = document.createElement('option');
+shouldBeFalse('option1.defaultSelected');
+shouldBeTrue('option1.defaultSelected = true; option1.hasAttribute("selected")');
+shouldBeTrue('option1.selected');
+shouldBeTrue('option1.selected = false; option1.defaultSelected');
+shouldBeFalse('option1.defaultSelected = false; option1.hasAttribute("selected")');
+shouldBeTrue('option1.setAttribute("selected", "no"); option1.defaultSelected');
+shouldBeFalse('option1.removeAttribute("selected"); option1.defaultSelected');
+
+var select1 = document.createElement('select');
+select1.innerHTML = '<option>1<option>2<option>3';
+shouldBeEqualToString('selectionMap(select1)', '100');
+
+
+shouldBeEqualToString('select1[2].defaultSelected = true; selectionMap(select1)', '001');
+shouldBeEqualToString('select1[1].defaultSelected = true; selectionMap(select1)', '010');
+shouldBeEqualToString('select1[1].defaultSelected = false; selectionMap(select1)', '010');
+shouldBeEqualToString('select1[2].selected = true; selectionMap(select1)', '001');
+</script>
+</body>

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -187,12 +187,9 @@ void HTMLOptionElement::parseAttribute(const QualifiedName& name, const AtomStri
         // FIXME: Use PseudoClassChangeInvalidation in other elements that implement matchesDefaultPseudoClass().
         Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClassDefault, !value.isNull());
         m_isDefault = !value.isNull();
-
-        // FIXME: This doesn't match what the HTML specification says.
-        // The specification implies that removing the selected attribute or
-        // changing the value of a selected attribute that is already present
-        // has no effect on whether the element is selected.
-        setSelectedState(!value.isNull());
+        
+        if (bool setSelectedState = !value.isNull())
+            setSelected(setSelectedState);
     } else
         HTMLElement::parseAttribute(name, value);
 }


### PR DESCRIPTION
<pre>

HTMLOptionElement::defaultSelected should affect selection state of other option elements

<a href="https://bugs.webkit.org/show_bug.cgi?id=119291">https://bugs.webkit.org/show_bug.cgi?id=119291</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/e8f0337fdc86554b48cf81d7ed8c286f251d2405">https://chromium.googlesource.com/chromium/blink/+/e8f0337fdc86554b48cf81d7ed8c286f251d2405</a>

HTMLOptionElement::defaultSelected should affect selection state of other option elements.

According to the standard, we should set selectedness to true if defaultSelected
is set to true, and we should not set selectedness to false if defaultSelected
is set to false because the standard says nothing about it.

[1]
> Whenever an option element's selected attribute is added, its selectedness
> must be set to true.

When the selectedness of an option is udpated, other options's selectedness
should become false.

[2]
> If the multiple attribute is absent, whenever an option element in the select
> element's list of options has its selectedness set to true, and whenever an
> option element with its selectedness set to true is added to the select
> element's list of options, the user agent must set the selectedness of all the
> other option elements in its list of options to false.

The old behavior doesn't match to the standard and any other browsers.
The new behavior matches to IE10, Chrome, Gecko and the standard.

* LayoutTests/fast/forms/select/option-defaultselected-expected.txt: Added Expectations
* LayoutTests/fast/forms/select/option-defaultselected.html: Added
* Source/WebCore/html/HTMLOptionElement.cpp
(HTMLOptionElement::parseAttribute): Updated to align with Blink / Chromium Patch

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9aa9cdc61822e6c0662cc731bee4ff6e8eea373

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96606 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149952 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29829 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26024 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79494 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91378 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92994 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24102 "Found 3 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/resetting-a-form/reset-form-2.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-element-constructor.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-selected.html") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74168 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23939 "Found 3 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/resetting-a-form/reset-form-2.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-element-constructor.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-selected.html") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79298 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66956 "Found 1 new API test failure: /WebKit2Gtk/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27545 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13131 "Found 3 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/resetting-a-form/reset-form-2.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-element-constructor.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-selected.html") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27497 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14147 "Found 3 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/resetting-a-form/reset-form-2.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-element-constructor.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-selected.html") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29184 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37007 "Found 3 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/resetting-a-form/reset-form-2.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-element-constructor.html, imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-selected.html") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33425 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->