### PR TITLE
Fragment Directive not removed from URL.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-same-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-same-doc-expected.txt
@@ -1,0 +1,5 @@
+This is a test page
+
+PASS Activated for same-document window.location setter
+PASS Activated for same-document window.location.replace
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-same-doc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-same-doc.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<title>Navigating to a same-document text fragment directive</title>
+<meta charset=utf-8>
+<link rel="help" href="https://wicg.github.io/ScrollToTextFragment/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+function isInView(element) {
+  let rect = element.getBoundingClientRect();
+  return rect.top >= 0 && rect.top <= window.innerHeight;
+}
+
+function checkScroll(resolve) {
+  let position = 'unknown';
+  requestAnimationFrame(() => {
+    if (window.scrollY == 0)
+      position = 'top';
+    else if (isInView(document.getElementById('text')))
+      position = 'text';
+    resolve(position);
+  });
+}
+
+function reset() {
+  window.location.hash = "";
+  window.scrollTo(0, 0);
+}
+
+function runTest() {
+  promise_test(t => new Promise(resolve => {
+    reset();
+    window.location.href = "#:~:text=test";
+    requestAnimationFrame(function() {
+      checkScroll(resolve);
+    });
+  }).then(position => {
+    assert_equals(position, 'text');
+    assert_equals(window.location.href.indexOf(':~:'), -1, 'Expected fragment directive to be stripped from the URL.');
+  }), 'Activated for same-document window.location setter');
+
+  promise_test(t => new Promise(resolve => {
+    reset();
+    window.location.replace("#:~:text=test");
+    requestAnimationFrame(function() {
+      checkScroll(resolve);
+    });
+  }).then(position => {
+    assert_equals(position, 'text');
+    assert_equals(window.location.href.indexOf(':~:'), -1, 'Expected fragment directive to be stripped from the URL.');
+  }), 'Activated for same-document window.location.replace');
+}
+</script>
+<style>
+  body {
+    height: 3200px;
+  }
+  #text {
+    position: absolute;
+    top: 3000px;
+  }
+</style>
+<body onload="runTest()">
+  <p id="text">This is a test page</p>
+</body>

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -238,6 +238,24 @@ StringView URL::fragmentIdentifier() const
     return StringView(m_string).substring(m_queryEnd + 1);
 }
 
