### PR TITLE
Use XPC connections between WebKit processes

### DIFF
--- a/Source/WTF/wtf/PlatformEnableCocoa.h
+++ b/Source/WTF/wtf/PlatformEnableCocoa.h
@@ -821,3 +821,7 @@
 #if (!defined(ENABLE_LOCKDOWN_MODE_API) && (PLATFORM(MAC) || PLATFORM(IOS)))
 #define ENABLE_LOCKDOWN_MODE_API 1
 #endif
+
+#if !defined(ENABLE_XPC_IPC)
+#define ENABLE_XPC_IPC 1
+#endif

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -38,6 +38,7 @@
 #include "NetworkLoadScheduler.h"
 #include "NetworkMDNSRegisterMessages.h"
 #include "NetworkProcess.h"
+#include "NetworkProcessConnectionInfo.h"
 #include "NetworkProcessConnectionMessages.h"
 #include "NetworkProcessMessages.h"
 #include "NetworkProcessProxyMessages.h"
@@ -1438,6 +1439,15 @@ RefPtr<NetworkResourceLoader> NetworkConnectionToWebProcess::takeNetworkResource
 void NetworkConnectionToWebProcess::installMockContentFilter(WebCore::MockContentFilterSettings&& settings)
 {
     MockContentFilterSettings::singleton() = WTFMove(settings);
+}
+#endif
+
+#if ENABLE(XPC_IPC)
+void NetworkConnectionToWebProcess::getNetworkProcessConnectionInfo(PAL::SessionID, CompletionHandler<void(WebCore::HTTPCookieAcceptPolicy)>&& completionHandler)
+{
+    auto* storage = networkProcess().storageSession(m_sessionID);
+    RELEASE_ASSERT(storage);
+    completionHandler(storage->cookieAcceptPolicy());
 }
 #endif
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -299,6 +299,10 @@ private:
     void getProcessDisplayName(audit_token_t, CompletionHandler<void(const String&)>&&);
 #endif
 
+#if ENABLE(XPC_IPC)
+    void getNetworkProcessConnectionInfo(PAL::SessionID, CompletionHandler<void(WebCore::HTTPCookieAcceptPolicy)>&&);
+#endif
+
 #if USE(LIBWEBRTC)
     NetworkRTCProvider& rtcProvider();
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -107,6 +107,9 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
     DidDeliverMessagePortMessages(uint64_t messageBatchIdentifier)
     RegisterURLSchemesAsCORSEnabled(Vector<String> schemes);
     SetCORSDisablingPatterns(WebCore::PageIdentifier pageIdentifier, Vector<String> patterns)
+#if ENABLE(XPC_IPC)
+    GetNetworkProcessConnectionInfo(PAL::SessionID sessionID) -> (enum:uint8_t WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy) Async
+#endif
 #if PLATFORM(MAC)
     GetProcessDisplayName(audit_token_t auditToken) -> (String displayName)
     UpdateActivePages(String name, Vector<String> activePagesOrigins, audit_token_t auditToken)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -392,6 +392,10 @@ public:
     void setEmulatedConditions(PAL::SessionID, std::optional<int64_t>&& bytesPerSecondLimit);
 #endif
 
+#if ENABLE(XPC_IPC)
+    void createXPCNetworkConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Identifier);
+#endif
+
 private:
     void platformInitializeNetworkProcess(const NetworkProcessCreationParameters&);
 
@@ -424,7 +428,7 @@ private:
     // Message Handlers
     bool didReceiveSyncNetworkProcessMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
     void initializeNetworkProcess(NetworkProcessCreationParameters&&, CompletionHandler<void()>&&);
-    void createNetworkConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, CompletionHandler<void(std::optional<IPC::Attachment>&&, WebCore::HTTPCookieAcceptPolicy)>&&);
+    void createNetworkConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, std::optional<audit_token_t>, CompletionHandler<void(std::optional<IPC::Attachment>&&, WebCore::HTTPCookieAcceptPolicy)>&&);
 
     void fetchWebsiteData(PAL::SessionID, OptionSet<WebsiteDataType>, OptionSet<WebsiteDataFetchOption>, CompletionHandler<void(WebsiteData&&)>&&);
     void deleteWebsiteData(PAL::SessionID, OptionSet<WebsiteDataType>, WallTime modifiedSince, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -23,7 +23,7 @@
 messages -> NetworkProcess LegacyReceiver {
     InitializeNetworkProcess(struct WebKit::NetworkProcessCreationParameters processCreationParameters) -> ()
 
-    CreateNetworkConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID) -> (std::optional<IPC::Attachment> connectionIdentifier, enum:uint8_t WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy)
+    CreateNetworkConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, std::optional<audit_token_t> auditToken) -> (std::optional<IPC::Attachment> connectionIdentifier, enum:uint8_t WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy) Async
 
 #if USE(SOUP)
     SetIgnoreTLSErrors(PAL::SessionID sessionID, bool ignoreTLSErrors)

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
@@ -26,15 +26,15 @@
 #pragma once
 
 #include "NetworkProcess.h"
+#include "NetworkProcessEndpoint.h"
 #include "NetworkProcessSupplement.h"
