### PR TITLE
Make sure RemoteLayerTreeDrawingArea::updateRendering calls didPaintLayers when we have flushing work to do.

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -376,10 +376,11 @@ void RemoteLayerTreeDrawingArea::updateRendering()
     commitEncoder.get() << WTFMove(message).arguments();
 
     auto flushers = backingStoreCollection.didFlushLayers(layerTransaction);
+    bool haveFlushers = flushers.size();
     RefPtr<BackingStoreFlusher> backingStoreFlusher = BackingStoreFlusher::create(WebProcess::singleton().parentProcessConnection(), WTFMove(commitEncoder), WTFMove(flushers));
     m_pendingBackingStoreFlusher = backingStoreFlusher;
 
-    if (flushers.size())
+    if (haveFlushers)
         m_webPage.didPaintLayers();
 
     auto pageID = m_webPage.identifier();


### PR DESCRIPTION
#### caf77f485fe2067d0e52dd73f5c12c93be047997
<pre>
Make sure RemoteLayerTreeDrawingArea::updateRendering calls didPaintLayers when we have flushing work to do.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244522">https://bugs.webkit.org/show_bug.cgi?id=244522</a>
&lt;rdar://98521353&gt;

Reviewed by Simon Fraser.

didPaintLayers is used to notify the remote rendering backend of transaction that include painting work,
and triggers eviction of resources that haven&apos;t been recently used (like fonts).
Without this we retain font resources much longer than intended and necessary.

Fixed by reading the size of the flushers vector before we WTFMove them into BackingStoreFlusher::create.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):

Canonical link: <a href="https://commits.webkit.org/254201@main">https://commits.webkit.org/254201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b297b6f19abe547b7410bda9c213a9def3437679

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96858 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30099 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26223 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79751 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91609 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24317 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74412 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24311 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79281 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79473 "Found 1 new API test failure: TestWebKitAPI.WKInspectorExtension.CanEvaluateScriptInExtensionTab (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67161 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27797 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13298 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27761 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14314 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2956 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37205 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29359 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33591 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->