### PR TITLE
[GStreamer] MediaPlayerPrivateGStreamer: Abort stale tasks on flushes

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
@@ -52,43 +52,54 @@ void webKitVideoSinkSetMediaPlayerPrivate(GstElement* appSink, MediaPlayerPrivat
     }), player);
 
     GRefPtr<GstPad> pad = adoptGRef(gst_element_get_static_pad(appSink, "sink"));
-    gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PUSH | GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM | GST_PAD_PROBE_TYPE_EVENT_FLUSH | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM), [](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
+    gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PUSH | GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM | GST_PAD_PROBE_TYPE_EVENT_FLUSH | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM), [](GstPad* pad, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
         auto* player = static_cast<MediaPlayerPrivateGStreamer*>(userData);
 
-        if (info->type & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM) {
-            if (GST_EVENT_TYPE(GST_PAD_PROBE_INFO_EVENT(info)) != GST_EVENT_TAG)
-                return GST_PAD_PROBE_OK;
+        if (info->type & GST_PAD_PROBE_TYPE_EVENT_FLUSH) {
+            if (GST_EVENT_TYPE(GST_PAD_PROBE_INFO_EVENT(info)) == GST_EVENT_FLUSH_START) {
+                GST_DEBUG_OBJECT(pad, "FLUSH_START received, aborting all pending tasks in the player sinkTaskQueue.");
+                player->sinkTaskQueue().startAborting();
+            } else if (GST_EVENT_TYPE(GST_PAD_PROBE_INFO_EVENT(info)) == GST_EVENT_FLUSH_STOP) {
+                GST_DEBUG_OBJECT(pad, "FLUSH_STOP received, allowing operation in the player sinkTaskQueue again.");
+                player->sinkTaskQueue().finishAborting();
+            }
+        }
+
+        if (info->type & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM && GST_EVENT_TYPE(GST_PAD_PROBE_INFO_EVENT(info)) == GST_EVENT_TAG) {
             GstTagList* tagList;
             gst_event_parse_tag(GST_PAD_PROBE_INFO_EVENT(info), &tagList);
+            GST_DEBUG_OBJECT(pad, "Tag event received, video orientation may need to be updated. %" GST_PTR_FORMAT, tagList);
             player->updateVideoOrientation(tagList);
-            return GST_PAD_PROBE_OK;
         }
 
-        if (info->type & GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM) {
-            auto* query = GST_PAD_PROBE_INFO_QUERY(info);
-            if (GST_QUERY_TYPE(query) == GST_QUERY_ALLOCATION) {
-                gst_query_add_allocation_meta(query, GST_VIDEO_META_API_TYPE, nullptr);
-                return GST_PAD_PROBE_OK;
-            }
-
-            // In some platforms (e.g. OpenMAX on the Raspberry Pi) when a resolution change occurs the
-            // pipeline has to be drained before a frame with the new resolution can be decoded.
-            // In this context, it's important that we don't hold references to any previous frame
-            // (e.g. m_sample) so that decoding can continue.
-            // We are also not supposed to keep the original frame after a flush.
-            if (GST_QUERY_TYPE(query) != GST_QUERY_DRAIN)
-                return GST_PAD_PROBE_OK;
-            GST_DEBUG("Acting upon DRAIN query");
-        }
-        if (info->type & GST_PAD_PROBE_TYPE_EVENT_FLUSH) {
-            if (GST_EVENT_TYPE(GST_PAD_PROBE_INFO_EVENT(info)) != GST_EVENT_FLUSH_START)
-                return GST_PAD_PROBE_OK;
-            GST_DEBUG("Acting upon flush-start event");
-        }
+        if (info->type & GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM && GST_QUERY_TYPE(GST_PAD_PROBE_INFO_QUERY(info)) == GST_QUERY_ALLOCATION)
+            gst_query_add_allocation_meta(GST_PAD_PROBE_INFO_QUERY(info), GST_VIDEO_META_API_TYPE, nullptr);
 
 #if USE(GSTREAMER_GL)
-        player->flushCurrentBuffer();
+        // FIXME: Verify the following comment. Investigate what actually should be done here.
+        //
+        // In some platforms (e.g. OpenMAX on the Raspberry Pi) when a resolution change occurs the
+        // pipeline has to be drained before a frame with the new resolution can be decoded.
+        // In this context, it's important that we don't hold references to any previous frame
+        // (e.g. m_sample) so that decoding can continue.
+        // We are also not supposed to keep the original frame after a flush.
+        //
+        // FIXME: We used to have code to call flushCurrentBuffer() on FLUSH_START. That code became
+        // accidentally unreachable in r287349. The current code doesn't preserve that call, partly
+        // because of a refactor of this probe function, partly because it seemed to caused test
+        // regressions that were out of the scope of that change.
+        //
+        // FIXME: flushCurrentBuffer(), when called, causes the video element to become blank for the
+        // user, and has been having this issue for a long time. This is definitely a bug, and needs
+        // to be fixed eventually.
+        //
+        // For more info: https://github.com/WebKit/WebKit/pull/3802#issuecomment-1234529142
+        if (info->type & GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM && GST_QUERY_TYPE(GST_PAD_PROBE_INFO_QUERY(info)) == GST_QUERY_DRAIN) {
+            GST_DEBUG_OBJECT(pad, "Flushing current buffer in response to %" GST_PTR_FORMAT, info->data);
+            player->flushCurrentBuffer();
+        }
 #endif
+
         return GST_PAD_PROBE_OK;
     }, player, nullptr);
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -248,6 +248,10 @@ public:
     const Logger& mediaPlayerLogger() { return logger(); }
 #endif
 
