### PR TITLE
[CoordinatedGraphics] Cache and reuse image-based backing stores

### DIFF
--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -111,6 +111,7 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/nicosia/texmap/NicosiaCompositionLayerTextureMapperImpl.cpp
         platform/graphics/nicosia/texmap/NicosiaContentLayerTextureMapperImpl.cpp
         platform/graphics/nicosia/texmap/NicosiaGCGLLayer.cpp
+        platform/graphics/nicosia/texmap/NicosiaImageBackingStore.cpp
         platform/graphics/nicosia/texmap/NicosiaImageBackingTextureMapperImpl.cpp
     )
     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
@@ -127,6 +128,7 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/nicosia/texmap/NicosiaBackingStoreTextureMapperImpl.h
         platform/graphics/nicosia/texmap/NicosiaCompositionLayerTextureMapperImpl.h
         platform/graphics/nicosia/texmap/NicosiaContentLayerTextureMapperImpl.h
+        platform/graphics/nicosia/texmap/NicosiaImageBackingStore.h
         platform/graphics/nicosia/texmap/NicosiaImageBackingTextureMapperImpl.h
     )
 else ()

--- a/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaImageBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaImageBackingStore.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Metrological Group B.V.
- * Copyright (C) 2018 Igalia S.L.
+ * Copyright (C) 2022 Metrological Group B.V.
+ * Copyright (C) 2022 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,44 +27,15 @@
  */
 
 #include "config.h"
-#include "NicosiaImageBackingTextureMapperImpl.h"
+#include "NicosiaImageBackingStore.h"
 
 #if USE(TEXTURE_MAPPER)
 
 namespace Nicosia {
 
-auto ImageBackingTextureMapperImpl::createFactory() -> Factory
-{
-    return Factory(
-        [](ImageBacking&) {
-            return makeUnique<ImageBackingTextureMapperImpl>();
-        });
-}
-
-ImageBackingTextureMapperImpl::ImageBackingTextureMapperImpl() = default;
-ImageBackingTextureMapperImpl::~ImageBackingTextureMapperImpl() = default;
-
-void ImageBackingTextureMapperImpl::flushUpdate()
-{
-    Locker locker { m_update.lock };
-
-    // If the update happens for the same image and there's no buffer, keep the current one
-    // so it can be received by the CoordinatedGraphicsScene. In that case we only need to update
-    // the isVisible flag.
-    if ((m_layerState.update.nativeImageID == m_update.update.nativeImageID) && !m_layerState.update.imageBackingStore) {
-        m_update.update.isVisible = m_layerState.update.isVisible;
-        return;
-    }
-
-    m_update.update = WTFMove(m_layerState.update);
-}
-
-auto ImageBackingTextureMapperImpl::takeUpdate() -> Update
-{
-    Locker locker { m_update.lock };
-    return WTFMove(m_update.update);
-}
+ImageBackingStore::ImageBackingStore() = default;
+ImageBackingStore::~ImageBackingStore() = default;
 
 } // namespace Nicosia
 
-#endif
+#endif // USE(TEXTURE_MAPPER)

--- a/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaImageBackingTextureMapperImpl.h
+++ b/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaImageBackingTextureMapperImpl.h
@@ -32,6 +32,7 @@
 
 #include "CoordinatedBackingStore.h"
 #include "NicosiaBuffer.h"
+#include "NicosiaImageBackingStore.h"
 #include "NicosiaPlatformLayer.h"
 #include <wtf/Lock.h>
 
@@ -59,8 +60,8 @@ public:
         Update& operator=(Update&&) = default;
 
         bool isVisible { false };
-        RefPtr<Nicosia::Buffer> buffer;
         uintptr_t nativeImageID { 0 };
+        RefPtr<Nicosia::ImageBackingStore> imageBackingStore;
     };
 
     // An immutable layer-side state object. flushUpdate() prepares
@@ -88,7 +89,7 @@ public:
         CompositionState(CompositionState&&) = delete;
         CompositionState& operator=(CompositionState&&) = delete;
 
-        RefPtr<WebCore::CoordinatedBackingStore> backingStore;
+        RefPtr<Nicosia::ImageBackingStore> imageBackingStore;
     };
     CompositionState& compositionState() { return m_compositionState; }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -23,7 +23,6 @@
 #if USE(COORDINATED_GRAPHICS)
 
 #include "GraphicsLayer.h"
