### PR TITLE
[AppSSO] Adjust life cycle of SOAuthorization to avoid premature cancellation

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,7 +50,7 @@ public:
 protected:
     using Callback = CompletionHandler<void(bool)>;
 
-    NavigationSOAuthorizationSession(SOAuthorization *, Ref<API::NavigationAction>&&, WebPageProxy&, InitiatingAction, Callback&&);
+    NavigationSOAuthorizationSession(Ref<API::NavigationAction>&&, WebPageProxy&, InitiatingAction, Callback&&);
 
     void invokeCallback(bool intercepted) { m_callback(intercepted); }
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,8 +35,8 @@
 
 namespace WebKit {
 
-NavigationSOAuthorizationSession::NavigationSOAuthorizationSession(SOAuthorization *soAuthorization, Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, InitiatingAction action, Callback&& completionHandler)
-    : SOAuthorizationSession(soAuthorization, WTFMove(navigationAction), page, action)
+NavigationSOAuthorizationSession::NavigationSOAuthorizationSession(Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, InitiatingAction action, Callback&& completionHandler)
+    : SOAuthorizationSession(WTFMove(navigationAction), page, action)
     , m_callback(WTFMove(completionHandler))
 {
 }

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,13 +45,13 @@ public:
     using NewPageCallback = CompletionHandler<void(RefPtr<WebPageProxy>&&)>;
     using UIClientCallback = Function<void(Ref<API::NavigationAction>&&, NewPageCallback&&)>;
 
-    static Ref<SOAuthorizationSession> create(SOAuthorization *soAuthorization, WebPageProxy& page, Ref<API::NavigationAction>&& navigationAction, NewPageCallback&& newPageCallback, UIClientCallback&& uiClientCallback);
+    static Ref<SOAuthorizationSession> create(WebPageProxy&, Ref<API::NavigationAction>&&, NewPageCallback&&, UIClientCallback&&);
     ~PopUpSOAuthorizationSession();
 
     void close(WKWebView *);
 
 private:
-    PopUpSOAuthorizationSession(SOAuthorization *, WebPageProxy&, Ref<API::NavigationAction>&&, NewPageCallback&&, UIClientCallback&&);
+    PopUpSOAuthorizationSession(WebPageProxy&, Ref<API::NavigationAction>&&, NewPageCallback&&, UIClientCallback&&);
 
     void shouldStartInternal() final;
     void fallBackToWebPathInternal() final;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -94,13 +94,13 @@
 
 namespace WebKit {
 
-Ref<SOAuthorizationSession> PopUpSOAuthorizationSession::create(SOAuthorization *soAuthorization, WebPageProxy& page, Ref<API::NavigationAction>&& navigationAction, NewPageCallback&& newPageCallback, UIClientCallback&& uiClientCallback)
+Ref<SOAuthorizationSession> PopUpSOAuthorizationSession::create(WebPageProxy& page, Ref<API::NavigationAction>&& navigationAction, NewPageCallback&& newPageCallback, UIClientCallback&& uiClientCallback)
 {
-    return adoptRef(*new PopUpSOAuthorizationSession(soAuthorization, page, WTFMove(navigationAction), WTFMove(newPageCallback), WTFMove(uiClientCallback)));
+    return adoptRef(*new PopUpSOAuthorizationSession(page, WTFMove(navigationAction), WTFMove(newPageCallback), WTFMove(uiClientCallback)));
 }
 
-PopUpSOAuthorizationSession::PopUpSOAuthorizationSession(SOAuthorization *soAuthorization, WebPageProxy& page, Ref<API::NavigationAction>&& navigationAction, NewPageCallback&& newPageCallback, UIClientCallback&& uiClientCallback)
-    : SOAuthorizationSession(soAuthorization, WTFMove(navigationAction), page, InitiatingAction::PopUp)
+PopUpSOAuthorizationSession::PopUpSOAuthorizationSession(WebPageProxy& page, Ref<API::NavigationAction>&& navigationAction, NewPageCallback&& newPageCallback, UIClientCallback&& uiClientCallback)
+    : SOAuthorizationSession(WTFMove(navigationAction), page, InitiatingAction::PopUp)
     , m_newPageCallback(WTFMove(newPageCallback))
     , m_uiClientCallback(WTFMove(uiClientCallback))
 {

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,10 +35,10 @@ class RedirectSOAuthorizationSession final : public NavigationSOAuthorizationSes
 public:
     using Callback = CompletionHandler<void(bool)>;
 
-    static Ref<SOAuthorizationSession> create(SOAuthorization *soAuthorization, Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Callback&& completionHandler);
+    static Ref<SOAuthorizationSession> create(Ref<API::NavigationAction>&&, WebPageProxy&, Callback&& completionHandler);
 
 private:
-    RedirectSOAuthorizationSession(SOAuthorization *, Ref<API::NavigationAction>&&, WebPageProxy&, Callback&&);
+    RedirectSOAuthorizationSession(Ref<API::NavigationAction>&&, WebPageProxy&, Callback&&);
 
     // SOAuthorizationSession
     void fallBackToWebPathInternal() final;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,13 +38,13 @@
 namespace WebKit {
 using namespace WebCore;
 
-Ref<SOAuthorizationSession> RedirectSOAuthorizationSession::create(SOAuthorization *soAuthorization, Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Callback&& completionHandler)
+Ref<SOAuthorizationSession> RedirectSOAuthorizationSession::create(Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Callback&& completionHandler)
 {
-    return adoptRef(*new RedirectSOAuthorizationSession(soAuthorization, WTFMove(navigationAction), page, WTFMove(completionHandler)));
+    return adoptRef(*new RedirectSOAuthorizationSession(WTFMove(navigationAction), page, WTFMove(completionHandler)));
 }
 
-RedirectSOAuthorizationSession::RedirectSOAuthorizationSession(SOAuthorization *soAuthorization, Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Callback&& completionHandler)
-    : NavigationSOAuthorizationSession(soAuthorization, WTFMove(navigationAction), page, InitiatingAction::Redirect, WTFMove(completionHandler))
+RedirectSOAuthorizationSession::RedirectSOAuthorizationSession(Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Callback&& completionHandler)
+    : NavigationSOAuthorizationSession(WTFMove(navigationAction), page, InitiatingAction::Redirect, WTFMove(completionHandler))
 {
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,7 +55,6 @@ SOAuthorizationCoordinator::SOAuthorizationCoordinator()
 #endif
     m_soAuthorization = adoptNS([PAL::allocSOAuthorizationInstance() init]);
     m_soAuthorizationDelegate = adoptNS([[WKSOAuthorizationDelegate alloc] init]);
-    m_soAuthorization.get().delegate = m_soAuthorizationDelegate.get();
     [NSURLSession _disableAppSSO];
 }
 
@@ -82,7 +81,7 @@ void SOAuthorizationCoordinator::tryAuthorize(Ref<API::NavigationAction>&& navig
         return;
     }
 
-    auto session = subframeNavigation ? SubFrameSOAuthorizationSession::create(m_soAuthorization.get(), WTFMove(navigationAction), page, WTFMove(completionHandler), targetFrame->handle()->frameID()) : RedirectSOAuthorizationSession::create(m_soAuthorization.get(), WTFMove(navigationAction), page, WTFMove(completionHandler));
+    auto session = subframeNavigation ? SubFrameSOAuthorizationSession::create(WTFMove(navigationAction), page, WTFMove(completionHandler), targetFrame->handle()->frameID()) : RedirectSOAuthorizationSession::create(WTFMove(navigationAction), page, WTFMove(completionHandler));
     [m_soAuthorizationDelegate setSession:WTFMove(session)];
 }
 
@@ -108,12 +107,13 @@ void SOAuthorizationCoordinator::tryAuthorize(Ref<API::NavigationAction>&& navig
         return;
     }
 
-    auto session = PopUpSOAuthorizationSession::create(m_soAuthorization.get(), page, WTFMove(navigationAction), WTFMove(newPageCallback), WTFMove(uiClientCallback));
+    auto session = PopUpSOAuthorizationSession::create(page, WTFMove(navigationAction), WTFMove(newPageCallback), WTFMove(uiClientCallback));
     [m_soAuthorizationDelegate setSession:WTFMove(session)];
 }
 
 } // namespace WebKit
 
+#undef AUTHORIZATIONCOORDINATOR_RELEASE_LOG_ERROR
 #undef AUTHORIZATIONCOORDINATOR_RELEASE_LOG
 
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +35,7 @@
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS SOAuthorization;
+OBJC_CLASS WKSOAuthorizationDelegate;
 
 namespace API {
 class NavigationAction;
@@ -63,6 +64,8 @@ public:
 
     virtual ~SOAuthorizationSession();
 
+    void setSOAuthorizationDelegate(WKSOAuthorizationDelegate *);
+
     // Probably not start immediately.
     void shouldStart();
 
@@ -87,7 +90,7 @@ protected:
         Completed
     };
 
-    SOAuthorizationSession(SOAuthorization *, Ref<API::NavigationAction>&&, WebPageProxy&, InitiatingAction);
+    SOAuthorizationSession(Ref<API::NavigationAction>&&, WebPageProxy&, InitiatingAction);
 
     void start();
     WebPageProxy* page() const { return m_page.get(); }
@@ -113,7 +116,7 @@ private:
     void continueStartAfterDecidePolicy(const SOAuthorizationLoadPolicy&);
 
     State m_state  { State::Idle };
-    WeakObjCPtr<SOAuthorization *> m_soAuthorization;
+    RetainPtr<SOAuthorization> m_soAuthorization;
     RefPtr<API::NavigationAction> m_navigationAction;
     WeakPtr<WebPageProxy> m_page;
     InitiatingAction m_action;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,7 +34,8 @@
 #import "APIUIClient.h"
 #import "Logging.h"
 #import "SOAuthorizationLoadPolicy.h"
-#import <WebKit/WKUIDelegatePrivate.h>
+#import "WKSOAuthorizationDelegate.h"
+#import "WKUIDelegatePrivate.h"
 #import "WKWebViewInternal.h"
 #import "WebPageProxy.h"
 #import "WebsiteDataStore.h"
@@ -86,8 +87,8 @@ static bool isSameOrigin(const WebCore::ResourceRequest& request, const WebCore:
 
 } // namespace
 
-SOAuthorizationSession::SOAuthorizationSession(SOAuthorization *soAuthorization, Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, InitiatingAction action)
-    : m_soAuthorization(soAuthorization)
+SOAuthorizationSession::SOAuthorizationSession(Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, InitiatingAction action)
+    : m_soAuthorization(adoptNS([PAL::allocSOAuthorizationInstance() init]))
     , m_navigationAction(WTFMove(navigationAction))
     , m_page(page)
     , m_action(action)
@@ -107,6 +108,11 @@ SOAuthorizationSession::~SOAuthorizationSession()
         becomeCompleted();
     else
         dismissViewController();
+}
+
+void SOAuthorizationSession::setSOAuthorizationDelegate(WKSOAuthorizationDelegate *delegate)
+{
+    [m_soAuthorization setDelegate:delegate];
 }
 
 const char* SOAuthorizationSession::initiatingActionString() const

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,14 +41,14 @@ public:
     using SOAuthorizationSession::weakPtrFactory;
     using WeakValueType = SOAuthorizationSession::WeakValueType;
 
