### PR TITLE
Fix negative z-index layers from triggering unnecessary compositing of foreground layers.

### DIFF
--- a/LayoutTests/compositing/layer-creation/no-compositing-for-negative-z-sibling-expected.txt
+++ b/LayoutTests/compositing/layer-creation/no-compositing-for-negative-z-sibling-expected.txt
@@ -1,0 +1,24 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 792.00 540.00)
+              (drawsContent 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/layer-creation/no-compositing-for-negative-z-sibling-nested-expected.txt
+++ b/LayoutTests/compositing/layer-creation/no-compositing-for-negative-z-sibling-nested-expected.txt
@@ -1,0 +1,31 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 204.00 121.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 204.00 108.00)
+                  (drawsContent 1)
+                  (transform [5.00 0.00 0.00 0.00] [0.00 5.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/layer-creation/no-compositing-for-negative-z-sibling-nested.html
+++ b/LayoutTests/compositing/layer-creation/no-compositing-for-negative-z-sibling-nested.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>test</title>
+  <script>
+    if (window.testRunner) {
+      testRunner.waitUntilDone();
+      testRunner.dumpAsText();
+    }
+
+    function doTest()
+    {
+      document.getElementById('results').innerText = window.internals.layerTreeAsText(document);
+      if (window.testRunner) {
+        testRunner.notifyDone();
+      }
+    }
+    
+    window.addEventListener('load', doTest, false);
+  </script>
+</head>
+
+<body style="position:fixed">
+  <div id="container" style="transform-origin: left top; transform: scale(5); ">
+    <div id="negative" style="position: relative; z-index: -1;">
+        <div style="position: relative; z-index:-1"></div>
+    </div>
+    <div id="positive" style="position: relative">
+      <iframe srcdoc="Hello, world" style="width: 200px; height: 100px;"></iframe>
+    </div>
+  </div>
+<pre id="results"></pre>
+</body>
+
+</html>
+

--- a/LayoutTests/compositing/layer-creation/no-compositing-for-negative-z-sibling.html
+++ b/LayoutTests/compositing/layer-creation/no-compositing-for-negative-z-sibling.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>test</title>
+  <script>
+    if (window.testRunner) {
+      testRunner.waitUntilDone();
+      testRunner.dumpAsText();
+    }
+
+    function doTest()
+    {
+      document.getElementById('results').innerText = window.internals.layerTreeAsText(document);
+      if (window.testRunner) {
+        testRunner.notifyDone();
+      }
+    }
+    
+    window.addEventListener('load', doTest, false);
+  </script>
+</head>
+
+<body style="position:fixed">
+  <div id="container" style="transform-origin: left top; transform: scale(5); ">
+    <div id="negative" style="position: relative; z-index: -1;"></div>
+    <div id="positive" style="position: relative">
+      <iframe srcdoc="Hello, world" style="width: 200px; height: 100px;"></iframe>
+    </div>
+  </div>
+<pre id="results"></pre>
+</body>
+
+</html>
+

--- a/LayoutTests/platform/ios-wk2/compositing/layer-creation/no-compositing-for-negative-z-sibling-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/layer-creation/no-compositing-for-negative-z-sibling-expected.txt
@@ -1,0 +1,24 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 792.00 545.00)
+              (drawsContent 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/ios-wk2/compositing/layer-creation/no-compositing-for-negative-z-sibling-nested-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/layer-creation/no-compositing-for-negative-z-sibling-nested-expected.txt
@@ -1,0 +1,31 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 204.00 122.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 204.00 109.00)
+                  (drawsContent 1)
+                  (transform [5.00 0.00 0.00 0.00] [0.00 5.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/rendering/LayerOverlapMap.h
+++ b/Source/WebCore/rendering/LayerOverlapMap.h
@@ -56,6 +56,10 @@ public:
     void pushCompositingContainer(const RenderLayer&);
     void popCompositingContainer(const RenderLayer&);
 
+    void pushSpeculativeCompositingContainer(const RenderLayer&);
+    void confirmSpeculativeCompositingContainer();
+    bool maybePopSpeculativeCompositingContainer();
+
     const RenderGeometryMap& geometryMap() const { return m_geometryMap; }
     RenderGeometryMap& geometryMap() { return m_geometryMap; }
 
@@ -63,6 +67,7 @@ public:
 
 private:
     Vector<std::unique_ptr<OverlapMapContainer>> m_overlapStack;
+    Vector<std::unique_ptr<OverlapMapContainer>> m_speculativeOverlapStack;
     RenderGeometryMap m_geometryMap;
     const RenderLayer& m_rootLayer;
     bool m_isEmpty { true };


### PR DESCRIPTION
#### be575e7192eed0f7fc0d3a335a1df8f91e909b30
<pre>
Fix negative z-index layers from triggering unnecessary compositing of foreground layers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244543">https://bugs.webkit.org/show_bug.cgi?id=244543</a>
&lt;rdar://99335877&gt;

Reviewed by Simon Fraser.

We currently push a speculative compositing container onto the overlap stack when processing
negative z-index children, in case any of them require compositing. We then pop it off it it doesn&apos;t
get used. Unfortunately other mutations can happen to the overlap stack while it&apos;s pushed, and just
popping the unused container isn&apos;t sufficient to restore this.

This instead duplicates the overlap stack when we push a speculative compositing container, and makes any
changes to both of them. Once we know which path is correct, we select the correct stack and throw away
the duplicate.

This fixes cases where negative z-index children weren&apos;t composited, but they ended up affecting overlaps
of positive z-index children and making them composited unnecessarily.

* LayoutTests/compositing/layer-creation/no-compositing-for-negative-z-sibling-expected.txt: Added.
* LayoutTests/compositing/layer-creation/no-compositing-for-negative-z-sibling.html: Added.
* Source/WebCore/rendering/LayerOverlapMap.cpp:
(WebCore::OverlapMapContainer::isEmpty const):
(WebCore::LayerOverlapMap::add):
(WebCore::LayerOverlapMap::overlapsLayers const):
(WebCore::LayerOverlapMap::pushCompositingContainer):
(WebCore::LayerOverlapMap::pushSpeculativeCompositingContainer):
(WebCore::LayerOverlapMap::confirmSpeculativeCompositingContainer):
(WebCore::LayerOverlapMap::maybePopSpeculativeCompositingContainer):
* Source/WebCore/rendering/LayerOverlapMap.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::computeCompositingRequirements):

Canonical link: <a href="https://commits.webkit.org/254746@main">https://commits.webkit.org/254746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc074cbb497b3f5452e3b01e8a70302013eab788

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99397 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156902 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33111 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93693 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26323 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76878 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26226 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69227 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/34295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15049 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15991 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3333 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/35880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38959 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/37781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35075 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->