### PR TITLE
PositionIterator should use RefPtr instead of raw pointers

### DIFF
--- a/Source/WebCore/dom/PositionIterator.cpp
+++ b/Source/WebCore/dom/PositionIterator.cpp
@@ -46,14 +46,14 @@ PositionIterator::operator Position() const
         ASSERT(m_nodeAfterPositionInAnchor->parentNode() == m_anchorNode);
         // FIXME: This check is inadaquete because any ancestor could be ignored by editing
         if (positionBeforeOrAfterNodeIsCandidate(*m_anchorNode))
-            return positionBeforeNode(m_anchorNode);
-        return positionInParentBeforeNode(m_nodeAfterPositionInAnchor);
+            return positionBeforeNode(m_anchorNode.get());
+        return positionInParentBeforeNode(m_nodeAfterPositionInAnchor.get());
     }
     if (positionBeforeOrAfterNodeIsCandidate(*m_anchorNode))
-        return atStartOfNode() ? positionBeforeNode(m_anchorNode) : positionAfterNode(m_anchorNode);
+        return atStartOfNode() ? positionBeforeNode(m_anchorNode.get()) : positionAfterNode(m_anchorNode.get());
     if (m_anchorNode->hasChildNodes())
-        return lastPositionInOrAfterNode(m_anchorNode);
-    return makeDeprecatedLegacyPosition(m_anchorNode, m_offsetInAnchor);
+        return lastPositionInOrAfterNode(m_anchorNode.get());
+    return makeDeprecatedLegacyPosition(m_anchorNode.get(), m_offsetInAnchor);
 }
 
 void PositionIterator::increment()
@@ -69,7 +69,7 @@ void PositionIterator::increment()
     }
 
     if (m_anchorNode->renderer() && !m_anchorNode->hasChildNodes() && m_offsetInAnchor < lastOffsetForEditing(*m_anchorNode))
-        m_offsetInAnchor = Position::uncheckedNextOffset(m_anchorNode, m_offsetInAnchor);
+        m_offsetInAnchor = Position::uncheckedNextOffset(m_anchorNode.get(), m_offsetInAnchor);
     else {
         m_nodeAfterPositionInAnchor = m_anchorNode;
         m_anchorNode = m_nodeAfterPositionInAnchor->parentNode();
@@ -101,7 +101,7 @@ void PositionIterator::decrement()
         m_offsetInAnchor = m_anchorNode->hasChildNodes()? 0: lastOffsetForEditing(*m_anchorNode);
     } else {
         if (m_offsetInAnchor && m_anchorNode->renderer())
-            m_offsetInAnchor = Position::uncheckedPreviousOffset(m_anchorNode, m_offsetInAnchor);
+            m_offsetInAnchor = Position::uncheckedPreviousOffset(m_anchorNode.get(), m_offsetInAnchor);
         else {
             m_nodeAfterPositionInAnchor = m_anchorNode;
             m_anchorNode = m_anchorNode->parentNode();
@@ -162,7 +162,7 @@ bool PositionIterator::isCandidate() const
         return Position(*this).isCandidate();
 
     if (is<RenderText>(*renderer))
-        return !Position::nodeIsUserSelectNone(m_anchorNode) && downcast<RenderText>(*renderer).containsCaretOffset(m_offsetInAnchor);
+        return !Position::nodeIsUserSelectNone(m_anchorNode.get()) && downcast<RenderText>(*renderer).containsCaretOffset(m_offsetInAnchor);
 
     if (positionBeforeOrAfterNodeIsCandidate(*m_anchorNode))
         return (atStartOfNode() || atEndOfNode()) && !Position::nodeIsUserSelectNone(m_anchorNode->parentNode());
@@ -174,13 +174,13 @@ bool PositionIterator::isCandidate() const
         auto& block = downcast<RenderBlock>(*renderer);
         if (block.logicalHeight() || is<HTMLBodyElement>(*m_anchorNode) || m_anchorNode->isRootEditableElement()) {
             if (!Position::hasRenderedNonAnonymousDescendantsWithHeight(block))
-                return atStartOfNode() && !Position::nodeIsUserSelectNone(m_anchorNode);
-            return m_anchorNode->hasEditableStyle() && !Position::nodeIsUserSelectNone(m_anchorNode) && Position(*this).atEditingBoundary();
+                return atStartOfNode() && !Position::nodeIsUserSelectNone(m_anchorNode.get());
+            return m_anchorNode->hasEditableStyle() && !Position::nodeIsUserSelectNone(m_anchorNode.get()) && Position(*this).atEditingBoundary();
         }
         return false;
     }
 
-    return m_anchorNode->hasEditableStyle() && !Position::nodeIsUserSelectNone(m_anchorNode) && Position(*this).atEditingBoundary();
+    return m_anchorNode->hasEditableStyle() && !Position::nodeIsUserSelectNone(m_anchorNode.get()) && Position(*this).atEditingBoundary();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PositionIterator.h
+++ b/Source/WebCore/dom/PositionIterator.h
@@ -46,7 +46,7 @@ public:
     void increment();
     void decrement();
 
-    Node* node() const { return m_anchorNode; }
+    Node* node() const { return m_anchorNode.get(); }
     int offsetInLeafNode() const { return m_offsetInAnchor; }
 
     bool atStart() const;
@@ -56,8 +56,8 @@ public:
     bool isCandidate() const;
 
 private:
-    Node* m_anchorNode { nullptr };
-    Node* m_nodeAfterPositionInAnchor { nullptr }; // If this is non-null, m_nodeAfterPositionInAnchor->parentNode() == m_anchorNode;
+    RefPtr<Node> m_anchorNode;
+    RefPtr<Node> m_nodeAfterPositionInAnchor; // If this is non-null, m_nodeAfterPositionInAnchor->parentNode() == m_anchorNode;
     int m_offsetInAnchor { 0 };
 };
 


### PR DESCRIPTION
#### b8a2a40618658cbcf941c40f31e11fd0ac690ea3
<pre>
PositionIterator should use RefPtr instead of raw pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=244376">https://bugs.webkit.org/show_bug.cgi?id=244376</a>

Reviewed by Chris Dumez.

* Source/WebCore/dom/PositionIterator.cpp:
(WebCore::PositionIterator::operator Position const):
(WebCore::PositionIterator::increment):
(WebCore::PositionIterator::decrement):
(WebCore::PositionIterator::isCandidate const):
* Source/WebCore/dom/PositionIterator.h:
(WebCore::PositionIterator::node const):

Canonical link: <a href="https://commits.webkit.org/253829@main">https://commits.webkit.org/253829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95ce61cd16d669742ed0935e9d289a85f93dbeea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96161 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149728 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29606 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25850 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79277 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91169 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23912 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73964 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/23828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78895 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79142 "Found 1 new API test failure: TestWebKitAPI.WKInspectorExtension.CanEvaluateScriptInExtensionTab") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/66841 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27331 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12978 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27278 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13992 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36852 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1084 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33269 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->