### PR TITLE
[JSC] Fix ShadowRealm test262 failures

### DIFF
--- a/JSTests/stress/shadow-realm-remote-function-copy-length-and-name.js
+++ b/JSTests/stress/shadow-realm-remote-function-copy-length-and-name.js
@@ -207,7 +207,7 @@ f = realm.evaluate(`(() => {
   let p = new Proxy(target, {
     getOwnPropertyDescriptor(t, p) {
       log(\`getOwnPropertyDescriptor \${p}\`);
-      return Reflect.getOwnProperty(...arguments);
+      return Reflect.getOwnPropertyDescriptor(...arguments);
     },
     get(t, p) {
       log(\`get \${p}\`);
@@ -299,6 +299,7 @@ shouldHaveDescriptor(f, "name", {
   configurable: true,
 });
 shouldBe(log(), [
+  "getOwnPropertyDescriptor length",
   "get length",
   "length getter",
   "get name",
@@ -316,7 +317,7 @@ f = realm.evaluate(`(() => {
   let p = new Proxy(target, {
     getOwnPropertyDescriptor(t, p) {
       log(\`getOwnPropertyDescriptor \${p}\`);
-      return Reflect.getOwnProperty(...arguments);
+      return Reflect.getOwnPropertyDescriptor(...arguments);
     },
     get(t, p) {
       log(\`get \${p}\`);
@@ -394,6 +395,7 @@ shouldHaveDescriptor(f, "name", {
   configurable: true,
 });
 shouldBe(log(), [
+  "getOwnPropertyDescriptor length",
   "get length",
   "get name",
   "apply",

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -822,12 +822,6 @@ test/built-ins/RegExp/prototype/exec/u-lastindex-adv.js:
 test/built-ins/RegExp/quantifier-integer-limit.js:
   default: 'SyntaxError: Invalid regular expression: number too large in {} quantifier'
   strict mode: 'SyntaxError: Invalid regular expression: number too large in {} quantifier'
-test/built-ins/ShadowRealm/prototype/evaluate/throws-typeerror-wrap-throwing.js:
-  default: 'Test262Error: TypeError on wrapping a callable proxy with throwing getOwnPropertyDescriptor trap Expected a TypeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: TypeError on wrapping a callable proxy with throwing getOwnPropertyDescriptor trap Expected a TypeError to be thrown but no exception was thrown at all'
-test/built-ins/ShadowRealm/prototype/importValue/throws-if-exportname-not-string.js:
-  default: 'Test262Error: Expected a TypeError but got a Test262Error'
-  strict mode: 'Test262Error: Expected a TypeError but got a Test262Error'
 test/built-ins/Temporal/Instant/prototype/since/largestunit.js:
   default: 'Test262Error: does not include higher units than necessary (largest unit unspecified) nanoseconds result Expected SameValue(«40», «101») to be true'
   strict mode: 'Test262Error: does not include higher units than necessary (largest unit unspecified) nanoseconds result Expected SameValue(«40», «101») to be true'


### PR DESCRIPTION
#### 9f1858ab127db7e2cf0f386203842deb795353a3
<pre>
[JSC] Fix ShadowRealm test262 failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=244572">https://bugs.webkit.org/show_bug.cgi?id=244572</a>

Reviewed by Ross Kirsling.

1. We should check exportName&apos;s type of importValue.
2. copyNameAndLength should perform GetOwnProperty, and if the slot is isTaintedByOpaqueObject (e.g. Proxy), we should do [[Get]] after that.

* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/ShadowRealmPrototype.js:
(linkTimeConstant.wrapRemoteValue):
(evaluate):
(linkTimeConstant.crossRealmThrow):
(importValue):
(linkTimeConstant.wrap): Deleted.
* Source/JavaScriptCore/runtime/JSRemoteFunction.cpp:
(JSC::JSRemoteFunction::copyNameAndLength):

Canonical link: <a href="https://commits.webkit.org/253977@main">https://commits.webkit.org/253977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6654fa0e3dbb645dac75012b784c31e2529723aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31779 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/18434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96890 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150698 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30137 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91637 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93313 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74444 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24340 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79307 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/18434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67190 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79497 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27832 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/18434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73215 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27798 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/18434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26046 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2799 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29493 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76045 "failed Failed to checkout and rebase branch from PR 3840") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29393 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/18434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/37/builds/76045 "failed Failed to checkout and rebase branch from PR 3840") | 
<!--EWS-Status-Bubble-End-->