### PR TITLE
[WPE] Gardening of imported/w3c/web-platform-tests/

### DIFF
--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-import.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-import.https-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.: securitypolicyviolation
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and keep-origin redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and keep-origin redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and no-redirect redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and no-redirect redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and swap-origin redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and swap-origin redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-https origin and swap-origin redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-https origin and swap-origin redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.https-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context.: securitypolicyviolation
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.https-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.: securitypolicyviolation
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and keep-origin redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and keep-origin redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and no-redirect redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and no-redirect redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and swap-origin redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and swap-origin redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-https origin and swap-origin redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-https origin and swap-origin redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.https-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context.: securitypolicyviolation
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/sharedworker-import.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/sharedworker-import.https-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.: securitypolicyviolation
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and keep-origin redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and keep-origin redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and no-redirect redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and no-redirect redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and swap-origin redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and swap-origin redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-https origin and swap-origin redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-https origin and swap-origin redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.https-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context.: securitypolicyviolation
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/sharedworker-import.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/sharedworker-import.https-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.: securitypolicyviolation
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and keep-origin redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and keep-origin redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and no-redirect redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and no-redirect redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and swap-origin redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-https origin and swap-origin redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-https origin and swap-origin redirection from https context. assert_unreached: main promise resolved unexpectedly Reached unreachable code
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-https origin and swap-origin redirection from https context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.https-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context.: securitypolicyviolation
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.window-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.window-expected.txt
@@ -1,7 +1,7 @@
 
 Harness Error (TIMEOUT), message = null
 