-#include "NicosiaBuffer.h"
 #include "TextureMapper.h"
 #include "TextureMapperGL.h"
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -21,6 +21,7 @@
 
 #if USE(COORDINATED_GRAPHICS)
 
+#include "NicosiaBuffer.h"
 #include "TextureMapper.h"
 #include "TextureMapperBackingStore.h"
 #include "TextureMapperTile.h"
@@ -28,10 +29,6 @@
 #include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
-
-namespace Nicosia {
-class Buffer;
-}
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -907,16 +907,19 @@ void CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly()
         layerState.imageID = imageID;
         layerState.update.isVisible = transformedVisibleRect().intersects(IntRect(contentsRect()));
         if (layerState.update.isVisible && layerState.update.nativeImageID != nativeImageID) {
-            auto buffer = Nicosia::Buffer::create(IntSize(image.size()),
-                !image.currentFrameKnownToBeOpaque() ? Nicosia::Buffer::SupportsAlpha : Nicosia::Buffer::NoFlags);
-            Nicosia::PaintingContext::paint(buffer,
-                [&image](GraphicsContext& context)
-                {
-                    IntRect rect { { }, IntSize { image.size() } };
-                    context.drawImage(image, rect, rect, ImagePaintingOptions(CompositeOperator::Copy));
-                });
             layerState.update.nativeImageID = nativeImageID;
-            layerState.update.buffer = WTFMove(buffer);
+            layerState.update.imageBackingStore = m_coordinator->imageBackingStore(nativeImageID,
+                [&] {
+                    auto buffer = Nicosia::Buffer::create(IntSize(image.size()),
+                        !image.currentFrameKnownToBeOpaque() ? Nicosia::Buffer::SupportsAlpha : Nicosia::Buffer::NoFlags);
+                    Nicosia::PaintingContext::paint(buffer,
+                        [&image](GraphicsContext& context)
+                        {
+                            IntRect rect { { }, IntSize { image.size() } };
+                            context.drawImage(image, rect, rect, ImagePaintingOptions(CompositeOperator::Copy));
+                        });
+                    return buffer;
+                });
             m_nicosia.delta.imageBackingChanged = true;
         }
     } else if (m_nicosia.imageBacking) {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -33,11 +33,13 @@
 #include "NicosiaBuffer.h"
 #include "NicosiaPlatformLayer.h"
 #include "TransformationMatrix.h"
+#include <wtf/Function.h>
 #include <wtf/RunLoop.h>
 #include <wtf/text/StringHash.h>
 
 namespace Nicosia {
 class Animations;
+class ImageBackingStore;
 class PaintingEngine;
 }
 
@@ -51,6 +53,7 @@ public:
     virtual void detachLayer(CoordinatedGraphicsLayer*) = 0;
     virtual void attachLayer(CoordinatedGraphicsLayer*) = 0;
     virtual Nicosia::PaintingEngine& paintingEngine() = 0;
+    virtual RefPtr<Nicosia::ImageBackingStore> imageBackingStore(uint64_t, Function<RefPtr<Nicosia::Buffer>()>) = 0;
     virtual void syncLayerState() = 0;
 };
 

--- a/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
@@ -155,19 +155,27 @@ void updateImageBacking(TextureMapperLayer& layer,
         return;
     }
 
-    if (!compositionState.backingStore)
-        compositionState.backingStore = CoordinatedBackingStore::create();
-    auto& backingStore = *compositionState.backingStore;
-    layer.setContentsLayer(&backingStore);
-
-    if (!update.buffer)
+    if (!update.imageBackingStore)
         return;
 
-    backingStore.createTile(1, 1.0);
-    WebCore::IntRect rect { { }, update.buffer->size() };
-    ASSERT(2000 >= std::max(rect.width(), rect.height()));
-    backingStore.setSize(rect.size());
-    backingStore.updateTile(1, rect, rect, WTFMove(update.buffer), rect.location());
+    compositionState.imageBackingStore = update.imageBackingStore;
+
+    auto& imageBackingStore = *compositionState.imageBackingStore;
+    auto& backingStore = imageBackingStore.compositionState().backingStoreContainer->backingStore;
+    if (!backingStore) {
+        backingStore = CoordinatedBackingStore::create();
+
+        auto buffer = WTFMove(imageBackingStore.backingStoreState().buffer);
+        if (buffer) {
+            backingStore->createTile(1, 1.0);
+            WebCore::IntRect rect { { }, buffer->size() };
+            ASSERT(2000 >= std::max(rect.width(), rect.height()));
+            backingStore->setSize(rect.size());
+            backingStore->updateTile(1, rect, rect, WTFMove(buffer), rect.location());
+        }
+    }
+
+    layer.setContentsLayer(backingStore.get());
 }
 
 void removeLayer(Nicosia::CompositionLayer& layer)
