### PR TITLE
[git-webkit] Add cherry-pick command

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -1,6 +1,7 @@
 #!/usr/bin/env {{ python }}
 
 import os
+import re
 import subprocess
 import sys
 
@@ -99,13 +100,49 @@ Reviewed by NOBODY (OOPS!).
     )
 
 
+def cherry_pick(content):
+    cherry_picked = os.environ.get('GIT_WEBKIT_CHERRY_PICKED')
+    bug = os.environ.get('GIT_WEBKIT_BUG')
+
+    if not cherry_picked or not bug:
+        LINK_RE = re.compile(r'^\S+:\/\/\S+\d+\S*$')
+        HASH_RE = re.compile(r'^# You are currently cherry-picking commit (?P<hash>[a-f0-9A-F]+)\.$')
+
+        for line in content.splitlines():
+            if not line:
+                continue
+            if not bug and LINK_RE.match(line):
+                bug = line
+            match = None if cherry_picked else HASH_RE.match(line)
+            if match:
+                cherry_picked = match.group('hash')
+
+            if bug and cherry_picked:
+                break
+
+    result = 'Cherry-pick {}. {}\n\n'.format(cherry_picked or '???', bug or '<bug>')
+    for line in content.splitlines():
+        if not line:
+            result += '\n'
+            continue
+        if line[0] != '#':
+            result += 4*' '
+        result += line + '\n'
+    return result
+
+
 def main(file_name=None, source=None, sha=None):
     with open(file_name, 'r') as commit_message_file:
         content = commit_message_file.read()
 
     if source not in (None, 'commit', 'template', 'merge'):
         return 0
-    
+
+    if source == 'merge' and os.environ.get('GIT_REFLOG_ACTION') == 'cherry-pick':
+        with open(file_name, 'w') as commit_message_file:
+            commit_message_file.write(cherry_pick(content))
+        return 0
+
     if source == 'merge' and not content.startswith('Revert'):
         return 0
 

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.4.0',
+    version='5.5.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 4, 0)
+version = Version(5, 5, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -28,6 +28,7 @@ import sys
 from .blame import Blame
 from .branch import Branch
 from .canonicalize import Canonicalize
+from .cherry_pick import CherryPick
 from .clean import Clean, DeletePRBranches
 from .command import Command
 from .commit import Commit
@@ -82,7 +83,7 @@ def main(
         Clean, Find, Info, Land, Log, Pull,
         PullRequest, Revert, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,
-        Pickable,
+        Pickable, CherryPick,
     ]
     if subversion:
         programs.append(SetupGitSvn)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/cherry_pick.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/cherry_pick.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+
+from .branch import Branch
+from .command import Command
+from webkitbugspy import Tracker
+from webkitcorepy import run
+from webkitscmpy import local
+
+
+class CherryPick(Command):
+    name = 'cherry-pick'
+    help = 'Cherry-pick a commit with an annotated commit message'
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        Branch.parser(parser, loggers=loggers)
+        parser.add_argument(
+            'argument', nargs=1,
+            type=str, default=None,
+            help='String representation of a commit to be cherry-picked',
+        )
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        if not repository:
+            sys.stderr.write('No repository provided\n')
+            return 1
+        if not isinstance(repository, local.Git):
+            sys.stderr.write("Can only cherry-pick from local 'git' repository\n")
+            return 1
+
+        try:
+            commit = repository.find(args.argument[0], include_log=False)
+        except (local.Scm.Exception, TypeError, ValueError) as exception:
+            # ValueErrors and Scm exceptions usually contain enough information to be displayed
+            # to the user as an error
+            sys.stderr.write(str(exception) + '\n')
+            return 1
+
+        issue = Tracker.from_string(args.issue) if args.issue else None
+        if str(commit) == commit.hash[:commit.HASH_LABEL_SIZE]:
+            cherry_pick_string = str(commit)
+        else:
+            cherry_pick_string = '{} ({})'.format(commit, commit.hash[:commit.HASH_LABEL_SIZE])
+
+        return run(
+            [repository.executable(), 'cherry-pick', '-e', commit.hash],
+            cwd=repository.root_path,
+            env=dict(
+                GIT_WEBKIT_CHERRY_PICKED=cherry_pick_string,
+                GIT_WEBKIT_BUG=issue.link if issue else '',
+            ), capture_output=False,
+        ).returncode

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import shutil
+import tempfile
+
+from mock import patch
+from webkitbugspy import Tracker, radar, mocks as bmocks
+from webkitcorepy import OutputCapture, testing
+from webkitcorepy.mocks import Time as MockTime
+from webkitscmpy import program, mocks
+
+
+class TestCherryPick(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def setUp(self):
+        super(TestCherryPick, self).setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    def test_none(self):
+        with OutputCapture() as captured, mocks.local.Git(), mocks.local.Svn(), MockTime:
+            self.assertEqual(1, program.main(
+                args=('cherry-pick', 'd8bce26fa65c'),
+                path=self.path,
+            ))
+        self.assertEqual(captured.stderr.getvalue(), 'No repository provided\n')
+
+    def test_basic(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), MockTime:
+            repo.head = repo.commits['branch-a'][-1]
+            self.assertEqual(0, program.main(
+                args=('cherry-pick', 'd8bce26fa65c'),
+                path=self.path,
+            ))
+            self.assertEqual(repo.head.hash, '5848f06de77d306791b7410ff2197bf3dd82b9e9')
+            self.assertEqual(repo.head.message, 'Cherry-pick 5@main (d8bce26fa65c). <bug>\n    Patch Series\n')
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_alternate_issue(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), bmocks.Radar(
+            issues=bmocks.ISSUES,
+        ), patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]), MockTime:
+            repo.head = repo.commits['branch-a'][-1]
+            self.assertEqual(0, program.main(
+                args=('cherry-pick', 'd8bce26fa65c', '-i', '<rdar://problem/123>'),
+                path=self.path,
+            ))
+            self.assertEqual(repo.head.hash, '200db1e4faae82ff005f1b826a12ad8c8260b179')
+            self.assertEqual(repo.head.message, 'Cherry-pick 5@main (d8bce26fa65c). <rdar://123>\n    Patch Series\n')
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        self.assertEqual(captured.stderr.getvalue(), '')


### PR DESCRIPTION
#### 1c1575f3ac690b93871b6947a502e54819250211
<pre>
[git-webkit] Add cherry-pick command
<a href="https://bugs.webkit.org/show_bug.cgi?id=244307">https://bugs.webkit.org/show_bug.cgi?id=244307</a>
&lt;rdar://problem/97399601&gt;

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/hooks/prepare-commit-msg: Format `cherry-pick` commit messages.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py: Support `cherry-pick`.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py: Add CherryPick command.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/cherry_pick.py: Added.
(CherryPick.parser):
(CherryPick.main): Convert argument to commit object, pass commit representation to `git cherry-pcik` command.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py: Added.
(TestCherryPick.setUp):
(TestCherryPick.test_none):
(TestCherryPick.test_basic):
(TestCherryPick.test_alternate_issue):

Canonical link: <a href="https://commits.webkit.org/253927@main">https://commits.webkit.org/253927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21fab886776ea07cac1847adedf28dfa7a27d7b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31585 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/18295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/96726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/150290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29949 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/91489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93115 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/74278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/91098 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/18295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27658 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/18295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/86581 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27610 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/18295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29300 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/74278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1111 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/29226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/18295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->