### PR TITLE
[WPE] WebGL test gardening

### DIFF
--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1237,28 +1237,13 @@ webkit.org/b/202736 http/wpt/cache-storage/cache-quota-after-restart.any.html [ 
 webkit.org/b/190626 imported/w3c/web-platform-tests/html/semantics/forms/the-datalist-element/datalistoptions.html [ Failure ]
 
 # WEBGL2 is disabled
-webkit.org/b/208188 fast/canvas/webgl/webgl2 [ Skip ]
-webkit.org/b/208188 fast/canvas/webgl/bufferData-offset-length.html [ Skip ]
-webkit.org/b/208188 fast/canvas/webgl/copyBufferSubData.html [ Skip ]
-webkit.org/b/208188 fast/canvas/webgl/getBufferSubData-webgl1.html [ Skip ]
-webkit.org/b/208188 fast/canvas/webgl/webgl2-buffer-targets.html [ Skip ]
-webkit.org/b/208188 fast/canvas/webgl/webgl2-buffers.html [ Skip ]
-webkit.org/b/208188 fast/canvas/webgl/webgl2-context-creation.html [ Skip ]
-webkit.org/b/208188 fast/canvas/webgl/webgl2-getActiveUniforms.html [ Skip ]
-webkit.org/b/208188 fast/canvas/webgl/webgl2-runtime-flag.html [ Skip ]
-webkit.org/b/208188 fast/canvas/webgl/webgl2-texStorage.html [ Skip ]
-webkit.org/b/208188 fast/canvas/webgl/webgl2-texture-upload-enums.html [ Skip ]
 webkit.org/b/208188 inspector/canvas/requestContent-webgl2.html [ Skip ]
 webkit.org/b/208188 inspector/canvas/create-context-webgl2.html [ Skip ]
 webkit.org/b/208188 inspector/canvas/recording-webgl2-snapshots.html [ Skip ]
 webkit.org/b/208188 inspector/canvas/resolveContext-webgl2.html [ Skip ]
 webkit.org/b/208188 inspector/canvas/shaderProgram-add-remove-webgl2.html [ Skip ]
-webkit.org/b/208188 webgl/webgl2-rendering-context-defined.html [ Skip ]
-webkit.org/b/208188 webgl/webgl2-rendering-context-obtain.html [ Skip ]
 webkit.org/b/208188 webgl/2.0.0 [ Skip ]
 webkit.org/b/208188 webgl/2.0.y [ Skip ]
-webkit.org/b/208188 webgl/pending/conformance2 [ Skip ]
-webkit.org/b/166536 http/tests/webgl/2.0.y/ [ Skip ]
 
 webkit.org/b/212080 mathml/presentation/href-enter.html [ ImageOnlyFailure ]
 webkit.org/b/212080 mathml/presentation/href-style.html [ ImageOnlyFailure ]
@@ -1349,6 +1334,10 @@ webkit.org/b/244476 fast/canvas/webgl/webgl-compressed-texture-size-limit.html [
 webkit.org/b/244479 webgl/1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-video-rgb565.html [ Failure ]
 
 webkit.org/b/244482 webgl/webgl2-primitive-restart.html [ ImageOnlyFailure ]
+
+webkit.org/b/244489 fast/canvas/webgl/bufferData-offset-length.html [ Failure ]
+webkit.org/b/244490 fast/canvas/webgl/copyBufferSubData.html [ Failure ]
+webkit.org/b/244491 fast/canvas/webgl/webgl2-texture-upload-enums.html [ Failure ]
 
 ######################################################
 # Test failures from turning GPU Process on by default


### PR DESCRIPTION
#### a035e072cff3c072f9afb8664bf1bd7cb7da836f
<pre>
[WPE] WebGL test gardening
<a href="https://bugs.webkit.org/show_bug.cgi?id=244496">https://bugs.webkit.org/show_bug.cgi?id=244496</a>

Unreviewed WPE gardening, managing a few test expectations for WebGL tests after
enabling ANGLE as the backing engine for WebGL content. Removing some skips,
adding new expectations for a few regressions.

* LayoutTests/platform/wpe/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253904@main">https://commits.webkit.org/253904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/783667e9f8935dbf6409f3b93cf251cd2f60b697

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96668 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/150054 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29894 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79559 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91439 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93058 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74226 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/23989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27604 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27558 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/14192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29246 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1104 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29173 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/33470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->