### PR TITLE
Change event isn't firing when the user reverts the value of a color/date/time input after JS changed the value

### DIFF
--- a/LayoutTests/fast/forms/color/input-color-choose-default-value-after-set-value-expected.txt
+++ b/LayoutTests/fast/forms/color/input-color-choose-default-value-after-set-value-expected.txt
@@ -1,0 +1,12 @@
+Test if change event fires when the user selects the default value after the value was changed by JS.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.value is "#ff0000"
+onchange fired: #ffffff
+PASS input.value is "#ffffff"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/color/input-color-choose-default-value-after-set-value.html
+++ b/LayoutTests/fast/forms/color/input-color-choose-default-value-after-set-value.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<input type="color" id="input" value="#ffffff">
+<script>
+description('Test if change event fires when the user selects the default value after the value was changed by JS.');
+jsTestIsAsync = true;
+
+var input = document.getElementById('input');
+
+input.onchange = function() {
+    debug("onchange fired: " + input.value);
+    finishJSTest();
+};
+
+clickElement(input);
+input.value = '#ff0000';
+shouldBe('input.value', '"#ff0000"');
+internals.selectColorInColorChooser(input, '#ffffff');
+shouldBe('input.value', '"#ffffff"');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/date-multiple-fields/date-multiple-fields-choose-default-value-after-set-value-expected.txt
+++ b/LayoutTests/fast/forms/date-multiple-fields/date-multiple-fields-choose-default-value-after-set-value-expected.txt
@@ -1,0 +1,17 @@
+Test if change event fires when the user selects the default value after the value was changed by JS.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.value is "2001-01-01"
+PASS eventsCounter.input is undefined.
+PASS eventsCounter.change is undefined.
+==> "input" event was dispatched.
+==> "change" event was dispatched.
+PASS input.value is "2000-01-01"
+PASS eventsCounter.input is 1
+PASS eventsCounter.change is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/date-multiple-fields/date-multiple-fields-choose-default-value-after-set-value.html
+++ b/LayoutTests/fast/forms/date-multiple-fields/date-multiple-fields-choose-default-value-after-set-value.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<input type="date" id="input" value="2000-01-01">
+<script>
+description('Test if change event fires when the user selects the default value after the value was changed by JS.');
+
+var eventsCounter = {};
+function recordEvent(event) {
+    if (eventsCounter[event.type] === undefined)
+        eventsCounter[event.type] = 0;
+    eventsCounter[event.type]++;
+    debug('==> "' + event.type + '" event was dispatched.');
+}
+
+var input = document.getElementById('input');
+input.addEventListener('input', recordEvent, false);
+input.addEventListener('change', recordEvent, false);
+
+input.value = '2001-01-01';
+
+shouldBeEqualToString('input.value', '2001-01-01');
+shouldBeUndefined('eventsCounter.input');
+shouldBeUndefined('eventsCounter.change');
+
+// We assume the date format is MM/dd/yyyy.
+
+input.focus();
+eventSender.keyDown('rightArrow');
+eventSender.keyDown('rightArrow');
+eventSender.keyDown('downArrow');
+
+shouldBeEqualToString('input.value', '2000-01-01');
+shouldBe('eventsCounter.input', '1');
+shouldBe('eventsCounter.change', '1');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal-multiple-fields/datetimelocal-multiple-fields-choose-default-value-after-set-value-expected.txt
+++ b/LayoutTests/fast/forms/datetimelocal-multiple-fields/datetimelocal-multiple-fields-choose-default-value-after-set-value-expected.txt
@@ -1,0 +1,17 @@
+Test if change event fires when the user selects the default value after the value was changed by JS.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.value is "2001-01-01T01:01:01"
+PASS eventsCounter.input is undefined.
+PASS eventsCounter.change is undefined.
+==> "input" event was dispatched.
+==> "change" event was dispatched.
+PASS input.value is "2000-01-01T01:01:01"
+PASS eventsCounter.input is 1
+PASS eventsCounter.change is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/datetimelocal-multiple-fields/datetimelocal-multiple-fields-choose-default-value-after-set-value.html
+++ b/LayoutTests/fast/forms/datetimelocal-multiple-fields/datetimelocal-multiple-fields-choose-default-value-after-set-value.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<input type="datetime-local" id="input" value="2000-01-01T01:01:01">
+<script>
+description('Test if change event fires when the user selects the default value after the value was changed by JS.');
+
+var eventsCounter = {};
+function recordEvent(event) {
+    if (eventsCounter[event.type] === undefined)
+        eventsCounter[event.type] = 0;
+    eventsCounter[event.type]++;
+    debug('==> "' + event.type + '" event was dispatched.');
+}
+
+var input = document.getElementById('input');
+input.addEventListener('input', recordEvent, false);
+input.addEventListener('change', recordEvent, false);
+
+input.value = '2001-01-01T01:01:01';
+
+shouldBeEqualToString('input.value', '2001-01-01T01:01:01');
+shouldBeUndefined('eventsCounter.input');
+shouldBeUndefined('eventsCounter.change');
+
+// We assume the date format is MM/dd/yyyy h:m a.
+
+input.focus();
+eventSender.keyDown('rightArrow');
+eventSender.keyDown('rightArrow');
+eventSender.keyDown('downArrow');
+
+shouldBeEqualToString('input.value', '2000-01-01T01:01:01');
+shouldBe('eventsCounter.input', '1');
+shouldBe('eventsCounter.change', '1');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/time-multiple-fields/time-multiple-fields-choose-default-value-after-set-value-expected.txt
+++ b/LayoutTests/fast/forms/time-multiple-fields/time-multiple-fields-choose-default-value-after-set-value-expected.txt
@@ -1,0 +1,17 @@
+Test if change event fires when the user selects the default value after the value was changed by JS.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.value is "02:01:01"
+PASS eventsCounter.input is undefined.
+PASS eventsCounter.change is undefined.
+==> "input" event was dispatched.
+==> "change" event was dispatched.
+PASS input.value is "01:01:01"
+PASS eventsCounter.input is 1
+PASS eventsCounter.change is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/time-multiple-fields/time-multiple-fields-choose-default-value-after-set-value.html
+++ b/LayoutTests/fast/forms/time-multiple-fields/time-multiple-fields-choose-default-value-after-set-value.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<input type="time" id="input" value="01:01:01">
+<script>
+description('Test if change event fires when the user selects the default value after the value was changed by JS.');
+
+var eventsCounter = {};
+function recordEvent(event) {
+    if (eventsCounter[event.type] === undefined)
+        eventsCounter[event.type] = 0;
+    eventsCounter[event.type]++;
+    debug('==> "' + event.type + '" event was dispatched.');
+}
+
+var input = document.getElementById('input');
+input.addEventListener('input', recordEvent, false);
+input.addEventListener('change', recordEvent, false);
+
+input.value = '02:01:01';
+
+shouldBeEqualToString('input.value', '02:01:01');
+shouldBeUndefined('eventsCounter.input');
+shouldBeUndefined('eventsCounter.change');
+
+// We assume the date format is h:m a.
+
+input.focus();
+
+beginTest("Digit keys");                               // [00]/00/00
+UIHelper.keyDown('downArrow');
+
+shouldBeEqualToString('input.value', '01:01:01');
+shouldBe('eventsCounter.input', '1');
+shouldBe('eventsCounter.change', '1');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1052,6 +1052,9 @@ ExceptionOr<void> HTMLInputElement::setValue(const String& value, TextFieldEvent
     setFormControlValueMatchesRenderer(false);
     m_inputType->setValue(WTFMove(sanitizedValue), valueChanged, eventBehavior, selection);
 
+    if (valueChanged && eventBehavior == DispatchNoEvent)
+        setTextAsOfLastFormControlChangeEvent(sanitizedValue);
+
     bool wasModifiedProgrammatically = eventBehavior == DispatchNoEvent;
     if (wasModifiedProgrammatically) {
         resignStrongPasswordAppearance();

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -176,8 +176,7 @@ void TextFieldInputType::setValue(const String& sanitizedValue, bool valueChange
         break;
     }
 
-    // FIXME: Why do we do this when eventBehavior == DispatchNoEvent
-    if (!input->focused() || eventBehavior == DispatchNoEvent)
+    if (!input->focused())
         input->setTextAsOfLastFormControlChangeEvent(sanitizedValue);
 
     if (UserTypingGestureIndicator::processingUserTypingGesture())


### PR DESCRIPTION
<pre>

Change event isn't firing when the user reverts the value of a color/date/time input after JS changed the value

<a href="https://bugs.webkit.org/show_bug.cgi?id=121590">https://bugs.webkit.org/show_bug.cgi?id=121590</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/3054068c08635caf65eb933794f5ac6bbaf80e23">https://chromium.googlesource.com/chromium/blink/+/3054068c08635caf65eb933794f5ac6bbaf80e23</a>

Setting the value through the value property wasn't setting the textAsOfLastFormControlChangeEvent.
So change events weren't firing when the user changes the value back to the one that was set before JS changed it.

* Source/WebCore/html/HTMLInputElement.cpp:
(HTMLInputElement::setValue) - Add if condition to add "santantizedValue" for setTextAsOfLastFormControlChangeEvent
* Source/WebCore/html/TextFieldInput.cpp:
(TextFieldIputType::setValue) - Remove FIXME and condition of eventBehavior being DispatchNoEvent

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c731cdb1916b488e30e4dcc6ab0d2f0ec8a6aee2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96848 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150610 "Found 3 new test failures: fast/forms/date-multiple-fields/date-multiple-fields-choose-default-value-after-set-value.html, fast/forms/datetimelocal-multiple-fields/datetimelocal-multiple-fields-choose-default-value-after-set-value.html, fast/forms/time-multiple-fields/time-multiple-fields-choose-default-value-after-set-value.html") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30086 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26214 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79741 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91600 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93259 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24308 "Found 3 new test failures: fast/forms/date-multiple-fields/date-multiple-fields-choose-default-value-after-set-value.html, fast/forms/datetimelocal-multiple-fields/datetimelocal-multiple-fields-choose-default-value-after-set-value.html, fast/forms/time-multiple-fields/time-multiple-fields-choose-default-value-after-set-value.html") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74401 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24133 "Found 1 new test failure: fast/forms/time-multiple-fields/time-multiple-fields-choose-default-value-after-set-value.html") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67149 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27786 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13293 "Found 3 new test failures: fast/forms/date-multiple-fields/date-multiple-fields-choose-default-value-after-set-value.html, fast/forms/datetimelocal-multiple-fields/datetimelocal-multiple-fields-choose-default-value-after-set-value.html, fast/forms/time-multiple-fields/time-multiple-fields-choose-default-value-after-set-value.html") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27748 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14309 "Found 1 new test failure: fast/forms/time-multiple-fields/time-multiple-fields-choose-default-value-after-set-value.html") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29441 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37196 "Found 1 new test failure: fast/forms/time-multiple-fields/time-multiple-fields-choose-default-value-after-set-value.html") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33586 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->