### PR TITLE
Add ReferrerPolicy to the PolicyContainer

### DIFF
--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -78,7 +78,6 @@ class ResourceRequest;
 class SocketProvider;
 class WebCoreOpaqueRoot;
 enum class LoadedFromOpaqueSource : uint8_t;
-enum class ReferrerPolicy : uint8_t;
 enum class TaskSource : uint8_t;
 
 #if ENABLE(NOTIFICATIONS)
@@ -114,8 +113,6 @@ public:
     virtual URL completeURL(const String& url, ForceUTF8 = ForceUTF8::No) const = 0;
 
     virtual String userAgent(const URL&) const = 0;
-
-    virtual ReferrerPolicy referrerPolicy() const = 0;
 
     virtual const Settings::Values& settingsValues() const = 0;
 

--- a/Source/WebCore/dom/SecurityContext.cpp
+++ b/Source/WebCore/dom/SecurityContext.cpp
@@ -174,7 +174,8 @@ PolicyContainer SecurityContext::policyContainer() const
 {
     return {
         crossOriginEmbedderPolicy(),
-        crossOriginOpenerPolicy()
+        crossOriginOpenerPolicy(),
+        referrerPolicy()
     };
 }
 

--- a/Source/WebCore/dom/SecurityContext.h
+++ b/Source/WebCore/dom/SecurityContext.h
@@ -40,6 +40,7 @@ class SecurityOriginPolicy;
 class ContentSecurityPolicy;
 struct CrossOriginOpenerPolicy;
 struct PolicyContainer;
+enum class ReferrerPolicy : uint8_t;
 
 enum SandboxFlag {
     // See http://www.whatwg.org/specs/web-apps/current-work/#attr-iframe-sandbox for a list of the sandbox flags.
@@ -95,6 +96,8 @@ public:
     void setCrossOriginEmbedderPolicy(const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy) { m_crossOriginEmbedderPolicy = crossOriginEmbedderPolicy; }
 
     virtual const CrossOriginOpenerPolicy& crossOriginOpenerPolicy() const;
+
+    virtual ReferrerPolicy referrerPolicy() const = 0;
 
     PolicyContainer policyContainer() const;
 


### PR DESCRIPTION
#### ea311869338ebe3af77d0ba9a935442816954bcf
<pre>
Add ReferrerPolicy to the PolicyContainer
<a href="https://bugs.webkit.org/show_bug.cgi?id=244561">https://bugs.webkit.org/show_bug.cgi?id=244561</a>

Reviewed by Brent Fulgham.

The HTML spec calls for ReferrerPolicy to be in the PolicyContainer
struct.[1] This adds the ReferrerPolicy enum to the PolicyContainer
struct to keep our implementation more in line with the spec.

This also shuffles around the virtual referrerPolicy getter so the
SecurityContext can construct a PolicyContainer given the implementation
from its subclasses.

No new tests, ReferrerPolicy already covered by existing tests.

[1] <a href="https://html.spec.whatwg.org/multipage/origin.html#policy-containers">https://html.spec.whatwg.org/multipage/origin.html#policy-containers</a>

* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/SecurityContext.cpp:
(WebCore::SecurityContext::policyContainer const):
* Source/WebCore/dom/SecurityContext.h:
* Source/WebCore/loader/PolicyContainer.h:
(WebCore::PolicyContainer::isolatedCopy const):
(WebCore::PolicyContainer::isolatedCopy):
(WebCore::operator==):
(WebCore::PolicyContainer::encode const):
(WebCore::PolicyContainer::decode):

Canonical link: <a href="https://commits.webkit.org/254003@main">https://commits.webkit.org/254003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14810f804932e1cb1ab9f209153f0393624b27a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96868 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150630 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30111 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26233 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79784 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91619 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93286 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24327 "Build was cancelled") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74422 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24334 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67186 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27807 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13304 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27772 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14320 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2816 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37213 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33597 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->