### PR TITLE
Typing style shouldn't inherit style from atomic elements

### DIFF
--- a/LayoutTests/editing/inserting/insert-without-inheriting-style-expected.txt
+++ b/LayoutTests/editing/inserting/insert-without-inheriting-style-expected.txt
@@ -1,0 +1,4 @@
+PASS $("sample").innerHTML is "foo quux&nbsp;baz"
+PASS successfullyParsed is true
+
+TEST COMPLETE

--- a/LayoutTests/editing/inserting/insert-without-inheriting-style.html
+++ b/LayoutTests/editing/inserting/insert-without-inheriting-style.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="container">
+<div contenteditable="true" id="sample">foo <input type="button" value="bar"> baz</div>
+</div>
+<script src="../../resources/js-test.js"></script>
+<script>
+function $(id) { return document.getElementById(id); }
+            
+var range = document.createRange();
+range.setStartAfter(document.querySelector('input'));
+                
+var selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    document.execCommand('Delete');
+    document.execCommand('InsertText', false, 'quux');
+shouldBeEqualToString('$("sample").innerHTML', 'foo quux&nbsp;baz');
+            
+if (window.testRunner)
+    $('container').outerHTML = '';
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -404,6 +404,12 @@ bool DeleteSelectionCommand::initializePositionData()
     return true;
 }
 
+    // We don't want to inherit style from an element which don't have contents.
+    static bool shouldNotInheritStyleFrom(const Node& node)
+    {
+        return !node.canContainRangeEndPoint();
+    }
+
 void DeleteSelectionCommand::saveTypingStyleState()
 {
     // A common case is deleting characters that are all from the same text node. In 
@@ -419,6 +425,9 @@ void DeleteSelectionCommand::saveTypingStyleState()
         document().selection().clearTypingStyle();
         return;
     }
+
+    if (shouldNotInheritStyleFrom(*m_selectionToDelete.start().anchorNode()))
+        return;
 
     // Figure out the typing style in effect before the delete is done.
     m_typingStyle = EditingStyle::create(m_selectionToDelete.start(), EditingStyle::EditingPropertiesInEffect);


### PR DESCRIPTION
<pre>

Typing style shouldn't inherit style from atomic elements

<a href="https://bugs.webkit.org/show_bug.cgi?id=119116">https://bugs.webkit.org/show_bug.cgi?id=119116</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/27371d2980715475f3443f7025141ebff8537179">https://chromium.googlesource.com/chromium/blink/+/27371d2980715475f3443f7025141ebff8537179</a>

This patch changes initialization of typing style not to populate from form control like elements, which can't have range ending point, e.g. img, input, object, textarea, and so on.

* Source/WebCore/editing/DeleteSelectionCommand.cpp
(DeleteSelectionCommand::initializePositionData()) - Updated to add static variable.
(DeleteSectionCommand::saveTypeStyleSheet()) - Added if condition to use static variable to not inherit style from atomic elements.

* LayoutTests/editing/inserting/insert-without-style.html - Testcase added from Blink / Chromium patch.
* LayoutTests/editing/inserting/insert-without-style-expected.txt- Added Testcase Expectations.

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/954effc6545173cfb49aed10bb1a6400f07db13d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87103 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96090 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149684 "Found 1 new test failure: editing/inserting/insert-without-inheriting-style.html") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29555 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25817 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79238 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91129 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92719 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23870 "Found 2 new test failures: editing/execCommand/underline-selection-containing-image.html, editing/inserting/insert-without-inheriting-style.html") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73922 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23813 "Found 1 new test failure: editing/inserting/insert-without-inheriting-style.html") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66825 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27283 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12954 "Found 2 new test failures: editing/execCommand/underline-selection-containing-image.html, editing/inserting/insert-without-inheriting-style.html") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27227 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13968 "Found 2 new test failures: editing/execCommand/underline-selection-containing-image.html, editing/inserting/insert-without-inheriting-style.html") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28911 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36822 "Found 2 new test failures: editing/execCommand/underline-selection-containing-image.html, editing/inserting/insert-without-inheriting-style.html") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33245 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->