### PR TITLE
test-webkitpy --all failures on main (Follow-up)

### DIFF
--- a/Tools/Scripts/webkitpy/common/checkout/scm/scm_unittest.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/scm_unittest.py
@@ -456,83 +456,6 @@ class SCMTest(unittest.TestCase):
         self.assertRegexpMatches(r3_patch, b'test2')
         self.assertRegexpMatches(self.scm.diff_for_revision(3), b'test2')
 
-    def _shared_test_svn_apply_git_patch(self):
-        self._setup_webkittools_scripts_symlink(self.scm)
-        git_binary_addition = """diff --git a/fizzbuzz7.gif b/fizzbuzz7.gif
-new file mode 100644
-index 0000000000000000000000000000000000000000..64a9532e7794fcd791f6f12157406d90
-60151690
-GIT binary patch
-literal 512
-zcmZ?wbhEHbRAx|MU|?iW{Kxc~?KofD;ckY;H+&5HnHl!!GQMD7h+sU{_)e9f^V3c?
-zhJP##HdZC#4K}7F68@!1jfWQg2daCm-gs#3|JREDT>c+pG4L<_2;w##WMO#ysPPap
-zLqpAf1OE938xAsSp4!5f-o><?VKe(#0jEcwfHGF4%M1^kRs14oVBp2ZEL{E1N<-zJ
-zsfLmOtKta;2_;2c#^S1-8cf<nb!QnGl>c!Xe6RXvrEtAWBvSDTgTO1j3vA31Puw!A
-zs(87q)j_mVDTqBo-P+03-P5mHCEnJ+x}YdCuS7#bCCyePUe(ynK+|4b-3qK)T?Z&)
-zYG+`tl4h?GZv_$t82}X4*DTE|$;{DEiPyF@)U-1+FaX++T9H{&%cag`W1|zVP@`%b
-zqiSkp6{BTpWTkCr!=<C6Q=?#~R8^JfrliAF6Q^gV9Iup8RqCXqqhqC`qsyhk<-nlB
-z00f{QZvfK&|Nm#oZ0TQl`Yr$BIa6A@16O26ud7H<QM=xl`toLKnz-3h@9c9q&wm|X
-z{89I|WPyD!*M?gv?q`;L=2YFeXrJQNti4?}s!zFo=5CzeBxC69xA<zrjP<wUcCRh4
-ptUl-ZG<%a~#LwkIWv&q!KSCH7tQ8cJDiw+|GV?MN)RjY50RTb-xvT&H
-
-literal 0
-HcmV?d00001
-
-"""
-        self.checkout.apply_patch(self._create_patch(git_binary_addition))
-        added = read_from_path('fizzbuzz7.gif', encoding=None)
-        self.assertEqual(512, len(added))
-        self.assertTrue(added.startswith(b'GIF89a'))
-        self.assertIn('fizzbuzz7.gif', self.scm.changed_files())
-
-        # The file already exists.
-        self.assertRaises(ScriptError, self.checkout.apply_patch, self._create_patch(git_binary_addition))
-
-        git_binary_modification = """diff --git a/fizzbuzz7.gif b/fizzbuzz7.gif
-index 64a9532e7794fcd791f6f12157406d9060151690..323fae03f4606ea9991df8befbb2fca7
-GIT binary patch
-literal 7
-OcmYex&reD$;sO8*F9L)B
-
-literal 512
-zcmZ?wbhEHbRAx|MU|?iW{Kxc~?KofD;ckY;H+&5HnHl!!GQMD7h+sU{_)e9f^V3c?
-zhJP##HdZC#4K}7F68@!1jfWQg2daCm-gs#3|JREDT>c+pG4L<_2;w##WMO#ysPPap
-zLqpAf1OE938xAsSp4!5f-o><?VKe(#0jEcwfHGF4%M1^kRs14oVBp2ZEL{E1N<-zJ
-zsfLmOtKta;2_;2c#^S1-8cf<nb!QnGl>c!Xe6RXvrEtAWBvSDTgTO1j3vA31Puw!A
-zs(87q)j_mVDTqBo-P+03-P5mHCEnJ+x}YdCuS7#bCCyePUe(ynK+|4b-3qK)T?Z&)
-zYG+`tl4h?GZv_$t82}X4*DTE|$;{DEiPyF@)U-1+FaX++T9H{&%cag`W1|zVP@`%b
-zqiSkp6{BTpWTkCr!=<C6Q=?#~R8^JfrliAF6Q^gV9Iup8RqCXqqhqC`qsyhk<-nlB
-z00f{QZvfK&|Nm#oZ0TQl`Yr$BIa6A@16O26ud7H<QM=xl`toLKnz-3h@9c9q&wm|X
-z{89I|WPyD!*M?gv?q`;L=2YFeXrJQNti4?}s!zFo=5CzeBxC69xA<zrjP<wUcCRh4
-ptUl-ZG<%a~#LwkIWv&q!KSCH7tQ8cJDiw+|GV?MN)RjY50RTb-xvT&H
-
-"""
-        self.checkout.apply_patch(self._create_patch(git_binary_modification))
-        modified = read_from_path('fizzbuzz7.gif', encoding=None)
-        self.assertEqual(b'foobar\n', modified)
-        self.assertIn('fizzbuzz7.gif', self.scm.changed_files())
-
-        # Applying the same modification should fail.
-        self.assertRaises(ScriptError, self.checkout.apply_patch, self._create_patch(git_binary_modification))
-
-        git_binary_deletion = """diff --git a/fizzbuzz7.gif b/fizzbuzz7.gif
-deleted file mode 100644
-index 323fae0..0000000
-GIT binary patch
-literal 0
-HcmV?d00001
-
-literal 7
-OcmYex&reD$;sO8*F9L)B
-
-"""
-        self.checkout.apply_patch(self._create_patch(git_binary_deletion))
-        self.assertFalse(os.path.exists('fizzbuzz7.gif'))
-        self.assertNotIn('fizzbuzz7.gif', self.scm.changed_files())
-
-        # Cannot delete again.
-        self.assertRaises(ScriptError, self.checkout.apply_patch, self._create_patch(git_binary_deletion))
-
     def _shared_test_add_recursively(self):
         os.mkdir("added_dir")
         write_into_file_at_path("added_dir/added_file", "new stuff")