-#include "XPCEndpoint.h"
 #include <wtf/Lock.h>
 #include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
 
 namespace WebKit {
 
-class LaunchServicesDatabaseObserver : public WebKit::XPCEndpoint, public NetworkProcessSupplement {
+class LaunchServicesDatabaseObserver : public NetworkProcessSupplement, public NetworkProcessEndpointObserver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     LaunchServicesDatabaseObserver(NetworkProcess&);
@@ -45,18 +45,9 @@ public:
 private:
     void startObserving(OSObjectPtr<xpc_connection_t>);
 
-    // XPCEndpoint
-    const char* xpcEndpointMessageNameKey() const override;
-    const char* xpcEndpointMessageName() const override;
-    const char* xpcEndpointNameKey() const override;
     void handleEvent(xpc_connection_t, xpc_object_t) override;
 
-    // NetworkProcessSupplement
-    void initializeConnection(IPC::Connection*) final;
-
-    RetainPtr<id> m_observer;
-    Lock m_connectionsLock;
-    Vector<OSObjectPtr<xpc_connection_t>> m_connections WTF_GUARDED_BY_LOCK(m_connectionsLock);
+    WeakPtr<NetworkProcess> m_networkProcess;
 };
 
 }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessEndpoint.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessEndpoint.mm
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2020 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "NetworkProcessEndpoint.h"
+
+#import "Connection.h"
+#import "NetworkProcessEndpointXPCConstants.h"
+#import <wtf/cocoa/Entitlements.h>
+#import <wtf/spi/cocoa/SecuritySPI.h>
+
+namespace WebKit {
+
+NetworkProcessEndpoint::NetworkProcessEndpoint(NetworkProcess& networkProcess)
+: m_networkProcess(WeakPtr { networkProcess })
+{
+}
+
+const char* NetworkProcessEndpoint::supplementName()
+{
+    return "NetworkProcessEndpointSupplement";
+}
+
+NetworkProcessEndpoint::~NetworkProcessEndpoint()
+{
+}
+
+void NetworkProcessEndpoint::addObserver(WeakPtr<NetworkProcessEndpointObserver> observer)
+{
+    m_observers.append(observer);
+}
+
+const char* NetworkProcessEndpoint::xpcEndpointMessageNameKey() const
+{
+    return xpcMessageNameKey;
+}
+
+const char* NetworkProcessEndpoint::xpcEndpointMessageName() const
+{
+    return NetworkProcessEndpointXPCConstants::xpcNetworkProcessXPCEndpointMessageName;
+}
+
+const char* NetworkProcessEndpoint::xpcEndpointNameKey() const
+{
+    return NetworkProcessEndpointXPCConstants::xpcNetworkProcessXPCEndpointNameKey;
+}
+
+void NetworkProcessEndpoint::didConnect(xpc_connection_t connection)
+{
+}
+
+void NetworkProcessEndpoint::didCloseConnection(xpc_connection_t connection)
+{
+    WTFLogAlways("WebKitXPC: NetworkProcessEndpoint::didCloseConnection");
+#if ENABLE(XPC_IPC)
+    IPC::Connection::handleXPCDisconnect(XPCObject { connection });
+#endif
+}
+
+void NetworkProcessEndpoint::handleEvent(xpc_connection_t connection, xpc_object_t event)
+{
+    if (xpc_get_type(event) == XPC_TYPE_DICTIONARY) {
+#if ENABLE(XPC_IPC)
+        auto messageName = xpc_dictionary_get_string(event, xpcMessageNameKey);
+        if (messageName && !strcmp(messageName, NetworkProcessEndpointXPCConstants::xpcBootstrapNetworkProcessConnectionMessageName)) {
+            auto sessionID = xpc_dictionary_get_uint64(event, NetworkProcessEndpointXPCConstants::xpcBootstrapNetworkProcessConnectionSessionIDKey);
+            auto processIdentifier = xpc_dictionary_get_uint64(event, NetworkProcessEndpointXPCConstants::xpcBootstrapNetworkProcessConnectionProcessIdentifierKey);
+            if (!m_networkProcess)
+                return;
+            m_networkProcess->createXPCNetworkConnectionToWebProcess(makeObjectIdentifier<WebCore::ProcessIdentifierType>(processIdentifier), PAL::SessionID(sessionID), IPC::Connection::Identifier(0, connection));
+            return;
+        }
+
+        if (IPC::Connection::handleXPCMessage(event))
+            return;
+#endif
+        // FIXME: Lock m_observers
+        for (auto& observer : m_observers) {
+            callOnMainRunLoop([observer, connection = OSObjectPtr(connection), event = OSObjectPtr(event)] {
+                observer->handleEvent(connection.get(), event.get());
+            });
+        }
+    }
+}
+
+void NetworkProcessEndpoint::initializeConnection(IPC::Connection* connection)
+{
+    sendEndpointToConnection(connection->xpcConnection());
+}
+
+}

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -315,12 +315,10 @@ Connection::~Connection()
     clearAsyncReplyHandlers(*this);
 }
 
