### PR TITLE
border-radius clipping of composited layers doesn't work

### DIFF
--- a/LayoutTests/compositing/clipping/border-radius-async-overflow-non-stacking.html
+++ b/LayoutTests/compositing/clipping/border-radius-async-overflow-non-stacking.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-140" />
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-180" />
     <style>
         .scroller {
             margin: 10px;

--- a/LayoutTests/compositing/clipping/border-radius-with-composited-descendant-dynamic-expected.html
+++ b/LayoutTests/compositing/clipping/border-radius-with-composited-descendant-dynamic-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .clipping {
+            margin: 10px;
+            width: 300px;
+            height: 200px;
+            overflow: hidden;
+            border: 30px solid green;
+            border-top-right-radius: 150px 100px;
+            border-bottom-left-radius: 150px 100px;
+        }
+
+        .composited {
+            transform: translateZ(0);
+            width: 100%;
+            height: 100%;
+            background-color: blue;
+        }
+    </style>
+</head>
+<body>
+    <div class="clipping">
+        <div class="composited"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/border-radius-with-composited-descendant-dynamic.html
+++ b/LayoutTests/compositing/clipping/border-radius-with-composited-descendant-dynamic.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .clipping {
+            margin: 10px;
+            width: 300px;
+            height: 200px;
+            overflow: hidden;
+            border: 30px solid green;
+        }
+
+        .composited {
+            transform: translateZ(0);
+            width: 100%;
+            height: 100%;
+            background-color: blue;
+        }
+
+        body.changed .clipping {
+            border-top-right-radius: 150px 100px;
+            border-bottom-left-radius: 150px 100px;
+        }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                document.body.classList.add('changed');
+                setTimeout(() => {
+                    if (window.testRunner)
+                        testRunner.notifyDone();
+                }, 0);
+            }, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="clipping">
+        <div class="composited"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/border-radius-with-composited-descendant-expected.html
+++ b/LayoutTests/compositing/clipping/border-radius-with-composited-descendant-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .clipping {
+            margin: 10px;
+            width: 300px;
+            height: 200px;
+            overflow: hidden;
+            border: 30px solid green;
+            border-top-right-radius: 150px 100px;
+            border-bottom-left-radius: 150px 100px;
+        }
+
+        .composited {
+            width: 100%;
+            height: 100%;
+            background-color: blue;
+        }
+    </style>
+</head>
+<body>
+    <div class="clipping">
+        <div class="composited"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/border-radius-with-composited-descendant-nested-expected.html
+++ b/LayoutTests/compositing/clipping/border-radius-with-composited-descendant-nested-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .container {
+            width: 400px;
+            height: 300px;
+            border: 20px solid black;
+            border-radius: 120px 50px;
+            overflow: hidden;
+        }
+
+        .intermediate {
+            background-color: rgba(0, 0, 0, 0.4);
+            width: 100%;
+            height: 100%;
+            margin: 50px 0 0 50px;;
+            border-radius: 100px;
+            border: 30px solid green;
+            overflow: hidden;
+        }
+        
+        .child {
+            height: 100%;
+            width: 100%;
+            background-color: blue;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="intermediate">
+        <div class="child"></div>
+    </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/border-radius-with-composited-descendant-nested.html
+++ b/LayoutTests/compositing/clipping/border-radius-with-composited-descendant-nested.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=0-62; totalPixels=0-360" />
+    <style>
+        .container {
+            width: 400px;
+            height: 300px;
+            border: 20px solid black;
+            border-radius: 120px 50px;
+            overflow: hidden;
+        }
+
+        .intermediate {
+            background-color: rgba(0, 0, 0, 0.4);
+            width: 100%;
+            height: 100%;
+            margin: 50px 0 0 50px;;
+            border-radius: 100px;
+            border: 30px solid green;
+            overflow: hidden;
+        }
+        
+        .child {
+            height: 100%;
+            width: 100%;
+            background-color: blue;
+        }
+        
+        .composited {
+            transform: translateZ(0);
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="intermediate">
+        <div class="composited child"></div>
+    </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/border-radius-with-composited-descendant.html
+++ b/LayoutTests/compositing/clipping/border-radius-with-composited-descendant.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=0-42; totalPixels=0-380" />
+    <style>
+        .clipping {
+            margin: 10px;
+            width: 300px;
+            height: 200px;
+            overflow: hidden;
+            border: 30px solid green;
+            border-top-right-radius: 150px 100px;
+            border-bottom-left-radius: 150px 100px;
+        }
+
+        .composited {
+            transform: translateZ(0);
+            width: 100%;
+            height: 100%;
+            background-color: blue;
+        }
+    </style>
+</head>
+<body>
+    <div class="clipping">
+        <div class="composited"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
+++ b/LayoutTests/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
@@ -68,9 +68,13 @@
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 10.00 10.00)
-              (bounds 100.00 80.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 100.00 80.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
@@ -84,14 +88,22 @@
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 21.00 111.00)
-              (bounds 285.00 200.00)
-              (clips 1)
               (children 1
                 (GraphicsLayer
-                  (position 10.00 10.00)
-                  (bounds 100.00 80.00)
-                  (contentsOpaque 1)
+                  (position 21.00 111.00)
+                  (bounds 285.00 200.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 10.00)
+                          (bounds 100.00 80.00)
+                          (contentsOpaque 1)
+                        )
+                      )
+                    )
+                  )
                 )
               )
             )
@@ -103,14 +115,22 @@
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 21.00 111.00)
-              (bounds 285.00 200.00)
-              (clips 1)
               (children 1
                 (GraphicsLayer
-                  (position 10.00 100.00)
-                  (bounds 100.00 80.00)
-                  (contentsOpaque 1)
+                  (position 21.00 111.00)
+                  (bounds 285.00 200.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 100.00)
+                          (bounds 100.00 80.00)
+                          (contentsOpaque 1)
+                        )
+                      )
+                    )
+                  )
                 )
               )
             )