@@ -608,100 +531,6 @@ class SVNTest(SCMTest):
         # svn-apply will update ChangeLog entries with today's date (as in Cupertino, CA, US)
         with TimezoneOverride('PST8PDT'):
             return changelog_entry.replace('DATE_HERE', date.today().isoformat())
-
-    @slow
-    @xfail
-    def test_svn_apply(self):
-        first_entry = """2009-10-26  Eric Seidel  <eric@webkit.org>
-
-        Reviewed by Foo Bar.
-
-        Most awesome change ever.
-
-        * scm_unittest.py:
-"""
-        intermediate_entry = """2009-10-27  Eric Seidel  <eric@webkit.org>
-
-        Reviewed by Baz Bar.
-
-        A more awesomer change yet!
-
-        * scm_unittest.py:
-"""
-        one_line_overlap_patch = """Index: ChangeLog
-===================================================================
---- ChangeLog	(revision 5)
-+++ ChangeLog	(working copy)
-@@ -1,5 +1,13 @@
- 2009-10-26  Eric Seidel  <eric@webkit.org>
-%(whitespace)s
-+        Reviewed by NOBODY (OOPS!).
-+
-+        Second most awesome change ever.
-+
-+        * scm_unittest.py:
-+
-+2009-10-26  Eric Seidel  <eric@webkit.org>
-+
-         Reviewed by Foo Bar.
-%(whitespace)s
-         Most awesome change ever.
-""" % {'whitespace': ' '}
-        one_line_overlap_entry = """DATE_HERE  Eric Seidel  <eric@webkit.org>
-
-        Reviewed by REVIEWER_HERE.
-
-        Second most awesome change ever.
-
-        * scm_unittest.py:
-"""
-        two_line_overlap_patch = """Index: ChangeLog
-===================================================================
---- ChangeLog	(revision 5)
-+++ ChangeLog	(working copy)
-@@ -2,6 +2,14 @@
-%(whitespace)s
-         Reviewed by Foo Bar.
-%(whitespace)s
-+        Second most awesome change ever.
-+
-+        * scm_unittest.py:
-+
-+2009-10-26  Eric Seidel  <eric@webkit.org>
-+
-+        Reviewed by Foo Bar.
-+
-         Most awesome change ever.
-%(whitespace)s
-         * scm_unittest.py:
-""" % {'whitespace': ' '}
-        two_line_overlap_entry = """DATE_HERE  Eric Seidel  <eric@webkit.org>
-
-        Reviewed by Foo Bar.
-
-        Second most awesome change ever.
-
-        * scm_unittest.py:
-"""
-        write_into_file_at_path('ChangeLog', first_entry)
-        run_command(['svn', 'add', 'ChangeLog'])
-        run_command(['svn', 'commit', '--quiet', '--message', 'ChangeLog commit'])
-
-        # Patch files were created against just 'first_entry'.
-        # Add a second commit to make svn-apply have to apply the patches with fuzz.
-        changelog_contents = "%s\n%s" % (intermediate_entry, first_entry)
-        write_into_file_at_path('ChangeLog', changelog_contents)
-        run_command(['svn', 'commit', '--quiet', '--message', 'Intermediate commit'])
-
-        self._setup_webkittools_scripts_symlink(self.scm)
-        self.checkout.apply_patch(self._create_patch(one_line_overlap_patch))
-        expected_changelog_contents = "%s\n%s" % (self._set_date_and_reviewer(one_line_overlap_entry), changelog_contents)
-        self.assertEqual(read_from_path('ChangeLog'), expected_changelog_contents)
-
-        self.scm.revert_files(['ChangeLog'])
-        self.checkout.apply_patch(self._create_patch(two_line_overlap_patch))
-        expected_changelog_contents = "%s\n%s" % (self._set_date_and_reviewer(two_line_overlap_entry), changelog_contents)
-        self.assertEqual(read_from_path('ChangeLog'), expected_changelog_contents)
 
     def setUp(self):
         SVNTestRepository.setup(self)
