### PR TITLE
TEST ADD (249952@main): [ macOS wk1 Debug ] workers/worker-web-lock-released-on-reload.html is a consistent crash

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -267,8 +267,6 @@ imported/w3c/web-platform-tests/IndexedDB/reading-autoincrement-store-cursors.an
 imported/w3c/web-platform-tests/IndexedDB/reading-autoincrement-store.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/IndexedDB/storage-buckets.https.any.sharedworker.html [ Skip ]
 
-webkit.org/b/244397 workers/worker-web-lock-released-on-reload.html [ Crash ]
-
 http/wpt/mediarecorder [ Skip ]
 imported/w3c/web-platform-tests/mediacapture-record [ Skip ]
 fast/history/page-cache-media-recorder.html [ Skip ]

--- a/LayoutTests/workers/worker-web-lock-released-on-reload.html
+++ b/LayoutTests/workers/worker-web-lock-released-on-reload.html
@@ -25,7 +25,9 @@ function lockAcquiredByWorker()
     }
 }
 
-popup = open("resources/worker-web-lock-released-on-reload-popup.html");
+onload = () => {
+    popup = open("resources/worker-web-lock-released-on-reload-popup.html");
+};
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### f167c5e2d604c1ed654d4a46bf96c44f7d7ab949
<pre>
TEST ADD (249952@main): [ macOS wk1 Debug ] workers/worker-web-lock-released-on-reload.html is a consistent crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=244397">https://bugs.webkit.org/show_bug.cgi?id=244397</a>
&lt;rdar://99195845&gt;

Reviewed by Sihui Liu.

DRT has an assertion that hit if you call window.open() before
testRunner-&gt;waitUntilDone() has been called. However, since the test uses
window.jsTestIsAsync, `testRunner-&gt;waitUntilDone()` gets called by js-test.js,
not explicitly by the test. To avoid the crash, we now call window.open()
from the load event, at which point we&apos;re certain that js-test.js has called
`testRunner-&gt;waitUntilDone()`.

* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/workers/worker-web-lock-released-on-reload.html:

Canonical link: <a href="https://commits.webkit.org/253844@main">https://commits.webkit.org/253844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d76b2dd2a2ad91159433d16cc4e69d1e6557bdb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96266 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149798 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29672 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91231 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92836 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74025 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79190 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27396 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13027 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27343 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/14042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2706 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29028 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/36898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33319 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->