### PR TITLE
REGRESSION(253383@main): Build broken with ENABLE(VIDEO) disabled

### DIFF
--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -66,8 +66,11 @@ static bool isSearchInvisible(const Node& node)
         || is<HTMLProgressElement>(node)
         || is<HTMLStyleElement>(node)
         || is<HTMLScriptElement>(node)
+#if ENABLE(VIDEO)
         || is<HTMLVideoElement>(node)
-        || is<HTMLAudioElement>(node))
+        || is<HTMLAudioElement>(node)
+#endif // ENABLE(VIDEO)
+        )
         return true;
     
     // FIXME: Is a select element whose multiple content attribute is absent.

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -1287,10 +1287,12 @@ void ContextMenuController::addDebuggingItems()
     ContextMenuItem InspectElementItem(ActionType, ContextMenuItemTagInspectElement, contextMenuItemTagInspectElement());
     appendItem(InspectElementItem, m_contextMenu.get());
 
+#if ENABLE(VIDEO)
     if (page->settings().showMediaStatsContextMenuItemEnabled() && !m_context.hitTestResult().absoluteMediaURL().isEmpty()) {
         ContextMenuItem ShowMediaStats(CheckableActionType, ContextMenuItemTagShowMediaStats, contextMenuItemTagShowMediaStats());
         appendItem(ShowMediaStats, m_contextMenu.get());
     }
+#endif // ENABLE(VIDEO)
 }
 
 void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const


### PR DESCRIPTION
#### 6989aa1a1476651700a98cceb83dc5646e580638
<pre>
REGRESSION(253383@main): Build broken with ENABLE(VIDEO) disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=244680">https://bugs.webkit.org/show_bug.cgi?id=244680</a>

Reviewed by Michael Catanzaro.

Sprinkle missing ENABLE(VIDEO) guards where needed.

* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::isSearchInvisible): Guard usage
of HTMLAudioElement and HTMLVideoElement.
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::addDebuggingItems): Guard addition of
media statistics entry to context menus.

Canonical link: <a href="https://commits.webkit.org/254094@main">https://commits.webkit.org/254094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06160cfb96ea6f2c376359dc0d06df73b6aab6a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97087 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152401 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30410 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26415 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80040 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91830 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24522 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74615 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24523 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/91536 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79610 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79697 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28123 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73442 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/86997 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28219 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14449 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26096 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2870 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37350 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76281 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33721 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16917 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode (failure)") | 
<!--EWS-Status-Bubble-End-->