### PR TITLE
[Cocoa] Support HEIC/HEIF images for Apple ports

### DIFF
--- a/LayoutTests/fast/canvas/toDataURL-unsupportedTypes-expected.txt
+++ b/LayoutTests/fast/canvas/toDataURL-unsupportedTypes-expected.txt
@@ -3,8 +3,6 @@ This is a test of the unsupported mime-types for canvas.toDataURL().
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS canvas.toDataURL('image/heic') is canvas.toDataURL('image/png')
-PASS canvas.toDataURL('image/heic-sequence') is canvas.toDataURL('image/png')
 PASS canvas.toDataURL('image/vnd.adobe.photoshop') is canvas.toDataURL('image/png')
 PASS canvas.toDataURL('application/pdf') is canvas.toDataURL('image/png')
 PASS canvas.toDataURL('image/targa') is canvas.toDataURL('image/png')

--- a/LayoutTests/fast/canvas/toDataURL-unsupportedTypes.html
+++ b/LayoutTests/fast/canvas/toDataURL-unsupportedTypes.html
@@ -10,8 +10,6 @@
         canvas.height = 8;
 
         description("This is a test of the unsupported mime-types for canvas.toDataURL().");
-        shouldBe("canvas.toDataURL('image/heic')", "canvas.toDataURL('image/png')");
-        shouldBe("canvas.toDataURL('image/heic-sequence')", "canvas.toDataURL('image/png')");
         shouldBe("canvas.toDataURL('image/vnd.adobe.photoshop')", "canvas.toDataURL('image/png')");
         shouldBe("canvas.toDataURL('application/pdf')", "canvas.toDataURL('image/png')");
         shouldBe("canvas.toDataURL('image/targa')", "canvas.toDataURL('image/png')");

--- a/LayoutTests/fast/forms/file/entries-api/image-no-transcode-drag-drop-expected.txt
+++ b/LayoutTests/fast/forms/file/entries-api/image-no-transcode-drag-drop-expected.txt
@@ -6,9 +6,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS fileList.length is 1
 PASS file.type is "image/heic"
 PASS file.size is non-zero.
-Image could not be loaded.
-PASS img.width is not 400
-PASS img.height is not 400
+Image was loaded.
+PASS img.width is 400
+PASS img.height is 400
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/file/entries-api/image-no-transcode-open-panel-expected.txt
+++ b/LayoutTests/fast/forms/file/entries-api/image-no-transcode-open-panel-expected.txt
@@ -7,9 +7,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS fileList.length is 1
 PASS file.type is "image/heic"
 PASS file.size is non-zero.
-Image could not be loaded.
-PASS img.width is not 400
-PASS img.height is not 400
+Image was loaded.
+PASS img.width is 400
+PASS img.height is 400
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2007-2009 Torch Mobile, Inc.
  * Copyright (C) 2010, 2011 Research In Motion Limited. All rights reserved.
  *
@@ -1267,6 +1267,10 @@
     || (PLATFORM(APPLETV) && __TV_OS_VERSION_MAX_ALLOWED >= 160000) \
     || (PLATFORM(WATCHOS) && __WATCH_OS_VERSION_MIN_REQUIRED >= 90000)
 #define HAVE_AVIF 1
+#endif
+
+#if PLATFORM(COCOA)
+#define HAVE_HEIC 1
 #endif
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012 Google, Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -134,7 +135,16 @@ static constexpr ASCIILiteral acceptHeaderValueForWebPImageResource()
 static constexpr ASCIILiteral acceptHeaderValueForAVIFImageResource()
 {
 #if HAVE(AVIF) || USE(AVIF)
-    return "image/avif,"_s;
+    return "image/avif,image/avif-sequence,"_s;
+#else
+    return ""_s;
+#endif
+}
+
+static constexpr ASCIILiteral acceptHeaderValueForHEICImageResource()
+{
+#if HAVE(HEIC)
+    return "image/heic,image/heic-sequence,image/heif,image/heif-sequence"_s;
 #else
     return ""_s;
 #endif
@@ -151,6 +161,7 @@ static String acceptHeaderValueForImageResource()
 {
     return String(acceptHeaderValueForWebPImageResource())
         + acceptHeaderValueForAVIFImageResource()
+        + acceptHeaderValueForHEICImageResource()
         + acceptHeaderValueForVideoImageResource(ImageDecoder::supportsMediaType(ImageDecoder::MediaType::Video))
         + "image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5"_s;
 }

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -96,12 +96,19 @@ constexpr ComparableCaseFoldingASCIILiteral supportedImageMIMETypeArray[] = {
 #endif
 #if HAVE(AVIF) || USE(AVIF)
     "image/avif",
+    "image/avif-sequence",
 #endif
     "image/bmp",
 #if PLATFORM(IOS_FAMILY)
     "image/gi_",
 #endif
     "image/gif",
+#if HAVE(HEIC)
+    "image/heic",
+    "image/heic-sequence",
+    "image/heif",
+    "image/heif-sequence",
+#endif
 #if USE(CG) || USE(OPENJPEG)
     "image/jp2",
 #endif

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Apple Inc.  All rights reserved.
+ * Copyright (C) 2017-2022 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,6 +62,11 @@ const MemoryCompactLookupOnlyRobinHoodHashSet<String>& defaultSupportedImageType
             "public.avif"_s,
             "public.avis"_s,
 #endif
+#if HAVE(HEIC)
+            "public.heic"_s,
+            "public.heics"_s,
+            "public.heif"_s,
+#endif
         };
 
         auto systemSupportedCFImageTypes = adoptCF(CGImageSourceCopyTypeIdentifiers());
@@ -94,6 +99,8 @@ void setAdditionalSupportedImageTypes(const Vector<String>& imageTypes)
 {
     MIMETypeRegistry::additionalSupportedImageMIMETypes().clear();
     for (const auto& imageType : imageTypes) {
+        if (isSupportedImageType(imageType))
+            continue;
         additionalSupportedImageTypes().add(imageType);
         auto mimeType = MIMETypeForImageType(imageType);
         if (!mimeType.isEmpty())


### PR DESCRIPTION
#### d9e697a1c1a7e5e888d1a5855edad51e8f9d3325
<pre>
[Cocoa] Support HEIC/HEIF images for Apple ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=244424">https://bugs.webkit.org/show_bug.cgi?id=244424</a>

Reviewed by NOBODY (OOPS!).

Patch by Said Abou-Hallawa &lt;said@apple.com&gt;.

Add the mime type and the UTI of the HEIC/HEIF to the list of the allowed image
formats. The system frameworks will be used to render the HEIC/HEIF images on
Apple ports. Because of sand-boxing limitations, software decoding has to be used
for these images.

* Source/WTF/wtf/PlatformHave.h:
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::acceptHeaderValueForAVIFImageResource):
(WebCore::acceptHeaderValueForHEICImageResource):
(WebCore::acceptHeaderValueForImageResource):
* Source/WebCore/platform/MIMETypeRegistry.cpp:
* Source/WebCore/platform/graphics/cg/UTIRegistry.cpp:
(WebCore::defaultSupportedImageTypes):
(WebCore::setAdditionalSupportedImageTypes):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9e697a1c1a7e5e888d1a5855edad51e8f9d3325

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103780 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164111 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3368 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31563 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86465 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99801 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99817 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80570 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29436 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72384 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85390 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37948 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17846 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80534 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35832 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19113 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27720 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39706 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83195 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38349 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18788 "Passed tests") | 
<!--EWS-Status-Bubble-End-->