### PR TITLE
REGRESSION(253764@main): Disconnecting a subtree makes :lang pseudo class to never match

### DIFF
--- a/LayoutTests/fast/css/lang-pseudo-disconnected-expected.txt
+++ b/LayoutTests/fast/css/lang-pseudo-disconnected-expected.txt
@@ -1,0 +1,13 @@
+:lang pseudo class should work in a disconnected subtree
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS target.matches(":lang(zh)") is true
+PASS target.parentNode.remove(); target.matches(":lang(zh)") is true
+PASS target.matches(":lang(fr)") is true
+PASS document.body.append(target.parentNode); target.matches(":lang(fr)") is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/lang-pseudo-disconnected.html
+++ b/LayoutTests/fast/css/lang-pseudo-disconnected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="container" lang="zh"><span></span></div>
+<script src="../../resources/js-test.js"></script>
+<script>
+description(':lang pseudo class should work in a disconnected subtree');
+let target = container.querySelector('span');
+shouldBeTrue('target.matches(":lang(zh)")');
+shouldBeTrue('target.parentNode.remove(); target.matches(":lang(zh)")');
+
+const anotherContainer = document.createElement('div');
+anotherContainer.innerHTML = '<div lang="fr"><span></span></div>';
+target = anotherContainer.querySelector('span');
+shouldBeTrue('target.matches(":lang(fr)")');
+shouldBeTrue('document.body.append(target.parentNode); target.matches(":lang(fr)")');
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 06479a26a2b932682f098b397b14a05e18a89db3
<pre>
REGRESSION(253764@main): Disconnecting a subtree makes :lang pseudo class to never match
<a href="https://bugs.webkit.org/show_bug.cgi?id=244484">https://bugs.webkit.org/show_bug.cgi?id=244484</a>

Reviewed by Antti Koivisto.

The bug was caused by removedFromAncestor always clearing the effective lang in ElementRareData
when the element itself doesn&apos;t have a lang content attribute specified. This is wrong; We need
to keep the effective lang when an ancestor of &quot;this&quot; element still has a lang content attribute.

This patch also fixes a bug in insertedIntoAncestor that the code to inherit the effective lang
from a parent node was not running when the subtree is not inside a document or a shadow root.
To this end, insertedIntoAncestor has been refactored to match the structure of removedFromAncestor.

Finally, this patch also removes the code in insertedIntoAncestor which was trying to clear
the effective lang when &quot;this&quot; element doesn&apos;t have a lang attribute. This is also clearly wrong
as any ancestor with a valid lang attribute should continue to apply the same effective lang.

* LayoutTests/fast/css/lang-pseudo-disconnected-expected.txt: Added.
* LayoutTests/fast/css/lang-pseudo-disconnected.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::insertedIntoAncestor):
(WebCore::Element::removedFromAncestor):

Canonical link: <a href="https://commits.webkit.org/253915@main">https://commits.webkit.org/253915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/225e389e5b4c8be8c22bd566e7ac94f391ee1ac2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96654 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150028 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91401 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29880 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26064 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79545 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91425 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24137 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74212 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23976 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66994 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27590 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13165 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27544 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14181 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37043 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1109 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33459 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->