### PR TITLE
Ignore numalign/denomalign attributes on mfrac with CoreMathMLEnabled=true

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1657,7 +1657,6 @@ webkit.org/b/187039 imported/w3c/web-platform-tests/mathml/relations/html5-tree/
 imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-bar-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-default-padding.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-linethickness-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-numalign-denomalign-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-parameters-gap-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-parameters-gap-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-parameters-gap-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-numalign-denomalign-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-numalign-denomalign-001-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ CoreMathMLEnabled=true ] -->
 <html>
   <head>
     <meta charset="utf-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-numalign-denomalign-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-numalign-denomalign-001.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ CoreMathMLEnabled=true ] -->
 <html>
   <head>
     <meta charset="utf-8">

--- a/Source/WebCore/mathml/MathMLFractionElement.cpp
+++ b/Source/WebCore/mathml/MathMLFractionElement.cpp
@@ -84,6 +84,11 @@ MathMLFractionElement::FractionAlignment MathMLFractionElement::cachedFractionAl
     if (alignment)
         return alignment.value();
 
+    if (document().settings().coreMathMLEnabled()) {
+        alignment = FractionAlignmentCenter;
+        return alignment.value();
+    }
+
     auto& value = attributeWithoutSynchronization(name);
     if (equalLettersIgnoringASCIICase(value, "left"_s))
         alignment = FractionAlignmentLeft;


### PR DESCRIPTION
#### 4515a6cc6d0bbf535267d0a5e44f1ebda171dc1d
<pre>
Ignore numalign/denomalign attributes on mfrac with CoreMathMLEnabled=true
<a href="https://bugs.webkit.org/show_bug.cgi?id=197495">https://bugs.webkit.org/show_bug.cgi?id=197495</a>

These attributes are not part of MathML Core [1]. This makes the
corresponding WPT test pass [2] while the legacy support is covered by
a non-core test [3].

[1] <a href="https://w3c.github.io/mathml-core/#fractions-mfrac">https://w3c.github.io/mathml-core/#fractions-mfrac</a>
[2] imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-numalign-denomalign-001.html
[3] mathml/non-core/frac-numalign-denomalign-001.html

Reviewed by Martin Robinson.

* LayoutTests/TestExpectations: Remove expectation failure.
* Source/WebCore/mathml/MathMLFractionElement.cpp:
(WebCore::MathMLFractionElement::cachedFractionAlignment):
  Parse numalign/denomalign as &quot;center&quot; when MathML Core is enabled.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-numalign-denomalign-001-expected.html: Force MathML Core to be enabled.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-numalign-denomalign-001.html: Ditto.

Canonical link: <a href="https://commits.webkit.org/254098@main">https://commits.webkit.org/254098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05420fff92a9ba8bab79844f79ba2c6d0490cd8b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97151 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152636 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30534 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26481 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80100 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91895 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24593 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74664 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24573 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79532 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28172 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28270 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14518 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2874 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31294 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33773 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->