### PR TITLE
[Curl] Represent IPv6 addresses according to RFC 5952 addressing architecture

### DIFF
--- a/Source/WebCore/platform/network/curl/OpenSSLHelper.h
+++ b/Source/WebCore/platform/network/curl/OpenSSLHelper.h
@@ -37,5 +37,6 @@ std::optional<WebCore::CertificateSummary> createSummaryInfo(const Vector<uint8_
 
 String tlsVersion(const SSL*);
 String tlsCipherName(const SSL*);
+String canonicalizeIPv6Address(Span<uint8_t, 16> data);
 
 } // namespace OpenSSL

--- a/Tools/TestWebKitAPI/PlatformPlayStation.cmake
+++ b/Tools/TestWebKitAPI/PlatformPlayStation.cmake
@@ -20,6 +20,8 @@ list(APPEND TestJavaScriptCore_PRIVATE_INCLUDE_DIRECTORIES
 
 list(APPEND TestWebCore_SOURCES
     ${test_main_SOURCES}
+
+    Tests/WebCore/curl/OpenSSLHelperTests.cpp
 )
 list(APPEND TestWebCore_PRIVATE_INCLUDE_DIRECTORIES
     ${WEBKIT_LIBRARIES_DIR}/include

--- a/Tools/TestWebKitAPI/PlatformWin.cmake
+++ b/Tools/TestWebKitAPI/PlatformWin.cmake
@@ -26,6 +26,7 @@ set(TestWTF_OUTPUT_NAME TestWTF${DEBUG_SUFFIX})
 list(APPEND TestWebCore_SOURCES
     ${test_main_SOURCES}
 
+    Tests/WebCore/curl/OpenSSLHelperTests.cpp
     Tests/WebCore/win/DIBPixelData.cpp
     Tests/WebCore/win/LinkedFonts.cpp
     Tests/WebCore/win/WebCoreBundle.cpp

--- a/Tools/TestWebKitAPI/Tests/WebCore/curl/OpenSSLHelperTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/curl/OpenSSLHelperTests.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2019 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if USE(CURL)
+
+#include <WebCore/OpenSSLHelper.h>
+
+using namespace WebCore;
+
+namespace TestWebKitAPI {
+
+namespace Curl {
+
+class OpenSSLHelperTests : public testing::Test {
+public:
+    OpenSSLHelperTests() { }
+};
+
+TEST(OpenSSLHelper, IPv6AddressCompression)
+{
+    String ipv6;
+    unsigned char ipAddress[] = { 0x2a, 0x00, 0x8a, 0x00, 0xa0, 0x00, 0x11, 0x90, 0x00, 0x00, 0x00, 0x01, 0x00, 0x0, 0x02, 0x52 };
+    ipv6 = OpenSSL::canonicalizeIPv6Address(ipAddress);
+    EXPECT_EQ("2a00:8a00:a000:1190:0:1:0:252"_s, ipv6);
+
+    // Ensure the zero compression could handle multiple octects.
+    unsigned char ipAddress2[] = { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x01 };
+    ipv6 = OpenSSL::canonicalizeIPv6Address(ipAddress2);
+    EXPECT_EQ("::1"_s, ipv6);
+
+    // Make sure multiple 0 octects compressed.
+    unsigned char ipAddress3[] = { 0xfe, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x02, 0xaa, 0x0, 0xff, 0xfe, 0x9a, 0x4c, 0xa2 };
+    ipv6 = OpenSSL::canonicalizeIPv6Address(ipAddress3);
+    EXPECT_EQ("fe80::2aa:ff:fe9a:4ca2"_s, ipv6);
+
+    // Test zero compression at the end of string.
+    unsigned char ipAddress4[] = { 0x2a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x11, 0x90, 0x0, 0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
+    ipv6 = OpenSSL::canonicalizeIPv6Address(ipAddress4);
+    EXPECT_EQ("2a00:0:0:1190:1::"_s, ipv6);
+
+    // Test zero compression at the beginning of string.
+    unsigned char ipAddress5[] = { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x11, 0x90, 0x0, 0x0, 0x0, 0x01, 0x0, 0x0, 0x0, 0x0 };
+    ipv6 = OpenSSL::canonicalizeIPv6Address(ipAddress5);
+    EXPECT_EQ("::1190:0:1:0:0"_s, ipv6);
+
+    // Test zero compression only done once.
+    unsigned char ipAddress6[] = { 0x0, 0x01, 0x0, 0x01, 0x0, 0x0, 0x11, 0x90, 0x0, 0x0, 0x0, 0x0, 0x0, 0x01, 0x0, 0x0 };
+    ipv6 = OpenSSL::canonicalizeIPv6Address(ipAddress6);
+    EXPECT_EQ("1:1:0:1190::1:0"_s, ipv6);
+
+    // Make sure noncompressable IPv6 is the same.
+    unsigned char ipAddress7[] = { 0x12, 0x34, 0x56, 0x78, 0xab, 0xcd, 0x12, 0x34, 0x56, 0x78, 0xab, 0xcd, 0x12, 0x34, 0x56, 0x78 };
+    ipv6 = OpenSSL::canonicalizeIPv6Address(ipAddress7);
+    EXPECT_EQ("1234:5678:abcd:1234:5678:abcd:1234:5678"_s, ipv6);
+
+    // When there are multiple consecutive octet sections that can be compressed, make sure the first occurring one is compressed.
+    unsigned char ipAddress8[] = { 0x0, 0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x01, 0x0, 0x0 };
+    ipv6 = OpenSSL::canonicalizeIPv6Address(ipAddress8);
+    EXPECT_EQ("1::1:0:0:1:0"_s, ipv6);
+}
+
+}
+
+}
+
+#endif


### PR DESCRIPTION
#### 8bec657f93e0bcb721dd1a5f107e867174091976
<pre>
[Curl] Represent IPv6 addresses according to RFC 5952 addressing architecture
<a href="https://bugs.webkit.org/show_bug.cgi?id=244520">https://bugs.webkit.org/show_bug.cgi?id=244520</a>

Reviewed by Alex Christensen.

Conform to RFC 5952, <a href="https://www.rfc-editor.org/rfc/rfc4291">https://www.rfc-editor.org/rfc/rfc4291</a>, when displaying certificate
information.

* Source/WebCore/platform/network/curl/OpenSSLHelper.cpp:
(OpenSSL::getSubjectAltName):
(OpenSSL::getIPv6):
* Source/WebCore/platform/network/curl/OpenSSLHelper.h:
* Tools/TestWebKitAPI/PlatformPlayStation.cmake:
* Tools/TestWebKitAPI/PlatformWin.cmake:
* Tools/TestWebKitAPI/Tests/WebCore/curl/OpenSSLHelperTests.cpp: Added.
(TestWebKitAPI::Curl::OpenSSLHelperTests::OpenSSLHelperTests):
(TestWebKitAPI::Curl::TEST):

Canonical link: <a href="https://commits.webkit.org/255147@main">https://commits.webkit.org/255147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ded5fbebce727e7e147b34991d218842d93e043

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22149 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/101233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/662 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83849 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97164 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/27374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35635 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33417 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/17122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3575 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37225 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36239 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->