### PR TITLE
REGRESSION (253762@main): [ macOS wk1 Debug ] fast/dom/lazy-image-loading-document-leak.html is a consistent crash under WebKit::WebStorageNamespaceProvider::copySessionStorageNamespace()

### DIFF
--- a/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp
+++ b/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp
@@ -140,14 +140,13 @@ void WebStorageNamespaceProvider::copySessionStorageNamespace(WebCore::Page& src
         return;
 
     auto& srcPageSessionStorageNamespaces = srcPageIt->value;
-
-    auto& dstSessionStorageNamespaces = static_cast<WebStorageNamespaceProvider&>(dstPage.storageNamespaceProvider()).m_sessionStorageNamespaces;
-    ASSERT(dstSessionStorageNamespaces.find(dstPage) == dstSessionStorageNamespaces.end());
-
-    HashMap<SecurityOriginData, RefPtr<StorageNamespace>> map;
-    auto& dstPageSessionStorageNamespaces = dstSessionStorageNamespaces.add(dstPage, map).iterator->value;
+    HashMap<SecurityOriginData, RefPtr<StorageNamespace>> dstPageSessionStorageNamespaces;
     for (auto& [origin, srcNamespace] : srcPageSessionStorageNamespaces)
         dstPageSessionStorageNamespaces.set(origin, srcNamespace->copy(dstPage));
+
+    auto& dstSessionStorageNamespaces = static_cast<WebStorageNamespaceProvider&>(dstPage.storageNamespaceProvider()).m_sessionStorageNamespaces;
+    ASSERT(!dstSessionStorageNamespaces.contains(dstPage));
+    dstSessionStorageNamespaces.set(dstPage, WTFMove(dstPageSessionStorageNamespaces));
 }
 
 }


### PR DESCRIPTION
#### 018d0e1fa829a0b5217c5462dac76527b027a768
<pre>
REGRESSION (253762@main): [ macOS wk1 Debug ] fast/dom/lazy-image-loading-document-leak.html is a consistent crash under WebKit::WebStorageNamespaceProvider::copySessionStorageNamespace()
<a href="https://bugs.webkit.org/show_bug.cgi?id=244516">https://bugs.webkit.org/show_bug.cgi?id=244516</a>

Reviewed by Ryosuke Niwa.

srcSessionStorageNamespaces can be the same as dstSessionStorageNamespaces, so inserting dstPageSessionStorageNamespaces
into dstSessionStorageNamespaces can invalidate srcPageIt. To fix this issue, we now copy entries from
srcPageSessionStorageNamespaces(srcPageIt) to dstPageSessionStorageNamespaces before inserting it into
dstSessionStorageNamespaces.

* Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp:
(WebKit::WebStorageNamespaceProvider::copySessionStorageNamespace):

Canonical link: <a href="https://commits.webkit.org/253941@main">https://commits.webkit.org/253941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfc55df571f1eb3fc17fdf18cc71b5524a61dea0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96762 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150494 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29988 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26148 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79654 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91518 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24230 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74315 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24056 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67074 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27696 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13234 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27649 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14250 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2774 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37125 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33528 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->