### PR TITLE
Different output during v.test(...) with custom valueOf func

### DIFF
--- a/JSTests/stress/non-trivial-lastindex-valueof.js
+++ b/JSTests/stress/non-trivial-lastindex-valueof.js
@@ -1,0 +1,17 @@
+let v8 = 0;
+function v0(v1,v2,v3,v4,v5) {
+    const v7 = /a/;
+    function v9() {
+        const v10 = v8++;
+    }
+    const v11 = {"valueOf":v9};
+    v7.lastIndex = v11;
+    const v12 = v7.test("zzzz");
+    return v8;
+}
+
+for (let v19 = 0; v19 < 10000; v19++) {
+  v0();
+}
+
+if (v8 !== 10000) throw new Error("expected v8 to be incremented 10000 times");

--- a/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
@@ -104,13 +104,13 @@ inline MatchResult RegExpObject::matchInline(
     String input = string->value(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
+    unsigned lastIndex = getRegExpObjectLastIndexAsUnsigned(globalObject, this, input);
+    RETURN_IF_EXCEPTION(scope, { });
     if (!regExp->global() && !regExp->sticky()) {
         scope.release();
         return globalObject->regExpGlobalData().performMatch(globalObject, regExp, string, input, 0);
     }
 
-    unsigned lastIndex = getRegExpObjectLastIndexAsUnsigned(globalObject, this, input);
-    RETURN_IF_EXCEPTION(scope, { });
     if (lastIndex == UINT_MAX) {
         scope.release();
         setLastIndex(globalObject, 0);


### PR DESCRIPTION
#### 6427225efff7dbfd73415569d48e906b8e5cfd3b
<pre>
Different output during v.test(...) with custom valueOf func
<a href="https://bugs.webkit.org/show_bug.cgi?id=242977">https://bugs.webkit.org/show_bug.cgi?id=242977</a>
rdar://97354388

In DFG compiled methods, RegExp string tests do not always access and coerce the lastIndex
field in the matching implementation. If the lastIndex field is an object with a non-trivial
valueOf, this can lead to differential behavior between JIT and non-JIT execution. This
change moves up the lastIndex access in matchInline(), ensuring we always attempt to read it
regardless of whether the regexp is global or sticky, consistent with both the spec
(<a href="https://tc39.es/ecma262/#sec-regexpbuiltinexec)">https://tc39.es/ecma262/#sec-regexpbuiltinexec)</a> and the similar execInline() method
(<a href="https://github.com/WebKit/WebKit/blob/main/Source/JavaScriptCore/runtime/RegExpObjectInlines.h#67).">https://github.com/WebKit/WebKit/blob/main/Source/JavaScriptCore/runtime/RegExpObjectInlines.h#67).</a>

Reviewed by Mark Lam.

* JSTests/stress/non-trivial-lastindex-valueof.js: Added.
(v9):
(v0):
* Source/JavaScriptCore/runtime/RegExpObjectInlines.h:
(JSC::RegExpObject::matchInline):

Canonical link: <a href="https://commits.webkit.org/253766@main">https://commits.webkit.org/253766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b495bf9fed4a1e306c4d66bdb4ef6a37729a1cf3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95888 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149585 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29456 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91036 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23779 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73832 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23771 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66780 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78892 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27188 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12885 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72556 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27131 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13899 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25868 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2663 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36750 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75356 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33176 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16678 "Passed tests") | 
<!--EWS-Status-Bubble-End-->