### PR TITLE
JSON FastStringifier should adapt its buffer capacity based on remaining stack capacity.

### DIFF
--- a/JSTests/stress/json-fast-stringifier-on-cyclic-structure.js
+++ b/JSTests/stress/json-fast-stringifier-on-cyclic-structure.js
@@ -1,0 +1,17 @@
+var array = [];
+var funky = {
+    toJSON: [array, -155]
+};
+
+array[0] = funky.toJSON;
+
+var exception;
+try {
+    JSON.stringify(array);
+} catch (e) {
+    exception = e;
+}
+
+if (exception != "TypeError: JSON.stringify cannot serialize cyclic structures.")
+    throw "FAILED";
+


### PR DESCRIPTION
#### 0762185035ffd66ed5e546b9dad4e97a22dac591
<pre>
JSON FastStringifier should adapt its buffer capacity based on remaining stack capacity.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244323">https://bugs.webkit.org/show_bug.cgi?id=244323</a>
&lt;rdar://problem/99064587&gt;

Reviewed by Darin Adler and Yusuke Suzuki.

FastStringifier relies on remainingCapacity() in m_buffer to limit recursion.

Since it is possible for a JS program to recurse very deep until it is near the bottom of the stack
before calling JSON.stringify(), it is incorrect for FastStringifier to assume that there will always
be enough remaining stack for it to parse and generate sizeof(m_buffer) worth of string.  Instead,
FastStringifier should reduce the amount of useable buffer space based on the amount of remaining
stack capacity available.

In this patch, we do the following:

1. Introduce a m_useableEnd to indicates where in m_buffer we can fill characters up to.
   This is how we reduce the amount of useable buffer space that FastStringifier can use.

2. Adds the computation of m_useableEnd in FastStringifier&apos;s constructor based on remaining
   available stack space.

3. Replace remainingCapacity() with hasRemainingCapacity(), which will:
   a. Check m_length + requested size against m_useableEnd.  Returns true if there&apos;s sufficient capacity.
   b. Else, call hasRemainingCapacitySlow() to recompute m_useableEnd based on actual unused buffer
      space (if necessary), and recompute the capacity check result in (a).
   Without this dynamic adaption of m_useableEnd based on real remaining stack space, Speedometer 2.1
   shows a regression on iOS where stacks are more shallow where the estimate causes us to bail out of
   FastStringifier too eagerly.

Note: we&apos;ve also previously tried a different algorithm where we track a m_cursor and m_cursorStart to
manage where we start filling in content in m_buffer (instead of tracking a m_useableEnd).  That
algorithm requires hasRemainingCapacitySlow() to memmove the filled in portion of m_buffer to shift the
content down every time we need to allow for more capacity in m_buffer.  While this algorithm appears to
be performance neutral, we learn that hasRemainingCapacitySlow() is called many times in the course of
normal operations for any reasonably sized stack.  Hence, we&apos;re potentially doing a lot more memmoves
with this algorithm.

Since both algorithms are performance neutral, we&apos;re going with the one that doesn&apos;t need all the memmoves.

* JSTests/stress/json-fast-stringifier-on-cyclic-structure.js: Added.
(catch):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::FastStringifier::length const):
(JSC::FastStringifier::useableBufferSize):
(JSC::FastStringifier::FastStringifier):
(JSC::FastStringifier::haveFailure const):
(JSC::FastStringifier::result const):
(JSC::FastStringifier::hasRemainingCapacity):
(JSC::FastStringifier::hasRemainingCapacitySlow):
(JSC::FastStringifier::append):
(JSC::FastStringifier::remainingCapacity const): Deleted.

Canonical link: <a href="https://commits.webkit.org/256154@main">https://commits.webkit.org/256154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d4fc61bde273175759ac0b12e727fa0d1135ea4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104532 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4159 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32255 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/87232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100595 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/81404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/87232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/87232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/86067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38667 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/81291 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36499 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/28002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40424 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/81404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83963 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2030 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42400 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/38819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/18979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->