### PR TITLE
Regression(r222993) Code in addChildNodesToDeletionQueue() that checks that node has a refcount of 0 is now dead

### DIFF
--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -181,14 +181,14 @@ RemovedSubtreeObservability notifyChildNodeRemoved(ContainerNode& oldParentOfRem
 void addChildNodesToDeletionQueue(Node*& head, Node*& tail, ContainerNode& container)
 {
     // We have to tell all children that their parent has died.
-    RefPtr<Node> next = nullptr;
-    for (RefPtr<Node> node = container.firstChild(); node; node = next) {
+    Node* next = nullptr;
+    for (auto* node = container.firstChild(); node; node = next) {
         ASSERT(!node->m_deletionHasBegun);
 
         next = node->nextSibling();
         node->setNextSibling(nullptr);
         node->setParentNode(nullptr);
-        container.setFirstChild(next.get());
+        container.setFirstChild(next);
         if (next)
             next->setPreviousSibling(nullptr);
 
@@ -199,12 +199,13 @@ void addChildNodesToDeletionQueue(Node*& head, Node*& tail, ContainerNode& conta
             // Add the node to the list of nodes to be deleted.
             // Reuse the nextSibling pointer for this purpose.
             if (tail)
-                tail->setNextSibling(node.get());
+                tail->setNextSibling(node);
             else
-                head = node.get();
+                head = node;
 
-            tail = node.get();
+            tail = node;
         } else {
+            Ref protectedNode { *node }; // removedFromDocument may remove remove all references to this node.
             node->setTreeScopeRecursively(container.document());
             if (node->isInTreeScope())
                 notifyChildNodeRemoved(container, *node);


### PR DESCRIPTION
#### 8547e6cbfce0d9a9979339e2bb25e3ec4978a5e2
<pre>
Regression(r222993) Code in addChildNodesToDeletionQueue() that checks that node has a refcount of 0 is now dead
<a href="https://bugs.webkit.org/show_bug.cgi?id=244558">https://bugs.webkit.org/show_bug.cgi?id=244558</a>

Reviewed by NOBODY (OOPS!).

Code in addChildNodesToDeletionQueue() that checks that node has a refcount of
0 is now dead after r222993. The node is protected now so its ref count
couldn&apos;t possibly be 0.

This patch reverts the changes made to addChildNodesToDeletionQueue() in
r222993 to address the issue. This would cause us to call
setTreeScopeRecursively() &amp; notifyChildNodeRemoved() unnecessarily in many
cases.

* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::addChildNodesToDeletionQueue):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8547e6cbfce0d9a9979339e2bb25e3ec4978a5e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96855 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150617 "Found 30 new test failures: accessibility/aria-tab-role-on-buttons.html, accessibility/svg-shape-labelled.html, accessibility/w3c-svg-presentational-role.html, css3/masking/reference-clip-path-bounds.html, dom/html/level2/html/HTMLFieldSetElement02.html, dom/html/level2/html/HTMLLegendElement01.html, dom/html/level2/html/HTMLLegendElement02.html, dom/html/level2/html/HTMLLegendElement03.html, dom/xhtml/level2/html/HTMLFieldSetElement02.xhtml, dom/xhtml/level2/html/HTMLLegendElement01.xhtml ...") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30095 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26221 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79761 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91607 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93268 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24319 "Found 30 new test failures: accessibility/aria-table-attributes.html, accessibility/input-type-hidden-in-aria-hidden-false.html, accessibility/ios-simulator/file-upload-button.html, accessibility/ios-simulator/has-touch-event-listener-with-shadow.html, dom/html/level2/html/HTMLHRElement01.html, dom/html/level2/html/HTMLLinkElement03.html, dom/xhtml/level2/html/HTMLFormElement02.xhtml, dom/xhtml/level2/html/HTMLLegendElement04.xhtml, fast/block/collapse-anon-block-with-float-siblings-only.html, fast/canvas/image-pattern-rotate.html ...") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74409 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24317 "Failure limit exceed. At least found 5 new test failures: fast/forms/input-image-submit.html, fast/forms/validation-message-detached-iframe2.html, imported/blink/svg/animations/viewspec-animated-viewbox.html, imported/w3c/web-platform-tests/fetch/origin/assorted.window.html, imported/w3c/web-platform-tests/service-workers/service-worker/svg-target-reftest.https.html") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79277 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79471 "Found 1 new API test failure: TestWebKitAPI.WebKitLegacy.HTMLFormCollectionNamedItemTest") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67168 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27794 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13297 "Found 30 new test failures: accessibility/aria-scrollbar-role.html, accessibility/frame-disconnect-textmarker-cache-crash.html, accessibility/mac/aria-expanded-not-exposed-when-undefined.html, accessibility/mac/html-with-aria-label.html, css3/blending/svg-blend-color-dodge.html, css3/masking/reference-clip-path-bounds.html, dom/html/level2/html/HTMLFieldSetElement02.html, dom/html/level2/html/HTMLLinkElement01.html, dom/xhtml/level2/html/HTMLFormElement02.xhtml, editing/deleting/delete-at-paragraph-boundaries-003.html ...") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27757 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14313 "Found 30 new test failures: accessibility/aria-selected.html, accessibility/focusable-div.html, accessibility/list-detection2.html, accessibility/mac/aria-drag-drop.html, accessibility/mac/ignore-redundant-groups-crash.html, accessibility/mac/search-subrole.html, accessibility/recompute-current-modal-after-aria-modal-element-appears.html, dom/html/level2/html/HTMLFormElement02.html, dom/html/level2/html/HTMLLegendElement02.html, dom/xhtml/level2/html/HTMLFormElement05.xhtml ...") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29450 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37201 "Found 30 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-focused-element-change.html, accessibility/accessibility-crash-setattribute.html, accessibility/accessibility-crash-with-dynamic-inline-content.html, accessibility/accessibility-node-reparent.html, accessibility/accessibility-object-detached.html, accessibility/mac/abbr-acronym-tags.html, accessibility/mac/accessibility-make-first-responder.html, accessibility/mac/accesskey.html, accessibility/mac/alt-for-css-content.html ...") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33590 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->