### PR TITLE
[AVF] Optimize MediaSampleAVF timing access

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
@@ -80,9 +80,15 @@ protected:
     WEBCORE_EXPORT MediaSampleAVFObjC(CMSampleBufferRef, AtomString trackID);
     WEBCORE_EXPORT MediaSampleAVFObjC(CMSampleBufferRef, uint64_t trackID);
     WEBCORE_EXPORT virtual ~MediaSampleAVFObjC();
+    
+    void initializeTimes();
 
     RetainPtr<CMSampleBufferRef> m_sample;
     AtomString m_id;
+    
+    MediaTime m_presentationTime;
+    MediaTime m_decodeTime;
+    MediaTime m_duration;
 
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
     Vector<Ref<SharedBuffer>> m_keyIDs;


### PR DESCRIPTION
#### f5f2798ff872749c51d48b4609da98e1735622a5
<pre>
[AVF] Optimize MediaSampleAVF timing access
<a href="https://bugs.webkit.org/show_bug.cgi?id=244322">https://bugs.webkit.org/show_bug.cgi?id=244322</a>
&lt;rdar://99119415&gt;

Reviewed by Jer Noble.

MediaSampleAVF calls directly into CoreMedia in order to fetch a media
timing which is then converted into a MediaTime object. Considering how
frequently these timings are accessed, we can optimize the access speed
by holding our own MediaTime object and caching the underlying timings.

Benchmark (ran 4150 times):
```
    MediaTime x;
    {
        TimingScope(&quot;sample&quot;);
        for (int i = 0; i &lt; 10000; i++)
            x += sample-&gt;presentationTime();
    }
```
before: 4150 calls, mean duration: 0.000022ms, total duration: 0.091249ms, max duration 0.000792ms
after: 4150 calls, mean duration: 0.000015ms, total duration: 0.062080ms, max duration 0.000333ms

* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm:
(WebCore::MediaSampleAVFObjC::MediaSampleAVFObjC):
(WebCore::MediaSampleAVFObjC::initializeTimes):
(WebCore::MediaSampleAVFObjC::presentationTime const):
(WebCore::MediaSampleAVFObjC::decodeTime const):
(WebCore::MediaSampleAVFObjC::duration const):
(WebCore::MediaSampleAVFObjC::offsetTimestampsBy):
(WebCore::MediaSampleAVFObjC::setTimestamps):

Canonical link: <a href="https://commits.webkit.org/253796@main">https://commits.webkit.org/253796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c6661ef4082262b11b74fd919f12978d5b5c8b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95910 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149599 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29470 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25754 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79153 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91049 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23790 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73843 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23778 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66787 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27202 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12891 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27144 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13905 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2681 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36757 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33182 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->