-    static Ref<SOAuthorizationSession> create(SOAuthorization *, Ref<API::NavigationAction>&&, WebPageProxy&, Callback&&, WebCore::FrameIdentifier);
+    static Ref<SOAuthorizationSession> create(Ref<API::NavigationAction>&&, WebPageProxy&, Callback&&, WebCore::FrameIdentifier);
 
     ~SubFrameSOAuthorizationSession();
 
 private:
     using Supplement = std::variant<Vector<uint8_t>, String>;
 
-    SubFrameSOAuthorizationSession(SOAuthorization *, Ref<API::NavigationAction>&&, WebPageProxy&, Callback&&, WebCore::FrameIdentifier);
+    SubFrameSOAuthorizationSession(Ref<API::NavigationAction>&&, WebPageProxy&, Callback&&, WebCore::FrameIdentifier);
 
     // SOAuthorizationSession
     void fallBackToWebPathInternal() final;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,13 +47,13 @@ const char* soAuthorizationPostDidCancelMessageToParent = "<script>parent.postMe
 
 } // namespace
 
-Ref<SOAuthorizationSession> SubFrameSOAuthorizationSession::create(SOAuthorization *soAuthorization, Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Callback&& completionHandler, FrameIdentifier frameID)
+Ref<SOAuthorizationSession> SubFrameSOAuthorizationSession::create(Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Callback&& completionHandler, FrameIdentifier frameID)
 {
-    return adoptRef(*new SubFrameSOAuthorizationSession(soAuthorization, WTFMove(navigationAction), page, WTFMove(completionHandler), frameID));
+    return adoptRef(*new SubFrameSOAuthorizationSession(WTFMove(navigationAction), page, WTFMove(completionHandler), frameID));
 }
 
