### PR TITLE
loadFromHTMLWithData only ever calls back on the main queue, creating deadlocks.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.h
@@ -73,6 +73,21 @@ typedef void (^NSAttributedStringCompletionHandler)(NSAttributedString * _Nullab
     NS_SWIFT_NAME(loadFromHTML(request:options:completionHandler:)) WK_SWIFT_ASYNC_NAME(fromHTML(request:options:)) WK_API_AVAILABLE(macos(10.15), ios(13.0));
 
 /*!
+ @abstract Loads an HTML URL request and converts the contents into an attributed string.
+ @param request The request specifying the URL to load.
+ @param options Document attributes for interpreting the document contents.
+ NSTextSizeMultiplierDocumentOption and NSTimeoutDocumentOption are supported option keys.
+ @param queue The queue to call back on.
+ @param completionHandler A block to invoke when the operation completes or fails.
+ @discussion The completionHandler is passed the attributed string result along with any
+ document-level attributes, or an error.
+*/
++ (void)loadFromHTMLWithRequest:(NSURLRequest *)request options:(NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *)options
+    queue:(dispatch_queue_t _Nullable)queue
+    completionHandler:(NSAttributedStringCompletionHandler)completionHandler
+    NS_SWIFT_NAME(loadFromHTML(request:options:queue:completionHandler:)) WK_SWIFT_ASYNC_NAME(fromHTML(request:options:queue:)) WK_API_AVAILABLE(WK_MAC_TBA, WK_IOS_TBA);
+
+/*!
  @abstract Converts a local HTML file into an attributed string.
  @param fileURL The file URL to load.
  @param options Document attributes for interpreting the document contents.
@@ -86,6 +101,22 @@ typedef void (^NSAttributedStringCompletionHandler)(NSAttributedString * _Nullab
 */
 + (void)loadFromHTMLWithFileURL:(NSURL *)fileURL options:(NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *)options completionHandler:(NSAttributedStringCompletionHandler)completionHandler
     NS_SWIFT_NAME(loadFromHTML(fileURL:options:completionHandler:)) WK_SWIFT_ASYNC_NAME(fromHTML(fileURL:options:)) WK_API_AVAILABLE(macos(10.15), ios(13.0));
+
+/*!
+ @abstract Converts a local HTML file into an attributed string.
+ @param fileURL The file URL to load.
+ @param options Document attributes for interpreting the document contents.
+ NSTextSizeMultiplierDocumentOption, NSTimeoutDocumentOption and NSReadAccessURLDocumentOption
+ are supported option keys.
+ @param queue The queue to call back on.
+ @param completionHandler A block to invoke when the operation completes or fails.
+ @discussion The completionHandler is passed the attributed string result along with any
+ document-level attributes, or an error. If NSReadAccessURLDocumentOption references a single file,
+ only that file may be loaded by WebKit. If NSReadAccessURLDocumentOption references a directory,
+ files inside that directory may be loaded by WebKit.
+*/
++ (void)loadFromHTMLWithFileURL:(NSURL *)fileURL options:(NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *)options queue:(dispatch_queue_t _Nullable)queue completionHandler:(NSAttributedStringCompletionHandler)completionHandler
+    NS_SWIFT_NAME(loadFromHTML(fileURL:options:queue:completionHandler:)) WK_SWIFT_ASYNC_NAME(fromHTML(fileURL:options:queue:)) WK_API_AVAILABLE(WK_MAC_TBA, WK_IOS_TBA);
 
 /*!
  @abstract Converts an HTML string into an attributed string.
@@ -102,6 +133,22 @@ typedef void (^NSAttributedStringCompletionHandler)(NSAttributedString * _Nullab
     NS_SWIFT_NAME(loadFromHTML(string:options:completionHandler:)) WK_SWIFT_ASYNC_NAME(fromHTML(_:options:)) WK_API_AVAILABLE(macos(10.15), ios(13.0));
 
 /*!
+ @abstract Converts an HTML string into an attributed string.
+ @param string The HTML string to use as the contents.
+ @param options Document attributes for interpreting the document contents.
+ NSTextSizeMultiplierDocumentOption, NSTimeoutDocumentOption and NSBaseURLDocumentOption
+ are supported option keys.
+ @param queue The queue to call back on.
+ @param completionHandler A block to invoke when the operation completes or fails.
+ @discussion The completionHandler is passed the attributed string result along with any
+ document-level attributes, or an error. NSBaseURLDocumentOption is used to resolve relative URLs
+ within the document.
+*/
++ (void)loadFromHTMLWithString:(NSString *)string options:(NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *)options queue:(dispatch_queue_t _Nullable)queue completionHandler:(NSAttributedStringCompletionHandler)completionHandler
+    NS_SWIFT_NAME(loadFromHTML(string:options:queue:completionHandler:)) WK_SWIFT_ASYNC_NAME(fromHTML(_:options:queue:)) WK_API_AVAILABLE(WK_MAC_TBA, WK_IOS_TBA);
+
+
+/*!
  @abstract Converts HTML data into an attributed string.
  @param data The HTML data to use as the contents.
  @param options Document attributes for interpreting the document contents.
@@ -114,6 +161,21 @@ typedef void (^NSAttributedStringCompletionHandler)(NSAttributedString * _Nullab
 */
 + (void)loadFromHTMLWithData:(NSData *)data options:(NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *)options completionHandler:(NSAttributedStringCompletionHandler)completionHandler
     NS_SWIFT_NAME(loadFromHTML(data:options:completionHandler:)) WK_SWIFT_ASYNC_NAME(fromHTML(_:options:)) WK_API_AVAILABLE(macos(10.15), ios(13.0));
+
+/*!
+ @abstract Converts HTML data into an attributed string.
+ @param data The HTML data to use as the contents.
+ @param options Document attributes for interpreting the document contents.
+ NSTextSizeMultiplierDocumentOption, NSTimeoutDocumentOption, NSTextEncodingNameDocumentOption,
+ and NSCharacterEncodingDocumentOption are supported option keys.
+ @param queue The queue to call back on.
+ @param completionHandler A block to invoke when the operation completes or fails.
+ @discussion The completionHandler is passed the attributed string result along with any
+ document-level attributes, or an error. If neither NSTextEncodingNameDocumentOption nor
+ NSCharacterEncodingDocumentOption is supplied, a best-guess encoding is used.
+*/
++ (void)loadFromHTMLWithData:(NSData *)data options:(NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *)options queue:(dispatch_queue_t _Nullable)queue completionHandler:(NSAttributedStringCompletionHandler)completionHandler
+    NS_SWIFT_NAME(loadFromHTML(data:options:queue:completionHandler:)) WK_SWIFT_ASYNC_NAME(fromHTML(_:options:queue:)) WK_API_AVAILABLE(WK_MAC_TBA, WK_IOS_TBA);
 
 @end
 


### PR DESCRIPTION
#### dbf953adf9a729d64779885c797c8f7645e1826d
<pre>
loadFromHTMLWithData only ever calls back on the main queue, creating deadlocks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244670">https://bugs.webkit.org/show_bug.cgi?id=244670</a>
&lt;rdar://99404547&gt;

Reviewed by NOBODY (OOPS!).

Accept a queue parameter in the NSAttributedString category static
methods allowing clients to ensure callbacks do not encounter
deadlocks in the event callers higher up the stack are utilizing
semaphores or spinning the runloop on the same queue.

* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.h:
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NSAttributedStringWebKitAdditions.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbf953adf9a729d64779885c797c8f7645e1826d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97062 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152115 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30377 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26389 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80002 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91805 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24507 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74595 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24495 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79460 "Found 1 new API test failure: TestWebKitAPI.NSAttributedStringWebKitAdditions.DirectoriesNotCreatedBackgroundQueue (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/28104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/28200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14429 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/31224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37331 "Passed tests") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/30174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33704 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->