### PR TITLE
REGRESSION (253685@main): [ Monterey wk2 ] fast/images/text-recognition/mac/cursor-types-for-recognized-text.html is a consistent failure

### DIFF
--- a/LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text-expected.txt
+++ b/LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text-expected.txt
@@ -1,12 +1,21 @@
 
 Testing <img id="inside-link">
-PASS cursor is "IBeam"
+PASS cursor is "Hand"
 
 Testing <img id="cursor-zoom-in">
 PASS cursor is "ZoomIn"
 
 Testing <img id="user-select-none-in-link">
 PASS cursor is "Hand"
+
+Testing overlay from <img id="inside-link">
+PASS cursor is "IBeam"
+
+Testing overlay from <img id="cursor-zoom-in">
+PASS cursor is "IBeam"
+
+Testing overlay from <img id="user-select-none-in-link">
+PASS cursor is "Pointer"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text.html
+++ b/LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text.html
@@ -25,6 +25,7 @@ a {
     top: 200px;
     -webkit-user-select: none;
 }
+
 </style>
 <script>
 addEventListener("load", () => {
@@ -49,15 +50,28 @@ addEventListener("load", () => {
     function testImage(imageID, expectedResult) {
         let image = document.getElementById(imageID);
         let rect = image.getBoundingClientRect();
-        eventSender.mouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
+        eventSender.mouseMoveTo(rect.left, rect.top);
         cursor = internals.getCurrentCursorInfo().match(/type=(\w+)\s/).pop();
         debug(`\nTesting &lt;img id="${imageID}"&gt;`);
         shouldBeEqualToString("cursor", expectedResult);
     }
 
-    testImage("inside-link", "IBeam");
+    function testOverlayDivFromImage(hostID, expectedResult) {
+        let image = document.getElementById(hostID);
+        let rect = image.getBoundingClientRect();
+        eventSender.mouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
+        cursor = internals.getCurrentCursorInfo().match(/type=(\w+)\s/).pop();
+        debug(`\nTesting overlay from &lt;img id="${hostID}"&gt;`);
+        shouldBeEqualToString("cursor", expectedResult);
+    }
+
+    testImage("inside-link", "Hand");
     testImage("cursor-zoom-in", "ZoomIn");
     testImage("user-select-none-in-link", "Hand");
+
+    testOverlayDivFromImage("inside-link", "IBeam");
+    testOverlayDivFromImage("cursor-zoom-in", "IBeam");
+    testOverlayDivFromImage("user-select-none-in-link", "Pointer");
 });
 </script>
 </head>

--- a/Source/WebCore/html/shadow/imageOverlay.css
+++ b/Source/WebCore/html/shadow/imageOverlay.css
@@ -32,6 +32,7 @@ div#image-overlay {
     text-indent: 0;
     text-align: center;
     font-family: system-ui;
+    cursor: auto;
 }
 
 :host(:not(img)) div#image-overlay:-webkit-full-screen-document {


### PR DESCRIPTION
#### 543df0e3b8ccc7ae09a84e62faf5c61cc880cb5f
<pre>
REGRESSION (253685@main): [ Monterey wk2 ] fast/images/text-recognition/mac/cursor-types-for-recognized-text.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244272">https://bugs.webkit.org/show_bug.cgi?id=244272</a>
&lt;rdar://99051044&gt;

Reviewed by Wenson Hsieh.

Test was failing because (253685@main) sets cursor:pointer for &lt;a&gt; with links,
since this behavior can&apos;t be obtained from cursor:auto according to specification.

Our live-text feature creates a overlay (a &lt;div&gt;) on the shadow DOM tree that depends on
cursor:auto behavior to render a IBeam cursor while hovering the text on top
of the image on the overlay. In this test, we had a &lt;img&gt; inside a &lt;a&gt;. After (253685@main)
the div overlay was inheriting cursor:pointer from the &lt;a&gt; and therefore, we would not
render a IBeam cursor for it.

Solution: We are now styling the div#image-overlay in imageOverlay.css with cursor:auto.
In that way, user can still style the wrapper image, and we preserve cursor:auto by default
for div#image-overlay.

* LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text-expected.txt:
* LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text.html:
testImage now tests the cursor hovering on the image area out of the text area.
testOverlayDivFromImage tests the cursor hovering the overlay div on the text area.

We have now 6 tests:
1. cursor on the image inside a link, out of text area, should be &quot;Hand&quot;.
2. cursor on the image, with custom cursor, out of text area, should custom cursor.
3. cursor on the image, with user-select-none, inside a link, should be &quot;Hand&quot;.
4. cursor on text area of overlay from image [1] should be &quot;IBeam&quot; (hinting selection).
5. cursor on text area of overlay from image [2] should be &quot;IBeam&quot; (hinting selection).
6. cursor on text area of overlay from image [3] should be Default (in our code called Pointer),
since [3] has user-select-none.

* Source/WebCore/html/shadow/imageOverlay.css:
(div#image-overlay):
Adding cursor:auto to div#image-overlay so we can hint text selection with IBeam cursor.

Canonical link: <a href="https://commits.webkit.org/253823@main">https://commits.webkit.org/253823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/889ca708121d963c92d55754dfff385b7625c2c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17965 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/96219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149698 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29575 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25830 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79251 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91143 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23883 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73937 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23819 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66831 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27302 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12962 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27247 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13976 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2696 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36830 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33253 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->