### PR TITLE
Omit document.referrer for third-party requests while in ephemeral mode

### DIFF
--- a/LayoutTests/http/tests/resourceLoadStatistics/omit-document-referrer-nested-third-party-iframe-ephemeral-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/omit-document-referrer-nested-third-party-iframe-ephemeral-expected.txt
@@ -1,0 +1,10 @@
+Tests that document.referrer is omitted in nested third-party iframes while in private browsing mode.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.referrer is [empty]
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/resourceLoadStatistics/omit-document-referrer-nested-third-party-iframe-ephemeral.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/omit-document-referrer-nested-third-party-iframe-ephemeral.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="resources/util.js"></script>
+</head>
+<body onload="runTest()">
+<script>
+    description("Tests that document.referrer is omitted in nested third-party iframes while in private browsing mode.");
+    jsTestIsAsync = true;
+
+    function receiveMessage(event) {
+        if (event.origin === "http://localhost:8000") {
+            if (event.data.indexOf("PASS") === -1)
+                testFailed(event.data.replace("FAIL ", ""));
+            else
+                testPassed(event.data.replace("PASS ", ""));
+        } else
+            testFailed("Received a message from an unexpected origin: " + event.origin);
+        setEnableFeature(false, finishJSTest);
+    }
+
+    window.addEventListener("message", receiveMessage, false);
+
+    function runTest() {
+        if (testRunner) {
+            setEnableFeature(true, function() {
+                let iframeElement = document.createElement("iframe");
+                iframeElement.src = "http://127.0.0.1:8000/resourceLoadStatistics/resources/nest-iframe-report-document-referrer.html";
+                document.body.appendChild(iframeElement);
+            });
+        }
+    }
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/resourceLoadStatistics/omit-document-referrer-third-party-iframe-ephemeral-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/omit-document-referrer-third-party-iframe-ephemeral-expected.txt
@@ -1,0 +1,10 @@
+Tests that document.referrer is omitted in third-party iframes while in private browsing mode.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.referrer is [empty]
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/resourceLoadStatistics/omit-document-referrer-third-party-iframe-ephemeral.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/omit-document-referrer-third-party-iframe-ephemeral.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="resources/util.js"></script>
+</head>
+<body onload="runTest()">
+<script>
+    description("Tests that document.referrer is omitted in third-party iframes while in private browsing mode.");
+    jsTestIsAsync = true;
+
+    function receiveMessage(event) {
+        if (event.origin === "http://localhost:8000") {
+            if (event.data.indexOf("PASS") === -1)
+                testFailed(event.data.replace("FAIL ", ""));
+            else
+                testPassed(event.data.replace("PASS ", ""));
+        } else
+            testFailed("Received a message from an unexpected origin: " + event.origin);
+        setEnableFeature(false, finishJSTest);
+    }
+
+    window.addEventListener("message", receiveMessage, false);
+
+    function runTest() {
+        if (testRunner) {
+            setEnableFeature(true, function() {
+                let iframeElement = document.createElement("iframe");
+                iframeElement.src = "http://localhost:8000/resourceLoadStatistics/resources/report-document-referrer.html";
+                document.body.appendChild(iframeElement);
+            });
+        }
+    }
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/resourceLoadStatistics/omit-referrer-for-navigation-ephemeral-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/omit-referrer-for-navigation-ephemeral-expected.txt
@@ -1,0 +1,10 @@
+Check that document.referrer is omitted after a cross-site navigation with link query while in private browsing mode.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The referrer is omitted.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/resourceLoadStatistics/omit-referrer-for-navigation-ephemeral.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/omit-referrer-for-navigation-ephemeral.html
@@ -1,0 +1,43 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="referrer" content="unsafe-url">
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="/cookies/resources/cookie-utilities.js"></script>
+    <script src="resources/util.js"></script>
+</head>
+<body onload="setTimeout('runTest()', 0)">
+<script>
+    description("Check that document.referrer is omitted after a cross-site navigation with link query while in private browsing mode.");
+    jsTestIsAsync = true;
+
+    let numberOfTries = 0;
+    function testReferrer() {
+        if (!document.referrer) {
+            testPassed("The referrer is omitted.");
+            setEnableFeature(false, finishJSTest);
+        } else if (++numberOfTries <= 5)
+            setTimeout(testReferrer, 200);
+        else {
+            testFailed("The referrer is not omitted: " + document.referrer);
+            setEnableFeature(false, finishJSTest);
+        }
+    }
+
+    function navigateCrossOrigin() {
+        document.location.href = destinationOrigin + "/resourceLoadStatistics/omit-referrer-for-navigation-ephemeral.html";
+    }
+
+    const destinationOrigin = "http://localhost:8000";
+    const prevalentResourceOrigin = "http://127.0.0.1:8000";
+    function runTest() {
+        if (document.location.origin === prevalentResourceOrigin) {
+            navigateCrossOrigin(); 
+        } else {
+            testReferrer();
+        }
+    }
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document+HTML.idl
+++ b/Source/WebCore/dom/Document+HTML.idl
@@ -32,7 +32,7 @@ partial interface Document {
     // resource metadata management
     [PutForwards=href, LegacyUnforgeable] readonly attribute Location? location;
     attribute USVString domain;
-    readonly attribute USVString referrer;
+    [ImplementedAs=referrerForBindings] readonly attribute USVString referrer;
     attribute USVString cookie;
     readonly attribute DOMString lastModified;
     readonly attribute DocumentReadyState readyState;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5437,6 +5437,15 @@ String Document::referrer()
     return String();
 }
 
