### PR TITLE
Flaky assertion hit under ScriptExecutionContext::dispatchMessagePortEvents()

### DIFF
--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -195,6 +195,7 @@ ScriptExecutionContext::~ScriptExecutionContext()
 
 void ScriptExecutionContext::processMessageWithMessagePortsSoon()
 {
+    ASSERT(isContextThread());
     if (m_willprocessMessageWithMessagePortsSoon)
         return;
 
@@ -206,6 +207,7 @@ void ScriptExecutionContext::processMessageWithMessagePortsSoon()
 
 void ScriptExecutionContext::dispatchMessagePortEvents()
 {
+    ASSERT(isContextThread());
     checkConsistency();
 
     Ref<ScriptExecutionContext> protectedThis(*this);


### PR DESCRIPTION
#### b91baa17acd7a77ed8e6253b19ecd3ff30d9eb2e
<pre>
Flaky assertion hit under ScriptExecutionContext::dispatchMessagePortEvents()
<a href="https://bugs.webkit.org/show_bug.cgi?id=244396">https://bugs.webkit.org/show_bug.cgi?id=244396</a>
&lt;rdar://99188062&gt;

Reviewed by Ryosuke Niwa.

The issue was that ScriptExecutionContext::processMessageWithMessagePortsSoon()
was not called on the ScriptExecutionContext&apos;s context thread. This wasn&apos;t safe
since processMessageWithMessagePortsSoon() and dispatchMessagePortEvents() would
both use/modify m_willprocessMessageWithMessagePortsSoon from different threads,
without synchronization.

To address the issue, we now make sure that processMessageWithMessagePortsSoon()
gets called on the ScriptExecutionContext&apos;s context thread.

* Source/WebCore/dom/MessagePort.cpp:
(WebCore::portToContextIdentifier):
(WebCore::MessagePort::deref const):
(WebCore::MessagePort::notifyMessageAvailable):
(WebCore::MessagePort::MessagePort):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::processMessageWithMessagePortsSoon):
(WebCore::ScriptExecutionContext::dispatchMessagePortEvents):

Canonical link: <a href="https://commits.webkit.org/253850@main">https://commits.webkit.org/253850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0afdf4ffdfc8c43b9f6e565f80beacc612cd218f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18058 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/96324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149811 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29687 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91242 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92851 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74037 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78960 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27409 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27357 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14050 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2710 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29041 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/36908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33327 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->