-PASS Parent embeds same-origin anonymous iframe
+TIMEOUT Parent embeds same-origin anonymous iframe Test timed out
 PASS Parent embeds cross-origin anonymous iframe
 TIMEOUT COEP:require-corp parent embeds same-origin anonymous iframe Test timed out
 TIMEOUT COEP:require-corp parent embeds cross-origin anonymous iframe Test timed out

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/same-hash-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/same-hash-expected.txt
@@ -1,0 +1,15 @@
+
+
+FAIL Using location.hash = "#te<st" must not reset scroll position assert_greater_than: First hash assignment scrolls the iframe expected a number greater than 150 but got 0
+PASS Using location.hash = "te<st" must not reset scroll position
+PASS Using location.hash = "#te%3Cst" must not reset scroll position
+PASS Using location.hash = "te%3Cst" must not reset scroll position
+PASS Using location.hash = "#te%3cst" must reset scroll position
+PASS Using location.hash = "te%3cst" must reset scroll position
+PASS Using location.href = "about:srcdoc#te<st" must reset scroll position
+PASS Using location.assign("about:srcdoc#te<st") must reset scroll position
+PASS Using location.href = "about:srcdoc#te%3cst" must reset scroll position
+PASS Using location.assign("about:srcdoc#te%3cst") must reset scroll position
+PASS Using location.href = "about:srcdoc#te%3Cst" must reset scroll position
+PASS Using location.assign("about:srcdoc#te%3Cst") must reset scroll position
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.getcontext-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.getcontext-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Test that getContext with un-supported string throws a TypeError.
+PASS Test that getContext with supported string returns correct results
+PASS Test that getContext twice with different context type returns null the second time
+PASS Test that 2dcontext.canvas should return the original OffscreenCanvas
+PASS Test that webglcontext.canvas should return the original OffscreenCanvas
+FAIL Test that OffscreenCanvasRenderingContext2D with alpha disabled makes the OffscreenCanvas opaque assert_approx_equals: Green channel of the pixel at (5, 5) expected 127 +/- 2 but got 255
+PASS Test that OffscreenCanvasRenderingContext2D with alpha enabled preserves the alpha
+PASS Test that 'alpha' context creation attribute is true by default
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.getcontext.worker-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.getcontext.worker-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Test that getContext with un-supported string throws a TypeError.
+FAIL Test that getContext with supported string returns correct results assert_true: expected true got false
+FAIL Test that getContext twice with different context type returns null the second time assert_equals: expected null but got object "[object OffscreenCanvasRenderingContext2D]"
+PASS Test that 2dcontext.canvas should return the original OffscreenCanvas
+FAIL Test that webglcontext.canvas should return the original OffscreenCanvas null is not an object (evaluating 'ctx.canvas')
+FAIL Test that OffscreenCanvasRenderingContext2D with alpha disabled makes the OffscreenCanvas opaque assert_approx_equals: Green channel of the pixel at (5, 5) expected 127 +/- 2 but got 255
+PASS Test that OffscreenCanvasRenderingContext2D with alpha enabled preserves the alpha
+PASS Test that 'alpha' context creation attribute is true by default
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.w-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.w-expected.txt
@@ -1,0 +1,13 @@
+CONSOLE MESSAGE: InvalidStateError: The object is in an invalid state.
+
+Harness Error (FAIL), message = InvalidStateError: The object is in an invalid state.
+
+FAIL Test that transferToImageBitmap returns an ImageBitmap with correct width and height in a worker assert_unreached: error Reached unreachable code
+PASS Test that transferToImageBitmap returns an ImageBitmap with correct color in a worker
+PASS Test that call transferToImageBitmap twice returns an ImageBitmap with correct color in a worker
+FAIL Test that call transferToImageBitmap twice on a alpha-disabled context returns an ImageBitmap with correct color in a worker assert_array_equals: expected property 3 to be 255 but got 0 (expected array [0, 0, 0, 255] got object "0,0,0,0")
+PASS Test that transferToImageBitmap won't change context's property in a worker
+PASS Test that call transferToImageBitmap preserves transform in a worker
+PASS Test that call transferToImageBitmap on a detached OffscreenCanvas throws an exception in a worker
+PASS Test that call transferToImageBitmap without a context throws an exception in a worker
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.w-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.w-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Test that OffscreenCanvas's size is correct after being transferred from a worker.
+PASS Test that transfer an OffscreenCanvas that has a 2d context throws exception in a worker.
+FAIL Test that transfer an OffscreenCanvas that has a webgl context throws exception in a worker. assert_true: expected true got object "[object OffscreenCanvas]"
+PASS Test that transfer an OffscreenCanvas twice throws exception in a worker.
+PASS Test that calling getContext('2d') on a detached OffscreenCanvas throws exception in a worker.
+PASS Test that calling getContext('webgl') on a detached OffscreenCanvas throws exception in a worker.
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/ar-module/xrDevice_requestSession_immersive-ar.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/ar-module/xrDevice_requestSession_immersive-ar.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Tests requestSession accepts immersive-ar mode - webgl
+PASS Tests requestSession accepts immersive-ar mode - webgl2
+PASS Tests requestSession rejects immersive-ar mode when unsupported
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_input_source_recreation.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_input_source_recreation.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Input sources are re-created when handedness or target ray mode changes - webgl
-FAIL Input sources are re-created when handedness or target ray mode changes - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Input sources are re-created when handedness or target ray mode changes - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_input_sources_change.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_input_sources_change.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Transient input sources fire events in the right order - webgl
-FAIL Transient input sources fire events in the right order - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Transient input sources fire events in the right order - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_session_select.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_session_select.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRInputSources primary input presses properly fires off the right events - webgl
-FAIL XRInputSources primary input presses properly fires off the right events - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRInputSources primary input presses properly fires off the right events - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_session_select_subframe.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_session_select_subframe.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Ensures that an XRInputSources primary input being pressed and released in the space of a single frame properly fires off the right events - webgl
-FAIL Ensures that an XRInputSources primary input being pressed and released in the space of a single frame properly fires off the right events - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Ensures that an XRInputSources primary input being pressed and released in the space of a single frame properly fires off the right events - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_session_squeeze.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_session_squeeze.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRInputSources primary input presses properly fires off the right events - webgl
-FAIL XRInputSources primary input presses properly fires off the right events - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRInputSources primary input presses properly fires off the right events - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/getInputPose_handedness.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/getInputPose_handedness.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRInputSources properly communicate their handedness - webgl
-FAIL XRInputSources properly communicate their handedness - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRInputSources properly communicate their handedness - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/getViewerPose_emulatedPosition.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/getViewerPose_emulatedPosition.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRFrame getViewerPose has emulatedPosition set properly. - webgl
-FAIL XRFrame getViewerPose has emulatedPosition set properly. - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRFrame getViewerPose has emulatedPosition set properly. - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/navigator_xr_sameObject.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/navigator_xr_sameObject.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Navigator.xr meets [SameObject] requirement - webgl
-FAIL Navigator.xr meets [SameObject] requirement - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Navigator.xr meets [SameObject] requirement - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/render_state_update.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/render_state_update.https-expected.txt
@@ -1,12 +1,12 @@
 
 PASS updateRenderState handles appropriately ended sessions - webgl
