### PR TITLE
[GStreamer][WebRTC] End-point pipeline improvements

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -898,101 +898,6 @@ webkit.org/b/234084 media/track/video-track-configuration.html [ Failure ]
 
 webkit.org/b/237901 media/media-source/media-source-interruption-with-resume-allowing-play.html [ Slow ]
 
-# DataChannel GstWebRTC implementation incomplete, missing stats support.
-webkit.org/b/235885 webrtc/datachannel/datachannel-stats.html [ Skip ]
-webkit.org/b/235885 webrtc/datachannel/getStats-no-prflx-remote-candidate.html [ Skip ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-statsSelector.html [ Skip ]
-
-# GStreamer's DTLS agent currently generates RSA certificates only. DTLS 1.2 is not supported yet (AFAIK).
-webrtc/datachannel/dtls10.html [ Failure ]
-
-# Too slow with filtering implemented in WebKit. Should be done directly by GstWebRTC.
-webrtc/datachannel/filter-ice-candidate.html [ Skip ]
-webrtc/datachannel/mdns-ice-candidates.html [ Skip ]
-
-# Expected to pass/fail in GStreamer 1.22, and a bit slow for us, creating 256 end-points in a row.
-webkit.org/b/235885 webrtc/datachannel/multiple-connections.html [ Pass Failure Timeout ]
-
-# Expectations for GStreamer 1.20. Remove these when updating to GStreamer 1.22.
-webrtc/datachannel/basic.html [ Pass Failure Timeout ]
-webrtc/datachannel/multi-channel.html [ Failure ]
-webrtc/datachannel/binary.html [ Failure ]
-
-# The GstWebRTC backend doesn't support transforms yet.
-webkit.org/b/235885 http/wpt/webrtc/no-webrtc-transform.html [ Skip ]
-webkit.org/b/235885 http/wpt/webrtc/audiovideo-script-transform.html [ Skip ]
-webkit.org/b/235885 http/wpt/webrtc/video-script-transform-keyframe-only.html [ Skip ]
-webkit.org/b/235885 http/wpt/webrtc/video-script-transform.html [ Skip ]
-webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-audio-transform.https.html [ Skip ]
-webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-change-transform.https.html [ Skip ]
-webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https.html [ Skip ]
-webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform.https.html [ Skip ]
-webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-write-twice-transform.https.html [ Skip ]
-
-# The generated SDP offer currently does not reflect the codec-preferences set
-# on transceivers. Instead the negotiated outgoing media source caps are used
-# and our current implementation of outgoing source doesn't support multiple
-# payload types.
-webkit.org/b/235885 webrtc/audio-peer-connection-g722.html [ Failure ]
-
-webkit.org/b/235885 webrtc/libwebrtc/release-while-getting-stats.html [ Timeout ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addIceCandidate.html [ Failure ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addTrack-reuse-sender.html [ Failure ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-local-offer.html [ Timeout Crash ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-local-pranswer.html [ Timeout Crash ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-remote-offer.html [ Failure ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-remote-pranswer.html [ Crash ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-icecandidate-event.html [ Failure ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-inspect-answer.html [ Failure ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-inspect-offer.html [ Failure ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-media-setup-callbacks-single-dialog.html [ Failure ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-media-setup-two-dialogs.html [ Crash ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-onnegotiationneeded.html [ Pass Timeout ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-page-cache.html [ Crash ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-remotely-assigned-transceiver-mid.html [ Pass Failure Timeout ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-setLocalDescription-offer.html [ Failure ]
-webkit.org/b/235885 http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html [ Failure ]
-webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpParameters-maxFramerate.html [ Failure ]
-webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html [ Failure ]
-webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-priority/RTCRtpParameters-encodings.html [ Failure ]
-webkit.org/b/235885 webrtc/addTransceiver-then-addTrack.html [ Failure ]
-webkit.org/b/235885 webrtc/audio-video-element-playing.html [ Timeout ]
-webkit.org/b/235885 webrtc/candidate-stats.html [ Failure ]
-webkit.org/b/235885 webrtc/canvas-to-peer-connection.html [ Failure ]
-webkit.org/b/235885 webrtc/canvas-to-peer-connection-vp8-2d.html [ Timeout ]
-webkit.org/b/235885 webrtc/canvas-to-peer-connection-vp8.html [ Timeout ]
-webkit.org/b/235885 webrtc/direction-change.html [ Failure ]
-webkit.org/b/235885 webrtc/disable-encryption.html [ Failure ]
-webkit.org/b/235885 webrtc/ephemeral-certificates-and-cnames.html [ Failure ]
-webkit.org/b/235885 webrtc/filtering-ice-candidate-after-reload.html [ Timeout ]
-webkit.org/b/235885 webrtc/h264-packetization-mode.html [ Timeout Failure ]
-webkit.org/b/235885 webrtc/libwebrtc/setLocalDescriptionCrash.html [ Failure ]
-webkit.org/b/235885 webrtc/peer-connection-remote-audio-mute.html [ Timeout ]
-webkit.org/b/235885 webrtc/peer-connection-remote-audio-mute2.html [ Timeout ]
-webkit.org/b/235885 webrtc/peer-connection-track-end.html [ Failure ]
-webkit.org/b/235885 webrtc/peerconnection-page-cache-long.html [ Timeout ]
-webkit.org/b/235885 webrtc/peerconnection-page-cache.html [ Timeout ]
-webkit.org/b/235885 webrtc/receiver-track-should-stay-live-even-if-receiver-is-inactive.html [ Failure ]
-webkit.org/b/235885 webrtc/remove-track.html [ Failure ]
-webkit.org/b/235885 webrtc/utf8-sdp.html [ Failure ]
-webkit.org/b/235885 webrtc/video-addTransceiver.html [ Failure ]
-webkit.org/b/235885 webrtc/video-getParameters.html [ Failure ]
-webkit.org/b/235885 webrtc/video-mediastreamtrack-stats.html [ Failure ]
-webkit.org/b/235885 webrtc/video-mute-vp8.html [ Timeout ]
-webkit.org/b/235885 webrtc/video-mute.html [ Timeout ]
-webkit.org/b/235885 webrtc/video-replace-track-to-null.html [ Failure ]
-webkit.org/b/235885 webrtc/video-replace-track.html [ Failure ]
-webkit.org/b/235885 webrtc/video-stats.html [ Timeout ]
-webkit.org/b/235885 webrtc/video.html [ Failure ]
-webkit.org/b/235885 webrtc/vp8-then-h264.html [ Failure ]
-webkit.org/b/235885 webrtc/vp9-svc.html [ Failure ]
-
-# Failing until additional WebRTC end-point patches have landed.
-webkit.org/b/235885 webrtc/vp9.html [ Skip ]
-
-# Expected to pass with GStreamer 1.22.
-webkit.org/b/235885 webrtc/no-port-zero-in-upd-candidates.html [ Failure ]
-
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of GStreamer-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////
@@ -1495,31 +1400,175 @@ webkit.org/b/79203 webkit.org/b/186678 fast/mediastream/MediaStream-video-elemen
 
 fast/mediastream/MediaDevices-addEventListener.html [ DumpJSConsoleLogInStdErr ]
 
-webkit.org/b/191006 webkit.org/b/235885 webrtc/simulcast-h264.html [ Failure Timeout ]
-
-webkit.org/b/193641 webkit.org/b/235885 webrtc/video-setDirection.html [ Failure Pass Timeout ]
-
 webkit.org/b/194611 http/wpt/webrtc/getUserMedia-processSwapping.html [ Failure ]
 
-[ Debug ] webrtc/video-h264.html [ Slow ]
-webrtc/vp9-profile2.html [ Slow ]
+webkit.org/b/227987 http/tests/media/media-stream/get-display-media-prompt.html [ Timeout Pass ]
 
-webkit.org/b/215005 webkit.org/b/218787 webrtc/h264-baseline.html [ Crash Timeout ]
-# h264-high.html is marked as slow in the root expectation
-webkit.org/b/215007 [ Release ] webrtc/h264-high.html [ Timeout ]
-webkit.org/b/215007 [ Debug ] webrtc/h264-high.html [ Slow Failure ]
+# DataChannel GstWebRTC implementation incomplete, missing stats support.
+webkit.org/b/235885 webrtc/datachannel/datachannel-stats.html [ Skip ]
+webkit.org/b/235885 webrtc/datachannel/getStats-no-prflx-remote-candidate.html [ Skip ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-statsSelector.html [ Skip ]
 
-webkit.org/b/216538 webrtc/captureCanvas-webrtc-software-h264-baseline.html [ Slow Failure ]
+# GStreamer's DTLS agent currently generates RSA certificates only. DTLS 1.2 is not supported yet (AFAIK).
+webrtc/datachannel/dtls10.html [ Failure ]
 
-webkit.org/b/216763 webkit.org/b/235885 webrtc/captureCanvas-webrtc-software-h264-high.html [ Crash Failure Timeout ]
+# Too slow with filtering implemented in WebKit. Should be done directly by GstWebRTC.
+webrtc/datachannel/filter-ice-candidate.html [ Skip ]
+webrtc/datachannel/mdns-ice-candidates.html [ Skip ]
+http/tests/webrtc/filtering-ice-candidate-cross-origin-frame.html [ Skip ]
+http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html [ Skip ]
 
+# Expected to pass/fail in GStreamer 1.22, and a bit slow for us, creating 256 end-points in a row.
+webkit.org/b/235885 webrtc/datachannel/multiple-connections.html [ Pass Failure Timeout ]
+
+# The GstWebRTC backend doesn't support transforms yet.
+webkit.org/b/235885 http/wpt/webrtc/no-webrtc-transform.html [ Skip ]
+webkit.org/b/235885 http/wpt/webrtc/audiovideo-script-transform.html [ Skip ]
+webkit.org/b/235885 http/wpt/webrtc/video-script-transform-keyframe-only.html [ Skip ]
+webkit.org/b/235885 http/wpt/webrtc/video-script-transform.html [ Skip ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-audio-transform.https.html [ Skip ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-change-transform.https.html [ Skip ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https.html [ Skip ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform.https.html [ Skip ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-write-twice-transform.https.html [ Skip ]
+imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform.html [ Skip ]
+imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-in-worker.https.html [ Skip ]
+imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-keys.https.html [ Skip ]
+imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-buffer-source.html [ Skip ]
+webkit.org/b/224068 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-late-transform.https.html [ Skip ]
+webrtc/audio-sframe.html [ Skip ]
+webrtc/sframe-test-vectors.html [ Skip ]
+webrtc/sframe-transform-buffer-source.html [ Skip ]
+webrtc/video-sframe.html [ Skip ]
+webkit.org/b/219825 webrtc/sframe-keys.html [ Skip ]
+webkit.org/b/229055 http/wpt/webrtc/sframe-transform-error.html [ Skip ]
+
+# On-the-fly track switching not supported yet.
+webkit.org/b/235885 webrtc/video-replace-track-to-null.html [ Skip ]
+webkit.org/b/235885 webrtc/video-replace-track.html [ Skip ]
+webkit.org/b/235885 webrtc/video-replace-muted-track.html
+webkit.org/b/216538 webrtc/captureCanvas-webrtc-software-h264-baseline.html [ Skip ]
+webkit.org/b/216763 webkit.org/b/235885 webrtc/captureCanvas-webrtc-software-h264-high.html [ Skip ]
+webkit.org/b/235885 webrtc/video-addTransceiver.html [ Skip ]
+
+# GstWebRTC doesn't support transceiver direction changes.
+webkit.org/b/193641 webkit.org/b/235885 webrtc/video-setDirection.html [ Skip ]
+webkit.org/b/235885 webrtc/direction-change.html [ Skip ]
+
+# Specific to LibWebRTC:
+webkit.org/b/235885 webrtc/disable-encryption.html [ Skip ]
+webkit.org/b/235885 webrtc/libwebrtc/release-while-getting-stats.html [ Skip ]
+
+# Pending investigation.
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addIceCandidate.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addTrack-reuse-sender.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-local-pranswer.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-remote-offer.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-remote-pranswer.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-icecandidate-event.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-inspect-answer.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-inspect-offer.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-media-setup-callbacks-single-dialog.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-media-setup-two-dialogs.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-onnegotiationneeded.html [ Pass Timeout ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-remotely-assigned-transceiver-mid.html [ Pass Failure Timeout ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-setLocalDescription-offer.html [ Failure ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpParameters-maxFramerate.html [ Failure ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-priority/RTCRtpParameters-encodings.html [ Failure ]
+webkit.org/b/235885 webrtc/addTransceiver-then-addTrack.html [ Failure ]
+webkit.org/b/235885 webrtc/audio-video-element-playing.html [ Timeout ]
+webkit.org/b/235885 webrtc/candidate-stats.html [ Failure ]
+webkit.org/b/235885 webrtc/ephemeral-certificates-and-cnames.html [ Failure ]
+webkit.org/b/235885 webrtc/filtering-ice-candidate-after-reload.html [ Failure ]
+webkit.org/b/235885 webrtc/libwebrtc/setLocalDescriptionCrash.html [ Failure ]
+webkit.org/b/235885 webrtc/peer-connection-track-end.html [ Failure ]
+webkit.org/b/235885 webrtc/peerconnection-page-cache-long.html [ Timeout ]
+webkit.org/b/235885 webrtc/peerconnection-page-cache.html [ Timeout ]
+webkit.org/b/235885 webrtc/remove-track.html [ Failure ]
+webkit.org/b/235885 webrtc/utf8-sdp.html [ Failure ]
+webkit.org/b/235885 webrtc/video-getParameters.html [ Failure ]
+webkit.org/b/235885 webrtc/video-mediastreamtrack-stats.html [ Failure ]
+webkit.org/b/235885 webrtc/video-mute-vp8.html [ Timeout ]
+webkit.org/b/235885 webrtc/video-mute.html [ Timeout ]
+webkit.org/b/235885 webrtc/video-stats.html [ Failure ]
+webkit.org/b/235885 webrtc/video.html [ Failure ]
+webkit.org/b/235885 webrtc/vp8-then-h264.html [ Failure ]
+
+# In these tests only one canvas frame is pushed towards the sender webrtcbin,
+# this is not enough for the receiver webrtcbin to create its video source pad,
+# because on sender side we need at least a complete GOP... So the tests time
+# out, awaiting forever a remote mediastream.
+webkit.org/b/235885 webrtc/canvas-to-peer-connection.html [ Skip ]
+webkit.org/b/235885 webrtc/canvas-to-peer-connection-vp8-2d.html [ Skip ]
+webkit.org/b/235885 webrtc/canvas-to-peer-connection-vp8.html [ Skip ]
+webkit.org/b/235885 webrtc/canvas-to-peer-connection-2d.html [ Skip ]
+webkit.org/b/235885 webrtc/captureCanvas-webrtc.html [ Skip ]
+
+# This is actually a flaky timeout but skipping nonetheless. GStreamer logs
+# highlight a srtpenc protection error when the test times out. Might be
+# related. Further investigation required.
+webrtc/video-vp8-videorange.html [ Skip ]
+
+# Pending investigation. Current status is out of 143 tests, only 44 run as
+# expected. The whole suite takes an hour(!) to run but ("only") reports 14
+# tests unexpected timeouts.
+imported/w3c/web-platform-tests/webrtc/ [ Skip ]
+
+# Pending investigation.
+webkit.org/b/187064 webrtc/video-addTrack.html [ Failure ]
+webkit.org/b/187064 webkit.org/b/235885 webrtc/video-disabled-black.html [ Failure ]
+webkit.org/b/187064 webrtc/video-rotation.html [ Failure ]
+webkit.org/b/187064 webrtc/video-with-data-channel.html [ Failure ]
+webkit.org/b/187064 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getStats.https.html [ Failure Pass ]
+webkit.org/b/177533 webrtc/video-interruption.html
+webkit.org/b/229346 webkit.org/b/235885 webrtc/multi-audio.html [ Timeout Pass Failure ]
+
+# GStreamerRtpReceiverBackend::getSynchronizationSources() unimplemented.
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html [ Skip ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html [ Skip ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/protocol/rtp-clockrate.html [ Skip ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html [ Skip ]
+
+# GStreamerRtpSenderBackend::setParameters() unimplemented.
+webkit.org/b/215005 webkit.org/b/218787 webrtc/h264-baseline.html [ Slow Failure ]
+webkit.org/b/215007 webrtc/h264-high.html [ Failure ]
+
+# We don't support spatial encoding yet.
+webkit.org/b/235885 webrtc/vp9-svc.html [ Skip ]
+
+# Simulcast not supported yet.
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/simulcast [ Skip ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/protocol/simulcast-answer.html [ Skip ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/protocol/simulcast-offer.html [ Skip ]
+webkit.org/b/191006 webkit.org/b/235885 webrtc/simulcast-h264.html [ Skip ]
+
+# DTMF not supported.
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-insertDTMF.https.html [ Skip ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonechange-long.https.html [ Skip ]
+webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonechange.https.html [ Skip ]
+webkit.org/b/235885 webrtc/dtmf-gc.html [ Skip ]
+
+webkit.org/b/235885 webrtc/video-h264.html [ Slow ]
+webkit.org/b/235885 webrtc/vp9-profile2.html [ Slow ]
+webkit.org/b/235885 webrtc/vp9.html [ Slow ]
+
+# Expectations for GStreamer 1.20. Remove these when updating to GStreamer 1.22.
+webrtc/datachannel/basic.html [ Pass Failure Timeout ]
+webrtc/datachannel/binary.html [ Pass Failure ]
+webrtc/no-port-zero-in-upd-candidates.html [ Failure ]
+webrtc/receiver-track-should-stay-live-even-if-receiver-is-inactive.html [ Failure ]
+
+# Re-enabling an incoming video track leads to a caps negotiation error. Might be a decodebin3 bug.
+webkit.org/b/187064 webkit.org/b/235885 webrtc/video-remote-mute.html [ Failure ]
+
+# Pending investigation.
 webkit.org/b/224074 webrtc/concurrentVideoPlayback.html [ Timeout Pass ]
+webkit.org/b/224074 webrtc/concurrentVideoPlayback2.html [ Timeout Pass ]
 
+# Pending investigation.
 webkit.org/b/206656 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-removetrack.https.html [ Crash Failure Timeout ]
 webkit.org/b/206656 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-MediaElement-preload-none-manual.https.html [ Crash Failure Pass ]
 webkit.org/b/210385 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-MediaElement-firstframe.https.html [ Failure Crash Pass ]
-
-webkit.org/b/227987 http/tests/media/media-stream/get-display-media-prompt.html [ Timeout Pass ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebRTC-related bugs
@@ -1932,10 +1981,6 @@ webkit.org/b/201274 media/presentationmodechanged-fired-once.html [ Skip ]
 
 webkit.org/b/214166 imported/w3c/web-platform-tests/media-source/idlharness.window.html [ Skip ]
 
-# TODO: There is no reason to entirely skip those. Needs to be unskipped and triaged.
-imported/w3c/web-platform-tests/webrtc/ [ Skip ]
-http/tests/webrtc [ Skip ]
-
 # Accessibility-related
 
 # Failing since more testcases were added in https://bugs.webkit.org/show_bug.cgi?id=242092
@@ -2014,18 +2059,6 @@ fast/dom/Window/slow-unload-handler-only-frame-is-stopped.html [ WontFix ]
 # Missing WebSpeech implementation
 webkit.org/b/136224 fast/speechsynthesis [ Skip ]
 webkit.org/b/136224 fast/speechrecognition [ Skip ]
-
-# No plans to support Sframes for a while
-imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform.html [ Skip ]
-imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-in-worker.https.html [ Skip ]
-imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-keys.https.html [ Skip ]
-imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-buffer-source.html [ Skip ]
-webrtc/audio-sframe.html [ Skip ]
-webrtc/sframe-test-vectors.html [ Skip ]
-webrtc/sframe-transform-buffer-source.html [ Skip ]
-webrtc/video-sframe.html [ Skip ]
-webkit.org/b/219825 webrtc/sframe-keys.html [ Skip ]
-webkit.org/b/229055 http/wpt/webrtc/sframe-transform-error.html [ Skip ]
 
 # Depends on HTTP Live Streaming (non-supported in non-Apple ports).
 fast/url/data-url-mediatype.html [ Skip ]
@@ -2325,7 +2358,6 @@ webkit.org/b/176648 fast/text/mark-matches-broken-line-rendering.html [ ImageOnl
 webkit.org/b/176648 fast/text/mark-matches-rendering.html [ ImageOnlyFailure ]
 webkit.org/b/176648 svg/transforms/transformed-text-fill-gradient.html [ ImageOnlyFailure ]
 webkit.org/b/176649 fast/text/international/synthesized-italic-vertical.html [ ImageOnlyFailure ]
-webkit.org/b/177533 webrtc/video-interruption.html
 webkit.org/b/177936 fast/text/all-small-caps-whitespace.html [ ImageOnlyFailure ]
 webkit.org/b/177936 fast/text/regional-indicator-symobls.html [ Failure ]
 webkit.org/b/177936 fast/text/selection-in-initial-advance-region.html [ Failure ]
@@ -2347,13 +2379,6 @@ webkit.org/b/186086 fast/text/font-collection.html [ ImageOnlyFailure ]
 
 webkit.org/b/186100 fast/hidpi/filters-turbulence.html [ ImageOnlyFailure ]
 webkit.org/b/187044 webanimations/opacity-animation-yields-compositing-span.html [ Failure ]
-
-webkit.org/b/187064 webrtc/video-addTrack.html [ Failure ]
-webkit.org/b/187064 webkit.org/b/235885 webrtc/video-disabled-black.html [ Crash Timeout ]
-webkit.org/b/187064 webkit.org/b/235885 webrtc/video-remote-mute.html [ Crash Failure ]
-webkit.org/b/187064 webrtc/video-rotation.html [ Failure ]
-webkit.org/b/187064 webrtc/video-with-data-channel.html [ Failure ]
-webkit.org/b/187064 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getStats.https.html [ Failure Pass ]
 
 webkit.org/b/187271 fast/text/emoji-with-joiner.html [ Failure ]
 webkit.org/b/189343 imported/w3c/web-platform-tests/xhr/sync-no-timeout.any.worker.html [ Failure ]
@@ -2489,8 +2514,6 @@ webkit.org/b/223965 http/tests/contentextensions/block-csp-report.py [ Crash ]
 webkit.org/b/223965 http/tests/contentextensions/block-everything-unless-domain-redirect.py [ Crash ]
 webkit.org/b/223965 http/tests/contentextensions/hide-on-csp-report.py [ Crash ]
 webkit.org/b/223965 http/tests/contentextensions/main-resource-redirect-blocked.py [ Crash ]
-
-webkit.org/b/224068 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-late-transform.https.html [ Failure ]
 
 webkit.org/b/155196 security/contentSecurityPolicy/video-with-file-url-allowed-by-media-src-star.html [ ImageOnlyFailure Pass ]
 webkit.org/b/224114 imported/w3c/web-platform-tests/wasm/webapi/instantiateStreaming-bad-imports.any.worker.html [ Failure Pass ]
@@ -2643,8 +2666,6 @@ webkit.org/b/229062 fast/forms/caps-lock-indicator-width.html [ Crash ]
 media/video-remote-control-playpause.html [ Skip ]
 
 webkit.org/b/207062 imported/w3c/web-platform-tests/media-source/mediasource-replay.html [ Failure Pass ]
-
-webkit.org/b/229346 webkit.org/b/235885 webrtc/multi-audio.html [ Timeout Pass Failure ]
 
 webkit.org/b/229738 fast/text/whitespace/tab-character-basics.html [ Failure ]
 webkit.org/b/229738 fast/text/word-break.html [ Failure ]

--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-have-local-offer-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-have-local-offer-expected.txt
@@ -1,0 +1,66 @@
+Tests RTCPeerConnection in have-local-offer state.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS pc.signalingState is "stable"
+PASS pc.setLocalDescription(sessionDescription).then(requestSucceeded1, finishIfFailed); did not throw exception.
+PASS setLocalDescription succeeded.
+PASS pc.localDescription.type is "offer"
+PASS pc.localDescription.sdp is "local"
+FAIL pc.remoteDescription should throw an exception. Was null.
+PASS pc.signalingState is "have-local-offer"
+PASS pc.setLocalDescription(sessionDescription).then(finishIfSucceeded, requestFailed1); did not throw exception.
+PASS setLocalDescription failed.
+FAIL errorReason.name should be InvalidSessionDescriptionError. Was InvalidStateError.
+PASS pc.localDescription.type is "offer"
+PASS pc.localDescription.sdp is "local"
+FAIL pc.remoteDescription should throw an exception. Was null.
+PASS pc.signalingState is "have-local-offer"
+PASS pc.setLocalDescription(sessionDescription).then(finishIfSucceeded, requestFailed2); did not throw exception.
+PASS setLocalDescription failed.
+FAIL errorReason.name should be InvalidSessionDescriptionError. Was InvalidStateError.
+PASS pc.localDescription.type is "offer"
+PASS pc.localDescription.sdp is "local"
+FAIL pc.remoteDescription should throw an exception. Was null.
+PASS pc.signalingState is "have-local-offer"
+PASS pc.setRemoteDescription(sessionDescription).then(finishIfSucceeded, requestFailed3); did not throw exception.
+PASS setRemoteDescription failed.
+FAIL errorReason.name should be InvalidSessionDescriptionError. Was InvalidStateError.
+PASS pc.localDescription.type is "offer"
+PASS pc.localDescription.sdp is "local"
+FAIL pc.remoteDescription should throw an exception. Was null.
+PASS pc.signalingState is "have-local-offer"
+PASS pc.setLocalDescription(sessionDescription).then(requestSucceeded2, finishIfFailed); did not throw exception.
+PASS setLocalDescription succeeded.
+PASS pc.localDescription.type is "offer"
+PASS pc.localDescription.sdp is "local"
+FAIL pc.remoteDescription should throw an exception. Was null.
+PASS pc.signalingState is "have-local-offer"
+PASS pc.setRemoteDescription(sessionDescription).then(requestSucceeded3, finishIfFailed); did not throw exception.
+PASS setRemoteDescription succeeded.
+PASS pc.localDescription.type is "offer"
+PASS pc.localDescription.sdp is "local"
+PASS pc.remoteDescription.type is "pranswer"
+PASS pc.remoteDescription.sdp is "remote"
+PASS pc.signalingState is "have-remote-pranswer"
+FAIL pc.localDescription should throw an exception. Was null.
+FAIL pc.remoteDescription should throw an exception. Was null.
+PASS pc.signalingState is "stable"
+PASS pc.setLocalDescription(sessionDescription).then(requestSucceeded4, finishIfFailed); did not throw exception.
+PASS setLocalDescription succeeded.
+PASS pc.localDescription.type is "offer"
+PASS pc.localDescription.sdp is "local"
+FAIL pc.remoteDescription should throw an exception. Was null.
+PASS pc.signalingState is "have-local-offer"
+PASS pc.setRemoteDescription(sessionDescription).then(requestSucceeded5, finishIfFailed); did not throw exception.
+PASS setRemoteDescription succeeded.
+PASS pc.localDescription.type is "offer"
+PASS pc.localDescription.sdp is "local"
+PASS pc.remoteDescription.type is "answer"
+PASS pc.remoteDescription.sdp is "remote"
+PASS pc.signalingState is "stable"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-localDescription-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-localDescription-expected.txt
@@ -8,11 +8,9 @@ PASS requestSucceeded was called.
 PASS pc.setLocalDescription(sessionDescription).then(requestSucceeded2, requestFailed2); did not throw exception.
 PASS requestFailed was called.
 PASS pc.localDescription.type is "offer"
-FAIL pc.localDescription.sdp should be local. Was t=0 0
-.
+PASS pc.localDescription.sdp is "local"
 PASS pc.localDescription.type is "offer"
-FAIL pc.localDescription.sdp should be local. Was t=0 0
-.
+PASS pc.localDescription.sdp is "local"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-remoteDescription-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-remoteDescription-expected.txt
@@ -8,11 +8,9 @@ PASS requestSucceeded was called.
 PASS pc.setRemoteDescription(sessionDescription).then(requestSucceeded2, requestFailed2); did not throw exception.
 PASS requestFailed was called.
 PASS pc.remoteDescription.type is "offer"
-FAIL pc.remoteDescription.sdp should be remote. Was t=0 0
-.
+PASS pc.remoteDescription.sdp is "remote"
 PASS pc.remoteDescription.type is "offer"
-FAIL pc.remoteDescription.sdp should be remote. Was t=0 0
-.
+PASS pc.remoteDescription.sdp is "remote"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-stable-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-stable-expected.txt
@@ -31,8 +31,7 @@ PASS pc.signalingState is "stable"
 PASS pc.setLocalDescription(sessionDescription).then(requestSucceeded1, finishIfFailed); did not throw exception.
 PASS setLocalDescription succeeded.
 PASS pc.localDescription.type is "offer"
-FAIL pc.localDescription.sdp should be local. Was t=0 0
-.
+PASS pc.localDescription.sdp is "local"
 FAIL pc.remoteDescription should throw an exception. Was null.
 PASS pc.signalingState is "have-local-offer"
 FAIL pc.localDescription should throw an exception. Was null.
@@ -42,8 +41,7 @@ PASS pc.setRemoteDescription(sessionDescription).then(requestSucceeded2, finishI
 PASS setRemoteDescription succeeded.
 FAIL pc.localDescription should throw an exception. Was null.
 PASS pc.remoteDescription.type is "offer"
-FAIL pc.remoteDescription.sdp should be remote. Was t=0 0
-.
+PASS pc.remoteDescription.sdp is "remote"
 PASS pc.signalingState is "have-remote-offer"
 PASS successfullyParsed is true
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -25,6 +25,7 @@
 #include "Document.h"
 #include "GStreamerCommon.h"
 #include "GStreamerDataChannelHandler.h"
+#include "GStreamerRegistryScanner.h"
 #include "GStreamerRtpReceiverBackend.h"
 #include "GStreamerRtpTransceiverBackend.h"
 #include "GStreamerSctpTransportBackend.h"
@@ -94,6 +95,15 @@ bool GStreamerMediaEndpoint::initializePipeline()
     if (!m_webrtcBin)
         return false;
 
+    g_signal_connect(GST_BIN_CAST(m_webrtcBin.get()), "deep-element-added", G_CALLBACK(+[](GstBin*, GstBin*, GstElement* element, gpointer) {
+        GUniquePtr<char> elementName(gst_element_get_name(element));
+
+        // Workaround for https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/issues/914
+        if (g_str_has_prefix(elementName.get(), "rtpjitterbuffer"))
+            g_object_set(element, "rtx-next-seqnum", FALSE, nullptr);
+
+    }), nullptr);
+
     m_statsCollector->setElement(m_webrtcBin.get());
     g_signal_connect_swapped(m_webrtcBin.get(), "notify::ice-connection-state", G_CALLBACK(+[](GStreamerMediaEndpoint* endPoint) {
         endPoint->onIceConnectionChange();
@@ -158,8 +168,7 @@ void GStreamerMediaEndpoint::teardownPipeline()
     disconnectSimpleBusMessageCallback(m_pipeline.get());
     gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
 
-    m_sources.clear();
-    m_remoteMLineInfos.clear();
+    m_incomingDataChannels.clear();
     m_remoteStreamsById.clear();
     m_webrtcBin = nullptr;
     m_pipeline = nullptr;
@@ -327,10 +336,30 @@ static std::optional<PeerConnectionBackend::DescriptionStates> descriptionsFromW
 
 void GStreamerMediaEndpoint::doSetLocalDescription(const RTCSessionDescription* description)
 {
-    setDescription(description, true, [protectedThis = Ref(*this), this] {
+    auto initialSDP = description ? description->sdp().isolatedCopy() : emptyString();
+    auto remoteDescription = m_peerConnectionBackend.connection().remoteDescription();
+
+    setDescription(description, DescriptionType::Local, [](const auto&) { }, [protectedThis = Ref(*this), this, initialSDP = WTFMove(initialSDP), remoteDescription](const GstSDPMessage& message) {
         if (protectedThis->isStopped())
             return;
+
         auto descriptions = descriptionsFromWebRTCBin(m_webrtcBin.get(), GatherSignalingState::Yes);
+
+        // The initial description we pass to webrtcbin might actually be invalid or empty SDP, so
+        // what we would get in return is an empty SDP message, without media line. When this
+        // happens, restore previous state on RTCPeerConnection.
+        if (!initialSDP.isEmpty() && descriptions && !gst_sdp_message_medias_len(&message)) {
+            if (!descriptions->pendingLocalDescriptionSdp.isEmpty())
+                descriptions->pendingLocalDescriptionSdp = initialSDP;
+            else if (!descriptions->currentLocalDescriptionSdp.isEmpty())
+                descriptions->currentLocalDescriptionSdp = initialSDP;
+
+            if (remoteDescription) {
+                descriptions->pendingRemoteDescriptionSdp = remoteDescription->sdp();
+                descriptions->pendingRemoteDescriptionSdpType = remoteDescription->type();
+            }
+        }
+
         GRefPtr<GstWebRTCSCTPTransport> transport;
         g_object_get(m_webrtcBin.get(), "sctp-transport", &transport.outPtr(), nullptr);
         m_peerConnectionBackend.setLocalDescriptionSucceeded(WTFMove(descriptions), transport ? makeUnique<GStreamerSctpTransportBackend>(WTFMove(transport)) : nullptr);
@@ -346,11 +375,59 @@ void GStreamerMediaEndpoint::doSetLocalDescription(const RTCSessionDescription* 
 
 void GStreamerMediaEndpoint::doSetRemoteDescription(const RTCSessionDescription& description)
 {
-    setDescription(&description, false, [protectedThis = Ref(*this), this] {
+    auto initialSDP = description.sdp().isolatedCopy();
+    auto localDescription = m_peerConnectionBackend.connection().localDescription();
+
+    setDescription(&description, DescriptionType::Remote, [this](const auto& message) {
+        unsigned numberOfMedias = gst_sdp_message_medias_len(&message);
+        for (unsigned i = 0; i < numberOfMedias; i++) {
+            const auto* media = gst_sdp_message_get_media(&message, i);
+            auto direction = getDirectionFromSDPMedia(media);
+            if (direction == GST_WEBRTC_RTP_TRANSCEIVER_DIRECTION_NONE)
+                continue;
+
+            GRefPtr<GstWebRTCRTPTransceiver> rtcTransceiver;
+            g_signal_emit_by_name(m_webrtcBin.get(), "get-transceiver", i, &rtcTransceiver.outPtr());
+            auto caps = capsFromSDPMedia(media);
+            if (rtcTransceiver)
+                g_object_set(rtcTransceiver.get(), "direction", direction, "codec-preferences", caps.get(), nullptr);
+            else
+                g_signal_emit_by_name(m_webrtcBin.get(), "add-transceiver", direction, caps.get(), &rtcTransceiver.outPtr());
+        }
+    }, [protectedThis = Ref(*this), this, initialSDP = WTFMove(initialSDP), localDescription](const GstSDPMessage& message) {
         if (protectedThis->isStopped())
             return;
+
+        processSDPMessage(&message, [this](unsigned, const char* mid, const auto* media) {
+            const char* mediaType = gst_sdp_media_get_media(media);
+            m_mediaForMid.set(String::fromLatin1(mid), g_str_equal(mediaType, "audio") ? RealtimeMediaSource::Type::Audio : RealtimeMediaSource::Type::Video);
+
+            // https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/1907
+            if (sdpMediaHasAttributeKey(media, "ice-lite")) {
+                GRefPtr<GObject> ice;
+                g_object_get(m_webrtcBin.get(), "ice-agent", &ice.outPtr(), nullptr);
+                g_object_set(ice.get(), "ice-lite", TRUE, nullptr);
+            }
+        });
+
         GST_DEBUG_OBJECT(m_pipeline.get(), "Acking remote description");
         auto descriptions = descriptionsFromWebRTCBin(m_webrtcBin.get(), GatherSignalingState::Yes);
+
+        // The initial description we pass to webrtcbin might actually be invalid or empty SDP, so
+        // what we would get in return is an empty SDP message, without media line. When this
+        // happens, restore previous state on RTCPeerConnection.
+        if (descriptions && !gst_sdp_message_medias_len(&message)) {
+            if (!descriptions->pendingRemoteDescriptionSdp.isEmpty())
+                descriptions->pendingRemoteDescriptionSdp = initialSDP;
+            else if (!descriptions->currentRemoteDescriptionSdp.isEmpty())
+                descriptions->currentRemoteDescriptionSdp = initialSDP;
+
+            if (localDescription) {
+                descriptions->pendingLocalDescriptionSdp = localDescription->sdp();
+                descriptions->pendingLocalDescriptionSdpType = localDescription->type();
+            }
+        }
+
         GRefPtr<GstWebRTCSCTPTransport> transport;
         g_object_get(m_webrtcBin.get(), "sctp-transport", &transport.outPtr(), nullptr);
         m_peerConnectionBackend.setRemoteDescriptionSucceeded(WTFMove(descriptions), transport ? makeUnique<GStreamerSctpTransportBackend>(WTFMove(transport)) : nullptr);
@@ -368,39 +445,50 @@ void GStreamerMediaEndpoint::doSetRemoteDescription(const RTCSessionDescription&
 }
 
 struct SetDescriptionCallData {
-    Function<void()> successCallback;
+    Function<void(const GstSDPMessage&)> successCallback;
     Function<void(const GError*)> failureCallback;
+    GUniqueOutPtr<GstSDPMessage> message;
 };
 
 WEBKIT_DEFINE_ASYNC_DATA_STRUCT(SetDescriptionCallData)
 
-void GStreamerMediaEndpoint::setDescription(const RTCSessionDescription* description, bool isLocal, Function<void()>&& successCallback, Function<void(const GError*)>&& failureCallback)
+void GStreamerMediaEndpoint::setDescription(const RTCSessionDescription* description, DescriptionType descriptionType, Function<void(const GstSDPMessage&)>&& preProcessCallback, Function<void(const GstSDPMessage&)>&& successCallback, Function<void(const GError*)>&& failureCallback)
 {
-    GstSDPMessage* message;
+    GUniqueOutPtr<GstSDPMessage> message;
     auto sdpType = RTCSdpType::Offer;
 
     if (description) {
-        if (gst_sdp_message_new_from_text(reinterpret_cast<const char*>(description->sdp().characters8()), &message) != GST_SDP_OK) {
+        if (description->sdp().isEmpty()) {
+            failureCallback(nullptr);
+            return;
+        }
+        if (gst_sdp_message_new_from_text(reinterpret_cast<const char*>(description->sdp().characters8()), &message.outPtr()) != GST_SDP_OK) {
             failureCallback(nullptr);
             return;
         }
         sdpType = description->type();
-    } else if (gst_sdp_message_new(&message) != GST_SDP_OK) {
+        preProcessCallback(*message.get());
+    } else if (gst_sdp_message_new(&message.outPtr()) != GST_SDP_OK) {
         failureCallback(nullptr);
         return;
     }
 
-    if (!isLocal)
-        storeRemoteMLineInfo(message);
-
     auto type = toSessionDescriptionType(sdpType);
-    GST_DEBUG_OBJECT(m_pipeline.get(), "Creating %s session for SDP %s", isLocal ? "local" : "remote", gst_webrtc_sdp_type_to_string(type));
+    const char* typeString = descriptionType == DescriptionType::Local ? "local" : "remote";
+    GST_DEBUG_OBJECT(m_pipeline.get(), "Creating %s session for SDP %s", typeString, gst_webrtc_sdp_type_to_string(type));
 
-    GUniquePtr<GstWebRTCSessionDescription> sessionDescription(gst_webrtc_session_description_new(type, message));
-    auto signalName = makeString("set-", isLocal ? "local" : "remote", "-description");
     auto* data = createSetDescriptionCallData();
     data->successCallback = WTFMove(successCallback);
     data->failureCallback = WTFMove(failureCallback);
+    gst_sdp_message_copy(message.get(), &data->message.outPtr());
+
+#ifndef GST_DISABLE_GST_DEBUG
+    GUniquePtr<char> sdp(gst_sdp_message_as_text(data->message.get()));
+    GST_DEBUG_OBJECT(m_pipeline.get(), "SDP: %s", sdp.get());
+#endif
+
+    GUniquePtr<GstWebRTCSessionDescription> sessionDescription(gst_webrtc_session_description_new(type, message.release()));
+    auto signalName = makeString("set-", typeString, "-description");
     g_signal_emit_by_name(m_webrtcBin.get(), signalName.ascii().data(), sessionDescription.get(), gst_promise_new_with_change_func([](GstPromise* rawPromise, gpointer userData) {
         auto* data = static_cast<SetDescriptionCallData*>(userData);
         auto promise = adoptGRef(rawPromise);
@@ -419,18 +507,16 @@ void GStreamerMediaEndpoint::setDescription(const RTCSessionDescription* descrip
             });
             return;
         }
-        callOnMainThread([successCallback = WTFMove(data->successCallback)] {
-            successCallback();
+
+        callOnMainThread([successCallback = WTFMove(data->successCallback), message = GUniquePtr<GstSDPMessage>(data->message.release())] {
+            successCallback(*message.get());
         });
     }, data, reinterpret_cast<GDestroyNotify>(destroySetDescriptionCallData)));
 }
 
-void GStreamerMediaEndpoint::storeRemoteMLineInfo(GstSDPMessage* message)
+void GStreamerMediaEndpoint::processSDPMessage(const GstSDPMessage* message, Function<void(unsigned, const char*, const GstSDPMedia*)> mediaCallback)
 {
-    m_remoteMLineInfos.clear();
     unsigned totalMedias = gst_sdp_message_medias_len(message);
-    m_remoteMLineInfos.reserveCapacity(totalMedias);
-    GST_DEBUG_OBJECT(m_pipeline.get(), "Storing %u remote pending mlines", totalMedias);
     for (unsigned mediaIndex = 0; mediaIndex < totalMedias; mediaIndex++) {
         const auto* media = gst_sdp_message_get_media(message, mediaIndex);
         const char* mediaType = gst_sdp_media_get_media(media);
@@ -459,86 +545,12 @@ void GStreamerMediaEndpoint::storeRemoteMLineInfo(GstSDPMessage* message)
             continue;
         }
 
-        m_mediaForMid.set(String::fromLatin1(mid), g_str_equal(mediaType, "audio"_s) ? RealtimeMediaSource::Type::Audio : RealtimeMediaSource::Type::Video);
-
-        // https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/1907
-        if (sdpMediaHasAttributeKey(media, "ice-lite")) {
-            GRefPtr<GObject> ice;
-            g_object_get(m_webrtcBin.get(), "ice-agent", &ice.outPtr(), nullptr);
-            g_object_set(ice.get(), "ice-lite", TRUE, nullptr);
-        }
-
-        auto caps = adoptGRef(gst_caps_new_empty());
-        Vector<int> payloadTypes;
-        unsigned totalFormats = gst_sdp_media_formats_len(media);
-        GST_DEBUG_OBJECT(m_pipeline.get(), "Media %s has %u formats", mediaType, totalFormats);
-        for (unsigned formatIndex = 0; formatIndex < totalFormats; formatIndex++) {
-            auto format = makeString(gst_sdp_media_get_format(media, formatIndex));
-            auto payloadType = parseInteger<int>(format);
-            if (!payloadType || !*payloadType) {
-                GST_WARNING_OBJECT(m_pipeline.get(), "Invalid payload type: %s", format.utf8().data());
-                continue;
-            }
-            auto formatCaps = adoptGRef(gst_sdp_media_get_caps_from_media(media, *payloadType));
-            if (!formatCaps) {
-                GST_WARNING_OBJECT(m_pipeline.get(), "No caps found for payload type %d", *payloadType);
-                continue;
-            }
-
-            // Relay SDP attributes to the caps, this is specially useful so that elements in
-            // webrtcbin will be able to enable RTP header extensions.
-            gst_sdp_media_attributes_to_caps(media, formatCaps.get());
-
-            gst_caps_append(caps.get(), formatCaps.leakRef());
-            m_ptCounter = std::max(m_ptCounter, *payloadType + 1);
-            payloadTypes.append(*payloadType);
-        }
-
-        unsigned totalCaps = gst_caps_get_size(caps.get());
-        if (totalCaps) {
-            for (unsigned capsIndex = 0; capsIndex < totalCaps; capsIndex++) {
-                GstStructure* structure = gst_caps_get_structure(caps.get(), capsIndex);
-                gst_structure_set_name(structure, "application/x-rtp");
-            }
-            GST_DEBUG_OBJECT(m_pipeline.get(), "Caching payload caps: %" GST_PTR_FORMAT, caps.get());
-            m_remoteMLineInfos.uncheckedAppend({ WTFMove(caps), false, WTFMove(payloadTypes) });
-        }
+        mediaCallback(mediaIndex, mid, media);
     }
 }
 
 void GStreamerMediaEndpoint::configureAndLinkSource(RealtimeOutgoingMediaSourceGStreamer& source)
 {
-    auto caps = source.allowedCaps();
-    std::optional<std::pair<PendingMLineInfo, GRefPtr<GstCaps>>> found;
-    for (auto& mLineInfo : m_remoteMLineInfos) {
-        if (mLineInfo.isUsed)
-            continue;
-
-        unsigned totalCaps = gst_caps_get_size(mLineInfo.caps.get());
-        for (unsigned capsIndex = 0; capsIndex < totalCaps; capsIndex++) {
-            auto* structure = gst_caps_get_structure(mLineInfo.caps.get(), capsIndex);
-            auto caps2 = adoptGRef(gst_caps_new_full(gst_structure_copy(structure), nullptr));
-            auto intersected = adoptGRef(gst_caps_intersect(caps.get(), caps2.get()));
-            if (!gst_caps_is_empty(intersected.get())) {
-                found = std::make_pair(mLineInfo, WTFMove(intersected));
-                break;
-            }
-        }
-        if (found.has_value())
-            break;
-    }
-
-    bool payloadTypeWasSet = false;
-    if (found) {
-        GST_DEBUG_OBJECT(m_pipeline.get(), "Unused and compatible caps found for %" GST_PTR_FORMAT "... %" GST_PTR_FORMAT, caps.get(), found->second.get());
-        payloadTypeWasSet = source.setPayloadType(found->second);
-        found->first.isUsed = true;
-    } else
-        payloadTypeWasSet = source.setPayloadType(caps);
-
-    if (!payloadTypeWasSet)
-        return;
-
     if (!source.pad()) {
         source.setSinkPad(requestPad(m_requestPadCounter, source.allowedCaps()));
         m_requestPadCounter++;
@@ -566,32 +578,37 @@ GRefPtr<GstPad> GStreamerMediaEndpoint::requestPad(unsigned mlineIndex, const GR
 {
     auto padId = makeString("sink_", mlineIndex);
     auto caps = adoptGRef(gst_caps_copy(allowedCaps.get()));
+    int payloadType = 96;
+    for (unsigned i = 0; i < gst_caps_get_size(caps.get()); i++) {
+        auto* structure = gst_caps_get_structure(caps.get(), i);
+        gst_structure_set(structure, "payload", G_TYPE_INT, payloadType++, nullptr);
+    }
 
-    gst_caps_map_in_place(caps.get(), [](GstCapsFeatures*, GstStructure* structure, gpointer userData) -> gboolean {
-        auto* endPoint = reinterpret_cast<GStreamerMediaEndpoint*>(userData);
-        gst_structure_set(structure, "payload", G_TYPE_INT, endPoint->m_ptCounter++, nullptr);
-        return TRUE;
-    }, this);
+    auto sinkPad = adoptGRef(gst_element_get_static_pad(m_webrtcBin.get(), padId.ascii().data()));
+    if (!sinkPad) {
+        // FIXME: Restricting caps and codec-preferences breaks caps negotiation of outgoing sources
+        // in some cases.
+        GST_DEBUG_OBJECT(m_pipeline.get(), "Requesting pad %s restricted to %" GST_PTR_FORMAT, padId.utf8().data(), caps.get());
+        auto* padTemplate = gst_element_get_pad_template(m_webrtcBin.get(), "sink_%u");
+        sinkPad = adoptGRef(gst_element_request_pad(m_webrtcBin.get(), padTemplate, padId.utf8().data(), caps.get()));
+    }
 
-    // FIXME: Restricting caps and codec-preferences breaks caps negotiation of outgoing sources in
-    // some case (jitsi).
-    GST_DEBUG_OBJECT(m_pipeline.get(), "Requesting pad %s restricted to %" GST_PTR_FORMAT, padId.utf8().data(), caps.get());
-    auto* padTemplate = gst_element_get_pad_template(m_webrtcBin.get(), "sink_%u");
-    auto sinkPad = adoptGRef(gst_element_request_pad(m_webrtcBin.get(), padTemplate, padId.utf8().data(), caps.get()));
     GRefPtr<GstWebRTCRTPTransceiver> transceiver;
     g_object_get(sinkPad.get(), "transceiver", &transceiver.outPtr(), nullptr);
     g_object_set(transceiver.get(), "codec-preferences", caps.get(), nullptr);
     return sinkPad;
 }
 
-bool GStreamerMediaEndpoint::addTrack(GStreamerRtpSenderBackend& sender, MediaStreamTrack& track, const FixedVector<String>&)
+bool GStreamerMediaEndpoint::addTrack(GStreamerRtpSenderBackend& sender, MediaStreamTrack& track, const FixedVector<String>& mediaStreamIds)
 {
     GStreamerRtpSenderBackend::Source source;
     GRefPtr<GstWebRTCRTPSender> rtcSender;
+    auto mediaStreamId = mediaStreamIds.isEmpty() ? emptyString() : mediaStreamIds[0];
 
+    GST_DEBUG_OBJECT(m_pipeline.get(), "Adding source for track %s", track.id().ascii().data());
     if (track.privateTrack().isAudio()) {
         GST_DEBUG_OBJECT(m_pipeline.get(), "Adding outgoing audio source");
-        auto audioSource = RealtimeOutgoingAudioSourceGStreamer::create(track.privateTrack());
+        auto audioSource = RealtimeOutgoingAudioSourceGStreamer::create(mediaStreamId, track);
         configureAndLinkSource(audioSource);
 
         rtcSender = audioSource->sender();
@@ -599,7 +616,7 @@ bool GStreamerMediaEndpoint::addTrack(GStreamerRtpSenderBackend& sender, MediaSt
     } else {
         ASSERT(track.privateTrack().isVideo());
         GST_DEBUG_OBJECT(m_pipeline.get(), "Adding outgoing video source");
-        auto videoSource = RealtimeOutgoingVideoSourceGStreamer::create(track.privateTrack());
+        auto videoSource = RealtimeOutgoingVideoSourceGStreamer::create(mediaStreamId, track);
         configureAndLinkSource(videoSource);
 
         rtcSender = videoSource->sender();
@@ -688,18 +705,20 @@ void GStreamerMediaEndpoint::getStats(GstPad* pad, Ref<DeferredPromise>&& promis
 {
     m_statsCollector->getStats([promise = WTFMove(promise), protectedThis = Ref(*this)](auto&& report) mutable {
         ASSERT(isMainThread());
-        if (protectedThis->isStopped() || !report)
+        if (protectedThis->isStopped() || !report) {
+            promise->resolve();
             return;
+        }
 
         promise->resolve<IDLInterface<RTCStatsReport>>(report.releaseNonNull());
     }, pad);
 }
 
-MediaStream& GStreamerMediaEndpoint::mediaStreamFromRTCStream(String label)
+MediaStream& GStreamerMediaEndpoint::mediaStreamFromRTCStream(String mediaStreamId)
 {
-    auto mediaStream = m_remoteStreamsById.ensure(label, [label, this]() mutable {
+    auto mediaStream = m_remoteStreamsById.ensure(mediaStreamId, [mediaStreamId, this]() mutable {
         auto& document = downcast<Document>(*m_peerConnectionBackend.connection().scriptExecutionContext());
-        return MediaStream::create(document, MediaStreamPrivate::create(document.logger(), { }, WTFMove(label)));
+        return MediaStream::create(document, MediaStreamPrivate::create(document.logger(), { }, WTFMove(mediaStreamId)));
     });
     return *mediaStream.iterator->value;
 }
@@ -731,24 +750,17 @@ void GStreamerMediaEndpoint::addRemoteStream(GstPad* pad)
 
     unsigned mLineIndex;
     g_object_get(rtcTransceiver.get(), "mlineindex", &mLineIndex, nullptr);
+
+    // Look-up the mediastream ID, using the msid attribute, fall back to pad name if there is no msid.
     const auto* media = gst_sdp_message_get_media(description->sdp, mLineIndex);
-    GUniquePtr<char> sdp(gst_sdp_media_as_text(media));
-    auto sdpString = makeString(sdp.get());
-
     GUniquePtr<gchar> name(gst_pad_get_name(pad));
-    auto label = String::fromLatin1(name.get());
-    auto key = makeString("msid:");
-    auto lines = sdpString.split('\n');
-    for (auto& line : lines) {
-        auto i = line.find(key);
-        if (i != notFound) {
-            auto tmp = line.substring(i + key.ascii().length());
-            label = tmp.left(tmp.find(' '));
-            break;
-        }
+    auto mediaStreamId = String::fromLatin1(name.get());
+    if (const char* msidAttribute = gst_sdp_media_get_attribute_val(media, "msid")) {
+        auto components = makeString(msidAttribute).split(' ');
+        if (components.size() == 2)
+            mediaStreamId = components[0];
     }
-
-    GST_DEBUG_OBJECT(m_pipeline.get(), "msid: %s", label.ascii().data());
+    GST_DEBUG_OBJECT(m_pipeline.get(), "msid: %s", mediaStreamId.ascii().data());
 
     GstElement* bin = nullptr;
     auto& track = transceiver->receiver().track();
@@ -767,19 +779,14 @@ void GStreamerMediaEndpoint::addRemoteStream(GstPad* pad)
     track.setEnabled(true);
     source.setMuted(false);
 
-    auto& mediaStream = mediaStreamFromRTCStream(label);
+    auto& mediaStream = mediaStreamFromRTCStream(mediaStreamId);
     mediaStream.addTrackFromPlatform(track);
-
-    Vector<RefPtr<MediaStream>> pendingStreams;
-    pendingStreams.reserveInitialCapacity(1);
-    pendingStreams.uncheckedAppend(&mediaStream);
-
-    m_peerConnectionBackend.addPendingTrackEvent({ Ref(transceiver->receiver()), Ref(transceiver->receiver().track()), WTFMove(pendingStreams), Ref(*transceiver) });
+    m_peerConnectionBackend.addPendingTrackEvent({ Ref(transceiver->receiver()), Ref(transceiver->receiver().track()), { }, Ref(*transceiver) });
 
     if (m_pendingIncomingStreams == gst_sdp_message_medias_len(description->sdp)) {
         GST_DEBUG_OBJECT(m_pipeline.get(), "Incoming streams gathered, now firing track events");
         m_pendingIncomingStreams = 0;
-        m_peerConnectionBackend.dispatchPendingTrackEvents();
+        m_peerConnectionBackend.dispatchPendingTrackEvents(mediaStream);
     }
 
 #ifndef GST_DISABLE_GST_DEBUG
@@ -801,30 +808,47 @@ std::optional<GStreamerMediaEndpoint::Backends> GStreamerMediaEndpoint::createTr
 
     GST_DEBUG_OBJECT(m_pipeline.get(), "%zu streams in init data", init.streams.size());
 
-    // FIXME: Should we build the caps from the init.sendEncodings? Problem is there is no
-    // encodingName or clockRate in RTCRtpEncodingParameters.
-    Vector<std::pair<const char*, int>> encodings;
-    const char* media = kind.utf8().data();
-    if (kind == "video"_s) {
-        encodings.reserveInitialCapacity(3);
-        encodings.uncheckedAppend({ "VP8", 90000 });
-        encodings.uncheckedAppend({ "VP9", 90000 });
-        encodings.uncheckedAppend({ "H264", 90000 });
-    } else {
-        encodings.reserveInitialCapacity(4);
-        encodings.uncheckedAppend({ "OPUS", 48000 });
-        encodings.uncheckedAppend({ "G722", 8000 });
-        encodings.uncheckedAppend({ "PCMA", 8000 });
-        encodings.uncheckedAppend({ "PCMU", 8000 });
-    }
-
-    auto caps = adoptGRef(gst_caps_new_empty());
-    for (auto& [encodingName, clockRate] : encodings) {
-        gst_caps_append_structure(caps.get(), gst_structure_new("application/x-rtp", "media", G_TYPE_STRING, media, "encoding-name", G_TYPE_STRING, encodingName,
-            "payload", G_TYPE_INT, m_ptCounter++, "clock-rate", G_TYPE_INT, clockRate, nullptr));
-    }
-
+    auto& registryScanner = GStreamerRegistryScanner::singleton();
     auto direction = fromRTCRtpTransceiverDirection(init.direction);
+    Vector<RTCRtpCodecCapability> codecs;
+
+    auto rtpExtensions = kind == "video"_s ? registryScanner.videoRtpExtensions() : registryScanner.audioRtpExtensions();
+
+    if (direction == GST_WEBRTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV) {
+        auto mergeCodecs = [&codecs](auto& additionalCodecs) {
+            for (auto& codec : additionalCodecs) {
+                auto result = codecs.findIf([mimeType = codec.mimeType](auto& item) {
+                    return item.mimeType == mimeType;
+                });
+                if (result == notFound)
+                    codecs.append(codec);
+            }
+        };
+        if (kind == "video"_s) {
+            codecs = registryScanner.videoRtpCapabilities(GStreamerRegistryScanner::Configuration::Encoding).codecs;
+            auto decodingCapabilities = registryScanner.videoRtpCapabilities(GStreamerRegistryScanner::Configuration::Decoding).codecs;
+            mergeCodecs(decodingCapabilities);
+        } else {
+            codecs = registryScanner.audioRtpCapabilities(GStreamerRegistryScanner::Configuration::Encoding).codecs;
+            auto decodingCapabilities = registryScanner.audioRtpCapabilities(GStreamerRegistryScanner::Configuration::Decoding).codecs;
+            mergeCodecs(decodingCapabilities);
+        }
+    } else if (direction == GST_WEBRTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY) {
+        if (kind == "video"_s)
+            codecs = registryScanner.videoRtpCapabilities(GStreamerRegistryScanner::Configuration::Encoding).codecs;
+        else
+            codecs = registryScanner.audioRtpCapabilities(GStreamerRegistryScanner::Configuration::Encoding).codecs;
+    } else if (direction == GST_WEBRTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY) {
+        if (kind == "video"_s)
+            codecs = registryScanner.videoRtpCapabilities(GStreamerRegistryScanner::Configuration::Decoding).codecs;
+        else
+            codecs = registryScanner.audioRtpCapabilities(GStreamerRegistryScanner::Configuration::Decoding).codecs;
+    }
+
+    auto caps = capsFromRtpCapabilities({ .codecs = codecs, .headerExtensions = rtpExtensions }, [this](GstStructure* structure) {
+        gst_structure_set(structure, "payload", G_TYPE_INT, m_ptCounter++, nullptr);
+    });
+
 #ifndef GST_DISABLE_GST_DEBUG
     GUniquePtr<char> desc(g_enum_to_string(GST_TYPE_WEBRTC_RTP_TRANSCEIVER_DIRECTION, direction));
     GST_DEBUG_OBJECT(m_pipeline.get(), "Adding %s transceiver for payload %" GST_PTR_FORMAT, desc.get(), caps.get());
@@ -884,10 +908,10 @@ std::optional<GStreamerMediaEndpoint::Backends> GStreamerMediaEndpoint::addTrans
 GStreamerRtpSenderBackend::Source GStreamerMediaEndpoint::createSourceForTrack(MediaStreamTrack& track)
 {
     if (track.privateTrack().isAudio())
-        return RealtimeOutgoingAudioSourceGStreamer::create(track.privateTrack());
+        return RealtimeOutgoingAudioSourceGStreamer::create(emptyString(), track);
 
     ASSERT(track.privateTrack().isVideo());
-    return RealtimeOutgoingVideoSourceGStreamer::create(track.privateTrack());
+    return RealtimeOutgoingVideoSourceGStreamer::create(emptyString(), track);
 }
 
 std::optional<GStreamerMediaEndpoint::Backends> GStreamerMediaEndpoint::addTransceiver(MediaStreamTrack& track, const RTCRtpTransceiverInit& init)
@@ -1094,16 +1118,17 @@ void GStreamerMediaEndpoint::onIceCandidate(guint sdpMLineIndex, gchararray cand
     if (isStopped())
         return;
 
-    // FIXME: Get mid from candidate?
-    GUniqueOutPtr<GstWebRTCSessionDescription> description;
-    g_object_get(m_webrtcBin.get(), "local-description", &description.outPtr(), nullptr);
-    if (!description)
-        return;
-
-    const auto* media = gst_sdp_message_get_media(description->sdp, sdpMLineIndex);
-    callOnMainThread([protectedThis = Ref(*this), this, mid = makeString(gst_sdp_media_get_attribute_val(media, "mid")), sdp = makeString(candidate), sdpMLineIndex]() mutable {
+    callOnMainThread([protectedThis = Ref(*this), this, sdp = makeString(candidate), sdpMLineIndex]() mutable {
         if (isStopped())
             return;
+
+        GUniqueOutPtr<GstWebRTCSessionDescription> description;
+        g_object_get(m_webrtcBin.get(), "local-description", &description.outPtr(), nullptr);
+        if (!description)
+            return;
+
+        const auto* media = gst_sdp_message_get_media(description->sdp, sdpMLineIndex);
+        auto mid = media ? makeString(gst_sdp_media_get_attribute_val(media, "mid")) : emptyString();
         auto descriptions = descriptionsFromWebRTCBin(m_webrtcBin.get());
         m_peerConnectionBackend.newICECandidate(WTFMove(sdp), WTFMove(mid), sdpMLineIndex, { }, WTFMove(descriptions));
     });
@@ -1140,6 +1165,7 @@ void GStreamerMediaEndpoint::createSessionDescriptionFailed(GUniquePtr<GError>&&
 void GStreamerMediaEndpoint::collectTransceivers()
 {
     GRefPtr<GArray> transceivers;
+    GST_DEBUG_OBJECT(m_pipeline.get(), "Collecting transceivers");
     g_signal_emit_by_name(m_webrtcBin.get(), "get-transceivers", &transceivers.outPtr());
     for (unsigned i = 0; i < transceivers->len; i++) {
         GstWebRTCRTPTransceiver* current = g_array_index(transceivers.get(), GstWebRTCRTPTransceiver*, i);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -97,7 +97,7 @@ private:
     void collectTransceivers() final;
 
     void addPendingTrackEvent(PendingTrackEvent&&);
-    void dispatchPendingTrackEvents();
+    void dispatchPendingTrackEvents(MediaStream&);
 
 private:
     bool isLocalDescriptionSet() const final { return m_isLocalDescriptionSet; }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -37,7 +37,9 @@ namespace WebCore {
 GStreamerRtpTransceiverBackend::GStreamerRtpTransceiverBackend(GRefPtr<GstWebRTCRTPTransceiver>&& rtcTransceiver)
     : m_rtcTransceiver(WTFMove(rtcTransceiver))
 {
-    g_object_set(m_rtcTransceiver.get(), "do-nack", TRUE, "fec-type", GST_WEBRTC_FEC_TYPE_ULP_RED, nullptr);
+    // FIXME: Enable FEC once flexfec is available. ULPFEC is a disaster, see also
+    // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/1407 ...
+    g_object_set(m_rtcTransceiver.get(), "do-nack", TRUE, nullptr);
 }
 
 std::unique_ptr<GStreamerRtpReceiverBackend> GStreamerRtpTransceiverBackend::createReceiverBackend()

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -263,5 +263,10 @@ std::optional<Ref<RTCCertificate>> generateCertificate(Ref<SecurityOrigin>&&, co
 
 bool sdpMediaHasAttributeKey(const GstSDPMedia*, const char* key);
 
+WARN_UNUSED_RETURN GRefPtr<GstCaps> capsFromRtpCapabilities(const RTCRtpCapabilities&, Function<void(GstStructure*)> supplementCapsCallback);
+
+GstWebRTCRTPTransceiverDirection getDirectionFromSDPMedia(const GstSDPMedia*);
+WARN_UNUSED_RETURN GRefPtr<GstCaps> capsFromSDPMedia(const GstSDPMedia*);
+
 }
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -847,6 +847,21 @@ void GStreamerRegistryScanner::fillVideoRtpCapabilities(Configuration configurat
         capabilities.codecs.append({ .mimeType = "video/VP9"_s, .clockRate = 90000, .sdpFmtpLine = "profile-id=2"_s });
     }
 }
+
+Vector<RTCRtpCapabilities::HeaderExtensionCapability> GStreamerRegistryScanner::audioRtpExtensions()
+{
+    if (!m_audioRtpExtensions)
+        m_audioRtpExtensions = probeRtpExtensions(m_allAudioRtpExtensions);
+    return *m_audioRtpExtensions;
+}
+
+Vector<RTCRtpCapabilities::HeaderExtensionCapability> GStreamerRegistryScanner::videoRtpExtensions()
+{
+    if (!m_videoRtpExtensions)
+        m_videoRtpExtensions = probeRtpExtensions(m_allVideoRtpExtensions);
+    return *m_videoRtpExtensions;
+}
+
 #endif // USE(GSTREAMER_WEBRTC)
 
 }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -68,6 +68,8 @@ public:
 #if USE(GSTREAMER_WEBRTC)
     RTCRtpCapabilities audioRtpCapabilities(Configuration);
     RTCRtpCapabilities videoRtpCapabilities(Configuration);
+    Vector<RTCRtpCapabilities::HeaderExtensionCapability> audioRtpExtensions();
+    Vector<RTCRtpCapabilities::HeaderExtensionCapability> videoRtpExtensions();
 #endif
 
 protected:

--- a/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
@@ -57,6 +57,7 @@ WTF_DEFINE_GPTR_DELETER(GstAudioConverter, gst_audio_converter_free)
 
 #if defined(BUILDING_WebCore) && USE(GSTREAMER_WEBRTC)
 WTF_DEFINE_GPTR_DELETER(GstWebRTCSessionDescription, gst_webrtc_session_description_free)
+WTF_DEFINE_GPTR_DELETER(GstSDPMessage, gst_sdp_message_free)
 #endif
 
 #if USE(WPE_VIDEO_PLANE_DISPLAY_DMABUF)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -23,7 +23,9 @@
 #if USE(GSTREAMER_WEBRTC)
 
 #include "GStreamerAudioCaptureSource.h"
-#include "GStreamerCommon.h"
+#include "GStreamerRegistryScanner.h"
+#include "MediaStreamTrack.h"
+
 #include <wtf/text/StringToIntegerConversion.h>
 
 GST_DEBUG_CATEGORY_EXTERN(webkit_webrtc_endpoint_debug);
@@ -31,59 +33,66 @@ GST_DEBUG_CATEGORY_EXTERN(webkit_webrtc_endpoint_debug);
 
 namespace WebCore {
 
-RealtimeOutgoingAudioSourceGStreamer::RealtimeOutgoingAudioSourceGStreamer(Ref<MediaStreamTrackPrivate>&& source)
-    : RealtimeOutgoingMediaSourceGStreamer()
+RealtimeOutgoingAudioSourceGStreamer::RealtimeOutgoingAudioSourceGStreamer(const String& mediaStreamId, MediaStreamTrack& track)
+    : RealtimeOutgoingMediaSourceGStreamer(mediaStreamId, track)
 {
-    Vector<std::pair<const char*, int>> encodings;
-    encodings.reserveInitialCapacity(4);
-    encodings.uncheckedAppend({ "OPUS", 48000 });
-    encodings.uncheckedAppend({ "G722", 8000 });
-    encodings.uncheckedAppend({ "PCMA", 8000 });
-    encodings.uncheckedAppend({ "PCMU", 8000 });
-    m_allowedCaps = adoptGRef(gst_caps_new_empty());
-    for (auto& [encodingName, clockRate] : encodings)
-        gst_caps_append_structure(m_allowedCaps.get(), gst_structure_new("application/x-rtp", "media", G_TYPE_STRING, "audio", "encoding-name", G_TYPE_STRING, encodingName, "clock-rate", G_TYPE_INT, clockRate, nullptr));
-
+    static Atomic<uint64_t> sourceCounter = 0;
+    gst_element_set_name(m_bin.get(), makeString("outgoing-audio-source-", sourceCounter.exchangeAdd(1)).ascii().data());
     m_audioconvert = makeGStreamerElement("audioconvert", nullptr);
     m_audioresample = makeGStreamerElement("audioresample", nullptr);
     gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_audioconvert.get(), m_audioresample.get(), nullptr);
-    setSource(WTFMove(source));
+}
+
+RTCRtpCapabilities RealtimeOutgoingAudioSourceGStreamer::rtpCapabilities() const
+{
+    auto& registryScanner = GStreamerRegistryScanner::singleton();
+    return registryScanner.audioRtpCapabilities(GStreamerRegistryScanner::Configuration::Encoding);
 }
 
 bool RealtimeOutgoingAudioSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>& caps)
 {
-    GST_DEBUG_OBJECT(m_bin.get(), "Outgoing audio source payload caps: %" GST_PTR_FORMAT, caps.get());
+    GST_DEBUG_OBJECT(m_bin.get(), "Setting payload caps: %" GST_PTR_FORMAT, caps.get());
     auto* structure = gst_caps_get_structure(caps.get(), 0);
-    if (const char* encodingName = gst_structure_get_string(structure, "encoding-name")) {
-        if (!strcmp(encodingName, "OPUS")) {
-            m_encoder = makeGStreamerElement("opusenc", nullptr);
-            m_payloader = makeGStreamerElement("rtpopuspay", nullptr);
-            if (!m_encoder || !m_payloader)
-                return false;
-
-            // FIXME: Enable dtx too?
-            gst_util_set_object_arg(G_OBJECT(m_encoder.get()), "audio-type", "voice");
-
-            if (const char* useInbandFec = gst_structure_get_string(structure, "useinbandfec")) {
-                if (!strcmp(useInbandFec, "1"))
-                    g_object_set(m_encoder.get(), "inband-fec", true, nullptr);
-            }
-        } else if (!strcmp(encodingName, "G722")) {
-            m_payloader = makeGStreamerElement("rtpg722pay", nullptr);
-            if (!m_payloader)
-                return false;
-        } else if (!strcmp(encodingName, "PCMA") || !strcmp(encodingName, "PCMU")) {
-            auto payloaderName = makeString("rtp", encodingName, "pay");
-            m_payloader = makeGStreamerElement(payloaderName.convertToASCIILowercase().ascii().data(), nullptr);
-            m_encoder = makeGStreamerElement("alawenc", nullptr);
-            if (!m_payloader || !m_encoder)
-                return false;
-        } else {
-            GST_ERROR_OBJECT(m_bin.get(), "Unsupported outgoing audio encoding: %s", encodingName);
-            return false;
-        }
-    } else {
+    const char* encodingName = gst_structure_get_string(structure, "encoding-name");
+    if (!encodingName) {
         GST_ERROR_OBJECT(m_bin.get(), "encoding-name not found");
+        return false;
+    }
+
+    auto encoding = makeString(encodingName).convertToASCIILowercase();
+    m_payloader = makeGStreamerElement(makeString("rtp"_s, encoding, "pay"_s).ascii().data(), nullptr);
+    if (UNLIKELY(!m_payloader)) {
+        GST_ERROR_OBJECT(m_bin.get(), "RTP payloader not found for encoding %s", encodingName);
+        return false;
+    }
+
+    if (encoding == "opus"_s) {
+        m_encoder = makeGStreamerElement("opusenc", nullptr);
+        if (!m_encoder)
+            return false;
+
+        // FIXME: Enable dtx too?
+        gst_util_set_object_arg(G_OBJECT(m_encoder.get()), "audio-type", "voice");
+
+        if (const char* useInbandFec = gst_structure_get_string(structure, "useinbandfec")) {
+            if (!strcmp(useInbandFec, "1"))
+                g_object_set(m_encoder.get(), "inband-fec", true, nullptr);
+        }
+    } else if (encoding == "g722"_s)
+        m_encoder = makeGStreamerElement("avenc_g722", nullptr);
+    else if (encoding == "pcma"_s)
+        m_encoder = makeGStreamerElement("alawenc", nullptr);
+    else if (encoding == "pcmu"_s)
+        m_encoder = makeGStreamerElement("mulawenc", nullptr);
+    else if (encoding == "isac"_s)
+        m_encoder = makeGStreamerElement("isacenc", nullptr);
+    else {
+        GST_ERROR_OBJECT(m_bin.get(), "Unsupported outgoing audio encoding: %s", encodingName);
+        return false;
+    }
+
+    if (!m_encoder) {
+        GST_ERROR_OBJECT(m_bin.get(), "Encoder not found for encoding %s", encodingName);
         return false;
     }
 
@@ -101,16 +110,34 @@ bool RealtimeOutgoingAudioSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
 
     g_object_set(m_capsFilter.get(), "caps", caps.get(), nullptr);
 
-    gst_bin_add(GST_BIN_CAST(m_bin.get()), m_payloader.get());
-    if (m_encoder) {
-        gst_bin_add(GST_BIN_CAST(m_bin.get()), m_encoder.get());
-        gst_element_link_many(m_outgoingSource.get(), m_valve.get(), m_audioconvert.get(), m_audioresample.get(),
-            m_preEncoderQueue.get(), m_encoder.get(), m_payloader.get(), m_postEncoderQueue.get(), nullptr);
-    } else {
-        gst_element_link_many(m_outgoingSource.get(), m_valve.get(), m_audioconvert.get(), m_audioresample.get(),
-            m_payloader.get(), m_postEncoderQueue.get(), nullptr);
-    }
+    gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_payloader.get(), m_encoder.get(), nullptr);
+
+    auto preEncoderSinkPad = adoptGRef(gst_element_get_static_pad(m_preEncoderQueue.get(), "sink"));
+    if (!gst_pad_is_linked(preEncoderSinkPad.get()))
+        gst_element_link_many(m_outgoingSource.get(), m_valve.get(), m_audioconvert.get(), m_audioresample.get(), m_preEncoderQueue.get(), nullptr);
+
+    gst_element_link_many(m_preEncoderQueue.get(), m_encoder.get(), m_payloader.get(), m_postEncoderQueue.get(), nullptr);
+    gst_bin_sync_children_states(GST_BIN_CAST(m_bin.get()));
     return true;
+}
+
+void RealtimeOutgoingAudioSourceGStreamer::codecPreferencesChanged(const GRefPtr<GstCaps>& codecPreferences)
+{
+    gst_element_set_locked_state(m_bin.get(), TRUE);
+    if (m_payloader) {
+        gst_element_set_locked_state(m_payloader.get(), TRUE);
+        gst_element_set_locked_state(m_encoder.get(), TRUE);
+        gst_element_set_state(m_payloader.get(), GST_STATE_NULL);
+        gst_element_set_state(m_encoder.get(), GST_STATE_NULL);
+        gst_element_unlink_many(m_preEncoderQueue.get(), m_encoder.get(), m_payloader.get(), m_postEncoderQueue.get(), nullptr);
+        gst_bin_remove_many(GST_BIN_CAST(m_bin.get()), m_payloader.get(), m_encoder.get(), nullptr);
+        m_payloader.clear();
+        m_encoder.clear();
+    }
+    setPayloadType(codecPreferences);
+    gst_element_set_locked_state(m_bin.get(), FALSE);
+    gst_element_sync_state_with_parent(m_bin.get());
+    GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(m_bin.get()), GST_DEBUG_GRAPH_SHOW_ALL, "outgoing-audio-new-codec-prefs");
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
@@ -27,14 +27,17 @@ namespace WebCore {
 
 class RealtimeOutgoingAudioSourceGStreamer final : public RealtimeOutgoingMediaSourceGStreamer {
 public:
-    static Ref<RealtimeOutgoingAudioSourceGStreamer> create(Ref<MediaStreamTrackPrivate>&& audioSource) { return adoptRef(*new RealtimeOutgoingAudioSourceGStreamer(WTFMove(audioSource))); }
+    static Ref<RealtimeOutgoingAudioSourceGStreamer> create(const String& mediaStreamId, MediaStreamTrack& track) { return adoptRef(*new RealtimeOutgoingAudioSourceGStreamer(mediaStreamId, track)); }
 
     bool setPayloadType(const GRefPtr<GstCaps>&) final;
 
 protected:
-    explicit RealtimeOutgoingAudioSourceGStreamer(Ref<MediaStreamTrackPrivate>&&);
+    explicit RealtimeOutgoingAudioSourceGStreamer(const String& mediaStreamId, MediaStreamTrack&);
 
 private:
+    void codecPreferencesChanged(const GRefPtr<GstCaps>&) final;
+    RTCRtpCapabilities rtpCapabilities() const final;
+
     GRefPtr<GstElement> m_audioconvert;
     GRefPtr<GstElement> m_audioresample;
 };

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
@@ -27,19 +27,20 @@ namespace WebCore {
 
 class RealtimeOutgoingVideoSourceGStreamer final : public RealtimeOutgoingMediaSourceGStreamer {
 public:
-    static Ref<RealtimeOutgoingVideoSourceGStreamer> create(Ref<MediaStreamTrackPrivate>&& source) { return adoptRef(*new RealtimeOutgoingVideoSourceGStreamer(WTFMove(source))); }
+    static Ref<RealtimeOutgoingVideoSourceGStreamer> create(const String& mediaStreamId, MediaStreamTrack& track) { return adoptRef(*new RealtimeOutgoingVideoSourceGStreamer(mediaStreamId, track)); }
 
     void setApplyRotation(bool shouldApplyRotation) { m_shouldApplyRotation = shouldApplyRotation; }
 
     bool setPayloadType(const GRefPtr<GstCaps>&) final;
 
 protected:
-    explicit RealtimeOutgoingVideoSourceGStreamer(Ref<MediaStreamTrackPrivate>&&);
+    explicit RealtimeOutgoingVideoSourceGStreamer(const String& mediaStreamId, MediaStreamTrack&);
 
     bool m_shouldApplyRotation { false };
 
 private:
     void codecPreferencesChanged(const GRefPtr<GstCaps>&) final;
+    RTCRtpCapabilities rtpCapabilities() const final;
 
     GRefPtr<GstElement> m_videoConvert;
     GRefPtr<GstElement> m_videoFlip;


### PR DESCRIPTION
#### 9559617ac47aa0dc02c9538ea34b812d8065aafd
<pre>
[GStreamer][WebRTC] End-point pipeline improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=243785">https://bugs.webkit.org/show_bug.cgi?id=243785</a>

Reviewed by Xabier Rodriguez-Calvar.

- Codec preferences should now be respected in outgoing sources.
- iSAC and g722 encoders/payloaders should be used if needed.
- the Local SDP offer should now reflect the probed support for RTP payloaders and encoders
- MediaStream IDs should now be exposed each SDP media.
- Crash fixes, specially in SDP handling.
- FEC is disabled on transceivers, because the ULPFEC implementation doesn&apos;t play well with RTX. For
  now we prefer to at least have somewhat working RTX.
- A big proportion of the WebRTC layout tests was triaged, some early diagnostics and notes added in TestExpectations.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-have-local-offer-expected.txt: Copied from LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-stable-expected.txt.
* LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-localDescription-expected.txt:
* LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-remoteDescription-expected.txt:
* LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-stable-expected.txt:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::initializePipeline):
(WebCore::GStreamerMediaEndpoint::teardownPipeline):
(WebCore::GStreamerMediaEndpoint::doSetLocalDescription):
(WebCore::GStreamerMediaEndpoint::doSetRemoteDescription):
(WebCore::GStreamerMediaEndpoint::setDescription):
(WebCore::GStreamerMediaEndpoint::processSDPMessage):
(WebCore::GStreamerMediaEndpoint::configureAndLinkSource):
(WebCore::GStreamerMediaEndpoint::requestPad):
(WebCore::GStreamerMediaEndpoint::addTrack):
(WebCore::GStreamerMediaEndpoint::getStats):
(WebCore::GStreamerMediaEndpoint::mediaStreamFromRTCStream):
(WebCore::GStreamerMediaEndpoint::addRemoteStream):
(WebCore::GStreamerMediaEndpoint::createTransceiverBackends):
(WebCore::GStreamerMediaEndpoint::createSourceForTrack):
(WebCore::GStreamerMediaEndpoint::onIceCandidate):
(WebCore::GStreamerMediaEndpoint::collectTransceivers):
(WebCore::GStreamerMediaEndpoint::storeRemoteMLineInfo): Deleted.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::addTrack):
(WebCore::GStreamerPeerConnectionBackend::dispatchPendingTrackEvents):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::GStreamerRtpTransceiverBackend::GStreamerRtpTransceiverBackend):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::capsFromRtpCapabilities):
(WebCore::getDirectionFromSDPMedia):
(WebCore::capsFromSDPMedia):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::audioRtpExtensions):
(WebCore::GStreamerRegistryScanner::videoRtpExtensions):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:
* Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::RealtimeOutgoingAudioSourceGStreamer):
(WebCore::RealtimeOutgoingAudioSourceGStreamer::rtpCapabilities const):
(WebCore::RealtimeOutgoingAudioSourceGStreamer::setPayloadType):
(WebCore::RealtimeOutgoingAudioSourceGStreamer::codecPreferencesChanged):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::RealtimeOutgoingMediaSourceGStreamer):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::~RealtimeOutgoingMediaSourceGStreamer):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::allowedCaps const):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::link):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::setSinkPad):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::allowedCaps const): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::RealtimeOutgoingVideoSourceGStreamer):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::rtpCapabilities const):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::setPayloadType):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::codecPreferencesChanged):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/253980@main">https://commits.webkit.org/253980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3d42643d33e064938419c9b77d1b675561da228

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31792 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/18443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96899 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150707 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91672 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30147 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91645 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24351 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74452 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24353 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79313 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/18443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67202 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27841 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/18443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27807 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/18443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2802 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29502 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29401 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/18443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->