### PR TITLE
Web Inspector: inline breakpoint widget should show auto-continue status

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/BreakpointInlineWidget.css
+++ b/Source/WebInspectorUI/UserInterface/Views/BreakpointInlineWidget.css
@@ -41,3 +41,14 @@
 .inline-widget.breakpoint.disabled {
     background-color: var(--breakpoint-color-disabled);
 }
+
+.inline-widget.breakpoint.auto-continue::after {
+    position: absolute;
+    right: 5px;
+    width: 3px;
+    height: 10px;
+    content: "";
+    clip-path: polygon(0 20%, 100% 50%, 0 80%);
+    background-color: var(--selected-foreground-color);
+    transform: scaleX(-1);
+}

--- a/Source/WebInspectorUI/UserInterface/Views/BreakpointInlineWidget.js
+++ b/Source/WebInspectorUI/UserInterface/Views/BreakpointInlineWidget.js
@@ -62,6 +62,7 @@ WI.BreakpointInlineWidget = class BreakpointInlineWidget
     _update()
     {
         this._element.classList.toggle("disabled", !this._breakpoint || this._breakpoint.disabled);
+        this._element.classList.toggle("auto-continue", !!this._breakpoint?.autoContinue);
     }
 
     _createBreakpoint() {
@@ -77,6 +78,7 @@ WI.BreakpointInlineWidget = class BreakpointInlineWidget
     _addBreakpointEventListeners()
     {
         this._breakpoint.addEventListener(WI.Breakpoint.Event.DisabledStateDidChange, this._handleBreakpointDisabledStateChanged, this);
+        this._breakpoint.addEventListener(WI.Breakpoint.Event.AutoContinueDidChange, this._handleBreakpointAutoContinueChanged, this);
 
         WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.BreakpointRemoved, this._handleBreakpointRemoved, this);
     }
@@ -124,6 +126,11 @@ WI.BreakpointInlineWidget = class BreakpointInlineWidget
         this._update();
     }
 
+    _handleBreakpointAutoContinueChanged(event)
+    {
+        this._update();
+    }
+
     _handleBreakpointRemoved(event)
     {
         let {breakpoint} = event.data;
@@ -131,6 +138,7 @@ WI.BreakpointInlineWidget = class BreakpointInlineWidget
             return;
 
         this._breakpoint.removeEventListener(WI.Breakpoint.Event.DisabledStateDidChange, this._handleBreakpointDisabledStateChanged, this);
+        this._breakpoint.removeEventListener(WI.Breakpoint.Event.AutoContinueDidChange, this._handleBreakpointAutoContinueChanged, this);
 
         WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.BreakpointRemoved, this._handleBreakpointRemoved, this);
 


### PR DESCRIPTION
#### 365834ef6217c30b6f4253a70f91c7cf1d8c8eb1
<pre>
Web Inspector: inline breakpoint widget should show auto-continue status
<a href="https://bugs.webkit.org/show_bug.cgi?id=244647">https://bugs.webkit.org/show_bug.cgi?id=244647</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/BreakpointInlineWidget.js:
(WI.BreakpointInlineWidget.prototype._update):
(WI.BreakpointInlineWidget.prototype._addBreakpointEventListeners):
(WI.BreakpointInlineWidget.prototype._handleBreakpointAutoContinueChanged): Added.
(WI.BreakpointInlineWidget.prototype._handleBreakpointRemoved):
* Source/WebInspectorUI/UserInterface/Views/BreakpointInlineWidget.css:
(.inline-widget.breakpoint.auto-continue::after): Added.

Canonical link: <a href="https://commits.webkit.org/254057@main">https://commits.webkit.org/254057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03724e4449323f8ea3ffc4036e78e827df48c571

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87917 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/69/builds/32038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/18624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/97076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/152233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30390 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80008 "Failed to checkout and rebase branch from PR 3919") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/91819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93530 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24513 "Failed to checkout and rebase branch from PR 3919") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/74605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/80008 "Failed to checkout and rebase branch from PR 3919") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79466 "Failed to checkout and rebase branch from PR 3919") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/18624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/80008 "Failed to checkout and rebase branch from PR 3919") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/28114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/18624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/28210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/18624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/31234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/74605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1161 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/30184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/18624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->