### PR TITLE
Order of actions for labeled control should be focus then click

### DIFF
--- a/LayoutTests/fast/forms/label/label-event-order-expected.txt
+++ b/LayoutTests/fast/forms/label/label-event-order-expected.txt
@@ -1,0 +1,12 @@
+Event order for a labeled control should be "focus" then "change"
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+"focus" event has been dispatched.
+PASS changeCount is 0
+"change" event has been dispatched.
+PASS focusCount is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/label/label-event-order.html
+++ b/LayoutTests/fast/forms/label/label-event-order.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<label><input type="checkbox">Label for a checkbox</label>
+<script>
+description('Event order for a labeled control should be "focus" then "change"');
+var label = document.querySelector('label');
+var checkbox = document.querySelector('input');
+var focusCount = 0;
+var changeCount = 0;
+
+checkbox.addEventListener('focus', function() {
+    debug('"focus" event has been dispatched.');
+    focusCount++;
+    shouldBe('changeCount', '0');
+    }, false);
+
+checkbox.addEventListener('change', function() {
+    debug('"change" event has been dispatched.');
+    changeCount++;
+    shouldBe('focusCount', '1');
+    }, false);
+
+label.click();
+label.remove();
+</script>
+</body>

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -153,11 +153,12 @@ void HTMLLabelElement::defaultEventHandler(Event& event)
 
         processingClick = true;
 
-        control->dispatchSimulatedClick(&event);
-
         document().updateLayoutIgnorePendingStylesheets();
         if (control->isMouseFocusable())
             control->focus({ { }, { }, { }, FocusTrigger::Click, { } });
+
+        // Click the corresponding control.
+        control->dispatchSimulatedClick(&event);
 
         processingClick = false;
 


### PR DESCRIPTION
<pre>
Order of actions for labeled control should be focus then click

<a href="https://bugs.webkit.org/show_bug.cgi?id=119372">https://bugs.webkit.org/show_bug.cgi?id=119372</a>

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/237028d603d5fe587ec282f6d2cf3b5a31c01902">https://chromium.googlesource.com/chromium/blink/+/237028d603d5fe587ec282f6d2cf3b5a31c01902</a>

Order of actions for labeled control should be focus then click.

When we click on a checkbox or a radio button, event order is:
 - mousedown
 - focus, triggered by mousedown
 - mouseup
 - change, triggered by the following click
 - click

That is to say, we focus on it first and then click it. Click on an
associated label should have same behavior.

It is align with behavior of Blink / Chromium and Gecko (Firefox).

* Source/WebCore/html/HTMLLabelElement.cpp:
(HTMLLabelElement::defaultEventHandler) - Move dispatchSimulatedClick after "updateLayourIgnorePendingStyleSheet".
* LayoutTests/fast/forms/label/label-event-order.html: Added new test
* LayoutTests/fast/forms/label/label-event-order-expected.txt: Added test expectations
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb2ac696860c26a5c00cbeb19515359b78950586

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96562 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149909 "Found 2 new test failures: fast/forms/label/label-becomes-visible-while-clicking-on-label.html, fast/forms/label/label-event-order.html") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29786 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25986 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91336 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92952 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24064 "Found 1 new test failure: fast/forms/label/label-event-order.html") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74127 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23909 "Found 2 new test failures: fast/forms/label/label-becomes-visible-while-clicking-on-label.html, fast/forms/label/label-event-order.html") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79259 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66925 "Found 1 new API test failure: /WebKit2Gtk/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27503 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13095 "Found 2 new test failures: fast/forms/label/label-becomes-visible-while-clicking-on-label.html, fast/forms/label/label-event-order.html") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27455 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14110 "Found 2 new test failures: fast/forms/label/label-becomes-visible-while-clicking-on-label.html, fast/forms/label/label-event-order.html") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29141 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36972 "Found 2 new test failures: fast/forms/label/label-becomes-visible-while-clicking-on-label.html, fast/forms/label/label-event-order.html") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33387 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->