### PR TITLE
RemoteVideoFrameObjectHeapProxyProcessor is using IPC in non-thread-safe manner

### DIFF
--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
@@ -66,6 +66,7 @@ public:
 
 private:
     explicit RemoteVideoFrameObjectHeapProxyProcessor(GPUProcessConnection&);
+    void initialize();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
@@ -83,7 +84,7 @@ private:
 
 private:
     Lock m_connectionLock;
-    IPC::Connection::UniqueID m_connectionID WTF_GUARDED_BY_LOCK(m_connectionLock);
+    RefPtr<IPC::Connection> m_connection WTF_GUARDED_BY_LOCK(m_connectionLock);
     Lock m_callbacksLock;
     HashMap<RemoteVideoFrameIdentifier, Callback> m_callbacks WTF_GUARDED_BY_LOCK(m_callbacksLock);
     Ref<WorkQueue> m_queue;


### PR DESCRIPTION
#### 07881767d61f02f289bb6607445e948fc80cfe62
<pre>
RemoteVideoFrameObjectHeapProxyProcessor is using IPC in non-thread-safe manner
<a href="https://bugs.webkit.org/show_bug.cgi?id=244493">https://bugs.webkit.org/show_bug.cgi?id=244493</a>
rdar://problem/99273408

Reviewed by Youenn Fablet.

Connection::UniqueID is not thread-safe and should not be used.
Code should be moved away from UniqueID.

Connection::addWorkQueueMessageReceiver(..., this) cannot be called from
the constructor, since it will invoke virtual functions through this,
which is not yet constructed at the time.

* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp:
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::create):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::RemoteVideoFrameObjectHeapProxyProcessor):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::initialize):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::gpuProcessConnectionDidClose):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::newVideoFrameBuffer):
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::getVideoFrameBuffer):
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h:

Canonical link: <a href="https://commits.webkit.org/253935@main">https://commits.webkit.org/253935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fcf16bbe4d7d864f9eb3e047094752767e5ca9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96663 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29889 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26073 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79554 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91434 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24147 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74221 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23986 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67004 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27599 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13173 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27553 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14189 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2769 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37051 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33467 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->