### PR TITLE
 Unreviewed, non-unified build fixes

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -58,6 +58,7 @@
 #include <JavaScriptCore/JSWebAssembly.h>
 #include <JavaScriptCore/Microtask.h>
 #include <JavaScriptCore/StrongInlines.h>
+#include <JavaScriptCore/VMTrapsInlines.h>
 #include <wtf/Language.h>
 #include <wtf/MainThread.h>
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
@@ -30,7 +30,6 @@
 
 #include "EllipsisBoxPainter.h"
 #include "InlineBoxPainter.h"
-#include "LayoutIntegrationBoxTree.h"
 #include "PaintInfo.h"
 #include "RenderBox.h"
 #include "RenderInline.h"

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
@@ -27,10 +27,14 @@
 
 #if ENABLE(LAYOUT_FORMATTING_CONTEXT)
 
+#include "LayoutIntegrationBoxTree.h"
 #include "LayoutPoint.h"
+#include "LayoutRect.h"
+#include <wtf/ListHashSet.h>
 
 namespace WebCore {
 
+class RenderBlock;
 class RenderBox;
 class RenderInline;
 
@@ -45,8 +49,6 @@ class ContainerBox;
 };
 
 namespace LayoutIntegration {
-
-class BoxTree;
 
 struct InlineContent;
 

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -38,6 +38,7 @@
 #include "PointerEventsHitRules.h"
 #include "RenderImageResource.h"
 #include "RenderLayer.h"
+#include "RenderSVGModelObjectInlines.h"
 #include "RenderSVGResource.h"
 #include "RenderSVGResourceFilter.h"
 #include "SVGElementTypeHelpers.h"


### PR DESCRIPTION
#### 0d57cf361295b82b3753f7b2e07766a85fb0ad94
<pre>
For regressions introduced this friday.

* Source/WebCore/bindings/js/JSDOMWindowBase.cpp: Include required
  VMTraps inlines.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp: Address changes from 253820@main
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h: Ditto.
* Source/WebCore/rendering/svg/RenderSVGImage.cpp: Include RenderSVGModelObjectInlines.h
</pre>