### PR TITLE
[Alternate WebM Player] Fix seek scrubbing lag

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -116,9 +116,15 @@ private:
     MediaTime durationMediaTime() const final { return m_duration; }
     MediaTime startTime() const final { return MediaTime::zeroTime(); }
     MediaTime initialTime() const final { return MediaTime::zeroTime(); }
+        
+    bool setCurrentTimeDidChangeCallback(MediaPlayer::CurrentTimeDidChangeCallback&&) final;
 
-    void seek(const MediaTime&) final;
-    bool seeking() const final { return m_seeking; }
+    void seekWithTolerance(const MediaTime&, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold) final;
+    bool seeking() const final;
+    void seekInternal();
+    void seekCompleted();
+    MediaTime clampTimeToLastSeekTime(const MediaTime&) const;
+    MediaTime fastSeekTimeForMediaTime(const MediaTime&, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold);
 
     void setRateDouble(double) final;
     double rate() const final { return m_rate; }
@@ -235,6 +241,8 @@ private:
     void destroyAudioRenderers();
     void clearTracks();
         
+    bool shouldBePlaying() const;
+        
     void registerNotifyWhenHasAvailableVideoFrame();
         
     void startVideoFrameMetadataGathering() final;
@@ -254,14 +262,32 @@ private:
     static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
 
+    struct PendingSeek {
+        WTF_MAKE_STRUCT_FAST_ALLOCATED;
+        PendingSeek(const MediaTime& targetTime, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold)
+            : targetTime(targetTime)
+            , negativeThreshold(negativeThreshold)
+            , positiveThreshold(positiveThreshold)
+        {
+        }
+        MediaTime targetTime;
+        MediaTime negativeThreshold;
+        MediaTime positiveThreshold;
+    };
+    std::unique_ptr<PendingSeek> m_pendingSeek;
+    
     MediaPlayer* m_player;
     RetainPtr<AVSampleBufferRenderSynchronizer> m_synchronizer;
+    mutable MediaPlayer::CurrentTimeDidChangeCallback m_currentTimeDidChangeCallback;
+    RetainPtr<id> m_timeChangedObserver;
+    RetainPtr<id> m_timeJumpedObserver;
     RetainPtr<id> m_durationObserver;
     RetainPtr<CVPixelBufferRef> m_lastPixelBuffer;
     RefPtr<NativeImage> m_lastImage;
     std::unique_ptr<PixelBufferConformerCV> m_rgbConformer;
     RefPtr<WebCoreDecompressionSession> m_decompressionSession;
     WeakPtr<WebMResourceClient> m_resourceClient;
+    Timer m_seekTimer;
 
     Vector<RefPtr<VideoTrackPrivateWebM>> m_videoTracks;
     Vector<RefPtr<AudioTrackPrivateWebM>> m_audioTracks;
@@ -294,7 +320,14 @@ private:
     ProcessIdentity m_resourceOwner;
     std::unique_ptr<BinarySemaphore> m_hasAvailableVideoFrameSemaphore;
 
+    enum SeekState {
+        Seeking,
+        WaitingForAvailableFame,
+        SeekCompleted,
+    };
+    SeekState m_seekCompleted { SeekCompleted };
     FloatSize m_naturalSize;
+    MediaTime m_lastSeekTime;
     MediaTime m_currentTime;
     MediaTime m_duration;
     double m_rate { 1 };
@@ -308,6 +341,7 @@ private:
     bool m_hasAudio { false };
     bool m_hasVideo { false };
     bool m_hasAvailableVideoFrame { false };
+    bool m_playing { false };
     bool m_seeking { false };
     bool m_visible { false };
     bool m_loadingProgressed { false };

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -82,20 +82,50 @@ static const MediaTime discontinuityTolerance = MediaTime(1, 1);
 MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer* player)
     : m_player(player)
     , m_synchronizer(adoptNS([PAL::allocAVSampleBufferRenderSynchronizerInstance() init]))
