### PR TITLE
Table row direction should be determined by the Table's direction

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/direction-on-table-parts-row-direction.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/direction-on-table-parts-row-direction.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <style>
+        .rtl {
+            direction: rtl;
+        }
+
+        .limeBackground {
+            background-color: lime;
+        }
+        .purpleBackground {
+            background-color: purple;
+        }
+
+        td {
+            height: 20px;
+            width: 20px;
+        }
+    </style>
+    <p>This test checks that the row direction is determined by the table's 'direction' property.</p>
+    <p>In all the tables below, the lime cell should be on the right of the purple cell.</p>
+    <table class="rtl">
+        <tbody>
+        <tr>
+            <td class="purpleBackground"></td>
+            <td class="limeBackground"></td>
+        </tr>
+        </tbody>
+    </table>
+    <table>
+        <tbody class="rtl">
+        <tr>
+            <td class="limeBackground"></td>
+            <td class="purpleBackground"></td>
+        </tr>
+        </tbody>
+    </table>
+    <table>
+        <tbody>
+        <tr class="rtl">
+            <td class="limeBackground"></td>
+            <td class="purpleBackground"></td>
+        </tr>
+        </tbody>
+    </table>
+</body></html>

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-tables/direction-on-table-parts-row-direction-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-tables/direction-on-table-parts-row-direction-expected.txt
@@ -1,0 +1,26 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x170
+  RenderBlock {HTML} at (0,0) size 800x170
+    RenderBody {BODY} at (8,16) size 784x146
+      RenderBlock {P} at (0,0) size 784x18
+        RenderText {#text} at (0,0) size 550x18
+          text run at (0,0) width 550: "This test checks that the row direction is determined by the table's 'direction' property."
+      RenderBlock {P} at (0,34) size 784x18
+        RenderText {#text} at (0,0) size 488x18
+          text run at (0,0) width 488: "In all the tables below, the lime cell should be on the right of the purple cell."
+      RenderTable {TABLE} at (0,68) size 50x26
+        RenderTableSection {TBODY} at (0,0) size 50x26
+          RenderTableRow {TR} at (0,2) size 50x22
+            RenderTableCell {TD} at (26,12) size 22x2 [bgcolor=#800080] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,12) size 22x2 [bgcolor=#00FF00] [r=0 c=1 rs=1 cs=1]
+      RenderTable {TABLE} at (0,94) size 50x26
+        RenderTableSection {TBODY} at (0,0) size 50x26
+          RenderTableRow {TR} at (0,2) size 50x22
+            RenderTableCell {TD} at (2,12) size 22x2 [bgcolor=#00FF00] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (26,12) size 22x2 [bgcolor=#800080] [r=0 c=1 rs=1 cs=1]
+      RenderTable {TABLE} at (0,120) size 50x26
+        RenderTableSection {TBODY} at (0,0) size 50x26
+          RenderTableRow {TR} at (0,2) size 50x22
+            RenderTableCell {TD} at (2,12) size 22x2 [bgcolor=#00FF00] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (26,12) size 22x2 [bgcolor=#800080] [r=0 c=1 rs=1 cs=1]

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -1179,7 +1179,7 @@ LayoutUnit RenderTable::calcBorderStart() const
         if (sectionAdjoiningBorder.style() > BorderStyle::Hidden)
             borderWidth = std::max(borderWidth, sectionAdjoiningBorder.width());
 
-        if (const RenderTableCell* adjoiningStartCell = topNonEmptySection->firstRowCellAdjoiningTableStart()) {
+        if (const RenderTableCell* adjoiningStartCell = topNonEmptySection->cellAt(0, 0).primaryCell()) {
             // FIXME: Make this work with perpendicular and flipped cells.
             const BorderValue& startCellAdjoiningBorder = adjoiningStartCell->borderAdjoiningTableStart();
             if (startCellAdjoiningBorder.style() == BorderStyle::Hidden)
@@ -1234,7 +1234,7 @@ LayoutUnit RenderTable::calcBorderEnd() const
         if (sectionAdjoiningBorder.style() > BorderStyle::Hidden)
             borderWidth = std::max(borderWidth, sectionAdjoiningBorder.width());
 
-        if (const RenderTableCell* adjoiningEndCell = topNonEmptySection->firstRowCellAdjoiningTableEnd()) {
+        if (const RenderTableCell* adjoiningEndCell = topNonEmptySection->cellAt(0, lastColumnIndex()).primaryCell()) {
             // FIXME: Make this work with perpendicular and flipped cells.
             const BorderValue& endCellAdjoiningBorder = adjoiningEndCell->borderAdjoiningTableEnd();
             if (endCellAdjoiningBorder.style() == BorderStyle::Hidden)

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -973,8 +973,9 @@ LayoutRect RenderTableSection::logicalRectForWritingModeAndDirection(const Layou
         tableAlignedRect = tableAlignedRect.transposedRect();
 
     const Vector<LayoutUnit>& columnPos = table()->columnPositions();
-    // FIXME: The table's direction should determine our row's direction, not the section's (see bug 96691).
-    if (!style().isLeftToRightDirection())
+
+    // The table's 'direction' determines in which direction the rows flow.
+    if (!table()->style().isLeftToRightDirection())
         tableAlignedRect.setX(columnPos[columnPos.size() - 1] - tableAlignedRect.maxX());
 
     return tableAlignedRect;
@@ -1399,18 +1400,6 @@ const BorderValue& RenderTableSection::borderAdjoiningEndCell(const RenderTableC
     return isDirectionSame(this, &cell) ? style().borderEnd() : style().borderStart();
 }
 
-const RenderTableCell* RenderTableSection::firstRowCellAdjoiningTableStart() const
-{
-    unsigned adjoiningStartCellColumnIndex = isDirectionSame(this, table()) ? 0 : table()->lastColumnIndex();
-    return cellAt(0, adjoiningStartCellColumnIndex).primaryCell();
-}
-
-const RenderTableCell* RenderTableSection::firstRowCellAdjoiningTableEnd() const
-{
-    unsigned adjoiningEndCellColumnIndex = isDirectionSame(this, table()) ? table()->lastColumnIndex() : 0;
-    return cellAt(0, adjoiningEndCellColumnIndex).primaryCell();
-}
-
 void RenderTableSection::appendColumn(unsigned pos)
 {
     ASSERT(!m_needsCellRecalc);
@@ -1564,8 +1553,8 @@ void RenderTableSection::setLogicalPositionForCell(RenderTableCell* cell, unsign
     LayoutPoint cellLocation(0_lu, m_rowPos[cell->rowIndex()]);
     LayoutUnit horizontalBorderSpacing = table()->hBorderSpacing();
 
-    // FIXME: The table's direction should determine our row's direction, not the section's (see bug 96691).
-    if (!style().isLeftToRightDirection())
+    // The table's 'direction' determines in which direction the rows flow.
+    if (!table()->style().isLeftToRightDirection())
         cellLocation.setX(table()->columnPositions()[table()->numEffCols()] - table()->columnPositions()[table()->colToEffCol(cell->col() + cell->colSpan())] + horizontalBorderSpacing);
     else
         cellLocation.setX(table()->columnPositions()[effectiveColumn] + horizontalBorderSpacing);

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -94,9 +94,6 @@ public:
     const BorderValue& borderAdjoiningStartCell(const RenderTableCell&) const;
     const BorderValue& borderAdjoiningEndCell(const RenderTableCell&) const;
 
-    const RenderTableCell* firstRowCellAdjoiningTableStart() const;
-    const RenderTableCell* firstRowCellAdjoiningTableEnd() const;
-
     CellStruct& cellAt(unsigned row,  unsigned col);
     const CellStruct& cellAt(unsigned row, unsigned col) const;
     RenderTableCell* primaryCellAt(unsigned row, unsigned col);


### PR DESCRIPTION
#### 165dfdf9fff6d53239903e2fc5e168dcce05de20
<pre>
Table row direction should be determined by the Table&apos;s direction
<a href="https://bugs.webkit.org/show_bug.cgi?id=96691">https://bugs.webkit.org/show_bug.cgi?id=96691</a>

Reviewed by NOBODY (OOPS!).

This patch is an adaption based on the bugzilla patch by Julien Chaffraix.

We should use the table&apos;s style to determine the rendering direction
how the table&apos;s rows should flow.

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/direction-on-table-parts-row-direction.html: Added.
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-tables/direction-on-table-parts-row-direction-expected.txt: Added.
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::calcBorderStart const):
(WebCore::RenderTable::calcBorderEnd const):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::logicalRectForWritingModeAndDirection const):
(WebCore::RenderTableSection::setLogicalPositionForCell const):
(WebCore::RenderTableSection::firstRowCellAdjoiningTableStart const): Deleted.
(WebCore::RenderTableSection::firstRowCellAdjoiningTableEnd const): Deleted.
* Source/WebCore/rendering/RenderTableSection.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c810f3df0a39f8ff4c30c1b7e91e06106e4c4cfe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97000 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/151574 "Found 6 new test failures: fast/table/border-collapsing/first-cell-left-border-hidden-table-ltr-section-rtl.html, fast/table/border-collapsing/last-cell-left-border-hidden-table-ltr-section-rtl.html, fast/table/border-collapsing/left-border-table-ltr-section-rtl.html, fast/table/border-collapsing/left-border-table-rtl-section-ltr.html, fast/table/border-collapsing/top-border-vertical-rl-table-ltr-section-rtl.html, fast/table/paint-collapsed-borders-rtl-section.html") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30274 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26336 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79911 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91744 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93434 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24450 "Found 7 new test failures: fast/table/border-collapsing/first-cell-left-border-hidden-table-ltr-section-rtl.html, fast/table/border-collapsing/last-cell-left-border-hidden-table-ltr-section-rtl.html, fast/table/border-collapsing/left-border-table-ltr-section-rtl.html, fast/table/border-collapsing/left-border-table-rtl-section-ltr.html, fast/table/border-collapsing/top-border-vertical-rl-table-ltr-section-rtl.html, fast/table/paint-collapsed-borders-rtl-section.html, imported/w3c/web-platform-tests/css/css-tables/direction-on-table-parts-row-direction.html") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74543 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24421 "Found 3 new test failures: fast/table/border-collapsing/top-border-vertical-rl-table-ltr-section-rtl.html, fast/table/paint-collapsed-borders-rtl-section.html, imported/w3c/web-platform-tests/css/css-tables/direction-on-table-parts-row-direction.html") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67268 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27944 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13372 "Found 6 new test failures: fast/table/border-collapsing/first-cell-left-border-hidden-table-ltr-section-rtl.html, fast/table/border-collapsing/last-cell-left-border-hidden-table-ltr-section-rtl.html, fast/table/border-collapsing/left-border-table-ltr-section-rtl.html, fast/table/border-collapsing/left-border-table-rtl-section-ltr.html, fast/table/border-collapsing/top-border-vertical-rl-table-ltr-section-rtl.html, fast/table/paint-collapsed-borders-rtl-section.html") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27926 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14387 "Found 6 new test failures: fast/table/border-collapsing/first-cell-left-border-hidden-table-ltr-section-rtl.html, fast/table/border-collapsing/last-cell-left-border-hidden-table-ltr-section-rtl.html, fast/table/border-collapsing/left-border-table-ltr-section-rtl.html, fast/table/border-collapsing/left-border-table-rtl-section-ltr.html, fast/table/border-collapsing/top-border-vertical-rl-table-ltr-section-rtl.html, fast/table/paint-collapsed-borders-rtl-section.html") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29617 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37298 "Found 6 new test failures: fast/table/border-collapsing/first-cell-left-border-hidden-table-ltr-section-rtl.html, fast/table/border-collapsing/last-cell-left-border-hidden-table-ltr-section-rtl.html, fast/table/border-collapsing/left-border-table-ltr-section-rtl.html, fast/table/border-collapsing/left-border-table-rtl-section-ltr.html, fast/table/border-collapsing/top-border-vertical-rl-table-ltr-section-rtl.html, fast/table/paint-collapsed-borders-rtl-section.html") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29507 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33663 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->