### PR TITLE
Misc compiler warnings, late August 2022

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -5646,6 +5646,8 @@ constexpr CSSValueID toCSSValueID(ContentVisibility contentVisibility)
     case ContentVisibility::Auto:
         return CSSValueAuto;
     }
+    ASSERT_NOT_REACHED();
+    return CSSValueVisible;
 }
 
 template<> inline CSSPrimitiveValue::CSSPrimitiveValue(ContentVisibility contentVisibility)

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2002,7 +2002,7 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
                 for (auto it = descendantsOfType<Element>(*this).begin(); it;) {
                     auto& element = *it;
                     if (auto* elementData = element.elementData()) {
-                        if (auto* attribute = elementData->findLanguageAttribute()) {
+                        if (elementData->findLanguageAttribute()) {
                             it.traverseNextSkippingChildren();
                             continue;
                         }


### PR DESCRIPTION
#### 76748b407b902d3025581a0cf17ce2be79d5ae1e
<pre>
Misc compiler warnings, late August 2022
<a href="https://bugs.webkit.org/show_bug.cgi?id=244348">https://bugs.webkit.org/show_bug.cgi?id=244348</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/253923@main">https://commits.webkit.org/253923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92025e10416e79bbfc276d1dc72b11612a4b3a5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96078 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149679 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29550 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25813 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79233 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91124 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23865 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73917 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23811 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66823 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27278 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12955 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27222 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13969 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2755 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36815 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33246 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->