### PR TITLE
[WGSL] Handle lexing of negative numbers

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -102,6 +102,11 @@ Token Lexer<T>::lex()
             shift();
             return makeToken(TokenType::Arrow);
         }
+        if (m_current == '-') {
+            shift();
+            return makeToken(TokenType::MinusMinus);
+        }
+        return makeToken(TokenType::Minus);
         break;
     case '0': {
         shift();

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -107,6 +107,10 @@ String toString(TokenType type)
         return ">"_s;
     case TokenType::LT:
         return "<"_s;
+    case TokenType::Minus:
+        return "-"_s;
+    case TokenType::MinusMinus:
+        return "--"_s;
     case TokenType::Period:
         return "."_s;
     case TokenType::ParenLeft:

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -81,6 +81,8 @@ enum class TokenType: uint32_t {
     Equal,
     GT,
     LT,
+    Minus,
+    MinusMinus,
     Period,
     ParenLeft,
     ParenRight,


### PR DESCRIPTION
#### b9fedd48387fde72b00ac63364bc447a59749ab8
<pre>
[WGSL] Handle lexing of negative numbers
<a href="https://bugs.webkit.org/show_bug.cgi?id=244702">https://bugs.webkit.org/show_bug.cgi?id=244702</a>
rdar://problem/99471597

Reviewed by Myles C. Maxfield.

* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lex):
lex `-` as TokenType::Minus
lex `--` as TokenType::MinusMinus
* Source/WebGPU/WGSL/Token.cpp:
(WGSL::toString):
Updated for new token types Minus &amp; MinusMinus
* Source/WebGPU/WGSL/Token.h:
Add new token types Minus &amp; MinusMinus
* Source/WebGPU/WGSLUnitTests/WGSLLexerTests.mm:
(-[WGSLLexerTests testLexerOfSpecialTokens]):
Test lexing of all supported special tokens
(-[WGSLLexerTests testLexerOnTriangleVert]):
Add a more comprehensive test that contains negaive floating point numbers.

Canonical link: <a href="https://commits.webkit.org/254096@main">https://commits.webkit.org/254096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bf4e2b2fbf7fa265d25bb0901d230b703c87396

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97132 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30515 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26463 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80081 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91877 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24570 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74651 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24553 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79515 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28158 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28255 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14491 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2872 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31279 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33753 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->