### PR TITLE
Generate IndexedDB object serializers

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.h
@@ -27,6 +27,7 @@
 
 #include "ClientOrigin.h"
 #include "SecurityOriginData.h"
+#include <wtf/ArgumentCoder.h>
 
 namespace WebCore {
 
@@ -73,9 +74,6 @@ public:
     String databaseDirectoryRelativeToRoot(const String& rootDirectory, ASCIILiteral versionString = "v1"_s) const;
     WEBCORE_EXPORT static String databaseDirectoryRelativeToRoot(const ClientOrigin&, const String& rootDirectory, ASCIILiteral versionString);
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<IDBDatabaseIdentifier> decode(Decoder&);
-
 #if !LOG_DISABLED
     String loggingString() const;
 #endif
@@ -83,6 +81,8 @@ public:
     bool isRelatedToOrigin(const SecurityOriginData& other) const { return m_origin.isRelated(other); }
 
 private:
+    friend struct IPC::ArgumentCoder<IDBDatabaseIdentifier, void>;
+
     String m_databaseName;
     ClientOrigin m_origin;
     bool m_isTransient { false };
@@ -104,37 +104,6 @@ struct IDBDatabaseIdentifierHashTraits : SimpleClassHashTraits<IDBDatabaseIdenti
     static const bool emptyValueIsZero = false;
     static bool isEmptyValue(const IDBDatabaseIdentifier& info) { return info.isEmpty(); }
 };
-
-template<class Encoder>
-void IDBDatabaseIdentifier::encode(Encoder& encoder) const
-{
-    encoder << m_databaseName << m_origin << m_isTransient;
-}
-
-template<class Decoder>
-std::optional<IDBDatabaseIdentifier> IDBDatabaseIdentifier::decode(Decoder& decoder)
-{
-    std::optional<String> databaseName;
-    decoder >> databaseName;
-    if (!databaseName)
-        return std::nullopt;
-
-    std::optional<ClientOrigin> origin;
-    decoder >> origin;
-    if (!origin)
-        return std::nullopt;
-
-    std::optional<bool> isTransient;
-    decoder >> isTransient;
-    if (!isTransient)
-        return std::nullopt;
-
-    IDBDatabaseIdentifier identifier;
-    identifier.m_databaseName = WTFMove(*databaseName); // FIXME: When decoding from IPC, databaseName can be null, and the non-empty constructor asserts that this is not the case.
-    identifier.m_origin = WTFMove(*origin);
-    identifier.m_isTransient = *isTransient;
-    return identifier;
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/indexeddb/IDBGetResult.h
+++ b/Source/WebCore/Modules/indexeddb/IDBGetResult.h
@@ -68,20 +68,13 @@ public:
     {
     }
 
-    IDBGetResult(const IDBKeyData& keyData, const IDBKeyData& primaryKeyData, IDBValue&& value, const std::optional<IDBKeyPath>& keyPath)
-        : m_value(WTFMove(value))
-        , m_keyData(keyData)
-        , m_primaryKeyData(primaryKeyData)
-        , m_keyPath(keyPath)
-    {
-    }
-
-    IDBGetResult(const IDBKeyData& keyData, const IDBKeyData& primaryKeyData, IDBValue&& value, const std::optional<IDBKeyPath>& keyPath, Vector<IDBCursorRecord>&& prefetechedRecords)
+    IDBGetResult(const IDBKeyData& keyData, const IDBKeyData& primaryKeyData, IDBValue&& value, const std::optional<IDBKeyPath>& keyPath, Vector<IDBCursorRecord>&& prefetechedRecords = { }, bool isDefined = true)
         : m_value(WTFMove(value))
         , m_keyData(keyData)
         , m_primaryKeyData(primaryKeyData)
         , m_keyPath(keyPath)
         , m_prefetchedRecords(WTFMove(prefetechedRecords))
+        , m_isDefined(isDefined)
     {
     }
 
@@ -99,9 +92,6 @@ public:
     const Vector<IDBCursorRecord>& prefetchedRecords() const { return m_prefetchedRecords; }
     bool isDefined() const { return m_isDefined; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, IDBGetResult&);
-
 private:
     static void isolatedCopy(const IDBGetResult& source, IDBGetResult& destination);
 
@@ -112,47 +102,5 @@ private:
     Vector<IDBCursorRecord> m_prefetchedRecords;
     bool m_isDefined { true };
 };