+// https://wicg.github.io/scroll-to-text-fragment/#the-fragment-directive
+String URL::consumefragmentDirective()
+{
+    ASCIILiteral fragmentDirectiveDelimiter = ":~:"_s;
+    auto fragment = fragmentIdentifier();
+    
+    auto fragmentDirectiveStart = fragment.find(fragmentDirectiveDelimiter);
+    
+    if (fragmentDirectiveStart == notFound)
+        return { };
+    
+    auto fragmentDirective = fragment.substring(fragmentDirectiveStart + fragmentDirectiveDelimiter.length()).toString();
+    
+    setFragmentIdentifier(fragment.left(fragmentDirectiveStart));
+    
+    return fragmentDirective;
+}
+
 URL URL::truncatedForUseAsBase() const
 {
     return URL(m_string.left(m_pathAfterLastSlash));

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -174,7 +174,7 @@ public:
 
     WTF_EXPORT_PRIVATE void setFragmentIdentifier(StringView);
     WTF_EXPORT_PRIVATE void removeFragmentIdentifier();
-
+    WTF_EXPORT_PRIVATE String consumefragmentDirective();
     WTF_EXPORT_PRIVATE void removeQueryAndFragmentIdentifier();
 
     WTF_EXPORT_PRIVATE static bool hostIsIPAddress(StringView);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3479,9 +3479,11 @@ void Document::logExceptionToConsole(const String& errorMessage, const String& s
 
 void Document::setURL(const URL& url)
 {
-    const URL& newURL = url.isEmpty() ? aboutBlankURL() : url;
+    URL newURL = url.isEmpty() ? aboutBlankURL() : url;
     if (newURL == m_url)
         return;
+    
+    m_fragmentDirective = newURL.consumefragmentDirective();
 
     m_url = newURL;
     if (SecurityOrigin::shouldIgnoreHost(m_url))

--- a/Source/WebCore/dom/FragmentDirectiveParser.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveParser.cpp
@@ -35,28 +35,8 @@
 
 namespace WebCore {
 
-FragmentDirectiveParser::FragmentDirectiveParser(const URL& url)
+FragmentDirectiveParser::FragmentDirectiveParser(StringView fragmentDirective)
 {
-    ASCIILiteral fragmentDirectiveDelimiter = ":~:"_s;
-    auto fragmentIdentifier = url.fragmentIdentifier();
-    
-    if (fragmentIdentifier.isEmpty()) {
-        m_remainingURLFragment = fragmentIdentifier;
-        return;
-    }
-        
-    auto fragmentDirectiveStart = fragmentIdentifier.find(StringView(fragmentDirectiveDelimiter));
-    
-    if (fragmentDirectiveStart == notFound) {
-        m_remainingURLFragment = fragmentIdentifier;
-        return;
-    }
-    
-    auto fragmentDirective = fragmentIdentifier.substring(fragmentDirectiveStart + fragmentDirectiveDelimiter.length());
-    
-    // FIXME: this needs to be set on the original URL
-    m_remainingURLFragment = fragmentIdentifier.left(fragmentDirectiveStart);
-    
     parseFragmentDirective(fragmentDirective);
     
     m_fragmentDirective = fragmentDirective;

--- a/Source/WebCore/dom/FragmentDirectiveParser.h
+++ b/Source/WebCore/dom/FragmentDirectiveParser.h
@@ -39,7 +39,7 @@ struct ParsedTextDirective {
 
 class FragmentDirectiveParser {
 public:
-    WEBCORE_EXPORT explicit FragmentDirectiveParser(const URL&);
+    WEBCORE_EXPORT explicit FragmentDirectiveParser(StringView);
     
     const Vector<ParsedTextDirective>& parsedTextDirectives() const { return m_parsedTextDirectives; };
     StringView fragmentDirective() const { return m_fragmentDirective; };

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -2219,14 +2219,12 @@ bool FrameView::scrollToFragment(const URL& url)
     Ref document = *frame().document();
     
     auto fragmentIdentifier = url.fragmentIdentifier();
+    auto fragmentDirective = document->fragmentDirective();
     
-    if (document->settings().scrollToTextFragmentEnabled()) {
-        FragmentDirectiveParser fragmentDirectiveParser(url);
+    if (document->settings().scrollToTextFragmentEnabled() && !fragmentDirective.isEmpty()) {
+        FragmentDirectiveParser fragmentDirectiveParser(fragmentDirective);
         
         if (fragmentDirectiveParser.isValid()) {
-            auto fragmentDirective = fragmentDirectiveParser.fragmentDirective().toString();
-            document->setFragmentDirective(fragmentDirective);
-            
             auto parsedTextDirectives = fragmentDirectiveParser.parsedTextDirectives();
             
             auto highlightRanges = FragmentDirectiveRangeFinder::findRangesFromTextDirectives(parsedTextDirectives, document);
@@ -2240,10 +2238,9 @@ bool FrameView::scrollToFragment(const URL& url)
                 m_pendingTextFragmentIndicatorText = plainText(range);
                 if (frame().settings().scrollToTextFragmentIndicatorEnabled())
                     m_delayedTextFragmentIndicatorTimer.startOneShot(100_ms);
+                return true;
             }
-            
-        } else
-            fragmentIdentifier = fragmentDirectiveParser.remainingURLFragment();
+        }
     }
     
     if (scrollToFragmentInternal(fragmentIdentifier))

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7579,7 +7579,12 @@ void WebPage::getTextFragmentMatch(CompletionHandler<void(const String&)>&& comp
         return;
     }
 
-    FragmentDirectiveParser fragmentDirectiveParser(mainWebFrame().url());
+    auto fragmentDirective = document->fragmentDirective();
+    if (fragmentDirective.isEmpty()) {
+        completionHandler({ });
+        return;
+    }
+    FragmentDirectiveParser fragmentDirectiveParser(fragmentDirective);
     if (!fragmentDirectiveParser.isValid()) {
         completionHandler({ });
         return;


### PR DESCRIPTION
#### c9e0352418fc0b8e92ed7e2f80370a38b75c148f
<pre>
Fragment Directive not removed from URL.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244318">https://bugs.webkit.org/show_bug.cgi?id=244318</a>

Reviewed by Ryosuke Niwa and Alex Christensen.

We were not stripping the fragment directive from the URL when setting the URL on the document.
This is necessary to be spec compliant as well as we would like to maintain user privacy and not
allow Text Fragment to become a tracking vector. Adding the WPT that now passes since all the
URL is stripped out, which was not the main thing that was being tested, but it now completely
passes where other tests still have failures I&apos;m working through.

* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-same-doc-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-same-doc.html: Added.
* Source/WTF/wtf/URL.cpp:
(WTF::URL::consumefragmentDirective):
* Source/WTF/wtf/URL.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setURL):
* Source/WebCore/dom/Document.h:
(WebCore::Document::fragmentDirective const):
* Source/WebCore/dom/FragmentDirectiveParser.cpp:
(WebCore::FragmentDirectiveParser::FragmentDirectiveParser):
* Source/WebCore/dom/FragmentDirectiveParser.h:
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::scrollToFragment):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::getTextFragmentMatch):

Canonical link: <a href="https://commits.webkit.org/253802@main">https://commits.webkit.org/253802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a1570faf823a06df902600b1eecd129381d43de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31218 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/96125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/149705 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29583 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/91148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92747 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73945 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79003 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27308 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72674 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27255 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25899 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2682 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28939 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/36837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75484 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28879 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16710 "Passed tests") | 
<!--EWS-Status-Bubble-End-->