### PR TITLE
Disable mini mode scavenger for apps

### DIFF
--- a/Source/bmalloc/bmalloc/ProcessCheck.h
+++ b/Source/bmalloc/bmalloc/ProcessCheck.h
@@ -39,6 +39,12 @@ bool gigacageEnabledForProcess();
 inline bool gigacageEnabledForProcess() { return true; }
 #endif
 
+#if BOS(DARWIN)
+bool shouldAllowMiniMode();
+#else
+inline bool shouldAllowMiniMode() { return true; }
+#endif
+
 #if BPLATFORM(IOS_FAMILY)
 bool shouldProcessUnconditionallyUseBmalloc();
 #endif

--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -28,6 +28,7 @@
 #include "DebugHeap.h"
 #include "Environment.h"
 #include "PerProcess.h"
+#include "ProcessCheck.h"
 
 #if BENABLE(LIBPAS)
 #include "bmalloc_heap_config.h"
@@ -198,6 +199,9 @@ void decommitAlignedPhysical(void* object, size_t size, HeapKind kind)
 void enableMiniMode()
 {
 #if BENABLE(LIBPAS)
+    if (!shouldAllowMiniMode())
+        return;
+
     // Speed up the scavenger.
     pas_scavenger_period_in_milliseconds = 5.;
     pas_scavenger_max_epoch_delta = 5ll * 1000ll * 1000ll;


### PR DESCRIPTION
#### 0df435b1b392cd078f13d555a63a36a96f519c57
<pre>
Disable mini mode scavenger for apps
<a href="https://bugs.webkit.org/show_bug.cgi?id=244355">https://bugs.webkit.org/show_bug.cgi?id=244355</a>
&lt;rdar://98989977&gt;

Reviewed by Yusuke Suzuki and Saam Barati.

We accidentally enabled the mini mode scavenger for Safari recently due to an entitlement
change. This is contributing to a regression in the power benchmarks, since the regular scavenger
has a period of 100 ms while the mini mode scavenger has a period of 5 ms. We should restore the old
behavior to mitigate this regression.

In talking to Geoff, it seems like he never intended for mini mode to be deployed so widely; it was
supposed to be an opt-in feature for bursty daemons that used JSC. As the mini mode appears to be
especially expensive for large apps that presumably have a lot of threads that might need to be
suspended, this patch disables the mini mode scavenger not only for Safari but for other apps as
well.

* Source/bmalloc/bmalloc/ProcessCheck.h:
(bmalloc::shouldAllowMiniMode):
* Source/bmalloc/bmalloc/ProcessCheck.mm:
(bmalloc::shouldAllowMiniMode):
* Source/bmalloc/bmalloc/bmalloc.cpp:
(bmalloc::api::enableMiniMode):

Canonical link: <a href="https://commits.webkit.org/253852@main">https://commits.webkit.org/253852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fd18f18bdc796cca40d3e7ffe32eeced679241e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96072 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149675 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29546 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25810 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79229 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91120 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23860 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73913 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23809 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66821 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78975 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27274 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12947 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72642 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27218 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13961 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25895 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2712 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36813 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75447 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33238 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16705 "Passed tests") | 
<!--EWS-Status-Bubble-End-->