### PR TITLE
WebGLRenderingContextBase::readPixels should early reject FLOAT_32_UNSIGNED_INT_24_8_REV type

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3327,7 +3327,7 @@ void WebGLRenderingContextBase::readPixels(GCGLint x, GCGLint y, GCGLsizei width
     // ANGLE will validate the readback from the framebuffer according
     // to WebGL's restrictions. At this level, just validate the type
     // of the readback against the typed array's type.
-    if (!validateArrayBufferType("readPixels", type, std::optional<JSC::TypedArrayType>(pixels.getType())))
+    if (!validateTypeAndArrayBufferType("readPixels", ArrayBufferViewFunctionType::ReadPixels, type, &pixels))
         return;
 
     clearIfComposited(CallerTypeOther);
@@ -3964,56 +3964,80 @@ ExceptionOr<void> WebGLRenderingContextBase::texSubImage2D(GCGLenum target, GCGL
     return texImageSourceHelper(TexImageFunctionID::TexSubImage2D, target, level, 0, 0, format, type, xoffset, yoffset, 0, sentinelEmptyRect(), 1, 0, WTFMove(*source));
 }
 
-bool WebGLRenderingContextBase::validateArrayBufferType(const char* functionName, GCGLenum type, std::optional<JSC::TypedArrayType> arrayType)
+bool WebGLRenderingContextBase::validateTypeAndArrayBufferType(const char* functionName, ArrayBufferViewFunctionType functionType, GCGLenum type, ArrayBufferView* pixels)
 {
-#define TYPE_VALIDATION_CASE(arrayTypeMacro) if (arrayType && arrayType.value() != JSC::arrayTypeMacro) { \
-            synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "ArrayBufferView not " #arrayTypeMacro); \
-            return false; \
-        } \
-        break;
-
-#define TYPE_VALIDATION_CASE_2(arrayTypeMacro, arrayTypeMacro2) if (arrayType && arrayType.value() != JSC::arrayTypeMacro && arrayType.value() != JSC::arrayTypeMacro2) { \
-            synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "ArrayBufferView not " #arrayTypeMacro " or " #arrayTypeMacro2); \
-            return false; \
-        } \
-        break;
-
+    JSC::TypedArrayType expectedArrayType = JSC::NotTypedArray;
+    const char* error = "pixels is not null";
     switch (type) {
-    case GraphicsContextGL::UNSIGNED_BYTE:
-        TYPE_VALIDATION_CASE_2(TypeUint8, TypeUint8Clamped);
+    case GraphicsContextGL::UNSIGNED_BYTE: {
+        if (!pixels)
+            return true;
+        auto type = pixels->getType();
+        if (type == JSC::TypeUint8 || type == JSC::TypeUint8Clamped)
+            return true;
+        synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "pixels is not TypeUint8 or TypeUint8Clamped");
+        return false;
+    }
     case GraphicsContextGL::BYTE:
-        TYPE_VALIDATION_CASE(TypeInt8);
+        expectedArrayType = JSC::TypeInt8;
+        error = "pixels is not TypeInt8";
+        break;
     case GraphicsContextGL::UNSIGNED_SHORT:
     case GraphicsContextGL::UNSIGNED_SHORT_5_6_5:
     case GraphicsContextGL::UNSIGNED_SHORT_4_4_4_4:
     case GraphicsContextGL::UNSIGNED_SHORT_5_5_5_1:
-        TYPE_VALIDATION_CASE(TypeUint16);
+        expectedArrayType = JSC::TypeUint16;
+        error = "pixels is not TypeUint16";
+        break;
     case GraphicsContextGL::SHORT:
-        TYPE_VALIDATION_CASE(TypeInt16);
+        expectedArrayType = JSC::TypeInt16;
+        error = "pixels is not TypeInt16";
+        break;
     case GraphicsContextGL::UNSIGNED_INT_2_10_10_10_REV:
     case GraphicsContextGL::UNSIGNED_INT_10F_11F_11F_REV:
     case GraphicsContextGL::UNSIGNED_INT_5_9_9_9_REV:
     case GraphicsContextGL::UNSIGNED_INT_24_8:
     case GraphicsContextGL::UNSIGNED_INT:
-        TYPE_VALIDATION_CASE(TypeUint32);
+        expectedArrayType = JSC::TypeUint32;
+        error = "pixels is not TypeUint32";
+        break;
     case GraphicsContextGL::INT:
-        TYPE_VALIDATION_CASE(TypeInt32);
+        expectedArrayType = JSC::TypeInt32;
+        error = "pixels is not TypeInt32";
+        break;
     case GraphicsContextGL::FLOAT: // OES_texture_float
-        TYPE_VALIDATION_CASE(TypeFloat32);
+        expectedArrayType = JSC::TypeFloat32;
+        error = "pixels is not TypeFloat32";
+        break;
     case GraphicsContextGL::HALF_FLOAT_OES: // OES_texture_half_float
     case GraphicsContextGL::HALF_FLOAT:
