### PR TITLE
Clean up HAVE_PASTEBOARD_DATA_OWNER

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
@@ -154,6 +154,17 @@ typedef enum {
 
 @end
 
+typedef NS_ENUM(NSInteger, _UIDataOwner) {
+    _UIDataOwnerUndefined,
+    _UIDataOwnerUser,
+    _UIDataOwnerEnterprise,
+    _UIDataOwnerShared,
+};
+
+@interface UIPasteboard ()
++ (void)_performAsDataOwner:(_UIDataOwner)dataOwner block:(void(^ NS_NOESCAPE)(void))block;
+@end
+
 @interface UIScreen ()
 
 @property (nonatomic, readonly) CGRect _referenceBounds;

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -88,7 +88,6 @@ RefPtr<SharedBuffer> PlatformPasteboard::bufferForType(const String& type) const
 
 void PlatformPasteboard::performAsDataOwner(DataOwnerType type, Function<void()>&& actions)
 {
-#if HAVE(PASTEBOARD_DATA_OWNER)
     auto dataOwner = _UIDataOwnerUndefined;
     switch (type) {
     case DataOwnerType::Undefined:
@@ -108,10 +107,6 @@ void PlatformPasteboard::performAsDataOwner(DataOwnerType type, Function<void()>
     [PAL::getUIPasteboardClass() _performAsDataOwner:dataOwner block:^{
         actions();
     }];
-#else
-    UNUSED_PARAM(type);
-    actions();
-#endif
 }
 
 void PlatformPasteboard::getPathnamesForType(Vector<String>&, const String&) const

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -164,6 +164,13 @@
 #import <UIKit/NSItemProvider+UIKitAdditions.h>
 #endif
 
+typedef NS_ENUM(NSInteger, _UIDataOwner) {
+    _UIDataOwnerUndefined,
+    _UIDataOwnerUser,
+    _UIDataOwnerEnterprise,
+    _UIDataOwnerShared,
+};
+
 #if HAVE(LINK_PREVIEW)
 typedef NS_ENUM(NSInteger, UIPreviewItemType) {
     UIPreviewItemTypeNone,
@@ -172,13 +179,6 @@ typedef NS_ENUM(NSInteger, UIPreviewItemType) {
     UIPreviewItemTypeImage,
     UIPreviewItemTypeText,
     UIPreviewItemTypeAttachment,
-};
-
-typedef NS_ENUM(NSInteger, _UIDataOwner) {
-    _UIDataOwnerUndefined,
-    _UIDataOwnerUser,
-    _UIDataOwnerEnterprise,
-    _UIDataOwnerShared,
 };
 
 @class UIPreviewItemController;
@@ -507,10 +507,8 @@ typedef enum {
 - (void)_wheelChangedWithEvent:(UIEvent *)event;
 - (void)_beginPinningInputViews;
 - (void)_endPinningInputViews;
-#if HAVE(PASTEBOARD_DATA_OWNER)
 @property (nonatomic, setter=_setDataOwnerForCopy:) _UIDataOwner _dataOwnerForCopy;
 @property (nonatomic, setter=_setDataOwnerForPaste:) _UIDataOwner _dataOwnerForPaste;
-#endif
 @end
 
 @class FBSDisplayConfiguration;

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -633,7 +633,6 @@ std::optional<DataOwnerType> WebPasteboardProxy::determineDataOwner(IPC::Connect
     if (!pageID)
         return DataOwnerType::Undefined;
 
-#if HAVE(PASTEBOARD_DATA_OWNER)
     std::optional<DataOwnerType> result;
     for (auto* page : process->pages()) {
         if (page->webPageID() == *pageID) {
@@ -645,10 +644,6 @@ std::optional<DataOwnerType> WebPasteboardProxy::determineDataOwner(IPC::Connect
     // currently known to the UI process.
     MESSAGE_CHECK_WITH_RETURN_VALUE(result.has_value(), std::nullopt);
     return result;
-#else
-    UNUSED_PARAM(intent);
-    return DataOwnerType::Undefined;
-#endif
 }
 
 void WebPasteboardProxy::PasteboardAccessInformation::grantAccess(WebProcessProxy& process, PasteboardAccessType type)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -553,9 +553,7 @@ public:
 
     virtual void makeViewBlank(bool) { }
 
-#if HAVE(PASTEBOARD_DATA_OWNER)
     virtual WebCore::DataOwnerType dataOwnerForPasteboard(PasteboardAccessIntent) const { return WebCore::DataOwnerType::Undefined; }
-#endif
 
     virtual bool hasResizableWindows() const { return false; }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10481,14 +10481,10 @@ void WebPageProxy::touchBarMenuItemDataRemoved(const TouchBarMenuItemData& touch
 }
 #endif
 
-#if HAVE(PASTEBOARD_DATA_OWNER)
-
 DataOwnerType WebPageProxy::dataOwnerForPasteboard(PasteboardAccessIntent intent) const
 {
     return pageClient().dataOwnerForPasteboard(intent);
 }
-
-#endif
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -265,6 +265,7 @@ class ValidationBubble;
 enum class AutoplayEvent : uint8_t;
 enum class CookieConsentDecisionResult : uint8_t;
 enum class CreateNewGroupForHighlight : bool;
+enum class DataOwnerType : uint8_t;
 enum class DOMPasteAccessCategory : uint8_t;
 enum class DOMPasteAccessResponse : uint8_t;
 enum class EditAction : uint8_t;
@@ -316,9 +317,6 @@ struct TextRecognitionResult;
 struct ViewportAttributes;
 struct WindowFeatures;
 
-#if HAVE(PASTEBOARD_DATA_OWNER)
-enum class DataOwnerType : uint8_t;
-#endif
 
 template<typename> class RectEdges;
 using FloatBoxExtent = RectEdges<float>;
@@ -1208,9 +1206,7 @@ public:
     bool useDarkAppearance() const;
     bool useElevatedUserInterfaceLevel() const;
 
-#if HAVE(PASTEBOARD_DATA_OWNER)
     WebCore::DataOwnerType dataOwnerForPasteboard(PasteboardAccessIntent) const;
-#endif
 
 #if PLATFORM(COCOA)
     // Called by the web process through a message.

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -137,9 +137,7 @@ private:
     RefPtr<WebDataListSuggestionsDropdown> createDataListSuggestionsDropdown(WebPageProxy&) final;
 #endif
 
-#if HAVE(PASTEBOARD_DATA_OWNER)
     WebCore::DataOwnerType dataOwnerForPasteboard(PasteboardAccessIntent) const final;
-#endif
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
     RefPtr<WebDateTimePicker> createDateTimePicker(WebPageProxy&) final;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -476,14 +476,10 @@ void PageClientImpl::requestTextRecognition(const URL& imageURL, const Shareable
 
 #endif // ENABLE(IMAGE_ANALYSIS)
 
-#if HAVE(PASTEBOARD_DATA_OWNER)
-
 WebCore::DataOwnerType PageClientImpl::dataOwnerForPasteboard(PasteboardAccessIntent intent) const
 {
     return [m_contentView _dataOwnerForPasteboard:intent];
 }
-
-#endif
 
 RefPtr<WebPopupMenuProxy> PageClientImpl::createPopupMenuProxy(WebPageProxy&)
 {

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -794,9 +794,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (BOOL)_formControlRefreshEnabled;
 #endif
 
-#if HAVE(PASTEBOARD_DATA_OWNER)
 - (WebCore::DataOwnerType)_dataOwnerForPasteboard:(WebKit::PasteboardAccessIntent)intent;
-#endif
 
 #if ENABLE(IMAGE_ANALYSIS)
 - (void)_endImageAnalysisGestureDeferral:(WebKit::ShouldPreventGestures)shouldPreventGestures;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8261,8 +8261,6 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
 
 #endif // ENABLE(IMAGE_ANALYSIS)
 
-#if HAVE(PASTEBOARD_DATA_OWNER)
-
 static WebCore::DataOwnerType coreDataOwnerType(_UIDataOwner platformType)
 {
     switch (platformType) {
@@ -8302,8 +8300,6 @@ static WebCore::DataOwnerType coreDataOwnerType(_UIDataOwner platformType)
 
     return WebCore::DataOwnerType::Undefined;
 }
-
-#endif // HAVE(PASTEBOARD_DATA_OWNER)
 
 - (RetainPtr<WKTargetedPreviewContainer>)_createPreviewContainerWithLayerName:(NSString *)layerName
 {

--- a/Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm
@@ -50,8 +50,6 @@ static void checkJSONWithLogging(NSString *jsonString, NSDictionary *expected)
         NSLog(@"Expected JSON: %@ to match values: %@", jsonString, expected);
 }
 
-#if HAVE(PASTEBOARD_DATA_OWNER)
-
 static _UIDataOwner gLastKnownDataOwner = _UIDataOwnerUndefined;
 
 @interface TestUIPasteboard : NSObject
@@ -79,8 +77,6 @@ static _UIDataOwner gLastKnownDataOwner = _UIDataOwnerUndefined;
 }
 
 @end
-
-#endif // HAVE(PASTEBOARD_DATA_OWNER)
 
 #endif // PLATFORM(IOS)
 
@@ -383,8 +379,6 @@ TEST(UIPasteboardTests, MissingPreferredPresentationSizeForImage)
     EXPECT_WK_STREQ("174", [webView stringByEvaluatingJavaScript:@"document.querySelector('img').height"]);
 }
 
-#if HAVE(PASTEBOARD_DATA_OWNER)
-
 TEST(UIPasteboardTests, PerformAsDataOwnerWhenCopying)
 {
     auto swizzler = ClassMethodSwizzler {
@@ -453,8 +447,6 @@ TEST(UIPasteboardTests, PerformAsDataOwnerWithManagedURL)
         EXPECT_EQ(gLastKnownDataOwner, _UIDataOwnerUser);
     }
 }
-
-#endif // HAVE(PASTEBOARD_DATA_OWNER)
 
 #endif // PLATFORM(IOS)
 

--- a/Tools/TestWebKitAPI/ios/UIKitSPI.h
+++ b/Tools/TestWebKitAPI/ios/UIKitSPI.h
@@ -251,10 +251,19 @@ IGNORE_WARNINGS_END
 @property (nonatomic, readonly) CGRect _referenceBounds;
 @end
 
+typedef NS_ENUM(NSInteger, _UIDataOwner) {
+    _UIDataOwnerUndefined,
+    _UIDataOwnerUser,
+    _UIDataOwnerEnterprise,
+    _UIDataOwnerShared,
+};
+
 @interface UIResponder (UIKitSPI)
 - (UIResponder *)firstResponder;
 - (void)makeTextWritingDirectionNatural:(id)sender;
 @property (nonatomic, setter=_setSuppressSoftwareKeyboard:) BOOL _suppressSoftwareKeyboard;
+@property (nonatomic, setter=_setDataOwnerForCopy:) _UIDataOwner _dataOwnerForCopy;
+@property (nonatomic, setter=_setDataOwnerForPaste:) _UIDataOwner _dataOwnerForPaste;
 @end
 
 @interface UIKeyboardImpl : UIView


### PR DESCRIPTION
#### 548422a12918d9a17699cc93f3cf813e7fca1205
<pre>
Clean up HAVE_PASTEBOARD_DATA_OWNER
<a href="https://bugs.webkit.org/show_bug.cgi?id=244144">https://bugs.webkit.org/show_bug.cgi?id=244144</a>

Reviewed by Alexey Proskuryakov.

Remove use of this HAVE macro, as the SPI it guards is available on all
iOS family OSes we support. This cleanup simplifies changes needed in
SPI headers to build open source for iOS 16.

As a result of this change, non-iOS-family platforms now declare
WebKit::WebPageProxy::dataOwnerForPasteboard() and
WebKit::PageClient::dataOwnerForPasteboard(). They return
WebCore::DataOwnerType::Undefined.

* Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h: Because
  HAVE_PASTEBOARD_DATA_OWNER was provided via AdditionalFeatureDefines,
  this code was never built or tested in open-source. Making it compile
  requires a bit more SPI.
* Source/WebKit/Platform/spi/ios/UIKitSPI.h: Ditto.
* Tools/TestWebKitAPI/ios/UIKitSPI.h: Ditto.

The rest of the patch is just removing #if blocks, or rewriting them to
be &quot;#if PLATFORM(IOS_FAMILY)&quot;.

* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::PlatformPasteboard::performAsDataOwner):
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::determineDataOwner const):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::dataOwnerForPasteboard const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
* Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm:

Canonical link: <a href="https://commits.webkit.org/254006@main">https://commits.webkit.org/254006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05a6690c3a45308845ed1d614584f26018de004e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96743 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150407 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29969 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26138 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79635 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91504 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24222 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74297 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24044 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67062 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27677 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13223 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27630 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14239 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2818 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37113 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33517 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->