### PR TITLE
[Reporting API] Support TestReportBody and 'generate_test_report' in WKTR

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -540,8 +540,6 @@ imported/w3c/web-platform-tests/reporting/document-reporting-default-endpoint.ht
 imported/w3c/web-platform-tests/reporting/document-reporting-named-endpoints.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/reporting/document-reporting-override-endpoint.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/reporting/document-reporting-path-absolute.https.sub.html [ Skip ]
-imported/w3c/web-platform-tests/reporting/nestedReport.html [ Skip ]
-imported/w3c/web-platform-tests/reporting/order.html [ Skip ]
 
 fast/files/file-reader-back-forward-cache.html [ DumpJSConsoleLogInStdErr ]
 fast/history/page-cache-createImageBitmap.html [ DumpJSConsoleLogInStdErr ]

--- a/LayoutTests/imported/w3c/web-platform-tests/reporting/bufferSize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/reporting/bufferSize-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Buffer size promise_test: Unhandled rejection with value: object "Error: unimplemented"
+PASS Buffer size
 

--- a/LayoutTests/imported/w3c/web-platform-tests/reporting/disconnect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/reporting/disconnect-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Disconnect promise_test: Unhandled rejection with value: object "Error: unimplemented"
+PASS Disconnect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/reporting/generateTestReport-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/reporting/generateTestReport-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Generate Test Report assert_unreached: generate test report failed Reached unreachable code
+PASS Generate Test Report
 

--- a/LayoutTests/imported/w3c/web-platform-tests/reporting/nestedReport-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/reporting/nestedReport-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Nested report Can't find variable: ReportingObserver
+PASS Nested report
 

--- a/LayoutTests/imported/w3c/web-platform-tests/reporting/order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/reporting/order-expected.txt
@@ -1,5 +1,5 @@
 No error
 
 
-FAIL Order Can't find variable: ReportingObserver
+PASS Order
 

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js
@@ -316,3 +316,11 @@ window.test_driver_internal.delete_all_cookies = function(context=null)
     return Promise.resolve();
 }
 
+window.test_driver_internal.generate_test_report = function(message, context=null)
+{
+    if (!window.testRunner)
+        return Promise.reject(new Error("unimplemented"));
+    testRunner.generateTestReport(message);
+    return Promise.resolve();
+}
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -287,6 +287,13 @@ imported/w3c/web-platform-tests/IndexedDB/reading-autoincrement-store-cursors.an
 imported/w3c/web-platform-tests/IndexedDB/reading-autoincrement-store.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/IndexedDB/storage-buckets.https.any.sharedworker.html [ Skip ]
 
