### PR TITLE
Web Inspector: Elements Tab: don't show the Target in the Event badge popover

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -2122,7 +2122,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
             popover.present(calculateTargetFrame(), preferredEdges, {updateContent: true, shouldAnimate: false});
         };
 
-        let sections = WI.EventListenerSectionGroup.groupIntoSectionsByEvent(listeners);
+        let sections = WI.EventListenerSectionGroup.groupIntoSectionsByEvent(listeners, {hideTarget: true});
         for (let section of sections) {
             section.addEventListener(WI.DetailsSection.Event.CollapsedStateChanged, function(event) {
                 const shouldAnimate = false;

--- a/Source/WebInspectorUI/UserInterface/Views/EventListenerSectionGroup.js
+++ b/Source/WebInspectorUI/UserInterface/Views/EventListenerSectionGroup.js
@@ -108,7 +108,7 @@ WI.EventListenerSectionGroup = class EventListenerSectionGroup extends WI.Detail
 
     // Static
 
-    static groupIntoSectionsByEvent(eventListeners)
+    static groupIntoSectionsByEvent(eventListeners, options = {})
     {
         let eventListenerTypes = new Map;
         for (let eventListener of eventListeners) {
@@ -127,12 +127,12 @@ WI.EventListenerSectionGroup = class EventListenerSectionGroup extends WI.Detail
         let types = Array.from(eventListenerTypes.keys());
         types.sort();
         for (let type of types)
-            rows.push(WI.EventListenerSectionGroup._createEventListenerSection(type, eventListenerTypes.get(type), {hideType: true}));
+            rows.push(WI.EventListenerSectionGroup._createEventListenerSection(type, eventListenerTypes.get(type), {...options, hideType: true}));
 
         return rows;
     }
 
-    static groupIntoSectionsByTarget(eventListeners, domNode)
+    static groupIntoSectionsByTarget(eventListeners, domNode, options = {})
     {
         const windowTargetIdentifier = Symbol("window");
 
@@ -161,7 +161,7 @@ WI.EventListenerSectionGroup = class EventListenerSectionGroup extends WI.Detail
             let title = target === windowTargetIdentifier ? WI.unlocalizedString("window") : target.displayName;
             let identifier = target === windowTargetIdentifier ? WI.unlocalizedString("window") : target.unescapedSelector;
 
-            let section = WI.EventListenerSectionGroup._createEventListenerSection(title, eventListenersForTarget, {hideTarget: true, identifier});
+            let section = WI.EventListenerSectionGroup._createEventListenerSection(title, eventListenersForTarget, {...options, hideTarget: true, identifier});
             if (target instanceof WI.DOMNode)
                 WI.bindInteractionsForNodeToElement(target, section.titleElement, {ignoreClick: true});
             rows.push(section);


### PR DESCRIPTION
#### 2a5a5c3fa186d352861bc319816cff5ea7b59a7a
<pre>
Web Inspector: Elements Tab: don&apos;t show the Target in the Event badge popover
<a href="https://bugs.webkit.org/show_bug.cgi?id=244645">https://bugs.webkit.org/show_bug.cgi?id=244645</a>

Reviewed by Patrick Angle.

The Event badge popover only shows event listeners attached directly on the related DOM node, so
there&apos;s no reason to show the Target as it&apos;ll always be that same DOM node.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype.async _handleEventBadgeClicked):
Explicitly `hideTarget: true`.

* Source/WebInspectorUI/UserInterface/Views/EventListenerSectionGroup.js:
(WI.EventListenerSectionGroup.groupIntoSectionsByEvent):
(WI.EventListenerSectionGroup.groupIntoSectionsByTarget):
Allow `options = {}` to be given to the `static` helper methods, which pipe to the `WI.EventListenerSectionGroup`.

Canonical link: <a href="https://commits.webkit.org/254018@main">https://commits.webkit.org/254018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba929825c0785007e4c69e45207b159d97a36d35

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87813 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/69/builds/31908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/18537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/96998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/151381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30268 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/91742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/93429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/74541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/18537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/27941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/18537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/27922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/18537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29612 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/74541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1148 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/29504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/18537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->