+    , m_seekTimer(*this, &MediaPlayerPrivateWebM::seekInternal)
     , m_parser(adoptRef(*new SourceBufferParserWebM()))
     , m_appendQueue(WorkQueue::create("MediaPlayerPrivateWebM data parser queue"))
     , m_logger(player->mediaPlayerLogger())
     , m_logIdentifier(player->mediaPlayerLogIdentifier())
     , m_videoLayerManager(makeUnique<VideoLayerManagerObjC>(m_logger, m_logIdentifier))
 {
-    ALWAYS_LOG(LOGIDENTIFIER);
+    auto logSiteIdentifier = LOGIDENTIFIER;
+    ALWAYS_LOG(logSiteIdentifier);
     m_parser->setLogger(m_logger, m_logIdentifier);
+
+    // addPeriodicTimeObserverForInterval: throws an exception if you pass a non-numeric CMTime, so just use
+    // an arbitrarily large time value of once an hour:
+    __block WeakPtr weakThis { *this };
+    m_timeJumpedObserver = [m_synchronizer addPeriodicTimeObserverForInterval:PAL::toCMTime(MediaTime::createWithDouble(3600)) queue:dispatch_get_main_queue() usingBlock:^(CMTime time) {
+        
+        auto clampedTime = CMTIME_IS_NUMERIC(time) ? clampTimeToLastSeekTime(PAL::toMediaTime(time)) : MediaTime::zeroTime();
+        ALWAYS_LOG(logSiteIdentifier, "synchronizer fired: time clamped = ", clampedTime, ", seeking = ", m_seeking, ", pending = ", !!m_pendingSeek);
+
+        if (m_seeking && !m_pendingSeek) {
+            m_seeking = false;
+
+            if (shouldBePlaying())
+                [m_synchronizer setRate:m_rate];
+            if (!seeking() && m_seekCompleted == SeekCompleted)
+                m_player->timeChanged();
+        }
+
+        if (m_pendingSeek)
+            seekInternal();
+
+        if (m_currentTimeDidChangeCallback)
+            m_currentTimeDidChangeCallback(clampedTime);
+    }];
 }
 
 MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    if (m_timeJumpedObserver)
+        [m_synchronizer removeTimeObserver:m_timeJumpedObserver.get()];
+    if (m_timeChangedObserver)
+        [m_synchronizer removeTimeObserver:m_timeChangedObserver.get()];
     if (m_durationObserver)
         [m_synchronizer removeTimeObserver:m_durationObserver.get()];
     if (m_videoFrameMetadataGatheringObserver)
@@ -105,6 +135,8 @@ MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM()
     destroyDecompressionSession();
     destroyAudioRenderers();
     clearTracks();
+    
+    m_seekTimer.stop();
 
     cancelLoad();
     abort();
@@ -233,6 +265,10 @@ void MediaPlayerPrivateWebM::play()
 #if PLATFORM(IOS_FAMILY)
     flushIfNeeded();
 #endif
+    
+    m_playing = true;
+    if (!shouldBePlaying())
+        return;
 
     [m_synchronizer setRate:m_rate];
 
@@ -242,6 +278,7 @@ void MediaPlayerPrivateWebM::play()
 
 void MediaPlayerPrivateWebM::pause()
 {
+    m_playing = false;
     [m_synchronizer setRate:0];
 }
 
@@ -261,29 +298,133 @@ void MediaPlayerPrivateWebM::setPageIsVisible(bool visible)
 
 MediaTime MediaPlayerPrivateWebM::currentMediaTime() const
 {
-    MediaTime synchronizerTime = PAL::toMediaTime(PAL::CMTimebaseGetTime([m_synchronizer timebase]));
+    MediaTime synchronizerTime = clampTimeToLastSeekTime(PAL::toMediaTime(PAL::CMTimebaseGetTime([m_synchronizer timebase])));
     if (synchronizerTime < MediaTime::zeroTime())
         return MediaTime::zeroTime();
-    if (synchronizerTime > durationMediaTime())
-        return durationMediaTime();
-
+    if (synchronizerTime < m_lastSeekTime)
+        return m_lastSeekTime;
     return synchronizerTime;
 }
 