-FAIL updateRenderState handles appropriately ended sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS updateRenderState handles appropriately ended sessions - webgl2
 PASS updateRenderState handles appropriately baseLayers created with different sessions - webgl
-FAIL updateRenderState handles appropriately baseLayers created with different sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS updateRenderState handles appropriately baseLayers created with different sessions - webgl2
 PASS updateRenderState handles appropriately immersive sessions with specified inlineVerticalFieldOfView - webgl
-FAIL updateRenderState handles appropriately immersive sessions with specified inlineVerticalFieldOfView - webgl2 assert_implements: webgl2 not supported. undefined
+PASS updateRenderState handles appropriately immersive sessions with specified inlineVerticalFieldOfView - webgl2
 PASS updateRenderState handles appropriately XRRenderStateInit with no params - webgl
-FAIL updateRenderState handles appropriately XRRenderStateInit with no params - webgl2 assert_implements: webgl2 not supported. undefined
+PASS updateRenderState handles appropriately XRRenderStateInit with no params - webgl2
 PASS updateRenderState handles appropriately XRRenderStateInit params - webgl
-FAIL updateRenderState handles appropriately XRRenderStateInit params - webgl2 assert_implements: webgl2 not supported. undefined
+PASS updateRenderState handles appropriately XRRenderStateInit params - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/render_state_vertical_fov_immersive.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/render_state_vertical_fov_immersive.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS inlineVerticalFieldOfView is set appropriately on immersively sessions - webgl
-FAIL inlineVerticalFieldOfView is set appropriately on immersively sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS inlineVerticalFieldOfView is set appropriately on immersively sessions - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/render_state_vertical_fov_inline.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/render_state_vertical_fov_inline.https-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL inlineVerticalFieldOfView is set appropriately on inline sessions - webgl promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
-FAIL inlineVerticalFieldOfView is set appropriately on inline sessions - webgl2 assert_implements: webgl2 not supported. undefined
+FAIL inlineVerticalFieldOfView is set appropriately on inline sessions - webgl2 promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Creating a webgl context with no device
-FAIL Creating a webgl2 context with no device assert_implements: webgl2 not supported. undefined
+PASS Creating a webgl2 context with no device
 FAIL An XR-compatible webgl context can be created promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
-FAIL An XR-compatible webgl2 context can be created assert_implements: webgl2 not supported. undefined
+FAIL An XR-compatible webgl2 context can be created promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/webGLCanvasContext_makecompatible_contextlost.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/webGLCanvasContext_makecompatible_contextlost.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS A lost webgl context should not be able to set xr compatibility
-FAIL A lost webgl2 context should not be able to set xr compatibility assert_implements: webgl2 not supported. undefined
+PASS A lost webgl2 context should not be able to set xr compatibility
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/webGLCanvasContext_makecompatible_reentrant.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/webGLCanvasContext_makecompatible_reentrant.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Verify promise from a non-reentrant call to makeXRCompatible() is resolved for webgl
-FAIL Verify promise from a non-reentrant call to makeXRCompatible() is resolved for webgl2 assert_implements: webgl2 not supported. undefined
+PASS Verify promise from a non-reentrant call to makeXRCompatible() is resolved for webgl2
 PASS Verify promises from reentrant calls to makeXRCompatible() are resolved for webgl