@@ -901,10 +730,6 @@ END
     @slow
     def test_diff_for_revision(self):
         self._shared_test_diff_for_revision()
-
-    @slow
-    def test_svn_apply_git_patch(self):
-        self._shared_test_svn_apply_git_patch()
 
     @slow
     def test_changed_files(self):
@@ -1287,29 +1112,6 @@ class GitSVNTest(SCMTest):
         self.assertNotRegexpMatches(diff_to_common_base, b'foo')
         self.assertRegexpMatches(diff_to_merge_base, b'foo')
 
-    @xfail
-    @slow
-    def test_rebase_in_progress(self):
-        svn_test_file = os.path.join(self.svn_checkout_path, 'test_file')
-        write_into_file_at_path(svn_test_file, "svn_checkout")
-        run_command(['svn', 'commit', '--message', 'commit to conflict with git commit'], cwd=self.svn_checkout_path)
-
-        git_test_file = os.path.join(self.git_checkout_path, 'test_file')
-        write_into_file_at_path(git_test_file, "git_checkout")
-        run_command(['git', 'commit', '-a', '-m', 'commit to be thrown away by rebase abort'])
-
-        # --quiet doesn't make git svn silent, so use run_silent to redirect output
-        self.assertRaises(ScriptError, run_silent, ['git', 'svn', '--quiet', 'rebase'])  # Will fail due to a conflict leaving us mid-rebase.
-
-        self.assertTrue(self.scm.rebase_in_progress())
-
-        # Make sure our cleanup works.
-        self.scm.discard_working_directory_changes()
-        self.assertFalse(self.scm.rebase_in_progress())
-
-        # Make sure cleanup doesn't throw when no rebase is in progress.
-        self.scm.discard_working_directory_changes()
-
     @slow
     def test_commitish_parsing(self):
         # Multiple revisions are cherry-picked.
@@ -1518,11 +1320,6 @@ class GitSVNTest(SCMTest):
     @xfail
     def test_diff_for_revision(self):
         self._shared_test_diff_for_revision()
-
-    @slow
-    @xfail
-    def test_svn_apply_git_patch(self):
-        self._shared_test_svn_apply_git_patch()
 
     @slow
     @xfail


### PR DESCRIPTION
#### a12e01f79c67c563ea4b2f602ff34d4dd7e154ee
<pre>
test-webkitpy --all failures on main (Follow-up)
<a href="https://bugs.webkit.org/show_bug.cgi?id=244292">https://bugs.webkit.org/show_bug.cgi?id=244292</a>
&lt;rdar://problem/99250197&gt;

Unreviewed test fix.

Delete tests which pass or fail based off of the existance of a Subversion binary.

* Tools/Scripts/webkitpy/common/checkout/scm/scm_unittest.py:
(SCMTest._shared_test_svn_apply_git_patch): Deleted.
(SVNTest.test_svn_apply): Deleted.
(test_svn_apply_git_patch): Deleted.
(GitSVNTest.test_rebase_in_progress): Deleted.
(GitSVNTest.test_svn_apply_git_patch): Deleted.

Canonical link: <a href="https://commits.webkit.org/254020@main">https://commits.webkit.org/254020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9cebf692994cb394e5f4b5287306a3ab64105bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87825 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/69/builds/31918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/18545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/97005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/151480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/91793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/64/builds/30280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/91749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/93440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/64/builds/30280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/74548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/91430 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/64/builds/30280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/18545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/27949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/18545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/27931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/18545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29623 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/74548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1149 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/29512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/18545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->