### PR TITLE
REGRESSION (252564@main): WK1 ScriptDisallowedScope assertion failure via WidgetHierarchyUpdatesSuspensionScope::moveWidgets()

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1958,8 +1958,6 @@ webkit.org/b/244347 storage/domstorage/sessionstorage/window-open-remove-item.ht
 
 webkit.org/b/244372 imported/w3c/web-platform-tests/intersection-observer/target-in-different-window.html [ Pass Failure ]
 
-webkit.org/b/244390 editing/selection/cleared-by-relayout.html [ Crash ]
-
 webkit.org/b/244395 [ Release X86_64 ] editing/execCommand/paste-as-quotation-disconnected-paragraph-ancestor-crash.html [ Skip ]
 
 webkit.org/b/244404 js/dom/modules/missing-exception-check-for-import.html [ Crash ]

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3617,7 +3617,7 @@ static void forEachRenderLayer(Element& element, const std::function<void(Render
 void Element::addToTopLayer()
 {
     RELEASE_ASSERT(!isInTopLayer());
-    ScriptDisallowedScope scriptDisallowedScope;
+    ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
     forEachRenderLayer(*this, [](RenderLayer& layer) {
         layer.establishesTopLayerWillChange();
@@ -3639,7 +3639,7 @@ void Element::addToTopLayer()
 void Element::removeFromTopLayer()
 {
     RELEASE_ASSERT(isInTopLayer());
-    ScriptDisallowedScope scriptDisallowedScope;
+    ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
     forEachRenderLayer(*this, [](RenderLayer& layer) {
         layer.establishesTopLayerWillChange();

--- a/Source/WebCore/dom/ScriptDisallowedScope.h
+++ b/Source/WebCore/dom/ScriptDisallowedScope.h
@@ -109,7 +109,31 @@ public:
 #endif
         }
     };
-    
+
+    class InMainThreadOfWebProcess {
+    public:
+        InMainThreadOfWebProcess()
+            : m_isInWebProcess(isInWebProcess())
+        {
+            ASSERT(isMainThread());
+            if (!m_isInWebProcess)
+                return;
+            ++s_count;
+        }
+
+        ~InMainThreadOfWebProcess()
+        {
+            ASSERT(isMainThread());
+            if (!m_isInWebProcess)
+                return;
+            ASSERT(s_count);
+            --s_count;
+        }
+
+    private:
+        bool m_isInWebProcess;
+    };
+
 #if ASSERT_ENABLED
     class EventAllowedScope {
     public:

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -77,7 +77,7 @@ static bool isTableRowEmpty(Node* row)
 
 static bool isSpecialHTMLElement(const Node& node)
 {
-    ScriptDisallowedScope scriptDisallowedScope;
+    ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
     if (!is<HTMLElement>(node))
         return false;
@@ -479,7 +479,7 @@ void DeleteSelectionCommand::insertBlockPlaceholderForTableCellIfNeeded(Element&
 {
     // Make sure empty cell has some height.
     {
-        ScriptDisallowedScope scriptDisallowedScope;
+        ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         auto* renderer = element.renderer();
         if (!is<RenderTableCell>(renderer))
             return;
@@ -941,7 +941,7 @@ String DeleteSelectionCommand::originalStringForAutocorrectionAtBeginningOfSelec
     if (!rangeOfFirstCharacter)
         return String();
 
-    ScriptDisallowedScope scriptDisallowedScope;
+    ScriptDisallowedScope::InMainThread scriptDisallowedScope;
     for (auto* marker : document().markers().markersInRange(*rangeOfFirstCharacter, DocumentMarker::Autocorrected)) {
         int startOffset = marker->startOffset();
         if (startOffset == startOfSelection.deepEquivalent().offsetInContainerNode())
@@ -1050,7 +1050,7 @@ void DeleteSelectionCommand::doApply()
     if (!document().editor().behavior().shouldRebalanceWhiteSpacesInSecureField()) {
         if (RefPtr endNode = m_endingPosition.deprecatedNode(); is<Text>(endNode)) {
             auto& textNode = downcast<Text>(*endNode);
-            ScriptDisallowedScope scriptDisallowedScope;
+            ScriptDisallowedScope::InMainThread scriptDisallowedScope;
             if (textNode.length() && textNode.renderer())
                 shouldRebalaceWhiteSpace = textNode.renderer()->style().textSecurity() == TextSecurity::None;
         }        

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2250,7 +2250,7 @@ void FrameSelection::updateAppearance()
 #endif
 
     {
-        ScriptDisallowedScope scriptDisallowedScope;
+        ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         auto* view = m_document->renderView();
         if (!view)
             return;


### PR DESCRIPTION
#### 4cc5aa54fb8664c2dc2b5369341bd167c41c90e7
<pre>
REGRESSION (252564@main): WK1 ScriptDisallowedScope assertion failure via WidgetHierarchyUpdatesSuspensionScope::moveWidgets()
<a href="https://bugs.webkit.org/show_bug.cgi?id=244390">https://bugs.webkit.org/show_bug.cgi?id=244390</a>

Reviewed by Alan Bujtas.

The assertion failure was caused by WidgetHierarchyUpdatesSuspensionScope&apos;s destructor updating the widget tree
and triggering focus/blur events. Fixed it by only enacting this debug assertion inside a WebContent process.

Also updated a few instances of ScriptDisallowedScope by more efficient equivalent: ScriptDisallowedScope:InMainThread.

* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle): Avoid assertion failure in WebKit1 by replacing ScriptDisallowedScope::InMainThread
with ScriptDisallowedScope::InMainThreadOfWebProcess which only enables debug/release assertion in a WebContent process.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::addToTopLayer): Use ScriptDisallowedScope:InMainThread instead of ScriptDisallowedScope.
(WebCore::Element::removeFromTopLayer): Ditto.

* Source/WebCore/dom/ScriptDisallowedScope.h:
(WebCore::ScriptDisallowedScope::InMainThreadOfWebProcess): Added.
(WebCore::ScriptDisallowedScope::InMainThreadOfWebProcess::InMainThreadOfWebProcess): Added.
(WebCore::ScriptDisallowedScope::InMainThreadOfWebProcess::~InMainThreadOfWebProcess): Added.

* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::isSpecialHTMLElement): Use ScriptDisallowedScope:InMainThread instead of ScriptDisallowedScope.
(WebCore::DeleteSelectionCommand::insertBlockPlaceholderForTableCellIfNeeded): Ditto.
(WebCore::DeleteSelectionCommand::originalStringForAutocorrectionAtBeginningOfSelection): Ditto.
(WebCore::DeleteSelectionCommand::doApply): Ditto.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::updateAppearance): Ditto.

Canonical link: <a href="https://commits.webkit.org/253870@main">https://commits.webkit.org/253870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a50b4b8edd77db8a5990f38571e29539d11dd22

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96417 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149868 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29745 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91293 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24031 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74089 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23877 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79005 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79229 "Found 1 new API test failure: TestWebKitAPI.WKInspectorExtension.CanEvaluateScriptInExtensionTab") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66892 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27462 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13065 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27414 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14080 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29100 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36945 "Found 1 new test failure: http/tests/media/fairplay/fps-mse-unmuxed-multiple-keys.html") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1096 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33357 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->