### PR TITLE
Removed dead support for relative length in table code

### DIFF
--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -53,12 +53,10 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTableSection);
 static const unsigned gMinTableSizeToUseFastPaintPathWithOverflowingCell = 75 * 75;
 static const float gMaxAllowedOverflowingCellRatioForFastPaintPath = 0.1f;
 
-static inline void setRowLogicalHeightToRowStyleLogicalHeightIfNotRelative(RenderTableSection::RowStruct& row)
+static inline void setRowLogicalHeightToRowStyleLogicalHeight(RenderTableSection::RowStruct& row)
 {
     ASSERT(row.rowRenderer);
     row.logicalHeight = row.rowRenderer->style().logicalHeight();
-    if (row.logicalHeight.isRelative())
-        row.logicalHeight = Length();
 }
 
 static inline void updateLogicalHeightForCell(RenderTableSection::RowStruct& row, const RenderTableCell* cell)
@@ -68,7 +66,7 @@ static inline void updateLogicalHeightForCell(RenderTableSection::RowStruct& row
         return;
 
     Length logicalHeight = cell->style().logicalHeight();
-    if (logicalHeight.isPositive() || (logicalHeight.isRelative() && logicalHeight.value() >= 0)) {
+    if (logicalHeight.isPositive()) {
         Length cRowLogicalHeight = row.logicalHeight;
         switch (logicalHeight.type()) {
         case LengthType::Percent:
@@ -80,7 +78,6 @@ static inline void updateLogicalHeightForCell(RenderTableSection::RowStruct& row
                 || (cRowLogicalHeight.isFixed() && cRowLogicalHeight.value() < logicalHeight.value()))
                 row.logicalHeight = logicalHeight;
             break;
-        case LengthType::Relative:
         default:
             break;
         }
@@ -136,7 +133,7 @@ void RenderTableSection::willInsertTableRow(RenderTableRow& child, RenderObject*
     child.setRowIndex(insertionRow);
 
     if (!beforeChild)
-        setRowLogicalHeightToRowStyleLogicalHeightIfNotRelative(m_grid[insertionRow]);
+        setRowLogicalHeightToRowStyleLogicalHeight(m_grid[insertionRow]);
 }
 
 void RenderTableSection::ensureRows(unsigned numRows)
@@ -1328,7 +1325,7 @@ void RenderTableSection::recalcCells()
 
         m_grid[insertionRow].rowRenderer = row;
         row->setRowIndex(insertionRow);
-        setRowLogicalHeightToRowStyleLogicalHeightIfNotRelative(m_grid[insertionRow]);
+        setRowLogicalHeightToRowStyleLogicalHeight(m_grid[insertionRow]);
 
         for (RenderTableCell* cell = row->firstCell(); cell; cell = cell->nextCell())
             addCell(cell, row);
@@ -1354,7 +1351,7 @@ void RenderTableSection::rowLogicalHeightChanged(unsigned rowIndex)
     if (needsCellRecalc())
         return;
 
-    setRowLogicalHeightToRowStyleLogicalHeightIfNotRelative(m_grid[rowIndex]);
+    setRowLogicalHeightToRowStyleLogicalHeight(m_grid[rowIndex]);
 
     for (RenderTableCell* cell = m_grid[rowIndex].rowRenderer->firstCell(); cell; cell = cell->nextCell())
         updateLogicalHeightForCell(m_grid[rowIndex], cell);


### PR DESCRIPTION
#### 31e8bf8c1bccced25199e680f090d244c73cf3b3
<pre>
Removed dead support for relative length in table code

Removed dead support for relative length in table code

<a href="https://bugs.webkit.org/show_bug.cgi?id=118044">https://bugs.webkit.org/show_bug.cgi?id=118044</a>

Reviewed by Alan Bujtas.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/9082e2bd2a83bb23c7e2852fb2d488c04d3ef368">https://chromium.googlesource.com/chromium/blink/+/9082e2bd2a83bb23c7e2852fb2d488c04d3ef368</a>

Removed dead support for relative length in table code

Relative length support was allowed by HTML4 on COLGROUP and COL&apos;s
&apos;width&apos; attribute (see
<a href="http://www.w3.org/TR/html4/struct/tables.html#h-11.2.4.1)">http://www.w3.org/TR/html4/struct/tables.html#h-11.2.4.1)</a> but it
never made it to HTML5.

The current code doesn&apos;t convert the &apos;width&apos; attribute to a Relative
Length internally, which means that we don&apos;t parse these lengths
properly and the code to handle them in table rendering is dead.

* Source/WebCore/rendering/AutoTableLayout.cpp
(AutoTableLayout::recalcColumn) - Remove LengthType:Relative case
(AutoTableLayout::calcEffectiveLogicalWidth) - Remove cellLogicalWidth.isRelative()
(AutoTableLayout::layout()) - Remove totalReflective, LengthType::Relative, Relative layout code and Priortization Code

* Source/WebCore/rendering/RenderTableSection.cpp
(Update setRowLogicalHeightToRowStyleLogicalHeightIfNotRelative to setRowLogicalHeightToRowStyleLogicalHeight) and Remove &quot;Relative&quot; case after ASSERT
(Update updateLogicalHeightForCell) - Remove row.logicalHeight for Relative and Relative case as well
(Update setRowLogicalHeightToRowStyleLogicalHeightIfNotRelative to setRowLogicalHeightToRowStyleLogicalHeight)
(Update setRowLogicalHeightToRowStyleLogicalHeightIfNotRelative to setRowLogicalHeightToRowStyleLogicalHeight)

Canonical link: <a href="https://commits.webkit.org/253879@main">https://commits.webkit.org/253879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6371d3142b315c8c26e98c76fe56a76d196ca22

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96367 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149834 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91233 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29710 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25930 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79371 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91265 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24005 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74060 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23867 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66882 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27432 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13051 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27380 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14066 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2728 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36927 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33343 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->