-// WTF_IGNORES_THREAD_SAFETY_ANALYSIS because this function accesses connectionMap() without locking.
-// It is safe because this function is only called on the main thread and Connection objects are only
-// constructed / destroyed on the main thread.
-Connection* Connection::connection(UniqueID uniqueID) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+Connection* Connection::connection(UniqueID uniqueID)
 {
     ASSERT(RunLoop::isMain());
+    Locker locker { s_connectionMapLock };
     return connectionMap().get(uniqueID);
 }
 

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -88,6 +88,7 @@ ShouldDispatchWhenWaitingForSyncReply Encoder::shouldDispatchMessageWhenWaitingF
 
 void Encoder::setShouldDispatchMessageWhenWaitingForSyncReply(ShouldDispatchWhenWaitingForSyncReply shouldDispatchWhenWaitingForSyncReply)
 {
+    WTFLogAlways("WebKitXPC: setShouldDispatchMessageWhenWaitingForSyncReply %hhu", shouldDispatchWhenWaitingForSyncReply);
     switch (shouldDispatchWhenWaitingForSyncReply) {
     case ShouldDispatchWhenWaitingForSyncReply::No:
         messageFlags().remove(MessageFlags::DispatchMessageWhenWaitingForSyncReply);

--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -38,6 +38,10 @@
 #include <windows.h>
 #endif
 
+#if ENABLE(XPC_IPC)
+#include <wtf/OSObjectPtr.h>
+#endif
+
 namespace IPC {
 class Decoder;
 class Encoder;
@@ -98,12 +102,14 @@ public:
         friend class SharedMemory;
 #if USE(UNIX_DOMAIN_SOCKETS)
         mutable IPC::Attachment m_attachment;
+#elif ENABLE(XPC_IPC)
+        OSObjectPtr<xpc_object_t> m_xpcObject;
 #elif OS(DARWIN)
         mutable mach_port_t m_port { MACH_PORT_NULL };
 #elif OS(WINDOWS)
         mutable HANDLE m_handle;
 #endif
-        size_t m_size;
+        size_t m_size { 0 };
     };
 
     // FIXME: Change these factory functions to return Ref<SharedMemory> and crash on failure.
@@ -154,6 +160,8 @@ private:
 #if USE(UNIX_DOMAIN_SOCKETS)
     std::optional<int> m_fileDescriptor;
     bool m_isWrappingMap { false };
+#elif ENABLE(XPC_IPC)
+    OSObjectPtr<xpc_object_t> m_xpcObject;
 #elif OS(DARWIN)
     mach_port_t m_port { MACH_PORT_NULL };
 #elif OS(WINDOWS)

--- a/Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm
+++ b/Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm
@@ -49,6 +49,7 @@ void AuthenticationManager::initializeConnection(IPC::Connection* connection)
     WeakPtr weakThis { *this };
     // The following xpc event handler overwrites the boostrap event handler and is only used
     // to capture client certificate credential.
+#if 0
     xpc_connection_set_event_handler(connection->xpcConnection(), ^(xpc_object_t event) {
         callOnMainRunLoop([event = OSObjectPtr(event), weakThis = weakThis] {
             RELEASE_ASSERT(isMainRunLoop());
@@ -101,6 +102,7 @@ void AuthenticationManager::initializeConnection(IPC::Connection* connection)
             weakThis->completeAuthenticationChallenge(makeObjectIdentifier<AuthenticationChallengeIdentifierType>(challengeID), AuthenticationChallengeDisposition::UseCredential, WebCore::Credential(adoptNS([[NSURLCredential alloc] initWithIdentity:identity.get() certificates:certificates persistence:(NSURLCredentialPersistence)persistence]).get()));
         });
     });
+#endif
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/NetworkProcessEndpointXPCConstants.h
+++ b/Source/WebKit/Shared/Cocoa/NetworkProcessEndpointXPCConstants.h
@@ -25,26 +25,16 @@
 
 #pragma once
 
-#import "NetworkProcessEndpointClient.h"
-#import <wtf/NeverDestroyed.h>
-#import <wtf/threads/BinarySemaphore.h>
-
 namespace WebKit {
 
-class LaunchServicesDatabaseManager : public WebKit::NetworkProcessEndpointObserver {
-public:
-    static LaunchServicesDatabaseManager& singleton();
+namespace NetworkProcessEndpointXPCConstants {
 
-    void waitForDatabaseUpdate();
+constexpr auto xpcNetworkProcessXPCEndpointNameKey = "network-process-xpc-endpoint";
+constexpr auto xpcNetworkProcessXPCEndpointMessageName = "network-process-xpc-endpoint-message";
+constexpr auto xpcBootstrapNetworkProcessConnectionMessageName = "bootstrap-network-process-connection";
+constexpr auto xpcBootstrapNetworkProcessConnectionSessionIDKey = "session-id";
+constexpr auto xpcBootstrapNetworkProcessConnectionProcessIdentifierKey = "process-identifier";
 
-private:
-    void handleEvent(xpc_object_t) override;
-    void didConnect(xpc_connection_t) override;
+} // namespace NetworkProcessEndpointXPCConstants
 
-    bool waitForDatabaseUpdate(Seconds);
-
-    std::atomic<bool> m_hasReceivedLaunchServicesDatabase { false };
-    BinarySemaphore m_semaphore;
-};
-
-}
+} // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/XPCObject.h
+++ b/Source/WebKit/Shared/Cocoa/XPCObject.h
@@ -25,26 +25,17 @@
 
 #pragma once
 
-#import "NetworkProcessEndpointClient.h"
-#import <wtf/NeverDestroyed.h>
-#import <wtf/threads/BinarySemaphore.h>
+#include <wtf/spi/darwin/XPCSPI.h>
 
 namespace WebKit {
 
-class LaunchServicesDatabaseManager : public WebKit::NetworkProcessEndpointObserver {
-public:
-    static LaunchServicesDatabaseManager& singleton();
+struct XPCObject {
 
-    void waitForDatabaseUpdate();
-
-private:
-    void handleEvent(xpc_object_t) override;
-    void didConnect(xpc_connection_t) override;
-
-    bool waitForDatabaseUpdate(Seconds);
-
-    std::atomic<bool> m_hasReceivedLaunchServicesDatabase { false };
-    BinarySemaphore m_semaphore;
+    union {
+        xpc_object_t xpcObject;
+        xpc_connection_t xpcConnection;
+        xpc_endpoint_t xpcEndpoint;
+    };
 };
 
 }

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -148,7 +148,7 @@ static void XPCServiceEventHandler(xpc_connection_t peer)
             return;
         }
 
-        handleXPCEndpointMessages(event, messageName);
+        handleXPCMessages(event, messageName);
     });
 
     xpc_connection_resume(peer);

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -82,6 +82,7 @@ Platform/classifier/ResourceLoadStatisticsClassifier.cpp
 
 Platform/cocoa/PaymentAuthorizationPresenter.mm
 Platform/cocoa/PaymentAuthorizationViewController.mm
+Platform/cocoa/SharedMemoryCocoa.cpp
 Platform/cocoa/WKPaymentAuthorizationDelegate.mm
 Platform/cocoa/WebKitAdditions.mm @no-unify
 

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -267,8 +267,14 @@ void ProcessLauncher::launchProcess()
                 eventHandler->handleXPCEvent(event.get());
             });
         }
+
+#if ENABLE(XPC_IPC)
+        IPC::Connection::handleXPCMessage(event);
+#endif
     };
 