-
-template<class Encoder>
-void IDBGetResult::encode(Encoder& encoder) const
-{
-    encoder << m_keyData << m_primaryKeyData << m_keyPath << m_isDefined << m_value << m_prefetchedRecords;
-}
-
-template<class Decoder>
-bool IDBGetResult::decode(Decoder& decoder, IDBGetResult& result)
-{
-    std::optional<IDBKeyData> keyData;
-    decoder >> keyData;
-    if (!keyData)
-        return false;
-    result.m_keyData = WTFMove(*keyData);
-
-    std::optional<IDBKeyData> primaryKeyData;
-    decoder >> primaryKeyData;
-    if (!primaryKeyData)
-        return false;
-    result.m_primaryKeyData = WTFMove(*primaryKeyData);
-
-    if (!decoder.decode(result.m_keyPath))
-        return false;
-
-    if (!decoder.decode(result.m_isDefined))
-        return false;
-
-    std::optional<IDBValue> value;
-    decoder >> value;
-    if (!value)
-        return false;
-    result.m_value = WTFMove(*value);
-
-    std::optional<Vector<IDBCursorRecord>> prefetchedRecords;
-    decoder >> prefetchedRecords;
-    if (!prefetchedRecords)
-        return false;
-    result.m_prefetchedRecords = WTFMove(*prefetchedRecords);
-
-    return true;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRangeData.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRangeData.h
@@ -62,6 +62,15 @@ struct IDBKeyRangeData {
         upperOpen = keyRange->upperOpen();
     }
 
+    IDBKeyRangeData(bool isNull, IDBKeyData&& lowerKey, IDBKeyData&& upperKey, bool lowerOpen, bool upperOpen)
+        : lowerKey(WTFMove(lowerKey))
+        , upperKey(WTFMove(upperKey))
+        , lowerOpen(WTFMove(lowerOpen))
+        , upperOpen(WTFMove(upperOpen))
+        , isNull(isNull)
+    {
+    }
+
     WEBCORE_EXPORT IDBKeyRangeData isolatedCopy() const;
 
     WEBCORE_EXPORT RefPtr<IDBKeyRange> maybeCreateIDBKeyRange() const;
@@ -69,9 +78,6 @@ struct IDBKeyRangeData {
     WEBCORE_EXPORT bool isExactlyOneKey() const;
     bool containsKey(const IDBKeyData&) const;
     bool isValid() const;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, IDBKeyRangeData&);
 
     IDBKeyData lowerKey;
     IDBKeyData upperKey;
@@ -85,45 +91,5 @@ struct IDBKeyRangeData {
     String loggingString() const;
 #endif
 };
-
-template<class Encoder>
-void IDBKeyRangeData::encode(Encoder& encoder) const
-{
-    encoder << isNull;
-    if (isNull)
-        return;
-
-    encoder << upperKey << lowerKey << upperOpen << lowerOpen;
-}
-
-template<class Decoder>
-bool IDBKeyRangeData::decode(Decoder& decoder, IDBKeyRangeData& keyRange)
-{
-    if (!decoder.decode(keyRange.isNull))
-        return false;
-
-    if (keyRange.isNull)
-        return true;
-
-    std::optional<IDBKeyData> upperKey;
-    decoder >> upperKey;
-    if (!upperKey)
-        return false;
-    keyRange.upperKey = WTFMove(*upperKey);
-    
-    std::optional<IDBKeyData> lowerKey;
-    decoder >> lowerKey;
-    if (!lowerKey)
-        return false;
-    keyRange.lowerKey = WTFMove(*lowerKey);
-
-    if (!decoder.decode(keyRange.upperOpen))
-        return false;
-
-    if (!decoder.decode(keyRange.lowerOpen))
-        return false;
-
-    return true;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/IDBValue.h
+++ b/Source/WebCore/Modules/indexeddb/IDBValue.h
@@ -39,7 +39,7 @@ public:
     IDBValue(const SerializedScriptValue&);
     IDBValue(const ThreadSafeDataBuffer&);
     IDBValue(const SerializedScriptValue&, const Vector<String>& blobURLs, const Vector<String>& blobFilePaths);
-    IDBValue(const ThreadSafeDataBuffer&, Vector<String>&& blobURLs, Vector<String>&& blobFilePaths);
+    WEBCORE_EXPORT IDBValue(const ThreadSafeDataBuffer&, Vector<String>&& blobURLs, Vector<String>&& blobFilePaths);
     IDBValue(const ThreadSafeDataBuffer&, const Vector<String>& blobURLs, const Vector<String>& blobFilePaths);
 
     void setAsIsolatedCopy(const IDBValue&);
@@ -49,38 +49,11 @@ public:
     const Vector<String>& blobURLs() const { return m_blobURLs; }
     const Vector<String>& blobFilePaths() const { return m_blobFilePaths; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<IDBValue> decode(Decoder&);
-
     size_t size() const;
 private:
     ThreadSafeDataBuffer m_data;
     Vector<String> m_blobURLs;
     Vector<String> m_blobFilePaths;
 };
-
-template<class Encoder>
-void IDBValue::encode(Encoder& encoder) const
-{
-    encoder << m_data;
-    encoder << m_blobURLs;
-    encoder << m_blobFilePaths;
-}
-
-template<class Decoder>
-std::optional<IDBValue> IDBValue::decode(Decoder& decoder)
-{
-    IDBValue result;
-    if (!decoder.decode(result.m_data))
-        return std::nullopt;
-
-    if (!decoder.decode(result.m_blobURLs))
-        return std::nullopt;
-
-    if (!decoder.decode(result.m_blobFilePaths))
-        return std::nullopt;
-
-    return result;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBCursorInfo.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBCursorInfo.h
@@ -27,6 +27,7 @@
 
 #include "IDBKeyRangeData.h"
 #include "IDBResourceIdentifier.h"
+#include <wtf/ArgumentCoder.h>
 
 namespace WebCore {
 
@@ -51,6 +52,7 @@ public:
     static IDBCursorInfo indexCursor(IDBTransaction&, uint64_t objectStoreIdentifier, uint64_t indexIdentifier, const IDBKeyRangeData&, IndexedDB::CursorDirection, IndexedDB::CursorType);
 
     IDBResourceIdentifier identifier() const { return m_cursorIdentifier; }
+    IDBResourceIdentifier transactionIdentifier() const { return m_transactionIdentifier; }
     uint64_t sourceIdentifier() const { return m_sourceIdentifier; }
     uint64_t objectStoreIdentifier() const { return m_objectStoreIdentifier; }
 
@@ -65,18 +67,16 @@ public:
     WEBCORE_EXPORT IDBCursorInfo isolatedCopy() const;
 
     WEBCORE_EXPORT IDBCursorInfo();
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, IDBCursorInfo&);
 
 #if !LOG_DISABLED
     String loggingString() const;
 #endif
 
 private:
+    friend struct IPC::ArgumentCoder<IDBCursorInfo, void>;
+    WEBCORE_EXPORT IDBCursorInfo(const IDBResourceIdentifier&, const IDBResourceIdentifier&, uint64_t, uint64_t, const IDBKeyRangeData&, IndexedDB::CursorSource, IndexedDB::CursorDirection, IndexedDB::CursorType);
     IDBCursorInfo(IDBTransaction&, uint64_t objectStoreIdentifier, const IDBKeyRangeData&, IndexedDB::CursorDirection, IndexedDB::CursorType);
     IDBCursorInfo(IDBTransaction&, uint64_t objectStoreIdentifier, uint64_t indexIdentifier, const IDBKeyRangeData&, IndexedDB::CursorDirection, IndexedDB::CursorType);
-
-    IDBCursorInfo(const IDBResourceIdentifier&, const IDBResourceIdentifier&, uint64_t, uint64_t, const IDBKeyRangeData&, IndexedDB::CursorSource, IndexedDB::CursorDirection, IndexedDB::CursorType);
 
     IDBResourceIdentifier m_cursorIdentifier;
     IDBResourceIdentifier m_transactionIdentifier;
@@ -89,45 +89,5 @@ private:
     IndexedDB::CursorDirection m_direction;
     IndexedDB::CursorType m_type;
 };
-
-template<class Encoder>
-void IDBCursorInfo::encode(Encoder& encoder) const
-{
-    encoder << m_cursorIdentifier << m_transactionIdentifier << m_objectStoreIdentifier << m_sourceIdentifier << m_range;
-
-    encoder << m_source;
-    encoder << m_direction;
-    encoder << m_type;
-}
-
-template<class Decoder>
-bool IDBCursorInfo::decode(Decoder& decoder, IDBCursorInfo& info)
-{
-    if (!decoder.decode(info.m_cursorIdentifier))
-        return false;
-
-    if (!decoder.decode(info.m_transactionIdentifier))
-        return false;
-
-    if (!decoder.decode(info.m_objectStoreIdentifier))
-        return false;
-
-    if (!decoder.decode(info.m_sourceIdentifier))
-        return false;
-
-    if (!decoder.decode(info.m_range))
-        return false;
-
-    if (!decoder.decode(info.m_source))
-        return false;
-
-    if (!decoder.decode(info.m_direction))
-        return false;
-
-    if (!decoder.decode(info.m_type))
-        return false;
-
-    return true;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBCursorRecord.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBCursorRecord.h
@@ -35,37 +35,8 @@ struct IDBCursorRecord {
     IDBKeyData primaryKey;
     IDBValue value;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, IDBCursorRecord&);
-
-    IDBCursorRecord isolatedCopy() const;
+    IDBCursorRecord isolatedCopy() const { return { key.isolatedCopy(), primaryKey.isolatedCopy(), value.isolatedCopy() }; }
     size_t size() const { return key.size() + primaryKey.size() + value.size(); }
 };
-
-template<class Encoder>
-void IDBCursorRecord::encode(Encoder& encoder) const
-{
-    encoder << key << primaryKey << value;
-}
-
-template<class Decoder>
-bool IDBCursorRecord::decode(Decoder& decoder, IDBCursorRecord& record)
-{
-    if (!decoder.decode(record.key))
-        return false;
-
-    if (!decoder.decode(record.primaryKey))
-        return false;
-
-    if (!decoder.decode(record.value))
-        return false;
-
-    return true;
-}
-
-inline IDBCursorRecord IDBCursorRecord::isolatedCopy() const
-{
-    return { key.isolatedCopy(), primaryKey.isolatedCopy(), value.isolatedCopy() };
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.cpp
@@ -33,14 +33,12 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(IDBDatabaseInfo);
 
-IDBDatabaseInfo::IDBDatabaseInfo()
-{
-}
-
-IDBDatabaseInfo::IDBDatabaseInfo(const String& name, uint64_t version, uint64_t maxIndexID)
+IDBDatabaseInfo::IDBDatabaseInfo(const String& name, uint64_t version, uint64_t maxIndexID, uint64_t maxObjectStoreID, HashMap<uint64_t, IDBObjectStoreInfo>&& objectStoreMap)
     : m_name(name)
     , m_version(version)
+    , m_maxObjectStoreID(maxObjectStoreID)
     , m_maxIndexID(maxIndexID)
+    , m_objectStoreMap(WTFMove(objectStoreMap))
 {
 }
 

--- a/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseNameAndVersion.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseNameAndVersion.h
@@ -33,31 +33,8 @@ struct IDBDatabaseNameAndVersion {
     String name;
     uint64_t version { 0 };
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<IDBDatabaseNameAndVersion> decode(Decoder&);
-
     IDBDatabaseNameAndVersion isolatedCopy() const & { return { name.isolatedCopy(), version }; }
     IDBDatabaseNameAndVersion isolatedCopy() && { return { WTFMove(name).isolatedCopy(), version }; }
 };
-
-template<class Encoder>
-void IDBDatabaseNameAndVersion::encode(Encoder& encoder) const
-{
-    encoder << name << version;
-}
-
-template<class Decoder>
-std::optional<IDBDatabaseNameAndVersion> IDBDatabaseNameAndVersion::decode(Decoder& decoder)
-{
-    IDBDatabaseNameAndVersion info;
-
-    if (!decoder.decode(info.name))
-        return std::nullopt;
-
-    if (!decoder.decode(info.version))
-        return std::nullopt;
-
-    return info;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBError.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBError.h
@@ -50,6 +50,7 @@ public:
     std::optional<ExceptionCode> code() const { return m_code; }
     String name() const;
     String message() const;
+    const String& messageForSerialization() const { return m_message; }
 
     bool isNull() const { return !m_code; }
     operator bool() const { return !isNull(); }
@@ -57,44 +58,9 @@ public:
     IDBError isolatedCopy() const & { return IDBError { m_code, m_message.isolatedCopy() }; }
     IDBError isolatedCopy() && { return IDBError { m_code, WTFMove(m_message).isolatedCopy() }; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, IDBError&);
-
 private:
     std::optional<ExceptionCode> m_code;
     String m_message;
 };
-
-template<class Encoder>
-void IDBError::encode(Encoder& encoder) const
-{
-    if (m_code) {
-        encoder << true;
-        encoder << m_code.value();
-    } else
-        encoder << false;
-    encoder << m_message;
-}
-    
-template<class Decoder>
-bool IDBError::decode(Decoder& decoder, IDBError& error)
-{
-    bool hasCode = false;
-    if (!decoder.decode(hasCode))
-        return false;
-
-    if (hasCode) {
-        ExceptionCode ec;
-        if (!decoder.decode(ec))
-            return false;
-        error.m_code = ec;
-    } else
-        error.m_code = std::nullopt;
-
-    if (!decoder.decode(error.m_message))
-        return false;
-
-    return true;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.h
@@ -45,38 +45,6 @@ struct IDBGetAllRecordsData {
 #if !LOG_DISABLED
     String loggingString() const;
 #endif
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, IDBGetAllRecordsData&);
 };
-
-template<class Encoder>
-void IDBGetAllRecordsData::encode(Encoder& encoder) const
-{
-    encoder << keyRangeData;
-    encoder << getAllType;
-    encoder << count << objectStoreIdentifier << indexIdentifier;
-}
-
-template<class Decoder>
-bool IDBGetAllRecordsData::decode(Decoder& decoder, IDBGetAllRecordsData& getAllRecordsData)
-{
-    if (!decoder.decode(getAllRecordsData.keyRangeData))
-        return false;
-
-    if (!decoder.decode(getAllRecordsData.getAllType))
-        return false;
-
-    if (!decoder.decode(getAllRecordsData.count))
-        return false;
-
-    if (!decoder.decode(getAllRecordsData.objectStoreIdentifier))
-        return false;
-
-    if (!decoder.decode(getAllRecordsData.indexIdentifier))
-        return false;
-
-    return true;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBGetRecordData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBGetRecordData.h
@@ -44,28 +44,6 @@ struct IDBGetRecordData {
 #if !LOG_DISABLED
     String loggingString() const;
 #endif
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, IDBGetRecordData&);
 };
-
-template<class Encoder>
-void IDBGetRecordData::encode(Encoder& encoder) const
-{
-    encoder << keyRangeData;
-    encoder << type;
-}
-
-template<class Decoder>
-bool IDBGetRecordData::decode(Decoder& decoder, IDBGetRecordData& getRecordData)
-{
-    if (!decoder.decode(getRecordData.keyRangeData))
-        return false;
-
-    if (!decoder.decode(getRecordData.type))
-        return false;
-
-    return true;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBIndexInfo.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBIndexInfo.h
@@ -33,7 +33,7 @@ namespace WebCore {
 class IDBIndexInfo {
 public:
     WEBCORE_EXPORT IDBIndexInfo();
-    IDBIndexInfo(uint64_t identifier, uint64_t objectStoreIdentifier, const String& name, IDBKeyPath&&, bool unique, bool multiEntry);
+    WEBCORE_EXPORT IDBIndexInfo(uint64_t identifier, uint64_t objectStoreIdentifier, const String& name, IDBKeyPath&&, bool unique, bool multiEntry);
 
     WEBCORE_EXPORT IDBIndexInfo isolatedCopy() const &;
     WEBCORE_EXPORT IDBIndexInfo isolatedCopy() &&;
@@ -46,9 +46,6 @@ public:
     bool multiEntry() const { return m_multiEntry; }
 
     void rename(const String& newName) { m_name = newName; }
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, IDBIndexInfo&);
 
 #if !LOG_DISABLED
     String loggingString(int indent = 0) const;
@@ -67,35 +64,5 @@ private:
     bool m_unique { true };
     bool m_multiEntry { false };
 };
-
-template<class Encoder>
-void IDBIndexInfo::encode(Encoder& encoder) const
-{
-    encoder << m_identifier << m_objectStoreIdentifier << m_name << m_keyPath << m_unique << m_multiEntry;
-}
-
-template<class Decoder>
-bool IDBIndexInfo::decode(Decoder& decoder, IDBIndexInfo& info)
-{
-    if (!decoder.decode(info.m_identifier))
-        return false;
-
-    if (!decoder.decode(info.m_objectStoreIdentifier))
-        return false;
-
-    if (!decoder.decode(info.m_name))
-        return false;
-
-    if (!decoder.decode(info.m_keyPath))
-        return false;
-
-    if (!decoder.decode(info.m_unique))
-        return false;
-
-    if (!decoder.decode(info.m_multiEntry))
-        return false;
-
-    return true;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBIterateCursorData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBIterateCursorData.h
@@ -32,7 +32,7 @@ namespace WebCore {
 struct IDBIterateCursorData {
     IDBKeyData keyData;
     IDBKeyData primaryKeyData;
-    unsigned count;
+    unsigned count { 0 };
     IndexedDB::CursorIterateOption option { IndexedDB::CursorIterateOption::Reply };
 
     WEBCORE_EXPORT IDBIterateCursorData isolatedCopy() const;
@@ -40,45 +40,6 @@ struct IDBIterateCursorData {
 #if !LOG_DISABLED
     String loggingString() const;
 #endif
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, IDBIterateCursorData&);
 };
-
-template<class Encoder>
-void IDBIterateCursorData::encode(Encoder& encoder) const
-{
-    encoder << keyData << primaryKeyData << static_cast<uint64_t>(count);
-    encoder << option;
-}
-
-template<class Decoder>
-bool IDBIterateCursorData::decode(Decoder& decoder, IDBIterateCursorData& iteratorCursorData)
-{
-    std::optional<IDBKeyData> keyData;
-    decoder >> keyData;
-    if (!keyData)
-        return false;
-    iteratorCursorData.keyData = WTFMove(*keyData);
-
-    std::optional<IDBKeyData> primaryKeyData;
-    decoder >> primaryKeyData;
-    if (!primaryKeyData)
-        return false;
-    iteratorCursorData.primaryKeyData = WTFMove(*primaryKeyData);
-
-    uint64_t count;
-    if (!decoder.decode(count))
-        return false;
-
-    if (count > std::numeric_limits<unsigned>::max())
-        return false;
-    iteratorCursorData.count = static_cast<unsigned>(count);
-
-    if (!decoder.decode(iteratorCursorData.option))
-        return false;
-
-    return true;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.cpp
@@ -35,11 +35,12 @@ IDBObjectStoreInfo::IDBObjectStoreInfo()
 {
 }
 
-IDBObjectStoreInfo::IDBObjectStoreInfo(uint64_t identifier, const String& name, std::optional<IDBKeyPath>&& keyPath, bool autoIncrement)
+IDBObjectStoreInfo::IDBObjectStoreInfo(uint64_t identifier, const String& name, std::optional<IDBKeyPath>&& keyPath, bool autoIncrement, HashMap<uint64_t, IDBIndexInfo>&& indexMap)
     : m_identifier(identifier)
     , m_name(name)
     , m_keyPath(WTFMove(keyPath))
     , m_autoIncrement(autoIncrement)
+    , m_indexMap(WTFMove(indexMap))
 {
 }
 

--- a/Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.h
@@ -35,7 +35,7 @@ namespace WebCore {
 class IDBObjectStoreInfo {
 public:
     WEBCORE_EXPORT IDBObjectStoreInfo();
-    IDBObjectStoreInfo(uint64_t identifier, const String& name, std::optional<IDBKeyPath>&&, bool autoIncrement);
+    WEBCORE_EXPORT IDBObjectStoreInfo(uint64_t identifier, const String& name, std::optional<IDBKeyPath>&&, bool autoIncrement, HashMap<uint64_t, IDBIndexInfo>&& = { });
 
     uint64_t identifier() const { return m_identifier; }
     const String& name() const { return m_name; }
@@ -60,9 +60,6 @@ public:
     void deleteIndex(const String& indexName);
     void deleteIndex(uint64_t indexIdentifier);
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, IDBObjectStoreInfo&);
-
 #if !LOG_DISABLED
     String loggingString(int indent = 0) const;
     String condensedLoggingString() const;
@@ -76,32 +73,5 @@ private:
 
     HashMap<uint64_t, IDBIndexInfo> m_indexMap;
 };
-
-template<class Encoder>
-void IDBObjectStoreInfo::encode(Encoder& encoder) const
-{
-    encoder << m_identifier << m_name << m_keyPath << m_autoIncrement << m_indexMap;
-}
-
-template<class Decoder>
-bool IDBObjectStoreInfo::decode(Decoder& decoder, IDBObjectStoreInfo& info)
-{
-    if (!decoder.decode(info.m_identifier))
-        return false;
-
-    if (!decoder.decode(info.m_name))
-        return false;
-
-    if (!decoder.decode(info.m_keyPath))
-        return false;
-
-    if (!decoder.decode(info.m_autoIncrement))
-        return false;
-
-    if (!decoder.decode(info.m_indexMap))
-        return false;
-
-    return true;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp
@@ -32,10 +32,6 @@
 
 namespace WebCore {
 
-IDBRequestData::IDBRequestData()
-{
-}
-
 IDBRequestData::IDBRequestData(const IDBClient::IDBConnectionProxy& connectionProxy, const IDBOpenDBRequest& request)
     : m_serverConnectionIdentifier(connectionProxy.serverConnectionIdentifier())
     , m_requestIdentifier(makeUnique<IDBResourceIdentifier>(connectionProxy, request))

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ProcessIdentifier.h"
+#include <wtf/ArgumentCoder.h>
 #include <wtf/Hasher.h>
 
 namespace WebCore {
@@ -71,15 +72,13 @@ public:
 #endif
 
     WEBCORE_EXPORT IDBResourceIdentifier();
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, IDBResourceIdentifier&);
-
 private:
+    friend struct IPC::ArgumentCoder<IDBResourceIdentifier, void>;
     friend struct IDBResourceIdentifierHashTraits;
     friend void add(Hasher&, const IDBResourceIdentifier&);
 
-    IDBResourceIdentifier(IDBConnectionIdentifier, uint64_t resourceIdentifier);
+    WEBCORE_EXPORT IDBResourceIdentifier(IDBConnectionIdentifier, uint64_t resourceIdentifier);
+
     IDBConnectionIdentifier m_idbConnectionIdentifier;
     uint64_t m_resourceNumber { 0 };
 };
@@ -119,24 +118,6 @@ struct IDBResourceIdentifierHashTraits : WTF::CustomHashTraits<IDBResourceIdenti
         return identifier.m_idbConnectionIdentifier.isHashTableDeletedValue();
     }
 };
-
-template<class Encoder>
-void IDBResourceIdentifier::encode(Encoder& encoder) const
-{
-    encoder << m_idbConnectionIdentifier << m_resourceNumber;
-}
-
-template<class Decoder>
-bool IDBResourceIdentifier::decode(Decoder& decoder, IDBResourceIdentifier& identifier)
-{
-    if (!decoder.decode(identifier.m_idbConnectionIdentifier))
-        return false;
-
-    if (!decoder.decode(identifier.m_resourceNumber))
-        return false;
-
-    return true;
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/indexeddb/shared/IDBTransactionInfo.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBTransactionInfo.cpp
@@ -30,10 +30,6 @@
 
 namespace WebCore {
 
-IDBTransactionInfo::IDBTransactionInfo()
-{
-}
-
 IDBTransactionInfo::IDBTransactionInfo(const IDBResourceIdentifier& identifier)
     : m_identifier(identifier)
 {

--- a/Source/WebCore/Modules/indexeddb/shared/IDBTransactionInfo.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBTransactionInfo.h
@@ -67,9 +67,13 @@ public:
 
     IDBDatabaseInfo* originalDatabaseInfo() const { return m_originalDatabaseInfo.get(); }
 
-    WEBCORE_EXPORT IDBTransactionInfo();
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, IDBTransactionInfo&);
+    IDBTransactionInfo(IDBResourceIdentifier identifier, IDBTransactionMode mode, IDBTransactionDurability durability, uint64_t newVersion, Vector<String>&& objectStores, std::unique_ptr<IDBDatabaseInfo> originalDatabaseInfo)
+        : m_identifier(identifier)
+        , m_mode(mode)
+        , m_durability(durability)
+        , m_newVersion(newVersion)
+        , m_objectStores(WTFMove(objectStores))
+        , m_originalDatabaseInfo(WTFMove(originalDatabaseInfo)) { }
 
 #if !LOG_DISABLED
     String loggingString() const;
@@ -88,48 +92,5 @@ private:
     Vector<String> m_objectStores;
     std::unique_ptr<IDBDatabaseInfo> m_originalDatabaseInfo;
 };
-
-template<class Encoder>
-void IDBTransactionInfo::encode(Encoder& encoder) const
-{
-    encoder << m_identifier << m_newVersion << m_objectStores;
-    encoder << m_mode << m_durability;
-
-    encoder << !!m_originalDatabaseInfo;
-    if (m_originalDatabaseInfo)
-        encoder << *m_originalDatabaseInfo;
-}
-
-template<class Decoder>
-bool IDBTransactionInfo::decode(Decoder& decoder, IDBTransactionInfo& info)
-{
-    if (!decoder.decode(info.m_identifier))
-        return false;
-
-    if (!decoder.decode(info.m_newVersion))
-        return false;
-
-    if (!decoder.decode(info.m_objectStores))
-        return false;
-
-    if (!decoder.decode(info.m_mode))
-        return false;
-
-    if (!decoder.decode(info.m_durability))
-        return false;
-
-    bool hasObject;
-    if (!decoder.decode(hasObject))
-        return false;
-
-    if (hasObject) {
-        std::unique_ptr<IDBDatabaseInfo> object = makeUnique<IDBDatabaseInfo>();
-        if (!decoder.decode(*object))
-            return false;
-        info.m_originalDatabaseInfo = WTFMove(object);
-    }
-
-    return true;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
@@ -47,36 +47,36 @@ JSC::JSValue JSIDBRequest::result(JSC::JSGlobalObject& lexicalGlobalObject) cons
 
     auto resultValue = result.releaseReturnValue();
     auto& resultWrapper = wrapped().resultWrapper();
-    return WTF::switchOn(resultValue, [] (IDBRequest::NullResultType result) {
+    return WTF::switchOn(resultValue, [] (const IDBRequest::NullResultType& result) {
         if (result == IDBRequest::NullResultType::Empty)
             return JSC::jsNull();
         return JSC::jsUndefined();
     }, [] (uint64_t number) {
         return toJS<IDLUnsignedLongLong>(number);
-    }, [&] (RefPtr<IDBCursor>& cursor) {
+    }, [&] (const RefPtr<IDBCursor>& cursor) {
         return cachedPropertyValue(lexicalGlobalObject, *this, resultWrapper, [&] {
             auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
             return toJS<IDLInterface<IDBCursor>>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), throwScope, cursor.get());
         });
-    }, [&] (RefPtr<IDBDatabase>& database) {
+    }, [&] (const RefPtr<IDBDatabase>& database) {
         return cachedPropertyValue(lexicalGlobalObject, *this, resultWrapper, [&] {
             auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
             return toJS<IDLInterface<IDBDatabase>>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), throwScope, database.get());
         });
-    }, [&] (IDBKeyData keyData) {
+    }, [&] (const IDBKeyData& keyData) {
         return cachedPropertyValue(lexicalGlobalObject, *this, resultWrapper, [&] {
             return toJS<IDLIDBKeyData>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), keyData);
         });
-    }, [&] (Vector<IDBKeyData> keyDatas) {
+    }, [&] (const Vector<IDBKeyData>& keyDatas) {
         return cachedPropertyValue(lexicalGlobalObject, *this, resultWrapper, [&] {
             return toJS<IDLSequence<IDLIDBKeyData>>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), keyDatas);
         });
-    }, [&] (IDBGetResult getResult) {
+    }, [&] (const IDBGetResult& getResult) {
         return cachedPropertyValue(lexicalGlobalObject, *this, resultWrapper, [&] {
             auto result = deserializeIDBValueWithKeyInjection(lexicalGlobalObject, getResult.value(), getResult.keyData(), getResult.keyPath());
             return result ? result.value() : jsNull();
         });
-    }, [&] (IDBGetAllResult getAllResult) {
+    }, [&] (const IDBGetAllResult& getAllResult) {
         return cachedPropertyValue(lexicalGlobalObject, *this, resultWrapper, [&] {
             auto& keys = getAllResult.keys();
             auto& values = getAllResult.values();

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -30,6 +30,8 @@
 namespace Namespace::Subnamespace { struct StructName; }
 namespace Namespace { class OtherClass; }
 namespace Namespace { class ReturnRefClass; }
+namespace Namespace { struct EmptyConstructorStruct; }
+namespace Namespace { class EmptyConstructorNullable; }
 
 namespace IPC {
 
@@ -53,6 +55,16 @@ template<> struct ArgumentCoder<Namespace::OtherClass> {
 template<> struct ArgumentCoder<Namespace::ReturnRefClass> {
     static void encode(Encoder&, const Namespace::ReturnRefClass&);
     static std::optional<Ref<Namespace::ReturnRefClass>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<Namespace::EmptyConstructorStruct> {
+    static void encode(Encoder&, const Namespace::EmptyConstructorStruct&);
+    static std::optional<Namespace::EmptyConstructorStruct> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<Namespace::EmptyConstructorNullable> {
+    static void encode(Encoder&, const Namespace::EmptyConstructorNullable&);
+    static std::optional<Namespace::EmptyConstructorNullable> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -38,12 +38,23 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             "RetainPtr<CFTypeRef>"_s,
         } },
         { "Namespace::OtherClass"_s, {
+            "bool"_s,
             "int"_s,
             "bool"_s,
         } },
         { "Namespace::ReturnRefClass"_s, {
             "double"_s,
             "double"_s,
+            "std::unique_ptr<int>"_s,
+        } },
+        { "Namespace::EmptyConstructorStruct"_s, {
+            "int"_s,
+            "double"_s,
+        } },
+        { "Namespace::EmptyConstructorNullable"_s, {
+            "bool"_s,
+            "MemberType"_s,
+            "OtherMemberType"_s,
         } },
     };
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -14,6 +14,7 @@ headers: "HeaderWithoutCondition"
 #endif
 
 class Namespace::OtherClass {
+    [ReturnEarlyIfTrue] bool isNull
     int a
     bool b
 }
@@ -21,4 +22,16 @@ class Namespace::OtherClass {
 [Return=Ref] class Namespace::ReturnRefClass {
     double functionCall().member1
     double functionCall().member2
+    std::unique_ptr<int> uniqueMember
+}
+
+[LegacyPopulateFrom=EmptyConstructor] struct Namespace::EmptyConstructorStruct {
+    int m_int;
+    double m_double;
+}
+
+[LegacyPopulateFrom=EmptyConstructor] class Namespace::EmptyConstructorNullable {
+    [ReturnEarlyIfTrue] bool m_isNull;
+    MemberType m_type;
+    OtherMemberType m_value;
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -82,3 +82,182 @@ header: <WebCore/FloatPoint3D.h>
     float y()
     float z()
 }
+
+header: <WebCore/IDBCursorRecord.h>
+struct WebCore::IDBCursorRecord {
+    WebCore::IDBKeyData key;
+    WebCore::IDBKeyData primaryKey;
+    WebCore::IDBValue value;
+}
+
+header: <WebCore/IDBCursorInfo.h>
+class WebCore::IDBCursorInfo {
+    WebCore::IDBResourceIdentifier identifier();
+    WebCore::IDBResourceIdentifier transactionIdentifier();
+    uint64_t objectStoreIdentifier();
+    uint64_t sourceIdentifier();
+
+    WebCore::IDBKeyRangeData range();
+
+    WebCore::IndexedDB::CursorSource cursorSource();
+    WebCore::IndexedDB::CursorDirection cursorDirection();
+    WebCore::IndexedDB::CursorType cursorType();
+};
+
+header: <WebCore/IDBError.h>
+class WebCore::IDBError {
+    std::optional<WebCore::ExceptionCode> code()
+    String messageForSerialization()
+}
+
+header: <WebCore/IDBGetAllRecordsData.h>
+struct WebCore::IDBGetAllRecordsData {
+    WebCore::IDBKeyRangeData keyRangeData;
+    WebCore::IndexedDB::GetAllType getAllType;
+    std::optional<uint32_t> count;
+    uint64_t objectStoreIdentifier;
+    uint64_t indexIdentifier;
+}
+
+header: <WebCore/IDBGetResult.h>
+class WebCore::IDBGetResult {
+    WebCore::IDBKeyData keyData()
+    WebCore::IDBKeyData primaryKeyData()
+    WebCore::IDBValue value()
+    std::optional<WebCore::IDBKeyPath> keyPath()
+    Vector<WebCore::IDBCursorRecord> prefetchedRecords()
+    bool isDefined()
+}
+
+header: <WebCore/IDBGetAllResult.h>
+class WebCore::IDBGetAllResult {
+    WebCore::IndexedDB::GetAllType type()
+    Vector<WebCore::IDBKeyData> keys()
+    Vector<WebCore::IDBValue> values()
+    std::optional<WebCore::IDBKeyPath> keyPath()
+}
+
+header: <WebCore/IDBDatabaseInfo.h>
+class WebCore::IDBDatabaseInfo {
+    String m_name
+    uint64_t m_version
+    uint64_t m_maxIndexID
+    uint64_t m_maxObjectStoreID
+    HashMap<uint64_t, WebCore::IDBObjectStoreInfo> m_objectStoreMap
+}
+
+header: <WebCore/IDBKeyRangeData.h>
+struct WebCore::IDBKeyRangeData {
+    [ReturnEarlyIfTrue] bool isNull;
+
+    WebCore::IDBKeyData lowerKey;
+    WebCore::IDBKeyData upperKey;
+
+    bool lowerOpen;
+    bool upperOpen;
+};
+
+header: <WebCore/IDBTransactionInfo.h>
+class WebCore::IDBTransactionInfo {
+    WebCore::IDBResourceIdentifier identifier();
+    WebCore::IDBTransactionMode mode();
+    WebCore::IDBTransactionDurability durability();
+    uint64_t newVersion();
+    Vector<String> objectStores();
+    std::unique_ptr<WebCore::IDBDatabaseInfo> originalDatabaseInfo();
+};
+
+header: <WebCore/IDBGetRecordData.h>
+struct WebCore::IDBGetRecordData {
+    WebCore::IDBKeyRangeData keyRangeData;
+    WebCore::IDBGetRecordDataType type;
+}
+
+header: <WebCore/IDBIndexInfo.h>
+class WebCore::IDBIndexInfo {
+    uint64_t identifier()
+    uint64_t objectStoreIdentifier()
+    String name()
+    WebCore::IDBKeyPath keyPath()
+    bool unique()
+    bool multiEntry()
+}
+
+header: <WebCore/IDBObjectStoreInfo.h>
+class WebCore::IDBObjectStoreInfo {
+    uint64_t identifier()
+    String name()
+    std::optional<WebCore::IDBKeyPath> keyPath()
+    bool autoIncrement()
+    HashMap<uint64_t, WebCore::IDBIndexInfo> indexMap()
+}
+
+header: <WebCore/IDBIterateCursorData.h>
+struct WebCore::IDBIterateCursorData {
+    WebCore::IDBKeyData keyData;
+    WebCore::IDBKeyData primaryKeyData;
+    unsigned count;
+    WebCore::IndexedDB::CursorIterateOption option;
+}
+
+header: <WebCore/IDBResourceIdentifier.h>
+class WebCore::IDBResourceIdentifier {
+    WebCore::IDBConnectionIdentifier m_idbConnectionIdentifier
+    uint64_t m_resourceNumber
+}
+
+header: <WebCore/IDBValue.h>
+class WebCore::IDBValue {
+    WebCore::ThreadSafeDataBuffer data()
+    Vector<String> blobURLs()
+    Vector<String> blobFilePaths()
+};
+
+header: <WebCore/IDBRequestData.h>
+class WebCore::IDBRequestData {
+    WebCore::IDBConnectionIdentifier m_serverConnectionIdentifier;
+    std::unique_ptr<WebCore::IDBResourceIdentifier> m_requestIdentifier;
+    std::unique_ptr<WebCore::IDBResourceIdentifier> m_transactionIdentifier;
+    std::unique_ptr<WebCore::IDBResourceIdentifier> m_cursorIdentifier;
+    uint64_t m_objectStoreIdentifier;
+    uint64_t m_indexIdentifier;
+    WebCore::IndexedDB::IndexRecordType m_indexRecordType;
+    std::optional<WebCore::IDBDatabaseIdentifier> m_databaseIdentifier;
+    uint64_t m_requestedVersion;
+    WebCore::IndexedDB::RequestType m_requestType;
+}
+
+header: <WebCore/IDBDatabaseIdentifier.h>
+# FIXME: When decoding from IPC, databaseName can be null, and the non-empty constructor asserts that this is not the case.
+[LegacyPopulateFrom=EmptyConstructor] class WebCore::IDBDatabaseIdentifier {
+    String m_databaseName
+    WebCore::ClientOrigin m_origin
+    bool m_isTransient
+}
+
+header: <WebCore/IDBDatabaseNameAndVersion.h>
+struct WebCore::IDBDatabaseNameAndVersion {
+    String name;
+    uint64_t version;
+}
+
+header: <WebCore/IDBResultData.h>
+[LegacyPopulateFrom=EmptyConstructor] class WebCore::IDBResultData {
+    WebCore::IDBResultType m_type;
+    WebCore::IDBResourceIdentifier m_requestIdentifier;
+    WebCore::IDBError m_error;
+    uint64_t m_databaseConnectionIdentifier;
+    std::unique_ptr<WebCore::IDBDatabaseInfo> m_databaseInfo;
+    std::unique_ptr<WebCore::IDBTransactionInfo> m_transactionInfo;
+    std::unique_ptr<WebCore::IDBKeyData> m_resultKey;
+    std::unique_ptr<WebCore::IDBGetResult> m_getResult;
+    std::unique_ptr<WebCore::IDBGetAllResult> m_getAllResult;
+    uint64_t m_resultInteger;
+}
+
+header: <WebCore/IDBKeyData.h>
+[LegacyPopulateFrom=EmptyConstructor] class WebCore::IDBKeyData {
+    [ReturnEarlyIfTrue] bool m_isNull;
+    WebCore::IndexedDB::KeyType m_type;
+    std::variant<Vector<WebCore::IDBKeyData>, String, double, WebCore::ThreadSafeDataBuffer> m_value;
+}


### PR DESCRIPTION
#### d4d3c5e42fefdd31a508016a05e758c4067e4915
<pre>
Generate IndexedDB object serializers
<a href="https://bugs.webkit.org/show_bug.cgi?id=244691">https://bugs.webkit.org/show_bug.cgi?id=244691</a>

Reviewed by Sihui Liu and Brady Eidson.

* Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.cpp:
(WebCore::IDBDatabaseIdentifier::IDBDatabaseIdentifier):
* Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.h:
(WebCore::IDBDatabaseIdentifier::encode const): Deleted.
(WebCore::IDBDatabaseIdentifier::decode): Deleted.
* Source/WebCore/Modules/indexeddb/IDBFactory.cpp:
(WebCore::IDBFactory::openInternal):
(WebCore::IDBFactory::deleteDatabase):
* Source/WebCore/Modules/indexeddb/IDBGetAllResult.h:
(WebCore::IDBGetAllResult::IDBGetAllResult):
(WebCore::IDBGetAllResult::encode const): Deleted.
(WebCore::IDBGetAllResult::decode): Deleted.
* Source/WebCore/Modules/indexeddb/IDBGetResult.h:
(WebCore::IDBGetResult::IDBGetResult):
(WebCore::IDBGetResult::encode const): Deleted.
(WebCore::IDBGetResult::decode): Deleted.
* Source/WebCore/Modules/indexeddb/IDBKeyRangeData.cpp:
(WebCore::IDBKeyRangeData::IDBKeyRangeData):
* Source/WebCore/Modules/indexeddb/IDBKeyRangeData.h:
(WebCore::IDBKeyRangeData::IDBKeyRangeData):
(WebCore::IDBKeyRangeData::encode const): Deleted.
(WebCore::IDBKeyRangeData::decode): Deleted.
* Source/WebCore/Modules/indexeddb/IDBValue.h:
(WebCore::IDBValue::encode const): Deleted.
(WebCore::IDBValue::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBCursorInfo.h:
(WebCore::IDBCursorInfo::transactionIdentifier const):
(WebCore::IDBCursorInfo::encode const): Deleted.
(WebCore::IDBCursorInfo::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBCursorRecord.h:
(WebCore::IDBCursorRecord::isolatedCopy const):
(WebCore::IDBCursorRecord::encode const): Deleted.
(WebCore::IDBCursorRecord::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.cpp:
(WebCore::IDBDatabaseInfo::IDBDatabaseInfo):
* Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.h:
(WebCore::IDBDatabaseInfo::IDBDatabaseInfo):
(WebCore::IDBDatabaseInfo::encode const): Deleted.
(WebCore::IDBDatabaseInfo::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBDatabaseNameAndVersion.h:
(WebCore::IDBDatabaseNameAndVersion::encode const): Deleted.
(WebCore::IDBDatabaseNameAndVersion::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBError.h:
(WebCore::IDBError::messageForSerialization const):
(WebCore::IDBError::encode const): Deleted.
(WebCore::IDBError::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.h:
(WebCore::IDBGetAllRecordsData::encode const): Deleted.
(WebCore::IDBGetAllRecordsData::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBGetRecordData.h:
(WebCore::IDBGetRecordData::encode const): Deleted.
(WebCore::IDBGetRecordData::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBIndexInfo.h:
(WebCore::IDBIndexInfo::encode const): Deleted.
(WebCore::IDBIndexInfo::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBIterateCursorData.h:
(WebCore::IDBIterateCursorData::encode const): Deleted.
(WebCore::IDBIterateCursorData::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.cpp:
(WebCore::IDBObjectStoreInfo::IDBObjectStoreInfo):
* Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.h:
(WebCore::IDBObjectStoreInfo::IDBObjectStoreInfo):
(WebCore::IDBObjectStoreInfo::encode const): Deleted.
(WebCore::IDBObjectStoreInfo::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp:
* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h:
(WebCore::IDBRequestData::IDBRequestData):
(WebCore::IDBRequestData::encode const): Deleted.
(WebCore::IDBRequestData::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h:
(WebCore::IDBResourceIdentifier::encode const): Deleted.
(WebCore::IDBResourceIdentifier::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBResultData.h:
(WebCore::IDBResultData::encode const): Deleted.
(WebCore::IDBResultData::decode): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBTransactionInfo.cpp:
* Source/WebCore/Modules/indexeddb/shared/IDBTransactionInfo.h:
(WebCore::IDBTransactionInfo::IDBTransactionInfo):
(WebCore::IDBTransactionInfo::encode const): Deleted.
(WebCore::IDBTransactionInfo::decode): Deleted.
* Source/WebCore/bindings/js/JSIDBRequestCustom.cpp:
(WebCore::JSIDBRequest::result const):
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(MemberVariable.unique_ptr_type):
(generate_cpp):
(parse_serialized_types):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::Subnamespace::StructName&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::ReturnRefClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::ReturnRefClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorStruct&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorStruct&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/254196@main">https://commits.webkit.org/254196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c32d59837da315a16ea632b7db6ec4960ead0421

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97557 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153030 "Hash c32d5983 for PR 3934 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31307 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26960 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92215 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24904 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75218 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24883 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/91967 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79805 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67847 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28919 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/28900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/14929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32101 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1200 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34042 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->