### PR TITLE
[JSC] Optimize arity-fixup via load-pair / store-pair

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -1607,6 +1607,16 @@ public:
         }
     }
 
+    void loadPair32(PreIndexAddress src, RegisterID dest1, RegisterID dest2)
+    {
+        m_assembler.ldp<32>(dest1, dest2, src.base, PairPreIndex(src.index));
+    }
+
+    void loadPair32(PostIndexAddress src, RegisterID dest1, RegisterID dest2)
+    {
+        m_assembler.ldp<32>(dest1, dest2, src.base, PairPostIndex(src.index));
+    }
+
     void loadPair64(RegisterID src, RegisterID dest1, RegisterID dest2)
     {
         loadPair64(src, TrustedImm32(0), dest1, dest2);
@@ -1626,6 +1636,16 @@ public:
             load64(Address(src, offset.m_value), dest1);
             load64(Address(src, offset.m_value + 8), dest2);
         }
+    }
+
+    void loadPair64(PreIndexAddress src, RegisterID dest1, RegisterID dest2)
+    {
+        m_assembler.ldp<64>(dest1, dest2, src.base, PairPreIndex(src.index));
+    }
+
+    void loadPair64(PostIndexAddress src, RegisterID dest1, RegisterID dest2)
+    {
+        m_assembler.ldp<64>(dest1, dest2, src.base, PairPostIndex(src.index));
     }
 
     void loadPair64WithNonTemporalAccess(RegisterID src, RegisterID dest1, RegisterID dest2)
@@ -2015,6 +2035,16 @@ public:
         store32(src2, Address(dest, offset.m_value + 4));
     }
 
+    void storePair32(RegisterID src1, RegisterID src2, PreIndexAddress dest)
+    {
+        m_assembler.stp<32>(src1, src2, dest.base, PairPreIndex(dest.index));
+    }
+
+    void storePair32(RegisterID src1, RegisterID src2, PostIndexAddress dest)
+    {
+        m_assembler.stp<32>(src1, src2, dest.base, PairPostIndex(dest.index));
+    }
+
     void storePair64(RegisterID src1, RegisterID src2, RegisterID dest)
     {
         storePair64(src1, src2, dest, TrustedImm32(0));
@@ -2028,6 +2058,16 @@ public:
         }
         store64(src1, Address(dest, offset.m_value));
         store64(src2, Address(dest, offset.m_value + 8));
+    }
+
+    void storePair64(RegisterID src1, RegisterID src2, PreIndexAddress dest)
+    {
+        m_assembler.stp<64>(src1, src2, dest.base, PairPreIndex(dest.index));
+    }
+
+    void storePair64(RegisterID src1, RegisterID src2, PostIndexAddress dest)
+    {
+        m_assembler.stp<64>(src1, src2, dest.base, PairPostIndex(dest.index));
     }
 
     void storePair64WithNonTemporalAccess(RegisterID src1, RegisterID src2, RegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -562,6 +562,17 @@ public:
             swap(src, X86Registers::ecx);
         }
     }
+
+    void lshift64(RegisterID src, TrustedImm32 imm, RegisterID dest)
+    {
+        if (src == dest)
+            lshift64(imm, src);
+        else {
+            move(src, dest);
+            lshift64(imm, dest);
+        }
+    }
+
     
     void rshift64(TrustedImm32 imm, RegisterID dest)
     {

--- a/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
+++ b/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
@@ -143,7 +143,7 @@ void A64DOpcode::init()
         lastGroups[i] = 0;
     }
 
-    for (unsigned i = 0; i < sizeof(opcodeGroupList) / sizeof(struct OpcodeGroupInitializer); i++) {
+    for (unsigned i = 0; i < std::size(opcodeGroupList); i++) {
         OpcodeGroup* newOpcodeGroup = new OpcodeGroup(opcodeGroupList[i].m_mask, opcodeGroupList[i].m_pattern, opcodeGroupList[i].m_format);
         uint32_t opcodeGroupNumber = opcodeGroupList[i].m_opcodeGroupNumber;
 
@@ -1392,15 +1392,14 @@ const char* A64DOpcodeLoadStoreRegisterPair::opName()
 
 const char* A64DOpcodeLoadStoreRegisterPair::format()
 {
+    // https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/LDP--Load-Pair-of-Registers-
+    // https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/STP--Store-Pair-of-Registers-
     const char* thisOpName = opName();
     
     if (size() == 0x3)
         return A64DOpcode::format();
 
     if ((offsetMode() < 0x1) || (offsetMode() > 0x3))
-        return A64DOpcode::format();
-
-    if ((offsetMode() == 0x1) && !vBit() && !lBit())
         return A64DOpcode::format();
 
     appendInstructionName(thisOpName);


### PR DESCRIPTION
#### 9b26f540049cca27cec69a742b09cd4a52d50022
<pre>
[JSC] Optimize arity-fixup via load-pair / store-pair
<a href="https://bugs.webkit.org/show_bug.cgi?id=244486">https://bugs.webkit.org/show_bug.cgi?id=244486</a>

Reviewed by Michael Saboff.

Add pre/post index for ldp and stp in ARM64, and use them in arity-fixup since we already know that the main loop is aligned with 16-bytes.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::loadPair32):
(JSC::MacroAssemblerARM64::loadPair64):
(JSC::MacroAssemblerARM64::storePair32):
(JSC::MacroAssemblerARM64::storePair64):
* Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp:
(JSC::ARM64Disassembler::A64DOpcode::init):
(JSC::ARM64Disassembler::A64DOpcodeLoadStoreRegisterPair::format):
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
(JSC::arityFixupGenerator):

Canonical link: <a href="https://commits.webkit.org/255940@main">https://commits.webkit.org/255940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/203bd30f671b1eca99c7efe7203cc3dc03c035fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103690 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164036 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3270 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31481 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86374 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99736 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99724 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2350 "Found 1 new test failure: fast/forms/ios/file-upload-panel-capture.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80484 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29373 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84276 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72325 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85310 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37869 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80441 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35744 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19057 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27692 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39617 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41625 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83098 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1931 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38289 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18755 "Passed tests") | 
<!--EWS-Status-Bubble-End-->