### PR TITLE
focusing of disabled fieldset element is not prevented

### DIFF
--- a/LayoutTests/fast/forms/fieldset/fieldset-disabled-expected.txt
+++ b/LayoutTests/fast/forms/fieldset/fieldset-disabled-expected.txt
@@ -88,6 +88,7 @@ PASS legendFieldSet.disabled is false
 PASS insertedLegendTextInput.value is "JJJK"
 PASS firstLegendTextInput.value is "IIK"
 PASS secondLegendTextInput.value is "K"
+PASS disabledFieldsetWithTabindex.focus(); document.activeElement is document.body
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/fieldset/fieldset-disabled.html
+++ b/LayoutTests/fast/forms/fieldset/fieldset-disabled.html
@@ -31,6 +31,8 @@ input:disabled {
 <input type="text" id="parserGeneratedInput9">
 </fieldset>
 </form>
+<fieldset tabindex=0 disabled id="fieldset-tabindex"></fieldset>
+</form>
 
 <script>
 description('Tests for HTMLFieldSetElement.disabled behavior.');
@@ -290,6 +292,10 @@ document.execCommand('insertText', false, 'K');
 shouldBe('insertedLegendTextInput.value', '"JJJK"');
 shouldBe('firstLegendTextInput.value', '"IIK"');
 shouldBe('secondLegendTextInput.value', '"K"');
+
+var disabledFieldsetWithTabindex = document.getElementById('fieldset-tabindex');
+document.activeElement.blur();
+shouldBe('disabledFieldsetWithTabindex.focus(); document.activeElement', 'document.body');
 
 document.body.removeChild(document.getElementsByTagName('form')[0]);
 document.body.removeChild(fieldSet);

--- a/Source/WebCore/html/HTMLFieldSetElement.cpp
+++ b/Source/WebCore/html/HTMLFieldSetElement.cpp
@@ -150,7 +150,7 @@ bool HTMLFieldSetElement::matchesInvalidPseudoClass() const
 
 bool HTMLFieldSetElement::supportsFocus() const
 {
-    return HTMLElement::supportsFocus();
+    return HTMLElement::supportsFocus() && !isDisabledFormControl();
 }
 
 const AtomString& HTMLFieldSetElement::formControlType() const


### PR DESCRIPTION
#### 8ddd66fb04db1553c97fca498169941a8206286c
<pre>
focusing of disabled fieldset element is not prevented

focusing of disabled fieldset element is not prevented

<a href="https://bugs.webkit.org/show_bug.cgi?id=141086">https://bugs.webkit.org/show_bug.cgi?id=141086</a>

Reviewed by Ryosuke Niwa.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/1637db318e525b5c1e3a960eeb59dee151f049ca">https://chromium.googlesource.com/chromium/src.git/+/1637db318e525b5c1e3a960eeb59dee151f049ca</a>

It is to align with web-specification and both Gecko and Blink.

<a href="https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled">https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled</a>

* Source/WebCore/html/HTMLFieldSetElement.cpp:
(HTMLFieldSetElement::supportsFocus()) - Modify to add !isDisabledFormControl logic to check before focusing.
* LayoutTests/fast/forms/fieldset/fieldset-disabled.html: Modified to accomodate &quot;tabindex&apos; case.
* LayoutTests/fast/forms/fieldset/fieldset-disabled-expected.txt: Updated Expectations for &apos;tabindex&apos; case

Canonical link: <a href="https://commits.webkit.org/253993@main">https://commits.webkit.org/253993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8254f0c1964d52fa5f2d04e9b01350bcbc2911f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96861 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150623 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30103 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26229 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79754 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91612 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24320 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74415 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24143 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67158 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27800 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13302 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27765 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14318 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29458 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37207 "Found 1 new test failure: http/tests/media/fairplay/fps-mse-unmuxed-multiple-keys.html") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1138 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29362 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33595 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->