### PR TITLE
[PlayStation] Copy some script files to run LayoutTest

### DIFF
--- a/Source/cmake/OptionsPlayStation.cmake
+++ b/Source/cmake/OptionsPlayStation.cmake
@@ -317,6 +317,9 @@ add_custom_target(playstation_tools_copy
     COMMAND ${CMAKE_COMMAND} -E copy_directory
         ${WEBKIT_LIBRARIES_DIR}/tools/sce_sys/
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sce_sys/
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${WEBKIT_LIBRARIES_DIR}/tools/scripts/
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/scripts/
     COMMAND ${CMAKE_COMMAND} -E touch
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ebootparam.ini
 )


### PR DESCRIPTION
#### ce1a64450db49a0fb04cef19eba3760cd0260c6b
<pre>
[PlayStation] Copy some script files to run LayoutTest
<a href="https://bugs.webkit.org/show_bug.cgi?id=244471">https://bugs.webkit.org/show_bug.cgi?id=244471</a>

Reviewed by Don Olmstead.

To run LayoutTest on PlayStation, some script files for the test
needs to be copied.

* Source/cmake/OptionsPlayStation.cmake: Added a command to copy script files.

Canonical link: <a href="https://commits.webkit.org/253933@main">https://commits.webkit.org/253933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53bd586102ea23ab48b7411db8db3b9a092b9211

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96641 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29864 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26054 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91412 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24128 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74200 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23967 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66984 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79258 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27578 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13157 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72939 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27530 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14173 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25973 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2766 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37034 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75760 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33451 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16788 "Passed tests") | 
<!--EWS-Status-Bubble-End-->