-FAIL Verify promises from reentrant calls to makeXRCompatible() are resolved for webgl2 assert_implements: webgl2 not supported. undefined
+PASS Verify promises from reentrant calls to makeXRCompatible() are resolved for webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrBoundedReferenceSpace_updates.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrBoundedReferenceSpace_updates.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS 'XRBoundedReferenceSpace updates properly when the changes are applied - webgl
-FAIL 'XRBoundedReferenceSpace updates properly when the changes are applied - webgl2 assert_implements: webgl2 not supported. undefined
+PASS 'XRBoundedReferenceSpace updates properly when the changes are applied - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrDevice_requestSession_immersive.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrDevice_requestSession_immersive.https-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Tests requestSession resolves when supported - webgl
-FAIL Tests requestSession resolves when supported - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Tests requestSession resolves when supported - webgl2
 PASS Tests requestSession accepts XRSessionInit dictionary - webgl
-FAIL Tests requestSession accepts XRSessionInit dictionary - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Tests requestSession accepts XRSessionInit dictionary - webgl2
 PASS Tests requestSession ignores unknown optionalFeatures - webgl
-FAIL Tests requestSession ignores unknown optionalFeatures - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Tests requestSession ignores unknown optionalFeatures - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrDevice_requestSession_optionalFeatures.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrDevice_requestSession_optionalFeatures.https-expected.txt
@@ -1,10 +1,10 @@
 
 PASS Tests requestSession accepts XRSessionInit dictionary - webgl
-FAIL Tests requestSession accepts XRSessionInit dictionary - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Tests requestSession accepts XRSessionInit dictionary - webgl2
 PASS Tests requestSession accepts XRSessionInit dictionary with empty feature lists - webgl
-FAIL Tests requestSession accepts XRSessionInit dictionary with empty feature lists - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Tests requestSession accepts XRSessionInit dictionary with empty feature lists - webgl2
 PASS Tests requestSession ignores unknown strings in optionalFeatures - webgl
-FAIL Tests requestSession ignores unknown strings in optionalFeatures - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Tests requestSession ignores unknown strings in optionalFeatures - webgl2
 PASS Tests requestSession ignores unknown objects in optionalFeatures - webgl
-FAIL Tests requestSession ignores unknown objects in optionalFeatures - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Tests requestSession ignores unknown objects in optionalFeatures - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrFrame_lifetime.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrFrame_lifetime.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS XRFrame methods throw exceptions outside of the requestAnimationFrame callback for immersive sessions - webgl
-FAIL XRFrame methods throw exceptions outside of the requestAnimationFrame callback for immersive sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRFrame methods throw exceptions outside of the requestAnimationFrame callback for immersive sessions - webgl2
 PASS XRFrame methods throw exceptions outside of the requestAnimationFrame callback for non-immersive sessions - webgl
