### PR TITLE
Regression(r222993) Code in addChildNodesToDeletionQueue() that checks that node has a refcount of 0 is now dead

### DIFF
--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -142,7 +142,7 @@ public:
 protected:
     explicit ContainerNode(Document&, ConstructionType = CreateContainer);
 
-    friend void addChildNodesToDeletionQueue(Node*& head, Node*& tail, ContainerNode&);
+    friend void removeDetachedChildrenInContainer(ContainerNode&);
 
     void removeDetachedChildren();
     void setFirstChild(Node* child) { m_firstChild = child; }


### PR DESCRIPTION
#### a6c5f820d22c03dde04394ab025584530a42fc27
<pre>
Regression(r222993) Code in addChildNodesToDeletionQueue() that checks that node has a refcount of 0 is now dead
<a href="https://bugs.webkit.org/show_bug.cgi?id=244558">https://bugs.webkit.org/show_bug.cgi?id=244558</a>

Reviewed by Ryosuke Niwa.

addChildNodesToDeletionQueue() was only adding nodes to the deletion queue if their ref count was 0,
which was impossible after r222993 since node is explicitly ref&apos;d in the function. Since we haven&apos;t
had a deletion queue since 2017, I am merely deleting the dead code.

* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::removeDetachedChildrenInContainer):
(WebCore::addChildNodesToDeletionQueue): Deleted.

Canonical link: <a href="https://commits.webkit.org/254044@main">https://commits.webkit.org/254044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a92533efccac65f74955e085a14de7cee1bc716

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87759 "failed 1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96958 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/150975 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30213 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26296 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91701 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24404 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74503 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24391 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79526 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67238 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27898 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13347 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27872 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14362 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2844 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37275 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33638 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->