### PR TITLE
Web Inspector: When selecting timeline records from a coalesced record bar, select the record nearest the cursor, not the first record in the group

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverviewGraph.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverviewGraph.js
@@ -262,9 +262,9 @@ WI.TimelineOverviewGraph = class TimelineOverviewGraph extends WI.View
 
     // TimelineRecordBar delegate
 
-    timelineRecordBarClicked(timelineRecordBar)
+    timelineRecordBarClicked(timelineRecord)
     {
-        this.selectedRecord = timelineRecordBar.records[0];
+        this.selectedRecord = timelineRecord;
     }
 
     // Protected


### PR DESCRIPTION
#### e9a80fbb0fb7a3ddf50f4107d6b469954585bc0c
<pre>
Web Inspector: When selecting timeline records from a coalesced record bar, select the record nearest the cursor, not the first record in the group
<a href="https://bugs.webkit.org/show_bug.cgi?id=236050">https://bugs.webkit.org/show_bug.cgi?id=236050</a>
rdar://78629845

Reviewed by Devin Rousso.

We now attempt to find the closest possible record to the location on the timeline the record bar was clicked. If we can
provide a record that starts before and end after the point that was clicked we return that record, otherwise falling
back to the record the either started or ended closest to the point that was clicked. This should make it easier to jump
to records the represent a larger portion of time, like a slow paint, without having to zoom all the way in on the
timeline.

Records with children are not considered since the children records will be the next records checked, and we want to
have selection be as targeted as possible.

* Source/WebInspectorUI/UserInterface/Views/TimelineOverviewGraph.js:
(WI.TimelineOverviewGraph.prototype.timelineRecordBarClicked):
* Source/WebInspectorUI/UserInterface/Views/TimelineRecordBar.js:
(WI.TimelineRecordBar):
(WI.TimelineRecordBar.prototype.refresh):
(WI.TimelineRecordBar.prototype._handleClick):

Canonical link: <a href="https://commits.webkit.org/254056@main">https://commits.webkit.org/254056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ff209272fd21c87e9e4dbec0cfe495a17fdfeac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97015 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/151611 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30296 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26351 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79927 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91759 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24456 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74558 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24429 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79414 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67276 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27961 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27945 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14393 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2851 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37305 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33669 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->