@@ -182,11 +190,6 @@ void removeLayer(Nicosia::CompositionLayer& layer)
 
             if (committed.contentLayer)
                 contentLayerImpl(*committed.contentLayer).proxy().invalidate();
-
-            if (committed.imageBacking) {
-                auto& compositionState = imageBackingImpl(*committed.imageBacking).compositionState();
-                compositionState.backingStore = nullptr;
-            }
         });
 
     auto& compositionState = compositionLayerImpl(layer).compositionState();
@@ -410,8 +413,14 @@ void CoordinatedGraphicsScene::updateSceneState()
             auto& compositionState = entry.imageBacking.get().compositionState();
             updateImageBacking(entry.layer.get(), compositionState, entry.update);
 
-            if (compositionState.backingStore)
-                backingStoresWithPendingBuffers.add(*compositionState.backingStore);
+            if (compositionState.imageBackingStore) {
+                auto& container = compositionState.imageBackingStore->compositionState().backingStoreContainer;
+                m_imageBackingStoreContainers.add(container);
+
+                auto& backingStore = container->backingStore;
+                if (backingStore)
+                    backingStoresWithPendingBuffers.add(*backingStore);
+            }
         }
 
         layersByBacking.imageBacking = { };
@@ -426,6 +435,12 @@ void CoordinatedGraphicsScene::updateSceneState()
     for (auto& proxy : replacedProxiesToInvalidate)
         proxy->invalidate();
     replacedProxiesToInvalidate = { };
+
+    // Eject any backing store container whose only reference is held in this scene's HashSet cache.
+    m_imageBackingStoreContainers.removeIf(
+        [](auto& container) {
+            return container->hasOneRef();
+        });
 }
 
 void CoordinatedGraphicsScene::ensureRootLayer()
@@ -457,6 +472,8 @@ void CoordinatedGraphicsScene::purgeGLResources()
             });
         m_nicosia.scene = nullptr;
     }
+
+    m_imageBackingStoreContainers = { };
 
     m_rootLayer = nullptr;
     m_rootLayerID = 0;

--- a/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.h
@@ -27,6 +27,7 @@
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/IntSize.h>
+#include <WebCore/NicosiaImageBackingStore.h>
 #include <WebCore/NicosiaPlatformLayer.h>
 #include <WebCore/TextureMapper.h>
 #include <WebCore/TextureMapperBackingStore.h>
@@ -92,6 +93,7 @@ private:
     } m_nicosia;
 
     std::unique_ptr<WebCore::TextureMapper> m_textureMapper;
+    HashSet<Ref<Nicosia::ImageBackingStore::BackingStoreContainer>> m_imageBackingStoreContainers;
 
     // Below two members are accessed by only the main thread. The painting thread must lock the main thread to access both members.
     CoordinatedGraphicsSceneClient* m_client;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -37,6 +37,7 @@
 #include <WebCore/InspectorController.h>
 #include <WebCore/NicosiaBackingStoreTextureMapperImpl.h>
 #include <WebCore/NicosiaContentLayerTextureMapperImpl.h>
+#include <WebCore/NicosiaImageBackingStore.h>
 #include <WebCore/NicosiaImageBackingTextureMapperImpl.h>
 #include <WebCore/NicosiaPaintingEngine.h>
 #include <WebCore/Page.h>
@@ -175,6 +176,12 @@ bool CompositingCoordinator::flushPendingLayerChanges(OptionSet<FinalizeRenderin
 
     m_page.didUpdateRendering();
 
+    // Eject any backing stores whose only reference is held in the HashMap cache.
+    m_imageBackingStores.removeIf(
+        [](auto& it) {
+            return it.value->hasOneRef();
+        });
+
     return true;
 }
 
@@ -306,6 +313,17 @@ void CompositingCoordinator::purgeBackingStores()
 Nicosia::PaintingEngine& CompositingCoordinator::paintingEngine()
 {
     return *m_paintingEngine;
+}
+
+RefPtr<Nicosia::ImageBackingStore> CompositingCoordinator::imageBackingStore(uint64_t nativeImageID, Function<RefPtr<Nicosia::Buffer>()> createBuffer)
+{
+    auto addResult = m_imageBackingStores.ensure(nativeImageID,
+        [&] {
+            auto store = adoptRef(*new Nicosia::ImageBackingStore);
+            store->backingStoreState().buffer = createBuffer();
+            return store;
+        });
+    return addResult.iterator->value.copyRef();
 }
 
 void CompositingCoordinator::requestUpdate()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
