### PR TITLE
[WPE] Enable USE_ANGLE_WEBGL

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1451,8 +1451,6 @@ webkit.org/b/232726 webaudio/AudioBuffer/huge-buffer.html [ Pass Slow ]
 # WebGL-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////
 
-webkit.org/b/211942 webgl/1.0.3/conformance/more/functions/copyTexImage2DBadArgs.html [ Crash ]
-
 webkit.org/b/169917 webgl/many-contexts.html [ Timeout Pass ]
 
 webkit.org/b/211887 [ Debug ] fast/canvas/webgl/tex-sub-image-2d-bad-args.html [ Crash ]
@@ -1460,15 +1458,6 @@ webkit.org/b/211887 [ Debug ] webgl/1.0.3/conformance/textures/tex-sub-image-2d-
 webkit.org/b/211887 [ Debug ] webgl/1.0.3/conformance/more/functions/texSubImage2DHTMLBadArgs.html [ Crash ]
 
 webkit.org/b/216071 fast/canvas/webgl/move-canvas-in-document-while-clean.html [ ImageOnlyFailure ]
-
-webkit.org/b/217813 webgl/conformance/extensions/ext-texture-compression-rgtc.html [ Failure ]
-webkit.org/b/217813 webgl/conformance/extensions/s3tc-and-rgtc.html [ Failure ]
-
-webkit.org/b/217816 webgl/conformance2/uniforms/gl-uniform-arrays-sub-source.html [ Failure ]
-
-webkit.org/b/218318 fast/canvas/webgl/webgl-clear-composited-notshowing.html [ Failure ]
-
-webkit.org/b/219251 fast/canvas/webgl/getIndexedParameter-crash.html [ Failure ]
 
 webkit.org/b/172812 fast/canvas/webgl/lose-context-on-status-failure.html [ Skip ]
 webkit.org/b/172812 webgl/lose-context-after-context-lost.html [ Failure ]
@@ -1479,27 +1468,7 @@ webkit.org/b/223624 webgl/conformance/extensions/khr-parallel-shader-compile.htm
 
 webkit.org/b/210239 fast/canvas/webgl/out-of-bounds-simulated-vertexAttrib0-drawArrays.html [ Slow ]
 
-webkit.org/b/219340 webgl/1.0.3/conformance/extensions/angle-instanced-arrays-out-of-bounds.html [ Failure ]
-
-webkit.org/b/243487 webgl/1.0.x/conformance/extensions/webgl-multi-draw.html [ Failure ]
-
-# Tests related with the WebGL/Metal backend, maybe should be skipped
-webkit.org/b/229050 fast/canvas/webgl/shader-with-comma-op.html [ Failure ]
-webkit.org/b/229050 fast/canvas/webgl/shader-with-struct-array.html [ Failure ]
-
-webkit.org/b/229051 webgl/1.0.x/conformance/glsl/bugs/character-set.html [ Failure ]
-webkit.org/b/229051 webgl/1.0.x/conformance/misc/invalid-passed-params.html [ Failure ]
-
 webkit.org/b/229052 webgl/1.0.x/conformance/textures/misc/texture-corner-case-videos.html [ Failure ]
-
-webkit.org/b/169917 webgl/1.0.3/conformance/context/context-lost-restored.html [ Failure ]
-webkit.org/b/169917 webgl/1.0.3/conformance/extensions/oes-texture-half-float.html [ Failure ]
-webkit.org/b/169917 webgl/1.0.3/conformance/extensions/webgl-compressed-texture-s3tc.html [ Failure ]
-webkit.org/b/169917 webgl/1.0.3/conformance/extensions/webgl-compressed-texture-size-limit.html [ Failure ]
-webkit.org/b/169917 webgl/1.0.3/conformance/misc/webgl-specific.html [ Failure ]
-webkit.org/b/169917 webgl/1.0.3/conformance/renderbuffers/framebuffer-object-attachment.html [ Failure ]
-webkit.org/b/169917 webgl/1.0.3/conformance/rendering/point-no-attributes.html [ Failure ]
-webkit.org/b/169917 webgl/1.0.3/conformance/textures/texture-copying-feedback-loops.html [ Failure ]
 
 # Not applicable.
 webgl/webgl-via-metal-flag-on.html [ Skip ]