-FAIL XRFrame methods throw exceptions outside of the requestAnimationFrame callback for non-immersive sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRFrame methods throw exceptions outside of the requestAnimationFrame callback for non-immersive sessions - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrInputSource_add_remove.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrInputSource_add_remove.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRInputSources can be properly added and removed from the session - webgl
-FAIL XRInputSources can be properly added and removed from the session - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRInputSources can be properly added and removed from the session - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrInputSource_emulatedPosition.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrInputSource_emulatedPosition.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Poses from XRInputSource.gripSpace have emulatedPosition set properly - webgl
-FAIL Poses from XRInputSource.gripSpace have emulatedPosition set properly - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Poses from XRInputSource.gripSpace have emulatedPosition set properly - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrInputSource_profiles.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrInputSource_profiles.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS WebXR InputSource's profiles list can be set - webgl
-FAIL WebXR InputSource's profiles list can be set - webgl2 assert_implements: webgl2 not supported. undefined
+PASS WebXR InputSource's profiles list can be set - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrInputSource_sameObject.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrInputSource_sameObject.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRInputSource attributes meet [SameObject] requirement - webgl
-FAIL XRInputSource attributes meet [SameObject] requirement - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRInputSource attributes meet [SameObject] requirement - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrPose_transform_sameObject.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrPose_transform_sameObject.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRPose.transform meets [SameObject] requirement - webgl
-FAIL XRPose.transform meets [SameObject] requirement - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRPose.transform meets [SameObject] requirement - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrReferenceSpace_originOffset.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrReferenceSpace_originOffset.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Updating XRReferenceSpace origin offset updates view and input matrices. - webgl
-FAIL Updating XRReferenceSpace origin offset updates view and input matrices. - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Updating XRReferenceSpace origin offset updates view and input matrices. - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrReferenceSpace_originOffsetBounded.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrReferenceSpace_originOffsetBounded.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Updating XRBoundedReferenceSpace origin offset updates view, input matrices, and bounds geometry. - webgl
-FAIL Updating XRBoundedReferenceSpace origin offset updates view, input matrices, and bounds geometry. - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Updating XRBoundedReferenceSpace origin offset updates view, input matrices, and bounds geometry. - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrReferenceSpace_originOffset_viewer.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrReferenceSpace_originOffset_viewer.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Creating XRReferenceSpace origin offset off of `viewer` space works. - webgl
-FAIL Creating XRReferenceSpace origin offset off of `viewer` space works. - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Creating XRReferenceSpace origin offset off of `viewer` space works. - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrReferenceSpace_relationships.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrReferenceSpace_relationships.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Bounded space, viewer space, local and local-floor space have correct poses w.r.t. each other - webgl
-FAIL Bounded space, viewer space, local and local-floor space have correct poses w.r.t. each other - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Bounded space, viewer space, local and local-floor space have correct poses w.r.t. each other - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrRigidTransform_constructor.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrRigidTransform_constructor.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRRigidTransform constructor works - webgl
-FAIL XRRigidTransform constructor works - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRRigidTransform constructor works - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrRigidTransform_inverse.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrRigidTransform_inverse.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRRigidTransform inverse works - webgl
-FAIL XRRigidTransform inverse works - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRRigidTransform inverse works - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrRigidTransform_sameObject.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrRigidTransform_sameObject.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRRigidTransform position and orientation meet [SameObject] requirements - webgl
-FAIL XRRigidTransform position and orientation meet [SameObject] requirements - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRRigidTransform position and orientation meet [SameObject] requirements - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_cancelAnimationFrame_invalidhandle.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_cancelAnimationFrame_invalidhandle.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS XRSession cancelAnimationFrame does not have unexpected behavior when given invalid handles on immersive testSession - webgl
-FAIL XRSession cancelAnimationFrame does not have unexpected behavior when given invalid handles on immersive testSession - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRSession cancelAnimationFrame does not have unexpected behavior when given invalid handles on immersive testSession - webgl2
 PASS XRSession cancelAnimationFrame does not have unexpected behavior when given invalid handles on non-immersive testSession - webgl
-FAIL XRSession cancelAnimationFrame does not have unexpected behavior when given invalid handles on non-immersive testSession - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRSession cancelAnimationFrame does not have unexpected behavior when given invalid handles on non-immersive testSession - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_end.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_end.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS end event fires when immersive session ends - webgl
-FAIL end event fires when immersive session ends - webgl2 assert_implements: webgl2 not supported. undefined
+PASS end event fires when immersive session ends - webgl2
 PASS end event fires when non-immersive session ends - webgl
