### PR TITLE
Blob should report its underlying memory cost to garbage collection

### DIFF
--- a/LayoutTests/fast/storage/serialized-script-value.html
+++ b/LayoutTests/fast/storage/serialized-script-value.html
@@ -6,7 +6,7 @@
     <body>
         <script>
 
-const currentVersion = 0x0a;
+const currentVersion = 0x0b;
 
 // Here's a little Q&D helper for future adventurers needing to rebaseline this.
 

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -90,7 +90,7 @@ std::optional<FetchBody> FetchBody::fromFormData(ScriptExecutionContext& context
     auto url = formData.asBlobURL();
     if (!url.isNull()) {
         // FIXME: Properly set mime type and size of the blob.
-        Ref<const Blob> blob = Blob::deserialize(&context, url, { }, { }, { });
+        Ref<const Blob> blob = Blob::deserialize(&context, url, { }, { }, 0, { });
         return FetchBody { WTFMove(blob) };
     }
 

--- a/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
@@ -477,12 +477,12 @@ ThreadableWebSocketChannel::SendResult WorkerThreadableWebSocketChannel::Bridge:
         return ThreadableWebSocketChannel::SendFail;
     setMethodNotCompleted();
 
-    m_loaderProxy.postTaskToLoader([peer = m_peer, url = binaryData.url().isolatedCopy(), type = binaryData.type().isolatedCopy(), size = binaryData.size()](ScriptExecutionContext& context) {
+    m_loaderProxy.postTaskToLoader([peer = m_peer, url = binaryData.url().isolatedCopy(), type = binaryData.type().isolatedCopy(), size = binaryData.size(), memoryCost = binaryData.memoryCost()](ScriptExecutionContext& context) {
         ASSERT(isMainThread());
         ASSERT_UNUSED(context, context.isDocument());
         ASSERT(peer);
 
-        peer->send(Blob::deserialize(&context, url, type, size, { }));
+        peer->send(Blob::deserialize(&context, url, type, size, memoryCost, { }));
     });
 
     Ref<Bridge> protectedThis(*this);

--- a/Source/WebCore/dom/MessageEvent.cpp
+++ b/Source/WebCore/dom/MessageEvent.cpp
@@ -121,7 +121,7 @@ size_t MessageEvent::memoryCost() const
     }, [] (const String& string) -> size_t {
         return string.sizeInBytes();
     }, [] (const Ref<Blob>& blob) -> size_t {
-        return blob->size();
+        return blob->memoryCost();
     }, [] (const Ref<ArrayBuffer>& buffer) -> size_t {
         return buffer->byteLength();
     });

--- a/Source/WebCore/fileapi/Blob.idl
+++ b/Source/WebCore/fileapi/Blob.idl
@@ -32,10 +32,11 @@ typedef (BufferSource or Blob or USVString) BlobPart;
 
 [
     ActiveDOMObject,
+    CustomToJSObject,
     ExportToWrappedFunction,
     Exposed=(Window,Worker),
     GenerateIsReachable=Impl,
-    CustomToJSObject,
+    ReportExtraMemoryCost
 ] interface Blob {
     [CallWith=CurrentScriptExecutionContext] constructor(optional sequence<BlobPart> blobParts, optional BlobPropertyBag options);
 

--- a/Source/WebCore/fileapi/File.cpp
+++ b/Source/WebCore/fileapi/File.cpp
@@ -68,7 +68,7 @@ File::File(ScriptExecutionContext* context, URL&& url, String&& type, String&& p
 }
 
 File::File(DeserializationContructor, ScriptExecutionContext* context, const String& path, const URL& url, const String& type, const String& name, const std::optional<int64_t>& lastModified)
-    : Blob(deserializationContructor, context, url, type, { }, path)
+    : Blob(deserializationContructor, context, url, type, { }, 0, path)
     , m_path(path)
     , m_name(name)
     , m_lastModifiedDateOverride(lastModified)


### PR DESCRIPTION
#### c51b8f774888924b36573b76dd14300d216b1166
<pre>
Blob should report its underlying memory cost to garbage collection
<a href="https://bugs.webkit.org/show_bug.cgi?id=244504">https://bugs.webkit.org/show_bug.cgi?id=244504</a>
&lt;rdar://99288771&gt;

Reviewed by Youenn Fablet.

* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::fromFormData):
* Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp:
(WebCore::WorkerThreadableWebSocketChannel::Bridge::send):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneDeserializer::readTerminal):
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::computeMemoryCost):
(WebCore::Blob::Blob):
* Source/WebCore/fileapi/Blob.h:
(WebCore::Blob::deserialize):
(WebCore::Blob::memoryCost const):
* Source/WebCore/fileapi/Blob.idl:
* Source/WebCore/fileapi/File.cpp:
(WebCore::File::File):

Canonical link: <a href="https://commits.webkit.org/254026@main">https://commits.webkit.org/254026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d710a80f55abfa7b8039cfdc9ae9da36cb8cac28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96968 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/151044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30226 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91712 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24415 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74513 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24399 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79373 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67246 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27910 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27884 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14371 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2828 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37283 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33647 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->