+    static NeverDestroyed<dispatch_queue_t> queue = dispatch_queue_create("WebKit XPC Event Handler", DISPATCH_QUEUE_SERIAL);
+    xpc_connection_set_target_queue(m_xpcConnection.get(), queue.get());
     xpc_connection_set_event_handler(m_xpcConnection.get(), eventHandler);
 
     xpc_connection_resume(m_xpcConnection.get());

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -298,7 +298,7 @@ void NetworkProcessProxy::getNetworkProcessConnection(WebProcessProxy& webProces
 {
     RELEASE_LOG(ProcessSuspension, "%p - NetworkProcessProxy is taking a background assertion because a web process is requesting a connection", this);
     startResponsivenessTimer(UseLazyStop::No);
-    sendWithAsyncReply(Messages::NetworkProcess::CreateNetworkConnectionToWebProcess { webProcessProxy.coreProcessIdentifier(), webProcessProxy.sessionID() }, [this, weakThis = WeakPtr { *this }, reply = WTFMove(reply)](auto&& identifier, auto cookieAcceptPolicy) mutable {
+    sendWithAsyncReply(Messages::NetworkProcess::CreateNetworkConnectionToWebProcess { webProcessProxy.coreProcessIdentifier(), webProcessProxy.sessionID(), webProcessProxy.connection()->getAuditToken() }, [this, weakThis = WeakPtr { *this }, reply = WTFMove(reply)](auto&& identifier, auto cookieAcceptPolicy) mutable {
         if (!weakThis) {
             RELEASE_LOG_ERROR(Process, "NetworkProcessProxy::getNetworkProcessConnection: NetworkProcessProxy deallocated during connection establishment");
             return reply({ });
@@ -313,6 +313,8 @@ void NetworkProcessProxy::getNetworkProcessConnection(WebProcessProxy& webProces
 #if USE(UNIX_DOMAIN_SOCKETS) || OS(WINDOWS)
         reply(NetworkProcessConnectionInfo { WTFMove(*identifier), cookieAcceptPolicy });
         UNUSED_VARIABLE(this);
+#elif ENABLE(XPC_IPC)
+        reply(NetworkProcessConnectionInfo { WTFMove(*identifier), cookieAcceptPolicy, connection()->getAuditToken() });
 #elif OS(DARWIN)
         MESSAGE_CHECK(MACH_PORT_VALID(identifier->sendRight()));
         reply(NetworkProcessConnectionInfo { WTFMove(*identifier) , cookieAcceptPolicy, connection()->getAuditToken() });

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
@@ -26,7 +26,7 @@
 #import "config.h"
 #import "NetworkProcessProxy.h"
 
-#import "LaunchServicesDatabaseXPCConstants.h"
+#import "NetworkProcessEndpointXPCConstants.h"
 #import "NetworkProcessMessages.h"
 #import "WebProcessPool.h"
 #import "XPCEndpoint.h"
@@ -58,7 +58,7 @@ bool NetworkProcessProxy::XPCEventHandler::handleXPCEvent(xpc_object_t event) co
     if (!messageName || !*messageName)
         return false;
 
-    if (LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseXPCEndpointMessageName == messageName) {
+    if (!strcmp(messageName, NetworkProcessEndpointXPCConstants::xpcNetworkProcessXPCEndpointMessageName)) {
         m_networkProcess->m_endpointMessage = event;
         for (auto& processPool : WebProcessPool::allProcessPools()) {
             for (auto& process : processPool->processes())

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2264,6 +2264,7 @@
 		E1E552C516AE065F004ED653 /* SandboxInitializationParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = E1E552C316AE065E004ED653 /* SandboxInitializationParameters.h */; };
 		E1EE53E311F8CFC000CCBEE4 /* InjectedBundlePageEditorClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E1EE53DC11F8CF9F00CCBEE4 /* InjectedBundlePageEditorClient.h */; };
 		E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E326E356284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm */; };
+		E3539AD728BE8DAA004BEA7B /* NetworkProcessEndpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A4A15C28B948C40068116E /* NetworkProcessEndpoint.h */; };
 		E36FF00327F36FBD004BE21A /* SandboxStateVariables.h in Headers */ = {isa = PBXBuildFile; fileRef = E36FF00127F36FBD004BE21A /* SandboxStateVariables.h */; };
 		E36FF00427F36FBD004BE21A /* preferences.sb in Resources */ = {isa = PBXBuildFile; fileRef = E36FF00227F36FBD004BE21A /* preferences.sb */; };
 		E3816B3D27E2463A005EAFC0 /* WebMockContentFilterManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3816B3B27E24639005EAFC0 /* WebMockContentFilterManager.cpp */; };
@@ -2277,6 +2278,12 @@
 		E38A1FC023A551BF00D2374F /* UserInterfaceIdiom.mm in Sources */ = {isa = PBXBuildFile; fileRef = E38A1FBF23A551BF00D2374F /* UserInterfaceIdiom.mm */; };
 		E39628DD23960CC600658ECD /* WebDeviceOrientationUpdateProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = E39628DB23960CC500658ECD /* WebDeviceOrientationUpdateProvider.h */; };
 		E39628DE23960CC600658ECD /* WebDeviceOrientationUpdateProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E39628DC23960CC600658ECD /* WebDeviceOrientationUpdateProvider.cpp */; };
+		E3A4A15528B7D1140068116E /* XPCObject.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A4A15428B7D1100068116E /* XPCObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3A4A15728B7D7280068116E /* NetworkProcessEndpointXPCConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A4A15628B7D7280068116E /* NetworkProcessEndpointXPCConstants.h */; };
+		E3A4A15928B7ECD40068116E /* NetworkProcessEndpointClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A4A15828B7ECD40068116E /* NetworkProcessEndpointClient.h */; };
+		E3A4A15E28B961680068116E /* Attachment.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3A4A15D28B961680068116E /* Attachment.mm */; };
+		E3A4A16028B968270068116E /* NetworkProcessEndpointClient.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3A4A15F28B968270068116E /* NetworkProcessEndpointClient.mm */; };
+		E3A4A16228B968360068116E /* NetworkProcessEndpoint.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3A4A16128B968360068116E /* NetworkProcessEndpoint.mm */; };
 		E3CAAA442413279900CED2E2 /* AccessibilitySupportSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E3CAAA432413278A00CED2E2 /* AccessibilitySupportSPI.h */; };
 		E413F59D1AC1ADC400345360 /* NetworkCacheEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = E413F59B1AC1ADB600345360 /* NetworkCacheEntry.h */; };
 		E42E06101AA7523B00B11699 /* NetworkCacheIOChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = E42E060B1AA7440D00B11699 /* NetworkCacheIOChannel.h */; };