+    // This AbortableTaskQueue must be aborted everytime a flush is sent downstream from the main thread
+    // to avoid deadlocks from threads in the playback pipeline waiting for the main thread.
+    AbortableTaskQueue& sinkTaskQueue() { return m_sinkTaskQueue; }
+
 protected:
     enum MainThreadNotification {
         VideoChanged = 1 << 0,
@@ -601,7 +605,7 @@ private:
 
     GRefPtr<GstStreamCollection> m_streamCollection;
 
-    AbortableTaskQueue m_abortableTaskQueue;
+    AbortableTaskQueue m_sinkTaskQueue;
 };
 
 }


### PR DESCRIPTION
#### e55d1903cf1086c65c6d1f1fdf87578d0d54596c
<pre>
[GStreamer] MediaPlayerPrivateGStreamer: Abort stale tasks on flushes
<a href="https://bugs.webkit.org/show_bug.cgi?id=244534">https://bugs.webkit.org/show_bug.cgi?id=244534</a>

Reviewed by Philippe Normand.

This patch is a combination of a follow-up of
<a href="https://github.com/WebKit/WebKit/pull/3746">https://github.com/WebKit/WebKit/pull/3746</a>, and a fix for a race
condition I independently discovered before said PR was published.

Minor cleanups for pr/3746 are done, additional logging is added,
MediaPlayerPrivateGStreamer::m_abortableTaskQueue is renamed to
MediaPlayerPrivateGStreamer::m_sinkTaskQueue, comments are added, and
most importantly: the task queue is flushed when a GStreamer flush is
received. This fixes a race condition on MSE flushes.

To compensate the additional logic added to the WebKit video sink probe,
this patch refactors the function, getting rid of the early return
spaghetti it had slowly become over the years.

In the process, I found the code for calling flushCurrentBuffer() on
FLUSH_START in the previous code was actually unreachable and had been
so for the most part of a year, as an accident of an early return in the
old code (FLUSH_START events have the
GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM flag. The old code did an early
return when that flag was found for an event other than a tag event).

Figuring out all bugs with flushCurrentBuffer() and what usages it
should have is very much outside of the scope of this patch. Instead,
this patch makes no change on behavior and adds a FIXME section
explaining the situation and how it needs further work.

* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp:
(webKitVideoSinkSetMediaPlayerPrivate):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::~MediaPlayerPrivateGStreamer):
(WebCore::MediaPlayerPrivateGStreamer::updateVideoOrientation):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
(WebCore::MediaPlayerPrivateGStreamer::sinkTaskQueue):

Canonical link: <a href="https://commits.webkit.org/254142@main">https://commits.webkit.org/254142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/539d948e90f7ef80458f8d716d9c4ad7ddcafaab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97204 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152697 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30591 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26533 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80158 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91945 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24656 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74705 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24621 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79701 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28220 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13575 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28320 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14643 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2911 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37453 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30294 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33812 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->