-void MediaPlayerPrivateWebM::seek(const MediaTime& time)
+bool MediaPlayerPrivateWebM::setCurrentTimeDidChangeCallback(MediaPlayer::CurrentTimeDidChangeCallback&& callback)
 {
-    ALWAYS_LOG(LOGIDENTIFIER, "time = ", time);
+    m_currentTimeDidChangeCallback = WTFMove(callback);
 
-    [m_synchronizer setRate:0 time:PAL::toCMTime(time)];
+    if (m_currentTimeDidChangeCallback) {
+        m_timeChangedObserver = [m_synchronizer addPeriodicTimeObserverForInterval:PAL::CMTimeMake(1, 10) queue:dispatch_get_main_queue() usingBlock:^(CMTime time) {
+            if (!m_currentTimeDidChangeCallback)
+                return;
+
+            auto clampedTime = CMTIME_IS_NUMERIC(time) ? clampTimeToLastSeekTime(PAL::toMediaTime(time)) : MediaTime::zeroTime();
+            m_currentTimeDidChangeCallback(clampedTime);
+        }];
+
+    } else
+        m_timeChangedObserver = nullptr;
+
+    return true;
+}
+
+void MediaPlayerPrivateWebM::seekWithTolerance(const MediaTime& time, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, "time = ", time, ", negativeThreshold = ", negativeThreshold, ", positiveThreshold = ", positiveThreshold);
+    
+    m_seeking = true;
+    m_pendingSeek = makeUnique<PendingSeek>(time, negativeThreshold, positiveThreshold);
+    
+    if (m_seekTimer.isActive())
+        m_seekTimer.stop();
+    m_seekTimer.startOneShot(0_s);
+}
+
+bool MediaPlayerPrivateWebM::seeking() const
+{
+    return m_seeking || m_seekCompleted != SeekCompleted;
+}
+
+void MediaPlayerPrivateWebM::seekInternal()
+{
+    std::unique_ptr<PendingSeek> pendingSeek;
+    pendingSeek.swap(m_pendingSeek);
+    
+    if (!pendingSeek)
+        return;
+    
+    if (!pendingSeek->negativeThreshold && !pendingSeek->positiveThreshold)
+        m_lastSeekTime = pendingSeek->targetTime;
+    else
+        m_lastSeekTime = fastSeekTimeForMediaTime(pendingSeek->targetTime, pendingSeek->positiveThreshold, pendingSeek->negativeThreshold);
+    
+    if (m_lastSeekTime.hasDoubleValue())
+        m_lastSeekTime = MediaTime::createWithDouble(m_lastSeekTime.toDouble(), MediaTime::DefaultTimeScale);
+    
+    auto synchronizerTime = PAL::toMediaTime(PAL::CMTimebaseGetTime([m_synchronizer timebase]));
+    ALWAYS_LOG(LOGIDENTIFIER, "seekTime = ", m_lastSeekTime, ", synchronizerTime = ", synchronizerTime);
+    
+    const auto doesNotRequireSeek = synchronizerTime == m_lastSeekTime;
+    
+    m_seekCompleted = Seeking;
+    flush();
+    [m_synchronizer setRate:0 time:PAL::toCMTime(m_lastSeekTime)];
     for (auto& trackBufferPair : m_trackBufferMap) {
         TrackBuffer& trackBuffer = trackBufferPair.value;
         auto trackId = trackBufferPair.key;
 
         trackBuffer.setNeedsReenqueueing(true);
-        reenqueueMediaForTime(trackBuffer, trackId, time);
+        reenqueueMediaForTime(trackBuffer, trackId, m_lastSeekTime);
     }
-    [m_synchronizer setRate:m_rate];
-    m_player->timeChanged();
+    seekCompleted();
+    // In cases where the destination seek time precisely matches the synchronizer's existing time
+    // no time jumped notification will be issued. In this case, just notify the MediaPlayer that
+    // the seek completed successfully.
+    if (doesNotRequireSeek) {
+        m_seeking = false;
+
+        if (shouldBePlaying())
+            [m_synchronizer setRate:m_rate];
+        if (!seeking() && m_seekCompleted)
+            m_player->timeChanged();
+    }
+}
+
+void MediaPlayerPrivateWebM::seekCompleted()
+{
+    if (m_seekCompleted == SeekCompleted)
+        return;
+    if (hasVideo() && !m_hasAvailableVideoFrame) {
+        ALWAYS_LOG(LOGIDENTIFIER, "waiting for video frame");
+        m_seekCompleted = WaitingForAvailableFame;
+        return;
+    }
+    ALWAYS_LOG(LOGIDENTIFIER);
+    m_seekCompleted = SeekCompleted;
+    if (shouldBePlaying())
+        [m_synchronizer setRate:m_rate];
+    if (!m_seeking)
+        m_player->timeChanged();
+}
+
+MediaTime MediaPlayerPrivateWebM::clampTimeToLastSeekTime(const MediaTime& time) const
+{
+    if (m_lastSeekTime.isFinite() && time < m_lastSeekTime)
+        return m_lastSeekTime;
+
+    return time;
+}
+
+MediaTime MediaPlayerPrivateWebM::fastSeekTimeForMediaTime(const MediaTime& targetTime, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold)
+{
+    auto seekTime = targetTime;
+
+    for (auto& trackBuffer : m_trackBufferMap.values()) {
+        // Find the sample which contains the target time.
+        auto trackSeekTime = trackBuffer->findSeekTimeForTargetTime(targetTime, negativeThreshold, positiveThreshold);
+        
+        if (trackSeekTime.isValid() && abs(targetTime - trackSeekTime) > abs(targetTime - seekTime))
+            seekTime = trackSeekTime;
+    }
+
+    return seekTime;
 }
 
 void MediaPlayerPrivateWebM::setRateDouble(double rate)
