### PR TITLE
Non-unified build fixes, late August 2022 edition

### DIFF
--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
@@ -30,6 +30,7 @@
 
 #include "EllipsisBoxPainter.h"
 #include "InlineBoxPainter.h"
+#include "LayoutIntegrationBoxTree.h"
 #include "PaintInfo.h"
 #include "RenderBox.h"
 #include "RenderInline.h"

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
@@ -27,11 +27,28 @@
 
 #if ENABLE(LAYOUT_FORMATTING_CONTEXT)
 
+#include "LayoutPoint.h"
+
 namespace WebCore {
+
+class RenderBox;
+class RenderInline;
 
 struct PaintInfo;
 
+namespace InlineDisplay {
+struct Box;
+};
+
+namespace Layout {
+class ContainerBox;
+};
+
 namespace LayoutIntegration {
+
+class BoxTree;
+
+struct InlineContent;
 
 class InlineContentPainter {
 public:

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLine.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLine.h
@@ -29,6 +29,8 @@
 
 #include "FloatRect.h"
 #include "LayoutBox.h"
+#include "TextRun.h"
+#include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
 namespace LayoutIntegration {

--- a/Source/WebCore/rendering/LegacyInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineBox.cpp
@@ -23,6 +23,7 @@
 #include "FontMetrics.h"
 #include "Frame.h"
 #include "HitTestResult.h"
+#include "LegacyEllipsisBox.h"
 #include "LegacyInlineFlowBox.h"
 #include "LegacyRootInlineBox.h"
 #include "RenderBlockFlow.h"

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNamedNodeMap.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNamedNodeMap.cpp
@@ -29,6 +29,7 @@
 #include <WebCore/CSSImportRule.h>
 #include <WebCore/DOMException.h>
 #include <WebCore/Document.h>
+#include <WebCore/Element.h>
 #include <WebCore/JSExecState.h>
 #include <wtf/GetPtr.h>
 #include <wtf/RefPtr.h>


### PR DESCRIPTION
#### 932ee6b97b6f68e42d98d9bae7c21d3a89496284
<pre>
Non-unified build fixes, late August 2022 edition

Unreviewed non-unified build fixes.

* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
  Add missing LayoutIntegrationBoxTree.h header inclusion.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h:
  Add missing LayoutPoint.h header inclusion, and forward declarations
  for WebCore::RenderBox, WebCore::RenderInline,
  WebCore::InlineDisplay::Box, WebCore::Layout::ContainerBox,
  WebCore::LayoutIntegration::BoxTree, and
  WebCore::LayoutIntegration::InlineContent.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLine.h:
  Add missing TextRun.h and wtf/unicode/CharacterNames.h header
  inclusions.
* Source/WebCore/rendering/LegacyInlineBox.cpp: Add missing
  LegacyEllipsisBox.h header inclusion.
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNamedNodeMap.cpp:
  Add missing WebCore/Element.h header inclusion.

Canonical link: <a href="https://commits.webkit.org/253841@main">https://commits.webkit.org/253841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8283243fd4056388fbba2fe5063f3c54fba911b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96183 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149743 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29621 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25860 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79290 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91183 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23924 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73977 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/23833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79154 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/66846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27346 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12990 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27293 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2703 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36861 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33281 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->