@@ -2009,7 +1978,6 @@ webkit.org/b/166536 fast/canvas/webgl/shader-mix-with-bool.html [ Skip ]
 webkit.org/b/166536 fast/canvas/webgl/shader-vec-array-deref-no-crash.html [ Skip ]
 webkit.org/b/166536 fast/canvas/webgl/shader-with-reserved-keyword.html [ Skip ]
 webkit.org/b/166536 webgl/pending/conformance/glsl/misc/shader-with-reserved-words-2.html [ Skip ]
-webkit.org/b/166536 webgl/webgl-allow-shared.html [ Failure ]
 
 # LFC (LayoutFormatingContext is disabled by default).
 fast/layoutformattingcontext/ [ Skip ]
@@ -2519,8 +2487,6 @@ webkit.org/b/223965 http/tests/contentextensions/hide-on-csp-report.py [ Crash ]
 webkit.org/b/223965 http/tests/contentextensions/main-resource-redirect-blocked.py [ Crash ]
 
 webkit.org/b/224068 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-late-transform.https.html [ Failure ]
-
-webkit.org/b/224071 webgl/pending/conformance/context/context-attributes-alpha-depth-stencil-antialias.html [ Timeout ]
 
 webkit.org/b/155196 security/contentSecurityPolicy/video-with-file-url-allowed-by-media-src-star.html [ ImageOnlyFailure Pass ]
 webkit.org/b/224114 imported/w3c/web-platform-tests/wasm/webapi/instantiateStreaming-bad-imports.any.worker.html [ Failure Pass ]

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -939,6 +939,8 @@ webkit.org/b/207605 [ Debug ] http/tests/websocket/tests/hybi/no-subprotocol.htm
 
 webkit.org/b/212232 editing/async-clipboard/clipboard-read-while-pasting.html [ Crash ]
 
