### PR TITLE
[git-webkit] Add track command

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.5.0',
+    version='5.6.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 5, 0)
+version = Version(5, 6, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -45,6 +45,7 @@ from .pull_request import PullRequest
 from .revert import Revert
 from .setup_git_svn import SetupGitSvn
 from .setup import Setup
+from .track import Track
 
 from webkitcorepy import arguments, log as webkitcorepy_log
 from webkitscmpy import local, log, remote
@@ -83,7 +84,7 @@ def main(
         Clean, Find, Info, Land, Log, Pull,
         PullRequest, Revert, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,
-        Pickable, CherryPick,
+        Pickable, CherryPick, Track,
     ]
     if subversion:
         programs.append(SetupGitSvn)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/track.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/track.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import re
+import sys
+
+from .command import Command
+from webkitcorepy import arguments, run
+from webkitscmpy import log, local
+
+
+class Track(Command):
+    name = 'track'
+    help = 'Track a specific remote branch (or branches) in your local checkout'
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            'arguments', nargs='+',
+            type=str, default=None,
+            help='String representation(s) of a branch to be tracked locally',
+        )
+        parser.add_argument(
+            '--fetch', '--no-fetch', '-f',
+            dest='fetch', default=None,
+            help='Fetch canonical remotes before determining which remote defines a branch',
+            action=arguments.NoAction,
+        )
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        if not repository:
+            sys.stderr.write('No repository provided\n')
+            return 1
+        if not isinstance(repository, local.Git):
+            sys.stderr.write("Can only 'track' branches in a git checkout\n")
+            return 1
+
+        code = 0
+        if 'all' in args.arguments:
+            args.fetch = True if args.fetch is None else args.fetch
+
+        if args.fetch:
+            for remote in repository.source_remotes():
+                log.info("Fetching '{}'...".format(remote))
+                result = run(
+                    [repository.executable(), 'fetch', remote, '--prune'],
+                    capture_output=True, cwd=repository.root_path, encoding='utf-8',
+                )
+                code += result.returncode
+                if result.returncode:
+                    sys.stderr.write(result.stderr)
+
+        if 'all' in args.arguments:
+            args.arguments.remove('all')
+            branches = set()
+            for remote in repository.source_remotes():
+                branches_for = repository.branches_for(remote=remote)
+                log.info("Adding {} branches from '{}'...".format(len(branches_for), remote))
+                for branch in branches_for:
+                    branches.add(branch)
+            args.arguments += list(branches)
+
+        for arg in args.arguments:
+            remote = repository.remote_for(arg)
+            if not remote:
+                sys.stderr.write("No remote for '{}' found\n".format(arg))
+                continue
+            print("Tracking '{}' via 'remotes/{}'".format(arg, remote))
+            result = run([
+                repository.executable(), 'branch',
+                '--set-upstream-to' if arg in repository.branches_for(remote=False) else '--track',
+                arg, '{}/{}'.format(remote, arg),
+            ], capture_output=True, encoding='utf-8', cwd=repository.root_path)
+            code += result.returncode
+            if result.returncode:
+                sys.stderr.write(result.stderr)
+
+        return code

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -540,7 +540,7 @@ CommitDate: {time_c}
             'origin': 'git@github.example.com:WebKit/WebKit.git',
             'fork': 'git@github.example.com:Contributor/WebKit.git',
             'security': 'git@github.example.com:WebKit/WebKit-security.git',
-            'fork-security': 'git@github.example.com:Contributor/WebKit-security.git',
+            'security-fork': 'git@github.example.com:Contributor/WebKit-security.git',
         }), OutputCapture():
             project_config = os.path.join(self.path, 'metadata', local.Git.GIT_CONFIG_EXTENSION)
             os.mkdir(os.path.dirname(project_config))
@@ -550,6 +550,10 @@ CommitDate: {time_c}
                 f.write('    security = git@github.example.com:WebKit/WebKit-security.git\n')
 
             self.assertEqual(local.Git(self.path).source_remotes(), ['origin', 'security'])
