### PR TITLE
REGRESSION(253529@main): 2X imported/w3c/web-platform-tests/mediacapture-record/ layout tests are failing

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1306,12 +1306,6 @@ webkit.org/b/222183 [ BigSur+ ] imported/w3c/web-platform-tests/media-source/med
 
 webkit.org/b/222365 inspector/dom/attributeModified.html [ Pass Timeout ]
 
-# webkit.org/b/222277
-imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-no-sink.https.html [ Skip ]
-imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html [ Skip ]
-imported/w3c/web-platform-tests/mediacapture-record/idlharness.window.html [ Skip ]
-imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-error.html [ Pass Failure ]
-
 webkit.org/b/222500 fast/canvas/webgl/texImage2D-video-flipY-false.html [ Pass Timeout ]
 
 webkit.org/b/222677 inspector/model/auditTestCase.html [ Pass Timeout ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1472,8 +1472,6 @@ fast/text/design-system-ui-14.html [ Pass ]
 fast/text/design-system-ui-15.html [ Pass ]
 fast/text/design-system-ui-16.html [ Pass ]
 
-imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-no-sink.https.html [ Pass Failure ]
-
 webkit.org/b/200128 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video_timeupdate_on_seek.html [ Timeout Pass ]
 
 # See bug 232916; this test can't pass as we do not support mid-stream resolution change.

--- a/Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm
@@ -88,10 +88,12 @@ bool AudioSampleBufferCompressor::initialize(CMBufferQueueTriggerCallback callba
 void AudioSampleBufferCompressor::flushInternal(bool isFinished)
 {
     m_serialDispatchQueue->dispatchSync([this, isFinished] {
-        processSampleBuffersUntilLowWaterTime(PAL::kCMTimeInvalid);
-
-        if (!isFinished)
+        if (!isFinished) {
+            // FIXME: we might want to compress not yet processed data (whose duration is at most LOW_WATER_TIME_IN_SECONDS).
             return;
+        }
+
+        processSampleBuffersUntilLowWaterTime(PAL::kCMTimeInvalid);
 
         auto error = PAL::CMBufferQueueMarkEndOfData(m_outputBufferQueue.get());
         RELEASE_LOG_ERROR_IF(error, MediaStream, "AudioSampleBufferCompressor CMBufferQueueMarkEndOfData failed %d", error);


### PR DESCRIPTION
#### 64285901cd497bab9802e0b359073f5be56ffd18
<pre>
REGRESSION(253529@main): 2X imported/w3c/web-platform-tests/mediacapture-record/ layout tests are failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=244208">https://bugs.webkit.org/show_bug.cgi?id=244208</a>
rdar://problem/98987676

Reviewed by Jer Noble and Eric Carlson.

When trying to convert with not enough data, the converter is blocked and does not process any future audio data.
This happened when flushing at the end and 253529@main made it happen when flushing to request data.
To workaround this, we no longer flush audio data but we make sure to let the compressor do its job.
At most 100 ms audio data might not get flushed. A follow-up should fix this.

Enable tests in mac since the underlying issue was solved a long time ago.

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm:
(WebCore::AudioSampleBufferCompressor::flushInternal):

Canonical link: <a href="https://commits.webkit.org/253907@main">https://commits.webkit.org/253907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e65931a374a3a168f5c6079ccdf6f0ddf4b4ee3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95990 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149629 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91024 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29499 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25776 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79184 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91076 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23818 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73869 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23795 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66804 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27229 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12926 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27172 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13940 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2745 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36780 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33217 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->