### PR TITLE
Connection::Identifier should be a struct for all ports

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -139,7 +139,7 @@ void GPUProcess::createGPUConnectionToWebProcess(WebCore::ProcessIdentifier iden
     auto connectionIdentifier = asConnectionIdentifier(WTFMove(connectionHandle));
     // If sender exited before we received the identifier, the identifier
     // may not be valid.
-    if (!IPC::Connection::identifierIsValid(connectionIdentifier))
+    if (!connectionIdentifier)
         return;
 
     auto newConnection = GPUConnectionToWebProcess::create(*this, identifier, sessionID, WTFMove(connectionIdentifier), WTFMove(parameters));

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -638,6 +638,6 @@ void Connection::didReceiveSyncReply(OptionSet<SendSyncOption>)
 std::optional<Connection::ConnectionIdentifierPair> Connection::createConnectionIdentifierPair()
 {
     Connection::SocketPair socketPair = Connection::createPlatformConnection();
-    return ConnectionIdentifierPair { socketPair.server, Attachment { UnixFileDescriptor { socketPair.client, UnixFileDescriptor::Adopt } } };
+    return ConnectionIdentifierPair { Identifier { socketPair.server }, Attachment { UnixFileDescriptor { socketPair.client, UnixFileDescriptor::Adopt } } };
 }
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
@@ -73,7 +73,7 @@ bool Connection::createServerAndClientIdentifiers(HANDLE& serverIdentifier, HAND
 
 void Connection::platformInitialize(Identifier identifier)
 {
-    m_connectionPipe = identifier;
+    m_connectionPipe = identifier.handle;
 }
 
 void Connection::platformInvalidate()
@@ -366,12 +366,13 @@ void Connection::EventListener::close()
 
 std::optional<Connection::ConnectionIdentifierPair> Connection::createConnectionIdentifierPair()
 {
-    Connection::Identifier serverIdentifier, clientIdentifier;
+    HANDLE serverIdentifier;
+    HANDLE clientIdentifier;
     if (!Connection::createServerAndClientIdentifiers(serverIdentifier, clientIdentifier)) {
         LOG_ERROR("Failed to create server and client identifiers");
         return std::nullopt;
     }
-    return ConnectionIdentifierPair { serverIdentifier, Attachment { clientIdentifier } };
+    return ConnectionIdentifierPair { Identifier { serverIdentifier }, Attachment { clientIdentifier } };
 }
 
 } // namespace IPC

--- a/Source/WebKit/Shared/IPCConnectionTester.cpp
+++ b/Source/WebKit/Shared/IPCConnectionTester.cpp
@@ -36,11 +36,11 @@ namespace WebKit {
 static IPC::Connection::Identifier asIdentifier(IPC::Attachment&& connectionIdentifier)
 {
 #if USE(UNIX_DOMAIN_SOCKETS)
-    return { connectionIdentifier.release().release() };
+    return IPC::Connection::Identifier { connectionIdentifier.release().release() };
 #elif OS(DARWIN)
-    return { connectionIdentifier.leakSendRight() };
+    return IPC::Connection::Identifier { connectionIdentifier.leakSendRight() };
 #elif OS(WINDOWS)
-    return { connectionIdentifier.handle() };
+    return IPC::Connection::Identifier { connectionIdentifier.handle() };
 #else
     notImplemented();
     return { };

--- a/Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp
+++ b/Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp
@@ -52,7 +52,7 @@ bool AuxiliaryProcessMainCommon::parseCommandLine(int argc, char** argv)
         return false;
 
     m_parameters.processIdentifier = makeObjectIdentifier<WebCore::ProcessIdentifierType>(atoll(argv[1]));
-    m_parameters.connectionIdentifier = atoi(argv[2]);
+    m_parameters.connectionIdentifier = IPC::Connection::Identifier { atoi(argv[2]) };
 #if ENABLE(DEVELOPER_MODE)
     if (argc > 3 && !strcmp(argv[3], "--configure-jsc-for-testing"))
         JSC::Config::configureForTesting();

--- a/Source/WebKit/Shared/win/AuxiliaryProcessMainWin.cpp
+++ b/Source/WebKit/Shared/win/AuxiliaryProcessMainWin.cpp
@@ -38,7 +38,7 @@ bool AuxiliaryProcessMainCommon::parseCommandLine(int argc, char** argv)
 {
     for (int i = 0; i < argc; i++) {
         if (!strcmp(argv[i], "-clientIdentifier") && i + 1 < argc)
-            m_parameters.connectionIdentifier = reinterpret_cast<HANDLE>(parseIntegerAllowingTrailingJunk<uint64_t>(StringView::fromLatin1(argv[++i])).value_or(0));
+            m_parameters.connectionIdentifier = IPC::Connection::Identifier { reinterpret_cast<HANDLE>(parseIntegerAllowingTrailingJunk<uint64_t>(StringView::fromLatin1(argv[++i])).value_or(0)) };
         else if (!strcmp(argv[i], "-processIdentifier") && i + 1 < argc)
             m_parameters.processIdentifier = makeObjectIdentifier<WebCore::ProcessIdentifierType>(parseIntegerAllowingTrailingJunk<uint64_t>(StringView::fromLatin1(argv[++i])).value_or(0));
         else if (!strcmp(argv[i], "-configure-jsc-for-testing"))

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -285,7 +285,7 @@ void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher*, IPC::Connection
     if (launchTime > 1_s)
         RELEASE_LOG_FAULT(Process, "%s process (%p) took %f seconds to launch", processName().characters(), this, launchTime.value());
     
-    if (!IPC::Connection::identifierIsValid(connectionIdentifier))
+    if (!connectionIdentifier)
         return;
 
     m_connection = IPC::Connection::createServerConnection(connectionIdentifier, *this);

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -477,7 +477,7 @@ void GPUProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connect
 {
     AuxiliaryProcessProxy::didFinishLaunching(launcher, connectionIdentifier);
 
-    if (!IPC::Connection::identifierIsValid(connectionIdentifier)) {
+    if (!connectionIdentifier) {
         gpuProcessExited(ProcessTerminationReason::Crash);
         return;
     }

--- a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
@@ -176,7 +176,7 @@ void ProcessLauncher::launchProcess()
 
     // We've finished launching the process, message back to the main run loop.
     RunLoop::main().dispatch([protectedThis = Ref { *this }, this, serverSocket = socketPair.server] {
-        didFinishLaunchingProcess(m_processIdentifier, serverSocket);
+        didFinishLaunchingProcess(m_processIdentifier, IPC::Connection::Identifier { serverSocket });
     });
 }
 

--- a/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
+++ b/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
@@ -118,7 +118,7 @@ void ProcessLauncher::launchProcess()
     WTF::ProcessID pid = processInformation.dwProcessId;
 
     RunLoop::main().dispatch([protectedThis, pid, serverIdentifier] {
-        protectedThis->didFinishLaunchingProcess(pid, serverIdentifier);
+        protectedThis->didFinishLaunchingProcess(pid, IPC::Connection::Identifier { serverIdentifier });
     });
 }
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -558,7 +558,7 @@ void NetworkProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Con
 
     AuxiliaryProcessProxy::didFinishLaunching(launcher, connectionIdentifier);
 
-    if (!IPC::Connection::identifierIsValid(connectionIdentifier)) {
+    if (!connectionIdentifier) {
         networkProcessDidTerminate(ProcessTerminationReason::Crash);
         return;
     }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1026,7 +1026,7 @@ void WebProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connect
     Ref protectedThis { *this };
     AuxiliaryProcessProxy::didFinishLaunching(launcher, connectionIdentifier);
 
-    if (!IPC::Connection::identifierIsValid(connectionIdentifier)) {
+    if (!connectionIdentifier) {
         WEBPROCESSPROXY_RELEASE_LOG_ERROR(Process, "didFinishLaunching: Invalid connection identifier (web process failed to launch)");
         processDidTerminateOrFailedToLaunch(ProcessTerminationReason::Crash);
         return;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1530,7 +1530,7 @@ void WebsiteDataStore::getNetworkProcessConnection(WebProcessProxy& webProcessPr
 {
     auto& networkProcessProxy = networkProcess();
     networkProcessProxy.getNetworkProcessConnection(webProcessProxy, [weakThis = WeakPtr { *this }, networkProcessProxy = WeakPtr { networkProcessProxy }, webProcessProxy = WeakPtr { webProcessProxy }, reply = WTFMove(reply), shouldRetryOnFailure] (auto& connectionInfo) mutable {
-        if (UNLIKELY(!IPC::Connection::identifierIsValid(connectionInfo.identifier()))) {
+        if (UNLIKELY(!connectionInfo.identifier())) {
             if (shouldRetryOnFailure == ShouldRetryOnFailure::No || !webProcessProxy) {
                 RELEASE_LOG_ERROR(Process, "getNetworkProcessConnection: Failed to get connection to network process, will reply invalid identifier ...");
                 reply({ });

--- a/Source/WebKit/WebProcess/Inspector/WebInspector.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspector.cpp
@@ -95,7 +95,7 @@ void WebInspector::setFrontendConnection(IPC::Attachment encodedConnectionIdenti
     return;
 #endif
 
-    if (!IPC::Connection::identifierIsValid(connectionIdentifier))
+    if (!connectionIdentifier)
         return;
 
     m_frontendConnection = IPC::Connection::createClientConnection(connectionIdentifier, *this);

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1141,7 +1141,7 @@ NO_RETURN inline void failedToSendSyncMessage()
 static NetworkProcessConnectionInfo getNetworkProcessConnection(IPC::Connection& connection)
 {
     NetworkProcessConnectionInfo connectionInfo;
-    auto requestConnection = [&] {
+    auto requestConnection = [&]() -> bool {
         if (!connection.isValid()) {
             // Connection to UIProcess has been severed, exit cleanly.
             exit(0);
@@ -1150,7 +1150,7 @@ static NetworkProcessConnectionInfo getNetworkProcessConnection(IPC::Connection&
             RELEASE_LOG_ERROR(Process, "getNetworkProcessConnection: Failed to send or receive message");
             return false;
         }
-        return IPC::Connection::identifierIsValid(connectionInfo.identifier());
+        return connectionInfo.identifier();
     };
 
     static constexpr unsigned maxFailedAttempts = 30;

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -117,7 +117,7 @@ TEST_F(ConnectionTest, CreateClientConnection)
 {
     auto identifiers = IPC::Connection::createConnectionIdentifierPair();
     ASSERT_NE(identifiers, std::nullopt);
-    Ref<IPC::Connection> connection = IPC::Connection::createClientConnection(identifiers->client.leakSendRight(), m_mockClientClient);
+    Ref<IPC::Connection> connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { identifiers->client.leakSendRight() }, m_mockClientClient);
     connection->invalidate();
 }
 
@@ -126,7 +126,7 @@ TEST_F(ConnectionTest, ConnectLocalConnection)
     auto identifiers = IPC::Connection::createConnectionIdentifierPair();
     ASSERT_NE(identifiers, std::nullopt);
     Ref<IPC::Connection> serverConnection = IPC::Connection::createServerConnection(WTFMove(identifiers->server), m_mockServerClient);
-    Ref<IPC::Connection> clientConnection = IPC::Connection::createClientConnection(identifiers->client.leakSendRight(), m_mockClientClient);
+    Ref<IPC::Connection> clientConnection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { identifiers->client.leakSendRight() }, m_mockClientClient);
     serverConnection->open();
     clientConnection->open();
     serverConnection->invalidate();
@@ -138,7 +138,7 @@ TEST_F(ConnectionTest, SendLocalMessage)
     auto identifiers = IPC::Connection::createConnectionIdentifierPair();
     ASSERT_NE(identifiers, std::nullopt);
     Ref<IPC::Connection> serverConnection = IPC::Connection::createServerConnection(WTFMove(identifiers->server), m_mockServerClient);
-    Ref<IPC::Connection> clientConnection = IPC::Connection::createClientConnection(identifiers->client.leakSendRight(), m_mockClientClient);
+    Ref<IPC::Connection> clientConnection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { identifiers->client.leakSendRight() }, m_mockClientClient);
     serverConnection->open();
     clientConnection->open();
 


### PR DESCRIPTION
#### 769a9e574726e7431d247b9481bf56c3221e37b9
<pre>
Connection::Identifier should be a struct for all ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=244579">https://bugs.webkit.org/show_bug.cgi?id=244579</a>
rdar://problem/99376431

Reviewed by Fujii Hironori.

Make Connection::Identifier a struct for all ports so
generic code can move towards passing Identifier with
rvalue reference. This helps avoiding leaking the
resources inside Identifier.

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::createGPUConnectionToWebProcess):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::Identifier::Identifier):
(IPC::Connection::Identifier::operator bool const):
(IPC::Connection::identifierIsValid): Deleted.
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::getNetworkProcessConnection):
* Source/WebKit/WebProcess/Inspector/WebInspector.cpp:
(WebKit::WebInspector::setFrontendConnection):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::getNetworkProcessConnection):

Canonical link: <a href="https://commits.webkit.org/254157@main">https://commits.webkit.org/254157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f939cd88ec92760da51d38d396f5e6c4a46ac0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97043 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/151969 "Failed to checkout and rebase branch from PR 3847") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30340 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26372 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79999 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91787 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24484 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74579 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24493 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79578 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67486 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28091 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13397 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28190 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14414 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2916 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37320 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33689 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->