### PR TITLE
REGRESSION (253234@main): [ macOS wk1 Debug ] js/dom/modules/missing-exception-check-for-import.html is a consistent crash

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1963,3 +1963,5 @@ webkit.org/b/244372 imported/w3c/web-platform-tests/intersection-observer/target
 webkit.org/b/244390 editing/selection/cleared-by-relayout.html [ Crash ]
 
 webkit.org/b/244395 [ Release X86_64 ] editing/execCommand/paste-as-quotation-disconnected-paragraph-ancestor-crash.html [ Skip ]
+
+webkit.org/b/244404 js/dom/modules/missing-exception-check-for-import.html [ Crash ]


### PR DESCRIPTION
#### 3912df658ad2096bb79bf5997f0d4b95e95fb94d
<pre>
REGRESSION (253234@main): [ macOS wk1 Debug ] js/dom/modules/missing-exception-check-for-import.html is a consistent crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=244404">https://bugs.webkit.org/show_bug.cgi?id=244404</a>
&lt;rdar://99198236&gt;

Reviewed by NOBODY (OOPS!).

Add missing exception checks.

* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::importModule):
</pre>