### PR TITLE
Unreviewed, non-unified build fixes leftovers from August

### DIFF
--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
@@ -28,6 +28,7 @@
 #include "InspectorAgentRegistry.h"
 #include "InspectorEnvironment.h"
 #include "InspectorFrontendRouter.h"
+#include "Strong.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/text/WTFString.h>

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(JIT)
 
+#include "DFGCodeOriginPool.h"
 #include "JITStubRoutine.h"
 #include "JSObject.h"
 #include "WriteBarrier.h"
@@ -35,9 +36,6 @@
 #include <wtf/Vector.h>
 
 namespace JSC {
-namespace DFG {
-class CodeOriginPool;
-}
 
 class AccessCase;
 class CallLinkInfo;

--- a/Source/JavaScriptCore/jit/JITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/JITStubRoutine.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "JITStubRoutine.h"
 
+#include "AccessCase.h"
+#include "CallLinkInfo.h"
 #include "GCAwareJITStubRoutine.h"
 #include "PolymorphicCallStubRoutine.h"
 

--- a/Source/WebCore/Modules/reporting/ReportBody.cpp
+++ b/Source/WebCore/Modules/reporting/ReportBody.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ReportBody.h"
 
+#include <wtf/IsoMallocInlines.h>
+
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ReportBody);

--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -35,6 +35,7 @@
 #include "ReportingScope.h"
 #include "ScriptExecutionContext.h"
 #include "WorkerGlobalScope.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -28,8 +28,11 @@
 
 #include "ContextDestructionObserver.h"
 #include "HeaderFieldTokenizer.h"
+#include "Report.h"
 #include "ReportingObserver.h"
 #include "ScriptExecutionContext.h"
+#include "SecurityOrigin.h"
+#include <wtf/IsoMallocInlines.h>
 #include <wtf/text/StringParsingBuffer.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/reporting/ReportingScope.h
+++ b/Source/WebCore/Modules/reporting/ReportingScope.h
@@ -30,6 +30,7 @@
 #include <wtf/IsoMalloc.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/WeakPtr.h>
 
 namespace WTF {
 class String;

--- a/Source/WebCore/dom/QualifiedNameCache.cpp
+++ b/Source/WebCore/dom/QualifiedNameCache.cpp
@@ -27,6 +27,9 @@
 #include "config.h"
 #include "QualifiedNameCache.h"
 
+#include "ElementName.h"
+#include "Namespace.h"
+
 namespace WebCore {
 
 struct QNameComponentsTranslator {


### PR DESCRIPTION
#### 72a938be1b78187f40f01c9ecd38d6be50d73ba1
<pre>
Unreviewed, non-unified build fixes leftovers from August

* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h: Add missing Strong include.
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h: Replace CodeOrigin foward decl with full include.
* Source/JavaScriptCore/jit/JITStubRoutine.cpp: Add missing AccesCase and CallLinkInfo headers
* Source/WebCore/Modules/reporting/ReportBody.cpp: Add missing IsoMallocInlines
* Source/WebCore/Modules/reporting/ReportingObserver.cpp: Ditto.
* Source/WebCore/Modules/reporting/ReportingScope.cpp: Ditto, alongside a couple more includes.
* Source/WebCore/Modules/reporting/ReportingScope.h: Add missing WeakPtr
* Source/WebCore/dom/QualifiedNameCache.cpp: Add missing Namespace and ElementName includes

Canonical link: <a href="https://commits.webkit.org/254034@main">https://commits.webkit.org/254034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f14072358116a79ee25dea0458c40c4bb6603bd6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31945 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/18565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/97023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/151721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30306 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79937 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/91767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24466 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/74566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24442 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/18565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/79628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27971 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/18565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73371 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27955 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/18565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26078 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2834 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29648 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/74566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76204 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29536 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/18565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16897 "Passed tests") | 
<!--EWS-Status-Bubble-End-->