@@ -7136,6 +7143,13 @@
 		E39628DB23960CC500658ECD /* WebDeviceOrientationUpdateProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebDeviceOrientationUpdateProvider.h; sourceTree = "<group>"; };
 		E39628DC23960CC600658ECD /* WebDeviceOrientationUpdateProvider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebDeviceOrientationUpdateProvider.cpp; sourceTree = "<group>"; };
 		E39628E423971F3400658ECD /* WebDeviceOrientationUpdateProvider.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebDeviceOrientationUpdateProvider.messages.in; sourceTree = "<group>"; };
+		E3A4A15428B7D1100068116E /* XPCObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XPCObject.h; sourceTree = "<group>"; };
+		E3A4A15628B7D7280068116E /* NetworkProcessEndpointXPCConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkProcessEndpointXPCConstants.h; sourceTree = "<group>"; };
+		E3A4A15828B7ECD40068116E /* NetworkProcessEndpointClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkProcessEndpointClient.h; sourceTree = "<group>"; };
+		E3A4A15C28B948C40068116E /* NetworkProcessEndpoint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkProcessEndpoint.h; sourceTree = "<group>"; };
+		E3A4A15D28B961680068116E /* Attachment.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Attachment.mm; sourceTree = "<group>"; };
+		E3A4A15F28B968270068116E /* NetworkProcessEndpointClient.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkProcessEndpointClient.mm; sourceTree = "<group>"; };
+		E3A4A16128B968360068116E /* NetworkProcessEndpoint.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkProcessEndpoint.mm; sourceTree = "<group>"; };
 		E3A86FBB26958D830059264D /* WebCaptionPreferencesDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebCaptionPreferencesDelegate.h; sourceTree = "<group>"; };
 		E3A86FBC26958E330059264D /* WebCaptionPreferencesDelegate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebCaptionPreferencesDelegate.cpp; sourceTree = "<group>"; };
 		E3BCE877267252120011D8DB /* AccessibilityPreferences.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AccessibilityPreferences.cpp; sourceTree = "<group>"; };
@@ -9847,6 +9861,7 @@
 				CE550E12228373C800D28791 /* InsertTextOptions.h */,
 				C1663E5A24AEA74200C6A3B2 /* LaunchServicesDatabaseXPCConstants.h */,
 				2D1087621D2C641B00B85F82 /* LoadParametersCocoa.mm */,
+				E3A4A15628B7D7280068116E /* NetworkProcessEndpointXPCConstants.h */,
 				2D440B8325EF235E00A98D87 /* PDFKitSoftLink.h */,
 				2D440B8225EF235E00A98D87 /* PDFKitSoftLink.mm */,
 				F4BE0D7627AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h */,
@@ -9889,6 +9904,7 @@
 				C14D306524B794E700480387 /* XPCEndpoint.mm */,
 				C14D306824B794E700480387 /* XPCEndpointClient.h */,
 				C14D306624B794E700480387 /* XPCEndpointClient.mm */,
+				E3A4A15428B7D1100068116E /* XPCObject.h */,
 			);
 			name = cocoa;
 			path = Cocoa;
@@ -11051,6 +11067,8 @@
 				C1A152D624E5A29A00978C8B /* HandleXPCEndpointMessages.mm */,
 				C14D37FC24ACDF45007FF014 /* LaunchServicesDatabaseManager.h */,
 				C14D37FD24ACE086007FF014 /* LaunchServicesDatabaseManager.mm */,
+				E3A4A15828B7ECD40068116E /* NetworkProcessEndpointClient.h */,
+				E3A4A15F28B968270068116E /* NetworkProcessEndpointClient.mm */,
 				CDA29A191CBDBF4100901CCF /* PlaybackSessionManager.h */,
 				CDA29A1C1CBDBF5B00901CCF /* PlaybackSessionManager.messages.in */,
 				CDA29A181CBDBF4100901CCF /* PlaybackSessionManager.mm */,
@@ -11088,6 +11106,8 @@
 				5321594F1DBAE6D70054AA3C /* NetworkDataTaskCocoa.h */,
 				5CBC9B8B1C65257300A8FDCF /* NetworkDataTaskCocoa.mm */,
 				7EC4F0F918E4A945008056AF /* NetworkProcessCocoa.mm */,
+				E3A4A15C28B948C40068116E /* NetworkProcessEndpoint.h */,
+				E3A4A16128B968360068116E /* NetworkProcessEndpoint.mm */,
 				532159501DBAE6D70054AA3C /* NetworkSessionCocoa.h */,
 				5C20CB9B1BB0DCD200895BB1 /* NetworkSessionCocoa.mm */,
 				41287D4C225C05C5009A3E26 /* WebSocketTaskCocoa.h */,
@@ -12571,6 +12591,7 @@
 		BCC56F751159955E001CCAF9 /* cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				E3A4A15D28B961680068116E /* Attachment.mm */,
 				1A30EAC5115D7DA30053E937 /* ConnectionCocoa.mm */,
 				5C1579E627172A5100ED5280 /* DaemonConnectionCocoa.mm */,
 				1A1EC69D1872092100B951F0 /* ImportanceAssertion.h */,
@@ -14442,6 +14463,9 @@
 				5179556A162876F300FA43B6 /* NetworkProcess.h in Headers */,
 				517CF0E4163A486C00C2950E /* NetworkProcessConnectionMessages.h in Headers */,
 				5C1426ED1C23F80900D41183 /* NetworkProcessCreationParameters.h in Headers */,
+				E3539AD728BE8DAA004BEA7B /* NetworkProcessEndpoint.h in Headers */,
+				E3A4A15928B7ECD40068116E /* NetworkProcessEndpointClient.h in Headers */,
+				E3A4A15728B7D7280068116E /* NetworkProcessEndpointXPCConstants.h in Headers */,
 				5163199516289A6300E22F00 /* NetworkProcessMessages.h in Headers */,
 				E14A954A16E016A40068DE82 /* NetworkProcessPlatformStrategies.h in Headers */,
 				5179556E162877B300FA43B6 /* NetworkProcessProxy.h in Headers */,
@@ -15542,6 +15566,7 @@
 				1A7C0DF71B7D1F1000A9B848 /* WKWindowFeaturesRef.h in Headers */,
 				C15E6CB324B7BE6F00E501A2 /* XPCEndpoint.h in Headers */,
 				C15E6CB424B7BE7600E501A2 /* XPCEndpointClient.h in Headers */,