+            self.assertEqual(
+                local.Git(self.path).source_remotes(personal=True),
+                ['origin', 'security', 'fork', 'security-fork'],
+            )
 
     def test_files_changed(self):
         with mocks.local.Git(self.path), OutputCapture():

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/track_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/track_unittest.py
@@ -1,0 +1,119 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import time
+import sys
+
+from datetime import datetime
+
+from webkitcorepy import OutputCapture, Terminal, testing
+from webkitcorepy.mocks import Time as MockTime
+from webkitscmpy import local, program, mocks, Commit
+
+
+class TestTrack(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def setUp(self):
+        super(TestTrack, self).setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    def test_none(self):
+        with OutputCapture() as captured, mocks.local.Git(), mocks.local.Svn(), MockTime, Terminal.override_atty(sys.stdin, isatty=False):
+            self.assertEqual(1, program.main(
+                args=('track', 'main'),
+                path=self.path,
+            ))
+
+        self.assertEqual(captured.stderr.getvalue(), 'No repository provided\n')
+
+    def test_main(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn(), MockTime, Terminal.override_atty(sys.stdin, isatty=False):
+            self.assertEqual(0, program.main(
+                args=('track', 'main'),
+                path=self.path,
+            ))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Tracking 'main' via 'remotes/origin'\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_branch(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path, remotes={
+            'origin': 'git@github.example.com:WebKit/WebKit.git',
+            'fork': 'git@github.example.com:Contributor/WebKit.git',
+            'security': 'git@github.example.com:WebKit/WebKit-security.git',
+            'security-fork': 'git@github.example.com:Contributor/WebKit-security.git',
+        }) as mocked, mocks.local.Svn(), MockTime, Terminal.override_atty(sys.stdin, isatty=False):
+            mocked.remotes['security/hidden-branch'] = [mocked.commits[mocked.branch][-1]]
+            mocked.remotes['security-fork/hidden-branch'] = [mocked.commits[mocked.branch][-1]]
+
+            project_config = os.path.join(self.path, 'metadata', local.Git.GIT_CONFIG_EXTENSION)
+            os.mkdir(os.path.dirname(project_config))
+            with open(project_config, 'w') as f:
+                f.write('[webkitscmpy "remotes"]\n')
+                f.write('    origin = git@github.example.com:WebKit/WebKit.git\n')
+                f.write('    security = git@github.example.com:WebKit/WebKit-security.git\n')
+
+            self.assertEqual(0, program.main(
+                args=('track', 'hidden-branch'),
+                path=self.path,
+            ))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Tracking 'hidden-branch' via 'remotes/security'\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_eng_branch(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path, remotes={
+            'origin': 'git@github.example.com:WebKit/WebKit.git',
+            'fork': 'git@github.example.com:Contributor/WebKit.git',
+            'security': 'git@github.example.com:WebKit/WebKit-security.git',
+            'security-fork': 'git@github.example.com:Contributor/WebKit-security.git',
+        }) as mocked, mocks.local.Svn(), MockTime, Terminal.override_atty(sys.stdin, isatty=False):
+            mocked.remotes['security/hidden-branch'] = [mocked.commits[mocked.branch][-1]]
+            mocked.remotes['security-fork/hidden-branch'] = [mocked.commits[mocked.branch][-1]]
+            mocked.remotes['security-fork/eng/hidden'] = [mocked.commits[mocked.branch][-1]]
+
+            project_config = os.path.join(self.path, 'metadata', local.Git.GIT_CONFIG_EXTENSION)
+            os.mkdir(os.path.dirname(project_config))
+            with open(project_config, 'w') as f:
+                f.write('[webkitscmpy "remotes"]\n')
+                f.write('    origin = git@github.example.com:WebKit/WebKit.git\n')
+                f.write('    security = git@github.example.com:WebKit/WebKit-security.git\n')
+
+            self.assertEqual(0, program.main(
+                args=('track', 'eng/hidden'),
+                path=self.path,
+            ))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Tracking 'eng/hidden' via 'remotes/security-fork'\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')


### PR DESCRIPTION
#### 6d76fa93cb36ae7475b93c07eaac86f05ba6d237
<pre>
[git-webkit] Add track command
<a href="https://bugs.webkit.org/show_bug.cgi?id=244510">https://bugs.webkit.org/show_bug.cgi?id=244510</a>
&lt;rdar://problem/99294417&gt;

Rubber-stamped by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.source_remotes): Support personal remotes.
(Git.checkout): Track a specific branch on the correct remote.
(Git.remote_for): Determine the correct remote to use for a given branch.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py: Add more support
for basic remote commands.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py: Add Track command.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/track.py: Added.
(Track): Add command which will track a given branch using the branch&apos;s canonical remote.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/track_unittest.py: Added.
(TestTrack.setUp):
(TestTrack.test_none):
(TestTrack.test_main):
(TestTrack.test_branch):
(TestTrack.test_eng_branch):

Canonical link: <a href="https://commits.webkit.org/254078@main">https://commits.webkit.org/254078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2578b963fa32f92d5c2610cfbe8374794189f2a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87960 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/69/builds/32096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/18673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/97110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/152580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/91929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30474 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/80054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/91856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93571 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/74634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/80054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/91567 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/18673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/80054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/28141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/18673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/87027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/28238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/18673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/31262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/74634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1173 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/30211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/18673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->