### PR TITLE
[JSC] Add RegExpLastIndex IC

### DIFF
--- a/JSTests/stress/regexp-last-index.js
+++ b/JSTests/stress/regexp-last-index.js
@@ -1,0 +1,47 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(regexp) {
+    regexp.lastIndex = 42;
+    shouldBe(regexp.lastIndex, 42);
+    regexp.lastIndex = "hey";
+    shouldBe(regexp.lastIndex, "hey");
+}
+noInline(test);
+
+var regexp = /test/;
+for (var i = 0; i < 1e4; ++i) {
+    test(regexp);
+    test({ lastIndex: 42 });
+}
+
+function test2(regexp) {
+    regexp.lastIndex = 42;
+    shouldBe(regexp.lastIndex, "hey");
+    regexp.lastIndex = "ok";
+    shouldBe(regexp.lastIndex, "hey");
+}
+noInline(test2);
+
+var regexp2 = /test2/;
+regexp2.lastIndex = "hey";
+Object.freeze(regexp2);
+for (var i = 0; i < 1e4; ++i)
+    test2(regexp2);

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -113,6 +113,8 @@ public:
         StringLength,
         DirectArgumentsLength,
         ScopedArgumentsLength,
+        RegExpLastIndex,
+        SetRegExpLastIndex,
         ModuleNamespaceLoad,
         InstanceOfHit,
         InstanceOfMiss,

--- a/Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp
@@ -963,6 +963,12 @@ void printInternal(PrintStream& out, AccessCase::AccessType type)
     case AccessCase::ScopedArgumentsLength:
         out.print("ScopedArgumentsLength");
         return;
+    case AccessCase::RegExpLastIndex:
+        out.print("RegExpLastIndex");
+        return;
+    case AccessCase::SetRegExpLastIndex:
+        out.print("SetRegExpLastIndex");
+        return;
     case AccessCase::ModuleNamespaceLoad:
         out.print("ModuleNamespaceLoad");
         return;

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -380,6 +380,9 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
                 if (!arguments->overrodeThings())
                     newCase = AccessCase::create(vm, codeBlock, AccessCase::ScopedArgumentsLength, propertyName);
             }
