### PR TITLE
[git-webkit] Add pickable command

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.3.7',
+    version='5.4.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 3, 7)
+version = Version(5, 4, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -35,6 +35,7 @@ from .squash import Squash
 from .checkout import Checkout
 from .credentials import Credentials
 from .find import Find, Info
+from .pickable import Pickable
 from .install_git_lfs import InstallGitLFS
 from .land import Land
 from .log import Log
@@ -80,7 +81,8 @@ def main(
         Blame, Branch, Canonicalize, Checkout,
         Clean, Find, Info, Land, Log, Pull,
         PullRequest, Revert, Setup, InstallGitLFS,
-        Credentials, Commit, DeletePRBranches, Squash
+        Credentials, Commit, DeletePRBranches, Squash,
+        Pickable,
     ]
     if subversion:
         programs.append(SetupGitSvn)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import sys
+from re import search
+
+from .command import Command
+from .find import Info
+from datetime import datetime
+from webkitcorepy import arguments
+from webkitscmpy import Commit, local
+
+
+class Pickable(Command):
+    name = 'pickable'
+    help = 'List commits in a range which can be cherry-picked'
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            'argument', nargs=1,
+            type=str, default=None,
+            help='String representation of a commit, branch or range of commits to filter for cherry-pickable commits',
+        )
+        parser.add_argument(
+            '--json', '-j',
+            help='Convert the commit to a machine-readable JSON object',
+            action='store_true',
+            dest='json',
+            default=False,
+        )
+
+    @classmethod
+    def pickable(cls, commits):
+        filtered_commits = []
+        for commit in commits:
+            title = commit.message.splitlines()[0]
+            if search('Cherry-pick', title) or search('Versioning', title):
+                continue
+            filtered_commits.append(commit)
+
+        # FIXME: We can eliminate more classes of commits by reasoning about commit relationship
+        #    For example, a revert of a non-pickable commit is not itself pickable
+        return filtered_commits
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        if not repository:
+            sys.stderr.write('No repository provided\n')
+            return 1
+
+        reference = args.argument[0]
+        if reference != repository.default_branch and reference in repository.branches:
+            reference = '0@{}..{}'.format(reference, reference)
+
+        try:
+            if '..' in reference:
+                if '...' in reference:
+                    sys.stderr.write("'pickable' sub-command only supports '..' notation\n")
+                    return 1
+                references = reference.split('..')
+                if len(references) > 2:
+                    sys.stderr.write('Can only include two references in a range\n')
+                    return 1
+                commits = [commit for commit in repository.commits(begin=dict(argument=references[0]), end=dict(argument=references[1]))]
+
+            else:
+                commits = [repository.find(reference, include_log=True)]
+
+        except (local.Scm.Exception, TypeError, ValueError) as exception:
+            # ValueErrors and Scm exceptions usually contain enough information to be displayed
+            # to the user as an error
+            sys.stderr.write(str(exception) + '\n')
+            return 1
+
+        commits = cls.pickable(commits)
+        if not commits:
+            sys.stderr.write("No commits in specified range are 'pickable'\n")
+            return 1
+        return Info.print_(args, cls.pickable(commits), verbose_default=1)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pickable_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pickable_unittest.py
@@ -1,0 +1,134 @@
+# Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import time
+import sys
+
+from datetime import datetime
+
+from webkitcorepy import OutputCapture, Terminal, testing
+from webkitcorepy.mocks import Time as MockTime
+from webkitscmpy import program, mocks, Commit
+
+
+class TestPickable(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def setUp(self):
+        super(TestPickable, self).setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    def test_none(self):
+        with OutputCapture() as captured, mocks.local.Git(), mocks.local.Svn(), MockTime, Terminal.override_atty(sys.stdin, isatty=False):
+            self.assertEqual(1, program.main(
+                args=('pickable', 'main'),
+                path=self.path,
+            ))
+
+        self.assertEqual(captured.stderr.getvalue(), 'No repository provided\n')
+
+    def test_main(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn(), MockTime, Terminal.override_atty(sys.stdin, isatty=False):
+            self.assertEqual(0, program.main(
+                args=('pickable', 'main'),
+                path=self.path,
+            ))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            '5@main | d8bce26fa65c | Patch Series\n',
+        )
+
+    def test_main_git_svn(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path, git_svn=True), mocks.local.Svn(), MockTime, Terminal.override_atty(sys.stdin, isatty=False):
+            self.assertEqual(0, program.main(
+                args=('pickable', 'main'),
+                path=self.path,
+            ))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            '5@main | d8bce26fa65c, r9 | Patch Series\n',
+        )
+
+    def test_branch(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), MockTime, Terminal.override_atty(sys.stdin, isatty=False):
+            repo.commits['safari-xxx-branch'] = [
+                repo.commits['main'][3],
+                Commit(
+                    hash='6eedcf4492c3b14a97b886c4df59e8698f10539f',
+                    author=repo.commits['main'][3].author,
+                    timestamp=int(time.time()) - 1000,
+                    branch='safari-xxx-branch',
+                    message='Versioning.\n',
+                    identifier='4.1@safari-xxx-branch',
+                ), Commit(
+                    hash='efbdb34cc1454d1772838a41e22df23d231567b9',
+                    author=repo.commits['main'][3].author,
+                    timestamp=int(time.time()) - 100,
+                    branch='safari-xxx-branch',
+                    message='[WebKit] Some change\n',
+                    identifier='4.2@safari-xxx-branch',
+                ), Commit(
+                    hash='d10204abba135b5b9588936d7eec7cd001d07d0f',
+                    author=repo.commits['main'][3].author,
+                    timestamp=int(time.time()) - 10,
+                    branch='safari-xxx-branch',
+                    message='Cherry-pick d8bce26fa65c.\n    Patch Series\n',
+                    identifier='4.3@safari-xxx-branch',
+                ),
+            ]
+            self.assertEqual(0, program.main(
+                args=('pickable', 'safari-xxx-branch'),
+                path=self.path,
+            ))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            '4.2@safari-xxx-branch | efbdb34cc145 | [WebKit] Some change\n',
+        )
+
+    def test_branch_none(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), MockTime, Terminal.override_atty(sys.stdin, isatty=False):
+            repo.commits['safari-xxx-branch'] = [
+                repo.commits['main'][3],
+                Commit(
+                    hash='6eedcf4492c3b14a97b886c4df59e8698f10539f',
+                    author=repo.commits['main'][3].author,
+                    timestamp=int(time.time()) - 1000,
+                    branch='safari-xxx-branch',
+                    message='Versioning.\n',
+                    identifier='4.1@safari-xxx-branch',
+                ),
+            ]
+            self.assertEqual(1, program.main(
+                args=('pickable', 'safari-xxx-branch'),
+                path=self.path,
+            ))
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            "No commits in specified range are 'pickable'\n",
+        )


### PR DESCRIPTION
#### 2f625033c95064c6f5a2a99c21be512eb0305bae
<pre>
[git-webkit] Add pickable command
<a href="https://bugs.webkit.org/show_bug.cgi?id=244296">https://bugs.webkit.org/show_bug.cgi?id=244296</a>
&lt;rdar://97398141&gt;

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py: Add &apos;Pickable&apos; command.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/find.py:
(Info.print): Create function for printing a commit series.
(Info.main): Move printing into seperate function.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py: Added.
(Pickable.parser):
(Pickable.pickable): Return a list of cherry-pickable commits.
(Pickable.main): Find a list of commits, filter that list with the &apos;pickable&apos; function and print the result.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pickable_unittest.py: Added.
(TestPickable.setUp):
(TestPickable.test_none):
(TestPickable.test_main):
(TestPickable.test_main_git_svn):
(TestPickable.test_branch):
(TestPickable.test_branch_none):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f625033c95064c6f5a2a99c21be512eb0305bae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31098 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/95899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/149592 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29463 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/91042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92628 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/90619 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27195 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/86114 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27138 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28820 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1060 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28761 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->