### PR TITLE
Media query - width in 'em's doesn't work on zoom

### DIFF
--- a/LayoutTests/fast/css/zoom-media-queries-expected.txt
+++ b/LayoutTests/fast/css/zoom-media-queries-expected.txt
@@ -1,0 +1,42 @@
+PASS matchMedia("(max-width: 300px)").matches is false
+PASS matchMedia("(max-width: 18.75em)").matches is false
+
+
+testRunner.zoomPageIn()
+PASS matchMedia("(max-width: 300px)").matches is matchMedia("(max-width: 18.75em)").matches
+testRunner.zoomPageIn()
+PASS matchMedia("(max-width: 300px)").matches is matchMedia("(max-width: 18.75em)").matches
+testRunner.zoomPageIn()
+PASS matchMedia("(max-width: 300px)").matches is matchMedia("(max-width: 18.75em)").matches
+testRunner.zoomPageIn()
+PASS matchMedia("(max-width: 300px)").matches is matchMedia("(max-width: 18.75em)").matches
+testRunner.zoomPageIn()
+PASS matchMedia("(max-width: 300px)").matches is matchMedia("(max-width: 18.75em)").matches
+testRunner.zoomPageIn()
+
+
+PASS matchMedia("(max-width: 300px)").matches is true
+PASS matchMedia("(max-width: 18.75em)").matches is true
+
+
+testRunner.zoomPageOut()
+PASS matchMedia("(max-width: 300px)").matches is false
+PASS matchMedia("(max-width: 18.75em)").matches is false
+testRunner.zoomPageOut()
+PASS matchMedia("(max-width: 300px)").matches is false
+PASS matchMedia("(max-width: 18.75em)").matches is false
+testRunner.zoomPageOut()
+PASS matchMedia("(max-width: 300px)").matches is false
+PASS matchMedia("(max-width: 18.75em)").matches is false
+testRunner.zoomPageOut()
+PASS matchMedia("(max-width: 300px)").matches is false
+PASS matchMedia("(max-width: 18.75em)").matches is false
+testRunner.zoomPageOut()
+PASS matchMedia("(max-width: 300px)").matches is false
+PASS matchMedia("(max-width: 18.75em)").matches is false
+testRunner.zoomPageOut()
+PASS matchMedia("(max-width: 300px)").matches is false
+PASS matchMedia("(max-width: 18.75em)").matches is false
+PASS successfullyParsed is true
+
+TEST COMPLETE

--- a/LayoutTests/fast/css/zoom-media-queries.html
+++ b/LayoutTests/fast/css/zoom-media-queries.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<style>
+    html { font-size: 16px; }
+</style>
+<script src="../../resources/js-test.js"></script>
+<script>
+    if (!window.testRunner) {
+        document.write("This test does not work in manual mode.");
+    } else {
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        // These media queries should be equivalent, since the documentElement
+        // has font-size:16px, so 300px should equal 18.75em. They should both
+        // initially be false (as the layout test runner is 800px wide).
+        shouldBeFalse(
+            'matchMedia("(max-width: 300px)").matches');
+        shouldBeFalse(
+            'matchMedia("(max-width: 18.75em)").matches');
+        debug("");
+
+        // While zooming in, the two media queries should either
+        // both match or both not match.
+        var maxZoomLevel = 20;
+        var zoomLevel = 0;
+        while (zoomLevel < maxZoomLevel) {
+            debug("testRunner.zoomPageIn()");
+            testRunner.zoomPageIn();
+            zoomLevel++;
+
+            if (matchMedia("(max-width: 300px)").matches)
+                break;
+
+            shouldBe(
+                'matchMedia("(max-width: 300px)").matches',
+                'matchMedia("(max-width: 18.75em)").matches');
+        }
+        debug("");
+
+        // Once sufficiently zoomed in, both should match.
+        shouldBeTrue(
+            'matchMedia("(max-width: 300px)").matches');
+        shouldBeTrue(
+            'matchMedia("(max-width: 18.75em)").matches');
+        debug("");
+
+        // As soon as we zoom back out, both should stop matching
+        // and continue to not match.
+        while (zoomLevel > 0) {
+            debug("testRunner.zoomPageOut()");
+            testRunner.zoomPageOut();
+            zoomLevel--;
+
+            shouldBeFalse(
+                'matchMedia("(max-width: 300px)").matches');
+            shouldBeFalse(
+                'matchMedia("(max-width: 18.75em)").matches');
+        }
+    }
+</script>

--- a/Source/WebCore/css/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/MediaQueryEvaluator.cpp
@@ -519,7 +519,7 @@ static std::optional<double> computeLength(CSSValue* value, bool strict, const C
     }
 
     if (primitiveValue.isLength())
-        return primitiveValue.computeLength<double>(conversionData);
+        return primitiveValue.computeLength<double>(conversionData.zoom());
 
     return std::nullopt;
 }


### PR DESCRIPTION

<pre>
Media query - width in 'em's doesn't work on zoom

<a href="https://bugs.webkit.org/show_bug.cgi?id=41063">https://bugs.webkit.org/show_bug.cgi?id=41063</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=152742">https://src.chromium.org/viewvc/blink?view=revision&revision=152742</a>

EM MQs were using calculated font size (which include the zooming factor) in order to translate the expected MQ size to CSS pixels. At the same time, adjustForAbsoluteZoom was taking the zoom into account to decrease the number of CSS pixels that fit into the viewport. That created a situation where the zoom is taken into account twice, causing a difference between EM MQs and PX MQs. That wasn't as bad as it could be because the calculated font size wasn't updating itself on every zoom step, but there was still visible difference.

This change simply turns off font calculation for the CSS pixel computation, which results in parity between PX and EM MQs.

* Source/WebCore/css/MediaQueryEvaluator.cpp
(Update "computeLength" to add Multiplier and "true" condition for ComputedFontSize)
* LayoutTests/fast/css/zoom-media-queries.html: Added Test Case
* LayoutTests/fast/css/zoom-media-queries-expected.txt: Added Test Case Expectations

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e40f71162fef67b279a90d1f7fb46add1e12817

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87434 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31523 "Hash 3e40f711 for PR 3734 does not build") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18240 "Hash 3e40f711 for PR 3734 does not build") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96662 "Hash 3e40f711 for PR 3734 does not build") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150046 "Hash 3e40f711 for PR 3734 does not build") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91409 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29888 "Hash 3e40f711 for PR 3734 does not build") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79553 "Hash 3e40f711 for PR 3734 does not build") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91433 "Hash 3e40f711 for PR 3734 does not build") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93052 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/64/builds/29888 "Hash 3e40f711 for PR 3734 does not build") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74220 "Hash 3e40f711 for PR 3734 does not build") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/79553 "Hash 3e40f711 for PR 3734 does not build") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/64/builds/29888 "Hash 3e40f711 for PR 3734 does not build") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/18240 "Hash 3e40f711 for PR 3734 does not build") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/79553 "Hash 3e40f711 for PR 3734 does not build") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27598 "Hash 3e40f711 for PR 3734 does not build") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/18240 "Hash 3e40f711 for PR 3734 does not build") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27552 "Hash 3e40f711 for PR 3734 does not build") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/18240 "Hash 3e40f711 for PR 3734 does not build") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29240 "Hash 3e40f711 for PR 3734 does not build") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/74220 "Hash 3e40f711 for PR 3734 does not build") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29167 "Hash 3e40f711 for PR 3734 does not build") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/18240 "Hash 3e40f711 for PR 3734 does not build") | | 
<!--EWS-Status-Bubble-End-->