### PR TITLE
[JSC] Remove vtable from AccessCase

### DIFF
--- a/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp
@@ -52,15 +52,7 @@ Ref<AccessCase> GetterSetterAccessCase::create(
     bool viaProxy, WatchpointSet* additionalSet, CodePtr<CustomAccessorPtrTag> customGetter, JSObject* customSlotBase,
     std::optional<DOMAttributeAnnotation> domAttribute, RefPtr<PolyProtoAccessChain>&& prototypeAccessChain)
 {
-    switch (type) {
-    case Getter:
-    case CustomAccessorGetter:
-    case CustomValueGetter:
-        break;
-    default:
-        ASSERT_NOT_REACHED();
-    };
-
+    ASSERT(type == Getter || type == CustomValueGetter || type == CustomAccessorGetter);
     auto result = adoptRef(*new GetterSetterAccessCase(vm, owner, type, identifier, offset, structure, conditionSet, viaProxy, additionalSet, customSlotBase, WTFMove(prototypeAccessChain)));
     result->m_domAttribute = domAttribute;
     if (customGetter)
@@ -79,12 +71,6 @@ Ref<AccessCase> GetterSetterAccessCase::create(VM& vm, JSCell* owner, AccessType
     return result;
 }
 
-
-GetterSetterAccessCase::~GetterSetterAccessCase()
-{
-}
-
-
 GetterSetterAccessCase::GetterSetterAccessCase(const GetterSetterAccessCase& other)
     : Base(other)
     , m_customSlotBase(other.m_customSlotBase)
@@ -93,25 +79,25 @@ GetterSetterAccessCase::GetterSetterAccessCase(const GetterSetterAccessCase& oth
     m_domAttribute = other.m_domAttribute;
 }
 
-Ref<AccessCase> GetterSetterAccessCase::clone() const
+Ref<AccessCase> GetterSetterAccessCase::cloneImpl() const
 {
     auto result = adoptRef(*new GetterSetterAccessCase(*this));
     result->resetState();
     return result;
 }
 
-bool GetterSetterAccessCase::hasAlternateBase() const
+bool GetterSetterAccessCase::hasAlternateBaseImpl() const
 {
     if (customSlotBase())
         return true;
-    return Base::hasAlternateBase();
+    return Base::hasAlternateBaseImpl();
 }
 
-JSObject* GetterSetterAccessCase::alternateBase() const
+JSObject* GetterSetterAccessCase::alternateBaseImpl() const
 {
     if (customSlotBase())
         return customSlotBase();
-    return Base::alternateBase();
+    return Base::alternateBaseImpl();
 }
 
 void GetterSetterAccessCase::dumpImpl(PrintStream& out, CommaPrinter& comma, Indenter& indent) const

--- a/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h
@@ -34,7 +34,7 @@ namespace JSC {
 
 class GetterSetterAccessCase final : public ProxyableAccessCase {
 public:
-    typedef ProxyableAccessCase Base;
+    using Base = ProxyableAccessCase;
     friend class AccessCase;
 
     // This can return null if it hasn't been generated yet. That's
@@ -48,9 +48,6 @@ public:
     JSObject* customSlotBase() const { return m_customSlotBase.get(); }
     std::optional<DOMAttributeAnnotation> domAttribute() const { return m_domAttribute; }
 
-    bool hasAlternateBase() const final;
-    JSObject* alternateBase() const final;
-
     void emitDOMJITGetter(AccessGenerationState&, const DOMJIT::GetterSetter*, GPRReg baseForGetGPR);
 
     static Ref<AccessCase> create(
@@ -62,17 +59,18 @@ public:
         const ObjectPropertyConditionSet&, RefPtr<PolyProtoAccessChain>&&, bool viaProxy = false,
         CodePtr<CustomAccessorPtrTag> customSetter = nullptr, JSObject* customSlotBase = nullptr);
 
-    void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const final;
-    Ref<AccessCase> clone() const final;
-
-    ~GetterSetterAccessCase() final;
-
     CodePtr<CustomAccessorPtrTag> customAccessor() const { return m_customAccessor; }
 
 private:
     GetterSetterAccessCase(VM&, JSCell*, AccessType, CacheableIdentifier, PropertyOffset, Structure*, const ObjectPropertyConditionSet&, bool viaProxy, WatchpointSet* additionalSet, JSObject* customSlotBase, RefPtr<PolyProtoAccessChain>&&);
 
     GetterSetterAccessCase(const GetterSetterAccessCase&);
+
+    bool hasAlternateBaseImpl() const;
+    JSObject* alternateBaseImpl() const;
+    void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const;
+    Ref<AccessCase> cloneImpl() const;
+
 
     WriteBarrier<JSObject> m_customSlotBase;
     OptimizingCallLinkInfo* m_callLinkInfo { nullptr };

--- a/Source/JavaScriptCore/bytecode/InstanceOfAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/InstanceOfAccessCase.cpp
@@ -36,6 +36,7 @@ Ref<AccessCase> InstanceOfAccessCase::create(
     VM& vm, JSCell* owner, AccessType accessType, Structure* structure,
     const ObjectPropertyConditionSet& conditionSet, JSObject* prototype)
 {
+    ASSERT(accessType == AccessCase::InstanceOfMiss || accessType == AccessCase::InstanceOfHit);
     return adoptRef(*new InstanceOfAccessCase(vm, owner, accessType, structure, conditionSet, prototype));
 }
 
@@ -45,15 +46,11 @@ void InstanceOfAccessCase::dumpImpl(PrintStream& out, CommaPrinter& comma, Inden
     out.print(comma, "prototype = ", JSValue(prototype()));
 }
 
-Ref<AccessCase> InstanceOfAccessCase::clone() const
+Ref<AccessCase> InstanceOfAccessCase::cloneImpl() const
 {
     auto result = adoptRef(*new InstanceOfAccessCase(*this));
     result->resetState();
     return result;
-}
-
-InstanceOfAccessCase::~InstanceOfAccessCase()
-{
 }
 
 InstanceOfAccessCase::InstanceOfAccessCase(

--- a/Source/JavaScriptCore/bytecode/InstanceOfAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/InstanceOfAccessCase.h
@@ -42,15 +42,13 @@ public:
     
     JSObject* prototype() const { return m_prototype.get(); }
     
-    void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const final;
-    Ref<AccessCase> clone() const final;
-    
-    ~InstanceOfAccessCase() final;
-
 private:
     InstanceOfAccessCase(
         VM&, JSCell*, AccessType, Structure*, const ObjectPropertyConditionSet&,
         JSObject* prototype);
+
+    void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const;
+    Ref<AccessCase> cloneImpl() const;
 
     WriteBarrier<JSObject> m_prototype;
 };

--- a/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.cpp
@@ -44,11 +44,7 @@ Ref<AccessCase> IntrinsicGetterAccessCase::create(VM& vm, JSCell* owner, Cacheab
     return adoptRef(*new IntrinsicGetterAccessCase(vm, owner, identifier, offset, structure, conditionSet, intrinsicFunction, WTFMove(prototypeAccessChain)));
 }
 
-IntrinsicGetterAccessCase::~IntrinsicGetterAccessCase()
-{
-}
-
-Ref<AccessCase> IntrinsicGetterAccessCase::clone() const
+Ref<AccessCase> IntrinsicGetterAccessCase::cloneImpl() const
 {
     auto result = adoptRef(*new IntrinsicGetterAccessCase(*this));
     result->resetState();

--- a/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.h
@@ -33,7 +33,7 @@ namespace JSC {
 
 class IntrinsicGetterAccessCase final : public AccessCase {
 public:
-    typedef AccessCase Base;
+    using Base = AccessCase;
     friend class AccessCase;
 
     JSFunction* intrinsicFunction() const { return m_intrinsicFunction.get(); }
@@ -44,12 +44,10 @@ public:
 
     static Ref<AccessCase> create(VM&, JSCell*, CacheableIdentifier, PropertyOffset, Structure*, const ObjectPropertyConditionSet&, JSFunction* intrinsicFunction, RefPtr<PolyProtoAccessChain>&&);
 
-    Ref<AccessCase> clone() const final;
-
-    ~IntrinsicGetterAccessCase() final;
-
 private:
     IntrinsicGetterAccessCase(VM&, JSCell*, CacheableIdentifier, PropertyOffset, Structure*, const ObjectPropertyConditionSet&, JSFunction* intrinsicFunction, RefPtr<PolyProtoAccessChain>&&);
+
+    Ref<AccessCase> cloneImpl() const;
 
     WriteBarrier<JSFunction> m_intrinsicFunction;
 };

--- a/Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.cpp
@@ -38,7 +38,7 @@
 namespace JSC {
 
 ModuleNamespaceAccessCase::ModuleNamespaceAccessCase(VM& vm, JSCell* owner, CacheableIdentifier identifier, JSModuleNamespaceObject* moduleNamespaceObject, JSModuleEnvironment* moduleEnvironment, ScopeOffset scopeOffset)
-    : Base(vm, owner, ModuleNamespaceLoad, identifier, invalidOffset, nullptr, ObjectPropertyConditionSet(), nullptr)
+    : Base(vm, owner, AccessType::ModuleNamespaceLoad, identifier, invalidOffset, nullptr, ObjectPropertyConditionSet(), nullptr)
     , m_scopeOffset(scopeOffset)
 {
     m_moduleNamespaceObject.set(vm, owner, moduleNamespaceObject);
@@ -50,11 +50,7 @@ Ref<AccessCase> ModuleNamespaceAccessCase::create(VM& vm, JSCell* owner, Cacheab
     return adoptRef(*new ModuleNamespaceAccessCase(vm, owner, identifier, moduleNamespaceObject, moduleEnvironment, scopeOffset));
 }
 
-ModuleNamespaceAccessCase::~ModuleNamespaceAccessCase()
-{
-}
-
-Ref<AccessCase> ModuleNamespaceAccessCase::clone() const
+Ref<AccessCase> ModuleNamespaceAccessCase::cloneImpl() const
 {
     auto result = adoptRef(*new ModuleNamespaceAccessCase(*this));
     result->resetState();

--- a/Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.h
@@ -46,14 +46,12 @@ public:
 
     static Ref<AccessCase> create(VM&, JSCell* owner, CacheableIdentifier, JSModuleNamespaceObject*, JSModuleEnvironment*, ScopeOffset);
 
-    Ref<AccessCase> clone() const final;
-
     void emit(AccessGenerationState&, MacroAssembler::JumpList& fallThrough);
-
-    ~ModuleNamespaceAccessCase() final;
 
 private:
     ModuleNamespaceAccessCase(VM&, JSCell* owner, CacheableIdentifier, JSModuleNamespaceObject*, JSModuleEnvironment*, ScopeOffset);
+
+    Ref<AccessCase> cloneImpl() const;
 
     WriteBarrier<JSModuleNamespaceObject> m_moduleNamespaceObject;
     WriteBarrier<JSModuleEnvironment> m_moduleEnvironment;

--- a/Source/JavaScriptCore/bytecode/ProxyableAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/ProxyableAccessCase.cpp
@@ -40,15 +40,11 @@ ProxyableAccessCase::ProxyableAccessCase(VM& vm, JSCell* owner, AccessType acces
 
 Ref<AccessCase> ProxyableAccessCase::create(VM& vm, JSCell* owner, AccessType type, CacheableIdentifier identifier, PropertyOffset offset, Structure* structure, const ObjectPropertyConditionSet& conditionSet, bool viaProxy, WatchpointSet* additionalSet, RefPtr<PolyProtoAccessChain>&& prototypeAccessChain)
 {
-    ASSERT(type == Load || type == Miss || type == GetGetter || type == Replace);
+    ASSERT(type == Load || type == Miss || type == GetGetter);
     return adoptRef(*new ProxyableAccessCase(vm, owner, type, identifier, offset, structure, conditionSet, viaProxy, additionalSet, WTFMove(prototypeAccessChain)));
 }
 
-ProxyableAccessCase::~ProxyableAccessCase()
-{
-}
-
-Ref<AccessCase> ProxyableAccessCase::clone() const
+Ref<AccessCase> ProxyableAccessCase::cloneImpl() const
 {
     auto result = adoptRef(*new ProxyableAccessCase(*this));
     result->resetState();

--- a/Source/JavaScriptCore/bytecode/ProxyableAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/ProxyableAccessCase.h
@@ -34,19 +34,17 @@ namespace JSC {
 class ProxyableAccessCase : public AccessCase {
 public:
     using Base = AccessCase;
-
-    WatchpointSet* additionalSet() const override { return m_additionalSet.get(); }
+    friend class AccessCase;
 
     static Ref<AccessCase> create(VM&, JSCell*, AccessType, CacheableIdentifier, PropertyOffset, Structure*, const ObjectPropertyConditionSet& = ObjectPropertyConditionSet(),
         bool viaProxy = false, WatchpointSet* additionalSet = nullptr, RefPtr<PolyProtoAccessChain>&& = nullptr);
 
-    void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const override;
-    Ref<AccessCase> clone() const override;
-
-    ~ProxyableAccessCase() override;
-
 protected:
     ProxyableAccessCase(VM&, JSCell*, AccessType, CacheableIdentifier, PropertyOffset, Structure*, const ObjectPropertyConditionSet&, bool viaProxy, WatchpointSet* additionalSet, RefPtr<PolyProtoAccessChain>&&);
+
+    WatchpointSet* additionalSetImpl() const { return m_additionalSet.get(); }
+    void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const;
+    Ref<AccessCase> cloneImpl() const;
 
 private:
     RefPtr<WatchpointSet> m_additionalSet;

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -888,7 +888,7 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
                     }
                 }
 
-                newCase = ProxyableAccessCase::create(vm, codeBlock, AccessCase::Replace, propertyName, slot.cachedOffset(), oldStructure, ObjectPropertyConditionSet(), isProxy);
+                newCase = AccessCase::createReplace(vm, codeBlock, propertyName, slot.cachedOffset(), oldStructure, isProxy);
             } else {
                 ASSERT(!isProxy);
                 ASSERT(slot.type() == PutPropertySlot::NewProperty);

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -338,6 +338,10 @@ using WTF::fastAlignedFree;
         ASSERT(location); \
         return location; \
     } \
+    static void freeAfterDestruction(void* p) \
+    { \
+        ::WTF::fastFree(p); \
+    } \
     using webkitFastMalloced = int; \
 
 // FIXME: WTF_MAKE_FAST_ALLOCATED should take class name so that we can create malloc_zone per this macro.
@@ -381,6 +385,10 @@ using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
     { \
         ASSERT(location); \
         return location; \
+    } \
+    static void freeAfterDestruction(void* p) \
+    { \
+        classname##Malloc::free(p); \
     } \
     using webkitFastMalloced = int; \
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -347,7 +347,7 @@ inline void NodeRareData::operator delete(NodeRareData* nodeRareData, std::destr
         static_cast<ElementRareData*>(nodeRareData)->~ElementRareData();
     else
         nodeRareData->~NodeRareData();
-    WTF::fastFree(nodeRareData);
+    NodeRareData::freeAfterDestruction(nodeRareData);
 }
 
 Node::Node(Document& document, ConstructionType type)

--- a/Source/bmalloc/bmalloc/IsoHeap.h
+++ b/Source/bmalloc/bmalloc/IsoHeap.h
@@ -145,8 +145,11 @@ public: \
     \
     void* operator new[](size_t size) = delete; \
     void operator delete[](void* p) = delete; \
-using webkitFastMalloced = int; \
+    \
+    exportMacro static void freeAfterDestruction(void*); \
+    \
+    using webkitFastMalloced = int; \
 private: \
-using __makeBisoMallocedMacroSemicolonifier BUNUSED_TYPE_ALIAS = int
+    using __makeBisoMallocedMacroSemicolonifier BUNUSED_TYPE_ALIAS = int
 
 } } // namespace bmalloc::api

--- a/Source/bmalloc/bmalloc/IsoHeapInlines.h
+++ b/Source/bmalloc/bmalloc/IsoHeapInlines.h
@@ -138,9 +138,15 @@ public: \
     \
     void* operator new[](size_t size) = delete; \
     void operator delete[](void* p) = delete; \
-using webkitFastMalloced = int; \
+    \
+    static void freeAfterDestruction(void* p) \
+    { \
+        bisoHeap().deallocate(p); \
+    } \
+    \
+    using webkitFastMalloced = int; \
 private: \
-using __makeBisoMallocedInlineMacroSemicolonifier BUNUSED_TYPE_ALIAS = int
+    using __makeBisoMallocedInlineMacroSemicolonifier BUNUSED_TYPE_ALIAS = int
 
 #define MAKE_BISO_MALLOCED_IMPL(isoType) \
 ::bmalloc::api::IsoHeap<isoType>& isoType::bisoHeap() \
@@ -156,6 +162,11 @@ void* isoType::operator new(size_t size) \
 } \
 \
 void isoType::operator delete(void* p) \
+{ \
+    bisoHeap().deallocate(p); \
+} \
+\
+void isoType::freeAfterDestruction(void* p) \
 { \
     bisoHeap().deallocate(p); \
 } \
@@ -179,6 +190,12 @@ void* isoType::operator new(size_t size) \
 \
 template<> \
 void isoType::operator delete(void* p) \
+{ \
+    bisoHeap().deallocate(p); \
+} \
+\
+template<> \
+void isoType::freeAfterDestruction(void* p) \
 { \
     bisoHeap().deallocate(p); \
 } \


### PR DESCRIPTION
#### 1614f1089459294e8a0a478e149c8168283f4607
<pre>
[JSC] Remove vtable from AccessCase
<a href="https://bugs.webkit.org/show_bug.cgi?id=244488">https://bugs.webkit.org/show_bug.cgi?id=244488</a>

Reviewed by Ross Kirsling, Mark Lam and Saam Barati.

This patch leverages std::destroying_delete so that we remove vtable from AccessCase.
AccessCase has m_type which represents derived classes so we can use this value to
dispatch appropriate methods. We can save one vtable pointer, and we can also remove
virtual function call for this class. We also use AccessCase for Replace IC for consistency,
it was using ProxyableAccessCase in some cases, but it is not necessary.

* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::createReplace):
(JSC::AccessCase::fromStructureStubInfo):
(JSC::AccessCase::hasAlternateBaseImpl const):
(JSC::AccessCase::alternateBaseImpl const):
(JSC::AccessCase::cloneImpl const):
(JSC::AccessCase::dump const):
(JSC::AccessCase::runWithDowncast):
(JSC::AccessCase::operator delete):
(JSC::AccessCase::clone const):
(JSC::AccessCase::additionalSet const):
(JSC::AccessCase::hasAlternateBase const):
(JSC::AccessCase::alternateBase const):
(JSC::AccessCase::~AccessCase): Deleted.
* Source/JavaScriptCore/bytecode/AccessCase.h:
(JSC::AccessCase::dumpImpl const):
(JSC::AccessCase::additionalSetImpl const):
(JSC::AccessCase::additionalSet const): Deleted.
* Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp:
(JSC::GetterSetterAccessCase::create):
(JSC::GetterSetterAccessCase::cloneImpl const):
(JSC::GetterSetterAccessCase::hasAlternateBaseImpl const):
(JSC::GetterSetterAccessCase::alternateBaseImpl const):
(JSC::GetterSetterAccessCase::~GetterSetterAccessCase): Deleted.
(JSC::GetterSetterAccessCase::clone const): Deleted.
(JSC::GetterSetterAccessCase::hasAlternateBase const): Deleted.
(JSC::GetterSetterAccessCase::alternateBase const): Deleted.
* Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h:
* Source/JavaScriptCore/bytecode/InstanceOfAccessCase.cpp:
(JSC::InstanceOfAccessCase::create):
(JSC::InstanceOfAccessCase::cloneImpl const):
(JSC::InstanceOfAccessCase::clone const): Deleted.
(JSC::InstanceOfAccessCase::~InstanceOfAccessCase): Deleted.
* Source/JavaScriptCore/bytecode/InstanceOfAccessCase.h:
* Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.cpp:
(JSC::IntrinsicGetterAccessCase::cloneImpl const):
(JSC::IntrinsicGetterAccessCase::clone const): Deleted.
* Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.h:
* Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.cpp:
(JSC::ModuleNamespaceAccessCase::ModuleNamespaceAccessCase):
(JSC::ModuleNamespaceAccessCase::cloneImpl const):
(JSC::ModuleNamespaceAccessCase::~ModuleNamespaceAccessCase): Deleted.
(JSC::ModuleNamespaceAccessCase::clone const): Deleted.
* Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.h:
* Source/JavaScriptCore/bytecode/ProxyableAccessCase.cpp:
(JSC::ProxyableAccessCase::create):
(JSC::ProxyableAccessCase::cloneImpl const):
(JSC::ProxyableAccessCase::~ProxyableAccessCase): Deleted.
(JSC::ProxyableAccessCase::clone const): Deleted.
* Source/JavaScriptCore/bytecode/ProxyableAccessCase.h:
(JSC::ProxyableAccessCase::additionalSetImpl const):
(): Deleted.
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCachePutBy):
* Source/WTF/wtf/FastMalloc.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::NodeRareData::operator delete):
* Source/bmalloc/bmalloc/IsoHeap.h:
* Source/bmalloc/bmalloc/IsoHeapInlines.h:

Canonical link: <a href="https://commits.webkit.org/253968@main">https://commits.webkit.org/253968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71dbce146dcbd72e9de3f4675fb13e805c2a327a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87652 "failed 2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31739 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/18407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96856 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150618 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30097 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79749 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/91608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93270 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74410 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/24142 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/18407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67157 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/79466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27795 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/18407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73171 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27759 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/18407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26036 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2793 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29452 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76002 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29357 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/18407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16854 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode") | 
<!--EWS-Status-Bubble-End-->