### PR TITLE
Speed up DocumentSharedObjectPool::cachedShareableElementDataWithAttributes()

### DIFF
--- a/Source/WebCore/dom/DocumentSharedObjectPool.cpp
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.cpp
@@ -29,14 +29,41 @@
 
 #include "Element.h"
 #include "ElementData.h"
+#include <wtf/UnalignedAccess.h>
 
 namespace WebCore {
+
+// Do comparisons 8 bytes-at-a-time on architectures where it's safe.
+#if (CPU(X86_64) || CPU(ARM64)) && !ASAN_ENABLED
+ALWAYS_INLINE bool equalAttributes(const uint8_t* a, const uint8_t* b, unsigned bytes)
+{
+    unsigned length = bytes >> 3;
+    for (unsigned i = 0; i != length; ++i) {
+        if (WTF::unalignedLoad<uint64_t>(a) != WTF::unalignedLoad<uint64_t>(b))
+            return false;
+
+        a += sizeof(uint64_t);
+        b += sizeof(uint64_t);
+    }
+
+    ASSERT(!(bytes & 4));
+    ASSERT(!(bytes & 2));
+    ASSERT(!(bytes & 1));
+
+    return true;
+}
+#else
+ALWAYS_INLINE bool equalAttributes(const uint8_t* a, const uint8_t* b, unsigned bytes)
+{
+    return !memcmp(a, b, bytes);
+}
+#endif
 
 inline bool hasSameAttributes(const Vector<Attribute>& attributes, ShareableElementData& elementData)
 {
     if (attributes.size() != elementData.length())
         return false;
-    return !memcmp(attributes.data(), elementData.m_attributeArray, attributes.size() * sizeof(Attribute));
+    return equalAttributes(reinterpret_cast<const uint8_t*>(attributes.data()), reinterpret_cast<const uint8_t*>(elementData.m_attributeArray), attributes.size() * sizeof(Attribute));
 }
 
 Ref<ShareableElementData> DocumentSharedObjectPool::cachedShareableElementDataWithAttributes(const Vector<Attribute>& attributes)


### PR DESCRIPTION
#### 96bb739ef6e52ae73fe6fb6b93d290fe254fd494
<pre>
Speed up DocumentSharedObjectPool::cachedShareableElementDataWithAttributes()
<a href="https://bugs.webkit.org/show_bug.cgi?id=244539">https://bugs.webkit.org/show_bug.cgi?id=244539</a>

Reviewed by Ryosuke Niwa.

Speed up attributes comparison in DocumentSharedObjectPool::cachedShareableElementDataWithAttributes()
by doing comparison 8 bytes at a time.

This is similar to what we do for string comparisons in WTF::equal(). This is a confirmed 0.62%
speed up on Speedometer 2.1 on Apple Silicon.

* Source/WebCore/dom/DocumentSharedObjectPool.cpp:
(WebCore::equalAttributes):
(WebCore::hasSameAttributes):

Canonical link: <a href="https://commits.webkit.org/253959@main">https://commits.webkit.org/253959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d502fe2bd2a701425b8e2ea23a4b372a14191f17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96810 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150571 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30041 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79702 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91563 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93206 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24270 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74360 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24104 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67120 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27746 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13271 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27702 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14287 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2786 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37162 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33564 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->