### PR TITLE
[Gardening]: [ macOS wk1 ] media/media-source/media-source-istypesupported-vp8-without-vp9.html is a constant text failure (Follow-up)

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2033,3 +2033,6 @@ webkit.org/b/244637 imported/w3c/web-platform-tests/content-security-policy/gene
 webkit.org/b/244649 [ Debug ] imported/w3c/web-platform-tests/css/css-align/baseline-rules/synthesized-baseline-flexbox-001.html [ Pass Crash ]
 
 webkit.org/b/244652 [ Debug ] imported/w3c/web-platform-tests/html/semantics/embedded-content/bfcache/embedded-mp4.html [ Pass Crash ]
+
+webkit.org/b/244677 [ Debug ] media/media-source/media-source-istypesupported-vp8-without-vp9.html [ Pass Failure ]
+


### PR DESCRIPTION
#### 9d311ee324b37ca4fff78c23020150be1e2f6d0a
<pre>
[Gardening]: [ macOS wk1 ] media/media-source/media-source-istypesupported-vp8-without-vp9.html is a constant text failure (Follow-up)
<a href="https://bugs.webkit.org/show_bug.cgi?id=244677">https://bugs.webkit.org/show_bug.cgi?id=244677</a>
&lt;rdar://99446320&gt;

Unreviewed test gardening.

* LayoutTests/platform/mac-wk1/TestExpectations: Test is failing on all Mac WK1 configurations.
</pre>