### PR TITLE
REGRESSION(253895@main): Broke non-unified GTK port builds

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
@@ -568,7 +568,7 @@ void WebPrintOperationGtk::printPagesDone()
     m_cairoContext = nullptr;
 }
 
-void WebPrintOperationGtk::printDone(RefPtr<FragmentedSharedBuffer>&& buffer, WebCore::ResourceError&& error)
+void WebPrintOperationGtk::printDone(RefPtr<WebCore::FragmentedSharedBuffer>&& buffer, WebCore::ResourceError&& error)
 {
     if (m_printPagesIdleId)
         g_source_remove(m_printPagesIdleId);

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.h
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.h
@@ -27,6 +27,7 @@
 
 #include "PrintInfo.h"
 #include <WebCore/RefPtrCairo.h>
+#include <WebCore/SharedBuffer.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/glib/GRefPtr.h>
@@ -36,7 +37,6 @@ typedef struct _GtkPageSetup GtkPageSetup;
 typedef struct _GtkPageRange GtkPageRange;
 
 namespace WebCore {
-class FragmentedSharedBuffer;
 class PrintContext;
 class ResourceError;
 };


### PR DESCRIPTION
#### 905af8d114112f67db100186e2fa8a8c95595fc5
<pre>
REGRESSION(253895@main): Broke non-unified GTK port builds

Unreviewed non-unified build fix.

* Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp:
  (WebKit::WebPrintOperationGtk::printDone): Add WebCore:: namespace
  prefix to usage of the WebCore::FragmentSharedBuffer type.
* Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.h: Add
  missing inclusion of the WebCore/SharedBuffer.h header, needed for
  SharedBufferBuilder; remove now-unneeded forward declaration of the
  WebCore::FragmentSharedBuffer type.

Canonical link: <a href="https://commits.webkit.org/253900@main">https://commits.webkit.org/253900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b517f14a6a92dd25b238eb930085128116a3342a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96659 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29885 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91430 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93049 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74217 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23980 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66998 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27595 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27549 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/14186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2741 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37047 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29164 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/33464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->