+webkit.org/b/211942 webgl/1.0.3/conformance/more/functions/copyTexImage2DBadArgs.html [ Crash ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Crashing tests
 #////////////////////////////////////////////////////////////////////////////////////////
@@ -1274,6 +1276,8 @@ webkit.org/b/219979 gamepad/gamepad-polling-access.html [ Timeout Pass ]
 
 # Test is flaky timing out. Also skipped in Mac and iOS.
 editing/selection/select-bidi-run.html [ Skip ]
+
+webkit.org/b/224071 webgl/pending/conformance/context/context-attributes-alpha-depth-stencil-antialias.html [ Timeout ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Tests timing out
@@ -1841,6 +1845,35 @@ imported/w3c/web-platform-tests/css/css-pseudo/target-text-007.html [ Failure ]
 
 # WebGL on GTK renders pixels with opacity slightly differently
 fast/canvas/toDataURL-alpha-permutation.html [ ImageOnlyFailure ]
+
+webkit.org/b/219251 fast/canvas/webgl/getIndexedParameter-crash.html [ Failure ]
+
+webkit.org/b/229050 fast/canvas/webgl/shader-with-comma-op.html [ Failure ]
+webkit.org/b/229050 fast/canvas/webgl/shader-with-struct-array.html [ Failure ]
+
+webkit.org/b/218318 fast/canvas/webgl/webgl-clear-composited-notshowing.html [ Failure ]
+
+webkit.org/b/166536 webgl/webgl-allow-shared.html [ Failure ]
+
+webkit.org/b/217813 webgl/conformance/extensions/ext-texture-compression-rgtc.html [ Failure ]
+webkit.org/b/217813 webgl/conformance/extensions/s3tc-and-rgtc.html [ Failure ]
+webkit.org/b/217816 webgl/conformance2/uniforms/gl-uniform-arrays-sub-source.html [ Failure ]
+
+webkit.org/b/243487 webgl/1.0.x/conformance/extensions/webgl-multi-draw.html [ Failure ]
+
+webkit.org/b/229051 webgl/1.0.x/conformance/glsl/bugs/character-set.html [ Failure ]
+webkit.org/b/229051 webgl/1.0.x/conformance/misc/invalid-passed-params.html [ Failure ]
+
+webkit.org/b/169917 webgl/1.0.3/conformance/context/context-lost-restored.html [ Failure ]
+webkit.org/b/219340 webgl/1.0.3/conformance/extensions/angle-instanced-arrays-out-of-bounds.html [ Failure ]
+webkit.org/b/169917 webgl/1.0.3/conformance/extensions/oes-texture-half-float.html [ Failure ]
+webkit.org/b/169917 webgl/1.0.3/conformance/extensions/webgl-compressed-texture-s3tc.html [ Failure ]
+webkit.org/b/169917 webgl/1.0.3/conformance/extensions/webgl-compressed-texture-size-limit.html [ Failure ]
+webkit.org/b/169917 webgl/1.0.3/conformance/misc/webgl-specific.html [ Failure ]
+webkit.org/b/169917 webgl/1.0.3/conformance/renderbuffers/framebuffer-object-attachment.html [ Failure ]
+webkit.org/b/169917 webgl/1.0.3/conformance/rendering/point-no-attributes.html [ Failure ]
+webkit.org/b/169917 webgl/1.0.3/conformance/textures/texture-copying-feedback-loops.html [ Failure ]
+
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of non-crashing, non-flaky tests failing

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -255,9 +255,6 @@ webkit.org/b/236430 imported/w3c/web-platform-tests/svg/import/filters-image-03-
 webkit.org/b/236430 imported/w3c/web-platform-tests/svg/import/filters-image-04-f-manual.svg [ Failure ]
 webkit.org/b/236430 imported/w3c/web-platform-tests/svg/import/filters-image-05-f-manual.svg [ Failure ]
 
-# WebGL
-webkit.org/b/213203 webgl/1.0.3/conformance/rendering/multisample-corruption.html [ Failure Timeout ]
-
 # WebXR
 webkit.org/b/229455 webxr/high-performance.html [ Failure ]
 
@@ -579,18 +576,12 @@ webkit.org/b/206885 css3/font-variant-font-face-override.html [ ImageOnlyFailure
 webkit.org/b/206885 imported/w3c/web-platform-tests/css/css-fonts/font-feature-settings-descriptor-01.html [ ImageOnlyFailure ]
 webkit.org/b/206885 imported/w3c/web-platform-tests/css/css-fonts/font-variant-ligatures.html [ ImageOnlyFailure ]
 
-webkit.org/b/210236 fast/canvas/webgl/hide-some-renderer-info.html [ Failure ]
-webkit.org/b/210236 fast/canvas/webgl/webgl2-glsl3-compile.html [ Failure ]
-webkit.org/b/210236 webgl/webgl-vertex-array-object-defined.html [ Failure ]
-
 webkit.org/b/210262 fast/selectors/text-field-selection-stroke-color.html [ ImageOnlyFailure ]
 webkit.org/b/210262 fast/selectors/text-field-selection-text-shadow.html [ ImageOnlyFailure ]
 
 # Only enabled on Mac/iOS so far.
 Bug(WPE) contentfiltering/ [ Skip ]
 Bug(WPE) http/tests/contentfiltering [ Skip ]
-
-webkit.org/b/212349 fast/canvas/webgl/readPixels-float.html [ Failure ]
 
 webkit.org/b/212351 fast/events/mouse-cursor-udpate-during-raf.html [ Failure ]
 
@@ -889,6 +880,9 @@ webkit.org/b/212144 http/tests/xmlhttprequest/on-network-timeout-error-during-pr
 # webkit.org/b/188506 fast/dom/timer-throttling-hidden-page.html [ Failure ]
 webkit.org/b/212350 fast/dom/timer-throttling-hidden-page.html [ Timeout ]
 
+webkit.org/b/244480 webgl/max-active-contexts-webglcontextlost-prevent-default.html [ Timeout ]
+webkit.org/b/244481 webgl/pending/conformance/textures/misc/tex-image-video-repeated.html [ Timeout ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # 8. TESTS FAILING
 #////////////////////////////////////////////////////////////////////////////////////////
@@ -904,15 +898,10 @@ Bug(WPE) ietestcenter/css3/flexbox/flexbox-layout-002.htm [ ImageOnlyFailure ]
 # webgl/1.0.3:
 #  Failing:
 Bug(WPE) webgl/1.0.3/conformance/context/premultiplyalpha-test.html [ Failure ]
-Bug(WPE) webgl/1.0.3/conformance/attribs/gl-bindAttribLocation-aliasing.html [ Failure ]
-Bug(WPE) webgl/1.0.3/conformance/attribs/gl-bindAttribLocation-matrix.html [ Failure ]
-Bug(WPE) webgl/1.0.3/conformance/renderbuffers/feedback-loop.html [ Failure ]
-webkit.org/b/204676 webgl/1.0.3/conformance/extensions/oes-texture-float.html [ Failure ]
 webkit.org/b/204676 webgl/1.0.3/conformance/more/functions/readPixelsBadArgs.html [ Failure ]
 webkit.org/b/204676 webgl/1.0.3/conformance/more/functions/texImage2DHTML.html [ Failure ]
 webkit.org/b/204676 webgl/1.0.3/conformance/more/functions/texSubImage2DHTML.html [ Failure ]
 #  Timing out:
-Bug(WPE) webgl/1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-video.html [ Timeout ]
 webkit.org/b/204676 webgl/1.0.3/conformance/glsl/constructors/glsl-construct-bvec2.html [ Timeout ]
 webkit.org/b/204676 webgl/1.0.3/conformance/glsl/constructors/glsl-construct-ivec2.html [ Timeout ]
 webkit.org/b/204676 webgl/1.0.3/conformance/glsl/constructors/glsl-construct-vec2.html [ Timeout ]
@@ -930,10 +919,7 @@ fast/canvas/canvas-quadratic-same-endpoint.html [ Failure ]
 fast/canvas/canvas-toDataURL-case-insensitive-mimetype.html [ Failure ]
 fast/canvas/canvas-toDataURL-webp.html [ Failure ]
 fast/canvas/toDataURL-supportedTypes.html [ Failure ]
-fast/canvas/webgl/antialiasing-enabled.html [ Failure ]
-fast/canvas/webgl/multisample-resolve-consistency.html [ Failure ]
 fast/canvas/webgl/premultiplyalpha-test.html [ Failure ]
-fast/canvas/webgl/webglcontextchangedevent.html [ Timeout ]
 
 # security/
 # Require EventSender support
@@ -1355,6 +1341,14 @@ Bug(WPE) media/video-canvas-createPattern.html [ Failure ]
 
 webkit.org/b/230277 imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-006.html [ ImageOnlyFailure ]
 webkit.org/b/230277 imported/w3c/web-platform-tests/css/css-transforms/scrollable-scroll-3d-transform-z.html [ ImageOnlyFailure ]
+
+webkit.org/b/244473 fast/canvas/webgl/draw-elements-out-of-bounds-uint-index.html [ Failure ]
+webkit.org/b/244474 fast/canvas/webgl/oes-texture-float-linear.html [ Failure ]
+webkit.org/b/244476 fast/canvas/webgl/webgl-compressed-texture-size-limit.html [ Failure ]
+
+webkit.org/b/244479 webgl/1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-video-rgb565.html [ Failure ]
+
+webkit.org/b/244482 webgl/webgl2-primitive-restart.html [ ImageOnlyFailure ]
 
 ######################################################
 # Test failures from turning GPU Process on by default

--- a/LayoutTests/platform/wpe/fast/canvas/webgl/copy-tex-image-and-sub-image-2d-bad-input-expected.txt
+++ b/LayoutTests/platform/wpe/fast/canvas/webgl/copy-tex-image-and-sub-image-2d-bad-input-expected.txt
@@ -1,0 +1,39 @@
+
+Verify copyTexImage2D and copyTexSubImage2D can handle bad input
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+Testing with antialias on
+Testing copyTexImage2D
+PASS getError was expected value: NO_ERROR :
+PASS getError was expected value: NO_ERROR :
+PASS pixel is correctColor
+PASS pixel is correctColor
+PASS pixel is correctColor
+PASS pixel is correctColor
+Testing copyTexSubImage2D
+PASS getError was expected value: NO_ERROR :
+PASS getError was expected value: NO_ERROR :
+PASS pixel is correctColor
+PASS pixel is correctColor
+PASS pixel is correctColor
+PASS pixel is correctColor
+Testing with antialias off
+Testing copyTexImage2D
+PASS getError was expected value: NO_ERROR :
+PASS getError was expected value: NO_ERROR :
+PASS pixel is correctColor
+PASS pixel is correctColor
+PASS pixel is correctColor
+PASS pixel is correctColor
+Testing copyTexSubImage2D
+PASS getError was expected value: NO_ERROR :
+PASS getError was expected value: NO_ERROR :
+PASS pixel is correctColor
+PASS pixel is correctColor
+PASS pixel is correctColor
+PASS pixel is correctColor
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/wpe/fast/canvas/webgl/drawElements-empty-vertex-data-expected.txt
+++ b/LayoutTests/platform/wpe/fast/canvas/webgl/drawElements-empty-vertex-data-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: drawElements: no buffer is bound to enabled attribute
+PASS: Unable to draw with invalid vertexAttribArray0

--- a/LayoutTests/platform/wpe/fast/canvas/webgl/simulated-vertexAttrib0-invalid-indicies-expected.txt
+++ b/LayoutTests/platform/wpe/fast/canvas/webgl/simulated-vertexAttrib0-invalid-indicies-expected.txt
@@ -1,0 +1,5 @@
+PASS: MAX_UINT index was unable to be simulated
+PASS: MAX_UINT index did not crash
+FAIL: Huge index did not fail validation
+PASS: Huge index did not crash
+

--- a/LayoutTests/platform/wpe/fast/canvas/webgl/vertexAttribPointer-with-bad-offset-expected.txt
+++ b/LayoutTests/platform/wpe/fast/canvas/webgl/vertexAttribPointer-with-bad-offset-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: vertexAttribPointer: bad offset
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: drawArrays: no buffer is bound to enabled attribute
+PASS: vertexAttribPointer should have an error.
+

--- a/LayoutTests/platform/wpe/fast/canvas/webgl/webgl-depth-texture-expected.txt
+++ b/LayoutTests/platform/wpe/fast/canvas/webgl/webgl-depth-texture-expected.txt
@@ -1,0 +1,16 @@
+This test verifies the functionality of the WEBGL_depth_texture extension, if it is available.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS WebGL context exists
+Testing binding enum with extension disabled
+PASS gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 1, 1, 0, gl.DEPTH_COMPONENT, gl.UNSIGNED_SHORT, null) generated expected GL error: INVALID_ENUM.
+PASS gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 1, 1, 0, gl.DEPTH_COMPONENT, gl.UNSIGNED_INT, null) generated expected GL error: INVALID_ENUM.
+PASS No WEBGL_depth_texture support -- this is legal
+PASS WEBGL_depth_texture not listed as supported and getExtension failed -- this is legal
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/wpe/fast/canvas/webgl/webgl-drawarrays-crash-2-expected.txt
+++ b/LayoutTests/platform/wpe/fast/canvas/webgl/webgl-drawarrays-crash-2-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: drawArrays: no buffer is bound to enabled attribute
+PASS. You didn't crash.
+

--- a/LayoutTests/platform/wpe/fast/canvas/webgl/webgl-drawarrays-crash-expected.txt
+++ b/LayoutTests/platform/wpe/fast/canvas/webgl/webgl-drawarrays-crash-expected.txt
@@ -1,0 +1,2 @@
+PASS. You didn't crash.
+

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -95,7 +95,7 @@ WEBKIT_OPTION_DEFINE(ENABLE_DOCUMENTATION "Whether to generate documentation." P
 WEBKIT_OPTION_DEFINE(ENABLE_INTROSPECTION "Whether to enable GObject introspection." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(ENABLE_JOURNALD_LOG "Whether to enable journald logging" PUBLIC ON)
 WEBKIT_OPTION_DEFINE(ENABLE_WPE_QT_API "Whether to enable support for the Qt5/QML plugin" PUBLIC ${ENABLE_DEVELOPER_MODE})
-WEBKIT_OPTION_DEFINE(USE_ANGLE_WEBGL "Whether to use ANGLE as WebGL backend." PUBLIC OFF)
+WEBKIT_OPTION_DEFINE(USE_ANGLE_WEBGL "Whether to use ANGLE as WebGL backend." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_AVIF "Whether to enable support for AVIF images." PUBLIC ${ENABLE_EXPERIMENTAL_FEATURES})
 WEBKIT_OPTION_DEFINE(USE_JPEGXL "Whether to enable support for JPEG-XL images." PUBLIC ${ENABLE_EXPERIMENTAL_FEATURES})
 WEBKIT_OPTION_DEFINE(USE_LCMS "Whether to enable support for image color management using libcms2." PUBLIC ON)


### PR DESCRIPTION
#### df180a175f4b01fd59c1e14d09a535115e6de7cb
<pre>
[WPE] Enable USE_ANGLE_WEBGL
<a href="https://bugs.webkit.org/show_bug.cgi?id=244485">https://bugs.webkit.org/show_bug.cgi?id=244485</a>

Reviewed by Adrian Perez de Castro.

Flip on the USE_ANGLE_WEBGL CMake option by default for the WPE port, meaning
ANGLE will be used as the WebGL backing.

Test expectations are updated accordingly, moving around or deleting existing
ones and adding a few new ones for possible regressions that still need
investigation.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* LayoutTests/platform/wpe/fast/canvas/webgl/copy-tex-image-and-sub-image-2d-bad-input-expected.txt: Added.
* LayoutTests/platform/wpe/fast/canvas/webgl/drawElements-empty-vertex-data-expected.txt: Added.
* LayoutTests/platform/wpe/fast/canvas/webgl/simulated-vertexAttrib0-invalid-indicies-expected.txt: Added.
* LayoutTests/platform/wpe/fast/canvas/webgl/vertexAttribPointer-with-bad-offset-expected.txt: Added.
* LayoutTests/platform/wpe/fast/canvas/webgl/webgl-depth-texture-expected.txt: Added.
* LayoutTests/platform/wpe/fast/canvas/webgl/webgl-drawarrays-crash-2-expected.txt: Added.
* LayoutTests/platform/wpe/fast/canvas/webgl/webgl-drawarrays-crash-expected.txt: Added.
* Source/cmake/OptionsWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/253898@main">https://commits.webkit.org/253898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/567a12a0cd5139a6c14b08454c4c22c5e898e3fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96646 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150010 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29869 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26059 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79534 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91417 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93034 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24131 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74205 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23969 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66986 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79263 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27583 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13159 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72944 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27535 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14175 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25977 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2740 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37036 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75765 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33453 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16791 "Passed tests") | 
<!--EWS-Status-Bubble-End-->