### PR TITLE
Use C++20 destroying operator delete for NodeRareData

### DIFF
--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -742,10 +742,6 @@ private:
 
     WEBCORE_EXPORT void notifyInspectorOfRendererChange();
     
-    struct NodeRareDataDeleter {
-        void operator()(NodeRareData*) const;
-    };
-
     mutable uint32_t m_refCountAndParentBit { s_refCountIncrement };
     mutable OptionSet<NodeFlag> m_nodeFlags;
 
@@ -754,7 +750,7 @@ private:
     Node* m_previous { nullptr };
     Node* m_next { nullptr };
     CompactPointerTuple<RenderObject*, uint16_t> m_rendererWithStyleFlags;
-    CompactUniquePtrTuple<NodeRareData, uint16_t, NodeRareDataDeleter> m_rareDataWithBitfields;
+    CompactUniquePtrTuple<NodeRareData, uint16_t> m_rareDataWithBitfields;
 };
 
 bool connectedInSameTreeScope(const Node*, const Node*);

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -28,6 +28,7 @@
 #include "MutationObserverRegistration.h"
 #include "QualifiedName.h"
 #include "TagCollection.h"
+#include <new>
 #include <wtf/HashSet.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/WeakPtr.h>
@@ -316,6 +317,8 @@ public:
         return result;
     }
 #endif
+
+    void operator delete(NodeRareData*, std::destroying_delete_t);
 
 protected:
     // Used by ElementRareData. Defined here for better packing in 64-bit.


### PR DESCRIPTION
#### a22fba88f8ed1b69a5889444b39f11b73d3487ef
<pre>
Use C++20 destroying operator delete for NodeRareData
<a href="https://bugs.webkit.org/show_bug.cgi?id=244325">https://bugs.webkit.org/show_bug.cgi?id=244325</a>

Reviewed by Ryosuke Niwa.

C++20 introduces destroying operator delete which can introduce a hook-point before calling a destructor.
This allows us to dispatch destructors by reading some data from the target without using `virtual` destructor.
This patch applies it to NodeRareData so that we no longer need to have custom deleter for NodeRareData.

* Source/WebCore/dom/Node.cpp:
(WebCore::NodeRareData::operator delete):
(WebCore::Node::materializeRareData):
(WebCore::Node::NodeRareDataDeleter::operator() const): Deleted.
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeRareData.h:

Canonical link: <a href="https://commits.webkit.org/253805@main">https://commits.webkit.org/253805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e50c1f4ad79adee009566b41cc8eaffa3582d548

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95956 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149608 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29479 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25761 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79161 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91057 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23799 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73850 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23783 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66792 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27210 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12898 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27152 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13912 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2684 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36766 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33189 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->