### PR TITLE
[Quirks] Disable resolution media feature on Expedia Group sites

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -230,7 +230,50 @@ bool Quirks::shouldDisableResolutionMediaQuery() const
     if (!needsQuirks())
         return false;
     auto host = m_document->url().host();
-    return equalLettersIgnoringASCIICase(host, "www.hotels.com"_s);
+
+    if (equalLettersIgnoringASCIICase(host, "www.carrentals.com"_s))
+        return true;
+
+    if (equalLettersIgnoringASCIICase(host, "www.cheaptickets.com"_s))
+        return true;
+
+    if (topPrivatelyControlledDomain(host.toString()).startsWith("ebookers."_s))
+        return true;
+
+    if (topPrivatelyControlledDomain(host.toString()).startsWith("expedia."_s))
+        return true;
+
+    if (host.endsWithIgnoringASCIICase(".hoteis.com"_s))
+        return true;
+
+    if (host.endsWithIgnoringASCIICase(".hoteles.com"_s))
+        return true;
+
+    if (equalLettersIgnoringASCIICase(host, "www.hotels.cn"_s))
+        return true;
+
+    if (host.endsWithIgnoringASCIICase(".hotels.com"_s))
+        return true;
+
+    if (equalLettersIgnoringASCIICase(host, "www.mrjet.se"_s))
+        return true;
+
+    if (equalLettersIgnoringASCIICase(host, "www.orbitz.com"_s))
+        return true;
+
+    if (equalLettersIgnoringASCIICase(host, "www.travelocity.ca"_s))
+        return true;
+
+    if (equalLettersIgnoringASCIICase(host, "www.travelocity.com"_s))
+        return true;
+
+    if (equalLettersIgnoringASCIICase(host, "www.wotif.com"_s))
+        return true;
+
+    if (equalLettersIgnoringASCIICase(host, "www.wotif.co.nz"_s))
+        return true;
+
+    return false;
 }
 
 bool Quirks::needsMillisecondResolutionForHighResTimeStamp() const


### PR DESCRIPTION
#### ee272e04a0b439155675e67c84d61009ef4c5934
<pre>
[Quirks] Disable resolution media feature on Expedia Group sites
<a href="https://bugs.webkit.org/show_bug.cgi?id=244627">https://bugs.webkit.org/show_bug.cgi?id=244627</a>
rdar://98750324

Reviewed by Chris Dumez.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisableResolutionMediaQuery const):

Canonical link: <a href="https://commits.webkit.org/254256@main">https://commits.webkit.org/254256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99035b2d00c4568dd21c582d0ee941c477d70a94

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96976 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/151160 "Hash 99035b2d for PR 3877 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30237 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26313 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91720 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24425 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74520 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24407 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67254 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27918 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13357 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27894 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14372 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2994 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37286 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33648 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->