-FAIL end event fires when non-immersive session ends - webgl2 assert_implements: webgl2 not supported. undefined
+PASS end event fires when non-immersive session ends - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestAnimationFrame_callback_calls.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestAnimationFrame_callback_calls.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS XRSession requestAnimationFrame calls the provided callback for an immersive session - webgl
-FAIL XRSession requestAnimationFrame calls the provided callback for an immersive session - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRSession requestAnimationFrame calls the provided callback for an immersive session - webgl2
 PASS XRSession requestAnimationFrame calls the provided callback a non-immersive session - webgl
-FAIL XRSession requestAnimationFrame calls the provided callback a non-immersive session - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRSession requestAnimationFrame calls the provided callback a non-immersive session - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestAnimationFrame_data_valid.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestAnimationFrame_data_valid.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS RequestAnimationFrame resolves with good data - webgl
-FAIL RequestAnimationFrame resolves with good data - webgl2 assert_implements: webgl2 not supported. undefined
+PASS RequestAnimationFrame resolves with good data - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestAnimationFrame_getViewerPose.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestAnimationFrame_getViewerPose.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS XRFrame getViewerPose updates on the next frame for non-immersive sessions - webgl
-FAIL XRFrame getViewerPose updates on the next frame for non-immersive sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRFrame getViewerPose updates on the next frame for non-immersive sessions - webgl2
 PASS XRFrame getViewerPose updates on the next frame for immersive sessions - webgl
-FAIL XRFrame getViewerPose updates on the next frame for immersive sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRFrame getViewerPose updates on the next frame for immersive sessions - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestAnimationFrame_timestamp.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestAnimationFrame_timestamp.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS XRFrame getViewerPose updates on the next frame for immersive - webgl
-FAIL XRFrame getViewerPose updates on the next frame for immersive - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRFrame getViewerPose updates on the next frame for immersive - webgl2
 PASS XRFrame getViewerPose updates on the next frame for non-immersive - webgl
-FAIL XRFrame getViewerPose updates on the next frame for non-immersive - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRFrame getViewerPose updates on the next frame for non-immersive - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestSessionDuringEnd.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestSessionDuringEnd.https-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL Create new session in OnSessionEnded event - webgl assert_unreached: Session creation should not throw: SecurityError: The operation is insecure. Reached unreachable code
-FAIL Create new session in OnSessionEnded event - webgl2 assert_implements: webgl2 not supported. undefined
+FAIL Create new session in OnSessionEnded event - webgl2 assert_unreached: Session creation should not throw: SecurityError: The operation is insecure. Reached unreachable code
 FAIL Create mew session in end promise - webgl assert_unreached: Session creation should not throw: SecurityError: The operation is insecure. Reached unreachable code
-FAIL Create mew session in end promise - webgl2 assert_implements: webgl2 not supported. undefined
+FAIL Create mew session in end promise - webgl2 assert_unreached: Session creation should not throw: SecurityError: The operation is insecure. Reached unreachable code
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_viewer_referenceSpace.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_viewer_referenceSpace.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Identity reference space provides correct poses for inline sessions - webgl
-FAIL Identity reference space provides correct poses for inline sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Identity reference space provides correct poses for inline sessions - webgl2
 PASS Identity reference space provides correct poses for immersive sessions - webgl
-FAIL Identity reference space provides correct poses for immersive sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Identity reference space provides correct poses for immersive sessions - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_visibilityState.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_visibilityState.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Ensures that the XRSession's visibilityState is correctly reported and that the associated visibilitychange event fires. - webgl
-FAIL Ensures that the XRSession's visibilityState is correctly reported and that the associated visibilitychange event fires. - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Ensures that the XRSession's visibilityState is correctly reported and that the associated visibilitychange event fires. - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrStationaryReferenceSpace_floorlevel_updates.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrStationaryReferenceSpace_floorlevel_updates.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS 'floor-level' XRStationaryReferenceSpace updates properly when the transform changes for immersive sessions - webgl
-FAIL 'floor-level' XRStationaryReferenceSpace updates properly when the transform changes for immersive sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS 'floor-level' XRStationaryReferenceSpace updates properly when the transform changes for immersive sessions - webgl2
 PASS 'floor-level' XRStationaryReferenceSpace updates properly when the transform changes for non-immersive sessions - webgl
