### PR TITLE
Support CanvasRenderingContext2D.filter

### DIFF
--- a/LayoutTests/fast/canvas/canvas-filter-basics-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-filter-basics-expected.txt
@@ -1,0 +1,35 @@
+This tests canavs filter setter
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+context.filter should be initialized with 'none'
+PASS context.filter is "none"
+PASS context.filter is "invert( 75% ) sepia(1) url(#svgDropShadow)"
+PASS context.filter is "invert( 75% ) sepia(1)"
+PASS context.filter is "invert( 75% )"
+PASS context.filter is "invert(75%)"
+
+Empty string , null and undefined should leave context.filter unchanged
+PASS context.filter is "invert(75%)"
+PASS context.filter is "invert(75%)"
+PASS context.filter is "invert(75%)"
+
+Unparsable strings should leave context.filter unchanged
+PASS context.filter is "invert(75%)"
+PASS context.filter is "invert(75%)"
+PASS context.filter is "invert(75%)"
+PASS context.filter is "invert(75%)"
+
+context.filter = 'none'; should disable filters for the context
+PASS context.filter is "none"
+
+context.filter is part of the context state
+PASS context.filter is "invert(75%)"
+PASS context.filter is "sepia(1)"
+PASS context.filter is "invert(75%)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/canvas-filter-basics.html
+++ b/LayoutTests/fast/canvas/canvas-filter-basics.html
@@ -1,0 +1,62 @@
+<html>
+<head>
+    <script src="../../resources/js-test.js"></script>
+</head>
+<body>
+    <canvas id="canvas"></canvas>
+    <script>
+        description("This tests canavs filter setter");
+
+        const canvas = document.getElementById('canvas');
+        const context = canvas.getContext('2d');
+
+        debug("");
+        debug("context.filter should be initialized with 'none'");
+        shouldBeEqualToString("context.filter", "none");
+
+        context.filter = "invert( 75% ) sepia(1) url(#svgDropShadow)";
+        shouldBeEqualToString("context.filter", "invert( 75% ) sepia(1) url(#svgDropShadow)");
+        context.filter = "invert( 75% ) sepia(1)";
+        shouldBeEqualToString("context.filter", "invert( 75% ) sepia(1)");
+        context.filter = "invert( 75% )";
+        shouldBeEqualToString("context.filter", "invert( 75% )");
+        context.filter = "invert(75%)";
+        shouldBeEqualToString("context.filter", "invert(75%)");
+
+        debug("");
+        debug("Empty string , null and undefined should leave context.filter unchanged");
+        context.filter = "";
+        shouldBeEqualToString("context.filter", "invert(75%)");
+        context.filter = null;
+        shouldBeEqualToString("context.filter", "invert(75%)");
+        context.filter = undefined;
+        shouldBeEqualToString("context.filter", "invert(75%)");
+
+        debug("");
+        debug("Unparsable strings should leave context.filter unchanged");
+        context.filter = "inherit";
+        shouldBeEqualToString("context.filter", "invert(75%)");
+        context.filter = "inherit(#svgDropShadow)";
+        shouldBeEqualToString("context.filter", "invert(75%)");
+        context.filter = 'initial';
+        shouldBeEqualToString("context.filter", "invert(75%)");
+        context.filter = 'unset';
+        shouldBeEqualToString("context.filter", "invert(75%)");
+
+        debug("");
+        debug("context.filter = 'none'; should disable filters for the context");
+        context.filter = "none";
+        shouldBeEqualToString("context.filter", "none");
+
+        debug("");
+        debug("context.filter is part of the context state");
+        context.filter = "invert(75%)";
+        shouldBeEqualToString("context.filter", "invert(75%)");
+        context.save();
+        context.filter = "sepia(1)";
+        shouldBeEqualToString("context.filter", "sepia(1)");
+        context.restore();
+        shouldBeEqualToString("context.filter", "invert(75%)");
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/canvas-filter-bounding-rect-expected.html
+++ b/LayoutTests/fast/canvas/canvas-filter-bounding-rect-expected.html
@@ -1,0 +1,58 @@
+<style>
+    canvas {
+        width: 700px;
+        height: 460px;
+    }
+</style>
+<body>
+    <h3>This tests the filter bounding rect is calculated correctly.</h3>
+    <canvas id="canvas"></canvas>
+    <script>
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        canvas.width = 700;
+        canvas.height = 460;
+
+        ctx.font = "120px serif";
+
+        ctx.fillStyle = 'green';
+        ctx.strokeStyle = 'green';
+        ctx.lineWidth = 10;
+
+        ctx.fillRect(20, 70, 100, 100);
+
+        ctx.strokeRect(345, 75, 90, 90);
+
+        ctx.fillRect(460, 20, 100, 100);
+
+        ctx.strokeRect(585, 125, 90, 90);
+
+        ctx.lineWidth = 2;
+
+        ctx.fillText("\u25A0", 30, 380);
+        ctx.strokeText("\u25A0", 350, 380);
+
+        ctx.fillRect(460, 240, 100, 100);
+        ctx.fillRect(580, 340, 100, 100);
+
+        ctx.fillStyle = '#666';
+        ctx.strokeStyle = '#666';
+        ctx.lineWidth = 10;
+
+        ctx.fillRect(120,  70, 100, 100);
+
+        ctx.strokeRect(245, 75, 90, 90);
+
+        ctx.fillRect(460, 120, 100, 100);
+
+        ctx.strokeRect(585, 25, 90, 90);
+
+        ctx.lineWidth = 2;
+
+        ctx.fillText("\u25A0", 130, 380);
+        ctx.strokeText("\u25A0", 250, 380);
+
+        ctx.fillRect(460, 340, 100, 100);
+        ctx.fillRect(580, 240, 100, 100);
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-filter-bounding-rect.html
+++ b/LayoutTests/fast/canvas/canvas-filter-bounding-rect.html
@@ -1,0 +1,81 @@
+<meta name="fuzzy" content="maxDifference=0-26; totalPixels=0-1000" />
+<style>
+     canvas {
+         width: 700px;
+         height: 460px;
+     }
+ </style>
+ <body>
+    <h3>This tests the filter bounding rect is calculated correctly.</h3>
+     <canvas id="canvas"></canvas>
+     <svg style="position: absolute; top: -99999px" xmlns="http://www.w3.org/2000/svg">
+         <filter id="svgDropShadow-left">
+             <feDropShadow dx="-100" dy="0" stdDeviation="0" flood-color="#666"/>
+         </filter>
+    </svg>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        canvas.width = 700;
+        canvas.height = 460;
+
+        ctx.font = "120px serif";
+
+        ctx.fillStyle = 'green';
+        ctx.strokeStyle = 'green';
+        ctx.lineWidth = 10;
+
+        ctx.filter = 'drop-shadow(100px 0 0 #666)';
+        ctx.fillRect(20, 70, 100, 100);
+
+        ctx.filter = 'drop-shadow(-100px 0 0 #666)';
+        ctx.strokeRect(345, 75, 90, 90);
+
+        ctx.filter = 'drop-shadow(0 100px 0 #666)';
+        ctx.beginPath();
+        ctx.moveTo(460, 20);
+        ctx.lineTo(560, 20);
+        ctx.lineTo(560, 120);
+        ctx.lineTo(460, 120);
+        ctx.fill();
+
+        ctx.filter = 'drop-shadow(0 -100px 0 #666)';
+        ctx.beginPath();
+        ctx.moveTo(585, 125);
+        ctx.lineTo(675, 125);
+        ctx.lineTo(675, 215);
+        ctx.lineTo(585, 215);
+        ctx.lineTo(585, 120);
+        ctx.stroke();
+
+        ctx.lineWidth = 2;
+
+        ctx.filter = 'drop-shadow(100px 0 0 #666)';
+        ctx.fillText("\u25A0", 30, 380);
+
+        ctx.filter = 'url(#svgDropShadow-left)';
+        ctx.strokeText("\u25A0", 350, 380);
+
+        let image = new Image;
+        image.addEventListener("load", (e) => {
+            ctx.filter = 'drop-shadow(0 100px 0 #666)';
+            ctx.drawImage(image, 460, 240);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+        image.src = "../images/resources/green-100x100.svg"
+
+        var tempCanvas = document.createElement("canvas");
+        const tempCtx = tempCanvas.getContext('2d');
+        tempCanvas .height = 100;
+        tempCanvas.width = 100;
+        tempCtx.fillStyle = 'green';
+        tempCtx.fillRect(0, 0, 100, 100);
+
+        ctx.filter = 'drop-shadow(0 -100px 0 #666)';
+        ctx.drawImage(tempCanvas, 580, 340);
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-filter-drawing-expected.html
+++ b/LayoutTests/fast/canvas/canvas-filter-drawing-expected.html
@@ -1,0 +1,42 @@
+<style>
+     canvas {
+         width: 350px;
+         height: 200px;
+     }
+ </style>
+ <body>
+    <h3>This tests the filter is drawn to the canvas.</h3>
+    <canvas id="canvas"></canvas>
+    <script>
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        canvas.width = 350;
+        canvas.height = 200;
+
+        function loadImage(src, x, y) {
+            return new Promise((resolve) => {
+                let image = new Image;
+                image.onload = (() => {
+                    ctx.drawImage(image, x, y);
+                    resolve();
+                });
+                image.src = src;
+            });
+        }
+
+        var images = [
+            { src: "resources/100x100-green-rect-filter-drop-shadow.svg", x: 20, y: 20 },
+            { src: "resources/100x100-green-rect-filter-blur.svg", x: 190, y: 10 },
+        ];
+
+        var promises = [];
+
+        for (let image of images)
+            promises.push(loadImage(image.src, image.x, image.y));
+            
+        Promise.all(promises).then(() => {
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-filter-drawing.html
+++ b/LayoutTests/fast/canvas/canvas-filter-drawing.html
@@ -1,0 +1,25 @@
+<meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-4920" />
+<style>
+     canvas {
+         width: 350px;
+         height: 200px;
+     }
+ </style>
+ <body>
+    <h3>This tests the filter is drawn to the canvas.</h3>
+    <canvas id="canvas"></canvas>
+    <script>
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        canvas.width = 350;
+        canvas.height = 200;
+
+        ctx.fillStyle = 'green';
+
+        ctx.filter = 'drop-shadow(10px 10px 0 #666)';
+        ctx.fillRect(20, 20, 100, 100);
+
+        ctx.filter = 'blur(5px)';
+        ctx.fillRect(200, 20, 100, 100);
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-filter-repaint-rect-expected.html
+++ b/LayoutTests/fast/canvas/canvas-filter-repaint-rect-expected.html
@@ -1,0 +1,30 @@
+<style>
+     canvas {
+         width: 340px;
+         height: 340px;
+     }
+ </style>
+ <body>
+    <h3>This tests the canvas repaints the filter bounding rect.</h3>
+    <canvas id="canvas"></canvas>
+    <script>
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        canvas.width = 340;
+        canvas.height = 340;
+
+        ctx.fillStyle = 'green';
+
+        ctx.filter = 'drop-shadow(-100px -100px 0 #666)';
+        ctx.fillRect(120, 120, 100, 100);
+
+        ctx.filter = 'drop-shadow(100px -100px 0 #666)';
+        ctx.fillRect(120, 120, 100, 100);
+
+        ctx.filter = 'drop-shadow(-100px 100px 0 #666)';
+        ctx.fillRect(120, 120, 100, 100);
+
+        ctx.filter = 'drop-shadow(100px 100px 0 #666)';
+        ctx.fillRect(120, 120, 100, 100);
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-filter-repaint-rect.html
+++ b/LayoutTests/fast/canvas/canvas-filter-repaint-rect.html
@@ -1,0 +1,52 @@
+<style>
+     canvas {
+         width: 340px;
+         height: 340px;
+     }
+ </style>
+ <body>
+    <h3>This tests the canvas repaints the filter bounding rect.</h3>
+    <canvas id="canvas"></canvas>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        canvas.width = 340;
+        canvas.height = 340;
+
+        ctx.fillStyle = 'green';
+
+        let count = 0;
+
+        function draw(timestamp) {
+            switch(++count) {
+            case 1:
+                ctx.filter = 'drop-shadow(-100px -100px 0 #666)';
+                break;
+            case 2:
+                ctx.filter = 'drop-shadow(100px -100px 0 #666)';
+                break;
+            case 3:
+                ctx.filter = 'drop-shadow(-100px 100px 0 #666)';
+                break;
+            case 4:
+                ctx.filter = 'drop-shadow(100px 100px 0 #666)';
+                break;
+            }
+
+            ctx.fillRect(120, 120, 100, 100);
+
+            if (count == 4) {
+                if (window.testRunner)
+                    testRunner.notifyDone();
+                return;
+            }
+
+            window.requestAnimationFrame(draw);
+        }
+
+        window.requestAnimationFrame(draw);
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-filter-save-restore-expected.html
+++ b/LayoutTests/fast/canvas/canvas-filter-save-restore-expected.html
@@ -1,0 +1,41 @@
+<style>
+     canvas {
+         width: 500px;
+         height: 260px;
+     }
+ </style>
+ <body>
+    <h3>This tests the canvas filter is maintained in its state.</h3>
+    <canvas id="canvas"></canvas>
+    <script>
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        canvas.width = 500;
+        canvas.height = 260;
+
+        ctx.fillStyle = 'green';
+
+        ctx.filter = 'blur(4px)';
+        ctx.fillRect(20, 20, 100, 100);
+
+        ctx.filter = 'sepia(1)';
+        ctx.fillRect(140, 20, 100, 100);
+
+        ctx.filter = 'invert(75%)';
+        ctx.fillRect(260, 20, 100, 100);
+
+        ctx.filter = 'saturate(400%)';
+        ctx.fillRect(380, 20, 100, 100);
+
+        ctx.fillRect(380, 140, 100, 100);
+
+        ctx.filter = 'invert(75%)';
+        ctx.fillRect(260, 140, 100, 100);
+
+        ctx.filter = 'sepia(1)';
+        ctx.fillRect(140, 140, 100, 100);
+
+        ctx.filter = 'blur(4px)';
+        ctx.fillRect(20, 140, 100, 100);
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-filter-save-restore.html
+++ b/LayoutTests/fast/canvas/canvas-filter-save-restore.html
@@ -1,0 +1,44 @@
+<style>
+     canvas {
+         width: 500px;
+         height: 260px;
+     }
+ </style>
+ <body>
+    <h3>This tests the canvas filter is maintained in its state.</h3>
+    <canvas id="canvas"></canvas>
+    <script>
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        canvas.width = 500;
+        canvas.height = 260;
+
+        ctx.fillStyle = 'green';
+
+        ctx.filter = 'blur(4px)';
+        ctx.fillRect(20, 20, 100, 100);
+
+        ctx.save();
+        ctx.filter = 'sepia(1)';
+        ctx.fillRect(140, 20, 100, 100);
+
+        ctx.save();
+        ctx.filter = 'invert(75%)';
+        ctx.fillRect(260, 20, 100, 100);
+
+        ctx.save();
+        ctx.filter = 'saturate(400%)';
+        ctx.fillRect(380, 20, 100, 100);
+
+        ctx.fillRect(380, 140, 100, 100);
+
+        ctx.restore();
+        ctx.fillRect(260, 140, 100, 100);
+
+        ctx.restore();
+        ctx.fillRect(140, 140, 100, 100);
+
+        ctx.restore();
+        ctx.fillRect(20, 140, 100, 100);
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/resources/100x100-green-rect-filter-blur.svg
+++ b/LayoutTests/fast/canvas/resources/100x100-green-rect-filter-blur.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+    <filter id="filter">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="5"/>
+    </filter>
+    <rect x="10" y="10" width="100" height="100" style="fill:green; filter:url(#filter);" />
+</svg>

--- a/LayoutTests/fast/canvas/resources/100x100-green-rect-filter-drop-shadow.svg
+++ b/LayoutTests/fast/canvas/resources/100x100-green-rect-filter-drop-shadow.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="110" height="110">
+    <filter id="filter" filterUnits="userSpaceOnUse">
+        <feDropShadow dx="10" dy="10" stdDeviation="0" flood-color="#666" />
+    </filter>
+    <rect width="100" height="100" style="fill:green; filter:url(#filter);" />
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject-expected.txt
@@ -1,6 +1,0 @@
-2d.filter.canvasFilterObject
-Test CanvasFilter() object
-Actual output:
-
-FAIL Test CanvasFilter() object assert_true: ctx.filter == 'none' expected true got false
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.blur.exceptions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.blur.exceptions-expected.txt
@@ -1,8 +1,0 @@
-2d.filter.canvasFilterObject.blur.exceptions
-Test exceptions on CanvasFilter() blur.object
-Actual output:
-
-FAIL Test exceptions on CanvasFilter() blur.object assert_throws_js: function "function() { ctx.filter = new CanvasFilter({filter: "gaussianBlur"}); }" threw object "ReferenceError: Can't find variable: CanvasFilter" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.colorMatrix-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.colorMatrix-expected.txt
@@ -1,8 +1,0 @@
-2d.filter.canvasFilterObject.colorMatrix
-Test the functionality of ColorMatrix filters in CanvasFilter objects
-Actual output:
-
-FAIL Test the functionality of ColorMatrix filters in CanvasFilter objects assert_throws_js: function "function() { new CanvasFilter({filter: "colorMatrix", values: undefined}); }" threw object "ReferenceError: Can't find variable: CanvasFilter" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.discrete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.discrete-expected.txt
@@ -1,6 +1,0 @@
-2d.filter.canvasFilterObject.componentTransfer.discrete
-Test pixels on CanvasFilter() componentTransfer with discrete type
-Actual output:
-
-FAIL Test pixels on CanvasFilter() componentTransfer with discrete type Can't find variable: CanvasFilter
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.gamma-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.gamma-expected.txt
@@ -1,6 +1,0 @@
-2d.filter.canvasFilterObject.componentTransfer.gamma
-Test pixels on CanvasFilter() componentTransfer with gamma type
-Actual output:
-
-FAIL Test pixels on CanvasFilter() componentTransfer with gamma type Can't find variable: CanvasFilter
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.identity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.identity-expected.txt
@@ -1,6 +1,0 @@
-2d.filter.canvasFilterObject.componentTransfer.identity
-Test pixels on CanvasFilter() componentTransfer with identity type
-Actual output:
-
-FAIL Test pixels on CanvasFilter() componentTransfer with identity type Can't find variable: CanvasFilter
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.linear-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.linear-expected.txt
@@ -1,6 +1,0 @@
-2d.filter.canvasFilterObject.componentTransfer.linear
-Test pixels on CanvasFilter() componentTransfer with linear type
-Actual output:
-
-FAIL Test pixels on CanvasFilter() componentTransfer with linear type Can't find variable: CanvasFilter
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.table-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.table-expected.txt
@@ -1,6 +1,0 @@
-2d.filter.canvasFilterObject.componentTransfer.table
-Test pixels on CanvasFilter() componentTransfer with table type
-Actual output:
-
-FAIL Test pixels on CanvasFilter() componentTransfer with table type Can't find variable: CanvasFilter
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.convolveMatrix.exceptions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.convolveMatrix.exceptions-expected.txt
@@ -1,8 +1,0 @@
-2d.filter.canvasFilterObject.convolveMatrix.exceptions
-Test exceptions on CanvasFilter() convolveMatrix
-Actual output:
-
-FAIL Test exceptions on CanvasFilter() convolveMatrix assert_throws_js: function "function() { new CanvasFilter({filter: "convolveMatrix"}); }" threw object "ReferenceError: Can't find variable: CanvasFilter" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.tentative-expected.txt
@@ -2,5 +2,5 @@
 Test CanvasFilter() object
 Actual output:
 
-FAIL Test CanvasFilter() object assert_true: ctx.filter == 'none' expected true got false
+FAIL Test CanvasFilter() object Can't find variable: CanvasFilter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.value-expected.txt
@@ -2,5 +2,5 @@
 test if ctx.filter works correctly
 Actual output:
 
-FAIL test if ctx.filter works correctly assert_true: ctx.filter == 'none' expected true got false
+PASS test if ctx.filter works correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.filter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.filter-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset assert_true: ctx.filter == default_value expected true got false
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.tentative-expected.txt
@@ -3,5 +3,5 @@
 Test CanvasFilter() object
 
 
-FAIL Test CanvasFilter() object assert_true: ctx.filter == 'none' expected true got false
+FAIL Test CanvasFilter() object assert_true: ctx.filter == 'blur(5px)' expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.tentative.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.tentative.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test CanvasFilter() object assert_true: ctx.filter == 'none' expected true got false
+FAIL Test CanvasFilter() object assert_true: ctx.filter == 'blur(5px)' expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.value-expected.txt
@@ -3,5 +3,5 @@
 test if ctx.filter works correctly
 
 
-FAIL test if ctx.filter works correctly assert_true: ctx.filter == 'none' expected true got false
+FAIL test if ctx.filter works correctly assert_true: ctx.filter == 'blur(5px)' expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.value.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.value.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL test if ctx.filter works correctly assert_true: ctx.filter == 'none' expected true got false
+FAIL test if ctx.filter works correctly assert_true: ctx.filter == 'blur(5px)' expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.filter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.filter-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset assert_true: ctx.filter == default_value expected true got false
+FAIL check that the state is reset assert_true: ctx.filter == 'blur(10px)' expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.filter.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.filter.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset assert_true: ctx.filter == default_value expected true got false
+FAIL check that the state is reset assert_true: ctx.filter == 'blur(10px)' expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -460,7 +460,7 @@ PASS CanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS CanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS CanvasRenderingContext2D interface: attribute shadowBlur
 PASS CanvasRenderingContext2D interface: attribute shadowColor
-FAIL CanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS CanvasRenderingContext2D interface: attribute filter
 PASS CanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
@@ -557,7 +557,7 @@ PASS CanvasRenderingContext2D interface: document.createElement("canvas").getCon
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowOffsetY" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowBlur" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowColor" with the proper type
-FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type assert_inherits: property "filter" not found in prototype chain
+PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type
 PASS CanvasRenderingContext2D interface: calling clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type
@@ -776,7 +776,7 @@ PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowBlur
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowColor
-FAIL OffscreenCanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute filter
 PASS OffscreenCanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -374,7 +374,7 @@ PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowBlur
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowColor
-FAIL OffscreenCanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute filter
 PASS OffscreenCanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -460,7 +460,7 @@ PASS CanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS CanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS CanvasRenderingContext2D interface: attribute shadowBlur
 PASS CanvasRenderingContext2D interface: attribute shadowColor
-FAIL CanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS CanvasRenderingContext2D interface: attribute filter
 PASS CanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
@@ -557,7 +557,7 @@ PASS CanvasRenderingContext2D interface: document.createElement("canvas").getCon
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowOffsetY" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowBlur" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowColor" with the proper type
-FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type assert_inherits: property "filter" not found in prototype chain
+PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type
 PASS CanvasRenderingContext2D interface: calling clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type
@@ -776,7 +776,7 @@ PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowBlur
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowColor
-FAIL OffscreenCanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute filter
 PASS OffscreenCanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -373,7 +373,7 @@ PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowBlur
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowColor
-FAIL OffscreenCanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute filter
 PASS OffscreenCanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -3965,7 +3965,7 @@ PASS CanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS CanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS CanvasRenderingContext2D interface: attribute shadowBlur
 PASS CanvasRenderingContext2D interface: attribute shadowColor
-FAIL CanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS CanvasRenderingContext2D interface: attribute filter
 PASS CanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
@@ -4062,7 +4062,7 @@ PASS CanvasRenderingContext2D interface: document.createElement("canvas").getCon
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowOffsetY" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowBlur" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowColor" with the proper type
-FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type assert_inherits: property "filter" not found in prototype chain
+PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type
 PASS CanvasRenderingContext2D interface: calling clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Apple Inc. All rights reserved.
+# Copyright (c) 2020-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -1389,7 +1389,7 @@ CanvasColorSpaceEnabled:
 
 CanvasFiltersEnabled:
   type: bool
-  status: unstable
+  status: testable
   category: dom
   webcoreOnChange: setNeedsRelayoutAllFrames
   humanReadableName: "Canvas Filters"

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1511,6 +1511,7 @@ html/ValidatedFormListedElement.cpp
 html/ValidationMessage.cpp
 html/WeekInputType.cpp
 html/canvas/ANGLEInstancedArrays.cpp
+html/canvas/CanvasFilterTargetSwitcher.cpp
 html/canvas/CanvasGradient.cpp
 html/canvas/CanvasPath.cpp
 html/canvas/CanvasPattern.cpp

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2021 Metrological Group B.V.
  * Copyright (C) 2021 Igalia S.L.
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 
 #include "CSSParserContext.h"
 #include "CSSPropertyParserHelpers.h"
+#include "FilterOperations.h"
 #include <wtf/RefPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -37,11 +38,15 @@ class CSSPrimitiveValue;
 class CSSValue;
 class CSSValueList;
 class CSSValuePool;
+class Document;
+class RenderStyle;
 class ScriptExecutionContext;
 
 class CSSPropertyParserWorkerSafe {
 public:
     static std::optional<CSSPropertyParserHelpers::FontRaw> parseFont(const String&, CSSParserMode = HTMLStandardMode);
+
+    static std::optional<FilterOperations> parseFilterString(const Document&, RenderStyle&, const String&, CSSParserMode = HTMLStandardMode);
 
     static RefPtr<CSSValueList> parseFontFaceSrc(const String&, const CSSParserContext&);
     static RefPtr<CSSValue> parseFontFaceStyle(const String&, ScriptExecutionContext&);

--- a/Source/WebCore/html/canvas/CanvasFilterTargetSwitcher.cpp
+++ b/Source/WebCore/html/canvas/CanvasFilterTargetSwitcher.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CanvasFilterTargetSwitcher.h"
+
+#include "CanvasRenderingContext2DBase.h"
+#include "Filter.h"
+#include "FilterTargetSwitcher.h"
+
+namespace WebCore {
+
+std::unique_ptr<CanvasFilterTargetSwitcher> CanvasFilterTargetSwitcher::create(CanvasRenderingContext2DBase& context, const DestinationColorSpace& colorSpace, Function<FloatRect()>&& boundsProvider)
+{
+    FloatRect bounds;
+    auto filter = context.createFilter([&]() {
+        bounds = boundsProvider();
+        return bounds;
+    });
+
+    if (!filter)
+        return nullptr;
+
+    // FIXME: Disable GraphicsContext filters for now. The CG coordinates need to be flipped before applying the style.
+    filter->setFilterRenderingModes(filter->filterRenderingModes() - FilterRenderingMode::GraphicsContext);
+
+    ASSERT(!bounds.isEmpty());
+    auto* destinationContext = context.drawingContext();
+
+    auto filterTargetSwitcher = FilterTargetSwitcher::create(*destinationContext, *filter, bounds, colorSpace);
+    if (!filterTargetSwitcher)
+        return nullptr;
+
+    filterTargetSwitcher->beginDrawSourceImage(*destinationContext);
+    context.setFilterTargetSwitcher(filterTargetSwitcher.get());
+
+    return makeUnique<CanvasFilterTargetSwitcher>(context, bounds, WTFMove(filterTargetSwitcher));
+}
+
+std::unique_ptr<CanvasFilterTargetSwitcher> CanvasFilterTargetSwitcher::create(CanvasRenderingContext2DBase& context, const DestinationColorSpace& colorSpace, const FloatRect& bounds)
+{
+    return create(context, colorSpace, [&]() {
+        return bounds;
+    });
+}
+
+CanvasFilterTargetSwitcher::CanvasFilterTargetSwitcher(CanvasRenderingContext2DBase& context, const FloatRect& bounds, std::unique_ptr<FilterTargetSwitcher>&& filterTargetSwitcher)
+    : m_context(context)
+    , m_bounds(bounds)
+    , m_filterTargetSwitcher(WTFMove(filterTargetSwitcher))
+{
+    m_context.setFilterTargetSwitcher(m_filterTargetSwitcher.get());
+}
+
+CanvasFilterTargetSwitcher::~CanvasFilterTargetSwitcher()
+{
+    m_context.setFilterTargetSwitcher(nullptr);
+
+    auto* destinationContext = m_context.drawingContext();
+    m_filterTargetSwitcher->endDrawSourceImage(*destinationContext, DestinationColorSpace::SRGB());
+}
+
+FloatBoxExtent CanvasFilterTargetSwitcher::outsets() const
+{
+    return m_context.calculateFilterOutsets(m_bounds);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasFilterTargetSwitcher.h
+++ b/Source/WebCore/html/canvas/CanvasFilterTargetSwitcher.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DestinationColorSpace.h"
+#include "FilterTargetSwitcher.h"
+#include "FloatRect.h"
+#include <wtf/FastMalloc.h>
+
+namespace WebCore {
+
+class CanvasRenderingContext2DBase;
+class Filter;
+class GraphicsContext;
+
+class CanvasFilterTargetSwitcher {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static std::unique_ptr<CanvasFilterTargetSwitcher> create(CanvasRenderingContext2DBase&, const DestinationColorSpace&, Function<FloatRect()>&& boundsProvider);
+    static std::unique_ptr<CanvasFilterTargetSwitcher> create(CanvasRenderingContext2DBase&, const DestinationColorSpace&, const FloatRect& bounds);
+
+    CanvasFilterTargetSwitcher(CanvasRenderingContext2DBase&, const FloatRect& bounds, std::unique_ptr<FilterTargetSwitcher>&&);
+    ~CanvasFilterTargetSwitcher();
+
+    FloatBoxExtent outsets() const;
+    FloatRect expandedBounds() const { return m_bounds + outsets(); }
+
+private:
+    CanvasRenderingContext2DBase& m_context;
+    FloatRect m_bounds;
+    std::unique_ptr<FilterTargetSwitcher> m_filterTargetSwitcher;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasFilters.idl
+++ b/Source/WebCore/html/canvas/CanvasFilters.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,5 @@
 // https://html.spec.whatwg.org/multipage/canvas.html#canvasfilters
 interface mixin CanvasFilters {
     // filters
-    // FIXME: Implement filter.
-    // attribute DOMString filter; // (default "none")
+    [ImplementedAs=filterString] attribute DOMString filter; // (default "none")
 };

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2008, 2010 Nokia Corporation and/or its subsidiary(-ies)
  * Copyright (C) 2007 Alp Toker <alp@atoker.com>
  * Copyright (C) 2008 Eric Seidel <eric@webkit.org>
@@ -33,6 +33,7 @@
 #include "config.h"
 #include "CanvasRenderingContext2D.h"
 
+#include "CSSFilter.h"
 #include "CSSFontSelector.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParserHelpers.h"
@@ -84,6 +85,65 @@ CanvasRenderingContext2D::CanvasRenderingContext2D(CanvasBase& canvas, CanvasRen
 }
 
 CanvasRenderingContext2D::~CanvasRenderingContext2D() = default;
+
+std::optional<FilterOperations> CanvasRenderingContext2D::setFilterStringWithoutUpdatingStyle(const String& filterString)
+{
+    Ref document = canvas().document();
+    if (!document->settings().canvasFiltersEnabled())
+        return std::nullopt;
+
+    document->updateStyleIfNeeded();
+
+    const auto* style = canvas().computedStyle();
+    if (!style)
+        return std::nullopt;
+
+    auto parserMode = strictToCSSParserMode(!usesCSSCompatibilityParseMode());
+    return CSSPropertyParserWorkerSafe::parseFilterString(document, const_cast<RenderStyle&>(*style), filterString, parserMode);
+}
+
+RefPtr<Filter> CanvasRenderingContext2D::createFilter(const Function<FloatRect()>& boundsProvider) const
+{
+    ASSERT(!state().filterOperations.isEmpty());
+
+    auto* context = drawingContext();
+    if (!context)
+        return nullptr;
+
+    CheckedPtr renderer = canvas().renderer();
+    if (!renderer)
+        return nullptr;
+
+    RefPtr page = canvas().document().page();
+    if (!page)
+        return nullptr;
+
+    auto bounds = boundsProvider();
+    if (bounds.isEmpty())
+        return nullptr;
+
+    auto preferredFilterRenderingModes = page->preferredFilterRenderingModes();
+    auto filter = CSSFilter::create(*renderer, state().filterOperations, preferredFilterRenderingModes, { 1, 1 }, bounds, *context);
+    if (!filter)
+        return nullptr;
+
+    auto outsets = calculateFilterOutsets(bounds);
+
+    filter->setFilterRegion(bounds + outsets);
+    return filter;
+}
+
+IntOutsets CanvasRenderingContext2D::calculateFilterOutsets(const FloatRect& bounds) const
+{
+    if (state().filterOperations.isEmpty())
+        return { };
+
+    CheckedPtr renderer = canvas().renderer();
+    if (!renderer)
+        return { };
+
+    return CSSFilter::calculateOutsets(*renderer, state().filterOperations, bounds);
+}
 
 void CanvasRenderingContext2D::drawFocusIfNeeded(Element& element)
 {

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006, 2007, 2009, 2010, 2011, 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,6 +58,10 @@ private:
 
     bool is2d() const final { return true; }
     const FontProxy* fontProxy() final;
+
+    std::optional<FilterOperations> setFilterStringWithoutUpdatingStyle(const String&) override;
+    RefPtr<Filter> createFilter(const Function<FloatRect()>& boundsProvider) const override;
+    IntOutsets calculateFilterOutsets(const FloatRect& bounds) const override;
 
     void setFontWithoutUpdatingStyle(const String&);
 

--- a/Source/WebCore/platform/RectEdges.h
+++ b/Source/WebCore/platform/RectEdges.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,6 +51,11 @@ public:
     template<typename U>
     RectEdges(U&& top, U&& right, U&& bottom, U&& left)
         : m_sides({ { std::forward<T>(top), std::forward<T>(right), std::forward<T>(bottom), std::forward<T>(left) } })
+    { }
+
+    template<typename U>
+    RectEdges(const RectEdges<U>& other)
+        : RectEdges(other.top(), other.right(), other.bottom(), other.left())
     { }
 
     T& at(BoxSide side) { return m_sides[static_cast<size_t>(side)]; }

--- a/Source/WebCore/platform/graphics/FloatRect.h
+++ b/Source/WebCore/platform/graphics/FloatRect.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2016 Apple Inc.  All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc.  All rights reserved.
  * Copyright (C) 2005 Nokia.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -308,6 +308,13 @@ constexpr FloatRect operator+(const FloatRect& a, const FloatRect& b)
         a.width() + b.width(),
         a.height() + b.height(),
     };
+}
+
+inline FloatRect operator+(const FloatRect& a, const FloatBoxExtent& b)
+{
+    FloatRect c = a;
+    c.expand(b);
+    return c;
 }
 
 inline bool areEssentiallyEqual(const FloatRect& a, const FloatRect& b)


### PR DESCRIPTION
#### 222707e7516546a71f05f44449f58374a2bc727c
<pre>
Support CanvasRenderingContext2D.filter
<a href="https://bugs.webkit.org/show_bug.cgi?id=198416">https://bugs.webkit.org/show_bug.cgi?id=198416</a>
<a href="https://rdar.apple.com/51303686">rdar://51303686</a>

Reviewed by Simon Fraser.

This implements the canvas filter API. According to the specs, the filter will
be defined as a string very similar to the CSS filter definition. An SVG filter
can be accessed via a URL like this `filter : url(#id);`.

To implement this feature without many changes in the CanvasRenderingContext2D
code, the new class CanvasFilterTargetSwitcher will be added. In its constructor
we are going to switch the rendering context to a source ImageBuffer. The next
draw commands will be drawn to this ImageBuffer. In its destructor, the filter
will be applied to the source ImageBuffer and the result will be composited back
to the original context.

Specs link: <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasfilters">https://html.spec.whatwg.org/multipage/canvas.html#canvasfilters</a>

* LayoutTests/fast/canvas/canvas-filter-basics-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-filter-basics.html: Added.
* LayoutTests/fast/canvas/canvas-filter-bounding-rect-expected.html: Added.
* LayoutTests/fast/canvas/canvas-filter-bounding-rect.html: Added.
* LayoutTests/fast/canvas/canvas-filter-drawing-expected.html: Added.
* LayoutTests/fast/canvas/canvas-filter-drawing.html: Added.
* LayoutTests/fast/canvas/canvas-filter-repaint-rect-expected.html: Added.
* LayoutTests/fast/canvas/canvas-filter-repaint-rect.html: Added.
* LayoutTests/fast/canvas/canvas-filter-save-restore-expected.html: Added.
* LayoutTests/fast/canvas/canvas-filter-save-restore.html: Added.
* LayoutTests/fast/canvas/resources/100x100-green-rect-filter-blur.svg: Added.
* LayoutTests/fast/canvas/resources/100x100-green-rect-filter-drop-shadow.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.blur.exceptions-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.colorMatrix-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.discrete-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.gamma-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.identity-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.linear-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.table-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.convolveMatrix.exceptions-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.value-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.filter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.tentative.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.value-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.value.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.filter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.filter.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserWorkerSafe::parseFilterString):
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h:
* Source/WebCore/html/canvas/CanvasFilterTargetSwitcher.cpp: Added.
(WebCore::CanvasFilterTargetSwitcher::create):
(WebCore::CanvasFilterTargetSwitcher::CanvasFilterTargetSwitcher):
(WebCore::CanvasFilterTargetSwitcher::~CanvasFilterTargetSwitcher):
(WebCore::CanvasFilterTargetSwitcher::outsets const):
* Source/WebCore/html/canvas/CanvasFilterTargetSwitcher.h: Added.
(WebCore::CanvasFilterTargetSwitcher::expandedBounds const):
* Source/WebCore/html/canvas/CanvasFilters.idl:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::setFilterStringWithoutUpdatingStyle):
(WebCore::CanvasRenderingContext2D::createFilter const):
(WebCore::CanvasRenderingContext2D::calculateFilterOutsets const):
* Source/WebCore/html/canvas/CanvasRenderingContext2D.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::State::State):
(WebCore::CanvasRenderingContext2DBase::setFilterString):
(WebCore::CanvasRenderingContext2DBase::fillInternal):
(WebCore::CanvasRenderingContext2DBase::strokeInternal):
(WebCore::CanvasRenderingContext2DBase::fillRect):
(WebCore::CanvasRenderingContext2DBase::strokeRect):
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::drawingContext const):
(WebCore::CanvasRenderingContext2DBase::inflatedStrokeRect const):
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):
(WebCore::CanvasRenderingContext2DBase::inflateStrokeRect const): Deleted.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
(WebCore::CanvasRenderingContext2DBase::filterString const):
(WebCore::CanvasRenderingContext2DBase::setFilterStringWithoutUpdatingStyle):
(WebCore::CanvasRenderingContext2DBase::createFilter const):
(WebCore::CanvasRenderingContext2DBase::calculateFilterOutsets const):
(WebCore::CanvasRenderingContext2DBase::setFilterTargetSwitcher):
* Source/WebCore/platform/RectEdges.h:
(WebCore::RectEdges::RectEdges):
* Source/WebCore/platform/graphics/FloatRect.h:
(WebCore::operator+):

Canonical link: <a href="https://commits.webkit.org/278000@main">https://commits.webkit.org/278000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0944eb552839234d57b180b3b00861b370b80722

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45197 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40133 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21246 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23410 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43505 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7433 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42411 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53818 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48601 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47453 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46431 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10819 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26266 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56096 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25186 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11537 "Passed tests") | 
<!--EWS-Status-Bubble-End-->