### PR TITLE
Cocoa SharedMemory::Handle should use MachSendRight

### DIFF
--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/MachSendRight.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
@@ -99,11 +100,11 @@ public:
 #if USE(UNIX_DOMAIN_SOCKETS)
         mutable IPC::Attachment m_attachment;
 #elif OS(DARWIN)
-        mutable mach_port_t m_port { MACH_PORT_NULL };
+        mutable MachSendRight m_handle;
 #elif OS(WINDOWS)
         mutable HANDLE m_handle;
 #endif
-        size_t m_size;
+        size_t m_size { 0 };
     };
 
     // FIXME: Change these factory functions to return Ref<SharedMemory> and crash on failure.
@@ -155,7 +156,7 @@ private:
     std::optional<int> m_fileDescriptor;
     bool m_isWrappingMap { false };
 #elif OS(DARWIN)
-    mach_port_t m_port { MACH_PORT_NULL };
+    MachSendRight m_sendRight;
 #elif OS(WINDOWS)
     HANDLE m_handle;
 #endif


### PR DESCRIPTION
#### a5a7844e79bd390f4994553e4c5e82cd40e37b77
<pre>
Cocoa SharedMemory::Handle should use MachSendRight
<a href="https://bugs.webkit.org/show_bug.cgi?id=244600">https://bugs.webkit.org/show_bug.cgi?id=244600</a>
rdar://problem/99379026

Reviewed by Antti Koivisto.

* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp:
(WebKit::SharedMemory::Handle::takeOwnershipOfMemory const):
(WebKit::SharedMemory::Handle::setOwnershipOfMemory const):
(WebKit::SharedMemory::Handle::isNull const):
(WebKit::SharedMemory::Handle::clear):
(WebKit::SharedMemory::Handle::encode const):
(WebKit::SharedMemory::Handle::decode):
(WebKit::SharedMemory::allocate):
(WebKit::SharedMemory::wrapMap):
(WebKit::SharedMemory::map):
(WebKit::SharedMemory::~SharedMemory):
(WebKit::SharedMemory::createHandle):
(WebKit::SharedMemory::createSendRight const):
(WebKit::SharedMemory::Handle::Handle): Deleted.
(WebKit::SharedMemory::Handle::operator=): Deleted.
(WebKit::SharedMemory::Handle::~Handle): Deleted.

Canonical link: <a href="https://commits.webkit.org/254037@main">https://commits.webkit.org/254037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08ee468c1b1263e2c1c71d31d1502c04efaaca03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96915 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30164 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26265 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79818 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91661 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24365 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74467 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24364 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79510 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67213 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27858 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13331 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27824 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14346 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2838 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29519 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37253 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33622 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->