### PR TITLE
Web Inspector: Assertion when removing event listener in CSSPropertyNameCompletions.js

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/CSSPropertyNameCompletions.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSPropertyNameCompletions.js
@@ -43,6 +43,7 @@ WI.CSSPropertyNameCompletions = class CSSPropertyNameCompletions extends WI.CSSC
 
         this._cachedSortedPropertyNames = this.values.slice();
         this._needsVariablesFromInspectedNode = true;
+        this._inspectedDOMNodeStyles = null;
 
         WI.domManager.addEventListener(WI.DOMManager.Event.InspectedNodeChanged, this._handleInspectedNodeChanged, this);
     }
@@ -92,10 +93,9 @@ WI.CSSPropertyNameCompletions = class CSSPropertyNameCompletions extends WI.CSSC
     {
         this._needsVariablesFromInspectedNode = true;
 
-        if (event.data.lastInspectedNode)
-            WI.cssManager.stylesForNode(event.data.lastInspectedNode).removeEventListener(WI.DOMNodeStyles.Event.NeedsRefresh, this._handleNodesStylesNeedsRefresh, this);
-
-        WI.cssManager.stylesForNode(WI.domManager.inspectedNode).addEventListener(WI.DOMNodeStyles.Event.NeedsRefresh, this._handleNodesStylesNeedsRefresh, this);
+        this._inspectedDOMNodeStyles?.removeEventListener(WI.DOMNodeStyles.Event.NeedsRefresh, this._handleNodesStylesNeedsRefresh, this);
+        this._inspectedDOMNodeStyles = WI.cssManager.stylesForNode(WI.domManager.inspectedNode);
+        this._inspectedDOMNodeStyles.addEventListener(WI.DOMNodeStyles.Event.NeedsRefresh, this._handleNodesStylesNeedsRefresh, this);
     }
 
     _handleNodesStylesNeedsRefresh(event)


### PR DESCRIPTION
#### 7d37933f4760f4c86aeb39d8f1735d57bb782ad8
<pre>
Web Inspector: Assertion when removing event listener in CSSPropertyNameCompletions.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=240606">https://bugs.webkit.org/show_bug.cgi?id=240606</a>

Reviewed by Patrick Angle.

When reloading the page with Web Inspector open:
- the map of `WI.DOMNodeStyles` is cleared in `WI.CSSManager._mainResourceDidChange()`;
- the selected node is re-selected and a new `WI.DOMNode` is created for it;
- the event `WI.DOMManager.Event.InspectedNodeChanged` is dispatched with the data payload member
`lastInspectedNode` pointing to this new instance;

When requesting the `WI.cssManager.stylesForNode(event.data.lastInspectedNode)`, a new instance
of `WI.DOMNodeStyles` is created and returned. This new instance did not have an event listener attached for
`WI.DOMNodeStyles.Event.NeedsRefresh`. Therefore, when attempting to remove the event listener, the assertion is hit.

This patch makes `CSSPropertyNameCompletions` hold its own reference to the inspected node&apos;s `WI.DOMNodeStyles`
and remove to reliably remove the event listener.

* Source/WebInspectorUI/UserInterface/Models/CSSPropertyNameCompletions.js:
(WI.CSSPropertyNameCompletions.prototype._handleInspectedNodeChanged):

Canonical link: <a href="https://commits.webkit.org/254072@main">https://commits.webkit.org/254072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/808b93877623ed66d4ab15df92f5468f2a9c3577

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18648 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/97094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152533 "Built successfully and passed tests") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/64/builds/30455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91837 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93551 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/64/builds/30455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/74621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/24516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/64/builds/30455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/28128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/28225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/14455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2860 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/31249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/74621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/30198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/33726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->