### PR TITLE
NamedSlotAssignment should use WeakHashSet

### DIFF
--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -108,7 +108,7 @@ inline bool NamedSlotAssignment::hasAssignedNodes(ShadowRoot& shadowRoot, Slot& 
 
 void NamedSlotAssignment::renameSlotElement(HTMLSlotElement& slotElement, const AtomString& oldName, const AtomString& newName, ShadowRoot& shadowRoot)
 {
-    ASSERT(m_slotElementsForConsistencyCheck.contains(&slotElement));
+    ASSERT(m_slotElementsForConsistencyCheck.contains(slotElement));
 
     m_slotMutationVersion++;
 
@@ -119,8 +119,8 @@ void NamedSlotAssignment::renameSlotElement(HTMLSlotElement& slotElement, const 
 void NamedSlotAssignment::addSlotElementByName(const AtomString& name, HTMLSlotElement& slotElement, ShadowRoot& shadowRoot)
 {
 #if ASSERT_ENABLED
-    ASSERT(!m_slotElementsForConsistencyCheck.contains(&slotElement));
-    m_slotElementsForConsistencyCheck.add(&slotElement);
+    ASSERT(!m_slotElementsForConsistencyCheck.contains(slotElement));
+    m_slotElementsForConsistencyCheck.add(slotElement);
 #endif
 
     // FIXME: We should be able to do a targeted reconstruction.
@@ -154,8 +154,8 @@ void NamedSlotAssignment::addSlotElementByName(const AtomString& name, HTMLSlotE
 void NamedSlotAssignment::removeSlotElementByName(const AtomString& name, HTMLSlotElement& slotElement, ContainerNode* oldParentOfRemovedTreeForRemoval, ShadowRoot& shadowRoot)
 {
 #if ASSERT_ENABLED
-    ASSERT(m_slotElementsForConsistencyCheck.contains(&slotElement));
-    m_slotElementsForConsistencyCheck.remove(&slotElement);
+    ASSERT(m_slotElementsForConsistencyCheck.contains(slotElement));
+    m_slotElementsForConsistencyCheck.remove(slotElement);
 #endif
 
     ASSERT(m_slotElementCount > 0);
@@ -380,7 +380,7 @@ const AtomString& NamedSlotAssignment::slotNameForHostChild(const Node& child) c
 
 HTMLSlotElement* NamedSlotAssignment::findFirstSlotElement(Slot& slot)
 {
-    ASSERT(!slot.element || m_slotElementsForConsistencyCheck.contains(slot.element.get()));
+    ASSERT(!slot.element || m_slotElementsForConsistencyCheck.contains(*slot.element));
 
     return slot.element.get();
 }

--- a/Source/WebCore/dom/SlotAssignment.h
+++ b/Source/WebCore/dom/SlotAssignment.h
@@ -136,7 +136,7 @@ private:
     HashMap<AtomString, std::unique_ptr<Slot>> m_slots;
 
 #if ASSERT_ENABLED
-    HashSet<HTMLSlotElement*> m_slotElementsForConsistencyCheck;
+    WeakHashSet<HTMLSlotElement> m_slotElementsForConsistencyCheck;
 #endif
 };
 


### PR DESCRIPTION
#### 695f95058b0e32564c8a3255b282cf48350771c6
<pre>
NamedSlotAssignment should use WeakHashSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=244377">https://bugs.webkit.org/show_bug.cgi?id=244377</a>

Reviewed by Chris Dumez.

Use WeakHashSet&lt;HTMLSlotElement&gt; instead of HashSet&lt;HTMLSlotElement*&gt;.

* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::NamedSlotAssignment::renameSlotElement):
(WebCore::NamedSlotAssignment::addSlotElementByName):
(WebCore::NamedSlotAssignment::removeSlotElementByName):
(WebCore::NamedSlotAssignment::findFirstSlotElement):
* Source/WebCore/dom/SlotAssignment.h:

Canonical link: <a href="https://commits.webkit.org/253830@main">https://commits.webkit.org/253830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4e25039fe46dc4da3593a846ffb9395b9006a79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96165 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149730 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29608 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79279 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91171 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23914 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73966 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/23829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79145 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/66842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27333 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12981 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27280 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13995 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36853 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1085 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28904 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33272 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->