### PR TITLE
[webkitdirs] Detect when internal builds are using the open-source workspace

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -20,7 +20,11 @@ BUILD_GOAL = $(notdir $(CURDIR))
 endif
 
 
-XCODE_OPTIONS = `perl -I$(SCRIPTS_PATH) -Mwebkitdirs -e 'print XcodeOptionString()' -- $(BUILD_WEBKIT_OPTIONS)` $(ARGS)
+XCODE_OPTIONS := $(shell perl -I$(SCRIPTS_PATH) -Mwebkitdirs -e 'print XcodeOptionString()' -- $(BUILD_WEBKIT_OPTIONS))
+ifeq ($(XCODE_OPTIONS),)
+$(error Computing base options for xcodebuild failed)
+endif
+XCODE_OPTIONS += $(ARGS)
 XCODE_OPTIONS += $(if $(GCC_PREPROCESSOR_ADDITIONS),GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_ADDITIONS) $$(inherited)')
 ifeq (ON,$(ENABLE_LLVM_PROFILE_GENERATION))
 	XCODE_OPTIONS += ENABLE_LLVM_PROFILE_GENERATION=ENABLE_LLVM_PROFILE_GENERATION

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -1179,7 +1179,13 @@ sub XcodeOptions
     push @options, "-UseSanitizedBuildSystemEnvironment=YES";
     push @options, "-ShowBuildOperationDuration=YES";
     if (!checkForArgumentAndRemoveFromARGV("--no-use-workspace")) {
-        my $workspace = $configuredXcodeWorkspace // sourceDir() . "/WebKit.xcworkspace";
+        my $defaultWorkspace = sourceDir() . "/WebKit.xcworkspace";
+        my $workspace = $configuredXcodeWorkspace // $defaultWorkspace;
+        if ($workspace eq $defaultWorkspace && $xcodeSDK =~ /\.internal$/) {
+            die "Refusing to build with an internal SDK ($xcodeSDK) using the workspace at $workspace.\n" .
+                "Either switch SDKs or select a different workspace to build from with\n" .
+                "    set-webkit-configuration --workspace=<workspace>\n";
+        }
         push @options, ("-workspace", $workspace) if $workspace;
     }
     push @options, ("-configuration", $configuration);


### PR DESCRIPTION
#### d398a88b431eeaf03f1f899429d65ba8f6420321
<pre>
[webkitdirs] Detect when internal builds are using the open-source workspace
<a href="https://bugs.webkit.org/show_bug.cgi?id=244653">https://bugs.webkit.org/show_bug.cgi?id=244653</a>

Reviewed by Alexey Proskuryakov.

* Makefile.shared: Call XcodeOptionString() while the Makefile is being
  parsed, and fail early if it does not evaluate. This prevents errors
  from webkitdirs becoming lost in the noise of an erroneous xcodebuild.

* Tools/Scripts/webkitdirs.pm:
(XcodeOptions): In the workspace selection logic, die if the open-source
  workspace has been selected yet we&apos;re building with an SDK ending in
  &quot;.internal&quot;. This is never a valid build configuration, and only works
  when a build directory is dirty with products like WebKitAdditions that
  were put there by a prior internal build.

Canonical link: <a href="https://commits.webkit.org/254059@main">https://commits.webkit.org/254059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12ce61bb463bbe169163e20a7d8ca6a7d62094db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97016 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/151873 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30297 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26352 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79928 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91760 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24460 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74559 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24432 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79417 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67279 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79621 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27962 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73362 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27946 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14395 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26074 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2853 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29639 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37306 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/idb-partitioned-basic.tentative.sub.html") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76195 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29527 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33671 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16893 "Passed tests") | 
<!--EWS-Status-Bubble-End-->