+# Reporting API "generate_test_report" is not supported on WebKitLegacy
+imported/w3c/web-platform-tests/reporting/bufferSize.html [ Skip ]
+imported/w3c/web-platform-tests/reporting/disconnect.html [ Skip ]
+imported/w3c/web-platform-tests/reporting/generateTestReport.html [ Skip ]
+imported/w3c/web-platform-tests/reporting/nestedReport.html [ Skip ]
+imported/w3c/web-platform-tests/reporting/order.html [ Skip ]
+
 http/wpt/mediarecorder [ Skip ]
 imported/w3c/web-platform-tests/mediacapture-record [ Skip ]
 fast/history/page-cache-media-recorder.html [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -354,6 +354,13 @@ imported/w3c/web-platform-tests/xhr/idlharness.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/xhr/open-url-redirected-sharedworker-origin.htm [ Skip ]
 imported/w3c/web-platform-tests/xhr/sync-no-timeout.any.sharedworker.html [ Skip ]
 
+# Reporting API "generate_test_report" is not supported on WebKitLegacy
+imported/w3c/web-platform-tests/reporting/bufferSize.html [ Skip ]
+imported/w3c/web-platform-tests/reporting/disconnect.html [ Skip ]
+imported/w3c/web-platform-tests/reporting/generateTestReport.html [ Skip ]
+imported/w3c/web-platform-tests/reporting/nestedReport.html [ Skip ]
+imported/w3c/web-platform-tests/reporting/order.html [ Skip ]
+
 # Dark mode not supported on Windows
 css-dark-mode [ Skip ]
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -554,6 +554,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/reporting/ReportBody.idl
     Modules/reporting/ReportingObserver.idl
     Modules/reporting/ReportingObserverCallback.idl
+    Modules/reporting/TestReportBody.idl
 
     Modules/speech/DOMWindow+SpeechSynthesis.idl
     Modules/speech/SpeechRecognitionErrorEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -611,6 +611,7 @@ $(PROJECT_DIR)/Modules/reporting/Report.idl
 $(PROJECT_DIR)/Modules/reporting/ReportBody.idl
 $(PROJECT_DIR)/Modules/reporting/ReportingObserver.idl
 $(PROJECT_DIR)/Modules/reporting/ReportingObserverCallback.idl
+$(PROJECT_DIR)/Modules/reporting/TestReportBody.idl
 $(PROJECT_DIR)/Modules/speech/DOMWindow+SpeechSynthesis.idl
 $(PROJECT_DIR)/Modules/speech/SpeechRecognition.idl
 $(PROJECT_DIR)/Modules/speech/SpeechRecognitionAlternative.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2642,6 +2642,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSubmitEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSubmitEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSubtleCrypto.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSubtleCrypto.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTestReportBody.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTestReportBody.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSText.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSText.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTextDecoder.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -533,6 +533,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/reporting/ReportBody.idl \
     $(WebCore)/Modules/reporting/ReportingObserver.idl \
     $(WebCore)/Modules/reporting/ReportingObserverCallback.idl \
+    $(WebCore)/Modules/reporting/TestReportBody.idl \
     $(WebCore)/Modules/speech/DOMWindow+SpeechSynthesis.idl \
     $(WebCore)/Modules/speech/SpeechSynthesis.idl \
     $(WebCore)/Modules/speech/SpeechSynthesisErrorCode.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -328,6 +328,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/reporting/ReportingObserver.h
     Modules/reporting/ReportingObserverCallback.h
     Modules/reporting/ReportingScope.h
+    Modules/reporting/TestReportBody.h
 
     Modules/speech/SpeechRecognitionCaptureSource.h
     Modules/speech/SpeechRecognitionCaptureSourceImpl.h

--- a/Source/WebCore/Modules/reporting/ReportBody.h
+++ b/Source/WebCore/Modules/reporting/ReportBody.h
@@ -32,6 +32,7 @@ namespace WebCore {
 
 enum class ReportBodyType : uint8_t {
     CSPViolation,
+    Test
     // More to come
 };
 
@@ -57,7 +58,8 @@ namespace WTF {
 template<> struct EnumTraits<WebCore::ReportBodyType> {
     using values = EnumValues<
     WebCore::ReportBodyType,
-    WebCore::ReportBodyType::CSPViolation
+    WebCore::ReportBodyType::CSPViolation,
+    WebCore::ReportBodyType::Test
     >;
 };
 

--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -45,6 +45,7 @@ static bool isVisibleToReportingObservers(const AtomString& type)
 {
     static NeverDestroyed<Vector<AtomString>> visibleTypes(std::initializer_list<AtomString> {
         AtomString { "csp-violation"_s },
+        AtomString { "test"_s },
     });
     return visibleTypes->contains(type);
 }

--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -32,6 +32,7 @@
 #include "ReportingObserver.h"
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
+#include "TestReportBody.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/StringParsingBuffer.h>
 
@@ -157,6 +158,16 @@ MemoryCompactRobinHoodHashMap<String, String> ReportingScope::parseReportingEndp
 String ReportingScope::endpointURIForToken(const String& reportTo) const
 {
     return m_reportingEndpoints.get(reportTo);
+}
+
+void ReportingScope::generateTestReport(String&& message)
+{
+    String reportURL { ""_s };
+    if (auto* document = dynamicDowncast<Document>(scriptExecutionContext()))
+        reportURL = document->url().strippedForUseAsReferrer();
+
+    // https://w3c.github.io/reporting/#generate-test-report-command, step 7.1.10.
+    notifyReportObservers(Report::create(TestReportBody::testReportType(), WTFMove(reportURL), TestReportBody::create(WTFMove(message))));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/reporting/ReportingScope.h
+++ b/Source/WebCore/Modules/reporting/ReportingScope.h
@@ -61,6 +61,8 @@ public:
 
     String endpointURIForToken(const String&) const;
 
+    void generateTestReport(String&& message);
+
 private:
     explicit ReportingScope(ScriptExecutionContext&);
 

--- a/Source/WebCore/Modules/reporting/TestReportBody.cpp
+++ b/Source/WebCore/Modules/reporting/TestReportBody.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestReportBody.h"
+
+#include "FormData.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(TestReportBody);
+
+const AtomString& TestReportBody::testReportType()
+{
+    static NeverDestroyed<AtomString> reportType { "test"_s };
+    return reportType;
+}
+
+TestReportBody::TestReportBody(String&& message)
+    : ReportBody(ReportBodyType::Test)
+    , m_bodyMessage(WTFMove(message))
+{
+}
+
+Ref<TestReportBody> TestReportBody::create(String&& message)
+{
+    return adoptRef(*new TestReportBody(WTFMove(message)));
+}
+
+const AtomString& TestReportBody::type() const
+{
+    return testReportType();
+}
+
+const String& TestReportBody::message() const
+{
+    // https://w3c.github.io/reporting/#generate-test-report-command, Step 7.1.7
+    return m_bodyMessage;
+}
+
+
+Ref<FormData> TestReportBody::createReportFormDataForViolation(const String& bodyMessage)
+{
+    // https://w3c.github.io/reporting/#generate-test-report-command, Step 7.1.10
+    // Suitable for network endpoints.
+    auto reportBody = JSON::Object::create();
+    reportBody->setString("body_message"_s, bodyMessage);
+
+    auto reportObject = JSON::Object::create();
+    reportObject->setString("type"_s, testReportType());
+    reportObject->setString("url"_s, ""_s);
+    reportObject->setObject("body"_s, WTFMove(reportBody));
+
+    return FormData::create(reportObject->toJSONString().utf8());
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/reporting/TestReportBody.h
+++ b/Source/WebCore/Modules/reporting/TestReportBody.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ReportBody.h"
+#include <wtf/IsoMalloc.h>
+
+namespace WebCore {
+
+class FormData;
+
+struct CSPInfo;
+struct SecurityPolicyViolationEventInit;
+
+class WEBCORE_EXPORT TestReportBody final : public ReportBody {
+    WTF_MAKE_ISO_ALLOCATED(TestReportBody);
+public:
+    static Ref<TestReportBody> create(String&& message);
+
+    const String& message() const;
+
+    static const AtomString& testReportType();
+
+    static Ref<FormData> createReportFormDataForViolation(const String& bodyMessage);
+
+    template<typename Encoder> void encode(Encoder&) const;
+    template<typename Decoder> static std::optional<RefPtr<WebCore::TestReportBody>> decode(Decoder&);
+
+private:
+    TestReportBody(String&& message);
+
+    const AtomString& type() const final;
+
+    const String m_bodyMessage;
+};
+
+template<typename Encoder>
+void TestReportBody::encode(Encoder& encoder) const
+{
+    encoder << m_bodyMessage;
+}
+
+template<typename Decoder>
+std::optional<RefPtr<TestReportBody>> TestReportBody::decode(Decoder& decoder)
+{
+    std::optional<String> bodymessage;
+    decoder >> bodymessage;
+    if (!bodymessage)
+        return std::nullopt;
+
+    return adoptRef(new TestReportBody(WTFMove(*bodymessage)));
+}
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::TestReportBody)
+    static bool isType(const WebCore::ReportBody& reportBody) { return reportBody.reportBodyType() == WebCore::ReportBodyType::Test; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/reporting/TestReportBody.idl
+++ b/Source/WebCore/Modules/reporting/TestReportBody.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+// https://w3c.github.io/reporting/#reportingobserver
+[
+    EnabledBySetting=ReportingEnabled,
+    Exposed=Window
+] interface TestReportBody : ReportBody {
+    readonly attribute USVString message;
+    [Default] object toJSON();
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -282,6 +282,7 @@ Modules/reporting/Report.cpp
 Modules/reporting/ReportBody.cpp
 Modules/reporting/ReportingObserver.cpp
 Modules/reporting/ReportingScope.cpp
+Modules/reporting/TestReportBody.cpp
 Modules/speech/SpeechRecognition.cpp
 Modules/speech/SpeechRecognitionAlternative.cpp
 Modules/speech/SpeechRecognitionErrorEvent.cpp
@@ -3999,6 +4000,7 @@ JSStyleSheet.cpp
 JSStyleSheetList.cpp
 JSSubmitEvent.cpp
 JSSubtleCrypto.cpp
+JSTestReportBody.cpp
 JSText.cpp
 JSTextDecoder.cpp
 JSTextDecoderStream.cpp

--- a/Source/WebCore/bindings/js/JSReportBodyCustom.cpp
+++ b/Source/WebCore/bindings/js/JSReportBodyCustom.cpp
@@ -29,7 +29,9 @@
 #include "CSPViolationReportBody.h"
 #include "JSCSPViolationReportBody.h"
 #include "JSDOMBinding.h"
+#include "JSTestReportBody.h"
 #include "ReportBody.h"
+#include "TestReportBody.h"
 
 namespace WebCore {
 using namespace JSC;
@@ -38,6 +40,8 @@ JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, 
 {
     if (is<CSPViolationReportBody>(reportBody))
         return createWrapper<CSPViolationReportBody>(globalObject, WTFMove(reportBody));
+    if (is<TestReportBody>(reportBody))
+        return createWrapper<TestReportBody>(globalObject, WTFMove(reportBody));
     return createWrapper<ReportBody>(globalObject, WTFMove(reportBody));
 }
 

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -383,6 +383,7 @@ namespace WebCore {
     macro(StorageManager) \
     macro(StorageManagerFileSystemAccess) \
     macro(SubtleCrypto) \
+    macro(TestReportBody) \
     macro(TextDecoderStream) \
     macro(TextDecoderStreamDecoder) \
     macro(TextEncoderStream) \

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -95,6 +95,7 @@
 #include <WebCore/ShareData.h>
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/SystemImage.h>
+#include <WebCore/TestReportBody.h>
 #include <WebCore/TextCheckerClient.h>
 #include <WebCore/TextIndicator.h>
 #include <WebCore/TimingFunction.h>
@@ -3086,6 +3087,9 @@ void ArgumentCoder<RefPtr<WebCore::ReportBody>>::encode(Encoder& encoder, const 
     case ReportBodyType::CSPViolation:
         downcast<CSPViolationReportBody>(reportBody.get())->encode(encoder);
         return;
+    case ReportBodyType::Test:
+        downcast<TestReportBody>(reportBody.get())->encode(encoder);
+        return;
     }
 
     RELEASE_ASSERT_NOT_REACHED();
@@ -3109,6 +3113,8 @@ std::optional<RefPtr<WebCore::ReportBody>> ArgumentCoder<RefPtr<WebCore::ReportB
     switch (*reportBodyType) {
     case ReportBodyType::CSPViolation:
         return CSPViolationReportBody::decode(decoder);
+    case ReportBodyType::Test:
+        return TestReportBody::decode(decoder);
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -44,6 +44,7 @@
 #include <WebCore/FrameLoader.h>
 #include <WebCore/FrameView.h>
 #include <WebCore/Page.h>
+#include <WebCore/ReportingScope.h>
 
 WKTypeID WKBundleFrameGetTypeID()
 {
@@ -287,4 +288,14 @@ void WKBundleFrameFocus(WKBundleFrameRef frameRef)
         return;
 
     CheckedRef(coreFrame->page()->focusController())->setFocusedFrame(coreFrame.get());
+}
+
+void _WKBundleFrameGenerateTestReport(WKBundleFrameRef frameRef, WKStringRef message)
+{
+    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreFrame();
+    if (!coreFrame)
+        return;
+
+    if (RefPtr document = coreFrame->document())
+        document->reportingScope().generateTestReport(WebKit::toWTFString(message));
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
@@ -56,6 +56,8 @@ WK_EXPORT bool WKBundleFrameHandlesPageScaleGesture(WKBundleFrameRef frame);
 
 WK_EXPORT void WKBundleFrameFocus(WKBundleFrameRef frame);
 
+WK_EXPORT void _WKBundleFrameGenerateTestReport(WKBundleFrameRef, WKStringRef message);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -432,4 +432,7 @@ interface TestRunner {
     undefined setIsMediaKeySystemPermissionGranted(boolean value);
 
     undefined takeViewPortSnapshot(object callback);
+
+    // Reporting API
+    undefined generateTestReport(DOMString message);
 };

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2232,6 +2232,11 @@ void TestRunner::viewPortSnapshotTaken(WKStringRef value)
     auto jsValue = JSValueMakeString(mainFrameJSContext(), toJS(value).get());
     callTestRunnerCallback(TakeViewPortSnapshotCallbackID, 1, &jsValue);
     m_takeViewPortSnapshot = false;
+}
+
+void TestRunner::generateTestReport(JSStringRef message)
+{
+    _WKBundleFrameGenerateTestReport(mainFrame(), toWK(message).get());
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_END

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -547,6 +547,9 @@ public:
 
     void takeViewPortSnapshot(JSValueRef callback);
     void viewPortSnapshotTaken(WKStringRef);
+
+    // Reporting API
+    void generateTestReport(JSStringRef message);
 
 private:
     TestRunner();


### PR DESCRIPTION
#### c9b558b5b45b2dfb2ebd61d82bd327100d769d21
<pre>
[Reporting API] Support TestReportBody and &apos;generate_test_report&apos; in WKTR
<a href="https://bugs.webkit.org/show_bug.cgi?id=244689">https://bugs.webkit.org/show_bug.cgi?id=244689</a>
&lt;rdar://problem/99459809&gt;

Reviewed by Ryosuke Niwa.

This patch adds a new TestReportBody type, and updates the wpt driver for WKTR to exercise this logic.

* LayoutTests/TestExpectations: Unskip tests that now work.
* LayoutTests/imported/w3c/web-platform-tests/reporting/bufferSize-expected.txt: Revise to show PASS.
* LayoutTests/imported/w3c/web-platform-tests/reporting/disconnect-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/reporting/generateTestReport-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/reporting/nestedReport-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/reporting/order-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js:
(window.test_driver_internal.generate_test_report): Update to call WKTR&apos;s new method to generate a test report.
* Source/WebCore/CMakeLists.txt: Update for new source files.
* Source/WebCore/DerivedSources-input.xcfilelist: Ditto.
* Source/WebCore/DerivedSources-output.xcfilelist: Ditto.
* Source/WebCore/DerivedSources.make: Ditto.
* Source/WebCore/Headers.cmake: Ditto.
* Source/WebCore/Modules/reporting/ReportBody.h: Update to recognize the new Test report type.
* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
(WebCore::isVisibleToReportingObservers): Allow observer to see &apos;test&apos; type reports.
* Source/WebCore/Modules/reporting/ReportingScope.cpp:
(WebCore::ReportingScope::generateTestReport): Added.
* Source/WebCore/Modules/reporting/ReportingScope.h:
* Source/WebCore/Modules/reporting/TestReportBody.cpp:
(WebCore::TestReportBody::testReportType): Added.
(WebCore::TestReportBody::TestReportBody): Added.
(WebCore::TestReportBody::create): Added.
(WebCore::TestReportBody::type const): Added.
(WebCore::TestReportBody::message const): Added.
(WebCore::TestReportBody::createReportFormDataForViolation): Added.
* Source/WebCore/Modules/reporting/TestReportBody.h: Copied from Source/WebCore/Modules/reporting/ReportBody.h.
(WebCore::TestReportBody::encode const): Added.
(WebCore::TestReportBody::decode): Added.
(isType): Added.
* Source/WebCore/Modules/reporting/TestReportBody.idl: Added.
* Source/WebCore/Sources.txt: Updated for new source files.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj: Ditto. Also add generated files to simplify debugging.
* Source/WebCore/bindings/js/JSReportBodyCustom.cpp:
(WebCore::toJSNewlyCreated): Update to recognize &apos;test&apos; reports.
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h: Add new TestReportBody type.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ReportBody&gt;&gt;::encode): Add new TestReportBody type.
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ReportBody&gt;&gt;::decode): Ditto.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(_WKBundleFrameGenerateTestReport): Added.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::generateTestReport): Added.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:

Canonical link: <a href="https://commits.webkit.org/254104@main">https://commits.webkit.org/254104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cbc93505b015a7528b921830c0fe51c61bab57c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97182 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152674 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30568 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26513 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80137 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91927 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24633 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74685 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/24605 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28198 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28300 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14553 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2878 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31324 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33796 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->