@@ -40,6 +40,7 @@
 #include <WebCore/NicosiaSceneIntegration.h>
 
 namespace Nicosia {
+class ImageBackingStore;
 class PaintingEngine;
 class SceneIntegration;
 }
@@ -47,6 +48,7 @@ class SceneIntegration;
 namespace WebCore {
 class GraphicsContext;
 class GraphicsLayer;
+class Image;
 }
 
 namespace WebKit {
@@ -102,6 +104,7 @@ private:
     void detachLayer(WebCore::CoordinatedGraphicsLayer*) override;
     void attachLayer(WebCore::CoordinatedGraphicsLayer*) override;
     Nicosia::PaintingEngine& paintingEngine() override;
+    RefPtr<Nicosia::ImageBackingStore> imageBackingStore(uint64_t, Function<RefPtr<Nicosia::Buffer>()>) override;
     void syncLayerState() override;
 
     // GraphicsLayerFactory
@@ -133,6 +136,7 @@ private:
     HashMap<Nicosia::PlatformLayer::LayerID, WebCore::CoordinatedGraphicsLayer*> m_registeredLayers;
 
     std::unique_ptr<Nicosia::PaintingEngine> m_paintingEngine;
+    HashMap<uint64_t, Ref<Nicosia::ImageBackingStore>> m_imageBackingStores;
 
     // We don't send the messages related to releasing resources to renderer during purging, because renderer already had removed all resources.
     bool m_isPurging { false };


### PR DESCRIPTION
#### 487411cb60839bfed6fa02d9d2ad34d30d250019
<pre>
[CoordinatedGraphics] Cache and reuse image-based backing stores
<a href="https://bugs.webkit.org/show_bug.cgi?id=242394">https://bugs.webkit.org/show_bug.cgi?id=242394</a>

Reviewed by Miguel Gomez.

Implement caching of image-based backing stores in the CoordinatedGraphics
subsystem. This allows for such backing stores to be shared between layers that
reuse the same image resource as its content.

The CompositingCoordinator object, in control of a given layer tree, now also
holds a cache of image-based backing store objects that can be shared between
different layers using the same image resource as its content. This cache is
then mirrored in CoordinatedGraphicsScene, but there the CoordinatedBackingStore
objects are cached instead, which are created with the desired image resource
upon entry into the cache. This way different layer objects can end up sharing
on-GPU memory for display of the desired image content, and the CPU-bound image
memory consumption can also be reduced.

* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/nicosia/texmap/NicosiaImageBackingStore.cpp: Copied from Source/WebCore/platform/graphics/nicosia/texmap/NicosiaImageBackingTextureMapperImpl.cpp.
* Source/WebCore/platform/graphics/nicosia/texmap/NicosiaImageBackingStore.h: Copied from Source/WebCore/platform/graphics/nicosia/texmap/NicosiaImageBackingTextureMapperImpl.cpp.
(Nicosia::ImageBackingStore::backingStoreState):
(Nicosia::ImageBackingStore::CompositionState::CompositionState):
(Nicosia::ImageBackingStore::compositionState):
* Source/WebCore/platform/graphics/nicosia/texmap/NicosiaImageBackingTextureMapperImpl.cpp:
(Nicosia::ImageBackingTextureMapperImpl::flushUpdate):
* Source/WebCore/platform/graphics/nicosia/texmap/NicosiaImageBackingTextureMapperImpl.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:
* Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp:
(WebKit::updateImageBacking):
(WebKit::removeLayer):
(WebKit::CoordinatedGraphicsScene::updateSceneState):
(WebKit::CoordinatedGraphicsScene::purgeGLResources):
* Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::flushPendingLayerChanges):
(WebKit::CompositingCoordinator::imageBackingStore):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h:

Canonical link: <a href="https://commits.webkit.org/253807@main">https://commits.webkit.org/253807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15670ab883dfbd9ca16fd8b3522453ce7e5ef354

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95988 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149627 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29497 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25775 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79182 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91074 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23817 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73867 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23794 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66803 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27227 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12916 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27170 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13930 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2687 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36778 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33207 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->