-        TYPE_VALIDATION_CASE(TypeUint16);
-    case GraphicsContextGL::FLOAT_32_UNSIGNED_INT_24_8_REV:
-        if (arrayType)
-            synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "type FLOAT_32_UNSIGNED_INT_24_8_REV but ArrayBufferView is not null");
+        expectedArrayType = JSC::TypeUint16;
+        error = "pixels is not TypeUint16";
         break;
+    case GraphicsContextGL::FLOAT_32_UNSIGNED_INT_24_8_REV:
+        if (functionType == ArrayBufferViewFunctionType::TexImage) {
+            expectedArrayType = JSC::NotTypedArray;
+            error = "type is FLOAT_32_UNSIGNED_INT_24_8_REV but pixels is not null";
+            break;
+        }
+        ASSERT(functionType == ArrayBufferViewFunctionType::ReadPixels);
+        FALLTHROUGH;
     default:
-        // This can now be reached in readPixels' ANGLE code path.
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid type");
         return false;
     }
-#undef TYPE_VALIDATION_CASE
-    return true;
+
+    if (!pixels)
+        return true;
+
+    if (expectedArrayType == JSC::NotTypedArray) {
+        synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, error);
+        return false;
+    }
+    if (pixels->getType() == expectedArrayType)
+        return true;
+    synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, error);
+    return false;
 }
 
 std::optional<GCGLSpan<const GCGLvoid>> WebGLRenderingContextBase::validateTexFuncData(const char* functionName, TexImageDimension texDimension, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, ArrayBufferView* pixels, NullDisposition disposition, GCGLuint srcOffset)
@@ -4032,8 +4056,7 @@ std::optional<GCGLSpan<const GCGLvoid>> WebGLRenderingContextBase::validateTexFu
     if (pixels && !validateSettableTexInternalFormat(functionName, format))
         return std::nullopt;
 
-    auto arrayType = pixels ? std::make_optional(pixels->getType()) : std::nullopt;
-    if (!validateArrayBufferType(functionName, type, arrayType))
+    if (!validateTypeAndArrayBufferType(functionName, ArrayBufferViewFunctionType::TexImage, type, pixels))
         return std::nullopt;
 
     unsigned totalBytesRequired, skipBytes;
@@ -4064,7 +4087,7 @@ std::optional<GCGLSpan<const GCGLvoid>> WebGLRenderingContextBase::validateTexFu
     auto data = static_cast<uint8_t*>(pixels->baseAddress());
     GCGLsizei byteLength = pixels->byteLength();
     if (srcOffset) {
-        size_t offset = srcOffset * JSC::elementSize(*arrayType);
+        size_t offset = srcOffset * JSC::elementSize(pixels->getType());
         data += offset;
         byteLength -= offset;
     }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -819,6 +819,10 @@ protected:
         // WebGL 2.0.
         SourceUnpackBuffer,
     };
+    enum class ArrayBufferViewFunctionType {
+        TexImage,
+        ReadPixels
+    };
 
     enum NullDisposition {
         NullAllowed,
@@ -1110,7 +1114,7 @@ protected:
     OffscreenCanvas* offscreenCanvas();
 #endif
 
-    bool validateArrayBufferType(const char* functionName, GCGLenum type, std::optional<JSC::TypedArrayType>);
+    bool validateTypeAndArrayBufferType(const char* functionName, ArrayBufferViewFunctionType, GCGLenum type, ArrayBufferView* pixels);
 
 private:
     void scheduleTaskToDispatchContextLostEvent();


### PR DESCRIPTION
#### 40438efc37ff8bdac5deacad93630826b8d0cb63
<pre>
WebGLRenderingContextBase::readPixels should early reject FLOAT_32_UNSIGNED_INT_24_8_REV type
<a href="https://bugs.webkit.org/show_bug.cgi?id=244290">https://bugs.webkit.org/show_bug.cgi?id=244290</a>
rdar://problem/99081375

Reviewed by Kenneth Russell.

Rename validateArrayBufferType to validateTypeAndArrayBufferType to better
reflect what the function does.

Add validation for type == FLOAT_32_UNSIGNED_INT_24_8_REV for read pixels.
It should always fail with INVALID_ENUM, regardless whether pixels are passed or not.

For texImage functions, the type != null case produces INVALID_OPERATION.

Tested by:
webgl/2.0.y/conformance/programs/program-test.html

TestExpectations is not yet changed as the test result is
Pass/Fail and currently another hunk of the test fails.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::readPixels):
(WebCore::WebGLRenderingContextBase::validateTypeAndArrayBufferType):
(WebCore::WebGLRenderingContextBase::validateTexFuncData):
WebCore::WebGLRenderingContextBase::validateArrayBufferType): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/255165@main">https://commits.webkit.org/255165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9aa39b32b1d698b06ba3c1ccb53dd01829e2337e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/833 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101322 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/829 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83941 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97282 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27444 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35746 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33501 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3587 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37342 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39247 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->