-SubFrameSOAuthorizationSession::SubFrameSOAuthorizationSession(SOAuthorization *soAuthorization, Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Callback&& completionHandler, FrameIdentifier frameID)
-    : NavigationSOAuthorizationSession(soAuthorization, WTFMove(navigationAction), page, InitiatingAction::SubFrame, WTFMove(completionHandler))
+SubFrameSOAuthorizationSession::SubFrameSOAuthorizationSession(Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Callback&& completionHandler, FrameIdentifier frameID)
+    : NavigationSOAuthorizationSession(WTFMove(navigationAction), page, InitiatingAction::SubFrame, WTFMove(completionHandler))
     , m_frameID(frameID)
 {
     if (auto* frame = page.process().webFrame(m_frameID))

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -144,9 +144,18 @@
 {
     RELEASE_ASSERT(RunLoop::isMain());
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("setSession: (existing session = %p, new session = %p)", _session.get(), session.get());
-    _session = WTFMove(session);
+    if (_session.get() == session.get())
+        return;
+
     if (_session)
+        _session->setSOAuthorizationDelegate(nil);
+
+    _session = WTFMove(session);
+
+    if (_session) {
+        _session->setSOAuthorizationDelegate(self);
         _session->shouldStart();
+    }
 }
 @end
 


### PR DESCRIPTION
#### bc90c50c6ba84974bbc861bcbb406bbcd35e845f
<pre>
[AppSSO] Adjust life cycle of SOAuthorization to avoid premature cancellation
<a href="https://bugs.webkit.org/show_bug.cgi?id=244364">https://bugs.webkit.org/show_bug.cgi?id=244364</a>
&lt;rdar://98413693&gt;

Reviewed by J Pascoe.

This patch modifies the SOAuthorizationSession logic to own the underlying SOAuthorization
Cocoa object. This simplifies the life cycle of the object, and helps clarify which
object is associated with a given load.

Originally we had thought that letting the SOAuthorizationController hold the SOAuthorization
would allow it to be reused in some cases, but in practice no such feature was needed, and
there is little performance gain from retaining a single object for a set of navigations.

Tested by existing SOAuthorization API tests.

* Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm:
(WebKit::NavigationSOAuthorizationSession::NavigationSOAuthorizationSession):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm:
(WebKit::PopUpSOAuthorizationSession::create):
(WebKit::PopUpSOAuthorizationSession::PopUpSOAuthorizationSession):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm:
(WebKit::RedirectSOAuthorizationSession::create):
(WebKit::RedirectSOAuthorizationSession::RedirectSOAuthorizationSession):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm:
(WebKit::SOAuthorizationCoordinator::SOAuthorizationCoordinator):
(WebKit::SOAuthorizationCoordinator::tryAuthorize):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::SOAuthorizationSession):
(WebKit::SOAuthorizationSession::setSOAuthorizationDelegate):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm:
(WebKit::SubFrameSOAuthorizationSession::create):
(WebKit::SubFrameSOAuthorizationSession::SubFrameSOAuthorizationSession):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm:
(-[WKSOAuthorizationDelegate setSession:]):

Canonical link: <a href="https://commits.webkit.org/253929@main">https://commits.webkit.org/253929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c55c4361a204ad331e7f80ecc4cb10611d5fef3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96231 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29652 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25882 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79317 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91213 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23955 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74006 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23844 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79176 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66858 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27377 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13013 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27324 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14028 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2761 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29009 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36884 "Found 2 new test failures: http/wpt/crypto/aes-ctr-crash.any.worker.html, http/wpt/crypto/rsa-oaep-crash.any.worker.html") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33305 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->