+String Document::referrerForBindings()
+{
+    if (auto* page = this->page(); page
+        && page->usesEphemeralSession()
+        && !RegistrableDomain { URL { frame()->loader().referrer() } }.matches(securityOrigin().data()))
+        return String();
+    return referrer();
+}
+
 String Document::domain() const
 {
     return securityOrigin().domain();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -994,6 +994,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<void> setCookie(const String&);
 
     WEBCORE_EXPORT String referrer();
+    String referrerForBindings();
 
     WEBCORE_EXPORT String domain() const;
     ExceptionOr<void> setDomain(const String& newDomain);


### PR DESCRIPTION
#### 09d247d939321de347298e1d0147bf28e69f9e4d
<pre>
Omit document.referrer for third-party requests while in ephemeral mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=244518">https://bugs.webkit.org/show_bug.cgi?id=244518</a>
&lt;rdar://99578273&gt;

For third-party requests, omit document.referrer when accessed from JavaScript bindings while in ephemeral mode.

Reviewed by Darin Adler.

* LayoutTests/http/tests/resourceLoadStatistics/omit-document-referrer-nested-third-party-iframe-ephemeral-expected.txt: Added.
* LayoutTests/http/tests/resourceLoadStatistics/omit-document-referrer-nested-third-party-iframe-ephemeral.html: Added.
* LayoutTests/http/tests/resourceLoadStatistics/omit-document-referrer-third-party-iframe-ephemeral-expected.txt: Added.
* LayoutTests/http/tests/resourceLoadStatistics/omit-document-referrer-third-party-iframe-ephemeral.html: Added.
* LayoutTests/http/tests/resourceLoadStatistics/omit-referrer-for-navigation-ephemeral-expected.txt: Added.
* LayoutTests/http/tests/resourceLoadStatistics/omit-referrer-for-navigation-ephemeral.html: Added.
* Source/WebCore/dom/Document+HTML.idl:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::referrerForBindings):
* Source/WebCore/dom/Document.h:

Canonical link: <a href="https://commits.webkit.org/255649@main">https://commits.webkit.org/255649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f6cd026ad69ce86ccfd76612d2fbc27784e3e03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102869 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97165 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2366 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30689 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85552 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98988 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98832 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79634 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28565 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71673 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37078 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34893 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3911 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38764 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37663 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->