### PR TITLE
Remove requestAnimationFrame from scroll snap tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-margin-visibility-check-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-margin-visibility-check-expected.txt
@@ -1,3 +1,3 @@
 
-PASS scroll-margin-visibility-check
+FAIL scroll-margin-visibility-check assert_true: Visibility check should not account for margin expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-margin-visibility-check.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-margin-visibility-check.html
@@ -35,9 +35,7 @@ let target = document.getElementById("target");
 test(t => {
   scroller.scrollTo(0, 0);
   target.focus();
-  window.requestAnimationFrame(t.step_func_done(() => {
-    assert_true(scroller.scrollTop > 0, "Visibility check should not account for margin");
-    assert_true(scroller.scrollLeft > 0, "Visibility check should not account for margin");
-  }));
+  assert_true(scroller.scrollTop > 0, "Visibility check should not account for margin");
+  assert_true(scroller.scrollLeft > 0, "Visibility check should not account for margin");
 });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/resnap-to-focused-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/resnap-to-focused-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Resnap to focused element after relayout
+FAIL Resnap to focused element after relayout assert_equals: After resize, should snap to row 4. expected 4 but got 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/resnap-to-focused.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/resnap-to-focused.html
@@ -71,15 +71,11 @@ function testSnap(t, child, expectedRow) {
         unsnappable.focus();
         container.style.width = "200px";
         var startingRow = container.scrollTop/100 + 1;
-        window.requestAnimationFrame(t.step_func_done(() => {
-            assert_equals(startingRow, 2, "Initially snapped to row 2");
-        }));
+        assert_equals(startingRow, 2, "Initially snapped to row 2");
         child.focus();
         container.style.width = "100px";
         var endingRow = container.scrollTop/100 + 1;
-        window.requestAnimationFrame(t.step_func_done(() => {
-            assert_equals(endingRow, expectedRow, `After resize, should snap to row ${expectedRow}.`);
-        }));
+        assert_equals(endingRow, expectedRow, `After resize, should snap to row ${expectedRow}.`);
     });
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/snap-to-different-targets-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/snap-to-different-targets-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Scroller should snap to at least one of the targets if unable to snap toboth after a layout change.
+FAIL Scroller should snap to at least one of the targets if unable to snap toboth after a layout change. assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/snap-to-different-targets.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/snap-to-different-targets.html
@@ -84,11 +84,9 @@ test(t => {
   // The style change makes it impossible for the scroller to snap to both
   // targets, but at least one of the targets should be preserved. The scroller
   // should then re-evaluate the snap point for the other axis.
-  window.requestAnimationFrame(t.step_func_done(() => {
-    const snapped_to_x = scroller.scrollLeft == 1000 && scroller.scrollTop == 300;
-    const snapped_to_y = scroller.scrollTop == 1000 && scroller.scrollLeft == 300;
-    assert_true(snapped_to_x || snapped_to_y);
-  }));
+  const snapped_to_x = scroller.scrollLeft == 1000 && scroller.scrollTop == 300;
+  const snapped_to_y = scroller.scrollTop == 1000 && scroller.scrollLeft == 300;
+  assert_true(snapped_to_x || snapped_to_y);
 }, "Scroller should snap to at least one of the targets if unable to snap to\
 both after a layout change.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-on-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-on-focus-expected.txt
@@ -1,3 +1,3 @@
 
-PASS scroll snap should happens on Element.focus()
+FAIL scroll snap should happens on Element.focus() assert_equals: expected 1200 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-on-focus.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-on-focus.html
@@ -47,11 +47,9 @@ div {
 </div>
 
 <script>
-test(t => {
+test(() => {
   document.querySelector(".no-snap").focus();
-  window.requestAnimationFrame(t.step_func_done(() => {
-      assert_equals(scroller.scrollTop, 1200);
-  }));
+  assert_equals(scroller.scrollTop, 1200);
 }, "scroll snap should happens on Element.focus()");
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-visible-areas-both-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-visible-areas-both-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Only snap to visible areas in the case where taking the closest snap point of   each axis does not snap to a visible area
+FAIL Only snap to visible areas in the case where taking the closest snap point of   each axis does not snap to a visible area assert_equals: expected 800 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-visible-areas-both.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-visible-areas-both.html
@@ -57,20 +57,14 @@ div {
 test(t => {
   const scroller = document.getElementById("scroller");
   scroller.scrollTo(0, 0);
-  window.requestAnimationFrame(t.step_func_done(() => {
-    assert_equals(scroller.scrollLeft, 0);
-    assert_equals(scroller.scrollTop, 0);
-  }));
+  assert_equals(scroller.scrollLeft, 0);
+  assert_equals(scroller.scrollTop, 0);
   scroller.scrollTo(500, 600);
-  window.requestAnimationFrame(t.step_func_done(() => {
-    assert_equals(scroller.scrollLeft, 0);
-    assert_equals(scroller.scrollTop, 800);
-  }));
+  assert_equals(scroller.scrollLeft, 0);
+  assert_equals(scroller.scrollTop, 800);
   scroller.scrollTo(600, 500);
-  window.requestAnimationFrame(t.step_func_done(() => {
-    assert_equals(scroller.scrollLeft, 800);
-    assert_equals(scroller.scrollTop, 0);
-  }));
+  assert_equals(scroller.scrollLeft, 800);
+  assert_equals(scroller.scrollTop, 0);
 }, 'Only snap to visible areas in the case where taking the closest snap point of \
   each axis does not snap to a visible area');
 </script>


### PR DESCRIPTION
#### 89903febc2f9e04ab0d170d0ee945351331ed43e
<pre>
Remove requestAnimationFrame from scroll snap tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=244371">https://bugs.webkit.org/show_bug.cgi?id=244371</a>

Reviewed by Tim Nguyen.

This function wasn&apos;t getting a callback, which caused the asserts not to run, so it looked like the tests passed.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-margin-visibility-check-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-margin-visibility-check.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/resnap-to-focused-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/resnap-to-focused.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/snap-to-different-targets-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/snap-to-different-targets.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-on-focus-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-on-focus.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-visible-areas-both-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-visible-areas-both.html:

Canonical link: <a href="https://commits.webkit.org/253853@main">https://commits.webkit.org/253853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c73a9ee3c6d914f1db50db0f084ba9b9af2098a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96129 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149706 "Found 1 new test failure: js/dom/Promise-reject-large-string.html") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29584 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25836 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79259 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91149 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23893 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73946 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23823 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66835 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27309 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12970 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27256 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13984 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2714 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36838 "Passed tests") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/75/builds/1093 "The change is no longer eligible for processing.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33261 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->