### PR TITLE
[JSC] JITStubRoutine should drop vtable

### DIFF
--- a/Source/JavaScriptCore/jit/JITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/JITStubRoutine.cpp
@@ -26,21 +26,88 @@
 #include "config.h"
 #include "JITStubRoutine.h"
 
+#include "GCAwareJITStubRoutine.h"
+#include "PolymorphicCallStubRoutine.h"
+
 #if ENABLE(JIT)
 
 namespace JSC {
 
-JITStubRoutine::~JITStubRoutine() { }
-
-bool JITStubRoutine::visitWeak(VM&)
+void JITStubRoutine::observeZeroRefCountImpl()
 {
-    return true;
+    RELEASE_ASSERT(!m_refCount);
+    delete this;
+}
+
+template<typename Func>
+void JITStubRoutine::runWithDowncast(const Func& function)
+{
+    switch (m_type) {
+    case Type::JITStubRoutineType:
+        function(static_cast<JITStubRoutine*>(this));
+        break;
+    case Type::GCAwareJITStubRoutineType:
+        function(static_cast<GCAwareJITStubRoutine*>(this));
+        break;
+    case Type::PolymorphicAccessJITStubRoutineType:
+        function(static_cast<PolymorphicAccessJITStubRoutine*>(this));
+        break;
+    case Type::PolymorphicCallStubRoutineType:
+        function(static_cast<PolymorphicCallStubRoutine*>(this));
+        break;
+    case Type::MarkingGCAwareJITStubRoutineType:
+        function(static_cast<MarkingGCAwareJITStubRoutine*>(this));
+        break;
+    case Type::GCAwareJITStubRoutineWithExceptionHandlerType:
+        function(static_cast<GCAwareJITStubRoutineWithExceptionHandler*>(this));
+        break;
+    }
+}
+
+void JITStubRoutine::aboutToDie()
+{
+    runWithDowncast([&](auto* derived) {
+        derived->aboutToDieImpl();
+    });
 }
 
 void JITStubRoutine::observeZeroRefCount()
 {
-    RELEASE_ASSERT(!m_refCount);
-    delete this;
+    runWithDowncast([&](auto* derived) {
+        derived->observeZeroRefCountImpl();
+    });
+}
+
+bool JITStubRoutine::visitWeak(VM& vm)
+{
+    bool result = true;
+    runWithDowncast([&](auto* derived) {
+        result = derived->visitWeakImpl(vm);
+    });
+    return result;
+}
+
+void JITStubRoutine::markRequiredObjects(AbstractSlotVisitor& visitor)
+{
+    runWithDowncast([&](auto* derived) {
+        derived->markRequiredObjectsImpl(visitor);
+    });
+}
+
+void JITStubRoutine::markRequiredObjects(SlotVisitor& visitor)
+{
+    runWithDowncast([&](auto* derived) {
+        derived->markRequiredObjectsImpl(visitor);
+    });
+}
+
+void JITStubRoutine::operator delete(JITStubRoutine* stubRoutine, std::destroying_delete_t)
+{
+    stubRoutine->runWithDowncast([&](auto* derived) {
+        using T = std::decay_t<decltype(*derived)>;
+        derived->~T();
+        T::freeAfterDestruction(derived);
+    });
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
@@ -68,7 +68,7 @@ PolymorphicCallStubRoutine::PolymorphicCallStubRoutine(
     const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& codeRef, VM& vm, const JSCell* owner, CallFrame* callerFrame,
     CallLinkInfo& info, const Vector<PolymorphicCallCase>& cases,
     UniqueArray<uint32_t>&& fastCounts)
-    : GCAwareJITStubRoutine(codeRef)
+    : GCAwareJITStubRoutine(Type::PolymorphicCallStubRoutineType, codeRef)
     , m_variants(cases.size())
     , m_fastCounts(WTFMove(fastCounts))
 {
@@ -83,8 +83,6 @@ PolymorphicCallStubRoutine::PolymorphicCallStubRoutine(
     WTF::storeStoreFence();
     makeGCAware(vm);
 }
-
-PolymorphicCallStubRoutine::~PolymorphicCallStubRoutine() { }
 
 CallVariantList PolymorphicCallStubRoutine::variants() const
 {
@@ -128,7 +126,7 @@ void PolymorphicCallStubRoutine::clearCallNodesFor(CallLinkInfo* info)
     }
 }
 
-bool PolymorphicCallStubRoutine::visitWeak(VM& vm)
+bool PolymorphicCallStubRoutine::visitWeakImpl(VM& vm)
 {
     bool isStillLive = true;
     forEachDependentCell([&](JSCell* cell) {
@@ -144,11 +142,11 @@ ALWAYS_INLINE void PolymorphicCallStubRoutine::markRequiredObjectsInternalImpl(V
         visitor.append(variant);
 }
 
-void PolymorphicCallStubRoutine::markRequiredObjectsInternal(AbstractSlotVisitor& visitor)
+void PolymorphicCallStubRoutine::markRequiredObjectsImpl(AbstractSlotVisitor& visitor)
 {
     markRequiredObjectsInternalImpl(visitor);
 }
-void PolymorphicCallStubRoutine::markRequiredObjectsInternal(SlotVisitor& visitor)
+void PolymorphicCallStubRoutine::markRequiredObjectsImpl(SlotVisitor& visitor)
 {
     markRequiredObjectsInternalImpl(visitor);
 }

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
@@ -82,12 +82,12 @@ private:
 
 class PolymorphicCallStubRoutine final : public GCAwareJITStubRoutine {
 public:
+    friend class JITStubRoutine;
+
     PolymorphicCallStubRoutine(
         const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, const JSCell* owner,
         CallFrame* callerFrame, CallLinkInfo&, const Vector<PolymorphicCallCase>&,
         UniqueArray<uint32_t>&& fastCounts);
-    
-    ~PolymorphicCallStubRoutine() final;
     
     CallVariantList variants() const;
     bool hasEdges() const;
@@ -102,12 +102,12 @@ public:
             functor(variant.get());
     }
 
-    bool visitWeak(VM&) final;
-
 private:
     template<typename Visitor> void markRequiredObjectsInternalImpl(Visitor&);
-    void markRequiredObjectsInternal(AbstractSlotVisitor&) final;
-    void markRequiredObjectsInternal(SlotVisitor&) final;
+    void markRequiredObjectsImpl(AbstractSlotVisitor&);
+    void markRequiredObjectsImpl(SlotVisitor&);
+
+    bool visitWeakImpl(VM&);
 
     FixedVector<WriteBarrier<JSCell>> m_variants;
     UniqueArray<uint32_t> m_fastCounts;


### PR DESCRIPTION
#### 5261cca9ae1f475f0833c6fc90a1ea29c58ee7ca
<pre>
[JSC] JITStubRoutine should drop vtable
<a href="https://bugs.webkit.org/show_bug.cgi?id=244567">https://bugs.webkit.org/show_bug.cgi?id=244567</a>

Reviewed by Ross Kirsling.

By using destroying delete, we can also drop vtable from JITStubRoutine.
It is also removing virtual calls for most of derived function cases.
For example, JITStubRoutine::visitWeak implementation becomes as follows,

JSC::JITStubRoutine::visitWeak(JSC::VM&amp;):
0000000000af8574        ldrb    w8, [x0, #0x18]
0000000000af8578        cmp     w8, #0x3
0000000000af857c        b.ne    0xaf8584
0000000000af8580        b       JSC::PolymorphicCallStubRoutine::visitWeakImpl(JSC::VM&amp;)
0000000000af8584        mov     w0, #0x1
0000000000af8588        ret

* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::GCAwareJITStubRoutine::GCAwareJITStubRoutine):
(JSC::GCAwareJITStubRoutine::observeZeroRefCountImpl):
(JSC::PolymorphicAccessJITStubRoutine::PolymorphicAccessJITStubRoutine):
(JSC::PolymorphicAccessJITStubRoutine::observeZeroRefCountImpl):
(JSC::MarkingGCAwareJITStubRoutine::MarkingGCAwareJITStubRoutine):
(JSC::MarkingGCAwareJITStubRoutine::markRequiredObjectsImpl):
(JSC::GCAwareJITStubRoutineWithExceptionHandler::GCAwareJITStubRoutineWithExceptionHandler):
(JSC::GCAwareJITStubRoutineWithExceptionHandler::observeZeroRefCountImpl):
(JSC::createICJITStubRoutine):
(JSC::GCAwareJITStubRoutine::~GCAwareJITStubRoutine): Deleted.
(JSC::GCAwareJITStubRoutine::observeZeroRefCount): Deleted.
(JSC::PolymorphicAccessJITStubRoutine::observeZeroRefCount): Deleted.
(JSC::MarkingGCAwareJITStubRoutine::~MarkingGCAwareJITStubRoutine): Deleted.
(JSC::MarkingGCAwareJITStubRoutine::markRequiredObjectsInternal): Deleted.
(JSC::GCAwareJITStubRoutineWithExceptionHandler::aboutToDie): Deleted.
(JSC::GCAwareJITStubRoutineWithExceptionHandler::observeZeroRefCount): Deleted.
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
(JSC::GCAwareJITStubRoutine::create):
(JSC::GCAwareJITStubRoutine::markRequiredObjects): Deleted.
(JSC::GCAwareJITStubRoutine::markRequiredObjectsInternal): Deleted.
* Source/JavaScriptCore/jit/JITStubRoutine.cpp:
(JSC::JITStubRoutine::observeZeroRefCountImpl):
(JSC::JITStubRoutine::runWithDowncast):
(JSC::JITStubRoutine::aboutToDie):
(JSC::JITStubRoutine::observeZeroRefCount):
(JSC::JITStubRoutine::visitWeak):
(JSC::JITStubRoutine::markRequiredObjects):
(JSC::JITStubRoutine::operator delete):
(JSC::JITStubRoutine::~JITStubRoutine): Deleted.
* Source/JavaScriptCore/jit/JITStubRoutine.h:
(JSC::JITStubRoutine::JITStubRoutine):
(JSC::JITStubRoutine::createSelfManagedRoutine):
(JSC::JITStubRoutine::aboutToDieImpl):
(JSC::JITStubRoutine::markRequiredObjectsImpl):
(JSC::JITStubRoutine::visitWeakImpl):
(JSC::JITStubRoutine::aboutToDie): Deleted.
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp:
(JSC::PolymorphicCallStubRoutine::PolymorphicCallStubRoutine):
(JSC::PolymorphicCallStubRoutine::visitWeakImpl):
(JSC::PolymorphicCallStubRoutine::markRequiredObjectsImpl):
(JSC::PolymorphicCallStubRoutine::~PolymorphicCallStubRoutine): Deleted.
(JSC::PolymorphicCallStubRoutine::visitWeak): Deleted.
(JSC::PolymorphicCallStubRoutine::markRequiredObjectsInternal): Deleted.
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h:

Canonical link: <a href="https://commits.webkit.org/253978@main">https://commits.webkit.org/253978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c2377d713dc911123d352d4b774bafdcf486cac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87678 "failed 5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96877 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150662 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30121 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79774 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91627 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93296 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74431 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24332 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79299 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67184 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79486 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27817 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73198 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27782 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14325 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26044 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2800 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37220 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76029 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33602 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16862 "Passed tests") | 
<!--EWS-Status-Bubble-End-->