-FAIL 'floor-level' XRStationaryReferenceSpace updates properly when the transform changes for non-immersive sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS 'floor-level' XRStationaryReferenceSpace updates properly when the transform changes for non-immersive sessions - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrView_eyes.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrView_eyes.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS XRView.eye is correct for immersive sessions - webgl
-FAIL XRView.eye is correct for immersive sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRView.eye is correct for immersive sessions - webgl2
 PASS XRView.eye is correct for non-immersive sessions - webgl
-FAIL XRView.eye is correct for non-immersive sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRView.eye is correct for non-immersive sessions - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrView_match.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrView_match.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRFrame contains the expected views - webgl
-FAIL XRFrame contains the expected views - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRFrame contains the expected views - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrView_oneframeupdate.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrView_oneframeupdate.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRView projection matrices update near and far depths on the next frame - webgl
-FAIL XRView projection matrices update near and far depths on the next frame - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRView projection matrices update near and far depths on the next frame - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrView_sameObject.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrView_sameObject.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRView attributes meet [SameObject] requirement - webgl
-FAIL XRView attributes meet [SameObject] requirement - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRView attributes meet [SameObject] requirement - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrViewerPose_views_sameObject.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrViewerPose_views_sameObject.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRViewerPose.views meets [SameObject] requirement - webgl
-FAIL XRViewerPose.views meets [SameObject] requirement - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRViewerPose.views meets [SameObject] requirement - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrViewport_valid.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrViewport_valid.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRViewport attributes are valid - webgl
-FAIL XRViewport attributes are valid - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRViewport attributes are valid - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_constructor.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_constructor.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Ensure that XRWebGLLayer's constructor throws appropriate errors using webgl
-FAIL Ensure that XRWebGLLayer's constructor throws appropriate errors using webgl2 assert_implements: webgl2 not supported. undefined
+PASS Ensure that XRWebGLLayer's constructor throws appropriate errors using webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_draw.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_draw.https-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Ensure a WebGL layer's framebuffer can only be drawn to inside a XR frame - webgl assert_equals: expected 0 but got 1280
+FAIL Ensure a WebGL layer's framebuffer can only be drawn to inside a XR frame - webgl2 assert_equals: expected 1286 but got 0
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_sameObject.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_sameObject.https-expected.txt
@@ -1,4 +1,4 @@
 
 PASS XRWebGLLayer.framebuffer meets [SameObject] requirement - webgl
-FAIL XRWebGLLayer.framebuffer meets [SameObject] requirement - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRWebGLLayer.framebuffer meets [SameObject] requirement - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https-expected.txt
@@ -1,23 +1,6 @@
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: deleteFramebuffer: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: framebufferTexture2D: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: framebufferRenderbuffer: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: framebufferRenderbuffer: An opaque framebuffer's attachments cannot be inspected or changed
-CONSOLE MESSAGE: WebGL: checkFramebufferStatus: An opaque framebuffer is considered incomplete outside of a requestAnimationFrame
 
-PASS Ensure that the framebuffer given by the WebGL layer is opaque for immersive - webgl
-FAIL Ensure that the framebuffer given by the WebGL layer is opaque for immersive - webgl2 assert_implements: webgl2 not supported. undefined
+FAIL Ensure that the framebuffer given by the WebGL layer is opaque for immersive - webgl assert_equals: expected 0 but got 1280
+FAIL Ensure that the framebuffer given by the WebGL layer is opaque for immersive - webgl2 assert_equals: expected 1282 but got 0
 PASS Ensure that the framebuffer given by the WebGL layer is opaque for non-immersive - webgl
-FAIL Ensure that the framebuffer given by the WebGL layer is opaque for non-immersive - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Ensure that the framebuffer given by the WebGL layer is opaque for non-immersive - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_viewports.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_viewports.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS XRWebGLLayer reports a valid viewports for immersive sessions - webgl
-FAIL XRWebGLLayer reports a valid viewports for immersive sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRWebGLLayer reports a valid viewports for immersive sessions - webgl2
 PASS XRWebGLLayer reports a valid viewports for inline sessions - webgl
