### PR TITLE
CSSFontFaceSrcValue should use WeakPtr<SVGFontFaceElement> instead of SVGFontFaceElement*

### DIFF
--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -40,6 +40,8 @@
 
 namespace WebCore {
 
+CSSFontFaceSrcValue::~CSSFontFaceSrcValue() = default;
+
 bool CSSFontFaceSrcValue::isSVGFontFaceSrc() const
 {
     return equalLettersIgnoringASCIICase(m_format, "svg"_s);
@@ -62,6 +64,16 @@ bool CSSFontFaceSrcValue::isSupportedFormat() const
     }
 
     return FontCustomPlatformData::supportsFormat(m_format) || isSVGFontFaceSrc();
+}
+
+SVGFontFaceElement* CSSFontFaceSrcValue::svgFontFaceElement() const
+{
+    return m_svgFontFaceElement.get();
+}
+
+void CSSFontFaceSrcValue::setSVGFontFaceElement(SVGFontFaceElement* element)
+{
+    m_svgFontFaceElement = element;
 }
 
 String CSSFontFaceSrcValue::customCSSText() const

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -49,6 +49,8 @@ public:
         return adoptRef(*new CSSFontFaceSrcValue(resource, true, LoadedFromOpaqueSource::No));
     }
 
+    ~CSSFontFaceSrcValue();
+
     const String& resource() const { return m_resource; }
     const String& format() const { return m_format; }
     bool isLocal() const { return m_isLocal; }
@@ -60,8 +62,8 @@ public:
     bool isSVGFontFaceSrc() const;
     bool isSVGFontTarget() const;
 
-    SVGFontFaceElement* svgFontFaceElement() const { return m_svgFontFaceElement; }
-    void setSVGFontFaceElement(SVGFontFaceElement* element) { m_svgFontFaceElement = element; }
+    SVGFontFaceElement* svgFontFaceElement() const;
+    void setSVGFontFaceElement(SVGFontFaceElement*);
 
     String customCSSText() const;
 
@@ -87,8 +89,7 @@ private:
     LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
 
     CachedResourceHandle<CachedFont> m_cachedFont;
-
-    SVGFontFaceElement* m_svgFontFaceElement;
+    WeakPtr<SVGFontFaceElement> m_svgFontFaceElement;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### a60482d1088a4a7a0b2e2486351ea267dcfa920e
<pre>
CSSFontFaceSrcValue should use WeakPtr&lt;SVGFontFaceElement&gt; instead of SVGFontFaceElement*
<a href="https://bugs.webkit.org/show_bug.cgi?id=244327">https://bugs.webkit.org/show_bug.cgi?id=244327</a>

Reviewed by Chris Dumez.

* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcValue::svgFontFaceElement const):
(WebCore::CSSFontFaceSrcValue::setSVGFontFaceElement):
* Source/WebCore/css/CSSFontFaceSrcValue.h:

Canonical link: <a href="https://commits.webkit.org/253772@main">https://commits.webkit.org/253772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db558cd4a2095d7daf017293da7d08003336d01b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95963 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149613 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29484 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79167 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91061 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23804 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73854 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23787 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66796 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27214 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12901 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27157 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13915 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2669 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36768 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33192 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->