+				E3A4A15528B7D1140068116E /* XPCObject.h in Headers */,
 				BCBECDE816B6416800047A1A /* XPCServiceEntryPoint.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -16931,6 +16956,7 @@
 				517B5F7E275E97B6002DC22D /* AppBundleRequest.mm in Sources */,
 				EBA8D3B227A5E33F00CB7900 /* ApplePushServiceConnection.mm in Sources */,
 				2DEB1D2E2127473600933906 /* ArgumentCodersCF.cpp in Sources */,
+				E3A4A15E28B961680068116E /* Attachment.mm in Sources */,
 				CD4570D424411D0F00A3DCEB /* AudioSessionRoutingArbitrator.cpp in Sources */,
 				CD4570D3244113B500A3DCEB /* AudioSessionRoutingArbitratorProxyMessageReceiver.cpp in Sources */,
 				512F58A212A883AD00629530 /* AuthenticationManagerMessageReceiver.cpp in Sources */,
@@ -16974,6 +17000,8 @@
 				52F060E11654318500F3281B /* NetworkContentRuleListManagerMessageReceiver.cpp in Sources */,
 				51F060E11654318500F3283F /* NetworkMDNSRegisterMessageReceiver.cpp in Sources */,
 				517CF0E3163A486C00C2950E /* NetworkProcessConnectionMessageReceiver.cpp in Sources */,
+				E3A4A16228B968360068116E /* NetworkProcessEndpoint.mm in Sources */,
+				E3A4A16028B968270068116E /* NetworkProcessEndpointClient.mm in Sources */,
 				5163199416289A6000E22F00 /* NetworkProcessMessageReceiver.cpp in Sources */,
 				513A163C163088F6005D7D22 /* NetworkProcessProxyMessageReceiver.cpp in Sources */,
 				E152551A17011819003D7ADB /* NetworkResourceLoaderMessageReceiver.cpp in Sources */,

--- a/Source/WebKit/WebProcess/Inspector/WebInspector.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspector.h
@@ -33,11 +33,19 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/text/WTFString.h>
 
