### PR TITLE
Incorrect image srcset candidate chosen for <img> cloned from <template>

### DIFF
--- a/LayoutTests/fast/images/hidpi-img-cloned-from-template-expected.html
+++ b/LayoutTests/fast/images/hidpi-img-cloned-from-template-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img src="resources/red-100x100.png" srcset="resources/red-100x100.png 1x, resources/green-400x400.png 2x">
+</body>
+</html>

--- a/LayoutTests/fast/images/hidpi-img-cloned-from-template.html
+++ b/LayoutTests/fast/images/hidpi-img-cloned-from-template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<template><img src="resources/red-100x100.png" srcset="resources/red-100x100.png 1x, resources/green-400x400.png 2x"></template>
+<script>
+document.body.appendChild(document.querySelector('template').content.cloneNode(true));
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -451,7 +451,7 @@ Node::InsertedIntoAncestorResult HTMLImageElement::insertedIntoAncestor(Insertio
     // If we have been inserted from a renderer-less document,
     // our loader may have not fetched the image, so do it now.
     if (insertionType.connectedToDocument && !m_imageLoader->image())
-        m_imageLoader->updateFromElement();
+        selectImageSource(RelevantMutation::Yes);
 
     return insertNotificationRequest;
 }


### PR DESCRIPTION
#### 3b88acfd3432ae1d49de70224017535944cea059
<pre>
Incorrect image srcset candidate chosen for &lt;img&gt; cloned from &lt;template&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=211620">https://bugs.webkit.org/show_bug.cgi?id=211620</a>

Reviewed by NOBODY (OOPS!).

The bug was caused by HTMLImageElement not updating its image candidate selection
upon getting adopted into a document from a template content document.

Fix the bug by calling selectImageSource instead of just m_imageLoader-&gt;updateFromElement.

* LayoutTests/fast/images/hidpi-img-cloned-from-template-expected.html: Added.
* LayoutTests/fast/images/hidpi-img-cloned-from-template.html: Added.
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::insertedIntoAncestor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b88acfd3432ae1d49de70224017535944cea059

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96959 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/151023 "Found 17 new test failures: fast/loader/null-request-after-willSendRequest.html, http/tests/misc/image-blocked-src-change.html, http/tests/misc/image-blocked-src-no-change.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-cross-origin-image-from-script.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-cross-origin-image.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image-from-script.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image.html, http/tests/security/contentSecurityPolicy/image-blocked-in-about-blank-window.html, http/tests/security/contentSecurityPolicy/image-blocked.html, http/tests/security/contentSecurityPolicy/image-full-host-wildcard-blocked.html ...") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30214 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26297 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79864 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91702 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93379 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24406 "Found 30 new test failures: css3/color-filters/color-filter-text-shadow.html, fast/canvas/image-pattern-rotate.html, fast/loader/null-request-after-willSendRequest.html, http/tests/app-privacy-report/user-attribution-cors-preflight-redirect.html, http/tests/misc/image-blocked-src-change.html, http/tests/misc/image-blocked-src-no-change.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-cross-origin-image-from-script.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-cross-origin-image.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image-from-script.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image-https.html ...") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74504 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24390 "Found 37 new test failures: fast/loader/null-request-after-willSendRequest.html, http/tests/contentextensions/video-element-resource-type.html, http/tests/misc/image-blocked-src-change.html, http/tests/misc/image-blocked-src-no-change.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-cross-origin-image-from-script.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-cross-origin-image.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image-from-script.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image-https.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image.html, http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-iframe-with-enforced-and-report-policies.html ...") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67237 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27899 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13348 "Found 30 new test failures: fast/loader/null-request-after-willSendRequest.html, http/tests/misc/image-blocked-src-no-change.html, http/tests/preload/onload_event.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-cross-origin-image-from-script.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-cross-origin-image.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image-from-script.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image-https.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image.html, http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-iframe-with-inherited-policy.html, http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-iframe.html ...") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27873 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14363 "Found 30 new test failures: fast/loader/null-request-after-willSendRequest.html, http/tests/contentextensions/basic-filter.html, http/tests/contentextensions/domain-rules.html, http/tests/contentextensions/filters-with-quantifiers-combined.html, http/tests/contentextensions/top-url.html, http/tests/contentextensions/video-element-resource-type.html, http/tests/misc/image-blocked-src-no-change.html, http/tests/privateClickMeasurement/store-private-click-measurement-with-source-nonce.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-cross-origin-image-from-script.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-cross-origin-image.html ...") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29559 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37276 "Found 30 new test failures: fast/loader/null-request-after-willSendRequest.html, http/tests/contentextensions/basic-filter.html, http/tests/contentextensions/domain-rules.html, http/tests/contentextensions/filters-with-quantifiers-combined.html, http/tests/contentextensions/top-url.html, http/tests/contentextensions/video-element-resource-type.html, http/tests/misc/image-blocked-src-no-change.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-cross-origin-image-from-script.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-cross-origin-image.html, http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image-from-script.html ...") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33639 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->