### PR TITLE
[MSE] Use arrow instead of .get() for track buffers

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -338,9 +338,9 @@ void MediaPlayerPrivateWebM::updateBufferedFromTrackBuffers(bool ended)
 {
     MediaTime highestEndTime = MediaTime::negativeInfiniteTime();
     for (auto& trackBuffer : m_trackBufferMap.values()) {
-        if (!trackBuffer.get().buffered().length())
+        if (!trackBuffer->buffered().length())
             continue;
-        highestEndTime = std::max(highestEndTime, trackBuffer.get().maximumBufferedTime());
+        highestEndTime = std::max(highestEndTime, trackBuffer->maximumBufferedTime());
     }
 
     // NOTE: Short circuit the following if none of the TrackBuffers have buffered ranges to avoid generating
@@ -353,10 +353,10 @@ void MediaPlayerPrivateWebM::updateBufferedFromTrackBuffers(bool ended)
     PlatformTimeRanges intersectionRanges { MediaTime::zeroTime(), highestEndTime };
 
     for (auto& trackBuffer : m_trackBufferMap.values()) {
-        if (!trackBuffer.get().buffered().length())
+        if (!trackBuffer->buffered().length())
             continue;
 
-        PlatformTimeRanges trackRanges = trackBuffer.get().buffered();
+        PlatformTimeRanges trackRanges = trackBuffer->buffered();
 
         if (ended)
             trackRanges.add(trackRanges.maximumBufferedTime(), highestEndTime);


### PR DESCRIPTION
#### 4c43ca86e5249b5db7b3e44533a0754d350ded79
<pre>
[MSE] Use arrow instead of .get() for track buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=244571">https://bugs.webkit.org/show_bug.cgi?id=244571</a>
&lt;rdar://99366929&gt;

Reviewed by Jean-Yves Avenard.

This patch cleans up SourceBufferPrivate and MediaPlayerPrivateWebM&apos;s
usage of trackBuffer.get() for the more readable arrow operator.

* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::resetTimestampOffsetInTrackBuffers):
(WebCore::SourceBufferPrivate::resetTrackBuffers):
(WebCore::SourceBufferPrivate::updateHighestPresentationTimestamp):
(WebCore::SourceBufferPrivate::updateBufferedFromTrackBuffers):
(WebCore::SourceBufferPrivate::clearTrackBuffers):
(WebCore::SourceBufferPrivate::fastSeekTimeForMediaTime):
(WebCore::SourceBufferPrivate::evictCodedFrames):
(WebCore::SourceBufferPrivate::totalTrackBufferSizeInBytes const):
(WebCore::SourceBufferPrivate::setAllTrackBuffersNeedRandomAccess):
(WebCore::SourceBufferPrivate::didReceiveSample):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::updateBufferedFromTrackBuffers):

Canonical link: <a href="https://commits.webkit.org/253989@main">https://commits.webkit.org/253989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7662efc71727a3f7bfe2a799b1b66f9d21b66aaa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96883 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150682 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30130 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79785 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91631 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24341 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74437 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24337 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67189 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27825 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27791 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14329 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2807 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29486 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37224 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33606 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->