@@ -293,7 +434,7 @@ void MediaPlayerPrivateWebM::setRateDouble(double rate)
 
     m_rate = std::max<double>(rate, 0);
 
-    if (!paused())
+    if (shouldBePlaying())
         [m_synchronizer setRate:m_rate];
 
     m_player->rateChanged();
@@ -548,6 +689,9 @@ void MediaPlayerPrivateWebM::setHasAvailableVideoFrame(bool hasAvailableVideoFra
 
     m_player->firstVideoFrameAvailable();
     setReadyState(MediaPlayer::ReadyState::HaveEnoughData);
+    
+    if (m_seekCompleted == WaitingForAvailableFame)
+        seekCompleted();
 }
 
 void MediaPlayerPrivateWebM::setDuration(MediaTime duration)
@@ -580,6 +724,9 @@ void MediaPlayerPrivateWebM::setDuration(MediaTime duration)
 
     }];
 
+    if (m_playing && duration <= currentMediaTime())
+        pause();
+    
     m_duration = WTFMove(duration);
     m_player->durationChanged();
 }
@@ -601,6 +748,11 @@ void MediaPlayerPrivateWebM::setReadyState(MediaPlayer::ReadyState state)
 
     ALWAYS_LOG(LOGIDENTIFIER, state);
     m_readyState = state;
+    
+    if (shouldBePlaying())
+        [m_synchronizer setRate:m_rate];
+    else
+        [m_synchronizer setRate:0];
     
     m_player->readyStateChanged();
 }
@@ -1434,6 +1586,11 @@ void MediaPlayerPrivateWebM::clearTracks()
         m_player->removeAudioTrack(*track);
     }
     m_audioTracks.clear();
+}
+
+bool MediaPlayerPrivateWebM::shouldBePlaying() const
+{
+    return m_playing && !seeking() && m_readyState >= MediaPlayer::ReadyState::HaveFutureData;
 }
 
 void MediaPlayerPrivateWebM::registerNotifyWhenHasAvailableVideoFrame()


### PR DESCRIPTION
#### 3964ebe6a700c40191fe43e318c33a27d6b35996
<pre>
[Alternate WebM Player] Fix seek scrubbing lag
<a href="https://bugs.webkit.org/show_bug.cgi?id=244569">https://bugs.webkit.org/show_bug.cgi?id=244569</a>
&lt;rdar://99365425&gt;

Reviewed by NOBODY (OOPS!).

This patch fixes the huge amounts of lag observed when scrubbing through
a WebM video.

The issue was caused by multiple seek events being passed onto the underlying
media player without waiting for the original seek operation to complete.
We fix this by only allowing a single seek operation at a time with a
seeking attribute and notifying the HTMLMediaElement when we are done seeking.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
(WebCore::MediaPlayerPrivateWebM::PendingSeek::PendingSeek):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::play):
(WebCore::MediaPlayerPrivateWebM::pause):
(WebCore::MediaPlayerPrivateWebM::currentMediaTime const):
(WebCore::MediaPlayerPrivateWebM::setCurrentTimeDidChangeCallback):
(WebCore::MediaPlayerPrivateWebM::seekWithTolerance):
(WebCore::MediaPlayerPrivateWebM::seeking const):
(WebCore::MediaPlayerPrivateWebM::seekInternal):
(WebCore::MediaPlayerPrivateWebM::seekCompleted):
(WebCore::MediaPlayerPrivateWebM::clampTimeToLastSeekTime const):
(WebCore::MediaPlayerPrivateWebM::fastSeekTimeForMediaTime):
(WebCore::MediaPlayerPrivateWebM::setRateDouble):
(WebCore::MediaPlayerPrivateWebM::setHasAvailableVideoFrame):
(WebCore::MediaPlayerPrivateWebM::setDuration):
(WebCore::MediaPlayerPrivateWebM::setReadyState):
(WebCore::MediaPlayerPrivateWebM::shouldBePlaying const):
(WebCore::MediaPlayerPrivateWebM::seek): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/334c4bb7ba8980a76e21373dc07c31e2ecf3afdc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96881 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150680 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91654 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30128 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26244 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79782 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91630 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93303 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-15-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74435 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24331 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67183 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27823 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13317 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27789 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14328 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37223 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33605 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->