### PR TITLE
Do not parse or scroll to text fragments in iframe URLs.

### DIFF
--- a/LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/no-iframe-match-expected.html
+++ b/LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/no-iframe-match-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
+<meta charset="utf-8" />
+<title>Scroll to text fragment - highlight simple start text</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<meta name="assert" content="This test checks that a fragment directive with start text is correctly highlighted.">
+<link rel="match" href="scroll-to-text-fragment-start-expected.html">
+
+<p>The test passes if there is no highlight in the following iframe.</p>
+<iframe width="400px" height="100px" src="../resources/iframe-scroll-to-text-fragment.html"></iframe>
+
+</html>

--- a/LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/no-iframe-match.html
+++ b/LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/no-iframe-match.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
+<meta charset="utf-8" />
+<title>Scroll to text fragment - highlight simple start text</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<meta name="assert" content="This test checks that a fragment directive with start text is correctly highlighted.">
+<link rel="match" href="scroll-to-text-fragment-start-expected.html">
+
+<p>The test passes if there is no highlight in the following iframe.</p>
+<iframe width="400px" height="100px" src="../resources/iframe-scroll-to-text-fragment.html#:~:text=Example"></iframe>
+
+<script>
+  location.href = "#:~:text=Example";
+</script>
+</html>

--- a/LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/resources/iframe-scroll-to-text-fragment.html
+++ b/LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/resources/iframe-scroll-to-text-fragment.html
@@ -1,0 +1,1 @@
+Example

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -2221,7 +2221,7 @@ bool FrameView::scrollToFragment(const URL& url)
     auto fragmentIdentifier = url.fragmentIdentifier();
     auto fragmentDirective = document->fragmentDirective();
     
-    if (document->settings().scrollToTextFragmentEnabled() && !fragmentDirective.isEmpty()) {
+    if (frame().isMainFrame() && document->settings().scrollToTextFragmentEnabled() && !fragmentDirective.isEmpty()) {
         FragmentDirectiveParser fragmentDirectiveParser(fragmentDirective);
         
         if (fragmentDirectiveParser.isValid()) {


### PR DESCRIPTION
#### 9a232d5a670960a3549444d5b8922b8dcd893f93
<pre>
Do not parse or scroll to text fragments in iframe URLs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244661">https://bugs.webkit.org/show_bug.cgi?id=244661</a>
rdar://99202126

Reviewed by Tim Horton.

Since we are unsure of all the security implications, do not search of text fragments in
iFrame URLs.

* LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/no-iframe-match-expected.html: Added.
* LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/no-iframe-match.html: Added.
* LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/resources/iframe-scroll-to-text-fragment.html: Added.
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::scrollToFragment):

Canonical link: <a href="https://commits.webkit.org/254073@main">https://commits.webkit.org/254073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa7f6d8d9c1de5c240fb3a8a3c44b9a311666d2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97084 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152403 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30405 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26412 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80016 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91827 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24520 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/74612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/24511 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/28120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/28216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14445 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2861 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/31240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/74612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/30190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33718 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->