+#if ENABLE(XPC_IPC)
+#include "XPCEndpointClient.h"
+#endif
+
 namespace WebKit {
 
 class WebPage;
 
-class WebInspector : public API::ObjectImpl<API::Object::Type::BundleInspector>, private IPC::Connection::Client {
+class WebInspector : public API::ObjectImpl<API::Object::Type::BundleInspector>
+#if ENABLE(XPC_IPC)
+, public XPCEndpointClient
+#endif
+, private IPC::Connection::Client {
 public:
     static Ref<WebInspector> create(WebPage*);
 
@@ -51,6 +59,13 @@ public:
     // IPC::Connection::Client
     void didClose(IPC::Connection&) override { close(); }
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) override { close(); }
+
+#if ENABLE(XPC_IPC)
+    // XPCEndpointClient
+    void handleEvent(xpc_object_t) override;
+    void didConnect() override;
+    void didCloseConnection(xpc_connection_t) override;
+#endif
 
     void show();
     void close();

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -492,4 +492,38 @@ String WebInspectorUI::localizedStringsURL() const
 }
 #endif // !PLATFORM(MAC) && !PLATFORM(GTK) && !PLATFORM(WIN)
 
+#if ENABLE(XPC_IPC)
+const char* WebInspectorUI::xpcEndpointMessageNameKey() const
+{
+    return nullptr;
+}
+
+const char* WebInspectorUI::xpcEndpointMessageName() const
+{
+    return nullptr;
+}
+
+const char* WebInspectorUI::xpcEndpointNameKey() const
+{
+    return nullptr;
+}
+
+void WebInspectorUI::didConnect(xpc_connection_t)
+{
+}
+
+void WebInspectorUI::didCloseConnection(xpc_connection_t connection)
+{
+    WTFLogAlways("WebKitXPC: WebInspectorUI::didCloseConnection");
+#if ENABLE(XPC_IPC)
+    IPC::Connection::handleXPCDisconnect(XPCObject { connection });
+#endif
+}
+
+void WebInspectorUI::handleEvent(xpc_connection_t, xpc_object_t message)
+{
+    IPC::Connection::handleXPCMessage(XPCObject { message });
+}
+#endif
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -80,9 +80,8 @@
 namespace WebKit {
 using namespace WebCore;
 
-NetworkProcessConnection::NetworkProcessConnection(IPC::Connection::Identifier connectionIdentifier, HTTPCookieAcceptPolicy cookieAcceptPolicy)
+NetworkProcessConnection::NetworkProcessConnection(IPC::Connection::Identifier connectionIdentifier)
     : m_connection(IPC::Connection::createClientConnection(connectionIdentifier, *this))
-    , m_cookieAcceptPolicy(cookieAcceptPolicy)
 {
     m_connection->open();
 

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -54,9 +54,9 @@ class WebSharedWorkerObjectConnection;
 
 class NetworkProcessConnection : public RefCounted<NetworkProcessConnection>, IPC::Connection::Client {
 public:
-    static Ref<NetworkProcessConnection> create(IPC::Connection::Identifier connectionIdentifier, WebCore::HTTPCookieAcceptPolicy httpCookieAcceptPolicy)
+    static Ref<NetworkProcessConnection> create(IPC::Connection::Identifier connectionIdentifier)
     {
-        return adoptRef(*new NetworkProcessConnection(connectionIdentifier, httpCookieAcceptPolicy));
+        return adoptRef(*new NetworkProcessConnection(connectionIdentifier));
     }
     ~NetworkProcessConnection();
     
@@ -79,6 +79,7 @@ public:
     std::optional<audit_token_t> networkProcessAuditToken() const { return m_networkProcessAuditToken; }
 #endif
 
+    void setCookieAcceptPolicy(WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy) { m_cookieAcceptPolicy = cookieAcceptPolicy; }
     WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy() const { return m_cookieAcceptPolicy; }
     bool cookiesEnabled() const;
 
@@ -89,7 +90,7 @@ public:
 #endif
 
 private:
-    NetworkProcessConnection(IPC::Connection::Identifier, WebCore::HTTPCookieAcceptPolicy);
+    NetworkProcessConnection(IPC::Connection::Identifier);
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.h
@@ -41,6 +41,9 @@ struct NetworkProcessConnectionInfo {
     {
 #if USE(UNIX_DOMAIN_SOCKETS)
         return IPC::Connection::Identifier(connection.fd().value());
+#elif ENABLE(XPC_IPC)
+        auto xpcConnection = static_cast<xpc_connection_t>(connection.xpcObject());
+        return IPC::Connection::Identifier(0, xpcConnection);
 #elif OS(DARWIN)
         return IPC::Connection::Identifier(connection.sendRight());
 #elif OS(WINDOWS)

--- a/Source/WebKit/WebProcess/cocoa/HandleXPCEndpointMessages.h
+++ b/Source/WebKit/WebProcess/cocoa/HandleXPCEndpointMessages.h
@@ -29,6 +29,6 @@
 
 namespace WebKit {
 
-void handleXPCEndpointMessages(xpc_object_t event, const char* messageName);
+void handleXPCMessages(xpc_object_t event, const char* messageName);
 
 }

--- a/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
@@ -59,16 +59,12 @@ void LaunchServicesDatabaseManager::handleEvent(xpc_object_t message)
     }
 }
 
-void LaunchServicesDatabaseManager::didConnect()
+void LaunchServicesDatabaseManager::didConnect(xpc_connection_t connection)
 {
     auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcRequestLaunchServicesDatabaseUpdateMessageName);
 
-    auto connection = this->connection();
-    if (!connection)
-        return;
-
-    xpc_connection_send_message(connection.get(), message.get());
+    xpc_connection_send_message(connection, message.get());
 }
 
 bool LaunchServicesDatabaseManager::waitForDatabaseUpdate(Seconds timeout)

--- a/Source/WebKit/WebProcess/cocoa/NetworkProcessEndpointClient.mm
+++ b/Source/WebKit/WebProcess/cocoa/NetworkProcessEndpointClient.mm
@@ -23,28 +23,50 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
+#import "config.h"
 #import "NetworkProcessEndpointClient.h"
-#import <wtf/NeverDestroyed.h>
-#import <wtf/threads/BinarySemaphore.h>
+
+#import "Connection.h"
+#import "XPCEndpoint.h"
+#import <wtf/spi/darwin/XPCSPI.h>
+#import <wtf/text/WTFString.h>
 
 namespace WebKit {
 
-class LaunchServicesDatabaseManager : public WebKit::NetworkProcessEndpointObserver {
-public:
-    static LaunchServicesDatabaseManager& singleton();
+NetworkProcessEndpointClient& NetworkProcessEndpointClient::singleton()
+{
+    static NeverDestroyed<NetworkProcessEndpointClient> manager;
+    return manager.get();
+}
 
-    void waitForDatabaseUpdate();
+void NetworkProcessEndpointClient::handleEvent(xpc_object_t message)
+{
+#if ENABLE(XPC_IPC)
+    if (IPC::Connection::handleXPCMessage(message))
+        return;
+#endif
 
-private:
-    void handleEvent(xpc_object_t) override;
-    void didConnect(xpc_connection_t) override;
+    for (auto& observer : m_observers)
+        observer->handleEvent(message);
+}
 
-    bool waitForDatabaseUpdate(Seconds);
+void NetworkProcessEndpointClient::didConnect()
+{
+    for (auto& observer : m_observers)
+        observer->didConnect(connection().get());
+}
 
-    std::atomic<bool> m_hasReceivedLaunchServicesDatabase { false };
-    BinarySemaphore m_semaphore;
-};
+void NetworkProcessEndpointClient::didCloseConnection(xpc_connection_t connection)
+{
+    WTFLogAlways("WebKitXPC: NetworkProcessEndpointClient::didCloseConnection");
+#if ENABLE(XPC_IPC)
+    IPC::Connection::handleXPCDisconnect(XPCObject { connection });
+#endif
+}
+
+void NetworkProcessEndpointClient::addObserver(WeakPtr<NetworkProcessEndpointObserver> observer)
+{
+    m_observers.append(observer);
+}
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
@@ -62,6 +62,9 @@ private:
             xpc_connection_send_message(connection, message.get());
         }
     }
+    void didCloseConnection(xpc_connection_t) override
+    {
+    }
 };
 
 class XPCEndpointClient final : public WebKit::XPCEndpointClient {
@@ -79,6 +82,9 @@ private:
         xpc_connection_send_message(connection().get(), message.get());
 
         clientConnectedToEndpoint = true;
+    }
+    void didCloseConnection(xpc_connection_t) override
+    {
     }
 };
 


### PR DESCRIPTION
#### cf8237cc1937f66287f21f34b5ae50ed51e490ac
<pre>
Use XPC connections between WebKit processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=244367">https://bugs.webkit.org/show_bug.cgi?id=244367</a>
&lt;rdar://problem/99347372&gt;

Reviewed by NOBODY (OOPS!).

Work in progress to switch to using XPC connections between WebKit processes.

