### PR TITLE
[WPE][GTK] fast/mediastream/stream-switch.html is flaky

### DIFF
--- a/LayoutTests/fast/mediastream/stream-switch.html
+++ b/LayoutTests/fast/mediastream/stream-switch.html
@@ -3,21 +3,22 @@
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
 <script src="../../media/media-file.js"></script>
+<script src="../../media/utilities.js"></script>
+<script src="../../webrtc/routines.js"></script>
 <script>
 promise_test(async() => {
     let stream = await navigator.mediaDevices.getUserMedia({audio : true});
-
-    localVideo.srcObject = stream;
-    await localVideo.play();
-
     let cptr = 0;
+    let videoFile = "../../media/" + findMediaFile('video', 'content/test');
     while (++cptr < 20) {
         localVideo.srcObject = stream;
         await localVideo.play();
         await new Promise(resolve => setTimeout(resolve, 10));
-        localVideo.src = findMediaFile('video', 'content/test');
+        localVideo.srcObject = null;
+        localVideo.src = videoFile;
+        localVideo.load();
         await localVideo.play();
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await waitForVideoFrame(localVideo);
     }
 }, "Check switching between playing with and without stream");
 
@@ -34,9 +35,9 @@ promise_test(async() => {
     let cptr = 0;
     while (++cptr < 20) {
         stream.removeTrack(audioTrack);
-        await new Promise(resolve => setTimeout(resolve, 100));
+        once(stream, 'onremovetrack');
         stream.addTrack(audioTrack);
-        await new Promise(resolve => setTimeout(resolve, 100));
+        once(stream, 'onaddtrack');
     }
 }, "Check adding and removing a track to a stream");
 </script>


### PR DESCRIPTION
#### 9173145faeceb6da360672207a674c17d2dcbd22
<pre>
[WPE][GTK] fast/mediastream/stream-switch.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=244432">https://bugs.webkit.org/show_bug.cgi?id=244432</a>

Reviewed by Youenn Fablet.

Ensure we clear srcObject before setting src, otherwise the underlying media player will keep using
srcObject. Also wait on first video frame when loading an actual valid video file (previous path was
incorrect).

* LayoutTests/fast/mediastream/stream-switch.html:

Canonical link: <a href="https://commits.webkit.org/253882@main">https://commits.webkit.org/253882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9731cbf43941a486ae114772175a2b386c5afb54

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96539 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149886 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29763 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25966 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91313 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24046 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74104 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23891 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66907 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27480 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13077 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27432 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14092 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2731 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36956 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33369 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->