### PR TITLE
Print AIR in WASM BBQ disassembly

### DIFF
--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -57,6 +57,8 @@ namespace DFG {
 struct OSRExit;
 }
 
+#define JIT_COMMENT(jit, ...) do { if (UNLIKELY(Options::dumpDisassembly())) { (jit).comment(__VA_ARGS__); } else { (void) jit; } } while (0);
+
 class AbstractMacroAssemblerBase {
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -480,9 +480,10 @@ void LinkBuffer::linkComments(MacroAssembler& assembler)
     for (const auto& [label, str] : assembler.m_comments) {
         void* commentLocation = locationOf<DisassemblyPtrTag>(label).dataLocation();
         auto key = reinterpret_cast<uintptr_t>(commentLocation);
-        RELEASE_ASSERT(!map.contains(reinterpret_cast<uintptr_t>(commentLocation)), 
-            "You cannot print more than one comment on the same line.");
-        map.add(key, str.isolatedCopy());
+        String strCopy = str.isolatedCopy();
+        if (map.contains(key))
+            strCopy = map.get(key).isolatedCopy() + "\n; " + strCopy;
+        map.set(key, WTFMove(strCopy));
     }
 
     AssemblyCommentRegistry::singleton().registerCodeRange(m_executableMemory->start().untaggedPtr(), m_executableMemory->end().untaggedPtr(), WTFMove(map));

--- a/Source/JavaScriptCore/b3/B3Common.cpp
+++ b/Source/JavaScriptCore/b3/B3Common.cpp
@@ -42,7 +42,7 @@ bool shouldDumpIR(Procedure& procedure, B3CompilationMode mode)
         return true;
 
 #if ENABLE(FTL_JIT)
-    return FTL::verboseCompilationEnabled() || FTL::shouldDumpDisassembly() || shouldDumpIRAtEachPhase(mode);
+    return FTL::verboseCompilationEnabled() || shouldDumpIRAtEachPhase(mode);
 #else
     return shouldDumpIRAtEachPhase(mode);
 #endif

--- a/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
@@ -34,6 +34,8 @@
 #include "B3StackmapGenerationParams.h"
 #include "B3ValueInlines.h"
 
+#include <wtf/ListDump.h>
+
 namespace JSC { namespace B3 {
 
 using Arg = Air::Arg;
@@ -162,6 +164,7 @@ MacroAssembler::Jump PatchpointSpecial::generate(Inst& inst, CCallHelpers& jit, 
     offset += value->numChildren();
 
     StackmapGenerationParams params(value, reps, context);
+    JIT_COMMENT(jit, "Patchpoint body start, with arg value reps: ", listDump(reps));
 
     for (unsigned i = value->numGPScratchRegisters; i--;)
         params.m_gpScratch.append(inst.args[offset++].gpr());

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -730,7 +730,21 @@ private:
 
     NO_RETURN_DUE_TO_CRASH static void badKind(Kind, unsigned);
 
+#if ASSERT_ENABLED
+    String m_compilerConstructionSite { generateCompilerConstructionSite() };
+
+    static String generateCompilerConstructionSite();
+#endif
+
 public:
+    String compilerConstructionSite() const
+    {
+#if ASSERT_ENABLED
+        return m_compilerConstructionSite;
+#endif
+        return "[(assertions are disabled)]"_s;
+    }
+
     BasicBlock* owner { nullptr }; // computed by Procedure::resetValueOwners().
 };
 

--- a/Source/JavaScriptCore/disassembler/X86Disassembler.cpp
+++ b/Source/JavaScriptCore/disassembler/X86Disassembler.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(ZYDIS)
 
+#include "AssemblyComments.h"
 #include "MacroAssemblerCodeRef.h"
 #include "Zydis.h"
 
@@ -53,9 +54,13 @@ bool tryToDisassemble(const CodePtr<DisassemblyPtrTag>& codePtr, size_t size, vo
     char formatted[1024];
     while (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder, data + offset, size - offset, &instruction))) {
         if (ZYAN_SUCCESS(ZydisFormatterFormatInstruction(&formatter, &instruction, formatted, sizeof(formatted), bitwise_cast<unsigned long long>(data + offset))))
-            out.printf("%s%#16llx: %s\n", prefix, static_cast<unsigned long long>(bitwise_cast<uintptr_t>(data + offset)), formatted);
+            out.printf("%s%#16llx: %s", prefix, static_cast<unsigned long long>(bitwise_cast<uintptr_t>(data + offset)), formatted);
         else
-            out.printf("%s%#16llx: failed-to-format\n", prefix, static_cast<unsigned long long>(bitwise_cast<uintptr_t>(data + offset)));
+            out.printf("%s%#16llx: failed-to-format", prefix, static_cast<unsigned long long>(bitwise_cast<uintptr_t>(data + offset)));
+        if (auto str = AssemblyCommentRegistry::singleton().comment(reinterpret_cast<void*>(static_cast<unsigned long long>(bitwise_cast<uintptr_t>(data + offset)))))
+            out.printf("; %s\n", str->ascii().data());
+        else
+            out.printf("\n");
         offset += instruction.length;
     }
 

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -214,7 +214,7 @@ void AssemblyHelpers::jitAssertArgumentCountSane()
 
 void AssemblyHelpers::jitAssertCodeBlockOnCallFrameWithType(GPRReg scratchGPR, JITType type)
 {
-    comment("jitAssertCodeBlockOnCallFrameWithType | ", scratchGPR, " = callFrame->codeBlock->jitCode->jitType == ", type);
+    JIT_COMMENT(*this, "jitAssertCodeBlockOnCallFrameWithType | ", scratchGPR, " = callFrame->codeBlock->jitCode->jitType == ", type);
     emitGetFromCallFrameHeaderPtr(CallFrameSlot::codeBlock, scratchGPR);
     loadPtr(Address(scratchGPR, CodeBlock::jitCodeOffset()), scratchGPR);
     load8(Address(scratchGPR, JITCode::offsetOfJITType()), scratchGPR);
@@ -228,17 +228,17 @@ void AssemblyHelpers::jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame
     if (block.codeType() != FunctionCode)
         return;
     auto kind = block.isConstructor() ? CodeForConstruct : CodeForCall;
-    comment("jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame with code block type: ", kind, " | ", scratchGPR, " = callFrame->callee->executableOrRareData");
+    JIT_COMMENT(*this, "jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame with code block type: ", kind, " | ", scratchGPR, " = callFrame->callee->executableOrRareData");
 
     emitGetFromCallFrameHeaderPtr(CallFrameSlot::callee, scratchGPR);
     loadPtr(Address(scratchGPR, JSFunction::offsetOfExecutableOrRareData()), scratchGPR);
     auto hasExecutable = branchTestPtr(Zero, scratchGPR, TrustedImm32(JSFunction::rareDataTag));
     loadPtr(Address(scratchGPR, FunctionRareData::offsetOfExecutable() - JSFunction::rareDataTag), scratchGPR);
     hasExecutable.link(this);
-    comment(scratchGPR, " = (", scratchGPR, ": Executable)->codeBlock");
+    JIT_COMMENT(*this, scratchGPR, " = (", scratchGPR, ": Executable)->codeBlock");
     loadPtr(Address(scratchGPR, FunctionExecutable::offsetOfCodeBlockFor(kind)), scratchGPR);
 
-    comment(scratchGPR2, " = callFrame->codeBlock");
+    JIT_COMMENT(*this, scratchGPR2, " = callFrame->codeBlock");
     emitGetFromCallFrameHeaderPtr(CallFrameSlot::codeBlock, scratchGPR2);
     Jump ok = branch32(Equal, scratchGPR, scratchGPR2);
     abortWithReason(AHInvalidCodeBlock);
@@ -672,6 +672,7 @@ void AssemblyHelpers::restoreCalleeSavesFromEntryFrameCalleeSavesBuffer(EntryFra
     RegisterAtOffsetList* allCalleeSaves = RegisterSet::vmCalleeSaveRegisterOffsets();
     RegisterSet dontRestoreRegisters = RegisterSet::stackRegisters();
     unsigned registerCount = allCalleeSaves->registerCount();
+    JIT_COMMENT(*this, "restoreCalleeSavesFromEntryFrameCalleeSavesBuffer ", *allCalleeSaves, " skip: ", dontRestoreRegisters);
 
     GPRReg scratch = InvalidGPRReg;
     unsigned scratchGPREntryIndex = 0;
@@ -758,6 +759,7 @@ void AssemblyHelpers::restoreCalleeSavesFromVMEntryFrameCalleeSavesBufferImpl(GP
     addPtr(TrustedImm32(EntryFrame::calleeSaveRegistersBufferOffset()), entryFrameGPR);
 
     RegisterAtOffsetList* allCalleeSaves = RegisterSet::vmCalleeSaveRegisterOffsets();
+    JIT_COMMENT(*this, "restoreCalleeSavesFromVMEntryFrameCalleeSavesBufferImpl ", entryFrameGPR, " callee saves: ", *allCalleeSaves, " skip: ", skipList);
     unsigned registerCount = allCalleeSaves->registerCount();
 
     LoadRegSpooler spooler(*this, entryFrameGPR);
@@ -1056,6 +1058,7 @@ AssemblyHelpers::JumpList AssemblyHelpers::branchIfValue(VM& vm, JSValueRegs val
 #if ENABLE(WEBASSEMBLY)
 void AssemblyHelpers::loadWasmContextInstance(GPRReg dst)
 {
+    JIT_COMMENT(*this, "Load wasm context instance to ", dst);
 #if ENABLE(FAST_TLS_JIT)
     if (Wasm::Context::useFastTLS()) {
         loadFromTLSPtr(fastTLSOffsetForKey(WTF_WASM_CONTEXT_KEY), dst);
@@ -1063,10 +1066,12 @@ void AssemblyHelpers::loadWasmContextInstance(GPRReg dst)
     }
 #endif
     move(Wasm::PinnedRegisterInfo::get().wasmContextInstancePointer, dst);
+    JIT_COMMENT(*this, "Load wasm instance done");
 }
 
 void AssemblyHelpers::storeWasmContextInstance(GPRReg src)
 {
+    JIT_COMMENT(*this, "Store wasm context instance from", src);
 #if ENABLE(FAST_TLS_JIT)
     if (Wasm::Context::useFastTLS()) {
         storeToTLSPtr(src, fastTLSOffsetForKey(WTF_WASM_CONTEXT_KEY));
@@ -1074,6 +1079,7 @@ void AssemblyHelpers::storeWasmContextInstance(GPRReg src)
     }
 #endif
     move(src, Wasm::PinnedRegisterInfo::get().wasmContextInstancePointer);
+    JIT_COMMENT(*this, "Store wasm context instance done");
 }
 
 bool AssemblyHelpers::loadWasmContextInstanceNeedsMacroScratchRegister()
@@ -1098,6 +1104,7 @@ bool AssemblyHelpers::storeWasmContextInstanceNeedsMacroScratchRegister()
 
 void AssemblyHelpers::debugCall(VM& vm, V_DebugOperation_EPP function, void* argument)
 {
+    JIT_COMMENT(*this, "debugCall");
     size_t scratchSize = sizeof(EncodedJSValue) * (GPRInfo::numberOfRegisters + FPRInfo::numberOfRegisters);
     ScratchBuffer* scratchBuffer = vm.scratchBufferForSize(scratchSize);
     EncodedJSValue* buffer = static_cast<EncodedJSValue*>(scratchBuffer->dataBuffer());
@@ -1142,6 +1149,7 @@ void AssemblyHelpers::debugCall(VM& vm, V_DebugOperation_EPP function, void* arg
 
 void AssemblyHelpers::copyCalleeSavesToEntryFrameCalleeSavesBufferImpl(GPRReg calleeSavesBuffer)
 {
+    JIT_COMMENT(*this, "copyCalleeSavesToEntryFrameCalleeSavesBufferImpl ", calleeSavesBuffer);
 #if NUMBER_OF_CALLEE_SAVES_REGISTERS > 0
     addPtr(TrustedImm32(EntryFrame::calleeSaveRegistersBufferOffset()), calleeSavesBuffer);
 
@@ -1255,6 +1263,7 @@ void AssemblyHelpers::cageConditionallyAndUntag(Gigacage::Kind kind, GPRReg stor
 
 void AssemblyHelpers::emitSave(const RegisterAtOffsetList& list)
 {
+    JIT_COMMENT(*this, "emitSave ", list);
     StoreRegSpooler spooler(*this, framePointerRegister);
 
     size_t registerCount = list.registerCount();
@@ -1274,6 +1283,7 @@ void AssemblyHelpers::emitSave(const RegisterAtOffsetList& list)
 
 void AssemblyHelpers::emitRestore(const RegisterAtOffsetList& list)
 {
+    JIT_COMMENT(*this, "emitRestore ", list);
     LoadRegSpooler spooler(*this, framePointerRegister);
 
     size_t registerCount = list.registerCount();
@@ -1295,6 +1305,7 @@ void AssemblyHelpers::emitSaveCalleeSavesFor(const RegisterAtOffsetList* calleeS
 {
     RegisterSet dontSaveRegisters = RegisterSet(RegisterSet::stackRegisters());
     unsigned registerCount = calleeSaves->registerCount();
+    JIT_COMMENT(*this, "emitSaveCalleeSavesFor ", *calleeSaves, " dontRestore: ", dontSaveRegisters);
 
     StoreRegSpooler spooler(*this, framePointerRegister);
 
@@ -1321,6 +1332,7 @@ void AssemblyHelpers::emitRestoreCalleeSavesFor(const RegisterAtOffsetList* call
 {
     RegisterSet dontRestoreRegisters = RegisterSet(RegisterSet::stackRegisters());
     unsigned registerCount = calleeSaves->registerCount();
+    JIT_COMMENT(*this, "emitRestoreCalleeSavesFor ", *calleeSaves, " dontSave: ", dontRestoreRegisters);
     
     LoadRegSpooler spooler(*this, framePointerRegister);
 

--- a/Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h
@@ -94,6 +94,9 @@ public:
     void execute(const RegisterAtOffset& entry)
     {
         RELEASE_ASSERT(RegDispatch<RegType>::hasSameType(entry.reg()));
+        auto& jit = m_jit;
+        JIT_COMMENT(jit, "Execute Spooler: ", entry);
+
         if constexpr (!hasPairOp)
             return op().executeSingle(entry.offset(), RegDispatch<RegType>::get(entry.reg()));
 

--- a/Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp
@@ -101,6 +101,8 @@ ScratchRegisterAllocator::PreservedState ScratchRegisterAllocator::preserveReuse
     if (!didReuseRegisters())
         return PreservedState(0, extraStackSpace);
 
+    JIT_COMMENT(jit, "preserveReusedRegistersByPushing");
+
     RegisterSet registersToSpill;
     for (unsigned i = 0; i < FPRInfo::numberOfRegisters; ++i) {
         FPRReg reg = FPRInfo::toRegister(i);
@@ -126,6 +128,8 @@ void ScratchRegisterAllocator::restoreReusedRegistersByPopping(AssemblyHelpers& 
     RELEASE_ASSERT(preservedState);
     if (!didReuseRegisters())
         return;
+    
+    JIT_COMMENT(jit, "restoreReusedRegistersByPopping");
 
     RegisterSet registersToFill;
     for (unsigned i = GPRInfo::numberOfRegisters; i--;) {
@@ -165,6 +169,7 @@ unsigned ScratchRegisterAllocator::preserveRegistersToStackForCall(AssemblyHelpe
     RELEASE_ASSERT(extraBytesAtTopOfStack % sizeof(void*) == 0);
     if (!usedRegisters.numberOfSetRegisters())
         return 0;
+    JIT_COMMENT(jit, "Preserve registers to stack for call: ", usedRegisters, "; Extra bytes at top of stack: ", extraBytesAtTopOfStack);
     
     unsigned stackOffset = (usedRegisters.numberOfSetRegisters()) * sizeof(EncodedJSValue);
     stackOffset += extraBytesAtTopOfStack;
@@ -204,6 +209,8 @@ void ScratchRegisterAllocator::restoreRegistersFromStackForCall(AssemblyHelpers&
         RELEASE_ASSERT(numberOfStackBytesUsedForRegisterPreservation == 0);
         return;
     }
+
+    JIT_COMMENT(jit, "Restore registers from stack for call: ", usedRegisters, "; Extra bytes at top of stack: ", extraBytesAtTopOfStack);
 
     AssemblyHelpers::LoadRegSpooler spooler(jit, MacroAssembler::stackPointerRegister);
 

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.h
@@ -79,6 +79,7 @@ public:
 
 private:
     bool prepareImpl() final;
+    void dumpDisassembly(CompilationContext&, LinkBuffer&);
     void compileFunction(uint32_t functionIndex) final;
     void didCompleteCompilation() WTF_REQUIRES_LOCK(m_lock) final;
 

--- a/Source/JavaScriptCore/wasm/WasmThunks.cpp
+++ b/Source/JavaScriptCore/wasm/WasmThunks.cpp
@@ -43,6 +43,7 @@ namespace JSC { namespace Wasm {
 MacroAssemblerCodeRef<JITThunkPtrTag> throwExceptionFromWasmThunkGenerator(const AbstractLocker&)
 {
     CCallHelpers jit;
+    JIT_COMMENT(jit, "throwExceptionFromWasmThunkGenerator");
 
     // The thing that jumps here must move ExceptionType into the argumentGPR1 before jumping here.
     // We're allowed to use temp registers here. We are not allowed to use callee saves.
@@ -64,6 +65,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> throwExceptionFromWasmThunkGenerator(const
 MacroAssemblerCodeRef<JITThunkPtrTag> throwStackOverflowFromWasmThunkGenerator(const AbstractLocker& locker)
 {
     CCallHelpers jit;
+    JIT_COMMENT(jit, "throwStackOverflowFromWasmThunkGenerator");
 
     int32_t stackSpace = WTF::roundUpToMultipleOf(stackAlignmentBytes(), RegisterSet::calleeSaveRegisters().numberOfSetRegisters() * sizeof(Register));
     ASSERT(static_cast<unsigned>(stackSpace) < Options::softReservedZoneSize());
@@ -80,6 +82,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> triggerOMGEntryTierUpThunkGenerator(const 
 {
     // We expect that the user has already put the function index into GPRInfo::argumentGPR1
     CCallHelpers jit;
+    JIT_COMMENT(jit, "triggerOMGEntryTierUpThunkGenerator");
 
     jit.emitFunctionPrologue();
 

--- a/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
+++ b/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
@@ -253,6 +253,15 @@ struct Type {
         return static_cast<bool>(nullable);
     }
 
+    void dump(PrintStream& out) const
+    {
+        switch (kind) {
+        #define CREATE_CASE(name, ...) case TypeKind::name: out.print(#name); break;
+        FOR_EACH_WASM_TYPE(CREATE_CASE)
+        #undef CREATE_CASE
+        }
+    }
+
     // Use Wasm::isFuncref and Wasm::isExternref instead because they check againts all kind of representations of function referenes and external references.
 
     #define CREATE_PREDICATE(name, ...) bool is ## name() const { return kind == TypeKind::name; }

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -43,6 +43,7 @@ void marshallJSResult(CCallHelpers& jit, const TypeDefinition& typeDefinition, c
 {
     const auto& signature = *typeDefinition.as<FunctionSignature>();
     auto boxWasmResult = [](CCallHelpers& jit, Type type, ValueLocation src, JSValueRegs dst) {
+        JIT_COMMENT(jit, "boxWasmResult ", type);
         switch (type.kind) {
         case TypeKind::Void:
             jit.moveTrustedValue(jsUndefined(), dst);
@@ -91,6 +92,7 @@ void marshallJSResult(CCallHelpers& jit, const TypeDefinition& typeDefinition, c
         jit.moveTrustedValue(jsUndefined(), JSRInfo::returnValueJSR);
     else if (signature.returnCount() == 1) {
         if (signature.returnType(0).isI64()) {
+            JIT_COMMENT(jit, "convert wasm return to big int");
             JSValueRegs inputJSR = wasmFrameConvention.results[0].jsr();
             GPRReg wasmContextInstanceGPR = PinnedRegisterInfo::get().wasmContextInstancePointer;
             if (Context::useFastTLS()) {
@@ -120,6 +122,7 @@ void marshallJSResult(CCallHelpers& jit, const TypeDefinition& typeDefinition, c
 
         // We can use the first floating point register as a scratch since it will always be moved onto the stack before other values.
         FPRReg fprScratch = wasmCallingConvention().fprArgs[0];
+        JIT_COMMENT(jit, "scratchFPR: ", fprScratch, " - Scratch jsr: ", scratchJSR, " - saved result registers: ", savedResultRegisters);
         bool hasI64 = false;
         for (unsigned i = 0; i < signature.returnCount(); ++i) {
             ValueLocation loc = wasmFrameConvention.results[i];
@@ -243,6 +246,7 @@ void marshallJSResult(CCallHelpers& jit, const TypeDefinition& typeDefinition, c
 
 std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers& jit, const TypeDefinition& typeDefinition, Vector<UnlinkedWasmToWasmCall>* unlinkedWasmToWasmCalls, const ModuleInformation& info, MemoryMode mode, unsigned functionIndex)
 {
+    JIT_COMMENT(jit, "jsToWasm wrapper for wasm-function[", functionIndex, "] : ", typeDefinition);
     auto result = makeUnique<InternalFunction>();
     jit.emitFunctionPrologue();
 
@@ -279,6 +283,7 @@ std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers& jit, const
     totalFrameSize += savedResultRegisters.sizeOfAreaInBytes();
 
     totalFrameSize = WTF::roundUpToMultipleOf(stackAlignmentBytes(), totalFrameSize);
+    JIT_COMMENT(jit, "Saved result registers: ", savedResultRegisters);
     jit.subPtr(MacroAssembler::TrustedImm32(totalFrameSize), MacroAssembler::stackPointerRegister);
 
     // We save all these registers regardless of having a memory or not.
@@ -315,6 +320,7 @@ std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers& jit, const
             RELEASE_ASSERT(jsFrameConvention.params[i].isStack());
 
             Type type = signature.argumentType(i);
+            JIT_COMMENT(jit, "Arg ", i, " : ", type);
             CCallHelpers::Address jsParam(GPRInfo::callFrameRegister, jsFrameConvention.params[i].offsetFromFP());
             if (wasmFrameConvention.params[i].isStackArgument()) {
                 CCallHelpers::Address addr { calleeFrame.withOffset(wasmFrameConvention.params[i].offsetFromSP()) };
@@ -375,8 +381,10 @@ std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers& jit, const
         unlinkedWasmToWasmCalls->append({ linkBuffer.locationOfNearCall<WasmEntryPtrTag>(call), functionIndexSpace });
     });
 
+    JIT_COMMENT(jit, "marshallJSResult");
     marshallJSResult(jit, typeDefinition, wasmFrameConvention, savedResultRegisters);
 
+    JIT_COMMENT(jit, "restore registersToSpill");
     for (const RegisterAtOffset& regAtOffset : registersToSpill) {
         GPRReg reg = regAtOffset.reg().gpr();
         ASSERT(!JSRInfo::returnValueJSR.uses(reg));

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -233,7 +233,7 @@ WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefix(const char*);
 WTF_EXPORT_PRIVATE void WTFReportBacktrace(void);
 #ifdef __cplusplus
 WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, const char*);
-void WTFPrintBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, void** stack, int size, const char* prefix);
+WTF_EXPORT_PRIVATE void WTFPrintBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, void** stack, int size, const char* prefix);
 #endif
 WTF_EXPORT_PRIVATE void WTFPrintBacktrace(void** stack, int size);
 #if !RELEASE_LOG_DISABLED


### PR DESCRIPTION
#### ad2e13b2a8e69c2ea538cdb8c7cb101a40555266
<pre>
Print AIR in WASM BBQ disassembly
<a href="https://bugs.webkit.org/show_bug.cgi?id=244644">https://bugs.webkit.org/show_bug.cgi?id=244644</a>

Reviewed by Yusuke Suzuki.

1) Print AIR in WASM disassembly

2) Add extra jit comments, notably the compiler backtrace where each patchpoint is constructed

3) Add support for multiple jit comments

4) Add support for printing jit comments on x86

* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::linkComments):
* Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp:
(JSC::B3::PatchpointSpecial::generate):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/disassembler/X86Disassembler.cpp:
(JSC::tryToDisassemble):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::restoreCalleeSavesFromEntryFrameCalleeSavesBuffer):
(JSC::AssemblyHelpers::restoreCalleeSavesFromVMEntryFrameCalleeSavesBufferImpl):
(JSC::AssemblyHelpers::loadWasmContextInstance):
(JSC::AssemblyHelpers::storeWasmContextInstance):
(JSC::AssemblyHelpers::debugCall):
(JSC::AssemblyHelpers::copyCalleeSavesToEntryFrameCalleeSavesBufferImpl):
(JSC::AssemblyHelpers::emitSave):
(JSC::AssemblyHelpers::emitRestore):
(JSC::AssemblyHelpers::emitSaveCalleeSavesFor):
(JSC::AssemblyHelpers::emitRestoreCalleeSavesFor):
* Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h:
(JSC::AssemblyHelpers::Spooler::execute):
* Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp:
(JSC::ScratchRegisterAllocator::preserveReusedRegistersByPushing):
(JSC::ScratchRegisterAllocator::restoreReusedRegistersByPopping):
(JSC::ScratchRegisterAllocator::preserveRegistersToStackForCall):
(JSC::ScratchRegisterAllocator::restoreRegistersFromStackForCall):
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::addCall):
(JSC::Wasm::parseAndCompileAir):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmThunks.cpp:
(JSC::Wasm::throwExceptionFromWasmThunkGenerator):
(JSC::Wasm::throwStackOverflowFromWasmThunkGenerator):
(JSC::Wasm::triggerOMGEntryTierUpThunkGenerator):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::marshallJSResult):
(JSC::Wasm::createJSToWasmWrapper):
* Source/WTF/wtf/Assertions.h:

Canonical link: <a href="https://commits.webkit.org/254198@main">https://commits.webkit.org/254198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/185e739ade9865ad257a164dd67edbc6d98e6d80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97213 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152707 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30601 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26541 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80186 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91952 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24664 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74714 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24645 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67630 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79821 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28230 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13591 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73574 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28329 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14582 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26199 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2955 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37470 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76418 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33818 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16960 "Passed tests") | 
<!--EWS-Status-Bubble-End-->