+        } else if (propertyName == vm.propertyNames->lastIndex) {
+            if (baseCell->inherits<RegExpObject>())
+                newCase = AccessCase::create(vm, codeBlock, AccessCase::RegExpLastIndex, propertyName);
         }
 
         if (!propertyName.isSymbol() && baseCell->inherits<JSModuleNamespaceObject>() && !slot.isUnset()) {
@@ -823,193 +826,201 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
         
         if (!baseValue.isCell())
             return GiveUpOnCache;
-        
-        if (!slot.isCacheablePut() && !slot.isCacheableCustom() && !slot.isCacheableSetter())
-            return GiveUpOnCache;
-
-        // FIXME: We should try to do something smarter here...
-        if (isCopyOnWrite(oldStructure->indexingMode()))
-            return GiveUpOnCache;
-        // We can't end up storing to a CoW on the prototype since it shouldn't own properties.
-        ASSERT(!isCopyOnWrite(slot.base()->indexingMode()));
-
-        if (!oldStructure->propertyAccessesAreCacheable())
-            return GiveUpOnCache;
 
         JSCell* baseCell = baseValue.asCell();
-
-        bool isProxy = false;
-        if (baseCell->type() == PureForwardingProxyType) {
-            baseCell = jsCast<JSProxy*>(baseCell)->target();
-            baseValue = baseCell;
-            isProxy = true;
-
-            // We currently only cache Replace and JS/Custom Setters on JSProxy. We don't
-            // cache transitions because global objects will never share the same structure
-            // in our current implementation.
-            bool isCacheableProxy = (slot.isCacheablePut() && slot.type() == PutPropertySlot::ExistingProperty)
-                || slot.isCacheableSetter()
-                || slot.isCacheableCustom();
-            if (!isCacheableProxy)
-                return GiveUpOnCache;
-        }
-
-        if (isProxy && (putKind == PutKind::DirectPrivateFieldSet || putKind == PutKind::DirectPrivateFieldDefine))
-            return GiveUpOnCache;
-
         RefPtr<AccessCase> newCase;
 
-        if (slot.base() == baseValue && slot.isCacheablePut()) {
-            if (slot.type() == PutPropertySlot::ExistingProperty) {
-                // This assert helps catch bugs if we accidentally forget to disable caching
-                // when we transition then store to an existing property. This is common among
-                // paths that reify lazy properties. If we reify a lazy property and forget
-                // to disable caching, we may come down this path. The Replace IC does not
-                // know how to model these types of structure transitions (or any structure
-                // transition for that matter).
-                RELEASE_ASSERT(baseValue.asCell()->structure() == oldStructure);
-
-                oldStructure->didCachePropertyReplacement(vm, slot.cachedOffset());
-            
-                if (stubInfo.cacheType() == CacheType::Unset
-                    && InlineAccess::canGenerateSelfPropertyReplace(codeBlock, stubInfo, slot.cachedOffset())
-                    && !oldStructure->needImpurePropertyWatchpoint()
-                    && !isProxy) {
-                    
-                    bool generatedCodeInline = InlineAccess::generateSelfPropertyReplace(codeBlock, stubInfo, oldStructure, slot.cachedOffset());
-                    if (generatedCodeInline) {
-                        LOG_IC((ICEvent::PutBySelfPatch, oldStructure->classInfoForCells(), ident, slot.base() == baseValue));
-                        repatchSlowPathCall(codeBlock, stubInfo, appropriateOptimizingPutByFunction(slot, putByKind, putKind));
-                        stubInfo.initPutByIdReplace(locker, codeBlock, oldStructure, slot.cachedOffset(), propertyName);
-                        return RetryCacheLater;
-                    }
-                }
-
-                newCase = AccessCase::createReplace(vm, codeBlock, propertyName, slot.cachedOffset(), oldStructure, isProxy);
-            } else {
-                ASSERT(!isProxy);
-                ASSERT(slot.type() == PutPropertySlot::NewProperty);
-
-                if (!oldStructure->isObject())
-                    return GiveUpOnCache;
-
-                // If the old structure is dictionary, it means that this is one-on-one between an object and a structure.
-                // If this is NewProperty operation, generating IC for this does not offer any benefit because this transition never happens again.
-                if (oldStructure->isDictionary())
-                    return RetryCacheLater;
-
-                PropertyOffset offset;
-                Structure* newStructure = Structure::addPropertyTransitionToExistingStructureConcurrently(oldStructure, ident.impl(), static_cast<unsigned>(PropertyAttribute::None), offset);
-                if (!newStructure || !newStructure->propertyAccessesAreCacheable())
-                    return GiveUpOnCache;
-
-                // If JSObject::put is overridden by UserObject, UserObject::put performs side-effect on JSObject::put, and it neglects to mark the PutPropertySlot as non-cachaeble,
-                // then arbitrary structure transitions can happen during the put operation, and this generates wrong transition information here as if oldStructure -> newStructure.
-                // In reality, the transition is oldStructure -> something unknown structures -> baseValue's structure.
-                // To guard against the embedder's potentially incorrect UserObject::put implementation, we should check for this condition and if found, and give up on caching the put.
-                ASSERT(baseValue.asCell()->structure() == newStructure);
-                if (baseValue.asCell()->structure() != newStructure)
-                    return GiveUpOnCache;
-
-                ASSERT(newStructure->previousID() == oldStructure);
-                ASSERT(!newStructure->isDictionary());
-                ASSERT(newStructure->isObject());
-                
-                RefPtr<PolyProtoAccessChain> prototypeAccessChain;
-                ObjectPropertyConditionSet conditionSet;
-                if (putKind == PutKind::NotDirect) {
-                    auto cacheStatus = prepareChainForCaching(globalObject, baseCell, nullptr);
-                    if (!cacheStatus)
-                        return GiveUpOnCache;
-
-                    if (cacheStatus->usesPolyProto) {
-                        prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, nullptr);
-                        if (!prototypeAccessChain)
-                            return GiveUpOnCache;
-                    } else {
-                        prototypeAccessChain = nullptr;
-                        conditionSet = generateConditionsForPropertySetterMiss(
-                            vm, codeBlock, globalObject, newStructure, ident.impl());
-                        if (!conditionSet.isValid())
-                            return GiveUpOnCache;
-                    }
-                }
-
-                if (putKind == PutKind::DirectPrivateFieldDefine) {
-                    ASSERT(ident.isPrivateName());
-                    conditionSet = generateConditionsForPropertyMiss(vm, codeBlock, globalObject, newStructure, ident.impl());
-                    if (!conditionSet.isValid())
-                        return GiveUpOnCache;
-                }
-
-                newCase = AccessCase::createTransition(vm, codeBlock, propertyName, offset, oldStructure, newStructure, conditionSet, WTFMove(prototypeAccessChain), stubInfo);
+        if (!(putKind == PutKind::DirectPrivateFieldSet || putKind == PutKind::DirectPrivateFieldDefine)) {
+            if (propertyName == vm.propertyNames->lastIndex) {
+                if (baseCell->inherits<RegExpObject>())
+                    newCase = AccessCase::create(vm, codeBlock, AccessCase::SetRegExpLastIndex, propertyName);
             }
-        } else if (slot.isCacheableCustom() || slot.isCacheableSetter()) {
-            if (slot.isCacheableCustom()) {
-                ObjectPropertyConditionSet conditionSet;
-                RefPtr<PolyProtoAccessChain> prototypeAccessChain;
+        }
 
-                // We need to do this even if we're a self custom, since we must disallow dictionaries
-                // because we need to be informed if the custom goes away since we cache the constant
-                // function pointer.
-                auto cacheStatus = prepareChainForCaching(globalObject, baseCell, slot.base());
-                if (!cacheStatus)
+        if (!newCase) {
+            if (!slot.isCacheablePut() && !slot.isCacheableCustom() && !slot.isCacheableSetter())
+                return GiveUpOnCache;
+
+            // FIXME: We should try to do something smarter here...
+            if (isCopyOnWrite(oldStructure->indexingMode()))
+                return GiveUpOnCache;
+            // We can't end up storing to a CoW on the prototype since it shouldn't own properties.
+            ASSERT(!isCopyOnWrite(slot.base()->indexingMode()));
+
+            if (!oldStructure->propertyAccessesAreCacheable())
+                return GiveUpOnCache;
+
+            bool isProxy = false;
+            if (baseCell->type() == PureForwardingProxyType) {
+                baseCell = jsCast<JSProxy*>(baseCell)->target();
+                baseValue = baseCell;
+                isProxy = true;
+
+                // We currently only cache Replace and JS/Custom Setters on JSProxy. We don't
+                // cache transitions because global objects will never share the same structure
+                // in our current implementation.
+                bool isCacheableProxy = (slot.isCacheablePut() && slot.type() == PutPropertySlot::ExistingProperty)
+                    || slot.isCacheableSetter()
+                    || slot.isCacheableCustom();
+                if (!isCacheableProxy)
                     return GiveUpOnCache;
+            }
 
-                if (slot.base() != baseValue) {
-                    if (cacheStatus->usesPolyProto) {
-                        prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, slot.base());
-                        if (!prototypeAccessChain)
+            if (isProxy && (putKind == PutKind::DirectPrivateFieldSet || putKind == PutKind::DirectPrivateFieldDefine))
+                return GiveUpOnCache;
+
+            if (slot.base() == baseValue && slot.isCacheablePut()) {
+                if (slot.type() == PutPropertySlot::ExistingProperty) {
+                    // This assert helps catch bugs if we accidentally forget to disable caching
+                    // when we transition then store to an existing property. This is common among
+                    // paths that reify lazy properties. If we reify a lazy property and forget
+                    // to disable caching, we may come down this path. The Replace IC does not
+                    // know how to model these types of structure transitions (or any structure
+                    // transition for that matter).
+                    RELEASE_ASSERT(baseValue.asCell()->structure() == oldStructure);
+
+                    oldStructure->didCachePropertyReplacement(vm, slot.cachedOffset());
+                
+                    if (stubInfo.cacheType() == CacheType::Unset
+                        && InlineAccess::canGenerateSelfPropertyReplace(codeBlock, stubInfo, slot.cachedOffset())
+                        && !oldStructure->needImpurePropertyWatchpoint()
+                        && !isProxy) {
+                        
+                        bool generatedCodeInline = InlineAccess::generateSelfPropertyReplace(codeBlock, stubInfo, oldStructure, slot.cachedOffset());
+                        if (generatedCodeInline) {
+                            LOG_IC((ICEvent::PutBySelfPatch, oldStructure->classInfoForCells(), ident, slot.base() == baseValue));
+                            repatchSlowPathCall(codeBlock, stubInfo, appropriateOptimizingPutByFunction(slot, putByKind, putKind));
+                            stubInfo.initPutByIdReplace(locker, codeBlock, oldStructure, slot.cachedOffset(), propertyName);
+                            return RetryCacheLater;
+                        }
+                    }
+
+                    newCase = AccessCase::createReplace(vm, codeBlock, propertyName, slot.cachedOffset(), oldStructure, isProxy);
+                } else {
+                    ASSERT(!isProxy);
+                    ASSERT(slot.type() == PutPropertySlot::NewProperty);
+
+                    if (!oldStructure->isObject())
+                        return GiveUpOnCache;
+
+                    // If the old structure is dictionary, it means that this is one-on-one between an object and a structure.
+                    // If this is NewProperty operation, generating IC for this does not offer any benefit because this transition never happens again.
+                    if (oldStructure->isDictionary())
+                        return RetryCacheLater;
+
+                    PropertyOffset offset;
+                    Structure* newStructure = Structure::addPropertyTransitionToExistingStructureConcurrently(oldStructure, ident.impl(), static_cast<unsigned>(PropertyAttribute::None), offset);
+                    if (!newStructure || !newStructure->propertyAccessesAreCacheable())
+                        return GiveUpOnCache;
+
+                    // If JSObject::put is overridden by UserObject, UserObject::put performs side-effect on JSObject::put, and it neglects to mark the PutPropertySlot as non-cachaeble,
+                    // then arbitrary structure transitions can happen during the put operation, and this generates wrong transition information here as if oldStructure -> newStructure.
+                    // In reality, the transition is oldStructure -> something unknown structures -> baseValue's structure.
+                    // To guard against the embedder's potentially incorrect UserObject::put implementation, we should check for this condition and if found, and give up on caching the put.
+                    ASSERT(baseValue.asCell()->structure() == newStructure);
+                    if (baseValue.asCell()->structure() != newStructure)
+                        return GiveUpOnCache;
+
+                    ASSERT(newStructure->previousID() == oldStructure);
+                    ASSERT(!newStructure->isDictionary());
+                    ASSERT(newStructure->isObject());
+                    
+                    RefPtr<PolyProtoAccessChain> prototypeAccessChain;
+                    ObjectPropertyConditionSet conditionSet;
+                    if (putKind == PutKind::NotDirect) {
+                        auto cacheStatus = prepareChainForCaching(globalObject, baseCell, nullptr);
+                        if (!cacheStatus)
                             return GiveUpOnCache;
-                    } else {
-                        prototypeAccessChain = nullptr;
-                        conditionSet = generateConditionsForPrototypePropertyHitCustom(
-                            vm, codeBlock, globalObject, oldStructure, slot.base(), ident.impl(), static_cast<unsigned>(PropertyAttribute::None));
+
+                        if (cacheStatus->usesPolyProto) {
+                            prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, nullptr);
+                            if (!prototypeAccessChain)
+                                return GiveUpOnCache;
+                        } else {
+                            prototypeAccessChain = nullptr;
+                            conditionSet = generateConditionsForPropertySetterMiss(
+                                vm, codeBlock, globalObject, newStructure, ident.impl());
+                            if (!conditionSet.isValid())
+                                return GiveUpOnCache;
+                        }
+                    }
+
+                    if (putKind == PutKind::DirectPrivateFieldDefine) {
+                        ASSERT(ident.isPrivateName());
+                        conditionSet = generateConditionsForPropertyMiss(vm, codeBlock, globalObject, newStructure, ident.impl());
                         if (!conditionSet.isValid())
                             return GiveUpOnCache;
                     }
+
+                    newCase = AccessCase::createTransition(vm, codeBlock, propertyName, offset, oldStructure, newStructure, conditionSet, WTFMove(prototypeAccessChain), stubInfo);
                 }
+            } else if (slot.isCacheableCustom() || slot.isCacheableSetter()) {
+                if (slot.isCacheableCustom()) {
+                    ObjectPropertyConditionSet conditionSet;
+                    RefPtr<PolyProtoAccessChain> prototypeAccessChain;
 
-                newCase = GetterSetterAccessCase::create(
-                    vm, codeBlock, slot.isCustomAccessor() ? AccessCase::CustomAccessorSetter : AccessCase::CustomValueSetter, oldStructure, propertyName,
-                    invalidOffset, conditionSet, WTFMove(prototypeAccessChain), isProxy, slot.customSetter(), slot.base() != baseValue ? slot.base() : nullptr);
-            } else {
-                ASSERT(slot.isCacheableSetter());
-                ObjectPropertyConditionSet conditionSet;
-                RefPtr<PolyProtoAccessChain> prototypeAccessChain;
-                PropertyOffset offset = slot.cachedOffset();
-
-                if (slot.base() != baseValue) {
+                    // We need to do this even if we're a self custom, since we must disallow dictionaries
+                    // because we need to be informed if the custom goes away since we cache the constant
+                    // function pointer.
                     auto cacheStatus = prepareChainForCaching(globalObject, baseCell, slot.base());
                     if (!cacheStatus)
                         return GiveUpOnCache;
-                    if (cacheStatus->flattenedDictionary)
-                        return RetryCacheLater;
 
-                    if (cacheStatus->usesPolyProto) {
-                        prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, slot.base());
-                        if (!prototypeAccessChain)
-                            return GiveUpOnCache;
-                        unsigned attributes;
-                        offset = prototypeAccessChain->slotBaseStructure(vm, baseCell->structure())->get(vm, ident.impl(), attributes);
-                        if (!isValidOffset(offset) || !(attributes & PropertyAttribute::Accessor))
-                            return RetryCacheLater;
-                    } else {
-                        prototypeAccessChain = nullptr;
-                        conditionSet = generateConditionsForPrototypePropertyHit(
-                            vm, codeBlock, globalObject, oldStructure, slot.base(), ident.impl());
-                        if (!conditionSet.isValid())
-                            return GiveUpOnCache;
-
-                        if (!(conditionSet.slotBaseCondition().attributes() & PropertyAttribute::Accessor))
-                            return GiveUpOnCache;
-
-                        offset = conditionSet.slotBaseCondition().offset();
+                    if (slot.base() != baseValue) {
+                        if (cacheStatus->usesPolyProto) {
+                            prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, slot.base());
+                            if (!prototypeAccessChain)
+                                return GiveUpOnCache;
+                        } else {
+                            prototypeAccessChain = nullptr;
+                            conditionSet = generateConditionsForPrototypePropertyHitCustom(
+                                vm, codeBlock, globalObject, oldStructure, slot.base(), ident.impl(), static_cast<unsigned>(PropertyAttribute::None));
+                            if (!conditionSet.isValid())
+                                return GiveUpOnCache;
+                        }
                     }
-                }
 
-                newCase = GetterSetterAccessCase::create(
-                    vm, codeBlock, AccessCase::Setter, oldStructure, propertyName, offset, conditionSet, WTFMove(prototypeAccessChain), isProxy);
+                    newCase = GetterSetterAccessCase::create(
+                        vm, codeBlock, slot.isCustomAccessor() ? AccessCase::CustomAccessorSetter : AccessCase::CustomValueSetter, oldStructure, propertyName,
+                        invalidOffset, conditionSet, WTFMove(prototypeAccessChain), isProxy, slot.customSetter(), slot.base() != baseValue ? slot.base() : nullptr);
+                } else {
+                    ASSERT(slot.isCacheableSetter());
+                    ObjectPropertyConditionSet conditionSet;
+                    RefPtr<PolyProtoAccessChain> prototypeAccessChain;
+                    PropertyOffset offset = slot.cachedOffset();
+
+                    if (slot.base() != baseValue) {
+                        auto cacheStatus = prepareChainForCaching(globalObject, baseCell, slot.base());
+                        if (!cacheStatus)
+                            return GiveUpOnCache;
+                        if (cacheStatus->flattenedDictionary)
+                            return RetryCacheLater;
+
+                        if (cacheStatus->usesPolyProto) {
+                            prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, slot.base());
+                            if (!prototypeAccessChain)
+                                return GiveUpOnCache;
+                            unsigned attributes;
+                            offset = prototypeAccessChain->slotBaseStructure(vm, baseCell->structure())->get(vm, ident.impl(), attributes);
+                            if (!isValidOffset(offset) || !(attributes & PropertyAttribute::Accessor))
+                                return RetryCacheLater;
+                        } else {
+                            prototypeAccessChain = nullptr;
+                            conditionSet = generateConditionsForPrototypePropertyHit(
+                                vm, codeBlock, globalObject, oldStructure, slot.base(), ident.impl());
+                            if (!conditionSet.isValid())
+                                return GiveUpOnCache;
+
+                            if (!(conditionSet.slotBaseCondition().attributes() & PropertyAttribute::Accessor))
+                                return GiveUpOnCache;
+
+                            offset = conditionSet.slotBaseCondition().offset();
+                        }
+                    }
+
+                    newCase = GetterSetterAccessCase::create(
+                        vm, codeBlock, AccessCase::Setter, oldStructure, propertyName, offset, conditionSet, WTFMove(prototypeAccessChain), isProxy);
+                }
             }
         }
 


### PR DESCRIPTION
#### a1500014380f5f6278d5e9d5683b733bbcaa001c
<pre>
[JSC] Add RegExpLastIndex IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=244460">https://bugs.webkit.org/show_bug.cgi?id=244460</a>

Reviewed by NOBODY (OOPS!).

Let&apos;s make it fast even in baseline JIT. This patch adds RegExpLastIndex / SetRegExpLastIndex IC
so that we can quickly load lastIndex property without consulting to C++ path.

* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::create):
(JSC::AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck const):
(JSC::AccessCase::requiresIdentifierNameMatch const):
(JSC::AccessCase::requiresInt32PropertyCheck const):
(JSC::AccessCase::needsScratchFPR const):
(JSC::AccessCase::forEachDependentCell const):
(JSC::AccessCase::doesCalls const):
(JSC::AccessCase::canReplace const):
(JSC::AccessCase::generateWithGuard):
(JSC::AccessCase::generateImpl):
(JSC::AccessCase::canBeShared):
* Source/JavaScriptCore/bytecode/AccessCase.h:
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheGetBy):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1500014380f5f6278d5e9d5683b733bbcaa001c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96985 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/151359 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30250 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26322 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79895 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91729 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24433 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74529 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24415 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67262 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79590 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27928 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13371 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73321 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27906 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14386 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26066 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37292 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76151 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29489 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33662 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16884 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode") | 
<!--EWS-Status-Bubble-End-->