### PR TITLE
ITP should hold off longer on deleting website data for domains with WebPush that the user interacts with

### DIFF
--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h
@@ -175,6 +175,7 @@ private:
         unsigned topFrameUniqueRedirectsToSinceSameSiteStrictEnforcement;
     };
     Vector<DomainData> domains() const;
+    bool hasHadRecentWebPushInteraction(const DomainData&) const;
     bool hasHadUnexpiredRecentUserInteraction(const DomainData&, OperatingDatesWindow);
     void clearGrandfathering(Vector<unsigned>&&);
     WebCore::StorageAccessPromptWasShown hasUserGrantedStorageAccessThroughPrompt(unsigned domainID, const RegistrableDomain&);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -627,7 +627,7 @@ TEST(WebPush, ITPCleanup)
     auto tempDir = setUpTestWebPushD();
     using namespace TestWebKitAPI;
     
-    NSError *error;
+    NSError *error = nil;
     [[NSFileManager defaultManager] removeItemAtURL:adoptNS([_WKWebsiteDataStoreConfiguration new]).get()._resourceLoadStatisticsDirectory error:&error];
     EXPECT_NULL(error);
 
@@ -736,9 +736,9 @@ TEST(WebPush, ITPCleanup)
         testPush(expectPushAfterITPCleanupToSucceed);
     };
 
-    // FIXME: This time interval should change when rdar://92694600 is fixed.
     runTestWithInterval(3600 * 24 * 0, true);
-    runTestWithInterval(3600 * 24 * 5, true);
+    runTestWithInterval(3600 * 24 * 29, true);
+    runTestWithInterval(3600 * 24 * 31, false);
     runTestWithInterval(3600 * 24 * 50, false);
     runTestWithInterval(3600 * 24 * 100, false);
 


### PR DESCRIPTION
#### c5e9bfec8ca40fa0224df9b8a47638953864edcd
<pre>
ITP should hold off longer on deleting website data for domains with WebPush that the user interacts with
<a href="https://bugs.webkit.org/show_bug.cgi?id=244609">https://bugs.webkit.org/show_bug.cgi?id=244609</a>
&lt;rdar://99148432&gt;

Reviewed by Alex Christensen.

* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp:
(WebKit::ResourceLoadStatisticsDatabaseStore::hasHadRecentWebPushInteraction const):
    New convenience function.
(WebKit::ResourceLoadStatisticsDatabaseStore::registrableDomainsToDeleteOrRestrictWebsiteDataFor):
    Now checks hasHadRecentWebPushInteraction() and exempts the domain if true.
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
    Updated the ITPCleanup test to cover the new behavior.

Canonical link: <a href="https://commits.webkit.org/254048@main">https://commits.webkit.org/254048@main</a>
</pre>