@@ -122,14 +142,22 @@
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 21.00 111.00)
-              (bounds 285.00 200.00)
-              (clips 1)
               (children 1
                 (GraphicsLayer
-                  (position 10.00 190.00)
-                  (bounds 100.00 80.00)
-                  (contentsOpaque 1)
+                  (position 21.00 111.00)
+                  (bounds 285.00 200.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 190.00)
+                          (bounds 100.00 80.00)
+                          (contentsOpaque 1)
+                        )
+                      )
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/compositing/layer-creation/clipping-scope/overlap-constrained-inside-scroller-expected.txt
+++ b/LayoutTests/compositing/layer-creation/clipping-scope/overlap-constrained-inside-scroller-expected.txt
@@ -30,9 +30,13 @@
           (bounds 285.00 300.00)
           (children 1
             (GraphicsLayer
-              (position 10.00 10.00)
-              (bounds 50.00 200.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 50.00 200.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
@@ -41,9 +45,13 @@
           (bounds 285.00 300.00)
           (children 1
             (GraphicsLayer
-              (position 40.00 20.00)
-              (bounds 100.00 100.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 40.00 20.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
@@ -52,9 +60,13 @@
           (bounds 285.00 300.00)
           (children 1
             (GraphicsLayer
-              (position 40.00 140.00)
-              (bounds 100.00 100.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 40.00 140.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
@@ -63,9 +75,13 @@
           (bounds 285.00 300.00)
           (children 1
             (GraphicsLayer
-              (position 40.00 260.00)
-              (bounds 100.00 100.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 40.00 260.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
@@ -74,9 +90,13 @@
           (bounds 285.00 300.00)
           (children 1
             (GraphicsLayer
-              (position 40.00 380.00)
-              (bounds 100.00 100.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 40.00 380.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/compositing/layer-creation/clipping-scope/scroller-with-negative-z-children-expected.txt
+++ b/LayoutTests/compositing/layer-creation/clipping-scope/scroller-with-negative-z-children-expected.txt
@@ -15,9 +15,13 @@
               (bounds 285.00 300.00)
               (children 1
                 (GraphicsLayer
-                  (position 40.00 140.00)
-                  (bounds 100.00 100.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 40.00 140.00)
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )
@@ -49,9 +53,13 @@
               (bounds 285.00 300.00)
               (children 1
                 (GraphicsLayer
-                  (position 10.00 10.00)
-                  (bounds 50.00 200.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 10.00 10.00)
+                      (bounds 50.00 200.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )
@@ -60,9 +68,13 @@
               (bounds 285.00 300.00)
               (children 1
                 (GraphicsLayer
-                  (position 40.00 20.00)
-                  (bounds 100.00 100.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 40.00 20.00)
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )
@@ -71,9 +83,13 @@
               (bounds 285.00 300.00)
               (children 1
                 (GraphicsLayer
-                  (position 40.00 260.00)
-                  (bounds 100.00 100.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 40.00 260.00)
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )
@@ -82,9 +98,13 @@
               (bounds 285.00 300.00)
               (children 1
                 (GraphicsLayer
-                  (position 40.00 380.00)
-                  (bounds 100.00 100.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 40.00 380.00)
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/compositing/overflow/scrolling-content-clip-to-viewport-expected.txt
+++ b/LayoutTests/compositing/overflow/scrolling-content-clip-to-viewport-expected.txt
@@ -24,10 +24,14 @@
           (bounds 305.00 325.00)
           (children 1
             (GraphicsLayer
-              (position 10.00 10.00)
-              (bounds 284.00 1204.00)
-              (contentsOpaque 1)
-              (drawsContent 1)
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 284.00 1204.00)
+                  (contentsOpaque 1)
+                  (drawsContent 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/compositing/rtl/rtl-scrolling-with-transformed-descendants-expected.txt
+++ b/LayoutTests/compositing/rtl/rtl-scrolling-with-transformed-descendants-expected.txt
@@ -32,53 +32,69 @@
         )
         (GraphicsLayer
           (position 10.00 10.00)
-          (bounds origin 366.00 0.00)
           (bounds 400.00 204.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 462.00 0.00)
-              (anchor 0.00 0.00)
-              (bounds 150.00 200.00)
-              (contentsOpaque 1)
+              (bounds origin 366.00 0.00)
+              (children 1
+                (GraphicsLayer
+                  (position 462.00 0.00)
+                  (anchor 0.00 0.00)
+                  (bounds 150.00 200.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
         (GraphicsLayer
           (position 10.00 10.00)
-          (bounds origin 366.00 0.00)
           (bounds 400.00 204.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 308.00 0.00)
-              (bounds 150.00 200.00)
-              (contentsOpaque 1)
+              (bounds origin 366.00 0.00)
+              (children 1
+                (GraphicsLayer
+                  (position 308.00 0.00)
+                  (bounds 150.00 200.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
         (GraphicsLayer
           (position 10.00 10.00)
-          (bounds origin 366.00 0.00)
           (bounds 400.00 204.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 154.00 0.00)
-              (bounds 150.00 200.00)
-              (contentsOpaque 1)
+              (bounds origin 366.00 0.00)
+              (children 1
+                (GraphicsLayer
+                  (position 154.00 0.00)
+                  (bounds 150.00 200.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
         (GraphicsLayer
           (position 10.00 10.00)
-          (bounds origin 366.00 0.00)
           (bounds 400.00 204.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (bounds 150.00 200.00)
-              (contentsOpaque 1)
+              (bounds origin 366.00 0.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 150.00 200.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-clipped-by-scroll-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-clipped-by-scroll-expected.txt
@@ -32,20 +32,24 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 300.00)
           (bounds 301.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 20.00 220.00)
-              (bounds 100.00 200.00)
-              (clips 1)
+              (bounds origin 0.00 300.00)
               (children 1
                 (GraphicsLayer
-                  (offsetFromRenderer width=-6 height=-6)
-                  (position 24.00 44.00)
-                  (bounds 112.00 112.00)
-                  (drawsContent 1)
+                  (position 20.00 220.00)
+                  (bounds 100.00 200.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (offsetFromRenderer width=-6 height=-6)
+                      (position 24.00 44.00)
+                      (bounds 112.00 112.00)
+                      (drawsContent 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-expected.txt
@@ -32,20 +32,24 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 301.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 34.00 234.00)
-              (bounds 100.00 86.00)
-              (clips 1)
+              (bounds origin 0.00 50.00)
               (children 1
                 (GraphicsLayer
-                  (offsetFromRenderer width=-6 height=-6)
-                  (position 24.00 44.00)
-                  (bounds 112.00 112.00)
-                  (drawsContent 1)
+                  (position 34.00 234.00)
+                  (bounds 100.00 86.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (offsetFromRenderer width=-6 height=-6)
+                      (position 24.00 44.00)
+                      (bounds 112.00 112.00)
+                      (drawsContent 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-nested-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-nested-expected.txt
@@ -76,31 +76,39 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 301.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 20.00 220.00)
-              (bounds 200.00 200.00)
-              (clips 1)
+              (bounds origin 0.00 50.00)
               (children 1
                 (GraphicsLayer
-                  (position 23.00 23.00)
-                  (bounds origin 0.00 150.00)
-                  (bounds 195.00 210.00)
+                  (position 20.00 220.00)
+                  (bounds 200.00 200.00)
                   (clips 1)
                   (children 1
                     (GraphicsLayer
-                      (position 2.00 202.00)
-                      (bounds 191.00 150.00)
+                      (position 23.00 23.00)
+                      (bounds 195.00 210.00)
                       (clips 1)
                       (children 1
                         (GraphicsLayer
-                          (offsetFromRenderer width=-6 height=-6)
-                          (position 24.00 44.00)
-                          (bounds 112.00 112.00)
-                          (drawsContent 1)
+                          (bounds origin 0.00 150.00)
+                          (children 1
+                            (GraphicsLayer
+                              (position 2.00 202.00)
+                              (bounds 191.00 150.00)
+                              (clips 1)
+                              (children 1
+                                (GraphicsLayer
+                                  (offsetFromRenderer width=-6 height=-6)
+                                  (position 24.00 44.00)
+                                  (bounds 112.00 112.00)
+                                  (drawsContent 1)
+                                )
+                              )
+                            )
+                          )
                         )
                       )
                     )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-for-negative-z-in-scroller-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-for-negative-z-in-scroller-expected.txt
@@ -15,9 +15,13 @@
               (clips 1)
               (children 1
                 (GraphicsLayer
-                  (position 20.00 20.00)
-                  (bounds 200.00 200.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 20.00 20.00)
+                      (bounds 200.00 200.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-clip-to-hidden-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-clip-to-hidden-expected.txt
@@ -32,20 +32,24 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 301.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 20.00 220.00)
-              (bounds 200.00 100.00)
-              (clips 1)
+              (bounds origin 0.00 50.00)
               (children 1
                 (GraphicsLayer
-                  (offsetFromRenderer width=-6 height=-6)
-                  (position 24.00 44.00)
-                  (bounds 112.00 112.00)
-                  (drawsContent 1)
+                  (position 20.00 220.00)
+                  (bounds 200.00 100.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (offsetFromRenderer width=-6 height=-6)
+                      (position 24.00 44.00)
+                      (bounds 112.00 112.00)
+                      (drawsContent 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-clip-to-visible-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-clip-to-visible-expected.txt
@@ -32,15 +32,19 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 301.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (offsetFromRenderer width=-6 height=-6)
-              (position 44.00 264.00)
-              (bounds 112.00 112.00)
-              (drawsContent 1)
+              (bounds origin 0.00 50.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=-6 height=-6)
+                  (position 44.00 264.00)
+                  (bounds 112.00 112.00)
+                  (drawsContent 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-expected.txt
@@ -32,15 +32,19 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 301.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (offsetFromRenderer width=-6 height=-6)
-              (position 32.00 202.00)
-              (bounds 112.00 112.00)
-              (drawsContent 1)
+              (bounds origin 0.00 50.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=-6 height=-6)
+                  (position 32.00 202.00)
+                  (bounds 112.00 112.00)
+                  (drawsContent 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-gain-clipping-layer-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-gain-clipping-layer-expected.txt
@@ -32,20 +32,24 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 301.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 20.00 220.00)
-              (bounds 200.00 100.00)
-              (clips 1)
+              (bounds origin 0.00 50.00)
               (children 1
                 (GraphicsLayer
-                  (offsetFromRenderer width=-6 height=-6)
-                  (position 24.00 44.00)
-                  (bounds 112.00 112.00)
-                  (drawsContent 1)
+                  (position 20.00 220.00)
+                  (bounds 200.00 100.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (offsetFromRenderer width=-6 height=-6)
+                      (position 24.00 44.00)
+                      (bounds 112.00 112.00)
+                      (drawsContent 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-in-clipped-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-in-clipped-expected.txt
@@ -44,15 +44,19 @@
           (children 1
             (GraphicsLayer
               (position 39.00 39.00)
-              (bounds origin 0.00 50.00)
               (bounds 301.00 316.00)
               (clips 1)
               (children 1
                 (GraphicsLayer
-                  (offsetFromRenderer width=-6 height=-6)
-                  (position 32.00 202.00)
-                  (bounds 112.00 112.00)
-                  (drawsContent 1)
+                  (bounds origin 0.00 50.00)
+                  (children 1
+                    (GraphicsLayer
+                      (offsetFromRenderer width=-6 height=-6)
+                      (position 32.00 202.00)
+                      (bounds 112.00 112.00)
+                      (drawsContent 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-lose-clipping-layer-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-lose-clipping-layer-expected.txt
@@ -32,15 +32,19 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 301.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (offsetFromRenderer width=-6 height=-6)
-              (position 44.00 264.00)
-              (bounds 112.00 112.00)
-              (drawsContent 1)
+              (bounds origin 0.00 50.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=-6 height=-6)
+                  (position 44.00 264.00)
+                  (bounds 112.00 112.00)
+                  (drawsContent 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/nested-scrollers-backing-attachment-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/nested-scrollers-backing-attachment-expected.txt
@@ -74,9 +74,14 @@
               (backingStoreAttached 1)
               (children 1
                 (GraphicsLayer
-                  (bounds 241.00 1000.00)
-                  (contentsOpaque 1)
-                  (backingStoreAttached 1)
+                  (backingStoreAttached 0)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 241.00 1000.00)
+                      (contentsOpaque 1)
+                      (backingStoreAttached 1)
+                    )
+                  )
                 )
               )
             )
@@ -122,52 +127,27 @@
           (backingStoreAttached 1)
           (children 1
             (GraphicsLayer
-              (bounds origin 0.00 1000.00)
               (bounds 429.00 485.00)
               (clips 1)
               (backingStoreAttached 1)
               (children 1
                 (GraphicsLayer
-                  (bounds 429.00 2810.00)
-                  (clips 1)
-                  (backingStoreAttached 1)
+                  (bounds origin 0.00 1000.00)
+                  (backingStoreAttached 0)
                   (children 1
                     (GraphicsLayer
-                      (position 10.00 300.00)
-                      (bounds 409.00 202.00)
-                      (contentsOpaque 1)
-                      (drawsContent 1)
-                      (backingStoreAttached 0)
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds origin 0.00 1000.00)
-              (bounds 429.00 485.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (bounds 429.00 2810.00)
-                  (clips 1)
-                  (backingStoreAttached 1)
-                  (children 1
-                    (GraphicsLayer
-                      (position 10.00 802.00)
-                      (bounds 409.00 202.00)
-                      (contentsOpaque 1)
-                      (drawsContent 1)
+                      (bounds 429.00 2810.00)
+                      (clips 1)
                       (backingStoreAttached 1)
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 300.00)
+                          (bounds 409.00 202.00)
+                          (contentsOpaque 1)
+                          (drawsContent 1)
+                          (backingStoreAttached 0)
+                        )
+                      )
                     )
                   )
                 )
@@ -182,22 +162,27 @@
           (backingStoreAttached 1)
           (children 1
             (GraphicsLayer
-              (bounds origin 0.00 1000.00)
               (bounds 429.00 485.00)
               (clips 1)
               (backingStoreAttached 1)
               (children 1
                 (GraphicsLayer
-                  (bounds 429.00 2810.00)
-                  (clips 1)
-                  (backingStoreAttached 1)
+                  (bounds origin 0.00 1000.00)
+                  (backingStoreAttached 0)
                   (children 1
                     (GraphicsLayer
-                      (position 10.00 1304.00)
-                      (bounds 409.00 202.00)
-                      (contentsOpaque 1)
-                      (drawsContent 1)
+                      (bounds 429.00 2810.00)
+                      (clips 1)
                       (backingStoreAttached 1)
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 802.00)
+                          (bounds 409.00 202.00)
+                          (contentsOpaque 1)
+                          (drawsContent 1)
+                          (backingStoreAttached 1)
+                        )
+                      )
                     )
                   )
                 )
@@ -212,22 +197,27 @@
           (backingStoreAttached 1)
           (children 1
             (GraphicsLayer
-              (bounds origin 0.00 1000.00)
               (bounds 429.00 485.00)
               (clips 1)
               (backingStoreAttached 1)
               (children 1
                 (GraphicsLayer
-                  (bounds 429.00 2810.00)
-                  (clips 1)
-                  (backingStoreAttached 1)
+                  (bounds origin 0.00 1000.00)
+                  (backingStoreAttached 0)
                   (children 1
                     (GraphicsLayer
-                      (position 10.00 1806.00)
-                      (bounds 409.00 202.00)
-                      (contentsOpaque 1)
-                      (drawsContent 1)
-                      (backingStoreAttached 0)
+                      (bounds 429.00 2810.00)
+                      (clips 1)
+                      (backingStoreAttached 1)
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 1304.00)
+                          (bounds 409.00 202.00)
+                          (contentsOpaque 1)
+                          (drawsContent 1)
+                          (backingStoreAttached 1)
+                        )
+                      )
                     )
                   )
                 )
@@ -242,22 +232,62 @@
           (backingStoreAttached 1)
           (children 1
             (GraphicsLayer
-              (bounds origin 0.00 1000.00)
               (bounds 429.00 485.00)
               (clips 1)
               (backingStoreAttached 1)
               (children 1
                 (GraphicsLayer
-                  (bounds 429.00 2810.00)
-                  (clips 1)
-                  (backingStoreAttached 1)
+                  (bounds origin 0.00 1000.00)
+                  (backingStoreAttached 0)
                   (children 1
                     (GraphicsLayer
-                      (position 10.00 2308.00)
-                      (bounds 409.00 202.00)
-                      (contentsOpaque 1)
-                      (drawsContent 1)
-                      (backingStoreAttached 0)
+                      (bounds 429.00 2810.00)
+                      (clips 1)
+                      (backingStoreAttached 1)
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 1806.00)
+                          (bounds 409.00 202.00)
+                          (contentsOpaque 1)
+                          (drawsContent 1)
+                          (backingStoreAttached 0)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 265.00 14.00)
+          (bounds 444.00 500.00)
+          (clips 1)
+          (backingStoreAttached 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 429.00 485.00)
+              (clips 1)
+              (backingStoreAttached 1)
+              (children 1
+                (GraphicsLayer
+                  (bounds origin 0.00 1000.00)
+                  (backingStoreAttached 0)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 429.00 2810.00)
+                      (clips 1)
+                      (backingStoreAttached 1)
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 2308.00)
+                          (bounds 409.00 202.00)
+                          (contentsOpaque 1)
+                          (drawsContent 1)
+                          (backingStoreAttached 0)
+                        )
+                      )
                     )
                   )
                 )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/overlapped-overlay-scrollbar-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/overlapped-overlay-scrollbar-expected.txt
@@ -36,9 +36,13 @@
           (bounds 300.00 300.00)
           (children 1
             (GraphicsLayer
-              (position 0.00 250.00)
-              (bounds 300.00 100.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 0.00 250.00)
+                  (bounds 300.00 100.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/overlapped-overlay-scrollbar-inside-hidden-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/overlapped-overlay-scrollbar-inside-hidden-expected.txt
@@ -42,9 +42,13 @@
               (bounds 300.00 300.00)
               (children 1
                 (GraphicsLayer
-                  (position 0.00 250.00)
-                  (bounds 300.00 100.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 0.00 250.00)
+                      (bounds 300.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/overlapped-overlay-scrollbar-nested-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/overlapped-overlay-scrollbar-nested-expected.txt
@@ -32,21 +32,25 @@ overlaps scrollbar
           (bounds 300.00 300.00)
           (children 1
             (GraphicsLayer
-              (offsetFromRenderer width=-14 height=-14)
-              (position 36.00 36.00)
-              (bounds 358.00 558.00)
-              (drawsContent 1)
               (children 1
                 (GraphicsLayer
-                  (offsetFromRenderer width=15 height=15)
-                  (position 29.00 29.00)
-                  (bounds 300.00 500.00)
+                  (offsetFromRenderer width=-14 height=-14)
+                  (position 36.00 36.00)
+                  (bounds 358.00 558.00)
+                  (drawsContent 1)
                   (children 1
                     (GraphicsLayer
                       (offsetFromRenderer width=15 height=15)
-                      (anchor 0.00 0.00)
-                      (bounds 300.00 750.00)
-                      (drawsContent 1)
+                      (position 29.00 29.00)
+                      (bounds 300.00 500.00)
+                      (children 1
+                        (GraphicsLayer
+                          (offsetFromRenderer width=15 height=15)
+                          (anchor 0.00 0.00)
+                          (bounds 300.00 750.00)
+                          (drawsContent 1)
+                        )
+                      )
                     )
                   )
                 )
@@ -63,14 +67,22 @@ overlaps scrollbar
           (bounds 300.00 300.00)
           (children 1
             (GraphicsLayer
-              (position 65.00 65.00)
-              (bounds 300.00 500.00)
               (children 1
                 (GraphicsLayer
-                  (position 0.00 250.00)
-                  (bounds 300.00 100.00)
-                  (contentsOpaque 1)
-                  (drawsContent 1)
+                  (position 65.00 65.00)
+                  (bounds 300.00 500.00)
+                  (children 1
+                    (GraphicsLayer
+                      (children 1
+                        (GraphicsLayer
+                          (position 0.00 250.00)
+                          (bounds 300.00 100.00)
+                          (contentsOpaque 1)
+                          (drawsContent 1)
+                        )
+                      )
+                    )
+                  )
                 )
               )
             )
@@ -81,13 +93,17 @@ overlaps scrollbar
           (bounds 300.00 300.00)
           (children 1
             (GraphicsLayer
-              (position 65.00 65.00)
-              (bounds 300.00 500.00)
               (children 1
                 (GraphicsLayer
-                  (position 285.00 0.00)
-                  (bounds 15.00 500.00)
-                  (drawsContent 1)
+                  (position 65.00 65.00)
+                  (bounds 300.00 500.00)
+                  (children 1
+                    (GraphicsLayer
+                      (position 285.00 0.00)
+                      (bounds 15.00 500.00)
+                      (drawsContent 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/composited-absolute-in-absolute-in-relative-in-scroller-expected.txt
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/composited-absolute-in-absolute-in-relative-in-scroller-expected.txt
@@ -31,9 +31,13 @@
           (bounds 385.00 400.00)
           (children 1
             (GraphicsLayer
-              (position 34.00 134.00)
-              (bounds 220.00 220.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 34.00 134.00)
+                  (bounds 220.00 220.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/previous-sibling-prevents-inclusiveness-expected.txt
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/previous-sibling-prevents-inclusiveness-expected.txt
@@ -49,9 +49,13 @@
               (clips 1)
               (children 1
                 (GraphicsLayer
-                  (position 20.00 20.00)
-                  (bounds 241.00 24.00)
-                  (drawsContent 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 20.00 20.00)
+                      (bounds 241.00 24.00)
+                      (drawsContent 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
@@ -56,9 +56,13 @@
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 10.00 10.00)
-              (bounds 100.00 80.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 100.00 80.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
@@ -72,14 +76,22 @@
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 21.00 111.00)
-              (bounds 300.00 200.00)
-              (clips 1)
               (children 1
                 (GraphicsLayer
-                  (position 10.00 10.00)
-                  (bounds 100.00 80.00)
-                  (contentsOpaque 1)
+                  (position 21.00 111.00)
+                  (bounds 300.00 200.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 10.00)
+                          (bounds 100.00 80.00)
+                          (contentsOpaque 1)
+                        )
+                      )
+                    )
+                  )
                 )
               )
             )
@@ -91,14 +103,22 @@
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 21.00 111.00)
-              (bounds 300.00 200.00)
-              (clips 1)
               (children 1
                 (GraphicsLayer
-                  (position 10.00 100.00)
-                  (bounds 100.00 80.00)
-                  (contentsOpaque 1)
+                  (position 21.00 111.00)
+                  (bounds 300.00 200.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 100.00)
+                          (bounds 100.00 80.00)
+                          (contentsOpaque 1)
+                        )
+                      )
+                    )
+                  )
                 )
               )
             )
@@ -110,14 +130,22 @@
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 21.00 111.00)
-              (bounds 300.00 200.00)
-              (clips 1)
               (children 1
                 (GraphicsLayer
-                  (position 10.00 190.00)
-                  (bounds 100.00 80.00)
-                  (contentsOpaque 1)
+                  (position 21.00 111.00)
+                  (bounds 300.00 200.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 190.00)
+                          (bounds 100.00 80.00)
+                          (contentsOpaque 1)
+                        )
+                      )
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/overlap-constrained-inside-scroller-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/overlap-constrained-inside-scroller-expected.txt
@@ -30,9 +30,13 @@
           (bounds 300.00 300.00)
           (children 1
             (GraphicsLayer
-              (position 10.00 10.00)
-              (bounds 50.00 200.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 50.00 200.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
@@ -41,9 +45,13 @@
           (bounds 300.00 300.00)
           (children 1
             (GraphicsLayer
-              (position 40.00 20.00)
-              (bounds 100.00 100.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 40.00 20.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
@@ -52,9 +60,13 @@
           (bounds 300.00 300.00)
           (children 1
             (GraphicsLayer
-              (position 40.00 140.00)
-              (bounds 100.00 100.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 40.00 140.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
@@ -63,9 +75,13 @@
           (bounds 300.00 300.00)
           (children 1
             (GraphicsLayer
-              (position 40.00 260.00)
-              (bounds 100.00 100.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 40.00 260.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
@@ -74,9 +90,13 @@
           (bounds 300.00 300.00)
           (children 1
             (GraphicsLayer
-              (position 40.00 380.00)
-              (bounds 100.00 100.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 40.00 380.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/scroller-with-negative-z-children-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/scroller-with-negative-z-children-expected.txt
@@ -15,9 +15,13 @@
               (bounds 300.00 300.00)
               (children 1
                 (GraphicsLayer
-                  (position 40.00 140.00)
-                  (bounds 100.00 100.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 40.00 140.00)
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )
@@ -49,9 +53,13 @@
               (bounds 300.00 300.00)
               (children 1
                 (GraphicsLayer
-                  (position 10.00 10.00)
-                  (bounds 50.00 200.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 10.00 10.00)
+                      (bounds 50.00 200.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )
@@ -60,9 +68,13 @@
               (bounds 300.00 300.00)
               (children 1
                 (GraphicsLayer
-                  (position 40.00 20.00)
-                  (bounds 100.00 100.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 40.00 20.00)
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )
@@ -71,9 +83,13 @@
               (bounds 300.00 300.00)
               (children 1
                 (GraphicsLayer
-                  (position 40.00 260.00)
-                  (bounds 100.00 100.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 40.00 260.00)
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )
@@ -82,9 +98,13 @@
               (bounds 300.00 300.00)
               (children 1
                 (GraphicsLayer
-                  (position 40.00 380.00)
-                  (bounds 100.00 100.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 40.00 380.00)
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-clipped-by-scroll-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-clipped-by-scroll-expected.txt
@@ -32,20 +32,24 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 300.00)
           (bounds 316.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 20.00 220.00)
-              (bounds 100.00 200.00)
-              (clips 1)
+              (bounds origin 0.00 300.00)
               (children 1
                 (GraphicsLayer
-                  (offsetFromRenderer width=-6 height=-6)
-                  (position 24.00 44.00)
-                  (bounds 112.00 112.00)
-                  (drawsContent 1)
+                  (position 20.00 220.00)
+                  (bounds 100.00 200.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (offsetFromRenderer width=-6 height=-6)
+                      (position 24.00 44.00)
+                      (bounds 112.00 112.00)
+                      (drawsContent 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-expected.txt
@@ -32,20 +32,24 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 316.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 34.00 234.00)
-              (bounds 100.00 86.00)
-              (clips 1)
+              (bounds origin 0.00 50.00)
               (children 1
                 (GraphicsLayer
-                  (offsetFromRenderer width=-6 height=-6)
-                  (position 24.00 44.00)
-                  (bounds 112.00 112.00)
-                  (drawsContent 1)
+                  (position 34.00 234.00)
+                  (bounds 100.00 86.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (offsetFromRenderer width=-6 height=-6)
+                      (position 24.00 44.00)
+                      (bounds 112.00 112.00)
+                      (drawsContent 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-nested-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-nested-expected.txt
@@ -64,31 +64,39 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 316.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 20.00 220.00)
-              (bounds 200.00 200.00)
-              (clips 1)
+              (bounds origin 0.00 50.00)
               (children 1
                 (GraphicsLayer
-                  (position 23.00 23.00)
-                  (bounds origin 0.00 150.00)
-                  (bounds 210.00 210.00)
+                  (position 20.00 220.00)
+                  (bounds 200.00 200.00)
                   (clips 1)
                   (children 1
                     (GraphicsLayer
-                      (position 2.00 202.00)
-                      (bounds 206.00 150.00)
+                      (position 23.00 23.00)
+                      (bounds 210.00 210.00)
                       (clips 1)
                       (children 1
                         (GraphicsLayer
-                          (offsetFromRenderer width=-6 height=-6)
-                          (position 24.00 44.00)
-                          (bounds 112.00 112.00)
-                          (drawsContent 1)
+                          (bounds origin 0.00 150.00)
+                          (children 1
+                            (GraphicsLayer
+                              (position 2.00 202.00)
+                              (bounds 206.00 150.00)
+                              (clips 1)
+                              (children 1
+                                (GraphicsLayer
+                                  (offsetFromRenderer width=-6 height=-6)
+                                  (position 24.00 44.00)
+                                  (bounds 112.00 112.00)
+                                  (drawsContent 1)
+                                )
+                              )
+                            )
+                          )
                         )
                       )
                     )

--- a/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-for-negative-z-in-scroller-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-for-negative-z-in-scroller-expected.txt
@@ -15,9 +15,13 @@
               (clips 1)
               (children 1
                 (GraphicsLayer
-                  (position 20.00 20.00)
-                  (bounds 200.00 200.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 20.00 20.00)
+                      (bounds 200.00 200.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-clip-to-hidden-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-clip-to-hidden-expected.txt
@@ -32,20 +32,24 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 316.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 20.00 220.00)
-              (bounds 200.00 100.00)
-              (clips 1)
+              (bounds origin 0.00 50.00)
               (children 1
                 (GraphicsLayer
-                  (offsetFromRenderer width=-6 height=-6)
-                  (position 24.00 44.00)
-                  (bounds 112.00 112.00)
-                  (drawsContent 1)
+                  (position 20.00 220.00)
+                  (bounds 200.00 100.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (offsetFromRenderer width=-6 height=-6)
+                      (position 24.00 44.00)
+                      (bounds 112.00 112.00)
+                      (drawsContent 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-clip-to-visible-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-clip-to-visible-expected.txt
@@ -32,15 +32,19 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 316.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (offsetFromRenderer width=-6 height=-6)
-              (position 44.00 264.00)
-              (bounds 112.00 112.00)
-              (drawsContent 1)
+              (bounds origin 0.00 50.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=-6 height=-6)
+                  (position 44.00 264.00)
+                  (bounds 112.00 112.00)
+                  (drawsContent 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-expected.txt
@@ -32,15 +32,19 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 316.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (offsetFromRenderer width=-6 height=-6)
-              (position 32.00 202.00)
-              (bounds 112.00 112.00)
-              (drawsContent 1)
+              (bounds origin 0.00 50.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=-6 height=-6)
+                  (position 32.00 202.00)
+                  (bounds 112.00 112.00)
+                  (drawsContent 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-gain-clipping-layer-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-gain-clipping-layer-expected.txt
@@ -32,20 +32,24 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 316.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 20.00 220.00)
-              (bounds 200.00 100.00)
-              (clips 1)
+              (bounds origin 0.00 50.00)
               (children 1
                 (GraphicsLayer
-                  (offsetFromRenderer width=-6 height=-6)
-                  (position 24.00 44.00)
-                  (bounds 112.00 112.00)
-                  (drawsContent 1)
+                  (position 20.00 220.00)
+                  (bounds 200.00 100.00)
+                  (clips 1)
+                  (children 1
+                    (GraphicsLayer
+                      (offsetFromRenderer width=-6 height=-6)
+                      (position 24.00 44.00)
+                      (bounds 112.00 112.00)
+                      (drawsContent 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-in-clipped-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-in-clipped-expected.txt
@@ -44,15 +44,19 @@
           (children 1
             (GraphicsLayer
               (position 39.00 39.00)
-              (bounds origin 0.00 50.00)
               (bounds 316.00 316.00)
               (clips 1)
               (children 1
                 (GraphicsLayer
-                  (offsetFromRenderer width=-6 height=-6)
-                  (position 32.00 202.00)
-                  (bounds 112.00 112.00)
-                  (drawsContent 1)
+                  (bounds origin 0.00 50.00)
+                  (children 1
+                    (GraphicsLayer
+                      (offsetFromRenderer width=-6 height=-6)
+                      (position 32.00 202.00)
+                      (bounds 112.00 112.00)
+                      (drawsContent 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-lose-clipping-layer-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-lose-clipping-layer-expected.txt
@@ -32,15 +32,19 @@
         )
         (GraphicsLayer
           (position 41.00 33.00)
-          (bounds origin 0.00 50.00)
           (bounds 316.00 316.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (offsetFromRenderer width=-6 height=-6)
-              (position 44.00 264.00)
-              (bounds 112.00 112.00)
-              (drawsContent 1)
+              (bounds origin 0.00 50.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=-6 height=-6)
+                  (position 44.00 264.00)
+                  (bounds 112.00 112.00)
+                  (drawsContent 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/nested-scrollers-backing-attachment-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/nested-scrollers-backing-attachment-expected.txt
@@ -74,66 +74,11 @@
               (backingStoreAttached 1)
               (children 1
                 (GraphicsLayer
-                  (bounds 256.00 1000.00)
-                  (contentsOpaque 1)
-                  (backingStoreAttached 1)
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds origin 0.00 1000.00)
-              (bounds 444.00 500.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (bounds 444.00 2810.00)
-                  (clips 1)
-                  (backingStoreAttached 1)
+                  (backingStoreAttached 0)
                   (children 1
                     (GraphicsLayer
-                      (position 10.00 300.00)
-                      (bounds 424.00 202.00)
+                      (bounds 256.00 1000.00)
                       (contentsOpaque 1)
-                      (drawsContent 1)
-                      (backingStoreAttached 0)
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds origin 0.00 1000.00)
-              (bounds 444.00 500.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (bounds 444.00 2810.00)
-                  (clips 1)
-                  (backingStoreAttached 1)
-                  (children 1
-                    (GraphicsLayer
-                      (position 10.00 802.00)
-                      (bounds 424.00 202.00)
-                      (contentsOpaque 1)
-                      (drawsContent 1)
                       (backingStoreAttached 1)
                     )
                   )
@@ -149,22 +94,27 @@
           (backingStoreAttached 1)
           (children 1
             (GraphicsLayer
-              (bounds origin 0.00 1000.00)
               (bounds 444.00 500.00)
               (clips 1)
               (backingStoreAttached 1)
               (children 1
                 (GraphicsLayer
-                  (bounds 444.00 2810.00)
-                  (clips 1)
-                  (backingStoreAttached 1)
+                  (bounds origin 0.00 1000.00)
+                  (backingStoreAttached 0)
                   (children 1
                     (GraphicsLayer
-                      (position 10.00 1304.00)
-                      (bounds 424.00 202.00)
-                      (contentsOpaque 1)
-                      (drawsContent 1)
+                      (bounds 444.00 2810.00)
+                      (clips 1)
                       (backingStoreAttached 1)
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 300.00)
+                          (bounds 424.00 202.00)
+                          (contentsOpaque 1)
+                          (drawsContent 1)
+                          (backingStoreAttached 0)
+                        )
+                      )
                     )
                   )
                 )
@@ -179,22 +129,27 @@
           (backingStoreAttached 1)
           (children 1
             (GraphicsLayer
-              (bounds origin 0.00 1000.00)
               (bounds 444.00 500.00)
               (clips 1)
               (backingStoreAttached 1)
               (children 1
                 (GraphicsLayer
-                  (bounds 444.00 2810.00)
-                  (clips 1)
-                  (backingStoreAttached 1)
+                  (bounds origin 0.00 1000.00)
+                  (backingStoreAttached 0)
                   (children 1
                     (GraphicsLayer
-                      (position 10.00 1806.00)
-                      (bounds 424.00 202.00)
-                      (contentsOpaque 1)
-                      (drawsContent 1)
-                      (backingStoreAttached 0)
+                      (bounds 444.00 2810.00)
+                      (clips 1)
+                      (backingStoreAttached 1)
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 802.00)
+                          (bounds 424.00 202.00)
+                          (contentsOpaque 1)
+                          (drawsContent 1)
+                          (backingStoreAttached 1)
+                        )
+                      )
                     )
                   )
                 )
@@ -209,22 +164,97 @@
           (backingStoreAttached 1)
           (children 1
             (GraphicsLayer
-              (bounds origin 0.00 1000.00)
               (bounds 444.00 500.00)
               (clips 1)
               (backingStoreAttached 1)
               (children 1
                 (GraphicsLayer
-                  (bounds 444.00 2810.00)
-                  (clips 1)
-                  (backingStoreAttached 1)
+                  (bounds origin 0.00 1000.00)
+                  (backingStoreAttached 0)
                   (children 1
                     (GraphicsLayer
-                      (position 10.00 2308.00)
-                      (bounds 424.00 202.00)
-                      (contentsOpaque 1)
-                      (drawsContent 1)
-                      (backingStoreAttached 0)
+                      (bounds 444.00 2810.00)
+                      (clips 1)
+                      (backingStoreAttached 1)
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 1304.00)
+                          (bounds 424.00 202.00)
+                          (contentsOpaque 1)
+                          (drawsContent 1)
+                          (backingStoreAttached 1)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 265.00 14.00)
+          (bounds 444.00 500.00)
+          (clips 1)
+          (backingStoreAttached 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 444.00 500.00)
+              (clips 1)
+              (backingStoreAttached 1)
+              (children 1
+                (GraphicsLayer
+                  (bounds origin 0.00 1000.00)
+                  (backingStoreAttached 0)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 444.00 2810.00)
+                      (clips 1)
+                      (backingStoreAttached 1)
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 1806.00)
+                          (bounds 424.00 202.00)
+                          (contentsOpaque 1)
+                          (drawsContent 1)
+                          (backingStoreAttached 0)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 265.00 14.00)
+          (bounds 444.00 500.00)
+          (clips 1)
+          (backingStoreAttached 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 444.00 500.00)
+              (clips 1)
+              (backingStoreAttached 1)
+              (children 1
+                (GraphicsLayer
+                  (bounds origin 0.00 1000.00)
+                  (backingStoreAttached 0)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 444.00 2810.00)
+                      (clips 1)
+                      (backingStoreAttached 1)
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 2308.00)
+                          (bounds 424.00 202.00)
+                          (contentsOpaque 1)
+                          (drawsContent 1)
+                          (backingStoreAttached 0)
+                        )
+                      )
                     )
                   )
                 )

--- a/LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/composited-absolute-in-absolute-in-relative-in-scroller-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/composited-absolute-in-absolute-in-relative-in-scroller-expected.txt
@@ -31,9 +31,13 @@
           (bounds 400.00 400.00)
           (children 1
             (GraphicsLayer
-              (position 34.00 134.00)
-              (bounds 220.00 220.00)
-              (contentsOpaque 1)
+              (children 1
+                (GraphicsLayer
+                  (position 34.00 134.00)
+                  (bounds 220.00 220.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/previous-sibling-prevents-inclusiveness-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/previous-sibling-prevents-inclusiveness-expected.txt
@@ -49,9 +49,13 @@
               (clips 1)
               (children 1
                 (GraphicsLayer
-                  (position 20.00 20.00)
-                  (bounds 256.00 24.00)
-                  (drawsContent 1)
+                  (children 1
+                    (GraphicsLayer
+                      (position 20.00 20.00)
+                      (bounds 256.00 24.00)
+                      (drawsContent 1)
+                    )
+                  )
                 )
               )
             )

--- a/Source/WebCore/platform/graphics/RoundedRect.cpp
+++ b/Source/WebCore/platform/graphics/RoundedRect.cpp
@@ -381,4 +381,14 @@ Region approximateAsRegion(const RoundedRect& roundedRect, unsigned stepLength)
     return region;
 }
 
+TextStream& operator<<(TextStream& ts, const RoundedRect& roundedRect)
+{
+    ts << roundedRect.rect();
+    ts.dumpProperty("top-left", roundedRect.radii().topLeft());
+    ts.dumpProperty("top-right", roundedRect.radii().topRight());
+    ts.dumpProperty("bottom-left", roundedRect.radii().bottomLeft());
+    ts.dumpProperty("bottom-right", roundedRect.radii().bottomRight());
+    return ts;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/RoundedRect.h
+++ b/Source/WebCore/platform/graphics/RoundedRect.h
@@ -134,6 +134,8 @@ inline bool operator==(const RoundedRect& a, const RoundedRect& b)
     return a.rect() == b.rect() && a.radii() == b.radii();
 }
 
+WTF::TextStream& operator<<(WTF::TextStream&, const RoundedRect&);
+
 // Snip away rectangles from corners, roughly one per step length of arc.
 WEBCORE_EXPORT Region approximateAsRegion(const RoundedRect&, unsigned stepLength = 20);
 

--- a/Source/WebCore/rendering/LayerAncestorClippingStack.h
+++ b/Source/WebCore/rendering/LayerAncestorClippingStack.h
@@ -40,9 +40,9 @@ namespace WebCore {
 class ScrollingCoordinator;
 
 struct CompositedClipData {
-    CompositedClipData(RenderLayer* layer, LayoutRect rect, bool isOverflowScrollEntry)
+    CompositedClipData(RenderLayer* layer, const RoundedRect& roundedRect, bool isOverflowScrollEntry)
         : clippingLayer(layer)
-        , clipRect(rect)
+        , clipRect(roundedRect)
         , isOverflowScroll(isOverflowScrollEntry)
     {
     }
@@ -60,7 +60,7 @@ struct CompositedClipData {
     }
 
     WeakPtr<RenderLayer> clippingLayer; // For scroller entries, the scrolling layer. For other entries, the most-descendant layer that has a clip.
-    LayoutRect clipRect; // In the coordinate system of the RenderLayer that owns the stack.
+    RoundedRect clipRect; // In the coordinate system of the RenderLayer that owns the stack.
     bool isOverflowScroll { false };
 };
 
@@ -85,14 +85,25 @@ public:
 
     void updateScrollingNodeLayers(ScrollingCoordinator&);
 
-    GraphicsLayer* firstClippingLayer() const;
-    GraphicsLayer* lastClippingLayer() const;
+    GraphicsLayer* firstLayer() const;
+    GraphicsLayer* lastLayer() const;
     ScrollingNodeID lastOverflowScrollProxyNodeID() const;
 
     struct ClippingStackEntry {
         CompositedClipData clipData;
         ScrollingNodeID overflowScrollProxyNodeID { 0 }; // The node for repositioning the scrolling proxy layer.
         RefPtr<GraphicsLayer> clippingLayer;
+        RefPtr<GraphicsLayer> scrollingLayer; // Only present for scrolling entries.
+
+        GraphicsLayer* parentForSublayers() const
+        {
+            return scrollingLayer ? scrollingLayer.get() : clippingLayer.get();
+        }
+        
+        GraphicsLayer* childForSuperlayers() const
+        {
+            return clippingLayer.get();
+        }
     };
 
     Vector<ClippingStackEntry>& stack() { return m_stack; }

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1178,7 +1178,7 @@ private:
 
     void setHasCompositingDescendant(bool b)  { m_hasCompositingDescendant = b; }
     void setHasCompositedNonContainedDescendants(bool value) { m_hasCompositedNonContainedDescendants = value; }
-    
+
     void setIndirectCompositingReason(IndirectCompositingReason reason) { m_indirectCompositingReason = static_cast<unsigned>(reason); }
     bool mustCompositeForIndirectReasons() const { return m_indirectCompositingReason; }
 
@@ -1234,8 +1234,8 @@ private:
     bool m_has3DTransformedDescendant : 1;  // Set on a stacking context layer that has 3D descendants anywhere
                                             // in a preserves3D hierarchy. Hint to do 3D-aware hit testing.
     bool m_hasCompositingDescendant : 1; // In the z-order tree.
+    bool m_hasCompositedNonContainedDescendants : 1; // Set when a layer has a composited descendant in z-order which is not a descendant in containing block order (e.g. opacity layer with an abspos descendant).
 
-    bool m_hasCompositedNonContainedDescendants : 1;
     bool m_hasCompositedScrollingAncestor : 1; // In the layer-order tree.
 
     bool m_hasFixedContainingBlockAncestor : 1;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1676,7 +1676,7 @@ void RenderLayerBacking::updateInternalHierarchy()
     GraphicsLayer* lastClippingLayer = nullptr;
     if (m_ancestorClippingStack) {
         connectClippingStackLayers(*m_ancestorClippingStack);
-        lastClippingLayer = m_ancestorClippingStack->lastClippingLayer();
+        lastClippingLayer = m_ancestorClippingStack->lastLayer();
     }
 
     constexpr size_t maxOrderedLayers = 5;
@@ -1979,24 +1979,42 @@ void RenderLayerBacking::ensureClippingStackLayers(LayerAncestorClippingStack& c
             entry.clippingLayer->setMasksToBounds(true);
             entry.clippingLayer->setPaintingPhase({ });
         }
+
+        if (entry.clipData.isOverflowScroll) {
+            if (!entry.scrollingLayer)
+                entry.scrollingLayer = createGraphicsLayer("scrolling proxy"_s);
+        } else if (entry.scrollingLayer)
+            GraphicsLayer::unparentAndClear(entry.scrollingLayer);
     }
 }
 
 void RenderLayerBacking::removeClippingStackLayers(LayerAncestorClippingStack& clippingStack)
 {
-    for (auto& entry : clippingStack.stack())
+    for (auto& entry : clippingStack.stack()) {
         GraphicsLayer::unparentAndClear(entry.clippingLayer);
+        GraphicsLayer::unparentAndClear(entry.scrollingLayer);
+    }
 }
 
 void RenderLayerBacking::connectClippingStackLayers(LayerAncestorClippingStack& clippingStack)
 {
+    auto connectEntryLayers = [](LayerAncestorClippingStack::ClippingStackEntry& entry) {
+        if (entry.scrollingLayer)
+            entry.clippingLayer->setChildren({ Ref { *entry.scrollingLayer } });
+    };
+
     auto& clippingEntryStack = clippingStack.stack();
     for (unsigned i = 0; i < clippingEntryStack.size() - 1; ++i) {
         auto& entry = clippingEntryStack.at(i);
-        entry.clippingLayer->setChildren({ Ref { *clippingEntryStack.at(i + 1).clippingLayer } });
+        connectEntryLayers(entry);
+
+        auto* entryParentForSublayers = entry.parentForSublayers();
+        auto* childLayer = clippingEntryStack.at(i + 1).childForSuperlayers();
+        entryParentForSublayers->setChildren({ Ref { *childLayer } });
     }
 
-    clippingEntryStack.last().clippingLayer->removeAllChildren();
+    connectEntryLayers(clippingEntryStack.last());
+    clippingEntryStack.last().parentForSublayers()->removeAllChildren();
 }
 
 void RenderLayerBacking::updateClippingStackLayerGeometry(LayerAncestorClippingStack& clippingStack, const RenderLayer* compositedAncestor, LayoutRect& parentGraphicsLayerRect)
@@ -2007,24 +2025,31 @@ void RenderLayerBacking::updateClippingStackLayerGeometry(LayerAncestorClippingS
 
     auto deviceScaleFactor = this->deviceScaleFactor();
     for (auto& entry : clippingStack.stack()) {
-        auto clipRect = entry.clipData.clipRect;
+        auto roundedClipRect = entry.clipData.clipRect;
+        auto clipRect = roundedClipRect.rect();
         LayoutSize clippingOffset = computeOffsetFromAncestorGraphicsLayer(compositedAncestor, clipRect.location() + offsetFromCompositedAncestor, deviceScaleFactor);
         LayoutRect snappedClippingLayerRect = snappedGraphicsLayer(clippingOffset, clipRect.size(), deviceScaleFactor).m_snappedRect;
-
-        entry.clippingLayer->setPosition(toLayoutPoint(snappedClippingLayerRect.location() - lastClipLayerRect.location()));
-        lastClipLayerRect = snappedClippingLayerRect;
-
+        
+        auto clippingLayerPosition = toLayoutPoint(snappedClippingLayerRect.location() - lastClipLayerRect.location());
+        entry.clippingLayer->setPosition(clippingLayerPosition);
         entry.clippingLayer->setSize(snappedClippingLayerRect.size());
+
+        clipRect.setLocation({ });
+        roundedClipRect.setRect(clipRect);
+        entry.clippingLayer->setContentsClippingRect(FloatRoundedRect(roundedClipRect));
+        entry.clippingLayer->setContentsRectClipsDescendants(true);
+
+        lastClipLayerRect = snappedClippingLayerRect;
 
         if (entry.clipData.isOverflowScroll) {
             ScrollOffset scrollOffset;
             if (auto* scrollableArea = entry.clipData.clippingLayer ? entry.clipData.clippingLayer->scrollableArea() : nullptr)
                 scrollOffset = scrollableArea->scrollOffset();
 
-            entry.clippingLayer->setBoundsOrigin(scrollOffset);
+            // scrollingLayer size and position are always 0,0.
+            entry.scrollingLayer->setBoundsOrigin(scrollOffset);
             lastClipLayerRect.moveBy(-scrollOffset);
-        } else
-            entry.clippingLayer->setBoundsOrigin({ });
+        }
     }
 
     parentGraphicsLayerRect = lastClipLayerRect;
@@ -3132,7 +3157,7 @@ GraphicsLayer* RenderLayerBacking::parentForSublayers() const
 GraphicsLayer* RenderLayerBacking::childForSuperlayers() const
 {
     if (m_ancestorClippingStack)
-        return m_ancestorClippingStack->firstClippingLayer();
+        return m_ancestorClippingStack->firstLayer();
 
     if (m_viewportAnchorLayer)
         return m_viewportAnchorLayer.get();

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1512,8 +1512,8 @@ void RenderLayerCompositor::adjustOverflowScrollbarContainerLayers(RenderLayer& 
             overflowBacking->ensureOverflowControlsHostLayerAncestorClippingStack(&stackingContextLayer);
 
         if (auto* overflowControlsAncestorClippingStack = overflowBacking->overflowControlsHostLayerAncestorClippingStack()) {
-            overflowControlsAncestorClippingStack->lastClippingLayer()->setChildren({ Ref { *overflowContainerLayer } });
-            overflowContainerLayer = overflowControlsAncestorClippingStack->firstClippingLayer();
+            overflowControlsAncestorClippingStack->lastLayer()->setChildren({ Ref { *overflowContainerLayer } });
+            overflowContainerLayer = overflowControlsAncestorClippingStack->firstLayer();
         }
 
         auto* lastDescendantGraphicsLayer = lastContainedDescendantBacking->childForSuperlayers();
@@ -1728,6 +1728,16 @@ void RenderLayerCompositor::layerStyleChanged(StyleDifference diff, RenderLayer&
                 layer.setNeedsPostLayoutCompositingUpdate();
 
             layer.setNeedsCompositingGeometryUpdate();
+        }
+    }
+
+    if (diff >= StyleDifference::Repaint && oldStyle) {
+        // This ensures that we update border-radius clips on layers that are descendants in containing-block order but not paint order. This is necessary even when
+        // the current layer is not composited.
+        bool changeAffectsClippingOfNonPaintOrderDescendants = !layer.isStackingContext() && layer.renderer().hasNonVisibleOverflow() && oldStyle->border() != newStyle.border();
+        if (changeAffectsClippingOfNonPaintOrderDescendants) {
+            if (auto* parent = layer.paintOrderParent())
+                parent->setChildrenNeedCompositingGeometryUpdate();
         }
     }
 
@@ -2916,11 +2926,14 @@ Vector<CompositedClipData> RenderLayerCompositor::computeAncestorClippingStack(c
         OptionSet<RenderLayer::ClipRectsOption> options;
         if (respectClip == RespectOverflowClip)
             options.add(RenderLayer::ClipRectsOption::RespectOverflowClip);
-        auto clipRect = clippedLayer.backgroundClipRect(RenderLayer::ClipRectsContext(&clippingRoot, TemporaryClipRects, options)).rect();
+
+        auto backgroundClip = clippedLayer.backgroundClipRect(RenderLayer::ClipRectsContext(&clippingRoot, TemporaryClipRects, options));
+        ASSERT(!backgroundClip.affectedByRadius());
+        auto clipRect = backgroundClip.rect();
         auto offset = layer.convertToLayerCoords(&clippingRoot, { }, RenderLayer::AdjustForColumns);
         clipRect.moveBy(-offset);
 
-        CompositedClipData clipData { const_cast<RenderLayer*>(&clippedLayer), clipRect, false };
+        CompositedClipData clipData { const_cast<RenderLayer*>(&clippedLayer), RoundedRect { clipRect }, false };
         newStack.insert(0, WTFMove(clipData));
     };
 
@@ -2936,17 +2949,32 @@ Vector<CompositedClipData> RenderLayerCompositor::computeAncestorClippingStack(c
         }
 
         if (isContainingBlockChain && ancestorLayer.renderer().hasClipOrNonVisibleOverflow()) {
+            auto* box = ancestorLayer.renderBox();
+            if (!box)
+                return AncestorTraversal::Continue;
+
             if (ancestorLayer.hasCompositedScrollableOverflow()) {
                 if (haveNonScrollableClippingIntermediateLayer) {
                     pushNonScrollableClip(*currentClippedLayer, ancestorLayer);
                     haveNonScrollableClippingIntermediateLayer = false;
                 }
 
-                auto clipRect = parentRelativeScrollableRect(ancestorLayer, &ancestorLayer);
+                auto clipRoundedRect = parentRelativeScrollableRect(ancestorLayer, &ancestorLayer);
                 auto offset = layer.convertToLayerCoords(&ancestorLayer, { }, RenderLayer::AdjustForColumns);
-                clipRect.moveBy(-offset);
+                clipRoundedRect.moveBy(-offset);
 
-                CompositedClipData clipData { const_cast<RenderLayer*>(&ancestorLayer), clipRect, true };
+                CompositedClipData clipData { const_cast<RenderLayer*>(&ancestorLayer), clipRoundedRect, true };
+                newStack.insert(0, WTFMove(clipData));
+                currentClippedLayer = &ancestorLayer;
+            } else if (box->hasNonVisibleOverflow() && box->style().hasBorderRadius()) {
+                auto clipRoundedRect = box->style().getRoundedInnerBorderFor(box->borderBoxRect());
+
+                auto offset = layer.convertToLayerCoords(&ancestorLayer, { }, RenderLayer::AdjustForColumns);
+                auto rect = clipRoundedRect.rect();
+                rect.moveBy(-offset);
+                clipRoundedRect.setRect(rect);
+
+                CompositedClipData clipData { const_cast<RenderLayer*>(&ancestorLayer), clipRoundedRect, false };
                 newStack.insert(0, WTFMove(clipData));
                 currentClippedLayer = &ancestorLayer;
             } else
@@ -4757,21 +4785,27 @@ ScrollingNodeID RenderLayerCompositor::updateScrollingNodeForViewportConstrained
     return newNodeID;
 }
 
-LayoutRect RenderLayerCompositor::parentRelativeScrollableRect(const RenderLayer& layer, const RenderLayer* ancestorLayer) const
+RoundedRect RenderLayerCompositor::parentRelativeScrollableRect(const RenderLayer& layer, const RenderLayer* ancestorLayer) const
 {
     // FIXME: ancestorLayer needs to be always non-null, so should become a reference.
     if (!ancestorLayer) {
         if (!layer.scrollableArea())
-            return LayoutRect();
-        return LayoutRect({ }, LayoutSize(layer.scrollableArea()->visibleSize()));
+            return RoundedRect { LayoutRect { } };
+        return RoundedRect { LayoutRect({ }, LayoutSize(layer.scrollableArea()->visibleSize())) };
     }
 
-    LayoutRect scrollableRect;
-    if (is<RenderBox>(layer.renderer()))
-        scrollableRect = downcast<RenderBox>(layer.renderer()).paddingBoxRect();
+    if (!is<RenderBox>(layer.renderer()))
+        return RoundedRect { LayoutRect { } };
 
-    auto offset = layer.convertToLayerCoords(ancestorLayer, scrollableRect.location()); // FIXME: broken for columns.
-    scrollableRect.setLocation(offset);
+    auto& box = downcast<RenderBox>(layer.renderer());
+    auto scrollableRect = RoundedRect { box.paddingBoxRect() };
+    if (box.style().hasBorderRadius())
+        scrollableRect = box.style().getRoundedInnerBorderFor(box.borderBoxRect());
+
+    auto offset = layer.convertToLayerCoords(ancestorLayer, scrollableRect.rect().location()); // FIXME: broken for columns.
+    auto rect = scrollableRect.rect();
+    rect.setLocation(offset);
+    scrollableRect.setRect(rect);
     return scrollableRect;
 }
 
@@ -4857,12 +4891,12 @@ ScrollingNodeID RenderLayerCompositor::updateScrollingNodeForScrollingProxyRole(
         }
         entry.overflowScrollProxyNodeID = nodeID;
 #if ENABLE(SCROLLING_THREAD)
-        if (entry.clippingLayer)
-            entry.clippingLayer->setScrollingNodeID(nodeID);
+        if (entry.scrollingLayer)
+            entry.scrollingLayer->setScrollingNodeID(nodeID);
 #endif
 
         if (changes & ScrollingNodeChangeFlags::Layer)
-            scrollingCoordinator->setNodeLayers(entry.overflowScrollProxyNodeID, { entry.clippingLayer.get() });
+            scrollingCoordinator->setNodeLayers(entry.overflowScrollProxyNodeID, { entry.scrollingLayer.get() });
 
         if (changes & ScrollingNodeChangeFlags::LayerGeometry) {
             ASSERT(entry.clipData.clippingLayer);

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -537,7 +537,7 @@ private:
     FixedPositionViewportConstraints computeFixedViewportConstraints(RenderLayer&) const;
     StickyPositionViewportConstraints computeStickyViewportConstraints(RenderLayer&) const;
 
-    LayoutRect parentRelativeScrollableRect(const RenderLayer&, const RenderLayer* ancestorLayer) const;
+    RoundedRect parentRelativeScrollableRect(const RenderLayer&, const RenderLayer* ancestorLayer) const;
 
     // Returns list of layers and their clip rects required to clip the given layer, which include clips in the
     // containing block chain between the given layer and its composited ancestor.


### PR DESCRIPTION
#### 97910542b25d8ccbabb97dc9f230461fd4a592e2
<pre>
border-radius clipping of composited layers doesn&apos;t work
<a href="https://bugs.webkit.org/show_bug.cgi?id=68196">https://bugs.webkit.org/show_bug.cgi?id=68196</a>
&lt;rdar://10133719&gt;

Reviewed by Alan Bujtas.

In CSS it&apos;s possible for clipping (via overflow:scroll, overflow:hidden and the `clip`
property) to apply to elements that are descendants in containing-block order, but
siblings in z-order, for example:
    &lt;div style=&quot;position: relative; overflow: hidden&quot;&gt;
      &lt;div style=&quot;position: absolute&quot;&gt;&lt;/div
    &lt;/div&gt;
If a non-z-order descendant here has a composited layer, we&apos;d fail to take border-radius
into account when clipping it.

In this layer configuration we fall into the &quot;AncestorClippingStack&quot; code path: the
descendant layer owns a stack of clips that represent clipping by non-paint-order
ancestors. Previously, all overflow:hidden clips were simply intersected and represented
as a single rectangular clipping GraphicsLayer, but when border-radius is present on
some or all of them, we need to maintain a layer for each, since you can&apos;t trivially
generate a path that is the intersection of rounded rects. Code was added to
RenderLayerCompositor::computeAncestorClippingStack() to do this.

When an intermediate clip with border radius represents a scrollable elements (i.e.
scrollable overflow), its corresponding entry in the ancestor clipping stack needs two
layers; one to apply the clipping, which doesn&apos;t scroll with the content, and one that
applies the scroll offset, so ClippingStackEntry gains a scrollingLayer, which is the
one handed off to the scrolling tree, and the rounded clip is applied to the clipping
layer. Logic is added to build the hierarchy of these layers.

When style changes we have to ensure that layers are updated with the new rounded rects;
notably, style can change on a non-composited RenderLayer (e.g. an overflow:hidden layer
with border-radius) which requires that non-z-order descendants need to update their
composited layer geometry; new code in RenderLayerCompositor::layerStyleChanged() takes
care of this. Tested by
compositing/clipping/border-radius-with-composited-descendant-dynamic.html

* LayoutTests/compositing/clipping/border-radius-async-overflow-non-stacking.html:
* LayoutTests/compositing/clipping/border-radius-with-composited-descendant-dynamic-expected.html: Added.
* LayoutTests/compositing/clipping/border-radius-with-composited-descendant-dynamic.html: Added.
* LayoutTests/compositing/clipping/border-radius-with-composited-descendant-expected.html: Added.
* LayoutTests/compositing/clipping/border-radius-with-composited-descendant-nested-expected.html: Added.
* LayoutTests/compositing/clipping/border-radius-with-composited-descendant-nested.html: Added.
* LayoutTests/compositing/clipping/border-radius-with-composited-descendant.html: Added.
* LayoutTests/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt:
* LayoutTests/compositing/layer-creation/clipping-scope/overlap-constrained-inside-scroller-expected.txt:
* LayoutTests/compositing/layer-creation/clipping-scope/scroller-with-negative-z-children-expected.txt:
* LayoutTests/compositing/overflow/scrolling-content-clip-to-viewport-expected.txt:
* LayoutTests/compositing/rtl/rtl-scrolling-with-transformed-descendants-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-clipped-by-scroll-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-nested-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-for-negative-z-in-scroller-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-clip-to-hidden-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-clip-to-visible-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-gain-clipping-layer-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-in-clipped-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-lose-clipping-layer-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/nested-scrollers-backing-attachment-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/overlapped-overlay-scrollbar-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/overlapped-overlay-scrollbar-inside-hidden-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/overlapped-overlay-scrollbar-nested-expected.txt:
* LayoutTests/compositing/shared-backing/overflow-scroll/composited-absolute-in-absolute-in-relative-in-scroller-expected.txt:
* LayoutTests/compositing/shared-backing/overflow-scroll/previous-sibling-prevents-inclusiveness-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/overlap-constrained-inside-scroller-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/scroller-with-negative-z-children-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-clipped-by-scroll-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-nested-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-for-negative-z-in-scroller-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-clip-to-hidden-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-clip-to-visible-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-gain-clipping-layer-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-in-clipped-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/layer-in-overflow-lose-clipping-layer-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/nested-scrollers-backing-attachment-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/composited-absolute-in-absolute-in-relative-in-scroller-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/previous-sibling-prevents-inclusiveness-expected.txt:
* Source/WebCore/platform/graphics/RoundedRect.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/RoundedRect.h:
* Source/WebCore/rendering/LayerAncestorClippingStack.cpp:
(WebCore::LayerAncestorClippingStack::LayerAncestorClippingStack):
(WebCore::LayerAncestorClippingStack::firstLayer const):
(WebCore::LayerAncestorClippingStack::lastLayer const):
(WebCore::LayerAncestorClippingStack::updateScrollingNodeLayers):
(WebCore::LayerAncestorClippingStack::updateWithClipData):
(WebCore::operator&lt;&lt;):
(WebCore::LayerAncestorClippingStack::firstClippingLayer const): Deleted.
(WebCore::LayerAncestorClippingStack::lastClippingLayer const): Deleted.
* Source/WebCore/rendering/LayerAncestorClippingStack.h:
(WebCore::CompositedClipData::CompositedClipData):
(WebCore::LayerAncestorClippingStack::ClippingStackEntry::parentForSublayers const):
(WebCore::LayerAncestorClippingStack::ClippingStackEntry::childForSuperlayers const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateInternalHierarchy):
(WebCore::RenderLayerBacking::ensureClippingStackLayers):
(WebCore::RenderLayerBacking::removeClippingStackLayers):
(WebCore::RenderLayerBacking::connectClippingStackLayers):
(WebCore::RenderLayerBacking::updateClippingStackLayerGeometry):
(WebCore::RenderLayerBacking::childForSuperlayers const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::adjustOverflowScrollbarContainerLayers):
(WebCore::RenderLayerCompositor::layerStyleChanged):
(WebCore::RenderLayerCompositor::computeAncestorClippingStack const):
(WebCore::RenderLayerCompositor::parentRelativeScrollableRect const):
(WebCore::RenderLayerCompositor::updateScrollingNodeForScrollingProxyRole):
* Source/WebCore/rendering/RenderLayerCompositor.h:

Canonical link: <a href="https://commits.webkit.org/254253@main">https://commits.webkit.org/254253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee7713b677fe644cdedfe4b73962defd0a3e9827

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97666 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153145 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31507 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27110 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80684 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92320 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25020 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75400 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24980 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79908 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67943 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29125 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/29092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15015 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2990 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32350 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37939 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34124 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->