-FAIL XRWebGLLayer reports a valid viewports for inline sessions - webgl2 assert_implements: webgl2 not supported. undefined
+PASS XRWebGLLayer reports a valid viewports for inline sessions - webgl2
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/xhr/send-authentication-basic-setrequestheader-existing-session-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/xhr/send-authentication-basic-setrequestheader-existing-session-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL XMLHttpRequest: send() - "Basic" authenticated request using setRequestHeader() when there is an existing session assert_equals: expected "f8947137-d721-4624-8bb5-1e3c2d8ac873\npass" but got "7972fecd-cba5-44a4-9968-acb5b8db190f\nopen-pass"
+FAIL XMLHttpRequest: send() - "Basic" authenticated request using setRequestHeader() when there is an existing session assert_equals: expected "95925d71-bf0c-44a7-ac2c-87c5a9f2896a\npass" but got "defb115b-5535-421f-bfcb-7f14990887b9\nopen-pass"
 Note: this test will only work as expected once per browsing session. Restart browser to re-test.


### PR DESCRIPTION
#### 22416fc5ba875ef4529ded6ee074ed9fe4d79714
<pre>
[WPE] Gardening of imported/w3c/web-platform-tests/
<a href="https://bugs.webkit.org/show_bug.cgi?id=244603">https://bugs.webkit.org/show_bug.cgi?id=244603</a>

Unreviewed gardening, adjusting or adding WPE-specific baselines for a larger
set of tests under imported/w3c/web-platform-tests/.

* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-import.https-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.https-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.https-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.https-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/sharedworker-import.https-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.https-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/sharedworker-import.https-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.https-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.window-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/same-hash-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.getcontext-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.getcontext.worker-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.w-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.w-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/ar-module/xrDevice_requestSession_immersive-ar.https-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_input_source_recreation.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_input_sources_change.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_session_select.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_session_select_subframe.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/events_session_squeeze.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/getInputPose_handedness.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/getViewerPose_emulatedPosition.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/navigator_xr_sameObject.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/render_state_update.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/render_state_vertical_fov_immersive.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/render_state_vertical_fov_inline.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/webGLCanvasContext_makecompatible_contextlost.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/webGLCanvasContext_makecompatible_reentrant.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrBoundedReferenceSpace_updates.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrDevice_requestSession_immersive.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrDevice_requestSession_optionalFeatures.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrFrame_lifetime.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrInputSource_add_remove.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrInputSource_emulatedPosition.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrInputSource_profiles.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrInputSource_sameObject.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrPose_transform_sameObject.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrReferenceSpace_originOffset.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrReferenceSpace_originOffsetBounded.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrReferenceSpace_originOffset_viewer.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrReferenceSpace_relationships.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrRigidTransform_constructor.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrRigidTransform_inverse.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrRigidTransform_sameObject.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_cancelAnimationFrame_invalidhandle.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_end.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestAnimationFrame_callback_calls.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestAnimationFrame_data_valid.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestAnimationFrame_getViewerPose.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestAnimationFrame_timestamp.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_requestSessionDuringEnd.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_viewer_referenceSpace.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrSession_visibilityState.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrStationaryReferenceSpace_floorlevel_updates.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrView_eyes.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrView_match.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrView_oneframeupdate.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrView_sameObject.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrViewerPose_views_sameObject.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrViewport_valid.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_constructor.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_draw.https-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_sameObject.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_viewports.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/xhr/send-authentication-basic-setrequestheader-existing-session-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253985@main">https://commits.webkit.org/253985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/569b396f1ed0667f56c7486a96b46f6d6c0d56ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31813 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/18461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/96921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/150732 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30170 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/91667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93345 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/74473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/18461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27864 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/18461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27830 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/18461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29525 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/74473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1128 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29423 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/18461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->