* Source/WTF/wtf/PlatformEnableCocoa.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::getNetworkProcessConnectionInfo):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::m_messagePortChannelRegistry):
(WebKit::NetworkProcess::createNetworkConnectionToWebProcess):
(WebKit::NetworkProcess::createXPCNetworkConnectionToWebProcess):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm:
(WebKit::LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver):
(WebKit::LaunchServicesDatabaseObserver::startObserving):
(WebKit::LaunchServicesDatabaseObserver::handleEvent):
(WebKit::LaunchServicesDatabaseObserver::xpcEndpointMessageNameKey const): Deleted.
(WebKit::LaunchServicesDatabaseObserver::xpcEndpointMessageName const): Deleted.
(WebKit::LaunchServicesDatabaseObserver::xpcEndpointNameKey const): Deleted.
(WebKit::LaunchServicesDatabaseObserver::initializeConnection): Deleted.
* Source/WebKit/Platform/IPC/Attachment.h:
(IPC::Attachment::Attachment::xpcObject const):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::connection):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::Identifier::Identifier):
(IPC::Connection::identifierIsValid):
(IPC::Connection::xpcConnection const):
* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::Encoder::setShouldDispatchMessageWhenWaitingForSyncReply):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::platformInvalidate):
(IPC::Connection::platformInitialize):
(IPC::Connection::open):
(IPC::Connection::platformCanSendOutgoingMessages const):
(IPC::Connection::sendOutgoingMessage):
(IPC::Connection::identifier const):
(IPC::Connection::getAuditToken):
(IPC::Connection::kill):
(IPC::Connection::remoteProcessID const):
(IPC::Connection::handleXPCDisconnect):
(IPC::Connection::handleXPCMessage):
* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Platform/cocoa/SharedMemoryCocoa.mm: Added.
(WebKit::safeRoundPage):
(WebKit::SharedMemory::Handle::Handle):
(WebKit::SharedMemory::Handle::operator=):
(WebKit::SharedMemory::Handle::~Handle):
(WebKit::SharedMemory::Handle::isNull const):
(WebKit::SharedMemory::Handle::clear):
(WebKit::SharedMemory::IPCHandle::encode const):
(WebKit::SharedMemory::IPCHandle::decode):
(WebKit::toPointer):
(WebKit::toVMAddress):
(WebKit::SharedMemory::allocate):
(WebKit::machProtection):
(WebKit::makeMemoryEntry):
(WebKit::SharedMemory::wrapMap):
(WebKit::SharedMemory::map):
(WebKit::SharedMemory::~SharedMemory):
(WebKit::SharedMemory::createHandle):
(WebKit::SharedMemory::createSendRight const):
* Source/WebKit/Shared/Authentication/cocoa/AuthenticationManagerCocoa.mm:
(WebKit::AuthenticationManager::initializeConnection):
* Source/WebKit/Shared/Cocoa/NetworkProcessEndpointXPCConstants.h: Copied from Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.h.
* Source/WebKit/Shared/Cocoa/XPCEndpoint.h:
(WebKit::XPCEndpoint::xpcEndpointMessageNameKey const):
(WebKit::XPCEndpoint::xpcEndpointMessageName const):
(WebKit::XPCEndpoint::xpcEndpointNameKey const):
(WebKit::XPCEndpoint::didConnect):
* Source/WebKit/Shared/Cocoa/XPCEndpoint.mm:
(WebKit::XPCEndpoint::XPCEndpoint):
(WebKit::XPCEndpoint::sendMessageOnAllConnections):
(WebKit::XPCEndpoint::connectionFromAuditToken):
* Source/WebKit/Shared/Cocoa/XPCEndpointClient.h:
* Source/WebKit/Shared/Cocoa/XPCEndpointClient.mm:
(WebKit::XPCEndpointClient::setEndpoint):
(WebKit::XPCEndpointClient::waitForConnection):
* Source/WebKit/Shared/Cocoa/XPCObject.h: Copied from Source/WebKit/WebProcess/cocoa/HandleXPCEndpointMessages.h.
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::getNetworkProcessConnection):
* Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm:
(WebKit::NetworkProcessProxy::XPCEventHandler::handleXPCEvent const):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Inspector/WebInspector.cpp:
(WebKit::WebInspector::setFrontendConnection):
(WebKit::WebInspector::handleEvent):
(WebKit::WebInspector::didConnect):
(WebKit::WebInspector::didCloseConnection):
* Source/WebKit/WebProcess/Inspector/WebInspector.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::xpcEndpointMessageNameKey const):
(WebKit::WebInspectorUI::xpcEndpointMessageName const):
(WebKit::WebInspectorUI::xpcEndpointNameKey const):
(WebKit::WebInspectorUI::didConnect):
(WebKit::WebInspectorUI::didCloseConnection):
(WebKit::WebInspectorUI::handleEvent):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::NetworkProcessConnection):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
(WebKit::NetworkProcessConnection::create):
(WebKit::NetworkProcessConnection::setCookieAcceptPolicy):
* Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.h:
(WebKit::NetworkProcessConnectionInfo::identifier const):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::ensureNetworkProcessConnection):
* Source/WebKit/WebProcess/cocoa/HandleXPCEndpointMessages.h:
* Source/WebKit/WebProcess/cocoa/HandleXPCEndpointMessages.mm:
(WebKit::handleXPCMessages):
(WebKit::handleXPCEndpointMessages): Deleted.
* Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.h:
* Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm:
(WebKit::LaunchServicesDatabaseManager::didConnect):
* Source/WebKit/WebProcess/cocoa/NetworkProcessEndpointClient.h: Copied from Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.h.
(WebKit::NetworkProcessEndpointObserver::~NetworkProcessEndpointObserver):
* Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf8237cc1937f66287f21f34b5ae50ed51e490ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87635 "8 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31723 "Hash cf8237cc for PR 3822 does not build") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18395 "Hash cf8237cc for PR 3822 does not build") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96843 "Hash cf8237cc for PR 3822 does not build") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150605 "Built successfully and passed tests") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30081 "Hash cf8237cc for PR 3822 does not build") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26211 "Hash cf8237cc for PR 3822 does not build") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79736 "Hash cf8237cc for PR 3822 does not build") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91595 "Hash cf8237cc for PR 3822 does not build") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93253 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/64/builds/30081 "Hash cf8237cc for PR 3822 does not build") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74396 "Hash cf8237cc for PR 3822 does not build") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/79736 "Hash cf8237cc for PR 3822 does not build") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/64/builds/30081 "Hash cf8237cc for PR 3822 does not build") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/18395 "Hash cf8237cc for PR 3822 does not build") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/79736 "Hash cf8237cc for PR 3822 does not build") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79454 "Built successfully and passed tests") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27781 "Hash cf8237cc for PR 3822 does not build") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/18395 "Hash cf8237cc for PR 3822 does not build") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73154 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27743 "Hash cf8237cc for PR 3822 does not build") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/18395 "Hash cf8237cc for PR 3822 does not build") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26028 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29435 "Hash cf8237cc for PR 3822 does not build") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/74396 "Hash cf8237cc for PR 3822 does not build") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75985 "Built successfully") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29343 "Hash cf8237cc for PR 3822 does not build") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/18395 "Hash cf8237cc for PR 3822 does not build") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16846 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode") | 
<!--EWS-Status-Bubble-End-->