### PR TITLE
Web Inspector: Elements Tab DOM Tree does not update when a top-level item in the DOM tree is added/removed

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeUpdater.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeUpdater.js
@@ -121,11 +121,21 @@ WI.DOMTreeUpdater.prototype = {
 
     _updateModifiedNodes: function()
     {
+        let documentNeedsUpdated = false;
+
         // Update for insertions and deletions before attribute modifications. This ensures
         // tree elements get created for newly attached children before we try to update them.
         let parentElementsToUpdate = new Set;
         let markNodeParentForUpdate = (value, key, map) => {
+            if (documentNeedsUpdated)
+                return;
+
             let parentNode = value.parent;
+            if (parentNode.nodeType() === Node.DOCUMENT_NODE) {
+                documentNeedsUpdated = true;
+                return;
+            }
+
             let parentTreeElement = this._treeOutline.findTreeElement(parentNode);
             if (parentTreeElement)
                 parentElementsToUpdate.add(parentTreeElement);
@@ -133,28 +143,32 @@ WI.DOMTreeUpdater.prototype = {
         this._recentlyInsertedNodes.forEach(markNodeParentForUpdate);
         this._recentlyDeletedNodes.forEach(markNodeParentForUpdate);
 
-        for (let parentTreeElement of parentElementsToUpdate) {
-            if (parentTreeElement.treeOutline && parentTreeElement.listItemElement) {
-                parentTreeElement.updateTitle();
-                parentTreeElement.updateChildren();
+        if (documentNeedsUpdated)
+            this._treeOutline.update();
+        else {
+            for (let parentTreeElement of parentElementsToUpdate) {
+                if (parentTreeElement.treeOutline && parentTreeElement.listItemElement) {
+                    parentTreeElement.updateTitle();
+                    parentTreeElement.updateChildren();
+                }
             }
-        }
 
-        for (let node of this._recentlyModifiedNodes.values()) {
-            let nodeTreeElement = this._treeOutline.findTreeElement(node);
-            if (!nodeTreeElement)
-                continue;
-
-            for (let [attribute, nodes] of this._recentlyModifiedAttributes.entries()) {
-                // Don't report textContent changes as attribute modifications.
-                if (attribute === this._textContentAttributeSymbol)
+            for (let node of this._recentlyModifiedNodes.values()) {
+                let nodeTreeElement = this._treeOutline.findTreeElement(node);
+                if (!nodeTreeElement)
                     continue;
 
-                if (nodes.has(node))
-                    nodeTreeElement.attributeDidChange(attribute);
-            }
+                for (let [attribute, nodes] of this._recentlyModifiedAttributes.entries()) {
+                    // Don't report textContent changes as attribute modifications.
+                    if (attribute === this._textContentAttributeSymbol)
+                        continue;
 
-            nodeTreeElement.updateTitle();
+                    if (nodes.has(node))
+                        nodeTreeElement.attributeDidChange(attribute);
+                }
+
+                nodeTreeElement.updateTitle();
+            }
         }
 
         this._recentlyInsertedNodes.clear();


### PR DESCRIPTION
#### f6c53589931096ae9cbc668da3bae4dd4e789dc0
<pre>
Web Inspector: Elements Tab DOM Tree does not update when a top-level item in the DOM tree is added/removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=227774">https://bugs.webkit.org/show_bug.cgi?id=227774</a>
rdar://31137058

Reviewed by Devin Rousso.

While unlikely to affect a majority of users, it is possible to call `document.write(&quot;&quot;)` followed by `document.close()`
to rewrite the entire documents contents, which means top-level items in the DOM tree outline view will need to be
removed and inserted.

Previously, updates were only performed for node insertion/deletion when that node had a parent node represented in the
DOM tree. However, this means for the above example where one or more nodes will never be represented by a parent node
in the DOM tree no update will be performed to reflect those insertions/deletions. In those cases, we should forgo the
per-item updating and instead update the entire tree, similar to how we handle all other insertions/deletions where we
will update all children of the updated node&apos;s parent.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeUpdater.js:
(WI.DOMTreeUpdater.prototype._updateModifiedNodes):

Canonical link: <a href="https://commits.webkit.org/254062@main">https://commits.webkit.org/254062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/524986defb56f2431b92318dfcedec15f5d82868

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97065 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152065 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30370 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26392 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/80021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91808 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24500 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/74598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24487 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79453 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/28107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/28203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14431 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2858 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/31227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/74598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/30177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33706 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->