### PR TITLE
EventTarget should hold EventTargetData in WeakPtrImpl

### DIFF
--- a/Source/WTF/wtf/CompactRefPtrTuple.h
+++ b/Source/WTF/wtf/CompactRefPtrTuple.h
@@ -55,6 +55,22 @@ public:
         WTF::DefaultRefDerefTraits<T>::derefIfNotNull(old);
     }
 
+    void setPointer(RefPtr<T>&& pointer)
+    {
+        auto willRelease = WTFMove(pointer);
+        auto* old = m_data.pointer();
+        m_data.setPointer(willRelease.leakRef());
+        WTF::DefaultRefDerefTraits<T>::derefIfNotNull(old);
+    }
+
+    void setPointer(Ref<T>&& pointer)
+    {
+        auto willRelease = WTFMove(pointer);
+        auto* old = m_data.pointer();
+        m_data.setPointer(&willRelease.leakRef());
+        WTF::DefaultRefDerefTraits<T>::derefIfNotNull(old);
+    }
+
     Type type() const { return m_data.type(); }
     void setType(Type type)
     {

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -32,6 +32,7 @@ class AtomStringImpl;
 class BinarySemaphore;
 class CString;
 class CrashOnOverflow;
+class DefaultWeakPtrImpl;
 class FunctionDispatcher;
 class Hasher;
 class Lock;
@@ -53,7 +54,6 @@ class UniquedStringImpl;
 class WallTime;
 
 struct AnyThreadsAccessTraits;
-struct EmptyCounter;
 struct FastMalloc;
 struct MainThreadAccessTraits;
 
@@ -87,7 +87,7 @@ template<typename> class StringParsingBuffer;
 template<typename, typename = void> class StringTypeAdapter;
 template<typename> class UniqueRef;
 template<typename, size_t = 0, typename = CrashOnOverflow, size_t = 16, typename Malloc = VectorMalloc> class Vector;
-template<typename, typename = EmptyCounter> class WeakPtr;
+template<typename, typename = DefaultWeakPtrImpl> class WeakPtr;
 
 template<typename> struct DefaultHash;
 template<> struct DefaultHash<AtomString>;

--- a/Source/WTF/wtf/WeakHashCountedSet.h
+++ b/Source/WTF/wtf/WeakHashCountedSet.h
@@ -29,11 +29,11 @@
 
 namespace WTF {
 
-template<typename Value, typename Counter = EmptyCounter>
+template<typename Value, typename WeakPtrImpl = DefaultWeakPtrImpl>
 class WeakHashCountedSet {
     WTF_MAKE_FAST_ALLOCATED;
 private:
-    using ImplType = WeakHashMap<Value, unsigned, Counter>;
+    using ImplType = WeakHashMap<Value, unsigned, WeakPtrImpl>;
 public:
     using ValueType = Value;
     using iterator = typename ImplType::iterator;
@@ -68,33 +68,33 @@ public:
     void clear() { m_impl.clear(); }
 
 private:
-    WeakHashMap<Value, unsigned, Counter> m_impl;
+    WeakHashMap<Value, unsigned, WeakPtrImpl> m_impl;
 };
 
-template<typename Value, typename Counter>
-inline auto WeakHashCountedSet<Value, Counter>::add(const ValueType &value) -> AddResult
+template<typename Value, typename WeakPtrImpl>
+inline auto WeakHashCountedSet<Value, WeakPtrImpl>::add(const ValueType &value) -> AddResult
 {
     auto result = m_impl.add(value, 0);
     ++result.iterator->value;
     return result;
 }
 
-template<typename Value, typename Counter>
-inline auto WeakHashCountedSet<Value, Counter>::add(ValueType&& value) -> AddResult
+template<typename Value, typename WeakPtrImpl>
+inline auto WeakHashCountedSet<Value, WeakPtrImpl>::add(ValueType&& value) -> AddResult
 {
     auto result = m_impl.add(std::forward<Value>(value), 0);
     ++result.iterator->value;
     return result;
 }
 
-template<typename Value, typename Counter>
-inline bool WeakHashCountedSet<Value, Counter>::remove(const ValueType& value)
+template<typename Value, typename WeakPtrImpl>
+inline bool WeakHashCountedSet<Value, WeakPtrImpl>::remove(const ValueType& value)
 {
     return remove(find(value));
 }
 
-template<typename Value, typename Counter>
-inline bool WeakHashCountedSet<Value, Counter>::remove(iterator it)
+template<typename Value, typename WeakPtrImpl>
+inline bool WeakHashCountedSet<Value, WeakPtrImpl>::remove(iterator it)
 {
     if (it == end())
         return false;

--- a/Source/WTF/wtf/WeakHashMap.h
+++ b/Source/WTF/wtf/WeakHashMap.h
@@ -32,12 +32,12 @@
 namespace WTF {
 
 // Value will be deleted lazily upon rehash or amortized over time. For manual cleanup, call removeNullReferences().
-template<typename KeyType, typename ValueType, typename Counter = EmptyCounter>
+template<typename KeyType, typename ValueType, typename WeakPtrImpl = DefaultWeakPtrImpl>
 class WeakHashMap final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
 
-    using RefType = Ref<WeakPtrImpl<Counter>>;
+    using RefType = Ref<WeakPtrImpl>;
     using KeyTraits = HashTraits<KeyType>;
     using ValueTraits = HashTraits<ValueType>;
     using WeakHashImplMap = HashMap<RefType, ValueType>;
@@ -366,12 +366,12 @@ private:
     }
 
     template <typename T>
-    static WeakPtrImpl<Counter>* keyImplIfExists(const T& key)
+    static WeakPtrImpl* keyImplIfExists(const T& key)
     {
         auto& weakPtrImpl = key.weakPtrFactory().m_impl;
-        if (!weakPtrImpl || !*weakPtrImpl)
-            return nullptr;
-        return weakPtrImpl.get();
+        if (auto* pointer = weakPtrImpl.pointer(); pointer && *pointer)
+            return pointer;
+        return nullptr;
     }
 
     WeakHashImplMap m_map;

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/CompactRefPtrTuple.h>
 #include <wtf/GetPtr.h>
 #include <wtf/HashTraits.h>
 #include <wtf/Threading.h>
@@ -33,29 +34,17 @@
 
 namespace WTF {
 
-struct EmptyCounter {
-    static void increment() { }
-    static void decrement() { }
-};
-
 enum class EnableWeakPtrThreadingAssertions : bool { No, Yes };
 template<typename, typename> class WeakPtrFactory;
 
 template<typename, typename, EnableWeakPtrThreadingAssertions> class WeakHashSet;
 
-template<typename Counter = EmptyCounter> class WeakPtrImpl : public ThreadSafeRefCounted<WeakPtrImpl<Counter>> {
-    WTF_MAKE_NONCOPYABLE(WeakPtrImpl);
+template<typename Derived>
+class WeakPtrImplBase : public ThreadSafeRefCounted<Derived> {
+    WTF_MAKE_NONCOPYABLE(WeakPtrImplBase);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    template<typename T> static Ref<WeakPtrImpl> create(T* ptr)
-    {
-        return adoptRef(*new WeakPtrImpl(ptr));
-    }
-
-    ~WeakPtrImpl()
-    {
-        Counter::decrement();
-    }
+    ~WeakPtrImplBase() = default;
 
     template<typename T> typename T::WeakValueType* get()
     {
@@ -69,37 +58,35 @@ public:
     bool wasConstructedOnMainThread() const { return m_wasConstructedOnMainThread; }
 #endif
 
-private:
-    template<typename T> explicit WeakPtrImpl(T* ptr)
+    template<typename T>
+    explicit WeakPtrImplBase(T* ptr)
         : m_ptr(static_cast<typename T::WeakValueType*>(ptr))
 #if ASSERT_ENABLED
         , m_wasConstructedOnMainThread(isMainThread())
 #endif
     {
-        Counter::increment();
     }
 
+private:
     void* m_ptr;
 #if ASSERT_ENABLED
     bool m_wasConstructedOnMainThread;
 #endif
 };
 
-template<typename Counter> struct HashTraits<Ref<WeakPtrImpl<Counter>>> : RefHashTraits<WeakPtrImpl<Counter>> {
-    static constexpr bool hasIsReleasedWeakValueFunction = true;
-    static bool isReleasedWeakValue(const Ref<WeakPtrImpl<Counter>>& value)
-    {
-        return !value.isHashTableDeletedValue() && !value.isHashTableEmptyValue() && !value.get();
-    }
+class DefaultWeakPtrImpl final : public WeakPtrImplBase<DefaultWeakPtrImpl> {
+public:
+    template<typename T>
+    explicit DefaultWeakPtrImpl(T* ptr) : WeakPtrImplBase<DefaultWeakPtrImpl>(ptr) { }
 };
 
-template<typename T, typename Counter> class WeakPtr {
+template<typename T, typename WeakPtrImpl> class WeakPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WeakPtr() { }
     WeakPtr(std::nullptr_t) { }
-    template<typename U> WeakPtr(const WeakPtr<U, Counter>&);
-    template<typename U> WeakPtr(WeakPtr<U, Counter>&&);
+    template<typename U> WeakPtr(const WeakPtr<U, WeakPtrImpl>&);
+    template<typename U> WeakPtr(WeakPtr<U, WeakPtrImpl>&&);
 
     template<typename = std::enable_if_t<!IsSmartPtr<T>::value>> WeakPtr(const T* object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
         : m_impl(object ? implForObject(*object) : nullptr)
@@ -140,8 +127,8 @@ public:
     explicit operator bool() const { return m_impl && *m_impl; }
 
     WeakPtr& operator=(std::nullptr_t) { m_impl = nullptr; return *this; }
-    template<typename U> WeakPtr& operator=(const WeakPtr<U, Counter>&);
-    template<typename U> WeakPtr& operator=(WeakPtr<U, Counter>&&);
+    template<typename U> WeakPtr& operator=(const WeakPtr<U, WeakPtrImpl>&);
+    template<typename U> WeakPtr& operator=(WeakPtr<U, WeakPtrImpl>&&);
 
     T* operator->() const
     {
@@ -163,7 +150,7 @@ private:
     template<typename, typename> friend class WeakPtr;
     template<typename, typename> friend class WeakPtrFactory;
 
-    explicit WeakPtr(Ref<WeakPtrImpl<Counter>>&& ref, EnableWeakPtrThreadingAssertions shouldEnableAssertions)
+    explicit WeakPtr(Ref<WeakPtrImpl>&& ref, EnableWeakPtrThreadingAssertions shouldEnableAssertions)
         : m_impl(WTFMove(ref))
 #if ASSERT_ENABLED
         , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
@@ -172,24 +159,24 @@ private:
         UNUSED_PARAM(shouldEnableAssertions);
     }
 
-    template<typename U> static WeakPtrImpl<Counter>* implForObject(const U& object)
+    template<typename U> static WeakPtrImpl* implForObject(const U& object)
     {
         object.weakPtrFactory().initializeIfNeeded(object);
-        return object.weakPtrFactory().m_impl.get();
+        return object.weakPtrFactory().m_impl.pointer();
     }
 
-    RefPtr<WeakPtrImpl<Counter>> m_impl;
+    RefPtr<WeakPtrImpl> m_impl;
 #if ASSERT_ENABLED
     bool m_shouldEnableAssertions { true };
 #endif
 };
 
 // Note: you probably want to inherit from CanMakeWeakPtr rather than use this directly.
-template<typename T, typename Counter = EmptyCounter> class WeakPtrFactory {
+template<typename T, typename WeakPtrImpl = DefaultWeakPtrImpl> class WeakPtrFactory {
     WTF_MAKE_NONCOPYABLE(WeakPtrFactory);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    using CounterType = Counter;
+    using WeakPtrImplType = WeakPtrImpl;
 
     WeakPtrFactory()
 #if ASSERT_ENABLED
@@ -200,49 +187,67 @@ public:
 
     ~WeakPtrFactory()
     {
-        if (!m_impl)
-            return;
-        m_impl->clear();
+        if (auto* pointer = m_impl.pointer())
+            pointer->clear();
+    }
+
+    WeakPtrImpl* impl()
+    {
+        return m_impl.pointer();
+    }
+
+    const WeakPtrImpl* impl() const
+    {
+        return m_impl.pointer();
     }
 
     void initializeIfNeeded(const T& object) const
     {
-        if (m_impl)
+        if (m_impl.pointer())
             return;
 
         ASSERT(m_wasConstructedOnMainThread == isMainThread());
-        m_impl = WeakPtrImpl<Counter>::create(const_cast<T*>(&object));
+
+        static_assert(std::is_final_v<WeakPtrImpl>);
+        m_impl.setPointer(adoptRef(*new WeakPtrImpl(const_cast<T*>(&object))));
     }
 
-    template<typename U> WeakPtr<U, Counter> createWeakPtr(U& object, EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) const
+    template<typename U> WeakPtr<U, WeakPtrImpl> createWeakPtr(U& object, EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) const
     {
         initializeIfNeeded(object);
 
-        ASSERT(&object == m_impl->template get<T>());
-        return WeakPtr<U, Counter>(*m_impl, enableWeakPtrThreadingAssertions);
+        ASSERT(&object == m_impl.pointer()->template get<T>());
+        return WeakPtr<U, WeakPtrImpl>(*m_impl.pointer(), enableWeakPtrThreadingAssertions);
     }
 
     void revokeAll()
     {
-        if (!m_impl)
-            return;
-
-        m_impl->clear();
-        m_impl = nullptr;
+        if (auto* pointer = m_impl.pointer()) {
+            pointer->clear();
+            m_impl.setPointer(nullptr);
+        }
     }
 
-    unsigned weakPtrCount() const { return m_impl ? m_impl->refCount() - 1 : 0; }
+    unsigned weakPtrCount() const
+    {
+        if (auto* pointer = m_impl.pointer())
+            return pointer->refCount() - 1;
+        return 0;
+    }
 
 #if ASSERT_ENABLED
-    bool isInitialized() const { return m_impl; }
+    bool isInitialized() const { return m_impl.pointer(); }
 #endif
+
+    uint16_t bitfield() const { return m_impl.type(); }
+    void setBitfield(uint16_t value) const { return m_impl.setType(value); }
 
 private:
     template<typename, typename, EnableWeakPtrThreadingAssertions> friend class WeakHashSet;
     template<typename, typename, typename> friend class WeakHashMap;
     template<typename, typename> friend class WeakPtr;
 
-    mutable RefPtr<WeakPtrImpl<Counter>> m_impl;
+    mutable CompactRefPtrTuple<WeakPtrImpl, uint16_t> m_impl;
 #if ASSERT_ENABLED
     bool m_wasConstructedOnMainThread;
 #endif
@@ -252,12 +257,13 @@ private:
 // initialization is however useful if you plan to call construct WeakPtrs from other threads.
 enum class WeakPtrFactoryInitialization { Lazy, Eager };
 
-template<typename T, WeakPtrFactoryInitialization initializationMode = WeakPtrFactoryInitialization::Lazy, typename Counter = EmptyCounter> class CanMakeWeakPtr {
+template<typename T, WeakPtrFactoryInitialization initializationMode = WeakPtrFactoryInitialization::Lazy, typename WeakPtrImpl = DefaultWeakPtrImpl> class CanMakeWeakPtr {
 public:
     using WeakValueType = T;
+    using WeakPtrImplType = WeakPtrImpl;
 
-    const WeakPtrFactory<T, Counter>& weakPtrFactory() const { return m_weakPtrFactory; }
-    WeakPtrFactory<T, Counter>& weakPtrFactory() { return m_weakPtrFactory; }
+    const WeakPtrFactory<T, WeakPtrImpl>& weakPtrFactory() const { return m_weakPtrFactory; }
+    WeakPtrFactory<T, WeakPtrImpl>& weakPtrFactory() { return m_weakPtrFactory; }
 
 protected:
     CanMakeWeakPtr()
@@ -272,89 +278,101 @@ protected:
     }
 
 private:
-    WeakPtrFactory<T, Counter> m_weakPtrFactory;
+    WeakPtrFactory<T, WeakPtrImpl> m_weakPtrFactory;
 };
 
-template<typename T, typename U, typename Counter> inline WeakPtrImpl<Counter>* weak_ptr_impl_cast(WeakPtrImpl<Counter>* impl)
+template<typename T, typename U, typename WeakPtrImpl> inline WeakPtrImpl* weak_ptr_impl_cast(WeakPtrImpl* impl)
 {
     static_assert(std::is_same_v<typename T::WeakValueType, typename U::WeakValueType>, "Invalid weak pointer cast");
     return impl;
 }
 
-template<typename T, typename Counter> template<typename U> inline WeakPtr<T, Counter>::WeakPtr(const WeakPtr<U, Counter>& o)
+template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>::WeakPtr(const WeakPtr<U, WeakPtrImpl>& o)
     : m_impl(weak_ptr_impl_cast<T, U>(o.m_impl.get()))
 {
 }
 
-template<typename T, typename Counter> template<typename U> inline WeakPtr<T, Counter>::WeakPtr(WeakPtr<U, Counter>&& o)
+template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>::WeakPtr(WeakPtr<U, WeakPtrImpl>&& o)
     : m_impl(adoptRef(weak_ptr_impl_cast<T, U>(o.m_impl.leakRef())))
 {
 }
 
-template<typename T, typename Counter> template<typename U> inline WeakPtr<T, Counter>& WeakPtr<T, Counter>::operator=(const WeakPtr<U, Counter>& o)
+template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>& WeakPtr<T, WeakPtrImpl>::operator=(const WeakPtr<U, WeakPtrImpl>& o)
 {
     m_impl = weak_ptr_impl_cast<T, U>(o.m_impl.get());
     return *this;
 }
 
-template<typename T, typename Counter> template<typename U> inline WeakPtr<T, Counter>& WeakPtr<T, Counter>::operator=(WeakPtr<U, Counter>&& o)
+template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>& WeakPtr<T, WeakPtrImpl>::operator=(WeakPtr<U, WeakPtrImpl>&& o)
 {
     m_impl = adoptRef(weak_ptr_impl_cast<T, U>(o.m_impl.leakRef()));
     return *this;
 }
 
-template <typename T, typename Counter>
-struct GetPtrHelper<WeakPtr<T, Counter>> {
+template <typename T, typename WeakPtrImpl>
+struct GetPtrHelper<WeakPtr<T, WeakPtrImpl>> {
     using PtrType = T*;
-    static T* getPtr(const WeakPtr<T, Counter>& p) { return const_cast<T*>(p.get()); }
+    static T* getPtr(const WeakPtr<T, WeakPtrImpl>& p) { return const_cast<T*>(p.get()); }
 };
 
-template <typename T, typename Counter>
-struct IsSmartPtr<WeakPtr<T, Counter>> {
+template <typename T, typename WeakPtrImpl>
+struct IsSmartPtr<WeakPtr<T, WeakPtrImpl>> {
     static constexpr bool value = true;
 };
 
-template<typename ExpectedType, typename ArgType, typename Counter>
-inline bool is(WeakPtr<ArgType, Counter>& source)
+template<typename ExpectedType, typename ArgType, typename WeakPtrImpl>
+inline bool is(WeakPtr<ArgType, WeakPtrImpl>& source)
 {
     return is<ExpectedType>(source.get());
 }
 
-template<typename ExpectedType, typename ArgType, typename Counter>
-inline bool is(const WeakPtr<ArgType, Counter>& source)
+template<typename ExpectedType, typename ArgType, typename WeakPtrImpl>
+inline bool is(const WeakPtr<ArgType, WeakPtrImpl>& source)
 {
     return is<ExpectedType>(source.get());
 }
 
-template<typename T, typename U, typename Counter> inline bool operator==(const WeakPtr<T, Counter>& a, const WeakPtr<U, Counter>& b)
+template<typename T, typename U, typename WeakPtrImpl> inline bool operator==(const WeakPtr<T, WeakPtrImpl>& a, const WeakPtr<U, WeakPtrImpl>& b)
 {
     return a.get() == b.get();
 }
 
-template<typename T, typename U, typename Counter> inline bool operator==(const WeakPtr<T, Counter>& a, U* b)
+template<typename T, typename U, typename WeakPtrImpl> inline bool operator==(const WeakPtr<T, WeakPtrImpl>& a, U* b)
 {
     return a.get() == b;
 }
 
-template<typename T, typename U, typename Counter> inline bool operator==(T* a, const WeakPtr<U, Counter>& b)
+template<typename T, typename U, typename WeakPtrImpl> inline bool operator==(T* a, const WeakPtr<U, WeakPtrImpl>& b)
 {
     return a == b.get();
 }
 
-template<typename T, typename U, typename Counter> inline bool operator!=(const WeakPtr<T, Counter>& a, const WeakPtr<U, Counter>& b)
+template<typename T, typename U, typename WeakPtrImpl> inline bool operator!=(const WeakPtr<T, WeakPtrImpl>& a, const WeakPtr<U, WeakPtrImpl>& b)
 {
     return a.get() != b.get();
 }
 
-template<typename T, typename U, typename Counter> inline bool operator!=(const WeakPtr<T, Counter>& a, U* b)
+template<typename T, typename U, typename WeakPtrImpl> inline bool operator!=(const WeakPtr<T, WeakPtrImpl>& a, U* b)
 {
     return a.get() != b;
 }
 
-template<typename T, typename U, typename Counter> inline bool operator!=(T* a, const WeakPtr<U, Counter>& b)
+template<typename T, typename U, typename WeakPtrImpl> inline bool operator!=(T* a, const WeakPtr<U, WeakPtrImpl>& b)
 {
     return a != b.get();
 }
+
+template<class T, typename = std::enable_if_t<!IsSmartPtr<T>::value>>
+WeakPtr(const T* value, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) -> WeakPtr<T, typename T::WeakPtrImplType>;
+
+template<class T, typename = std::enable_if_t<!IsSmartPtr<T>::value && !std::is_pointer_v<T>>>
+WeakPtr(const T& value, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) -> WeakPtr<T, typename T::WeakPtrImplType>;
+
+template<class T, typename = std::enable_if_t<!IsSmartPtr<T>::value>>
+WeakPtr(const Ref<T>& value, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) -> WeakPtr<T, typename T::WeakPtrImplType>;
+
+template<class T, typename = std::enable_if_t<!IsSmartPtr<T>::value>>
+WeakPtr(const RefPtr<T>& value, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) -> WeakPtr<T, typename T::WeakPtrImplType>;
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -252,8 +252,8 @@ TextStream& operator<<(TextStream& ts, const Vector<ItemType, inlineCapacity>& v
     return ts << "]";
 }
 
-template<typename T>
-TextStream& operator<<(TextStream& ts, const WeakPtr<T>& item)
+template<typename T, typename Counter>
+TextStream& operator<<(TextStream& ts, const WeakPtr<T, Counter>& item)
 {
     if (item)
         return ts << *item;
@@ -354,8 +354,8 @@ struct supports_text_stream_insertion<OptionSet<T>> : supports_text_stream_inser
 template<typename T>
 struct supports_text_stream_insertion<std::optional<T>> : supports_text_stream_insertion<T> { };
 
-template<typename T>
-struct supports_text_stream_insertion<WeakPtr<T>> : supports_text_stream_insertion<T> { };
+template<typename T, typename Counter>
+struct supports_text_stream_insertion<WeakPtr<T, Counter>> : supports_text_stream_insertion<T> { };
 
 template<typename T>
 struct supports_text_stream_insertion<RefPtr<T>> : supports_text_stream_insertion<T> { };

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -75,7 +75,7 @@ class GPUSupportedLimits;
 class GPUTexture;
 struct GPUTextureDescriptor;
 
-class GPUDevice : public RefCounted<GPUDevice>, public ActiveDOMObject, public EventTargetWithInlineData {
+class GPUDevice : public RefCounted<GPUDevice>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(GPUDevice);
 public:
     static Ref<GPUDevice> create(ScriptExecutionContext* scriptExecutionContext, Ref<PAL::WebGPU::Device>&& backing)
@@ -142,7 +142,7 @@ private:
     // FIXME: We probably need to override more methods to make this work properly.
     const char* activeDOMObjectName() const final { return "GPUDevice"; }
 
-    // EventTargetWithInlineData.
+    // EventTarget.
     EventTargetInterface eventTargetInterface() const final { return GPUDeviceEventTargetInterfaceType; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/Modules/applepay/ApplePaySession.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.h
@@ -58,7 +58,7 @@ struct ApplePayPaymentMethodUpdate;
 struct ApplePayShippingContactUpdate;
 struct ApplePayShippingMethodUpdate;
 
-class ApplePaySession final : public PaymentSession, public ActiveDOMObject, public EventTargetWithInlineData {
+class ApplePaySession final : public PaymentSession, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(ApplePaySession);
 public:
     static ExceptionOr<Ref<ApplePaySession>> create(Document&, unsigned version, ApplePayPaymentRequest&&);
@@ -109,7 +109,7 @@ private:
     void suspend(ReasonForSuspension) override;
     bool virtualHasPendingActivity() const final;
 
-    // EventTargetWithInlineData.
+    // EventTarget.
     EventTargetInterface eventTargetInterface() const override { return ApplePaySessionEventTargetInterfaceType; }
     ScriptExecutionContext* scriptExecutionContext() const override { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() override { ref(); }

--- a/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
@@ -75,7 +75,7 @@ bool PaymentCoordinator::canMakePayments()
 
 void PaymentCoordinator::canMakePaymentsWithActiveCard(Document& document, const String& merchantIdentifier, Function<void(bool)>&& completionHandler)
 {
-    m_client.canMakePaymentsWithActiveCard(merchantIdentifier, document.domain(), [this, weakThis = WeakPtr { *this }, document = WeakPtr { document }, completionHandler = WTFMove(completionHandler)](bool canMakePayments) {
+    m_client.canMakePaymentsWithActiveCard(merchantIdentifier, document.domain(), [this, weakThis = WeakPtr { *this }, document = WeakPtr<Document, WeakPtrImplWithEventTargetData> { document }, completionHandler = WTFMove(completionHandler)](bool canMakePayments) {
         if (!weakThis)
             return completionHandler(false);
 

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.h
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.h
@@ -39,7 +39,7 @@ class Navigator;
 class Pasteboard;
 class PasteboardCustomData;
 
-class Clipboard final : public RefCounted<Clipboard>, public EventTargetWithInlineData {
+class Clipboard final : public RefCounted<Clipboard>, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(Clipboard);
 public:
     static Ref<Clipboard> create(Navigator&);
@@ -98,7 +98,7 @@ private:
         void didSetAllData();
         void reject();
 
-        WeakPtr<Clipboard> m_clipboard;
+        WeakPtr<Clipboard, WeakPtrImplWithEventTargetData> m_clipboard;
         Vector<std::optional<PasteboardCustomData>> m_dataToWrite;
         RefPtr<DeferredPromise> m_promise;
         unsigned m_pendingItemCount;

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.h
@@ -39,6 +39,7 @@ class Clipboard;
 class ClipboardItemDataSource;
 class DeferredPromise;
 class DOMPromise;
+class WeakPtrImplWithEventTargetData;
 class Navigator;
 class PasteboardCustomData;
 class ScriptExecutionContext;
@@ -71,7 +72,7 @@ private:
     ClipboardItem(Vector<KeyValuePair<String, RefPtr<DOMPromise>>>&&, const Options&);
     ClipboardItem(Clipboard&, const PasteboardItemInfo&);
 
-    WeakPtr<Clipboard> m_clipboard;
+    WeakPtr<Clipboard, WeakPtrImplWithEventTargetData> m_clipboard;
     WeakPtr<Navigator> m_navigator;
     std::unique_ptr<ClipboardItemDataSource> m_dataSource;
     PresentationStyle m_presentationStyle { PresentationStyle::Unspecified };

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
@@ -36,6 +36,7 @@ namespace WebCore {
 class Blob;
 class SharedBuffer;
 class DOMPromise;
+class WeakPtrImplWithEventTargetData;
 class FileReaderLoader;
 class PasteboardCustomData;
 class ScriptExecutionContext;
@@ -91,7 +92,7 @@ private:
     unsigned m_numberOfPendingClipboardTypes { 0 };
     CompletionHandler<void(std::optional<PasteboardCustomData>)> m_completionHandler;
     Vector<Ref<ClipboardItemTypeLoader>> m_itemTypeLoaders;
-    WeakPtr<Clipboard> m_writingDestination;
+    WeakPtr<Clipboard, WeakPtrImplWithEventTargetData> m_writingDestination;
 
     Vector<KeyValuePair<String, RefPtr<DOMPromise>>> m_itemPromises;
 };

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -41,7 +41,7 @@
 
 namespace WebCore {
 
-CredentialsContainer::CredentialsContainer(WeakPtr<Document>&& document)
+CredentialsContainer::CredentialsContainer(WeakPtr<Document, WeakPtrImplWithEventTargetData>&& document)
     : m_document(WTFMove(document))
 {
 }

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
@@ -42,10 +42,11 @@ class Document;
 
 struct CredentialCreationOptions;
 struct CredentialRequestOptions;
+class WeakPtrImplWithEventTargetData;
 
 class CredentialsContainer : public RefCounted<CredentialsContainer> {
 public:
-    static Ref<CredentialsContainer> create(WeakPtr<Document>&& document) { return adoptRef(*new CredentialsContainer(WTFMove(document))); }
+    static Ref<CredentialsContainer> create(WeakPtr<Document, WeakPtrImplWithEventTargetData>&& document) { return adoptRef(*new CredentialsContainer(WTFMove(document))); }
 
     void get(CredentialRequestOptions&&, CredentialPromise&&);
 
@@ -56,11 +57,11 @@ public:
     void preventSilentAccess(DOMPromiseDeferred<void>&&) const;
 
 private:
-    CredentialsContainer(WeakPtr<Document>&&);
+    CredentialsContainer(WeakPtr<Document, WeakPtrImplWithEventTargetData>&&);
 
     ScopeAndCrossOriginParent scopeAndCrossOriginParent() const;
 
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp
@@ -44,7 +44,7 @@ const char* NavigatorCredentials::supplementName()
     return "NavigatorCredentials";
 }
 
-CredentialsContainer* NavigatorCredentials::credentials(WeakPtr<Document>&& document)
+CredentialsContainer* NavigatorCredentials::credentials(WeakPtr<Document, WeakPtrImplWithEventTargetData>&& document)
 {
     if (!m_credentialsContainer)
         m_credentialsContainer = CredentialsContainer::create(WTFMove(document));

--- a/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h
+++ b/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h
@@ -34,6 +34,7 @@
 
 namespace WebCore {
 
+class WeakPtrImplWithEventTargetData;
 class Navigator;
 
 class NavigatorCredentials final : public Supplement<Navigator> {
@@ -45,7 +46,7 @@ public:
     static CredentialsContainer* credentials(Navigator&);
 
 private:
-    CredentialsContainer* credentials(WeakPtr<Document>&&);
+    CredentialsContainer* credentials(WeakPtr<Document, WeakPtrImplWithEventTargetData>&&);
 
     static NavigatorCredentials* from(Navigator*);
     static const char* supplementName();

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -61,14 +61,15 @@ class SharedBuffer;
 
 template<typename IDLType> class DOMPromiseProxy;
 
-class MediaKeySession final : public RefCounted<MediaKeySession>, public EventTargetWithInlineData, public ActiveDOMObject, public CDMInstanceSessionClient {
+class MediaKeySession final : public RefCounted<MediaKeySession>, public EventTarget, public ActiveDOMObject, public CDMInstanceSessionClient {
     WTF_MAKE_ISO_ALLOCATED(MediaKeySession);
 public:
     static Ref<MediaKeySession> create(Document&, WeakPtr<MediaKeys>&&, MediaKeySessionType, bool useDistinctiveIdentifier, Ref<CDM>&&, Ref<CDMInstanceSession>&&);
     virtual ~MediaKeySession();
 
     using CDMInstanceSessionClient::weakPtrFactory;
-    using WeakValueType = CDMInstanceSessionClient::WeakValueType;
+    using CDMInstanceSessionClient::WeakValueType;
+    using CDMInstanceSessionClient::WeakPtrImplType;
     using RefCounted<MediaKeySession>::ref;
     using RefCounted<MediaKeySession>::deref;
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp
@@ -64,7 +64,7 @@ void MediaKeySystemAccess::createMediaKeys(Document& document, Ref<DeferredPromi
     // When this method is invoked, the user agent must run the following steps:
     // 1. Let promise be a new promise.
     // 2. Run the following steps in parallel:
-    document.eventLoop().queueTask(TaskSource::MediaElement, [this, weakThis = WeakPtr { *this }, weakDocument = WeakPtr { document }, promise = WTFMove(promise)] () mutable {
+    document.eventLoop().queueTask(TaskSource::MediaElement, [this, weakThis = WeakPtr { *this }, weakDocument = WeakPtr<Document, WeakPtrImplWithEventTargetData> { document }, promise = WTFMove(promise)] () mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -40,7 +40,7 @@ namespace WebCore {
 class WebKitMediaKeyError;
 class WebKitMediaKeys;
 
-class WebKitMediaKeySession final : public RefCounted<WebKitMediaKeySession>, public EventTargetWithInlineData, public ActiveDOMObject, private LegacyCDMSessionClient {
+class WebKitMediaKeySession final : public RefCounted<WebKitMediaKeySession>, public EventTarget, public ActiveDOMObject, private LegacyCDMSessionClient {
     WTF_MAKE_ISO_ALLOCATED(WebKitMediaKeySession);
 public:
     static Ref<WebKitMediaKeySession> create(Document&, WebKitMediaKeys&, const String& keySystem);

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.h
@@ -36,6 +36,7 @@
 namespace WebCore {
 
 class Document;
+class WeakPtrImplWithEventTargetData;
 class HTMLMediaElement;
 class WebKitMediaKeySession;
 
@@ -61,7 +62,7 @@ private:
     WebKitMediaKeys(const String& keySystem, std::unique_ptr<LegacyCDM>&&);
 
     Vector<Ref<WebKitMediaKeySession>> m_sessions;
-    WeakPtr<HTMLMediaElement> m_mediaElement;
+    WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElement;
     String m_keySystem;
     std::unique_ptr<LegacyCDM> m_cdm;
 };

--- a/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 
+class WeakPtrImplWithEventTargetData;
 class FileHandle;
 class FileSystemSyncAccessHandle;
 class WorkerGlobalScope;
@@ -76,7 +77,7 @@ private:
     void unregisterSyncAccessHandle(FileSystemSyncAccessHandleIdentifier) final;
     void invalidateAccessHandle(FileSystemSyncAccessHandleIdentifier) final;
 
-    WeakPtr<WorkerGlobalScope> m_scope;
+    WeakPtr<WorkerGlobalScope, WeakPtrImplWithEventTargetData> m_scope;
     RefPtr<FileSystemStorageConnection> m_mainThreadConnection;
     HashMap<CallbackIdentifier, FileSystemStorageConnection::SameEntryCallback> m_sameEntryCallbacks;
     HashMap<CallbackIdentifier, FileSystemStorageConnection::GetHandleCallback> m_getHandleCallbacks;

--- a/Source/WebCore/Modules/gamepad/GamepadManager.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.cpp
@@ -82,7 +82,7 @@ void GamepadManager::platformGamepadDisconnected(PlatformGamepad& platformGamepa
     HashSet<NavigatorGamepad*> notifiedNavigators;
 
     // Handle the disconnect for all DOMWindows with event listeners and their Navigators.
-    for (auto& window : copyToVectorOf<WeakPtr<DOMWindow>>(m_domWindows)) {
+    for (auto& window : copyToVectorOf<WeakPtr<DOMWindow, WeakPtrImplWithEventTargetData>>(m_domWindows)) {
         // Event dispatch might have made this window go away.
         if (!window)
             continue;
@@ -139,7 +139,7 @@ void GamepadManager::makeGamepadVisible(PlatformGamepad& platformGamepad, HashSe
     for (auto* navigator : navigatorSet)
         navigator->gamepadConnected(platformGamepad);
 
-    for (auto& window : copyToVectorOf<WeakPtr<DOMWindow>>(m_domWindows)) {
+    for (auto& window : copyToVectorOf<WeakPtr<DOMWindow, WeakPtrImplWithEventTargetData>>(m_domWindows)) {
         // Event dispatch might have made this window go away.
         if (!window)
             continue;

--- a/Source/WebCore/Modules/highlight/AppHighlightStorage.h
+++ b/Source/WebCore/Modules/highlight/AppHighlightStorage.h
@@ -63,7 +63,7 @@ public:
 private:
     bool attemptToRestoreHighlightAndScroll(AppHighlightRangeData&, ScrollToHighlight);
     
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     MonotonicTime m_timeAtLastRangeSearch;
     Vector<AppHighlightRangeData> m_unrestoredHighlights;
     std::optional<AppHighlightRangeData> m_unrestoredScrollHighlight;

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.h
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.h
@@ -100,7 +100,7 @@ private:
 
     IDBCursorInfo m_info;
     Source m_source;
-    WeakPtr<IDBRequest> m_request;
+    WeakPtr<IDBRequest, WeakPtrImplWithEventTargetData> m_request;
 
     bool m_gotValue { false };
 

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -467,7 +467,7 @@ void IDBDatabase::dispatchEvent(Event& event)
 
     Ref protectedThis { *this };
 
-    EventTargetWithInlineData::dispatchEvent(event);
+    EventTarget::dispatchEvent(event);
 
     if (event.isVersionChangeEvent() && event.type() == m_eventNames.versionchangeEvent)
         m_connectionProxy->didFireVersionChangeEvent(m_databaseConnectionIdentifier, downcast<IDBVersionChangeEvent>(event).requestIdentifier());

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -43,7 +43,7 @@ class IDBTransactionInfo;
 
 struct EventNames;
 
-class IDBDatabase final : public ThreadSafeRefCounted<IDBDatabase>, public EventTargetWithInlineData, public IDBActiveDOMObject {
+class IDBDatabase final : public ThreadSafeRefCounted<IDBDatabase>, public EventTarget, public IDBActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(IDBDatabase);
 public:
     static Ref<IDBDatabase> create(ScriptExecutionContext&, IDBClient::IDBConnectionProxy&, const IDBResultData&);

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -61,7 +61,7 @@ class IDBConnectionProxy;
 class IDBConnectionToServer;
 }
 
-class IDBRequest : public EventTargetWithInlineData, public IDBActiveDOMObject, public ThreadSafeRefCounted<IDBRequest> {
+class IDBRequest : public EventTarget, public IDBActiveDOMObject, public ThreadSafeRefCounted<IDBRequest> {
     WTF_MAKE_ISO_ALLOCATED(IDBRequest);
 public:
     enum class NullResultType {

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -64,7 +64,7 @@ class IDBConnectionProxy;
 class TransactionOperation;
 }
 
-class IDBTransaction final : public ThreadSafeRefCounted<IDBTransaction>, public EventTargetWithInlineData, public IDBActiveDOMObject {
+class IDBTransaction final : public ThreadSafeRefCounted<IDBTransaction>, public EventTarget, public IDBActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(IDBTransaction, WEBCORE_EXPORT);
 public:
     static Ref<IDBTransaction> create(IDBDatabase&, const IDBTransactionInfo&);

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -38,6 +38,7 @@ namespace WebCore {
 class AudioTrack;
 class AudioTrackList;
 class Element;
+class WeakPtrImplWithEventTargetData;
 class HTMLElement;
 class HTMLMediaElement;
 class MediaControlTextTrackContainerElement;
@@ -107,7 +108,7 @@ public:
 private:
     explicit MediaControlsHost(HTMLMediaElement&);
 
-    WeakPtr<HTMLMediaElement> m_mediaElement;
+    WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElement;
     RefPtr<MediaControlTextTrackContainerElement> m_textTrackContainer;
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -45,7 +45,7 @@ class MediaRecorderPrivate;
 class MediaRecorder final
     : public ActiveDOMObject
     , public RefCounted<MediaRecorder>
-    , public EventTargetWithInlineData
+    , public EventTarget
     , private MediaStreamPrivate::Observer
     , private MediaStreamTrackPrivate::Observer {
     WTF_MAKE_ISO_ALLOCATED(MediaRecorder);

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
@@ -44,7 +44,7 @@ class MediaSessionCoordinator
     , public MediaSessionCoordinatorClient
     , public MediaSession::Observer
     , public ActiveDOMObject
-    , public EventTargetWithInlineData  {
+    , public EventTarget  {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT static Ref<MediaSessionCoordinator> create(ScriptExecutionContext*);
@@ -66,7 +66,8 @@ public:
     void setMediaSession(MediaSession*);
 
     using MediaSessionCoordinatorClient::weakPtrFactory;
-    using WeakValueType = MediaSessionCoordinatorClient::WeakValueType;
+    using MediaSessionCoordinatorClient::WeakValueType;
+    using MediaSessionCoordinatorClient::WeakPtrImplType;
     using RefCounted::ref;
     using RefCounted::deref;
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -54,7 +54,7 @@ class MediaSource final
     : public RefCounted<MediaSource>
     , public MediaSourcePrivateClient
     , public ActiveDOMObject
-    , public EventTargetWithInlineData
+    , public EventTarget
     , public URLRegistrable
 #if !RELEASE_LOG_DISABLED
     , private LoggerHelper
@@ -171,7 +171,7 @@ private:
     RefPtr<SourceBufferList> m_activeSourceBuffers;
     std::unique_ptr<PlatformTimeRanges> m_buffered;
     std::unique_ptr<PlatformTimeRanges> m_liveSeekable;
-    WeakPtr<HTMLMediaElement> m_mediaElement;
+    WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElement;
     MediaTime m_duration;
     MediaTime m_pendingSeekTime;
     ReadyState m_readyState { ReadyState::Closed };

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -60,7 +60,7 @@ class WebCoreOpaqueRoot;
 class SourceBuffer final
     : public RefCounted<SourceBuffer>
     , public ActiveDOMObject
-    , public EventTargetWithInlineData
+    , public EventTarget
     , private SourceBufferPrivateClient
     , private AudioTrackClient
     , private VideoTrackClient
@@ -71,8 +71,9 @@ class SourceBuffer final
 {
     WTF_MAKE_ISO_ALLOCATED(SourceBuffer);
 public:
-    using WeakValueType = EventTarget::WeakValueType;
     using EventTarget::weakPtrFactory;
+    using EventTarget::WeakValueType;
+    using EventTarget::WeakPtrImplType;
 
     static Ref<SourceBuffer> create(Ref<SourceBufferPrivate>&&, MediaSource*);
     virtual ~SourceBuffer();

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.h
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.h
@@ -42,7 +42,7 @@ namespace WebCore {
 class SourceBuffer;
 class WebCoreOpaqueRoot;
 
-class SourceBufferList final : public RefCounted<SourceBufferList>, public EventTargetWithInlineData, public ActiveDOMObject {
+class SourceBufferList final : public RefCounted<SourceBufferList>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(SourceBufferList);
 public:
     static Ref<SourceBufferList> create(ScriptExecutionContext*);

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -411,7 +411,7 @@ bool MediaDevices::addEventListener(const AtomString& eventType, Ref<EventListen
     if (eventType == eventNames().devicechangeEvent)
         listenForDeviceChanges();
 
-    return EventTargetWithInlineData::addEventListener(eventType, WTFMove(listener), options);
+    return EventTarget::addEventListener(eventType, WTFMove(listener), options);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -56,7 +56,7 @@ struct MediaTrackSupportedConstraints;
 
 template<typename IDLType> class DOMPromiseDeferred;
 
-class MediaDevices final : public RefCounted<MediaDevices>, public ActiveDOMObject, public EventTargetWithInlineData {
+class MediaDevices final : public RefCounted<MediaDevices>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(MediaDevices);
 public:
     static Ref<MediaDevices> create(Document&);
@@ -111,7 +111,7 @@ private:
     void stop() final;
     bool virtualHasPendingActivity() const final;
 
-    // EventTargetWithInlineData.
+    // EventTarget.
     EventTargetInterface eventTargetInterface() const final { return MediaDevicesEventTargetInterfaceType; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -47,7 +47,7 @@ namespace WebCore {
 class Document;
 
 class MediaStream final
-    : public EventTargetWithInlineData
+    : public EventTarget
     , public ActiveDOMObject
     , public MediaStreamPrivate::Observer
     , private MediaCanStartListener
@@ -78,8 +78,9 @@ public:
 
     RefPtr<MediaStream> clone();
 
-    using WeakValueType = MediaStreamPrivate::Observer::WeakValueType;
     using MediaStreamPrivate::Observer::weakPtrFactory;
+    using MediaStreamPrivate::Observer::WeakValueType;
+    using MediaStreamPrivate::Observer::WeakPtrImplType;
 
     bool active() const { return m_isActive; }
     bool muted() const { return m_private->muted(); }

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -51,7 +51,7 @@ template<typename IDLType> class DOMPromiseDeferred;
 class MediaStreamTrack
     : public RefCounted<MediaStreamTrack>
     , public ActiveDOMObject
-    , public EventTargetWithInlineData
+    , public EventTarget
     , private MediaStreamTrackPrivate::Observer
     , private PlatformMediaSession::AudioCaptureSource
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
@@ -39,7 +39,7 @@ class MediaStreamTrack;
 class RTCDTMFSenderBackend;
 class RTCRtpSender;
 
-class RTCDTMFSender final : public RefCounted<RTCDTMFSender>, public EventTargetWithInlineData, public ActiveDOMObject {
+class RTCDTMFSender final : public RefCounted<RTCDTMFSender>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(RTCDTMFSender);
 public:
     static Ref<RTCDTMFSender> create(ScriptExecutionContext&, RTCRtpSender&, std::unique_ptr<RTCDTMFSenderBackend>&&);

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -50,7 +50,7 @@ namespace WebCore {
 class Blob;
 class RTCPeerConnectionHandler;
 
-class RTCDataChannel final : public RefCounted<RTCDataChannel>, public ActiveDOMObject, public RTCDataChannelHandlerClient, public EventTargetWithInlineData {
+class RTCDataChannel final : public RefCounted<RTCDataChannel>, public ActiveDOMObject, public RTCDataChannelHandlerClient, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(RTCDataChannel);
 public:
     static Ref<RTCDataChannel> create(ScriptExecutionContext&, std::unique_ptr<RTCDataChannelHandler>&&, String&&, RTCDataChannelInit&&);

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
@@ -39,7 +39,7 @@ class RTCIceTransport;
 class RTCPeerConnection;
 class ScriptExecutionContext;
 
-class RTCDtlsTransport final : public RefCounted<RTCDtlsTransport>, public ActiveDOMObject, public EventTargetWithInlineData, public RTCDtlsTransportBackend::Client {
+class RTCDtlsTransport final : public RefCounted<RTCDtlsTransport>, public ActiveDOMObject, public EventTarget, public RTCDtlsTransportBackend::Client {
     WTF_MAKE_ISO_ALLOCATED(RTCDtlsTransport);
 public:
     static Ref<RTCDtlsTransport> create(ScriptExecutionContext&, UniqueRef<RTCDtlsTransportBackend>&&, Ref<RTCIceTransport>&&);
@@ -59,7 +59,7 @@ public:
 private:
     RTCDtlsTransport(ScriptExecutionContext&, UniqueRef<RTCDtlsTransportBackend>&&, Ref<RTCIceTransport>&&);
 
-    // EventTargetWithInlineData
+    // EventTarget
     EventTargetInterface eventTargetInterface() const final { return RTCDtlsTransportEventTargetInterfaceType; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.h
@@ -47,7 +47,7 @@ namespace WebCore {
 
 class RTCPeerConnection;
 
-class RTCIceTransport : public RefCounted<RTCIceTransport>, public ActiveDOMObject, public EventTargetWithInlineData, public RTCIceTransportBackend::Client {
+class RTCIceTransport : public RefCounted<RTCIceTransport>, public ActiveDOMObject, public EventTarget, public RTCIceTransportBackend::Client {
     WTF_MAKE_ISO_ALLOCATED(RTCIceTransport);
 public:
     static Ref<RTCIceTransport> create(ScriptExecutionContext&, UniqueRef<RTCIceTransportBackend>&&, RTCPeerConnection&);
@@ -71,7 +71,7 @@ public:
 private:
     RTCIceTransport(ScriptExecutionContext&, UniqueRef<RTCIceTransportBackend>&&, RTCPeerConnection&);
 
-    // EventTargetWithInlineData
+    // EventTarget
     EventTargetInterface eventTargetInterface() const final { return RTCIceTransportEventTargetInterfaceType; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
@@ -89,7 +89,7 @@ private:
 
     bool m_isStopped { false };
     UniqueRef<RTCIceTransportBackend> m_backend;
-    WeakPtr<RTCPeerConnection> m_connection;
+    WeakPtr<RTCPeerConnection, WeakPtrImplWithEventTargetData> m_connection;
     RTCIceTransportState m_transportState { RTCIceTransportState::New };
     RTCIceGatheringState m_gatheringState { RTCIceGatheringState::New };
     std::optional<CandidatePair> m_selectedCandidatePair;

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -83,7 +83,7 @@ struct RTCRtpTransceiverInit {
 
 class RTCPeerConnection final
     : public RefCounted<RTCPeerConnection>
-    , public EventTargetWithInlineData
+    , public EventTarget
     , public ActiveDOMObject
 #if !RELEASE_LOG_DISABLED
     , private LoggerHelper

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -122,7 +122,7 @@ static RTCRtpSFrameTransformErrorEvent::Type errorTypeFromInformation(const RTCR
     }
 }
 
-static std::optional<Vector<uint8_t>> processFrame(Span<const uint8_t> data, RTCRtpSFrameTransformer& transformer, ScriptExecutionContextIdentifier identifier, const WeakPtr<RTCRtpSFrameTransform>& weakTransform)
+static std::optional<Vector<uint8_t>> processFrame(Span<const uint8_t> data, RTCRtpSFrameTransformer& transformer, ScriptExecutionContextIdentifier identifier, const WeakPtr<RTCRtpSFrameTransform, WeakPtrImplWithEventTargetData>& weakTransform)
 {
     auto result = transformer.transform(data);
     if (!result.has_value()) {
@@ -194,7 +194,7 @@ void RTCRtpSFrameTransform::willClearBackend(RTCRtpTransformBackend& backend)
     backend.clearTransformableFrameCallback();
 }
 
-static void transformFrame(Span<const uint8_t> data, JSDOMGlobalObject& globalObject, RTCRtpSFrameTransformer& transformer, SimpleReadableStreamSource& source, ScriptExecutionContextIdentifier identifier, const WeakPtr<RTCRtpSFrameTransform>& weakTransform)
+static void transformFrame(Span<const uint8_t> data, JSDOMGlobalObject& globalObject, RTCRtpSFrameTransformer& transformer, SimpleReadableStreamSource& source, ScriptExecutionContextIdentifier identifier, const WeakPtr<RTCRtpSFrameTransform, WeakPtrImplWithEventTargetData>& weakTransform)
 {
     auto result = processFrame(data, transformer, identifier, weakTransform);
     auto buffer = result ? SharedBuffer::create(WTFMove(*result)) : SharedBuffer::create();
@@ -202,7 +202,7 @@ static void transformFrame(Span<const uint8_t> data, JSDOMGlobalObject& globalOb
 }
 
 template<typename Frame>
-void transformFrame(Frame& frame, JSDOMGlobalObject& globalObject, RTCRtpSFrameTransformer& transformer, SimpleReadableStreamSource& source, ScriptExecutionContextIdentifier identifier, const WeakPtr<RTCRtpSFrameTransform>& weakTransform)
+void transformFrame(Frame& frame, JSDOMGlobalObject& globalObject, RTCRtpSFrameTransformer& transformer, SimpleReadableStreamSource& source, ScriptExecutionContextIdentifier identifier, const WeakPtr<RTCRtpSFrameTransform, WeakPtrImplWithEventTargetData>& weakTransform)
 {
     auto chunk = frame.rtcFrame().data();
     auto result = processFrame(chunk, transformer, identifier, weakTransform);

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -45,7 +45,7 @@ class ReadableStream;
 class SimpleReadableStreamSource;
 class WritableStream;
 
-class RTCRtpSFrameTransform : public RefCounted<RTCRtpSFrameTransform>, public ActiveDOMObject, public EventTargetWithInlineData {
+class RTCRtpSFrameTransform : public RefCounted<RTCRtpSFrameTransform>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(RTCRtpSFrameTransform);
 public:
     enum class Role { Encrypt, Decrypt };
@@ -85,7 +85,7 @@ private:
     const char* activeDOMObjectName() const final { return "RTCRtpSFrameTransform"; }
     bool virtualHasPendingActivity() const final;
 
-    // EventTargetWithInlineData
+    // EventTarget
     EventTargetInterface eventTargetInterface() const final { return RTCRtpSFrameTransformEventTargetInterfaceType; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.h
@@ -45,7 +45,7 @@ class Worker;
 class RTCRtpScriptTransform final
     : public ThreadSafeRefCounted<RTCRtpScriptTransform, WTF::DestructionThread::Main>
     , public ActiveDOMObject
-    , public EventTargetWithInlineData {
+    , public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(RTCRtpScriptTransform);
 public:
     static ExceptionOr<Ref<RTCRtpScriptTransform>> create(JSC::JSGlobalObject&, Worker&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&&);

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.h
@@ -111,7 +111,7 @@ private:
     String m_trackId;
     String m_trackKind;
     std::unique_ptr<RTCRtpSenderBackend> m_backend;
-    WeakPtr<RTCPeerConnection> m_connection;
+    WeakPtr<RTCPeerConnection, WeakPtrImplWithEventTargetData> m_connection;
     RefPtr<RTCDTMFSender> m_dtmfSender;
     std::unique_ptr<RTCRtpTransform> m_transform;
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
@@ -87,7 +87,7 @@ private:
     bool m_stopped { false };
 
     std::unique_ptr<RTCRtpTransceiverBackend> m_backend;
-    WeakPtr<RTCPeerConnection> m_connection;
+    WeakPtr<RTCPeerConnection, WeakPtrImplWithEventTargetData> m_connection;
 };
 
 class RtpTransceiverSet {

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class RTCDtlsTransport;
 
-class RTCSctpTransport final : public RefCounted<RTCSctpTransport>, public ActiveDOMObject, public EventTargetWithInlineData, public RTCSctpTransportBackend::Client {
+class RTCSctpTransport final : public RefCounted<RTCSctpTransport>, public ActiveDOMObject, public EventTarget, public RTCSctpTransportBackend::Client {
     WTF_MAKE_ISO_ALLOCATED(RTCSctpTransport);
 public:
     static Ref<RTCSctpTransport> create(ScriptExecutionContext&, UniqueRef<RTCSctpTransportBackend>&&, Ref<RTCDtlsTransport>&&);
@@ -56,7 +56,7 @@ public:
 private:
     RTCSctpTransport(ScriptExecutionContext&, UniqueRef<RTCSctpTransportBackend>&&, Ref<RTCDtlsTransport>&&);
 
-    // EventTargetWithInlineData
+    // EventTarget
     EventTargetInterface eventTargetInterface() const final { return RTCSctpTransportEventTargetInterfaceType; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -54,8 +54,9 @@ template<typename IDLType> class DOMPromiseProxyWithResolveCallback;
 class HTMLModelElement final : public HTMLElement, private CachedRawResourceClient, public ModelPlayerClient, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(HTMLModelElement);
 public:
-    using WeakValueType = HTMLElement::WeakValueType;
     using HTMLElement::weakPtrFactory;
+    using HTMLElement::WeakValueType;
+    using HTMLElement::WeakPtrImplType;
 
     static Ref<HTMLModelElement> create(const QualifiedName&, Document&);
     virtual ~HTMLModelElement();

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -55,7 +55,7 @@ class NotificationResourcesLoader;
 
 struct NotificationData;
 
-class Notification final : public ThreadSafeRefCounted<Notification>, public ActiveDOMObject, public EventTargetWithInlineData {
+class Notification final : public ThreadSafeRefCounted<Notification>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(Notification, WEBCORE_EXPORT);
 public:
     using Permission = NotificationPermission;

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
@@ -52,7 +52,7 @@ struct PaymentDetailsUpdate;
 struct PaymentMethodData;
 template<typename IDLType> class DOMPromiseDeferred;
 
-class PaymentRequest final : public ActiveDOMObject, public EventTargetWithInlineData, public RefCounted<PaymentRequest> {
+class PaymentRequest final : public ActiveDOMObject, public EventTarget, public RefCounted<PaymentRequest> {
     WTF_MAKE_ISO_ALLOCATED(PaymentRequest);
 public:
     using AbortPromise = DOMPromiseDeferred<void>;

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
@@ -46,7 +46,7 @@ enum class PaymentComplete;
 
 template<typename IDLType> class DOMPromiseDeferred;
 
-class PaymentResponse final : public ActiveDOMObject, public EventTargetWithInlineData, public RefCounted<PaymentResponse> {
+class PaymentResponse final : public ActiveDOMObject, public EventTarget, public RefCounted<PaymentResponse> {
     WTF_MAKE_ISO_ALLOCATED(PaymentResponse);
 public:
     using DetailsFunction = Function<JSC::Strong<JSC::JSObject>(JSC::JSGlobalObject&)>;
@@ -116,7 +116,7 @@ private:
         Stopped,
     };
 
-    WeakPtr<PaymentRequest> m_request;
+    WeakPtr<PaymentRequest, WeakPtrImplWithEventTargetData> m_request;
     String m_requestId;
     String m_methodName;
     DetailsFunction m_detailsFunction;

--- a/Source/WebCore/Modules/permissions/PermissionStatus.h
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class ScriptExecutionContext;
 
-class PermissionStatus final : public PermissionObserver, public ActiveDOMObject, public RefCounted<PermissionStatus>, public EventTargetWithInlineData  {
+class PermissionStatus final : public PermissionObserver, public ActiveDOMObject, public RefCounted<PermissionStatus>, public EventTarget  {
     WTF_MAKE_ISO_ALLOCATED(PermissionStatus);
 public:
     static Ref<PermissionStatus> create(ScriptExecutionContext&, PermissionState, const PermissionDescriptor&);
@@ -50,7 +50,8 @@ public:
     using RefCounted::deref;
 
     using PermissionObserver::weakPtrFactory;
-    using WeakValueType = PermissionObserver::WeakValueType;
+    using PermissionObserver::WeakValueType;
+    using PermissionObserver::WeakPtrImplType;
 
 private:
     PermissionStatus(ScriptExecutionContext&, PermissionState, const PermissionDescriptor&);

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class PictureInPictureWindow final
     : public ActiveDOMObject
-    , public EventTargetWithInlineData
+    , public EventTarget
     , public RefCounted<PictureInPictureWindow> {
     WTF_MAKE_ISO_ALLOCATED(PictureInPictureWindow);
 public:

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.h
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 
+class WeakPtrImplWithEventTargetData;
 class YouTubeEmbedShadowElement;
 
 class YouTubePluginReplacement final : public PluginReplacement {
@@ -55,7 +56,7 @@ private:
     bool willCreateRenderer() final { return m_embedShadowElement; }
     RenderPtr<RenderElement> createElementRenderer(HTMLPlugInElement&, RenderStyle&&, const RenderTreePosition&) final;
 
-    WeakPtr<HTMLPlugInElement> m_parentElement;
+    WeakPtr<HTMLPlugInElement, WeakPtrImplWithEventTargetData> m_parentElement;
     RefPtr<YouTubeEmbedShadowElement> m_embedShadowElement;
     HashMap<AtomString, AtomString> m_attributes;
 };

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -42,7 +42,7 @@ class MediaPlaybackTarget;
 class Node;
 class RemotePlaybackAvailabilityCallback;
 
-class RemotePlayback final : public RefCounted<RemotePlayback>, public ActiveDOMObject, public EventTargetWithInlineData {
+class RemotePlayback final : public RefCounted<RemotePlayback>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(RemotePlayback);
 public:
     static Ref<RemotePlayback> create(HTMLMediaElement&);
@@ -86,11 +86,11 @@ private:
     // ActiveDOMObject.
     const char* activeDOMObjectName() const final;
 
-    // EventTargetWithInlineData.
+    // EventTarget.
     EventTargetInterface eventTargetInterface() const final { return RemotePlaybackEventTargetInterfaceType; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
-    WeakPtr<HTMLMediaElement> m_mediaElement;
+    WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElement;
     uint32_t m_nextId { 0 };
 
     using CallbackMap = HashMap<int32_t, Ref<RemotePlaybackAvailabilityCallback>>;

--- a/Source/WebCore/Modules/speech/SpeechRecognition.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.h
@@ -36,13 +36,14 @@ namespace WebCore {
 class Document;
 class SpeechRecognitionResult;
 
-class SpeechRecognition : public SpeechRecognitionConnectionClient, public ActiveDOMObject, public RefCounted<SpeechRecognition>, public EventTargetWithInlineData  {
+class SpeechRecognition : public SpeechRecognitionConnectionClient, public ActiveDOMObject, public RefCounted<SpeechRecognition>, public EventTarget  {
     WTF_MAKE_ISO_ALLOCATED(SpeechRecognition);
 public:
     static Ref<SpeechRecognition> create(Document&);
 
     using SpeechRecognitionConnectionClient::weakPtrFactory;
-    using WeakValueType = SpeechRecognitionConnectionClient::WeakValueType;
+    using SpeechRecognitionConnectionClient::WeakValueType;
+    using SpeechRecognitionConnectionClient::WeakPtrImplType;
 
     const String& lang() const { return m_lang; }
     void setLang(String&& lang) { m_lang = WTFMove(lang); }

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -42,7 +42,7 @@ class Document;
 class PlatformSpeechSynthesizerClient;
 class SpeechSynthesisVoice;
 
-class SpeechSynthesis : public PlatformSpeechSynthesizerClient, public SpeechSynthesisClientObserver, public RefCounted<SpeechSynthesis>, public ContextDestructionObserver, public EventTargetWithInlineData {
+class SpeechSynthesis : public PlatformSpeechSynthesizerClient, public SpeechSynthesisClientObserver, public RefCounted<SpeechSynthesis>, public ContextDestructionObserver, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(SpeechSynthesis);
 public:
     static Ref<SpeechSynthesis> create(ScriptExecutionContext&);

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-class WEBCORE_EXPORT SpeechSynthesisUtterance final : public PlatformSpeechSynthesisUtteranceClient, public RefCounted<SpeechSynthesisUtterance>, public EventTargetWithInlineData {
+class WEBCORE_EXPORT SpeechSynthesisUtterance final : public PlatformSpeechSynthesisUtteranceClient, public RefCounted<SpeechSynthesisUtterance>, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(SpeechSynthesisUtterance);
 public:
     using UtteranceCompletionHandler = Function<void(const SpeechSynthesisUtterance&)>;

--- a/Source/WebCore/Modules/storage/WorkerStorageConnection.h
+++ b/Source/WebCore/Modules/storage/WorkerStorageConnection.h
@@ -30,6 +30,7 @@
 
 namespace WebCore {
 
+class WeakPtrImplWithEventTargetData;
 class WorkerGlobalScope;
 
 class WorkerStorageConnection final : public StorageConnection  {
@@ -46,7 +47,7 @@ private:
     void getPersisted(ClientOrigin&&, StorageConnection::PersistCallback&&) final;
     void fileSystemGetDirectory(ClientOrigin&&, StorageConnection::GetDirectoryCallback&&) final;
 
-    WeakPtr<WorkerGlobalScope> m_scope;
+    WeakPtr<WorkerGlobalScope, WeakPtrImplWithEventTargetData> m_scope;
     uint64_t m_lastCallbackIdentifier { 0 };
     HashMap<uint64_t, StorageConnection::PersistCallback> m_getPersistedCallbacks;
     HashMap<uint64_t, StorageConnection::GetDirectoryCallback> m_getDirectoryCallbacks;

--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -698,7 +698,7 @@ BaseAudioContext& AudioNode::context()
 {
     return WTF::switchOn(m_context, [](Ref<BaseAudioContext>& context) -> BaseAudioContext& {
         return context.get();
-    }, [](WeakPtr<BaseAudioContext>& context) -> BaseAudioContext& {
+    }, [](WeakPtr<BaseAudioContext, WeakPtrImplWithEventTargetData>& context) -> BaseAudioContext& {
         return *context;
     });
 }
@@ -707,7 +707,7 @@ const BaseAudioContext& AudioNode::context() const
 {
     return WTF::switchOn(m_context, [](const Ref<BaseAudioContext>& context) -> const BaseAudioContext& {
         return context.get();
-    }, [](const WeakPtr<BaseAudioContext>& context) -> const BaseAudioContext& {
+    }, [](const WeakPtr<BaseAudioContext, WeakPtrImplWithEventTargetData>& context) -> const BaseAudioContext& {
         return *context;
     });
 }

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -50,7 +50,7 @@ class BaseAudioContext;
 // Most processing nodes such as filters will have one input and one output, although multiple inputs and outputs are possible.
 
 class AudioNode
-    : public EventTargetWithInlineData
+    : public EventTarget
 #if !RELEASE_LOG_DISABLED
     , private LoggerHelper
 #endif
@@ -231,7 +231,7 @@ protected:
     virtual void updatePullStatus() { }
 
 private:
-    using WeakOrStrongContext = std::variant<Ref<BaseAudioContext>, WeakPtr<BaseAudioContext>>;
+    using WeakOrStrongContext = std::variant<Ref<BaseAudioContext>, WeakPtr<BaseAudioContext, WeakPtrImplWithEventTargetData>>;
     static WeakOrStrongContext toWeakOrStrongContext(BaseAudioContext&, NodeType);
 
     // EventTarget

--- a/Source/WebCore/Modules/webaudio/AudioSummingJunction.h
+++ b/Source/WebCore/Modules/webaudio/AudioSummingJunction.h
@@ -31,8 +31,9 @@
 
 namespace WebCore {
 
-class BaseAudioContext;
 class AudioNodeOutput;
+class BaseAudioContext;
+class WeakPtrImplWithEventTargetData;
 
 // An AudioSummingJunction represents a point where zero, one, or more AudioNodeOutputs connect.
 
@@ -68,7 +69,7 @@ public:
     unsigned numberOfConnections() const { return m_outputs.size(); }
 
 protected:
-    WeakPtr<BaseAudioContext> m_context;
+    WeakPtr<BaseAudioContext, WeakPtrImplWithEventTargetData> m_context;
 
     unsigned maximumNumberOfChannels() const;
 

--- a/Source/WebCore/Modules/webaudio/AudioWorklet.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorklet.h
@@ -55,7 +55,7 @@ private:
     // Worklet.
     Vector<Ref<WorkletGlobalScopeProxy>> createGlobalScopes() final;
 
-    WeakPtr<BaseAudioContext> m_audioContext;
+    WeakPtr<BaseAudioContext, WeakPtrImplWithEventTargetData> m_audioContext;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
@@ -84,7 +84,7 @@ private:
     const float m_sampleRate;
     MemoryCompactRobinHoodHashMap<String, RefPtr<JSAudioWorkletProcessorConstructor>> m_processorConstructorMap;
     Lock m_processorsLock;
-    WeakHashSet<AudioWorkletProcessor, WTF::EmptyCounter, EnableWeakPtrThreadingAssertions::No> m_processors WTF_GUARDED_BY_LOCK(m_processorsLock);
+    WeakHashSet<AudioWorkletProcessor, WTF::DefaultWeakPtrImpl, EnableWeakPtrThreadingAssertions::No> m_processors WTF_GUARDED_BY_LOCK(m_processorsLock);
     std::unique_ptr<AudioWorkletProcessorConstructionData> m_pendingProcessorConstructionData;
     std::optional<JSC::JSLockHolder> m_lockDuringRendering;
 };

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -84,7 +84,7 @@ template<typename IDLType> class DOMPromiseDeferred;
 class BaseAudioContext
     : public ActiveDOMObject
     , public ThreadSafeRefCounted<BaseAudioContext>
-    , public EventTargetWithInlineData
+    , public EventTarget
 #if !RELEASE_LOG_DISABLED
     , public LoggerHelper
 #endif

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -48,7 +48,7 @@ namespace WebCore {
 class Blob;
 class ThreadableWebSocketChannel;
 
-class WebSocket final : public RefCounted<WebSocket>, public EventTargetWithInlineData, public ActiveDOMObject, private WebSocketChannelClient {
+class WebSocket final : public RefCounted<WebSocket>, public EventTarget, public ActiveDOMObject, private WebSocketChannelClient {
     WTF_MAKE_ISO_ALLOCATED(WebSocket);
 public:
     static ASCIILiteral subprotocolSeparator();

--- a/Source/WebCore/Modules/websockets/WebSocketChannel.h
+++ b/Source/WebCore/Modules/websockets/WebSocketChannel.h
@@ -197,7 +197,7 @@ private:
         BlobLoaderFailed
     };
 
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     WeakPtr<WebSocketChannelClient> m_client;
     std::unique_ptr<WebSocketHandshake> m_handshake;
     RefPtr<SocketStreamHandle> m_handle;

--- a/Source/WebCore/Modules/websockets/WebSocketChannelInspector.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketChannelInspector.cpp
@@ -40,6 +40,8 @@ WebSocketChannelInspector::WebSocketChannelInspector(Document& document)
 {
 }
 
+WebSocketChannelInspector::~WebSocketChannelInspector() = default;
+
 void WebSocketChannelInspector::didCreateWebSocket(const URL& url) const
 {
     if (!m_progressIdentifier || !m_document)

--- a/Source/WebCore/Modules/websockets/WebSocketChannelInspector.h
+++ b/Source/WebCore/Modules/websockets/WebSocketChannelInspector.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "EventTarget.h"
 #include "WebSocketFrame.h"
 #include <wtf/Forward.h>
 #include <wtf/ObjectIdentifier.h>
@@ -32,6 +33,7 @@
 namespace WebCore {
 
 class Document;
+class WeakPtrImplWithEventTargetData;
 class ResourceRequest;
 class ResourceResponse;
 class WebSocketChannel;
@@ -42,6 +44,7 @@ using WebSocketChannelIdentifier = ObjectIdentifier<WebSocketChannel>;
 class WEBCORE_EXPORT WebSocketChannelInspector {
 public:
     explicit WebSocketChannelInspector(Document&);
+    ~WebSocketChannelInspector();
 
     void didCreateWebSocket(const URL&) const;
     void willSendWebSocketHandshakeRequest(const ResourceRequest&) const;
@@ -56,7 +59,7 @@ public:
     static WebSocketFrame createFrame(const uint8_t* data, size_t length, WebSocketFrame::OpCode);
 
 private:
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     WebSocketChannelIdentifier m_progressIdentifier;
 };
 

--- a/Source/WebCore/Modules/webxr/WebXRLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRLayer.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class ScriptExecutionContext;
 
-class WebXRLayer : public RefCounted<WebXRLayer>, public EventTargetWithInlineData, public ContextDestructionObserver {
+class WebXRLayer : public RefCounted<WebXRLayer>, public EventTarget, public ContextDestructionObserver {
     WTF_MAKE_ISO_ALLOCATED(WebXRLayer);
 public:
     ~WebXRLayer();

--- a/Source/WebCore/Modules/webxr/WebXRRenderState.h
+++ b/Source/WebCore/Modules/webxr/WebXRRenderState.h
@@ -72,7 +72,7 @@ private:
     } m_depth;
     std::optional<double> m_inlineVerticalFieldOfView; // in radians
     RefPtr<WebXRWebGLLayer> m_baseLayer;
-    WeakPtr<HTMLCanvasElement> m_outputCanvas;
+    WeakPtr<HTMLCanvasElement, WeakPtrImplWithEventTargetData> m_outputCanvas;
     bool m_compositionEnabled { true };
 };
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -53,7 +53,7 @@ class WebXRView;
 class WebXRViewerSpace;
 struct XRRenderStateInit;
 
-class WebXRSession final : public RefCounted<WebXRSession>, public EventTargetWithInlineData, public ActiveDOMObject, public PlatformXR::TrackingAndRenderingClient {
+class WebXRSession final : public RefCounted<WebXRSession>, public EventTarget, public ActiveDOMObject, public PlatformXR::TrackingAndRenderingClient {
     WTF_MAKE_ISO_ALLOCATED(WebXRSession);
 public:
     using RequestReferenceSpacePromise = DOMPromiseDeferred<IDLInterface<WebXRReferenceSpace>>;
@@ -67,7 +67,8 @@ public:
     using RefCounted<WebXRSession>::deref;
 
     using TrackingAndRenderingClient::weakPtrFactory;
-    using WeakValueType = TrackingAndRenderingClient::WeakValueType;
+    using TrackingAndRenderingClient::WeakValueType;
+    using TrackingAndRenderingClient::WeakPtrImplType;
 
     XREnvironmentBlendMode environmentBlendMode() const;
     XRInteractionMode interactionMode() const;

--- a/Source/WebCore/Modules/webxr/WebXRSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRSpace.h
@@ -39,7 +39,7 @@ class Document;
 class ScriptExecutionContext;
 class WebXRRigidTransform;
 
-class WebXRSpace : public EventTargetWithInlineData, public ContextDestructionObserver {
+class WebXRSpace : public EventTarget, public ContextDestructionObserver {
     WTF_MAKE_ISO_ALLOCATED(WebXRSpace);
 public:
     virtual ~WebXRSpace();

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -54,7 +54,7 @@ class WebXRSession;
 struct SecurityOriginData;
 struct XRSessionInit;
 
-class WebXRSystem final : public RefCounted<WebXRSystem>, public EventTargetWithInlineData, public ActiveDOMObject {
+class WebXRSystem final : public RefCounted<WebXRSystem>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(WebXRSystem);
 public:
     using IsSessionSupportedPromise = DOMPromiseDeferred<IDLBoolean>;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3383,8 +3383,8 @@ static void filterListForRemoval(const ListHashSet<T>& list, const Document& doc
         conditionallyAddNodeToFilterList(node, document, nodesToRemove);
 }
 
-template<typename T>
-static void filterWeakHashSetForRemoval(WeakHashSet<T>& weakHashSet, const Document& document, HashSet<Ref<Node>>& nodesToRemove)
+template<typename WeakHashSet>
+static void filterWeakHashSetForRemoval(WeakHashSet& weakHashSet, const Document& document, HashSet<Ref<Node>>& nodesToRemove)
 {
     weakHashSet.forEach([&] (auto& element) {
         conditionallyAddNodeToFilterList(&element, document, nodesToRemove);

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -556,7 +556,7 @@ private:
     Timer m_liveRegionChangedPostTimer;
     ListHashSet<RefPtr<AccessibilityObject>> m_liveRegionObjectsSet;
 
-    WeakPtr<Element> m_currentModalElement;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_currentModalElement;
     // Multiple aria-modals behavior is undefined by spec. We keep them sorted based on DOM order here.
     // If that changes to require only one aria-modal we could change this to a WeakHashSet, or discard the set completely.
     ListHashSet<Element*> m_modalElementsSet;
@@ -566,14 +566,14 @@ private:
     Timer m_performCacheUpdateTimer;
 
     AXTextStateChangeIntent m_textSelectionIntent;
-    WeakHashSet<Element> m_deferredRecomputeIsIgnoredList;
-    WeakHashSet<HTMLTableElement> m_deferredRecomputeTableIsExposedList;
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_deferredRecomputeIsIgnoredList;
+    WeakHashSet<HTMLTableElement, WeakPtrImplWithEventTargetData> m_deferredRecomputeTableIsExposedList;
     ListHashSet<Node*> m_deferredTextChangedList;
-    WeakHashSet<Element> m_deferredSelectedChildredChangedList;
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_deferredSelectedChildredChangedList;
     ListHashSet<RefPtr<AccessibilityObject>> m_deferredChildrenChangedList;
     ListHashSet<Node*> m_deferredNodeAddedOrRemovedList;
-    WeakHashSet<Element> m_deferredModalChangedList;
-    WeakHashSet<Element> m_deferredMenuListChange;
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_deferredModalChangedList;
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_deferredMenuListChange;
     HashMap<Element*, String> m_deferredTextFormControlValue;
     Vector<std::pair<Element*, QualifiedName>> m_deferredAttributeChange;
     Vector<std::pair<Node*, Node*>> m_deferredFocusedNodeChange;

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.h
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.h
@@ -65,7 +65,7 @@ private:
     AccessibilityObject* listBoxOptionAccessibilityObject(HTMLElement*) const;
     bool computeAccessibilityIsIgnored() const final;
 
-    WeakPtr<HTMLElement> m_optionElement;
+    WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_optionElement;
 };
     
 } // namespace WebCore 

--- a/Source/WebCore/accessibility/AccessibilityMenuListOption.h
+++ b/Source/WebCore/accessibility/AccessibilityMenuListOption.h
@@ -58,7 +58,7 @@ private:
     String stringValue() const final;
     bool computeAccessibilityIsIgnored() const final;
 
-    WeakPtr<HTMLOptionElement> m_element;
+    WeakPtr<HTMLOptionElement, WeakPtrImplWithEventTargetData> m_element;
     AccessibilityObject* m_parent;
 };
 

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -81,7 +81,7 @@ private:
     void removeChildScrollbar(AccessibilityObject*);
 
     WeakPtr<ScrollView> m_scrollView;
-    WeakPtr<HTMLFrameOwnerElement> m_frameOwnerElement;
+    WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_frameOwnerElement;
     RefPtr<AccessibilityObject> m_horizontalScrollbar;
     RefPtr<AccessibilityObject> m_verticalScrollbar;
     bool m_childrenDirty;

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -114,7 +114,7 @@ private:
     FillMode m_fill { FillMode::Auto };
     PlaybackDirection m_direction { PlaybackDirection::Normal };
 
-    WeakPtr<WebAnimation> m_animation;
+    WeakPtr<WebAnimation, WeakPtrImplWithEventTargetData> m_animation;
     RefPtr<TimingFunction> m_timingFunction;
 
     double m_iterationStart { 0 };

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -54,7 +54,7 @@ public:
 protected:
     explicit AnimationTimeline();
 
-    Vector<WeakPtr<WebAnimation>> m_allAnimations;
+    Vector<WeakPtr<WebAnimation, WeakPtrImplWithEventTargetData>> m_allAnimations;
     AnimationCollection m_animations;
 
 private:

--- a/Source/WebCore/animation/DeclarativeAnimation.h
+++ b/Source/WebCore/animation/DeclarativeAnimation.h
@@ -88,7 +88,7 @@ private:
     bool m_wasPending { false };
     AnimationEffectPhase m_previousPhase { AnimationEffectPhase::Idle };
 
-    WeakPtr<Element> m_owningElement;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_owningElement;
     PseudoId m_owningPseudoId;
     Ref<Animation> m_backingAnimation;
     double m_previousIteration;

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -97,7 +97,7 @@ private:
     Timer m_tickScheduleTimer;
     HashSet<RefPtr<WebAnimation>> m_acceleratedAnimationsPendingRunningStateChange;
     AnimationEvents m_pendingAnimationEvents;
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     Seconds m_originTime;
     unsigned m_numberOfAnimationTimelineInvalidationsForTesting { 0 };
     bool m_animationResolutionScheduled { false };

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -54,7 +54,7 @@ namespace Style {
 struct ResolutionContext;
 }
 
-class WebAnimation : public RefCounted<WebAnimation>, public EventTargetWithInlineData, public ActiveDOMObject {
+class WebAnimation : public RefCounted<WebAnimation>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(WebAnimation);
 public:
     static Ref<WebAnimation> create(Document&, AnimationEffect*);

--- a/Source/WebCore/bindings/js/JSLazyEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSLazyEventListener.cpp
@@ -46,7 +46,7 @@ struct JSLazyEventListener::CreationArguments {
     const QualifiedName& attributeName;
     const AtomString& attributeValue;
     Document& document;
-    WeakPtr<ContainerNode> node;
+    WeakPtr<ContainerNode, WeakPtrImplWithEventTargetData> node;
     JSObject* wrapper;
     bool shouldUseSVGEventName;
 };

--- a/Source/WebCore/bindings/js/JSLazyEventListener.h
+++ b/Source/WebCore/bindings/js/JSLazyEventListener.h
@@ -59,7 +59,7 @@ private:
     String m_code;
     URL m_sourceURL;
     TextPosition m_sourcePosition;
-    WeakPtr<ContainerNode> m_originalNode;
+    WeakPtr<ContainerNode, WeakPtrImplWithEventTargetData> m_originalNode;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCursorImageValue.h
+++ b/Source/WebCore/css/CSSCursorImageValue.h
@@ -28,6 +28,7 @@
 namespace WebCore {
 
 class Document;
+class WeakPtrImplWithEventTargetData;
 class SVGCursorElement;
 
 struct ImageWithScale;
@@ -64,7 +65,7 @@ private:
     URL m_originalURL;
     Ref<CSSValue> m_imageValue;
     std::optional<IntPoint> m_hotSpot;
-    WeakHashSet<SVGCursorElement> m_cursorElements;
+    WeakHashSet<SVGCursorElement, WeakPtrImplWithEventTargetData> m_cursorElements;
     LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
 };
 

--- a/Source/WebCore/css/CSSFontFaceSource.h
+++ b/Source/WebCore/css/CSSFontFaceSource.h
@@ -36,6 +36,7 @@ class CSSFontFace;
 class CSSFontSelector;
 class SharedBuffer;
 class Document;
+class WeakPtrImplWithEventTargetData;
 class Font;
 class FontCreationContext;
 struct FontCustomPlatformData;
@@ -97,7 +98,7 @@ private:
     RefPtr<JSC::ArrayBufferView> m_immediateSource;
     std::unique_ptr<FontCustomPlatformData> m_immediateFontCustomPlatformData;
 
-    WeakPtr<SVGFontFaceElement> m_svgFontFaceElement;
+    WeakPtr<SVGFontFaceElement, WeakPtrImplWithEventTargetData> m_svgFontFaceElement;
     std::unique_ptr<FontCustomPlatformData> m_inDocumentCustomPlatformData;
 
     Status m_status { Status::Pending };

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -89,7 +89,7 @@ private:
     LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
 
     CachedResourceHandle<CachedFont> m_cachedFont;
-    WeakPtr<SVGFontFaceElement> m_svgFontFaceElement;
+    WeakPtr<SVGFontFaceElement, WeakPtrImplWithEventTargetData> m_svgFontFaceElement;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -40,6 +40,7 @@ class CSSStyleSheet;
 class CachedCSSStyleSheet;
 class Document;
 class Element;
+class WeakPtrImplWithEventTargetData;
 class MediaQuerySet;
 class StyleRuleKeyframes;
 class StyleSheetContents;
@@ -151,7 +152,7 @@ private:
     RefPtr<MediaQuerySet> m_mediaQueries;
     WeakPtr<Style::Scope> m_styleScope;
 
-    WeakPtr<Node> m_ownerNode;
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_ownerNode;
     WeakPtr<CSSImportRule> m_ownerRule;
 
     TextPosition m_startPosition;

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -38,7 +38,7 @@ template<typename IDLType> class DOMPromiseProxyWithResolveCallback;
 
 class DOMException;
 
-class FontFaceSet final : public RefCounted<FontFaceSet>, private CSSFontFaceSet::FontEventClient, public EventTargetWithInlineData, public ActiveDOMObject {
+class FontFaceSet final : public RefCounted<FontFaceSet>, private CSSFontFaceSet::FontEventClient, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(FontFaceSet);
 public:
     static Ref<FontFaceSet> create(ScriptExecutionContext&, const Vector<RefPtr<FontFace>>& initialFaces);

--- a/Source/WebCore/css/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/MediaQueryEvaluator.h
@@ -34,6 +34,7 @@
 namespace WebCore {
 
 class Document;
+class WeakPtrImplWithEventTargetData;
 class MediaQuerySet;
 class RenderStyle;
 
@@ -90,7 +91,7 @@ public:
 
 private:
     String m_mediaType;
-    WeakPtr<const Document> m_document;
+    WeakPtr<const Document, WeakPtrImplWithEventTargetData> m_document;
     const RenderStyle* m_style { nullptr };
     bool m_fallbackResult { false };
 };

--- a/Source/WebCore/css/MediaQueryList.h
+++ b/Source/WebCore/css/MediaQueryList.h
@@ -32,7 +32,7 @@ namespace WebCore {
 // retrieve the current value of the given media query and to add/remove listeners that
 // will be called whenever the value of the query changes.
 
-class MediaQueryList final : public RefCounted<MediaQueryList>, public EventTargetWithInlineData, public ActiveDOMObject {
+class MediaQueryList final : public RefCounted<MediaQueryList>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(MediaQueryList);
 public:
     static Ref<MediaQueryList> create(Document&, MediaQueryMatcher&, Ref<MediaQuerySet>&&, bool matches);

--- a/Source/WebCore/css/MediaQueryMatcher.h
+++ b/Source/WebCore/css/MediaQueryMatcher.h
@@ -60,8 +60,8 @@ private:
     std::unique_ptr<RenderStyle> documentElementUserAgentStyle() const;
     String mediaType() const;
 
-    WeakPtr<Document> m_document;
-    Vector<WeakPtr<MediaQueryList>> m_mediaQueryLists;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+    Vector<WeakPtr<MediaQueryList, WeakPtrImplWithEventTargetData>> m_mediaQueryLists;
 
     // This value is incremented at style selector changes.
     // It is used to avoid evaluating queries more then once and to make sure

--- a/Source/WebCore/css/StyleSheetList.h
+++ b/Source/WebCore/css/StyleSheetList.h
@@ -55,7 +55,7 @@ private:
     StyleSheetList(ShadowRoot&);
     const Vector<RefPtr<StyleSheet>>& styleSheets() const;
 
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     ShadowRoot* m_shadowRoot { nullptr };
     Vector<RefPtr<StyleSheet>> m_detachedStyleSheets;
 };

--- a/Source/WebCore/css/typedom/CSSStyleImageValue.h
+++ b/Source/WebCore/css/typedom/CSSStyleImageValue.h
@@ -37,6 +37,7 @@
 namespace WebCore {
 
 class Document;
+class WeakPtrImplWithEventTargetData;
 
 class CSSStyleImageValue final : public CSSStyleValue {
     WTF_MAKE_ISO_ALLOCATED(CSSStyleImageValue);
@@ -57,7 +58,7 @@ private:
     CSSStyleImageValue(Ref<CSSImageValue>&&, Document*);
 
     Ref<CSSImageValue> m_cssValue;
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -123,7 +123,7 @@ void AbortSignal::signalFollow(AbortSignal& signal)
 
     ASSERT(!m_followingSignal);
     m_followingSignal = signal;
-    signal.addAlgorithm([weakThis = WeakPtr { this }](JSC::JSValue reason) {
+    signal.addAlgorithm([weakThis = WeakPtr<AbortSignal, WeakPtrImplWithEventTargetData> { this }](JSC::JSValue reason) {
         if (weakThis)
             weakThis->signalAbort(reason);
     });

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -40,7 +40,7 @@ class AbortAlgorithm;
 class ScriptExecutionContext;
 class WebCoreOpaqueRoot;
 
-class AbortSignal final : public RefCounted<AbortSignal>, public EventTargetWithInlineData, private ContextDestructionObserver {
+class AbortSignal final : public RefCounted<AbortSignal>, public EventTarget, private ContextDestructionObserver {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(AbortSignal, WEBCORE_EXPORT);
 public:
     static Ref<AbortSignal> create(ScriptExecutionContext*);
@@ -85,7 +85,7 @@ private:
     
     bool m_aborted { false };
     Vector<Algorithm> m_algorithms;
-    WeakPtr<AbortSignal> m_followingSignal;
+    WeakPtr<AbortSignal, WeakPtrImplWithEventTargetData> m_followingSignal;
     JSValueInWrappedObject m_reason;
     bool m_hasActiveTimeoutTimer { false };
     bool m_hasAbortEventListener { false };

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -76,7 +76,7 @@ private:
 
     // Attr wraps either an element/name, or a name/value pair (when it's a standalone Node.)
     // Note that m_name is always set, but m_element/m_standaloneValue may be null.
-    WeakPtr<Element> m_element;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element;
     QualifiedName m_name;
     AtomString m_standaloneValue;
 

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -84,7 +84,7 @@ private:
 
     void ensureOnMainThread(Function<void(Document&)>&&);
 
-    WeakPtr<BroadcastChannel> m_broadcastChannel;
+    WeakPtr<BroadcastChannel, WeakPtrImplWithEventTargetData> m_broadcastChannel;
     const BroadcastChannelIdentifier m_identifier;
     const String m_name; // Main thread only.
     std::optional<PartitionedSecurityOrigin> m_origin; // Main thread only.

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -42,7 +42,7 @@ namespace WebCore {
 
 class SerializedScriptValue;
 
-class BroadcastChannel : public RefCounted<BroadcastChannel>, public EventTargetWithInlineData, public ActiveDOMObject {
+class BroadcastChannel : public RefCounted<BroadcastChannel>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(BroadcastChannel);
 public:
     static Ref<BroadcastChannel> create(ScriptExecutionContext& context, const String& name)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -846,8 +846,8 @@ Element* Document::elementForAccessKey(const String& key)
 
 void Document::buildAccessKeyCache()
 {
-    m_accessKeyCache = makeUnique<HashMap<String, WeakPtr<Element>, ASCIICaseInsensitiveHash>>([this] {
-        HashMap<String, WeakPtr<Element>, ASCIICaseInsensitiveHash> map;
+    m_accessKeyCache = makeUnique<HashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash>>([this] {
+        HashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash> map;
         for (auto& node : composedTreeDescendants(*this)) {
             auto element = dynamicDowncast<Element>(node);
             if (!element)
@@ -4010,10 +4010,10 @@ void Document::metaElementThemeColorChanged(HTMLMetaElement& metaElement)
     themeColorChanged();
 }
 
-WeakPtr<HTMLMetaElement> Document::determineActiveThemeColorMetaElement()
+WeakPtr<HTMLMetaElement, WeakPtrImplWithEventTargetData> Document::determineActiveThemeColorMetaElement()
 {
     if (!m_metaThemeColorElements) {
-        Vector<WeakPtr<HTMLMetaElement>> metaThemeColorElements;
+        Vector<WeakPtr<HTMLMetaElement, WeakPtrImplWithEventTargetData>> metaThemeColorElements;
         for (auto& metaElement : descendantsOfType<HTMLMetaElement>(*this)) {
             if (equalLettersIgnoringASCIICase(metaElement.name(), "theme-color"_s) && metaElement.contentColor().isValid())
                 metaThemeColorElements.append(metaElement);
@@ -8841,7 +8841,7 @@ void Document::didLogMessage(const WTFLogChannel& channel, WTFLogLevel level, Ve
     if (messageSource == MessageSource::Other)
         return;
 
-    eventLoop().queueTask(TaskSource::InternalAsyncTask, [weakThis = WeakPtr { *this }, level, messageSource, logMessages = WTFMove(logMessages)]() mutable {
+    eventLoop().queueTask(TaskSource::InternalAsyncTask, [weakThis = WeakPtr<Document, WeakPtrImplWithEventTargetData> { *this }, level, messageSource, logMessages = WTFMove(logMessages)]() mutable {
         if (!weakThis || !weakThis->page())
             return;
 
@@ -8880,7 +8880,7 @@ void Document::navigateFromServiceWorker(const URL& url, CompletionHandler<void(
         callback(false);
         return;
     }
-    eventLoop().queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }, url, callback = WTFMove(callback)]() mutable {
+    eventLoop().queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr<Document, WeakPtrImplWithEventTargetData> { *this }, url, callback = WTFMove(callback)]() mutable {
         auto* frame = weakThis ? weakThis->frame() : nullptr;
         if (!frame) {
             callback(false);
@@ -9054,7 +9054,7 @@ void Document::didRejectSyncXHRDuringPageDismissal()
     if (m_numberOfRejectedSyncXHRs > 1)
         return;
 
-    postTask([this, weakThis = WeakPtr { *this }](auto&) mutable {
+    postTask([this, weakThis = WeakPtr<Document, WeakPtrImplWithEventTargetData> { *this }](auto&) mutable {
         if (weakThis)
             m_numberOfRejectedSyncXHRs = 0;
     });

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -339,7 +339,7 @@ public:
     WEBCORE_EXPORT ~DocumentParserYieldToken();
 
 private:
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 class Document
@@ -354,8 +354,9 @@ class Document
     , public ReportingClient {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(Document, WEBCORE_EXPORT);
 public:
-    using WeakValueType = EventTarget::WeakValueType;
     using EventTarget::weakPtrFactory;
+    using EventTarget::WeakValueType;
+    using EventTarget::WeakPtrImplType;
 
     inline static Ref<Document> create(const Settings&, const URL&);
     static Ref<Document> createNonRenderedPlaceholder(Frame&, const URL&);
@@ -1759,7 +1760,7 @@ private:
     void updateTitle(const StringWithDirection&);
     void updateBaseURL();
 
-    WeakPtr<HTMLMetaElement> determineActiveThemeColorMetaElement();
+    WeakPtr<HTMLMetaElement, WeakPtrImplWithEventTargetData> determineActiveThemeColorMetaElement();
     void themeColorChanged();
 
     void invalidateAccessKeyCacheSlowCase();
@@ -1836,7 +1837,7 @@ private:
     UniqueRef<Quirks> m_quirks;
 
     RefPtr<DOMWindow> m_domWindow;
-    WeakPtr<Document> m_contextDocument;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_contextDocument;
 
     Ref<CachedResourceLoader> m_cachedResourceLoader;
     RefPtr<DocumentParser> m_parser;
@@ -1870,7 +1871,7 @@ private:
     std::unique_ptr<DOMImplementation> m_implementation;
 
     RefPtr<Node> m_focusNavigationStartingNode;
-    Deque<WeakPtr<Element>> m_autofocusCandidates;
+    Deque<WeakPtr<Element, WeakPtrImplWithEventTargetData>> m_autofocusCandidates;
     RefPtr<Element> m_focusedElement;
     RefPtr<Element> m_hoveredElement;
     RefPtr<Element> m_activeElement;
@@ -1892,8 +1893,8 @@ private:
     std::unique_ptr<FormController> m_formController;
 
     Color m_cachedThemeColor;
-    std::optional<Vector<WeakPtr<HTMLMetaElement>>> m_metaThemeColorElements;
-    WeakPtr<HTMLMetaElement> m_activeThemeColorMetaElement;
+    std::optional<Vector<WeakPtr<HTMLMetaElement, WeakPtrImplWithEventTargetData>>> m_metaThemeColorElements;
+    WeakPtr<HTMLMetaElement, WeakPtrImplWithEventTargetData> m_activeThemeColorMetaElement;
     Color m_applicationManifestThemeColor;
 
     Color m_textColor { Color::black };
@@ -1957,7 +1958,7 @@ private:
     // Collection of canvas objects that need to do work after they've
     // rendered but before compositing, for the next frame. The set is
     // cleared after they've been called.
-    WeakHashSet<HTMLCanvasElement> m_canvasesNeedingDisplayPreparation;
+    WeakHashSet<HTMLCanvasElement, WeakPtrImplWithEventTargetData> m_canvasesNeedingDisplayPreparation;
 
 #if ENABLE(DARK_MODE_CSS)
     OptionSet<ColorScheme> m_colorScheme;
@@ -1966,23 +1967,23 @@ private:
 
     HashMap<String, RefPtr<HTMLCanvasElement>> m_cssCanvasElements;
 
-    WeakHashSet<Element> m_documentSuspensionCallbackElements;
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_documentSuspensionCallbackElements;
 
 #if ENABLE(VIDEO)
-    WeakHashSet<HTMLMediaElement> m_mediaElements;
+    WeakHashSet<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElements;
 #endif
 
 #if ENABLE(VIDEO)
-    WeakHashSet<HTMLMediaElement> m_captionPreferencesChangedElements;
-    WeakPtr<HTMLMediaElement> m_mediaElementShowingTextTrack;
+    WeakHashSet<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_captionPreferencesChangedElements;
+    WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElementShowingTextTrack;
 #endif
 
-    WeakPtr<Element> m_mainArticleElement;
-    WeakHashSet<Element> m_articleElements;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_mainArticleElement;
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_articleElements;
 
     WeakHashSet<VisibilityChangeClient> m_visibilityStateCallbackClients;
 
-    std::unique_ptr<HashMap<String, WeakPtr<Element>, ASCIICaseInsensitiveHash>> m_accessKeyCache;
+    std::unique_ptr<HashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash>> m_accessKeyCache;
 
     std::unique_ptr<ConstantPropertyMap> m_constantPropertyMap;
 
@@ -1999,7 +2000,7 @@ private:
     UniqueRef<FullscreenManager> m_fullscreenManager;
 #endif
 
-    WeakHashSet<HTMLImageElement> m_dynamicMediaQueryDependentImages;
+    WeakHashSet<HTMLImageElement, WeakPtrImplWithEventTargetData> m_dynamicMediaQueryDependentImages;
 
     Vector<WeakPtr<IntersectionObserver>> m_intersectionObservers;
     Timer m_intersectionObserversInitialUpdateTimer;
@@ -2075,7 +2076,7 @@ private:
     LocaleIdentifierToLocaleMap m_localeCache;
 
     RefPtr<Document> m_templateDocument;
-    WeakPtr<Document> m_templateDocumentHost; // Manually managed weakref (backpointer from m_templateDocument).
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_templateDocumentHost; // Manually managed weakref (backpointer from m_templateDocument).
 
     RefPtr<DocumentFragment> m_documentFragmentForInnerOuterHTML;
 
@@ -2109,7 +2110,7 @@ private:
 
     std::optional<WallTime> m_overrideLastModified;
 
-    WeakHashSet<Element> m_associatedFormControls;
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_associatedFormControls;
     unsigned m_disabledFieldsetElementsCount { 0 };
 
     unsigned m_dataListElementCount { 0 };
@@ -2280,7 +2281,7 @@ private:
 #endif
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
-    WeakPtr<HTMLVideoElement> m_pictureInPictureElement;
+    WeakPtr<HTMLVideoElement, WeakPtrImplWithEventTargetData> m_pictureInPictureElement;
 #endif
 
     std::unique_ptr<TextManipulationController> m_textManipulationController;
@@ -2301,7 +2302,7 @@ private:
 
     Vector<Function<void()>> m_whenIsVisibleHandlers;
 
-    WeakHashSet<Element> m_elementsWithPendingUserAgentShadowTreeUpdates;
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_elementsWithPendingUserAgentShadowTreeUpdates;
 
     Ref<ReportingScope> m_reportingScope;
 };

--- a/Source/WebCore/dom/DocumentParser.h
+++ b/Source/WebCore/dom/DocumentParser.h
@@ -113,7 +113,7 @@ private:
 
     // Every DocumentParser needs a pointer back to the document.
     // m_document will be 0 after the parser is stopped.
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2089,7 +2089,7 @@ void Element::setElementAttribute(const QualifiedName& attributeName, Element* e
     else
         setAttribute(attributeName, emptyAtom());
 
-    explicitlySetAttrElementsMap().set(attributeName, Vector<WeakPtr<Element>> { element });
+    explicitlySetAttrElementsMap().set(attributeName, Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> { element });
 }
 
 std::optional<Vector<RefPtr<Element>>> Element::getElementsArrayAttribute(const QualifiedName& attributeName) const
@@ -2135,7 +2135,7 @@ void Element::setElementsArrayAttribute(const QualifiedName& attributeName, std:
         return;
     }
 
-    Vector<WeakPtr<Element>> newElements;
+    Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> newElements;
     newElements.reserveInitialCapacity(elements->size());
     StringBuilder value;
     for (auto element : elements.value()) {
@@ -4971,9 +4971,9 @@ Vector<RefPtr<WebAnimation>> Element::getAnimations(std::optional<GetAnimationsO
     return animations;
 }
 
-static WeakHashMap<Element, ElementIdentifier>& elementIdentifiersMap()
+static WeakHashMap<Element, ElementIdentifier, WeakPtrImplWithEventTargetData>& elementIdentifiersMap()
 {
-    static MainThreadNeverDestroyed<WeakHashMap<Element, ElementIdentifier>> map;
+    static MainThreadNeverDestroyed<WeakHashMap<Element, ElementIdentifier, WeakPtrImplWithEventTargetData>> map;
     return map;
 }
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -94,7 +94,7 @@ struct ScrollToOptions;
 struct SecurityPolicyViolationEventInit;
 struct ShadowRootInit;
 
-using ExplicitlySetAttrElementsMap = HashMap<QualifiedName, Vector<WeakPtr<Element>>>;
+using ExplicitlySetAttrElementsMap = HashMap<QualifiedName, Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>>;
 
 namespace Style {
 class Resolver;

--- a/Source/WebCore/dom/ElementInternals.h
+++ b/Source/WebCore/dom/ElementInternals.h
@@ -49,7 +49,7 @@ private:
     {
     }
 
-    WeakPtr<HTMLElement> m_element;
+    WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_element;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/EventListenerMap.h
+++ b/Source/WebCore/dom/EventListenerMap.h
@@ -47,7 +47,7 @@ using EventListenerVector = Vector<RefPtr<RegisteredEventListener>, 1, CrashOnOv
 
 class EventListenerMap {
 public:
-    EventListenerMap();
+    WEBCORE_EXPORT EventListenerMap();
 
     bool isEmpty() const { return m_entries.isEmpty(); }
     bool contains(const AtomString& eventType) const { return find(eventType); }
@@ -55,6 +55,10 @@ public:
     bool containsActive(const AtomString& eventType) const;
 
     void clear();
+    void clearEntriesForTearDown()
+    {
+        m_entries.clear();
+    }
 
     void replace(const AtomString& eventType, EventListener& oldListener, Ref<EventListener>&& newListener, const RegisteredEventListener::Options&);
     bool add(const AtomString& eventType, Ref<EventListener>&&, const RegisteredEventListener::Options&);

--- a/Source/WebCore/dom/EventSender.h
+++ b/Source/WebCore/dom/EventSender.h
@@ -32,8 +32,9 @@
 namespace WebCore {
 
 class Page;
+class WeakPtrImplWithEventTargetData;
 
-template<typename T> class EventSender {
+template<typename T, typename Counter> class EventSender {
     WTF_MAKE_NONCOPYABLE(EventSender); WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit EventSender(const AtomString& eventType);
@@ -55,24 +56,24 @@ private:
 
     AtomString m_eventType;
     Timer m_timer;
-    Vector<WeakPtr<T>> m_dispatchSoonList;
-    Vector<WeakPtr<T>> m_dispatchingList;
+    Vector<WeakPtr<T, Counter>> m_dispatchSoonList;
+    Vector<WeakPtr<T, Counter>> m_dispatchingList;
 };
 
-template<typename T> EventSender<T>::EventSender(const AtomString& eventType)
+template<typename T, typename Counter> EventSender<T, Counter>::EventSender(const AtomString& eventType)
     : m_eventType(eventType)
     , m_timer(*this, &EventSender::timerFired)
 {
 }
 
-template<typename T> void EventSender<T>::dispatchEventSoon(T& sender)
+template<typename T, typename Counter> void EventSender<T, Counter>::dispatchEventSoon(T& sender)
 {
     m_dispatchSoonList.append(sender);
     if (!m_timer.isActive())
         m_timer.startOneShot(0_s);
 }
 
-template<typename T> void EventSender<T>::cancelEvent(T& sender)
+template<typename T, typename Counter> void EventSender<T, Counter>::cancelEvent(T& sender)
 {
     // Remove instances of this sender from both lists.
     // Use loops because we allow multiple instances to get into the lists.
@@ -86,7 +87,7 @@ template<typename T> void EventSender<T>::cancelEvent(T& sender)
     }
 }
 
-template<typename T> void EventSender<T>::dispatchPendingEvents(Page* page)
+template<typename T, typename Counter> void EventSender<T, Counter>::dispatchPendingEvents(Page* page)
 {
     // Need to avoid re-entering this function; if new dispatches are
     // scheduled before the parent finishes processing the list, they

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -57,14 +57,21 @@
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(EventTarget);
-WTF_MAKE_ISO_ALLOCATED_IMPL(EventTargetWithInlineData);
 
 Ref<EventTarget> EventTarget::create(ScriptExecutionContext& context)
 {
     return EventTargetConcrete::create(context);
 }
 
-EventTarget::~EventTarget() = default;
+EventTarget::~EventTarget()
+{
+    // Explicitly tearing down since WeakPtrImpl can be alive longer than EventTarget.
+    if (hasEventTargetData()) {
+        auto* eventTargetData = this->eventTargetData();
+        ASSERT(eventTargetData);
+        eventTargetData->clear();
+    }
+}
 
 bool EventTarget::isNode() const
 {

--- a/Source/WebCore/dom/EventTargetConcrete.h
+++ b/Source/WebCore/dom/EventTargetConcrete.h
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-class EventTargetConcrete final : public RefCounted<EventTargetConcrete>, public EventTargetWithInlineData, private ContextDestructionObserver {
+class EventTargetConcrete final : public RefCounted<EventTargetConcrete>, public EventTarget, private ContextDestructionObserver {
     WTF_MAKE_ISO_ALLOCATED(EventTargetConcrete);
 public:
     static Ref<EventTargetConcrete> create(ScriptExecutionContext&);

--- a/Source/WebCore/dom/IdleCallbackController.h
+++ b/Source/WebCore/dom/IdleCallbackController.h
@@ -34,6 +34,7 @@
 namespace WebCore {
 
 class Document;
+class WeakPtrImplWithEventTargetData;
 
 class IdleCallbackController {
     WTF_MAKE_FAST_ALLOCATED;
@@ -60,7 +61,7 @@ private:
 
     Deque<IdleRequest> m_idleRequestCallbacks;
     Deque<IdleRequest> m_runnableIdleCallbacks;
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -443,12 +443,12 @@ bool MessagePort::addEventListener(const AtomString& eventType, Ref<EventListene
         registerLocalActivity();
     }
 
-    return EventTargetWithInlineData::addEventListener(eventType, WTFMove(listener), options);
+    return EventTarget::addEventListener(eventType, WTFMove(listener), options);
 }
 
 bool MessagePort::removeEventListener(const AtomString& eventType, EventListener& listener, const EventListenerOptions& options)
 {
-    auto result = EventTargetWithInlineData::removeEventListener(eventType, listener, options);
+    auto result = EventTarget::removeEventListener(eventType, listener, options);
 
     if (!hasEventListeners(eventNames().messageEvent))
         m_hasMessageEventListener = false;

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -47,7 +47,7 @@ class WebCoreOpaqueRoot;
 
 struct StructuredSerializeOptions;
 
-class MessagePort final : public ActiveDOMObject, public EventTargetWithInlineData {
+class MessagePort final : public ActiveDOMObject, public EventTarget {
     WTF_MAKE_NONCOPYABLE(MessagePort);
     WTF_MAKE_ISO_ALLOCATED(MessagePort);
 public:
@@ -86,7 +86,7 @@ public:
 
     WEBCORE_EXPORT bool isLocallyReachable() const;
 
-    // EventTargetWithInlineData.
+    // EventTarget.
     EventTargetInterface eventTargetInterface() const final { return MessagePortEventTargetInterfaceType; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -341,9 +341,6 @@ public:
     bool isLink() const { return hasNodeFlag(NodeFlag::IsLink); }
     void setIsLink(bool flag) { setNodeFlag(NodeFlag::IsLink, flag); }
 
-    bool hasEventTargetData() const { return hasNodeFlag(NodeFlag::HasEventTargetData); }
-    void setHasEventTargetData(bool flag) { setNodeFlag(NodeFlag::HasEventTargetData, flag); }
-
     bool isInGCReacheableRefMap() const { return hasNodeFlag(NodeFlag::IsInGCReachableRefMap); }
     void setIsInGCReacheableRefMap(bool flag) { setNodeFlag(NodeFlag::IsInGCReachableRefMap, flag); }
 
@@ -523,10 +520,6 @@ public:
     bool m_adoptionIsRequired { true };
 #endif
 
-    EventTargetData* eventTargetData() final;
-    EventTargetData* eventTargetDataConcurrently() final;
-    EventTargetData& ensureEventTargetData() final;
-
     HashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions> registeredMutationObservers(MutationObserverOptionType, const QualifiedName* attributeName);
     void registerMutationObserver(MutationObserver&, MutationObserverOptions, const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& attributeFilter);
     void unregisterMutationObserver(MutationObserverRegistration&);
@@ -572,7 +565,6 @@ protected:
         IsConnected = 1 << 10,
         IsInShadowTree = 1 << 11,
         IsUnknownElement = 1 << 12,
-        HasEventTargetData = 1 << 13,
 
         // These bits are used by derived classes, pulled up here so they can
         // be stored in the same memory word as the Node bits above.
@@ -711,8 +703,6 @@ protected:
     NodeRareData* rareData() const { return m_rareDataWithBitfields.pointer(); }
     NodeRareData& ensureRareData();
     void clearRareData();
-
-    void clearEventTargetData();
 
     void setHasCustomStyleResolveCallbacks() { setNodeFlag(NodeFlag::HasCustomStyleResolveCallbacks); }
 

--- a/Source/WebCore/dom/NodeRareData.cpp
+++ b/Source/WebCore/dom/NodeRareData.cpp
@@ -39,7 +39,7 @@ struct SameSizeAsNodeRareData {
     uint32_t m_tabIndex;
     uint32_t m_childIndexAndIsElementRareDataFlag;
     void* m_pointer[2];
-    WeakPtr<Node> m_weakPointer;
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_weakPointer;
 };
 
 static_assert(sizeof(NodeRareData) == sizeof(SameSizeAsNodeRareData), "NodeRareData should stay small");

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -330,7 +330,7 @@ private:
 
     std::unique_ptr<NodeListsNodeData> m_nodeLists;
     std::unique_ptr<NodeMutationObserverData> m_mutationObserverData;
-    WeakPtr<HTMLSlotElement> m_manuallyAssignedSlot;
+    WeakPtr<HTMLSlotElement, WeakPtrImplWithEventTargetData> m_manuallyAssignedSlot;
 };
 
 template<> struct NodeListTypeIdentifier<NameNodeList> {

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -34,8 +34,9 @@ class CSSStyleSheet;
 class ProcessingInstruction final : public CharacterData, private CachedStyleSheetClient {
     WTF_MAKE_ISO_ALLOCATED(ProcessingInstruction);
 public:
-    using WeakValueType = CharacterData::WeakValueType;
     using CharacterData::weakPtrFactory;
+    using CharacterData::WeakValueType;
+    using CharacterData::WeakPtrImplType;
 
     static Ref<ProcessingInstruction> create(Document&, String&& target, String&& data);
     virtual ~ProcessingInstruction();

--- a/Source/WebCore/dom/PseudoElement.h
+++ b/Source/WebCore/dom/PseudoElement.h
@@ -50,7 +50,7 @@ private:
 
     PseudoId customPseudoId() const override { return m_pseudoId; }
 
-    WeakPtr<Element> m_hostElement;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_hostElement;
     PseudoId m_pseudoId;
 };
 

--- a/Source/WebCore/dom/RadioButtonGroups.cpp
+++ b/Source/WebCore/dom/RadioButtonGroups.cpp
@@ -47,8 +47,8 @@ private:
     bool isValid() const;
     void setCheckedButton(HTMLInputElement*);
 
-    WeakHashSet<HTMLInputElement> m_members;
-    WeakPtr<HTMLInputElement> m_checkedButton;
+    WeakHashSet<HTMLInputElement, WeakPtrImplWithEventTargetData> m_members;
+    WeakPtr<HTMLInputElement, WeakPtrImplWithEventTargetData> m_checkedButton;
     size_t m_requiredCount { 0 };
 };
 

--- a/Source/WebCore/dom/ScriptedAnimationController.h
+++ b/Source/WebCore/dom/ScriptedAnimationController.h
@@ -80,7 +80,7 @@ private:
     };
     Vector<CallbackData> m_callbackDataList;
 
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     CallbackId m_nextCallbackId { 0 };
     int m_suspendCount { 0 };
 

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -55,14 +55,14 @@ struct SameSizeAsShadowRoot : public DocumentFragment, public TreeScope {
     uint8_t mode;
     void* styleScope;
     void* styleSheetList;
-    WeakPtr<Element> host;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> host;
     void* slotAssignment;
     std::optional<HashMap<AtomString, AtomString>> partMappings;
 };
 
 static_assert(sizeof(ShadowRoot) == sizeof(SameSizeAsShadowRoot), "shadowroot should stay small");
 #if !ASSERT_ENABLED
-static_assert(sizeof(WeakPtr<Element>) == sizeof(void*), "WeakPtr should be same size as raw pointer");
+static_assert(sizeof(WeakPtr<Element, WeakPtrImplWithEventTargetData>) == sizeof(void*), "WeakPtr should be same size as raw pointer");
 #endif
 
 ShadowRoot::ShadowRoot(Document& document, ShadowRootMode type, SlotAssignmentMode assignmentMode, DelegatesFocus delegatesFocus, AvailableToElementInternals availableToElementInternals)
@@ -266,7 +266,7 @@ void ShadowRoot::removeSlotElementByName(const AtomString& name, HTMLSlotElement
     return m_slotAssignment->removeSlotElementByName(name, slot, &oldParentOfRemovedTree, *this);
 }
 
-void ShadowRoot::slotManualAssignmentDidChange(HTMLSlotElement& slot, Vector<WeakPtr<Node>>& previous, Vector<WeakPtr<Node>>& current)
+void ShadowRoot::slotManualAssignmentDidChange(HTMLSlotElement& slot, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& previous, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& current)
 {
     ASSERT(m_slotAssignment);
     m_slotAssignment->slotManualAssignmentDidChange(slot, previous, current, *this);
@@ -284,7 +284,7 @@ void ShadowRoot::slotFallbackDidChange(HTMLSlotElement& slot)
     return m_slotAssignment->slotFallbackDidChange(slot, *this);
 }
 
-const Vector<WeakPtr<Node>>* ShadowRoot::assignedNodesForSlot(const HTMLSlotElement& slot)
+const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* ShadowRoot::assignedNodesForSlot(const HTMLSlotElement& slot)
 {
     if (!m_slotAssignment)
         return nullptr;

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -80,7 +80,7 @@ public:
     bool isAvailableToElementInternals() const { return m_availableToElementInternals; }
 
     Element* host() const { return m_host.get(); }
-    void setHost(WeakPtr<Element>&& host) { m_host = WTFMove(host); }
+    void setHost(WeakPtr<Element, WeakPtrImplWithEventTargetData>&& host) { m_host = WTFMove(host); }
 
     String innerHTML() const;
     ExceptionOr<void> setInnerHTML(const String&);
@@ -98,7 +98,7 @@ public:
     void renameSlotElement(HTMLSlotElement&, const AtomString& oldName, const AtomString& newName);
     void addSlotElementByName(const AtomString&, HTMLSlotElement&);
     void removeSlotElementByName(const AtomString&, HTMLSlotElement&, ContainerNode& oldParentOfRemovedTree);
-    void slotManualAssignmentDidChange(HTMLSlotElement&, Vector<WeakPtr<Node>>& previous, Vector<WeakPtr<Node>>& current);
+    void slotManualAssignmentDidChange(HTMLSlotElement&, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& previous, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& current);
     void didRemoveManuallyAssignedNode(HTMLSlotElement&, const Node&);
     void slotFallbackDidChange(HTMLSlotElement&);
     void resolveSlotsBeforeNodeInsertionOrRemoval();
@@ -110,7 +110,7 @@ public:
     void hostChildElementDidChange(const Element&);
     void hostChildElementDidChangeSlotAttribute(Element&, const AtomString& oldValue, const AtomString& newValue);
 
-    const Vector<WeakPtr<Node>>* assignedNodesForSlot(const HTMLSlotElement&);
+    const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* assignedNodesForSlot(const HTMLSlotElement&);
 
     void moveShadowRootToNewParentScope(TreeScope&, Document&);
     void moveShadowRootToNewDocument(Document&);
@@ -146,7 +146,7 @@ private:
     ShadowRootMode m_type { ShadowRootMode::UserAgent };
     SlotAssignmentMode m_slotAssignmentMode { SlotAssignmentMode::Named };
 
-    WeakPtr<Element> m_host;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_host;
     RefPtr<StyleSheetList> m_styleSheetList;
 
     std::unique_ptr<Style::Scope> m_styleScope;

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -271,7 +271,7 @@ void NamedSlotAssignment::resolveSlotsAfterSlotMutation(ShadowRoot& shadowRoot, 
     }
 }
 
-void NamedSlotAssignment::slotManualAssignmentDidChange(HTMLSlotElement&, Vector<WeakPtr<Node>>&, Vector<WeakPtr<Node>>&, ShadowRoot&)
+void NamedSlotAssignment::slotManualAssignmentDidChange(HTMLSlotElement&, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>&, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>&, ShadowRoot&)
 {
 }
 
@@ -332,7 +332,7 @@ void NamedSlotAssignment::hostChildElementDidChangeSlotAttribute(Element& elemen
     RenderTreeUpdater::tearDownRenderers(element);
 }
 
-const Vector<WeakPtr<Node>>* NamedSlotAssignment::assignedNodesForSlot(const HTMLSlotElement& slotElement, ShadowRoot& shadowRoot)
+const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* NamedSlotAssignment::assignedNodesForSlot(const HTMLSlotElement& slotElement, ShadowRoot& shadowRoot)
 {
     ASSERT(slotElement.containingShadowRoot() == &shadowRoot);
     const AtomString& slotName = slotNameFromAttributeValue(slotElement.attributeWithoutSynchronization(nameAttr));
@@ -431,16 +431,16 @@ HTMLSlotElement* ManualSlotAssignment::findAssignedSlot(const Node& node)
     return containingShadowRoot && containingShadowRoot->host() == node.parentNode() ? slot : nullptr;
 }
 
-static Vector<WeakPtr<Node>> effectiveAssignedNodes(ShadowRoot& shadowRoot, const Vector<WeakPtr<Node>>& manuallyAssingedNodes)
+static Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>> effectiveAssignedNodes(ShadowRoot& shadowRoot, const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& manuallyAssingedNodes)
 {
-    return WTF::compactMap(manuallyAssingedNodes, [&](auto& node) -> std::optional<WeakPtr<Node>> {
+    return WTF::compactMap(manuallyAssingedNodes, [&](auto& node) -> std::optional<WeakPtr<Node, WeakPtrImplWithEventTargetData>> {
         if (node->parentNode() != shadowRoot.host())
             return std::nullopt;
         return WeakPtr { node.get() };
     });
 }
 
-const Vector<WeakPtr<Node>>* ManualSlotAssignment::assignedNodesForSlot(const HTMLSlotElement& slot, ShadowRoot& shadowRoot)
+const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* ManualSlotAssignment::assignedNodesForSlot(const HTMLSlotElement& slot, ShadowRoot& shadowRoot)
 {
     auto addResult = m_slots.ensure(slot, []() {
         return Slot { };
@@ -488,7 +488,7 @@ void ManualSlotAssignment::removeSlotElementByName(const AtomString&, HTMLSlotEl
     }
 }
 
-void ManualSlotAssignment::slotManualAssignmentDidChange(HTMLSlotElement& slot, Vector<WeakPtr<Node>>& previous, Vector<WeakPtr<Node>>& current, ShadowRoot& shadowRoot)
+void ManualSlotAssignment::slotManualAssignmentDidChange(HTMLSlotElement& slot, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& previous, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& current, ShadowRoot& shadowRoot)
 {
     auto effectivePrevious = effectiveAssignedNodes(shadowRoot, previous);
     HashSet<Ref<HTMLSlotElement>> affectedSlots;

--- a/Source/WebCore/dom/SlotAssignment.h
+++ b/Source/WebCore/dom/SlotAssignment.h
@@ -51,12 +51,12 @@ public:
     void willRemoveAllChildren();
 
     virtual HTMLSlotElement* findAssignedSlot(const Node&) = 0;
-    virtual const Vector<WeakPtr<Node>>* assignedNodesForSlot(const HTMLSlotElement&, ShadowRoot&) = 0;
+    virtual const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* assignedNodesForSlot(const HTMLSlotElement&, ShadowRoot&) = 0;
 
     virtual void renameSlotElement(HTMLSlotElement&, const AtomString& oldName, const AtomString& newName, ShadowRoot&) = 0;
     virtual void addSlotElementByName(const AtomString&, HTMLSlotElement&, ShadowRoot&) = 0;
     virtual void removeSlotElementByName(const AtomString&, HTMLSlotElement&, ContainerNode* oldParentOfRemovedTreeForRemoval, ShadowRoot&) = 0;
-    virtual void slotManualAssignmentDidChange(HTMLSlotElement&, Vector<WeakPtr<Node>>& previous, Vector<WeakPtr<Node>>& current, ShadowRoot&) = 0;
+    virtual void slotManualAssignmentDidChange(HTMLSlotElement&, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& previous, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& current, ShadowRoot&) = 0;
     virtual void didRemoveManuallyAssignedNode(HTMLSlotElement&, const Node&, ShadowRoot&) = 0;
     virtual void slotFallbackDidChange(HTMLSlotElement&, ShadowRoot&) = 0;
 
@@ -91,11 +91,11 @@ private:
     void renameSlotElement(HTMLSlotElement&, const AtomString& oldName, const AtomString& newName, ShadowRoot&) final;
     void addSlotElementByName(const AtomString&, HTMLSlotElement&, ShadowRoot&) final;
     void removeSlotElementByName(const AtomString&, HTMLSlotElement&, ContainerNode* oldParentOfRemovedTreeForRemoval, ShadowRoot&) final;
-    void slotManualAssignmentDidChange(HTMLSlotElement&, Vector<WeakPtr<Node>>& previous, Vector<WeakPtr<Node>>& current, ShadowRoot&) final;
+    void slotManualAssignmentDidChange(HTMLSlotElement&, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& previous, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& current, ShadowRoot&) final;
     void didRemoveManuallyAssignedNode(HTMLSlotElement&, const Node&, ShadowRoot&) final;
     void slotFallbackDidChange(HTMLSlotElement&, ShadowRoot&) final;
 
-    const Vector<WeakPtr<Node>>* assignedNodesForSlot(const HTMLSlotElement&, ShadowRoot&) final;
+    const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* assignedNodesForSlot(const HTMLSlotElement&, ShadowRoot&) final;
     void willRemoveAssignedNode(const Node&, ShadowRoot&) final;
 
     void didRemoveAllChildrenOfShadowHost(ShadowRoot&) final;
@@ -112,11 +112,11 @@ private:
         bool hasDuplicatedSlotElements() { return elementCount > 1; }
         bool shouldResolveSlotElement() { return !element && elementCount; }
 
-        WeakPtr<HTMLSlotElement> element;
-        WeakPtr<HTMLSlotElement> oldElement; // Set by resolveSlotsAfterSlotMutation to dispatch slotchange in tree order.
+        WeakPtr<HTMLSlotElement, WeakPtrImplWithEventTargetData> element;
+        WeakPtr<HTMLSlotElement, WeakPtrImplWithEventTargetData> oldElement; // Set by resolveSlotsAfterSlotMutation to dispatch slotchange in tree order.
         unsigned elementCount { 0 };
         bool seenFirstElement { false }; // Used in resolveSlotsAfterSlotMutation.
-        Vector<WeakPtr<Node>> assignedNodes;
+        Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>> assignedNodes;
     };
 
     bool hasAssignedNodes(ShadowRoot&, Slot&);
@@ -136,7 +136,7 @@ private:
     HashMap<AtomString, std::unique_ptr<Slot>> m_slots;
 
 #if ASSERT_ENABLED
-    WeakHashSet<HTMLSlotElement> m_slotElementsForConsistencyCheck;
+    WeakHashSet<HTMLSlotElement, WeakPtrImplWithEventTargetData> m_slotElementsForConsistencyCheck;
 #endif
 };
 
@@ -146,11 +146,11 @@ public:
 
     HTMLSlotElement* findAssignedSlot(const Node&) final;
 
-    const Vector<WeakPtr<Node>>* assignedNodesForSlot(const HTMLSlotElement&, ShadowRoot&) final;
+    const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* assignedNodesForSlot(const HTMLSlotElement&, ShadowRoot&) final;
     void renameSlotElement(HTMLSlotElement&, const AtomString&, const AtomString&, ShadowRoot&) final;
     void addSlotElementByName(const AtomString&, HTMLSlotElement&, ShadowRoot&) final;
     void removeSlotElementByName(const AtomString&, HTMLSlotElement&, ContainerNode*, ShadowRoot&) final;
-    void slotManualAssignmentDidChange(HTMLSlotElement&, Vector<WeakPtr<Node>>& previous, Vector<WeakPtr<Node>>& current, ShadowRoot&) final;
+    void slotManualAssignmentDidChange(HTMLSlotElement&, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& previous, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& current, ShadowRoot&) final;
     void didRemoveManuallyAssignedNode(HTMLSlotElement&, const Node&, ShadowRoot&) final;
     void slotFallbackDidChange(HTMLSlotElement&, ShadowRoot&) final;
 
@@ -163,10 +163,10 @@ public:
 
 private:
     struct Slot {
-        Vector<WeakPtr<Node>> cachedAssignment;
+        Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>> cachedAssignment;
         uint64_t cachedVersion { 0 };
     };
-    WeakHashMap<HTMLSlotElement, Slot> m_slots;
+    WeakHashMap<HTMLSlotElement, Slot, WeakPtrImplWithEventTargetData> m_slots;
     uint64_t m_slottableVersion { 0 };
     unsigned m_slotElementCount { 0 };
 };

--- a/Source/WebCore/dom/TemplateContentDocumentFragment.h
+++ b/Source/WebCore/dom/TemplateContentDocumentFragment.h
@@ -52,7 +52,7 @@ private:
 
     bool isTemplateContent() const override { return true; }
 
-    WeakPtr<const Element> m_host;
+    WeakPtr<const Element, WeakPtrImplWithEventTargetData> m_host;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/UserGestureIndicator.h
+++ b/Source/WebCore/dom/UserGestureIndicator.h
@@ -37,6 +37,7 @@
 namespace WebCore {
 
 class Document;
+class WeakPtrImplWithEventTargetData;
 
 enum ProcessingUserGestureState {
     ProcessingUserGesture,
@@ -110,7 +111,7 @@ private:
     ProcessingUserGestureState m_state = NotProcessingUserGesture;
     Vector<Function<void(UserGestureToken&)>> m_destructionObservers;
     UserGestureType m_gestureType;
-    WeakHashSet<Document> m_documentsImpactedByUserGesture;
+    WeakHashSet<Document, WeakPtrImplWithEventTargetData> m_documentsImpactedByUserGesture;
     DOMPasteAccessPolicy m_domPasteAccessPolicy { DOMPasteAccessPolicy::NotRequestedYet };
     GestureScope m_scope { GestureScope::All };
     MonotonicTime m_startTime { MonotonicTime::now() };

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2894,12 +2894,12 @@ void FrameSelection::setCaretColor(const Color& caretColor)
 
 #endif // PLATFORM(IOS_FAMILY)
 
-static bool containsEndpoints(const WeakPtr<Document>& document, const std::optional<SimpleRange>& range)
+static bool containsEndpoints(const WeakPtr<Document, WeakPtrImplWithEventTargetData>& document, const std::optional<SimpleRange>& range)
 {
     return document && range && document->contains(range->start.container) && document->contains(range->end.container);
 }
 
-static bool containsEndpoints(const WeakPtr<Document>& document, const Range& liveRange)
+static bool containsEndpoints(const WeakPtr<Document, WeakPtrImplWithEventTargetData>& document, const Range& liveRange)
 {
     // Only need to check the start container because live ranges enforce the invariant that start and end have a common ancestor.
     return document && document->contains(liveRange.startContainer());

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -323,7 +323,7 @@ private:
 
     void updateAssociatedLiveRange();
 
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     RefPtr<Range> m_associatedLiveRange;
     std::optional<LayoutUnit> m_xPosForVerticalArrowNavigation;
     VisibleSelection m_selection;

--- a/Source/WebCore/editing/TextManipulationController.h
+++ b/Source/WebCore/editing/TextManipulationController.h
@@ -145,7 +145,7 @@ private:
         Position start;
         Position end;
 
-        WeakPtr<Element> element;
+        WeakPtr<Element, WeakPtrImplWithEventTargetData> element;
         QualifiedName attributeName { nullQName() };
 
         Vector<ManipulationToken> tokens;
@@ -178,12 +178,12 @@ private:
     void updateInsertions(Vector<NodeEntry>&, const Vector<Ref<Node>>&, Node*, HashSet<Ref<Node>>&, Vector<NodeInsertion>&);
     std::optional<ManipulationFailureType> replace(const ManipulationItemData&, const Vector<ManipulationToken>&, HashSet<Ref<Node>>& containersWithoutVisualOverflowBeforeReplacement);
 
-    WeakPtr<Document> m_document;
-    WeakHashSet<Element> m_elementsWithNewRenderer;
-    WeakHashSet<Node> m_textNodesWithNewRenderer;
-    WeakHashSet<Node> m_manipulatedNodes;
-    WeakHashSet<Node> m_manipulatedNodesWithNewContent;
-    WeakHashSet<Node> m_addedOrNewlyRenderedNodes;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_elementsWithNewRenderer;
+    WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_textNodesWithNewRenderer;
+    WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_manipulatedNodes;
+    WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_manipulatedNodesWithNewContent;
+    WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_addedOrNewlyRenderedNodes;
 
     HashMap<String, bool> m_cachedFontFamilyExclusionResults;
 

--- a/Source/WebCore/fileapi/FileReader.h
+++ b/Source/WebCore/fileapi/FileReader.h
@@ -49,7 +49,7 @@ namespace WebCore {
 
 class Blob;
 
-class FileReader final : public RefCounted<FileReader>, public ActiveDOMObject, public EventTargetWithInlineData, private FileReaderLoaderClient {
+class FileReader final : public RefCounted<FileReader>, public ActiveDOMObject, public EventTarget, private FileReaderLoaderClient {
     WTF_MAKE_ISO_ALLOCATED(FileReader);
 public:
     static Ref<FileReader> create(ScriptExecutionContext&);

--- a/Source/WebCore/html/FormAssociatedElement.h
+++ b/Source/WebCore/html/FormAssociatedElement.h
@@ -120,8 +120,8 @@ private:
     bool isFormAssociatedElement() const final { return true; }
 
     std::unique_ptr<FormAttributeTargetObserver> m_formAttributeTargetObserver;
-    WeakPtr<HTMLFormElement> m_form;
-    WeakPtr<HTMLFormElement> m_formSetByParser;
+    WeakPtr<HTMLFormElement, WeakPtrImplWithEventTargetData> m_form;
+    WeakPtr<HTMLFormElement, WeakPtrImplWithEventTargetData> m_formSetByParser;
     String m_customValidationMessage;
 };
 

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -168,7 +168,7 @@ public:
     void willDeleteForm(HTMLFormElement&);
 
 private:
-    WeakHashMap<HTMLFormElement, String> m_formToKeyMap;
+    WeakHashMap<HTMLFormElement, String, WeakPtrImplWithEventTargetData> m_formToKeyMap;
     HashMap<String, unsigned> m_formSignatureToNextIndexMap;
 };
 

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -682,7 +682,7 @@ bool HTMLAnchorElement::willRespondToMouseClickEventsWithEditability(Editability
 
 static auto& rootEditableElementMap()
 {
-    static NeverDestroyed<WeakHashMap<HTMLAnchorElement, WeakPtr<Element>>> map;
+    static NeverDestroyed<WeakHashMap<HTMLAnchorElement, WeakPtr<Element, WeakPtrImplWithEventTargetData>, WeakPtrImplWithEventTargetData>> map;
     return map.get();
 }
 

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -48,8 +48,8 @@ private:
     bool isInteractiveContent() const final { return true; }
 
     bool m_isOpen { false };
-    WeakPtr<HTMLSlotElement> m_summarySlot;
-    WeakPtr<HTMLSummaryElement> m_defaultSummary;
+    WeakPtr<HTMLSlotElement, WeakPtrImplWithEventTargetData> m_summarySlot;
+    WeakPtr<HTMLSummaryElement, WeakPtrImplWithEventTargetData> m_defaultSummary;
     RefPtr<HTMLSlotElement> m_defaultSlot;
     bool m_isToggleEventTaskQueued { false };
 };

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -57,7 +57,7 @@ private:
 
     String m_returnValue;
     bool m_isModal { false };
-    WeakPtr<Element> m_previouslyFocusedElement;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_previouslyFocusedElement;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLFieldSetElement.h
+++ b/Source/WebCore/html/HTMLFieldSetElement.h
@@ -60,7 +60,7 @@ private:
     bool matchesValidPseudoClass() const final;
     bool matchesInvalidPseudoClass() const final;
 
-    WeakHashSet<HTMLFormControlElement> m_invalidDescendants;
+    WeakHashSet<HTMLFormControlElement, WeakPtrImplWithEventTargetData> m_invalidDescendants;
     bool m_hasDisabledAttribute { false };
 };
 

--- a/Source/WebCore/html/HTMLFormControlsCollection.cpp
+++ b/Source/WebCore/html/HTMLFormControlsCollection.cpp
@@ -66,7 +66,7 @@ std::optional<std::variant<RefPtr<RadioNodeList>, RefPtr<Element>>> HTMLFormCont
     return std::variant<RefPtr<RadioNodeList>, RefPtr<Element>> { RefPtr<RadioNodeList> { ownerNode().radioNodeList(name) } };
 }
 
-static unsigned findFormAssociatedElement(const Vector<WeakPtr<HTMLElement>>& elements, const Element& element)
+static unsigned findFormAssociatedElement(const Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>& elements, const Element& element)
 {
     for (unsigned i = 0; i < elements.size(); ++i) {
         RefPtr currentElement = elements[i].get();

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -984,7 +984,7 @@ void HTMLFormElement::finishParsingChildren()
     document().formController().restoreControlStateIn(*this);
 }
 
-const Vector<WeakPtr<HTMLElement>>& HTMLFormElement::unsafeAssociatedElements() const
+const Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>& HTMLFormElement::unsafeAssociatedElements() const
 {
     ASSERT(ScriptDisallowedScope::InMainThread::hasDisallowedScope());
     return m_associatedElements;

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -119,9 +119,9 @@ public:
 
     RadioButtonGroups& radioButtonGroups() { return m_radioButtonGroups; }
 
-    WEBCORE_EXPORT const Vector<WeakPtr<HTMLElement>>& unsafeAssociatedElements() const;
+    WEBCORE_EXPORT const Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>& unsafeAssociatedElements() const;
     Vector<Ref<FormAssociatedElement>> copyAssociatedElementsVector() const;
-    const Vector<WeakPtr<HTMLImageElement>>& imageElements() const { return m_imageElements; }
+    const Vector<WeakPtr<HTMLImageElement, WeakPtrImplWithEventTargetData>>& imageElements() const { return m_imageElements; }
 
     StringPairVector textFieldValues() const;
 
@@ -175,16 +175,16 @@ private:
     RefPtr<HTMLFormControlElement> findSubmitButton(HTMLFormControlElement* submitter, bool needButtonActivation);
 
     FormSubmission::Attributes m_attributes;
-    HashMap<AtomString, WeakPtr<HTMLElement>> m_pastNamesMap;
+    HashMap<AtomString, WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>> m_pastNamesMap;
 
     RadioButtonGroups m_radioButtonGroups;
-    mutable WeakPtr<HTMLFormControlElement> m_defaultButton;
+    mutable WeakPtr<HTMLFormControlElement, WeakPtrImplWithEventTargetData> m_defaultButton;
 
     unsigned m_associatedElementsBeforeIndex { 0 };
     unsigned m_associatedElementsAfterIndex { 0 };
-    Vector<WeakPtr<HTMLElement>> m_associatedElements;
-    Vector<WeakPtr<HTMLImageElement>> m_imageElements;
-    WeakHashSet<HTMLFormControlElement> m_invalidAssociatedFormControls;
+    Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>> m_associatedElements;
+    Vector<WeakPtr<HTMLImageElement, WeakPtrImplWithEventTargetData>> m_imageElements;
+    WeakHashSet<HTMLFormControlElement, WeakPtrImplWithEventTargetData> m_invalidAssociatedFormControls;
     WeakPtr<FormSubmission> m_plannedFormSubmission;
     std::unique_ptr<DOMTokenList> m_relList;
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -214,8 +214,8 @@ private:
     void setSourceElement(HTMLSourceElement*);
 
     std::unique_ptr<HTMLImageLoader> m_imageLoader;
-    WeakPtr<HTMLFormElement> m_form;
-    WeakPtr<HTMLFormElement> m_formSetByParser;
+    WeakPtr<HTMLFormElement, WeakPtrImplWithEventTargetData> m_form;
+    WeakPtr<HTMLFormElement, WeakPtrImplWithEventTargetData> m_formSetByParser;
 
     CompositeOperator m_compositeOperator;
     AtomString m_bestFitImageURL;
@@ -228,9 +228,9 @@ private:
     bool m_hadNameBeforeAttributeChanged { false }; // FIXME: We only need this because parseAttribute() can't see the old value.
     bool m_isDroppedImagePlaceholder { false };
 
-    WeakPtr<HTMLPictureElement> m_pictureElement;
+    WeakPtr<HTMLPictureElement, WeakPtrImplWithEventTargetData> m_pictureElement;
     // The source element that was selected to provide the source URL.
-    WeakPtr<HTMLSourceElement> m_sourceElement;
+    WeakPtr<HTMLSourceElement, WeakPtrImplWithEventTargetData> m_sourceElement;
     MediaQueryDynamicResults m_mediaQueryDynamicResults;
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -98,7 +98,7 @@ public:
     void idTargetChanged() override;
 
 private:
-    WeakPtr<HTMLInputElement> m_element;
+    WeakPtr<HTMLInputElement, WeakPtrImplWithEventTargetData> m_element;
 };
 #endif
 

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -39,14 +39,15 @@ class HTMLLinkElement;
 class Page;
 struct MediaQueryParserContext;
 
-template<typename T> class EventSender;
-using LinkEventSender = EventSender<HTMLLinkElement>;
+template<typename T, typename Counter> class EventSender;
+using LinkEventSender = EventSender<HTMLLinkElement, WeakPtrImplWithEventTargetData>;
 
 class HTMLLinkElement final : public HTMLElement, public CachedStyleSheetClient, public LinkLoaderClient {
     WTF_MAKE_ISO_ALLOCATED(HTMLLinkElement);
 public:
-    using WeakValueType = HTMLElement::WeakValueType;
     using HTMLElement::weakPtrFactory;
+    using HTMLElement::WeakValueType;
+    using HTMLElement::WeakPtrImplType;
 
     static Ref<HTMLLinkElement> create(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLLinkElement();

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1773,7 +1773,7 @@ void HTMLMediaElement::updateActiveTextTrackCues(const MediaTime& movieTime)
     INFO_LOG(identifier, "nextInterestingTime:", nextInterestingTime);
 
     if (nextInterestingTime.isValid() && m_player) {
-        m_player->performTaskAtMediaTime([this, weakThis = WeakPtr { *this }, identifier] {
+        m_player->performTaskAtMediaTime([this, weakThis = WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> { *this }, identifier] {
             if (!weakThis)
                 return;
 
@@ -1959,7 +1959,7 @@ void HTMLMediaElement::speakCueText(TextTrackCue& cue)
         cancelSpeakingCueText();
 
     m_cueBeingSpoken = &cue;
-    cue.speak(m_reportedPlaybackRate ? m_reportedPlaybackRate : m_requestedPlaybackRate, volume(), [weakThis = WeakPtr { *this }](const TextTrackCue&) {
+    cue.speak(m_reportedPlaybackRate ? m_reportedPlaybackRate : m_requestedPlaybackRate, volume(), [weakThis = WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> { *this }](const TextTrackCue&) {
         ASSERT(isMainThread());
         if (!weakThis)
             return;
@@ -3160,7 +3160,7 @@ void HTMLMediaElement::progressEventTimerFired()
     if (!m_player->supportsProgressMonitoring())
         return;
 
-    m_player->didLoadingProgress([this, weakThis = WeakPtr { *this }](bool progress) {
+    m_player->didLoadingProgress([this, weakThis = WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> { *this }](bool progress) {
         if (!weakThis)
             return;
         MonotonicTime time = MonotonicTime::now();

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -151,8 +151,9 @@ class HTMLMediaElement
 {
     WTF_MAKE_ISO_ALLOCATED(HTMLMediaElement);
 public:
-    using WeakValueType = HTMLElement::WeakValueType;
     using HTMLElement::weakPtrFactory;
+    using HTMLElement::WeakValueType;
+    using HTMLElement::WeakPtrImplType;
 
     RefPtr<MediaPlayer> player() const { return m_player; }
     WEBCORE_EXPORT std::optional<MediaPlayerIdentifier> playerIdentifier() const;

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -101,7 +101,7 @@ void HTMLSlotElement::attributeChanged(const QualifiedName& name, const AtomStri
     }
 }
 
-const Vector<WeakPtr<Node>>* HTMLSlotElement::assignedNodes() const
+const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* HTMLSlotElement::assignedNodes() const
 {
     RefPtr shadowRoot = containingShadowRoot();
     if (!shadowRoot)
@@ -177,8 +177,8 @@ void HTMLSlotElement::assign(FixedVector<ElementOrText>&& nodes)
 
     auto previous = std::exchange(m_manuallyAssignedNodes, { });
     HashSet<RefPtr<Node>> seenNodes;
-    m_manuallyAssignedNodes = WTF::compactMap(nodes, [&seenNodes](ElementOrText& node) -> std::optional<WeakPtr<Node>> {
-        auto mapper = [&seenNodes]<typename T>(RefPtr<T>& node) -> std::optional<WeakPtr<Node>> {
+    m_manuallyAssignedNodes = WTF::compactMap(nodes, [&seenNodes](ElementOrText& node) -> std::optional<WeakPtr<Node, WeakPtrImplWithEventTargetData>> {
+        auto mapper = [&seenNodes]<typename T>(RefPtr<T>& node) -> std::optional<WeakPtr<Node, WeakPtrImplWithEventTargetData>> {
             if (seenNodes.contains(node))
                 return std::nullopt;
             seenNodes.add(node);

--- a/Source/WebCore/html/HTMLSlotElement.h
+++ b/Source/WebCore/html/HTMLSlotElement.h
@@ -36,7 +36,7 @@ public:
 
     static Ref<HTMLSlotElement> create(const QualifiedName&, Document&);
 
-    const Vector<WeakPtr<Node>>* assignedNodes() const;
+    const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* assignedNodes() const;
     struct AssignedNodesOptions {
         bool flatten;
     };
@@ -44,7 +44,7 @@ public:
     Vector<Ref<Element>> assignedElements(const AssignedNodesOptions&) const;
 
     void assign(FixedVector<ElementOrText>&&);
-    const Vector<WeakPtr<Node>>& manuallyAssignedNodes() const { return m_manuallyAssignedNodes; }
+    const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& manuallyAssignedNodes() const { return m_manuallyAssignedNodes; }
     void removeManuallyAssignedNode(Node&);
 
     void enqueueSlotChangeEvent();
@@ -64,7 +64,7 @@ private:
 
     bool m_inSignalSlotList { false };
     bool m_isInInsertedIntoAncestor { false };
-    Vector<WeakPtr<Node>> m_manuallyAssignedNodes;
+    Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>> m_manuallyAssignedNodes;
 };
 
 }

--- a/Source/WebCore/html/HTMLStyleElement.h
+++ b/Source/WebCore/html/HTMLStyleElement.h
@@ -31,9 +31,9 @@ class HTMLStyleElement;
 class Page;
 class StyleSheet;
 
-template<typename T> class EventSender;
+template<typename T, typename Counter> class EventSender;
 
-using StyleEventSender = EventSender<HTMLStyleElement>;
+using StyleEventSender = EventSender<HTMLStyleElement, WeakPtrImplWithEventTargetData>;
 
 class HTMLStyleElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLStyleElement);

--- a/Source/WebCore/html/ImageDocument.h
+++ b/Source/WebCore/html/ImageDocument.h
@@ -68,7 +68,7 @@ private:
 
     void imageUpdated();
 
-    WeakPtr<ImageDocumentElement> m_imageElement;
+    WeakPtr<ImageDocumentElement, WeakPtrImplWithEventTargetData> m_imageElement;
 
     // Whether enough of the image has been loaded to determine its size.
     bool m_imageSizeIsKnown;

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -420,7 +420,7 @@ private:
     const Type m_type;
     bool m_hasCreatedShadowSubtree { false };
     // m_element is null if this InputType is no longer associated with an element (either the element died or changed input type).
-    WeakPtr<HTMLInputElement> m_element;
+    WeakPtr<HTMLInputElement, WeakPtrImplWithEventTargetData> m_element;
 };
 
 template<typename DowncastedType>

--- a/Source/WebCore/html/MediaController.h
+++ b/Source/WebCore/html/MediaController.h
@@ -46,7 +46,7 @@ class MediaController final
     : public RefCounted<MediaController>
     , public MediaControllerInterface
     , public ContextDestructionObserver
-    , public EventTargetWithInlineData {
+    , public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(MediaController);
 public:
     static Ref<MediaController> create(ScriptExecutionContext&);

--- a/Source/WebCore/html/MediaDocument.cpp
+++ b/Source/WebCore/html/MediaDocument.cpp
@@ -77,7 +77,7 @@ private:
     void appendBytes(DocumentWriter&, const uint8_t*, size_t) final;
     void createDocumentStructure();
 
-    WeakPtr<HTMLMediaElement> m_mediaElement;
+    WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElement;
     String m_outgoingReferrer;
 };
     

--- a/Source/WebCore/html/ModelDocument.cpp
+++ b/Source/WebCore/html/ModelDocument.cpp
@@ -70,7 +70,7 @@ private:
     void appendBytes(DocumentWriter&, const uint8_t*, size_t) final;
     void finish() final;
 
-    WeakPtr<HTMLModelElement> m_modelElement;
+    WeakPtr<HTMLModelElement, WeakPtrImplWithEventTargetData> m_modelElement;
     String m_outgoingReferrer;
 };
 

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -68,7 +68,7 @@ RefPtr<ImageBuffer> DetachedOffscreenCanvas::takeImageBuffer()
     return WTFMove(m_buffer);
 }
 
-WeakPtr<HTMLCanvasElement> DetachedOffscreenCanvas::takePlaceholderCanvas()
+WeakPtr<HTMLCanvasElement, WeakPtrImplWithEventTargetData> DetachedOffscreenCanvas::takePlaceholderCanvas()
 {
     ASSERT(isMainThread());
     return std::exchange(m_placeholderCanvas, nullptr);

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -89,16 +89,16 @@ public:
             return buffer->memoryCost();
         return 0;
     }
-    WeakPtr<HTMLCanvasElement> takePlaceholderCanvas();
+    WeakPtr<HTMLCanvasElement, WeakPtrImplWithEventTargetData> takePlaceholderCanvas();
 
 private:
     RefPtr<ImageBuffer> m_buffer;
     IntSize m_size;
     bool m_originClean;
-    WeakPtr<HTMLCanvasElement> m_placeholderCanvas;
+    WeakPtr<HTMLCanvasElement, WeakPtrImplWithEventTargetData> m_placeholderCanvas;
 };
 
-class OffscreenCanvas final : public RefCounted<OffscreenCanvas>, public CanvasBase, public EventTargetWithInlineData, private ContextDestructionObserver {
+class OffscreenCanvas final : public RefCounted<OffscreenCanvas>, public CanvasBase, public EventTarget, private ContextDestructionObserver {
     WTF_MAKE_ISO_ALLOCATED(OffscreenCanvas);
 public:
 
@@ -199,7 +199,7 @@ private:
             return adoptRef(*new PlaceholderData);
         }
 
-        WeakPtr<HTMLCanvasElement> canvas;
+        WeakPtr<HTMLCanvasElement, WeakPtrImplWithEventTargetData> canvas;
         RefPtr<ImageBufferPipe::Source> bufferPipeSource;
         RefPtr<ImageBuffer> pendingCommitBuffer;
         mutable Lock bufferLock;

--- a/Source/WebCore/html/PDFDocument.cpp
+++ b/Source/WebCore/html/PDFDocument.cpp
@@ -108,7 +108,7 @@ private:
     bool operator==(const EventListener&) const override;
     void handleEvent(ScriptExecutionContext&, Event&) override;
 
-    WeakPtr<PDFDocument> m_document;
+    WeakPtr<PDFDocument, WeakPtrImplWithEventTargetData> m_document;
 };
 
 void PDFDocumentEventListener::handleEvent(ScriptExecutionContext&, Event& event)

--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -62,7 +62,7 @@ private:
     void appendBytes(DocumentWriter&, const uint8_t*, size_t) final;
     void createDocumentStructure();
 
-    WeakPtr<HTMLEmbedElement> m_embedElement;
+    WeakPtr<HTMLEmbedElement, WeakPtrImplWithEventTargetData> m_embedElement;
 };
 
 void PluginDocumentParser::createDocumentStructure()

--- a/Source/WebCore/html/ValidationMessage.h
+++ b/Source/WebCore/html/ValidationMessage.h
@@ -39,6 +39,7 @@
 
 namespace WebCore {
 
+class WeakPtrImplWithEventTargetData;
 class HTMLElement;
 class HTMLFormControlElement;
 class Node;
@@ -65,7 +66,7 @@ private:
     void buildBubbleTree();
     void deleteBubbleTree();
 
-    WeakPtr<HTMLFormControlElement> m_element;
+    WeakPtr<HTMLFormControlElement, WeakPtrImplWithEventTargetData> m_element;
     String m_message;
     std::unique_ptr<Timer> m_timer;
     RefPtr<HTMLElement> m_bubble;

--- a/Source/WebCore/html/parser/HTMLScriptRunner.h
+++ b/Source/WebCore/html/parser/HTMLScriptRunner.h
@@ -72,7 +72,7 @@ private:
     void stopWatchingForLoad(PendingScript&);
     bool isPendingScriptReady(const PendingScript&);
 
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     HTMLScriptRunnerHost& m_host;
     RefPtr<PendingScript> m_parserBlockingScript;
     Deque<Ref<PendingScript>> m_scriptsToExecuteAfterParsing; // http://www.whatwg.org/specs/web-apps/current-work/#list-of-scripts-that-will-execute-when-the-document-has-finished-parsing

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
@@ -96,7 +96,7 @@ private:
 
     std::unique_ptr<TextTrackRepresentation> m_textTrackRepresentation;
 
-    WeakPtr<HTMLMediaElement> m_mediaElement;
+    WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElement;
     IntRect m_videoDisplaySize;
     int m_fontSize { 0 };
     bool m_fontSizeIsImportant { false };

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -45,7 +45,7 @@ class TextTrackCueList;
 class VTTRegion;
 class VTTRegionList;
 
-class TextTrack : public TrackBase, public EventTargetWithInlineData, public ActiveDOMObject {
+class TextTrack : public TrackBase, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(TextTrack);
 public:
     static Ref<TextTrack> create(Document*, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language);

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -61,10 +61,10 @@ protected:
 
 private:
 
-    WeakPtr<TextTrackCue> m_cue;
+    WeakPtr<TextTrackCue, WeakPtrImplWithEventTargetData> m_cue;
 };
 
-class TextTrackCue : public RefCounted<TextTrackCue>, public EventTargetWithInlineData, public ActiveDOMObject {
+class TextTrackCue : public RefCounted<TextTrackCue>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(TextTrackCue);
 public:
     static ExceptionOr<Ref<TextTrackCue>> create(Document&, double start, double end, DocumentFragment&);

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -99,7 +99,7 @@ private:
     RefPtr<const Logger> m_logger;
     const void* m_logIdentifier { nullptr };
 #endif
-    WeakPtr<TrackListBase> m_trackList;
+    WeakPtr<TrackListBase, WeakPtrImplWithEventTargetData> m_trackList;
 };
 
 class MediaTrackBase : public TrackBase {

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -39,7 +39,7 @@ namespace WebCore {
 
 class TrackBase;
 
-class TrackListBase : public RefCounted<TrackListBase>, public EventTargetWithInlineData, public ActiveDOMObject {
+class TrackListBase : public RefCounted<TrackListBase>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(TrackListBase);
 public:
     virtual ~TrackListBase();

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -601,7 +601,7 @@ void InspectorOverlay::setShowRulers(bool showRulers)
 
 bool InspectorOverlay::removeGridOverlayForNode(Node& node)
 {
-    // Try to remove `node`. Also clear any grid overlays whose WeakPtr<Node> has been cleared.
+    // Try to remove `node`. Also clear any grid overlays whose WeakPtr<Node, WeakPtrImplWithEventTargetData> has been cleared.
     return m_activeGridOverlays.removeAllMatching([&] (const InspectorOverlay::Grid& gridOverlay) {
         return !gridOverlay.gridNode || gridOverlay.gridNode.get() == &node;
     });
@@ -641,7 +641,7 @@ void InspectorOverlay::clearAllGridOverlays()
 
 bool InspectorOverlay::removeFlexOverlayForNode(Node& node)
 {
-    // Try to remove `node`. Also clear any grid overlays whose WeakPtr<Node> has been cleared.
+    // Try to remove `node`. Also clear any grid overlays whose WeakPtr<Node, WeakPtrImplWithEventTargetData> has been cleared.
     return m_activeFlexOverlays.removeAllMatching([&] (const InspectorOverlay::Flex& flexOverlay) {
         return !flexOverlay.flexNode || flexOverlay.flexNode.get() == &node;
     });

--- a/Source/WebCore/inspector/InspectorOverlay.h
+++ b/Source/WebCore/inspector/InspectorOverlay.h
@@ -53,6 +53,7 @@ using ErrorStringOr = Expected<T, ErrorString>;
 
 namespace WebCore {
 
+class WeakPtrImplWithEventTargetData;
 class FontCascade;
 class FloatPoint;
 class GraphicsContext;
@@ -171,7 +172,7 @@ public:
             bool showAreaNames;
         };
 
-        WeakPtr<Node> gridNode;
+        WeakPtr<Node, WeakPtrImplWithEventTargetData> gridNode;
         Config config;
     };
 
@@ -185,7 +186,7 @@ public:
             bool showOrderNumbers;
         };
 
-        WeakPtr<Node> flexNode;
+        WeakPtr<Node, WeakPtrImplWithEventTargetData> flexNode;
         Config config;
     };
 

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -195,8 +195,8 @@ private:
     int m_lastStyleSheetId { 1 };
     bool m_creatingViaInspectorStyleSheet { false };
 
-    WeakHashMap<Node, OptionSet<LayoutFlag>> m_lastLayoutFlagsForNode;
-    WeakHashSet<Node> m_nodesWithPendingLayoutFlagsChange;
+    WeakHashMap<Node, OptionSet<LayoutFlag>, WeakPtrImplWithEventTargetData> m_lastLayoutFlagsForNode;
+    WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_nodesWithPendingLayoutFlagsChange;
     Timer m_nodesWithPendingLayoutFlagsChangeDispatchTimer;
 
     Inspector::Protocol::CSS::LayoutContextTypeChangedMode m_layoutContextTypeChangedMode { Inspector::Protocol::CSS::LayoutContextTypeChangedMode::Observed };

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -261,8 +261,8 @@ private:
     RefPtr<Inspector::DOMBackendDispatcher> m_backendDispatcher;
     Page& m_inspectedPage;
     InspectorOverlay* m_overlay { nullptr };
-    WeakHashMap<Node, Inspector::Protocol::DOM::NodeId> m_nodeToId;
-    HashMap<Inspector::Protocol::DOM::NodeId, WeakPtr<Node>> m_idToNode;
+    WeakHashMap<Node, Inspector::Protocol::DOM::NodeId, WeakPtrImplWithEventTargetData> m_nodeToId;
+    HashMap<Inspector::Protocol::DOM::NodeId, WeakPtr<Node, WeakPtrImplWithEventTargetData>> m_idToNode;
     HashSet<Inspector::Protocol::DOM::NodeId> m_childrenRequested;
     Inspector::Protocol::DOM::NodeId m_lastNodeId { 1 };
     RefPtr<Document> m_document;
@@ -296,7 +296,7 @@ private:
     };
 
     // The pointer key for this map should not be used for anything other than matching.
-    WeakHashMap<HTMLMediaElement, MediaMetrics> m_mediaMetrics;
+    WeakHashMap<HTMLMediaElement, MediaMetrics, WeakPtrImplWithEventTargetData> m_mediaMetrics;
 #endif
 
     struct InspectorEventListener {

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
@@ -88,8 +88,8 @@ private:
     HashMap<const RenderLayer*, Inspector::Protocol::LayerTree::LayerId> m_documentLayerToIdMap;
     HashMap<Inspector::Protocol::LayerTree::LayerId, const RenderLayer*> m_idToLayer;
 
-    WeakHashMap<PseudoElement, Inspector::Protocol::LayerTree::PseudoElementId> m_pseudoElementToIdMap;
-    HashMap<Inspector::Protocol::LayerTree::PseudoElementId, WeakPtr<PseudoElement>> m_idToPseudoElement;
+    WeakHashMap<PseudoElement, Inspector::Protocol::LayerTree::PseudoElementId, WeakPtrImplWithEventTargetData> m_pseudoElementToIdMap;
+    HashMap<Inspector::Protocol::LayerTree::PseudoElementId, WeakPtr<PseudoElement, WeakPtrImplWithEventTargetData>> m_idToPseudoElement;
 
     bool m_suppressLayerChangeEvents { false };
 };

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -876,7 +876,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::enable()
             auto identifier = channel->progressIdentifier();
             didCreateWebSocket(identifier, webSocket->url());
 
-            auto cookieRequestHeaderFieldValue = [document = WeakPtr { document }](const URL& url) -> String {
+            auto cookieRequestHeaderFieldValue = [document = WeakPtr<Document, WeakPtrImplWithEventTargetData> { document }](const URL& url) -> String {
                 if (!document || !document->page())
                     return { };
                 return document->page()->cookieJar().cookieRequestHeaderFieldValue(*document, url);

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -37,8 +37,8 @@ class ImageLoader;
 class Page;
 class RenderImageResource;
 
-template<typename T> class EventSender;
-using ImageEventSender = EventSender<ImageLoader>;
+template<typename T, typename Counter> class EventSender;
+using ImageEventSender = EventSender<ImageLoader, WTF::DefaultWeakPtrImpl>;
 
 enum class RelevantMutation : bool { No, Yes };
 enum class LazyImageLoadState : uint8_t { None, Deferred, LoadImmediately, FullImage };

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -216,7 +216,7 @@ void LinkLoader::preconnectIfNeeded(const LinkLoadParameters& params, Document& 
     if (equalLettersIgnoringASCIICase(params.crossOrigin, "anonymous"_s) && !document.securityOrigin().isSameOriginDomain(SecurityOrigin::create(href)))
         storageCredentialsPolicy = StoredCredentialsPolicy::DoNotUse;
     ASSERT(document.frame()->loader().networkingContext());
-    platformStrategies()->loaderStrategy()->preconnectTo(document.frame()->loader(), href, storageCredentialsPolicy, LoaderStrategy::ShouldPreconnectAsFirstParty::No, [weakDocument = WeakPtr { document }, href](ResourceError error) {
+    platformStrategies()->loaderStrategy()->preconnectTo(document.frame()->loader(), href, storageCredentialsPolicy, LoaderStrategy::ShouldPreconnectAsFirstParty::No, [weakDocument = WeakPtr<Document, WeakPtrImplWithEventTargetData> { document }, href](ResourceError error) {
         if (!weakDocument)
             return;
 

--- a/Source/WebCore/loader/MediaResourceLoader.h
+++ b/Source/WebCore/loader/MediaResourceLoader.h
@@ -64,8 +64,8 @@ public:
 private:
     void contextDestroyed() override;
 
-    WeakPtr<Document> m_document;
-    WeakPtr<Element> m_element;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element;
     String m_crossOriginMode;
     HashSet<MediaResource*> m_resources;
     Vector<ResourceResponse> m_responsesForTesting;

--- a/Source/WebCore/loader/appcache/ApplicationCacheHost.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheHost.h
@@ -149,7 +149,7 @@ private:
     ApplicationCache* mainResourceApplicationCache() const { return m_mainResourceApplicationCache.get(); }
     bool maybeLoadFallbackForMainError(const ResourceRequest&, const ResourceError&);
 
-    WeakPtr<DOMApplicationCache> m_domApplicationCache;
+    WeakPtr<DOMApplicationCache, WeakPtrImplWithEventTargetData> m_domApplicationCache;
     DocumentLoader& m_documentLoader;
 
     bool m_defersEvents { true }; // Events are deferred until after document onload.

--- a/Source/WebCore/loader/appcache/DOMApplicationCache.h
+++ b/Source/WebCore/loader/appcache/DOMApplicationCache.h
@@ -34,7 +34,7 @@ namespace WebCore {
 class ApplicationCacheHost;
 class Frame;
 
-class DOMApplicationCache final : public RefCounted<DOMApplicationCache>, public EventTargetWithInlineData, public DOMWindowProperty {
+class DOMApplicationCache final : public RefCounted<DOMApplicationCache>, public EventTarget, public DOMWindowProperty {
     WTF_MAKE_ISO_ALLOCATED(DOMApplicationCache);
 public:
     static Ref<DOMApplicationCache> create(DOMWindow& window) { return adoptRef(*new DOMApplicationCache(window)); }

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class CachedImageClient;
 class CachedResourceLoader;
+class WeakPtrImplWithEventTargetData;
 class FloatSize;
 class MemoryCache;
 class RenderElement;
@@ -190,7 +191,7 @@ private:
 
     MonotonicTime m_lastUpdateImageDataTime;
 
-    WeakPtr<Document> m_skippingRevalidationDocument;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_skippingRevalidationDocument;
 
     static constexpr unsigned maxUpdateImageDataCount = 4;
     unsigned m_updateImageDataCount : 3;

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -203,7 +203,7 @@ private:
     MemoryCompactRobinHoodHashSet<URL> m_validatedURLs;
     MemoryCompactRobinHoodHashSet<URL> m_cachedSVGImagesURLs;
     mutable DocumentResourceMap m_documentResources;
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     DocumentLoader* m_documentLoader;
 
     int m_requestCount { 0 };

--- a/Source/WebCore/page/AbstractDOMWindow.h
+++ b/Source/WebCore/page/AbstractDOMWindow.h
@@ -36,7 +36,7 @@ namespace WebCore {
 class AbstractFrame;
 
 // FIXME: Rename DOMWindow to LocalWindow and AbstractDOMWindow to DOMWindow.
-class AbstractDOMWindow : public RefCounted<AbstractDOMWindow>, public EventTargetWithInlineData {
+class AbstractDOMWindow : public RefCounted<AbstractDOMWindow>, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(AbstractDOMWindow);
 public:
     virtual ~AbstractDOMWindow();

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -157,9 +157,9 @@ using namespace Inspector;
 
 static constexpr Seconds defaultTransientActivationDuration { 5_s };
 
-static WeakHashSet<DOMWindow>& windowsInterestedInStorageEvents()
+static WeakHashSet<DOMWindow, WeakPtrImplWithEventTargetData>& windowsInterestedInStorageEvents()
 {
-    static MainThreadNeverDestroyed<WeakHashSet<DOMWindow>> set;
+    static MainThreadNeverDestroyed<WeakHashSet<DOMWindow, WeakPtrImplWithEventTargetData>> set;
     return set;
 }
 

--- a/Source/WebCore/page/DOMWindowExtension.h
+++ b/Source/WebCore/page/DOMWindowExtension.h
@@ -56,7 +56,7 @@ public:
 private:
     WEBCORE_EXPORT DOMWindowExtension(DOMWindow*, DOMWrapperWorld&);
 
-    WeakPtr<DOMWindow> m_window;
+    WeakPtr<DOMWindow, WeakPtrImplWithEventTargetData> m_window;
     Ref<DOMWrapperWorld> m_world;
     RefPtr<Frame> m_disconnectedFrame;
     bool m_wasDetached;

--- a/Source/WebCore/page/DOMWindowProperty.h
+++ b/Source/WebCore/page/DOMWindowProperty.h
@@ -42,7 +42,7 @@ protected:
     ~DOMWindowProperty() = default;
 
 private:
-    WeakPtr<DOMWindow> m_window;
+    WeakPtr<DOMWindow, WeakPtrImplWithEventTargetData> m_window;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -46,7 +46,7 @@ class MessageEvent;
 class TextResourceDecoder;
 class ThreadableLoader;
 
-class EventSource final : public RefCounted<EventSource>, public EventTargetWithInlineData, private ThreadableLoaderClient, public ActiveDOMObject {
+class EventSource final : public RefCounted<EventSource>, public EventTarget, private ThreadableLoaderClient, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(EventSource);
 public:
     struct Init {

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -327,7 +327,7 @@ private:
     UniqueRef<FrameLoader> m_loader;
     mutable UniqueRef<NavigationScheduler> m_navigationScheduler;
 
-    WeakPtr<HTMLFrameOwnerElement> m_ownerElement;
+    WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_ownerElement;
     RefPtr<FrameView> m_view;
     RefPtr<Document> m_doc;
 

--- a/Source/WebCore/page/ImageAnalysisQueue.h
+++ b/Source/WebCore/page/ImageAnalysisQueue.h
@@ -66,7 +66,7 @@ private:
 
     enum class Priority : bool { Low, High };
     struct Task {
-        WeakPtr<HTMLImageElement> element;
+        WeakPtr<HTMLImageElement, WeakPtrImplWithEventTargetData> element;
         Priority priority { Priority::Low };
         unsigned taskNumber { 0 };
     };
@@ -79,7 +79,7 @@ private:
     String m_targetLanguageIdentifier;
     WeakPtr<Page> m_page;
     Timer m_resumeProcessingTimer;
-    WeakHashMap<HTMLImageElement, URL> m_queuedElements;
+    WeakHashMap<HTMLImageElement, URL, WeakPtrImplWithEventTargetData> m_queuedElements;
     PriorityQueue<Task, firstIsHigherPriority> m_queue;
     unsigned m_pendingRequestCount { 0 };
     unsigned m_currentTaskNumber { 0 };

--- a/Source/WebCore/page/ImageOverlayController.h
+++ b/Source/WebCore/page/ImageOverlayController.h
@@ -92,16 +92,16 @@ private:
 
     WeakPtr<Page> m_page;
     RefPtr<PageOverlay> m_overlay;
-    WeakPtr<HTMLElement> m_hostElementForSelection;
+    WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_hostElementForSelection;
     Vector<FloatQuad> m_selectionQuads;
     LayoutRect m_selectionClipRect;
     Color m_selectionBackgroundColor { Color::transparentBlack };
 
 #if PLATFORM(MAC)
-    using ContainerAndHighlight = std::pair<WeakPtr<HTMLElement>, Ref<DataDetectorHighlight>>;
+    using ContainerAndHighlight = std::pair<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>, Ref<DataDetectorHighlight>>;
     Vector<ContainerAndHighlight> m_dataDetectorContainersAndHighlights;
     RefPtr<DataDetectorHighlight> m_activeDataDetectorHighlight;
-    WeakPtr<HTMLElement> m_hostElementForDataDetectors;
+    WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_hostElementForDataDetectors;
 #endif
 };
 

--- a/Source/WebCore/page/IntersectionObserver.h
+++ b/Source/WebCore/page/IntersectionObserver.h
@@ -82,7 +82,7 @@ public:
     String rootMargin() const;
     const LengthBox& rootMarginBox() const { return m_rootMargin; }
     const Vector<double>& thresholds() const { return m_thresholds; }
-    const Vector<WeakPtr<Element>>& observationTargets() const { return m_observationTargets; }
+    const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>& observationTargets() const { return m_observationTargets; }
     bool hasObservationTargets() const { return m_observationTargets.size(); }
     bool isObserving(const Element&) const;
 
@@ -113,12 +113,12 @@ private:
     bool removeTargetRegistration(Element&);
     void removeAllTargets();
 
-    WeakPtr<Document> m_implicitRootDocument;
-    WeakPtr<ContainerNode> m_root;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_implicitRootDocument;
+    WeakPtr<ContainerNode, WeakPtrImplWithEventTargetData> m_root;
     LengthBox m_rootMargin;
     Vector<double> m_thresholds;
     RefPtr<IntersectionObserverCallback> m_callback;
-    Vector<WeakPtr<Element>> m_observationTargets;
+    Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> m_observationTargets;
     Vector<GCReachableRef<Element>> m_pendingTargets;
     Vector<Ref<IntersectionObserverEntry>> m_queuedEntries;
     Vector<GCReachableRef<Element>> m_targetsWaitingForFirstObservation;

--- a/Source/WebCore/page/ModalContainerObserver.cpp
+++ b/Source/WebCore/page/ModalContainerObserver.cpp
@@ -451,7 +451,7 @@ public:
     Document* document() const { return m_document.get(); }
 
 private:
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     bool m_continueHidingModalContainerAfterScope { false };
 };
 
@@ -500,13 +500,13 @@ void ModalContainerObserver::collectClickableElementsTimerFired()
                 return;
 
             struct ClassifiedControls {
-                Vector<WeakPtr<HTMLElement>> positive;
-                Vector<WeakPtr<HTMLElement>> neutral;
-                Vector<WeakPtr<HTMLElement>> negative;
+                Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>> positive;
+                Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>> neutral;
+                Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>> negative;
 
                 HTMLElement* controlToClick(ModalContainerDecision decision) const
                 {
-                    auto matchNonNull = [&](const WeakPtr<HTMLElement>& element) {
+                    auto matchNonNull = [&](const WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>& element) {
                         return !!element;
                     };
 
@@ -711,7 +711,7 @@ void ModalContainerObserver::revealModalContainer()
         element->invalidateStyle();
 }
 
-std::pair<Vector<WeakPtr<HTMLElement>>, Vector<String>> ModalContainerObserver::collectClickableElements()
+std::pair<Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>, Vector<String>> ModalContainerObserver::collectClickableElements()
 {
     Ref container = *this->container();
     m_collectingClickableElements = true;
@@ -748,7 +748,7 @@ std::pair<Vector<WeakPtr<HTMLElement>>, Vector<String>> ModalContainerObserver::
     removeElementsWithEmptyBounds(clickableControls);
     removeParentOrChildElements(clickableControls);
 
-    Vector<WeakPtr<HTMLElement>> classifiableControls;
+    Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>> classifiableControls;
     Vector<String> controlTextsToClassify;
     classifiableControls.reserveInitialCapacity(clickableControls.size());
     controlTextsToClassify.reserveInitialCapacity(clickableControls.size());

--- a/Source/WebCore/page/ModalContainerObserver.h
+++ b/Source/WebCore/page/ModalContainerObserver.h
@@ -71,13 +71,13 @@ private:
     Element* container() const;
     HTMLFrameOwnerElement* frameOwnerForControls() const;
 
-    std::pair<Vector<WeakPtr<HTMLElement>>, Vector<String>> collectClickableElements();
+    std::pair<Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>, Vector<String>> collectClickableElements();
     void hideUserInteractionBlockingElementIfNeeded();
 
-    WeakHashSet<Element> m_elementsToIgnoreWhenSearching;
-    std::pair<WeakPtr<Element>, WeakPtr<HTMLFrameOwnerElement>> m_containerAndFrameOwnerForControls;
-    WeakHashMap<HTMLFrameOwnerElement, WeakPtr<Element>> m_frameOwnersAndContainersToSearchAgain;
-    WeakPtr<Element> m_userInteractionBlockingElement;
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_elementsToIgnoreWhenSearching;
+    std::pair<WeakPtr<Element, WeakPtrImplWithEventTargetData>, WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData>> m_containerAndFrameOwnerForControls;
+    WeakHashMap<HTMLFrameOwnerElement, WeakPtr<Element, WeakPtrImplWithEventTargetData>, WeakPtrImplWithEventTargetData> m_frameOwnersAndContainersToSearchAgain;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_userInteractionBlockingElement;
     AtomString m_overrideSearchTermForTesting;
     Timer m_collectClickableElementsTimer;
     bool m_collectingClickableElements { false };

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1643,7 +1643,7 @@ void Page::updateRendering()
 #endif
 
     // Timestamps should not change while serving the rendering update steps.
-    Vector<WeakPtr<Document>> initialDocuments;
+    Vector<WeakPtr<Document, WeakPtrImplWithEventTargetData>> initialDocuments;
     forEachDocument([&initialDocuments] (Document& document) {
         document.domWindow()->freezeNowTimestamp();
         initialDocuments.append(document);
@@ -1771,7 +1771,7 @@ void Page::doAfterUpdateRendering()
         
         if (appHighlightStorage->hasUnrestoredHighlights() && MonotonicTime::now() - appHighlightStorage->lastRangeSearchTime() > 1_s) {
             appHighlightStorage->resetLastRangeSearchTime();
-            document.eventLoop().queueTask(TaskSource::InternalAsyncTask, [weakDocument = WeakPtr { document }] {
+            document.eventLoop().queueTask(TaskSource::InternalAsyncTask, [weakDocument = WeakPtr<Document, WeakPtrImplWithEventTargetData> { document }] {
                 RefPtr document { weakDocument.get() };
                 if (!document)
                     return;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1198,7 +1198,7 @@ private:
     WeakHashSet<ActivityStateChangeObserver> m_activityStateChangeObservers;
 
 #if ENABLE(SERVICE_WORKER)
-    WeakPtr<ServiceWorkerGlobalScope> m_serviceWorkerGlobalScope;
+    WeakPtr<ServiceWorkerGlobalScope, WeakPtrImplWithEventTargetData> m_serviceWorkerGlobalScope;
 #endif
 
 #if ENABLE(RESOURCE_USAGE)
@@ -1328,7 +1328,7 @@ private:
 
 #if ENABLE(IMAGE_ANALYSIS)
     using CachedTextRecognitionResult = std::pair<TextRecognitionResult, IntRect>;
-    WeakHashMap<HTMLElement, CachedTextRecognitionResult> m_textRecognitionResults;
+    WeakHashMap<HTMLElement, CachedTextRecognitionResult, WeakPtrImplWithEventTargetData> m_textRecognitionResults;
 #endif
 
 #if USE(ATSPI)

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -68,7 +68,7 @@ class ScriptExecutionContext;
 struct PerformanceMarkOptions;
 struct PerformanceMeasureOptions;
 
-class Performance final : public RefCounted<Performance>, public ContextDestructionObserver, public EventTargetWithInlineData {
+class Performance final : public RefCounted<Performance>, public ContextDestructionObserver, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(Performance);
 public:
     static Ref<Performance> create(ScriptExecutionContext* context, MonotonicTime timeOrigin) { return adoptRef(*new Performance(context, timeOrigin)); }

--- a/Source/WebCore/page/PointerLockController.h
+++ b/Source/WebCore/page/PointerLockController.h
@@ -71,8 +71,8 @@ private:
     bool m_unlockPending { false };
     bool m_forceCursorVisibleUponUnlock { false };
     RefPtr<Element> m_element;
-    WeakPtr<Document> m_documentOfRemovedElementWhileWaitingForUnlock;
-    WeakPtr<Document> m_documentAllowedToRelockWithoutUserGesture;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_documentOfRemovedElementWhileWaitingForUnlock;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_documentAllowedToRelockWithoutUserGesture;
 };
 
 inline void PointerLockController::elementWasRemoved(Element& element)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -171,7 +171,7 @@ private:
     bool isGoogleMaps() const;
 #endif
 
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 
     mutable std::optional<bool> m_hasBrokenEncryptedMediaAPISupportQuirk;
     mutable std::optional<bool> m_needsFullWidthHeightFullscreenStyleQuirk;

--- a/Source/WebCore/page/ResizeObservation.h
+++ b/Source/WebCore/page/ResizeObservation.h
@@ -71,7 +71,7 @@ private:
     BoxSizes computeObservedSizes() const;
     LayoutPoint computeTargetLocation() const;
 
-    WeakPtr<Element> m_target;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_target;
     BoxSizes m_lastObservationSizes;
     ResizeObserverBoxOptions m_observedBox;
 };

--- a/Source/WebCore/page/ResizeObserver.h
+++ b/Source/WebCore/page/ResizeObserver.h
@@ -78,7 +78,7 @@ private:
     void removeAllTargets();
     bool removeObservation(const Element&);
 
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     RefPtr<ResizeObserverCallback> m_callback;
     Vector<Ref<ResizeObservation>> m_observations;
 

--- a/Source/WebCore/page/UndoItem.h
+++ b/Source/WebCore/page/UndoItem.h
@@ -74,7 +74,7 @@ private:
     Ref<VoidCallback> m_undoHandler;
     Ref<VoidCallback> m_redoHandler;
     WeakPtr<UndoManager> m_undoManager;
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/VisualViewport.h
+++ b/Source/WebCore/page/VisualViewport.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-class VisualViewport final : public RefCounted<VisualViewport>, public EventTargetWithInlineData, public DOMWindowProperty {
+class VisualViewport final : public RefCounted<VisualViewport>, public EventTarget, public DOMWindowProperty {
     WTF_MAKE_ISO_ALLOCATED(VisualViewport);
 public:
     static Ref<VisualViewport> create(DOMWindow& window) { return adoptRef(*new VisualViewport(window)); }

--- a/Source/WebCore/page/ios/ContentChangeObserver.h
+++ b/Source/WebCore/page/ios/ContentChangeObserver.h
@@ -211,11 +211,11 @@ private:
     Document& m_document;
     Timer m_contentObservationTimer;
     WeakHashSet<const DOMTimer> m_DOMTimerList;
-    WeakHashSet<const Element> m_elementsWithTransition;
-    WeakHashSet<const Element> m_elementsWithDestroyedVisibleRenderer;
+    WeakHashSet<const Element, WeakPtrImplWithEventTargetData> m_elementsWithTransition;
+    WeakHashSet<const Element, WeakPtrImplWithEventTargetData> m_elementsWithDestroyedVisibleRenderer;
     WKContentChange m_observedContentState { WKContentNoChange };
-    WeakPtr<Element> m_hiddenTouchTargetElement;
-    WeakHashSet<Element> m_visibilityCandidateList;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_hiddenTouchTargetElement;
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_visibilityCandidateList;
     bool m_touchEventIsBeingDispatched { false };
     bool m_isWaitingForStyleRecalc { false };
     bool m_isInObservedStyleRecalc { false };

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -45,7 +45,7 @@ public:
 
 private:
     FrameView& m_frameView;
-    WeakPtr<Element> m_anchorElement;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_anchorElement;
     FloatPoint m_lastPositionForAnchorElement;
 };
 

--- a/Source/WebCore/page/scrolling/ScrollLatchingController.h
+++ b/Source/WebCore/page/scrolling/ScrollLatchingController.h
@@ -70,7 +70,7 @@ public:
 
 private:
     struct FrameState {
-        WeakPtr<Element> wheelEventElement;
+        WeakPtr<Element, WeakPtrImplWithEventTargetData> wheelEventElement;
         WeakPtr<ScrollableArea> scrollableArea;
         Frame* frame { nullptr };
         bool isOverWidget { false };

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -67,8 +67,9 @@ class ScrollView : public Widget, public ScrollableArea {
 public:
     virtual ~ScrollView();
 
-    using WeakValueType = Widget::WeakValueType;
     using Widget::weakPtrFactory;
+    using Widget::WeakValueType;
+    using Widget::WeakPtrImplType;
 
     // ScrollableArea functions.
     WEBCORE_EXPORT void setScrollOffset(const ScrollOffset&) final;

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -55,7 +55,9 @@ struct SameSizeAsScrollableArea {
     bool bytes[9];
 };
 
+#if CPU(ADDRESS64)
 static_assert(sizeof(ScrollableArea) == sizeof(SameSizeAsScrollableArea), "ScrollableArea should stay small");
+#endif
 
 ScrollableArea::ScrollableArea() = default;
 ScrollableArea::~ScrollableArea() = default;

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -54,6 +54,8 @@ public:
     static WEBCORE_EXPORT void providePresentingApplicationPID();
 
     using MediaSessionHelperClient::weakPtrFactory;
+    using MediaSessionHelperClient::WeakValueType;
+    using MediaSessionHelperClient::WeakPtrImplType;
 
 private:
     friend class PlatformMediaSessionManager;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -85,7 +85,8 @@ public:
     WTFLogChannel& logChannel() const final;
 
     using MediaStreamTrackPrivate::Observer::weakPtrFactory;
-    using WeakValueType = MediaStreamTrackPrivate::Observer::WeakValueType;
+    using MediaStreamTrackPrivate::Observer::WeakValueType;
+    using MediaStreamTrackPrivate::Observer::WeakPtrImplType;
 
 private:
     PlatformLayer* rootLayer() const;

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -102,7 +102,8 @@ private:
     void unobserveSource();
 
     using MediaStreamTrackPrivate::Observer::weakPtrFactory;
-    using WeakValueType = MediaStreamTrackPrivate::Observer::WeakValueType;
+    using MediaStreamTrackPrivate::Observer::WeakValueType;
+    using MediaStreamTrackPrivate::Observer::WeakPtrImplType;
 
     // Notifier API
     void RegisterObserver(webrtc::ObserverInterface*) final { }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -121,7 +121,9 @@ struct SameSizeAsRenderObject {
     unsigned m_bitfields;
 };
 
+#if CPU(ADDRESS64)
 static_assert(sizeof(RenderObject) == sizeof(SameSizeAsRenderObject), "RenderObject should stay small");
+#endif
 
 DEFINE_DEBUG_ONLY_GLOBAL(WTF::RefCountedLeakCounter, renderObjectCounter, ("RenderObject"));
 

--- a/Source/WebCore/rendering/svg/RenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResource.cpp
@@ -179,7 +179,7 @@ static void removeFromCacheAndInvalidateDependencies(RenderElement& renderer, bo
         if (auto* renderer = element->renderer()) {
             // We allow cycles in SVGDocumentExtensions reference sets in order to avoid expensive
             // reference graph adjustments on changes, so we need to break possible cycles here.
-            static NeverDestroyed<WeakHashSet<SVGElement>> invalidatingDependencies;
+            static NeverDestroyed<WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>> invalidatingDependencies;
             if (UNLIKELY(!invalidatingDependencies.get().add(element.get()).isNewEntry)) {
                 // Reference cycle: we are in process of invalidating this dependant.
                 continue;

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -48,6 +48,7 @@ namespace WebCore {
 class CSSStyleSheet;
 class Document;
 class Element;
+class WeakPtrImplWithEventTargetData;
 class HTMLSlotElement;
 class Node;
 class ProcessingInstruction;
@@ -201,9 +202,9 @@ private:
     // Sheets loaded using the @import directive are not included in this count.
     // We use this count of pending sheets to detect when we can begin attaching
     // elements and when it is safe to execute scripts.
-    WeakHashSet<const ProcessingInstruction> m_processingInstructionsWithPendingSheets;
-    WeakHashSet<const Element> m_elementsInHeadWithPendingSheets;
-    WeakHashSet<const Element> m_elementsInBodyWithPendingSheets;
+    WeakHashSet<const ProcessingInstruction, WeakPtrImplWithEventTargetData> m_processingInstructionsWithPendingSheets;
+    WeakHashSet<const Element, WeakPtrImplWithEventTargetData> m_elementsInHeadWithPendingSheets;
+    WeakHashSet<const Element, WeakPtrImplWithEventTargetData> m_elementsInBodyWithPendingSheets;
 
     ListHashSet<Node*> m_styleSheetCandidateNodes;
 
@@ -217,7 +218,7 @@ private:
     bool m_isUpdatingStyleResolver { false };
 
     std::optional<MediaQueryViewportState> m_viewportStateOnPreviousMediaQueryEvaluation;
-    WeakHashMap<Element, LayoutSize> m_queryContainerStates;
+    WeakHashMap<Element, LayoutSize, WeakPtrImplWithEventTargetData> m_queryContainerStates;
 
     // FIXME: These (and some things above) are only relevant for the root scope.
     HashMap<ResolverSharingKey, Ref<Resolver>> m_sharedShadowTreeResolvers;

--- a/Source/WebCore/svg/SVGDocumentExtensions.cpp
+++ b/Source/WebCore/svg/SVGDocumentExtensions.cpp
@@ -144,7 +144,7 @@ void SVGDocumentExtensions::addPendingResource(const AtomString& id, SVGElement&
     if (id.isEmpty())
         return;
 
-    auto result = m_pendingResources.add(id, WeakHashSet<SVGElement> { });
+    auto result = m_pendingResources.add(id, WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData> { });
     result.iterator->value.add(element);
 
     element.setHasPendingResources();

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -69,17 +69,17 @@ public:
     void clearTargetDependencies(SVGElement&);
     void rebuildAllElementReferencesForTarget(SVGElement&);
 
-    const WeakHashSet<SVGFontFaceElement>& svgFontFaceElements() const { return m_svgFontFaceElements; }
+    const WeakHashSet<SVGFontFaceElement, WeakPtrImplWithEventTargetData>& svgFontFaceElements() const { return m_svgFontFaceElements; }
     void registerSVGFontFaceElement(SVGFontFaceElement&);
     void unregisterSVGFontFaceElement(SVGFontFaceElement&);
 
 private:
     Document& m_document;
-    WeakHashSet<SVGSVGElement> m_timeContainers; // For SVG 1.2 support this will need to be made more general.
-    WeakHashSet<SVGFontFaceElement> m_svgFontFaceElements;
+    WeakHashSet<SVGSVGElement, WeakPtrImplWithEventTargetData> m_timeContainers; // For SVG 1.2 support this will need to be made more general.
+    WeakHashSet<SVGFontFaceElement, WeakPtrImplWithEventTargetData> m_svgFontFaceElements;
     MemoryCompactRobinHoodHashMap<AtomString, RenderSVGResourceContainer*> m_resources;
-    MemoryCompactRobinHoodHashMap<AtomString, WeakHashSet<SVGElement>> m_pendingResources; // Resources that are pending.
-    MemoryCompactRobinHoodHashMap<AtomString, WeakHashSet<SVGElement>> m_pendingResourcesForRemoval; // Resources that are pending and scheduled for removal.
+    MemoryCompactRobinHoodHashMap<AtomString, WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>> m_pendingResources; // Resources that are pending.
+    MemoryCompactRobinHoodHashMap<AtomString, WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>> m_pendingResourcesForRemoval; // Resources that are pending and scheduled for removal.
     std::unique_ptr<SVGResourcesCache> m_resourcesCache;
 
     Vector<Ref<SVGElement>> m_rebuildElements;
@@ -94,7 +94,7 @@ public:
     bool isPendingResource(SVGElement&, const AtomString& id) const;
     void clearHasPendingResourcesIfPossible(SVGElement&);
     void removeElementFromPendingResources(SVGElement&);
-    WeakHashSet<SVGElement> removePendingResource(const AtomString& id) { return m_pendingResources.take(id); }
+    WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData> removePendingResource(const AtomString& id) { return m_pendingResources.take(id); }
 
     // The following two functions are used for scheduling a pending resource to be removed.
     void markPendingResourcesForRemoval(const AtomString&);

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -312,10 +312,10 @@ SVGElement* SVGElement::viewportElement() const
     return nullptr;
 }
  
-const WeakHashSet<SVGElement>& SVGElement::instances() const
+const WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>& SVGElement::instances() const
 {
     if (!m_svgRareData) {
-        static NeverDestroyed<WeakHashSet<SVGElement>> emptyInstances;
+        static NeverDestroyed<WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>> emptyInstances;
         return emptyInstances;
     }
     return m_svgRareData->instances();

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -94,7 +94,7 @@ public:
     void updateSVGRendererForElementChange();
 
     // The instances of an element are clones made in shadow trees to implement <use>.
-    const WeakHashSet<SVGElement>& instances() const;
+    const WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>& instances() const;
 
     std::optional<FloatRect> getBoundingBox() const;
 
@@ -205,7 +205,7 @@ private:
 
     std::unique_ptr<SVGElementRareData> m_svgRareData;
 
-    WeakHashSet<SVGElement> m_elementsWithRelativeLengths;
+    WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData> m_elementsWithRelativeLengths;
 
     std::unique_ptr<SVGPropertyAnimatorFactory> m_propertyAnimatorFactory;
 

--- a/Source/WebCore/svg/SVGElementRareData.h
+++ b/Source/WebCore/svg/SVGElementRareData.h
@@ -44,17 +44,17 @@ public:
 
     void addInstance(SVGElement& element) { m_instances.add(element); }
     void removeInstance(SVGElement& element) { m_instances.remove(element); }
-    const WeakHashSet<SVGElement>& instances() const { return m_instances; }
+    const WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>& instances() const { return m_instances; }
 
     bool instanceUpdatesBlocked() const { return m_instancesUpdatesBlocked; }
     void setInstanceUpdatesBlocked(bool value) { m_instancesUpdatesBlocked = value; }
 
     void addReferencingElement(SVGElement& element) { m_referencingElements.add(element); }
     void removeReferencingElement(SVGElement& element) { m_referencingElements.remove(element); }
-    const WeakHashSet<SVGElement>& referencingElements() const { return m_referencingElements; }
-    WeakHashSet<SVGElement> takeReferencingElements() { return std::exchange(m_referencingElements, { }); }
+    const WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>& referencingElements() const { return m_referencingElements; }
+    WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData> takeReferencingElements() { return std::exchange(m_referencingElements, { }); }
     SVGElement* referenceTarget() const { return m_referenceTarget.get(); }
-    void setReferenceTarget(WeakPtr<SVGElement>&& element) { m_referenceTarget = WTFMove(element); }
+    void setReferenceTarget(WeakPtr<SVGElement, WeakPtrImplWithEventTargetData>&& element) { m_referenceTarget = WTFMove(element); }
 
     void addReferencingCSSClient(SVGResourceElementClient& client) { m_referencingCSSClients.add(client); }
     void removeReferencingCSSClient(SVGResourceElementClient& client) { m_referencingCSSClients.remove(client); }
@@ -89,13 +89,13 @@ public:
     void setNeedsOverrideComputedStyleUpdate() { m_needsOverrideComputedStyleUpdate = true; }
 
 private:
-    WeakHashSet<SVGElement> m_referencingElements;
-    WeakPtr<SVGElement> m_referenceTarget;
+    WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData> m_referencingElements;
+    WeakPtr<SVGElement, WeakPtrImplWithEventTargetData> m_referenceTarget;
 
     WeakHashSet<SVGResourceElementClient> m_referencingCSSClients;
 
-    WeakHashSet<SVGElement> m_instances;
-    WeakPtr<SVGElement> m_correspondingElement;
+    WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData> m_instances;
+    WeakPtr<SVGElement, WeakPtrImplWithEventTargetData> m_correspondingElement;
     bool m_instancesUpdatesBlocked : 1;
     bool m_useOverrideComputedStyle : 1;
     bool m_needsOverrideComputedStyleUpdate : 1;

--- a/Source/WebCore/svg/SVGFontFaceElement.h
+++ b/Source/WebCore/svg/SVGFontFaceElement.h
@@ -64,7 +64,7 @@ private:
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 
     Ref<StyleRuleFontFace> m_fontFaceRule;
-    WeakPtr<SVGFontElement> m_fontElement;
+    WeakPtr<SVGFontElement, WeakPtrImplWithEventTargetData> m_fontElement;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGViewElement.h
+++ b/Source/WebCore/svg/SVGViewElement.h
@@ -51,7 +51,7 @@ private:
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 
-    WeakPtr<SVGSVGElement> m_targetElement;
+    WeakPtr<SVGSVGElement, WeakPtrImplWithEventTargetData> m_targetElement;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGViewSpec.h
+++ b/Source/WebCore/svg/SVGViewSpec.h
@@ -46,14 +46,14 @@ public:
     String transformString() const { return m_transform->valueAsString(); }
     Ref<SVGTransformList>& transform() { return m_transform; }
 
-    const WeakPtr<SVGElement>& contextElementConcurrently() const { return m_contextElement; }
+    const WeakPtr<SVGElement, WeakPtrImplWithEventTargetData>& contextElementConcurrently() const { return m_contextElement; }
 
 private:
     explicit SVGViewSpec(SVGElement&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGViewSpec, SVGFitToViewBox>;
 
-    WeakPtr<SVGElement> m_contextElement;
+    WeakPtr<SVGElement, WeakPtrImplWithEventTargetData> m_contextElement;
     String m_viewTargetString;
     Ref<SVGTransformList> m_transform;
 };

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -1157,7 +1157,7 @@ bool SVGSMILElement::progress(SMILTime elapsed, SVGSMILElement& firstAnimation, 
 void SVGSMILElement::notifyDependentsIntervalChanged(NewOrExistingInterval newOrExisting)
 {
     ASSERT(m_intervalBegin.isFinite());
-    static NeverDestroyed<WeakHashSet<SVGSMILElement>> loopBreaker;
+    static NeverDestroyed<WeakHashSet<SVGSMILElement, WeakPtrImplWithEventTargetData>> loopBreaker;
     if (loopBreaker->contains(*this))
         return;
     loopBreaker->add(*this);

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -35,9 +35,9 @@ class ConditionEventListener;
 class SMILTimeContainer;
 class SVGSMILElement;
 
-template<typename T> class EventSender;
+template<typename T, typename Counter> class EventSender;
 
-using SMILEventSender = EventSender<SVGSMILElement>;
+using SMILEventSender = EventSender<SVGSMILElement, WeakPtrImplWithEventTargetData>;
 
 // This class implements SMIL interval timing model as needed for SVG animation.
 class SVGSMILElement : public SVGElement {
@@ -185,7 +185,7 @@ private:
 
     QualifiedName m_attributeName;
 
-    WeakPtr<SVGElement> m_targetElement;
+    WeakPtr<SVGElement, WeakPtrImplWithEventTargetData> m_targetElement;
 
     Vector<Condition> m_conditions;
     bool m_conditionsConnected;
@@ -193,7 +193,7 @@ private:
 
     bool m_isWaitingForFirstInterval;
 
-    WeakHashSet<SVGSMILElement> m_timeDependents;
+    WeakHashSet<SVGSMILElement, WeakPtrImplWithEventTargetData> m_timeDependents;
 
     // Instance time lists
     Vector<SMILTimeWithOrigin> m_beginTimes;

--- a/Source/WebCore/testing/WebXRTest.h
+++ b/Source/WebCore/testing/WebXRTest.h
@@ -54,7 +54,7 @@ public:
         std::optional<FakeXRRigidTransformInit> viewerOrigin;
     };
 
-    static Ref<WebXRTest> create(WeakPtr<WebXRSystem>&& system) { return adoptRef(*new WebXRTest(WTFMove(system))); }
+    static Ref<WebXRTest> create(WeakPtr<WebXRSystem, WeakPtrImplWithEventTargetData>&& system) { return adoptRef(*new WebXRTest(WTFMove(system))); }
     virtual ~WebXRTest();
 
     using WebFakeXRDevicePromise = DOMPromiseDeferred<IDLInterface<WebFakeXRDevice>>;
@@ -69,10 +69,10 @@ public:
     void disconnectAllDevices(DOMPromiseDeferred<void>&&);
 
 private:
-    WebXRTest(WeakPtr<WebXRSystem>&& system)
+    WebXRTest(WeakPtr<WebXRSystem, WeakPtrImplWithEventTargetData>&& system)
         : m_context(WTFMove(system)) { }
 
-    WeakPtr<WebXRSystem> m_context;
+    WeakPtr<WebXRSystem, WeakPtrImplWithEventTargetData> m_context;
     Vector<Ref<WebFakeXRDevice>> m_devices;
 };
 

--- a/Source/WebCore/workers/AbstractWorker.h
+++ b/Source/WebCore/workers/AbstractWorker.h
@@ -39,7 +39,7 @@ namespace WebCore {
 struct FetchOptions;
 struct WorkerOptions;
 
-class AbstractWorker : public RefCounted<AbstractWorker>, public EventTargetWithInlineData {
+class AbstractWorker : public RefCounted<AbstractWorker>, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(AbstractWorker);
 public:
     using RefCounted::ref;

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -92,8 +92,9 @@ public:
     void suspend() final;
     void resume() final;
 
-    using WeakValueType = EventTarget::WeakValueType;
     using EventTarget::weakPtrFactory;
+    using EventTarget::WeakValueType;
+    using EventTarget::WeakPtrImplType;
     WorkerStorageConnection& storageConnection();
     static void postFileSystemStorageTask(Function<void()>&&);
     WorkerFileSystemStorageConnection& getFileSystemStorageConnection(Ref<FileSystemStorageConnection>&&);

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
@@ -39,14 +39,15 @@ class WorkerInspectorController;
 class WorkerOrWorkletScriptController;
 class WorkerOrWorkletThread;
 
-class WorkerOrWorkletGlobalScope : public ScriptExecutionContext, public RefCounted<WorkerOrWorkletGlobalScope>, public EventTargetWithInlineData {
+class WorkerOrWorkletGlobalScope : public ScriptExecutionContext, public RefCounted<WorkerOrWorkletGlobalScope>, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(WorkerOrWorkletGlobalScope);
     WTF_MAKE_NONCOPYABLE(WorkerOrWorkletGlobalScope);
 public:
     virtual ~WorkerOrWorkletGlobalScope();
 
     using ScriptExecutionContext::weakPtrFactory;
-    using WeakValueType = ScriptExecutionContext::WeakValueType;
+    using ScriptExecutionContext::WeakValueType;
+    using ScriptExecutionContext::WeakPtrImplType;
 
     bool isClosing() const { return m_isClosing; }
     WorkerOrWorkletThread* workerOrWorkletThread() const { return m_thread; }

--- a/Source/WebCore/workers/WorkerRunLoop.h
+++ b/Source/WebCore/workers/WorkerRunLoop.h
@@ -37,6 +37,7 @@
 
 namespace WebCore {
 
+class WeakPtrImplWithEventTargetData;
 class ModePredicate;
 class WorkerOrWorkletGlobalScope;
 class WorkerSharedTimer;

--- a/Source/WebCore/workers/service/ServiceWorker.h
+++ b/Source/WebCore/workers/service/ServiceWorker.h
@@ -47,7 +47,7 @@ class SWClientConnection;
 
 struct StructuredSerializeOptions;
 
-class ServiceWorker final : public RefCounted<ServiceWorker>, public EventTargetWithInlineData, public ActiveDOMObject {
+class ServiceWorker final : public RefCounted<ServiceWorker>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(ServiceWorker);
 public:
     using State = ServiceWorkerState;

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -683,7 +683,7 @@ bool ServiceWorkerContainer::addEventListener(const AtomString& eventType, Ref<E
     if (eventListener->isAttribute() && eventType == eventNames().messageEvent)
         startMessages();
 
-    return EventTargetWithInlineData::addEventListener(eventType, WTFMove(eventListener), options);
+    return EventTarget::addEventListener(eventType, WTFMove(eventListener), options);
 }
 
 void ServiceWorkerContainer::enableNavigationPreload(ServiceWorkerRegistrationIdentifier identifier, VoidPromise&& promise)

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -54,7 +54,7 @@ enum class WorkerType : bool;
 
 template<typename IDLType> class DOMPromiseProxy;
 
-class ServiceWorkerContainer final : public EventTargetWithInlineData, public ActiveDOMObject, public ServiceWorkerJobClient {
+class ServiceWorkerContainer final : public EventTarget, public ActiveDOMObject, public ServiceWorkerJobClient {
     WTF_MAKE_NONCOPYABLE(ServiceWorkerContainer);
     WTF_MAKE_ISO_ALLOCATED(ServiceWorkerContainer);
 public:

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.h
@@ -51,7 +51,7 @@ class ServiceWorker;
 class ServiceWorkerContainer;
 class WebCoreOpaqueRoot;
 
-class ServiceWorkerRegistration final : public RefCounted<ServiceWorkerRegistration>, public Supplementable<ServiceWorkerRegistration>, public EventTargetWithInlineData, public ActiveDOMObject {
+class ServiceWorkerRegistration final : public RefCounted<ServiceWorkerRegistration>, public Supplementable<ServiceWorkerRegistration>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(ServiceWorkerRegistration, WEBCORE_EXPORT);
 public:
     static Ref<ServiceWorkerRegistration> getOrCreate(ScriptExecutionContext&, Ref<ServiceWorkerContainer>&&, ServiceWorkerRegistrationData&&);

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -117,7 +117,7 @@ private:
     String userAgent(const URL&) const final;
     const Settings::Values& settingsValues() const final { return m_settingsValues; }
 
-    WeakPtr<Document> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 
     Ref<SecurityOrigin> m_topOrigin;
 

--- a/Source/WebCore/xml/DOMParser.h
+++ b/Source/WebCore/xml/DOMParser.h
@@ -24,6 +24,7 @@
 namespace WebCore {
 
 class Document;
+class WeakPtrImplWithEventTargetData;
 class Settings;
 
 class DOMParser : public RefCounted<DOMParser> {
@@ -36,7 +37,7 @@ public:
 private:
     explicit DOMParser(Document& contextDocument);
 
-    WeakPtr<Document> m_contextDocument;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_contextDocument;
     const Ref<const Settings> m_settings;
 };
 

--- a/Source/WebCore/xml/XMLHttpRequestEventTarget.h
+++ b/Source/WebCore/xml/XMLHttpRequestEventTarget.h
@@ -29,8 +29,8 @@
 
 namespace WebCore {
 
-class XMLHttpRequestEventTarget : public EventTargetWithInlineData {
+class XMLHttpRequestEventTarget : public EventTarget {
 };
-static_assert(sizeof(XMLHttpRequestEventTarget) == sizeof(EventTargetWithInlineData));
+static_assert(sizeof(XMLHttpRequestEventTarget) == sizeof(EventTarget));
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -106,7 +106,7 @@ private:
 
     void clearXSLStylesheetDocument();
 
-    WeakPtr<Node> m_ownerNode;
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_ownerNode;
     String m_originalURL;
     URL m_finalURL;
     bool m_isDisabled { false };

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -124,7 +124,8 @@ public:
     virtual ~GPUConnectionToWebProcess();
 
     using WebCore::NowPlayingManager::Client::weakPtrFactory;
-    using WeakValueType = WebCore::NowPlayingManager::Client::WeakValueType;
+    using WebCore::NowPlayingManager::Client::WeakValueType;
+    using WebCore::NowPlayingManager::Client::WeakPtrImplType;
 
     IPC::Connection& connection() { return m_connection.get(); }
     IPC::MessageReceiverMap& messageReceiverMap() { return m_messageReceiverMap; }

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
@@ -58,7 +58,8 @@ public:
     void updatePresentingProcesses();
 
     using WebCore::AudioSession::InterruptionObserver::weakPtrFactory;
-    using WeakValueType = WebCore::AudioSession::InterruptionObserver::WeakValueType;
+    using WebCore::AudioSession::InterruptionObserver::WeakValueType;
+    using WebCore::AudioSession::InterruptionObserver::WeakPtrImplType;
 
 private:
     void beginAudioSessionInterruption() final;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
@@ -53,7 +53,8 @@ class RemoteCDMInstanceSessionProxy;
 class RemoteCDMInstanceProxy : public WebCore::CDMInstanceClient, private IPC::MessageReceiver  {
 public:
     using WebCore::CDMInstanceClient::weakPtrFactory;
-    using WeakValueType = WebCore::CDMInstanceClient::WeakValueType;
+    using WebCore::CDMInstanceClient::WeakValueType;
+    using WebCore::CDMInstanceClient::WeakPtrImplType;
 
     static std::unique_ptr<RemoteCDMInstanceProxy> create(RemoteCDMProxy&, Ref<WebCore::CDMInstance>&&, RemoteCDMInstanceIdentifier);
     ~RemoteCDMInstanceProxy();

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -65,7 +65,8 @@ public:
     void setShouldRegisterAsSpeakerSamplesProducer(bool);
 
     using WebCore::AudioSession::InterruptionObserver::weakPtrFactory;
-    using WeakValueType = WebCore::AudioSession::InterruptionObserver::WeakValueType;
+    using WebCore::AudioSession::InterruptionObserver::WeakValueType;
+    using WebCore::AudioSession::InterruptionObserver::WeakPtrImplType;
 
 private:
     void storageChanged(SharedMemory*, const WebCore::CAAudioStreamDescription&, size_t);

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -52,7 +52,8 @@ public:
     ~RemoteSampleBufferDisplayLayer();
 
     using WebCore::SampleBufferDisplayLayer::Client::weakPtrFactory;
-    using WeakValueType = WebCore::SampleBufferDisplayLayer::Client::WeakValueType;
+    using WebCore::SampleBufferDisplayLayer::Client::WeakValueType;
+    using WebCore::SampleBufferDisplayLayer::Client::WeakPtrImplType;
 
     using LayerInitializationCallback = CompletionHandler<void(std::optional<LayerHostingContextID>)>;
     void initialize(bool hideRootLayer, WebCore::IntSize, LayerInitializationCallback&&);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
@@ -66,6 +66,7 @@ public:
 
     using NetworkDataTask::weakPtrFactory;
     using NetworkDataTask::WeakValueType;
+    using NetworkDataTask::WeakPtrImplType;
 
 private:
     ServiceWorkerDownloadTask(NetworkSession&, NetworkDataTaskClient&, WebSWServerToContextConnection&, WebCore::ServiceWorkerIdentifier, WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier, const WebCore::ResourceRequest&, DownloadID);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -72,7 +72,8 @@ public:
     ~WebSWServerConnection() final;
 
     using WebCore::SWServer::Connection::weakPtrFactory;
-    using WeakValueType = WebCore::SWServer::Connection::WeakValueType;
+    using WebCore::SWServer::Connection::WeakValueType;
+    using WebCore::SWServer::Connection::WeakPtrImplType;
 
     IPC::Connection& ipcConnection() const { return m_contentConnection.get(); }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -481,7 +481,8 @@
         }
 
         using WebCore::MediaSessionCoordinatorClient::weakPtrFactory;
-        using WeakValueType = WebCore::MediaSessionCoordinatorClient::WeakValueType;
+        using WebCore::MediaSessionCoordinatorClient::WeakValueType;
+        using WebCore::MediaSessionCoordinatorClient::WeakPtrImplType;
 
     private:
         explicit WKMediaSessionCoordinatorForTesting(id <_WKMediaSessionCoordinator> clientCoordinator)

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
@@ -43,7 +43,8 @@ namespace WebKit {
 class NavigationSOAuthorizationSession : public SOAuthorizationSession, private WebViewDidMoveToWindowObserver {
 public:
     using SOAuthorizationSession::weakPtrFactory;
-    using WeakValueType = SOAuthorizationSession::WeakValueType;
+    using SOAuthorizationSession::WeakValueType;
+    using SOAuthorizationSession::WeakPtrImplType;
 
     ~NavigationSOAuthorizationSession();
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
@@ -39,7 +39,8 @@ class SubFrameSOAuthorizationSession final : public NavigationSOAuthorizationSes
 public:
     using Callback = CompletionHandler<void(bool)>;
     using SOAuthorizationSession::weakPtrFactory;
-    using WeakValueType = SOAuthorizationSession::WeakValueType;
+    using SOAuthorizationSession::WeakValueType;
+    using SOAuthorizationSession::WeakPtrImplType;
 
     static Ref<SOAuthorizationSession> create(Ref<API::NavigationAction>&&, WebPageProxy&, Callback&&, WebCore::FrameIdentifier);
 

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
@@ -55,7 +55,8 @@ public:
     void setTrack(const String&, CompletionHandler<void(bool)>&&);
 
     using MediaSessionCoordinatorClient::weakPtrFactory;
-    using WeakValueType = MediaSessionCoordinatorClient::WeakValueType;
+    using MediaSessionCoordinatorClient::WeakValueType;
+    using MediaSessionCoordinatorClient::WeakPtrImplType;
 
 private:
     explicit RemoteMediaSessionCoordinatorProxy(WebPageProxy&, Ref<MediaSessionCoordinatorProxyPrivate>&&);

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -56,7 +56,8 @@ public:
     using TransportSet = HashSet<WebCore::AuthenticatorTransport, WTF::IntHash<WebCore::AuthenticatorTransport>, WTF::StrongEnumHashTraits<WebCore::AuthenticatorTransport>>;
 
     using AuthenticatorTransportService::Observer::weakPtrFactory;
-    using WeakValueType = AuthenticatorTransportService::Observer::WeakValueType;
+    using AuthenticatorTransportService::Observer::WeakValueType;
+    using AuthenticatorTransportService::Observer::WeakPtrImplType;
 
     const static size_t maxTransportNumber;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -472,7 +472,8 @@ public:
     virtual ~WebPageProxy();
 
     using IPC::MessageReceiver::weakPtrFactory;
-    using WeakValueType = IPC::MessageReceiver::WeakValueType;
+    using IPC::MessageReceiver::WeakValueType;
+    using IPC::MessageReceiver::WeakPtrImplType;
 
     static void forMostVisibleWebPageIfAny(PAL::SessionID, const WebCore::SecurityOriginData&, CompletionHandler<void(WebPageProxy*)>&&);
 

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -51,7 +51,8 @@ public:
     virtual ~PlatformXRSystem();
 
     using PlatformXRCoordinator::SessionEventClient::weakPtrFactory;
-    using WeakValueType = PlatformXRCoordinator::SessionEventClient::WeakValueType;
+    using PlatformXRCoordinator::SessionEventClient::WeakValueType;
+    using PlatformXRCoordinator::SessionEventClient::WeakPtrImplType;
 
     void invalidate();
 

--- a/Source/WebKit/WebProcess/Automation/WebAutomationDOMWindowObserver.h
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationDOMWindowObserver.h
@@ -52,7 +52,7 @@ public:
 private:
     WebAutomationDOMWindowObserver(WebCore::DOMWindow&, WTF::Function<void(WebAutomationDOMWindowObserver&)>&&);
 
-    WeakPtr<WebCore::DOMWindow> m_window;
+    WeakPtr<WebCore::DOMWindow, WebCore::WeakPtrImplWithEventTargetData> m_window;
     bool m_wasDetached { false };
     WTF::Function<void(WebAutomationDOMWindowObserver&)> m_callback;
 };

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -44,6 +44,7 @@ class Decoder;
 namespace WebCore {
 class IntRect;
 class Element;
+class WeakPtrImplWithEventTargetData;
 class GraphicsLayer;
 class HTMLVideoElement;
 }
@@ -114,7 +115,7 @@ private:
     void updateMainVideoElement();
     void setMainVideoElement(RefPtr<WebCore::HTMLVideoElement>&&);
 
-    WeakPtr<WebCore::HTMLVideoElement> m_mainVideoElement;
+    WeakPtr<WebCore::HTMLVideoElement, WebCore::WeakPtrImplWithEventTargetData> m_mainVideoElement;
     RunLoop::Timer<WebFullScreenManager> m_mainVideoElementTextRecognitionTimer;
     bool m_isPerformingTextRecognitionInMainVideo { false };
 #endif // ENABLE(VIDEO)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -73,7 +73,8 @@ public:
     ~RemoteRenderingBackendProxy();
 
     using GPUProcessConnection::Client::weakPtrFactory;
-    using WeakValueType = GPUProcessConnection::Client::WeakValueType;
+    using GPUProcessConnection::Client::WeakValueType;
+    using GPUProcessConnection::Client::WeakPtrImplType;
 
     RemoteResourceCacheProxy& remoteResourceCacheProxy() { return m_remoteResourceCacheProxy; }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
@@ -48,7 +48,8 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
     using GPUProcessConnection::Client::weakPtrFactory;
-    using WeakValueType = GPUProcessConnection::Client::WeakValueType;
+    using GPUProcessConnection::Client::WeakValueType;
+    using GPUProcessConnection::Client::WeakPtrImplType;
 
 private:
     SampleBufferDisplayLayer(SampleBufferDisplayLayerManager&, WebCore::SampleBufferDisplayLayer::Client&);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/DOMObjectCache.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/DOMObjectCache.cpp
@@ -132,7 +132,7 @@ private:
             m_frameObserver.willDetachGlobalObjectFromFrame();
         }
 
-        WeakPtr<WebCore::DOMWindow> m_window;
+        WeakPtr<WebCore::DOMWindow, WebCore::WeakPtrImplWithEventTargetData> m_window;
         DOMObjectCacheFrameObserver& m_frameObserver;
     };
 

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
@@ -44,7 +44,8 @@ class UserMediaPermissionRequestManager : public WebCore::MediaCanStartListener
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using WebCore::MediaCanStartListener::weakPtrFactory;
-    using WeakValueType = WebCore::MediaCanStartListener::WeakValueType;
+    using WebCore::MediaCanStartListener::WeakValueType;
+    using WebCore::MediaCanStartListener::WeakPtrImplType;
 
     explicit UserMediaPermissionRequestManager(WebPage&);
     ~UserMediaPermissionRequestManager() = default;

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.h
@@ -42,6 +42,10 @@ class Connection;
 class Decoder;
 }
 
+namespace WebCore {
+class WeakPtrImplWithEventTargetData;
+}
+
 namespace WebKit {
 
 class WebSocketChannel : public IPC::MessageSender, public IPC::MessageReceiver, public WebCore::ThreadableWebSocketChannel, public RefCounted<WebSocketChannel> {
@@ -104,7 +108,7 @@ private:
     WebCore::ResourceRequest clientHandshakeRequest(const CookieGetter&) const final { return m_handshakeRequest; }
     const WebCore::ResourceResponse& serverHandshakeResponse() const final { return m_handshakeResponse; }
 
-    WeakPtr<WebCore::Document> m_document;
+    WeakPtr<WebCore::Document, WebCore::WeakPtrImplWithEventTargetData> m_document;
     WeakPtr<WebCore::WebSocketChannelClient> m_client;
     URL m_url;
     String m_subprotocol;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -162,12 +162,12 @@ static const uint32_t nonLinearizedPDFSentinel = std::numeric_limits<uint32_t>::
     PDFLayerController *_pdfLayerController;
     WeakObjCPtr<NSObject> _parent;
     WebKit::PDFPlugin* _pdfPlugin;
-    WeakPtr<WebCore::HTMLPlugInElement> _pluginElement;
+    WeakPtr<WebCore::HTMLPlugInElement, WebCore::WeakPtrImplWithEventTargetData> _pluginElement;
 }
 
 @property (assign) PDFLayerController *pdfLayerController;
 @property (assign) WebKit::PDFPlugin* pdfPlugin;
-@property (assign) WeakPtr<WebCore::HTMLPlugInElement> pluginElement;
+@property (assign) WeakPtr<WebCore::HTMLPlugInElement, WebCore::WeakPtrImplWithEventTargetData> pluginElement;
 
 - (id)initWithPDFPlugin:(WebKit::PDFPlugin *)plugin andElement:(WebCore::HTMLPlugInElement *)element;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -191,6 +191,7 @@ class CachedPage;
 class CaptureDevice;
 class DocumentLoader;
 class DragData;
+class WeakPtrImplWithEventTargetData;
 class FontAttributeChanges;
 class FontChanges;
 class Frame;
@@ -2504,7 +2505,7 @@ private:
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS)
-    Vector<std::pair<WeakPtr<WebCore::HTMLElement>, Vector<CompletionHandler<void(RefPtr<WebCore::Element>&&)>>>> m_elementsPendingTextRecognition;
+    Vector<std::pair<WeakPtr<WebCore::HTMLElement, WebCore::WeakPtrImplWithEventTargetData>, Vector<CompletionHandler<void(RefPtr<WebCore::Element>&&)>>>> m_elementsPendingTextRecognition;
 #endif
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
@@ -2516,7 +2517,7 @@ private:
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    WeakHashSet<WebCore::HTMLImageElement> m_elementsToExcludeFromRemoveBackground;
+    WeakHashSet<WebCore::HTMLImageElement, WebCore::WeakPtrImplWithEventTargetData> m_elementsToExcludeFromRemoveBackground;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -828,7 +828,7 @@ void WebPage::didFinishContentChangeObserving(WKContentChange observedContentCha
     LOG_WITH_STREAM(ContentObservation, stream << "didFinishContentChangeObserving: pending target node(" << m_pendingSyntheticClickNode << ")");
     if (!m_pendingSyntheticClickNode)
         return;
-    callOnMainRunLoop([protectedThis = Ref { *this }, targetNode = Ref<Node>(*m_pendingSyntheticClickNode), originalDocument = WeakPtr { m_pendingSyntheticClickNode->document() }, observedContentChange, location = m_pendingSyntheticClickLocation, modifiers = m_pendingSyntheticClickModifiers, pointerId = m_pendingSyntheticClickPointerId] {
+    callOnMainRunLoop([protectedThis = Ref { *this }, targetNode = Ref<Node>(*m_pendingSyntheticClickNode), originalDocument = WeakPtr<Document, WeakPtrImplWithEventTargetData> { m_pendingSyntheticClickNode->document() }, observedContentChange, location = m_pendingSyntheticClickLocation, modifiers = m_pendingSyntheticClickModifiers, pointerId = m_pendingSyntheticClickPointerId] {
         if (protectedThis->m_isClosed || !protectedThis->corePage())
             return;
         if (!originalDocument || &targetNode->document() != originalDocument)

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
@@ -177,7 +177,7 @@ protected:
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;
     PlaybackSessionContextIdentifier m_controlsManagerContextId;
     HashMap<PlaybackSessionContextIdentifier, int> m_clientCounts;
-    WeakPtr<WebCore::HTMLVideoElement> m_videoElementInPictureInPicture;
+    WeakPtr<WebCore::HTMLVideoElement, WebCore::WeakPtrImplWithEventTargetData> m_videoElementInPictureInPicture;
     bool m_currentlyInFullscreen { false };
 };
 

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -33,16 +33,29 @@ namespace TestWebKitAPI {
 
 static unsigned s_baseWeakReferences = 0;
 
-struct WeakPtrCounter {
+class WeakPtrImplWithCounter final : public WTF::WeakPtrImplBase<WeakPtrImplWithCounter> {
+public:
+    template<typename T>
+    WeakPtrImplWithCounter(T* ptr)
+        : WTF::WeakPtrImplBase<WeakPtrImplWithCounter>(ptr)
+    {
+        increment();
+    }
+
+    ~WeakPtrImplWithCounter()
+    {
+        decrement();
+    }
+
     static void increment() { ++s_baseWeakReferences; }
     static void decrement() { --s_baseWeakReferences; }
 };
 
-template<typename T> using CanMakeWeakPtr = WTF::CanMakeWeakPtr<T, WeakPtrFactoryInitialization::Lazy, WeakPtrCounter>;
-template<typename T, typename U> using WeakHashMap = WTF::WeakHashMap<T, U, WeakPtrCounter>;
-template<typename T> using WeakHashSet = WTF::WeakHashSet<T, WeakPtrCounter>;
-template<typename T> using WeakPtr = WTF::WeakPtr<T, WeakPtrCounter>;
-template<typename T> using WeakPtrFactory = WTF::WeakPtrFactory<T, WeakPtrCounter>;
+template<typename T> using CanMakeWeakPtr = WTF::CanMakeWeakPtr<T, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithCounter>;
+template<typename T, typename U> using WeakHashMap = WTF::WeakHashMap<T, U, WeakPtrImplWithCounter>;
+template<typename T> using WeakHashSet = WTF::WeakHashSet<T, WeakPtrImplWithCounter>;
+template<typename T> using WeakPtr = WTF::WeakPtr<T, WeakPtrImplWithCounter>;
+template<typename T> using WeakPtrFactory = WTF::WeakPtrFactory<T, WeakPtrImplWithCounter>;
 
 // FIXME: Drop when we support C++20. C++17 does not support template parameter deduction for aliases and WeakPtr is an alias in this file.
 template<typename T, typename = std::enable_if_t<!WTF::IsSmartPtr<T>::value>> inline auto makeWeakPtr(T& object, EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes)


### PR DESCRIPTION
#### d0b2d6ef6a62c77b5b799d332dc2511573931ab8
<pre>
EventTarget should hold EventTargetData in WeakPtrImpl
<a href="https://bugs.webkit.org/show_bug.cgi?id=244710">https://bugs.webkit.org/show_bug.cgi?id=244710</a>

Reviewed by Ryosuke Niwa.

This patch integrates EventTargetData into WeakPtrImpl so that we remove HashMap based side data in Node.
Now, we make WeakPtr&apos;s WeakPtrImpl customizable. For EventTarget, we use WeakPtrImplWithEventTargetData, which embed EventTargetData.
The benefit of this design is that (1) we do not increase sizeof(Node), (2) unifying the location of EventTargetData for all
EventTarget derived classes so we remove virtual function calls for eventTargetData(), and (3) removing HashMap lookup for Node&apos;s EventTargetData,
it is not only slow but also memory consuming and involving costly locking. This new design deploys WTF::storeStoreFence
at the right timing so that we can drop this lock completely.

We also use CompactRefPtrTuple in WeakPtrFactory so we migrate some of flags from Node to WeakPtrFactory&apos;s bitfields.
This includes HasEventTargetData which can tell us that info quickly. We should have this flag separately from WeakPtrFactory&apos;s
WeakPtrImpl&apos;s pointer&apos;s null check because we have many fast path which skips event related thing if HasEventTargetData is false.
We would like to keep this fast path working even if we create WeakPtr for this EventTarget class.

A/B test ensured that this offers 0.37% Speedometer2.1 progression with 98% confidence on AppleSilicon.

* Source/WTF/wtf/WeakHashMap.h:
* Source/WTF/wtf/WeakHashSet.h:
(WTF::copyToVector):
* Source/WTF/wtf/WeakPtr.h:
(WTF::EmptyCounter::increment):
(WTF::EmptyCounter::decrement):
(WTF::WeakPtrImpl::~WeakPtrImpl):
(WTF::WeakPtrImpl::counter):
(WTF::WeakPtrImpl::counter const):
(WTF::WeakPtrImpl::WeakPtrImpl):
(WTF::WeakPtr::implForObject):
(WTF::WeakPtrFactory::~WeakPtrFactory):
(WTF::WeakPtrFactory::counter):
(WTF::WeakPtrFactory::counter const):
(WTF::WeakPtrFactory::initializeIfNeeded const):
(WTF::WeakPtrFactory::createWeakPtr const):
(WTF::WeakPtrFactory::revokeAll):
(WTF::WeakPtrFactory::weakPtrCount const):
(WTF::WeakPtrFactory::isInitialized const):
(WTF::WeakPtrFactory::bitfield const):
(WTF::WeakPtrFactory::setBitfield const):
* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/applepay/ApplePaySession.h:
* Source/WebCore/Modules/applepay/PaymentCoordinator.cpp:
(WebCore::PaymentCoordinator::canMakePaymentsWithActiveCard):
* Source/WebCore/Modules/async-clipboard/Clipboard.h:
* Source/WebCore/Modules/async-clipboard/ClipboardItem.h:
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::CredentialsContainer):
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h:
(WebCore::CredentialsContainer::create):
* Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp:
(WebCore::NavigatorCredentials::credentials):
* Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::generateRequest):
(WebCore::MediaKeySession::load):
(WebCore::MediaKeySession::update):
(WebCore::MediaKeySession::close):
(WebCore::MediaKeySession::remove):
(WebCore::MediaKeySession::stop):
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp:
(WebCore::MediaKeySystemAccess::createMediaKeys):
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.h:
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h:
* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::GamepadManager::platformGamepadDisconnected):
(WebCore::GamepadManager::makeGamepadVisible):
* Source/WebCore/Modules/highlight/AppHighlightStorage.h:
* Source/WebCore/Modules/indexeddb/IDBCursor.h:
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
(WebCore::IDBDatabase::dispatchEvent):
* Source/WebCore/Modules/indexeddb/IDBDatabase.h:
* Source/WebCore/Modules/indexeddb/IDBRequest.h:
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h:
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h:
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediasource/SourceBufferList.h:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::addEventListener):
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/RTCDTMFSender.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.h:
* Source/WebCore/Modules/mediastream/RTCIceTransport.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
(WebCore::processFrame):
(WebCore::transformFrame):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.h:
* Source/WebCore/Modules/mediastream/RTCRtpSender.h:
* Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h:
* Source/WebCore/Modules/mediastream/RTCSctpTransport.h:
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.h:
* Source/WebCore/Modules/paymentrequest/PaymentResponse.h:
* Source/WebCore/Modules/permissions/PermissionStatus.h:
* Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h:
* Source/WebCore/Modules/plugins/YouTubePluginReplacement.h:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:
* Source/WebCore/Modules/speech/SpeechRecognition.h:
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
* Source/WebCore/Modules/storage/WorkerStorageConnection.h:
* Source/WebCore/Modules/webaudio/AudioNode.cpp:
(WebCore::AudioNode::context):
(WebCore::AudioNode::context const):
* Source/WebCore/Modules/webaudio/AudioNode.h:
* Source/WebCore/Modules/webaudio/AudioSummingJunction.h:
* Source/WebCore/Modules/webaudio/AudioWorklet.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
* Source/WebCore/Modules/websockets/WebSocket.h:
* Source/WebCore/Modules/websockets/WebSocketChannel.h:
* Source/WebCore/Modules/websockets/WebSocketChannelInspector.h:
* Source/WebCore/Modules/webxr/WebXRLayer.h:
* Source/WebCore/Modules/webxr/WebXRRenderState.h:
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSpace.h:
* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::filterWeakHashSetForRemoval):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityListBoxOption.h:
* Source/WebCore/accessibility/AccessibilityMenuListOption.h:
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/animation/AnimationEffect.h:
* Source/WebCore/animation/AnimationTimeline.h:
* Source/WebCore/animation/DeclarativeAnimation.h:
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/bindings/js/JSLazyEventListener.cpp:
* Source/WebCore/bindings/js/JSLazyEventListener.h:
* Source/WebCore/css/CSSCursorImageValue.h:
* Source/WebCore/css/CSSFontFaceSource.h:
* Source/WebCore/css/CSSFontFaceSrcValue.h:
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/css/MediaQueryEvaluator.h:
* Source/WebCore/css/MediaQueryList.h:
* Source/WebCore/css/MediaQueryMatcher.h:
* Source/WebCore/css/StyleSheetList.h:
* Source/WebCore/css/typedom/CSSStyleImageValue.h:
* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::signalFollow):
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/Attr.h:
* Source/WebCore/dom/BroadcastChannel.cpp:
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::buildAccessKeyCache):
(WebCore::Document::determineActiveThemeColorMetaElement):
(WebCore::Document::didLogMessage):
(WebCore::Document::navigateFromServiceWorker):
(WebCore::Document::didRejectSyncXHRDuringPageDismissal):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentParser.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setElementAttribute):
(WebCore::Element::setElementsArrayAttribute):
(WebCore::elementIdentifiersMap):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementInternals.h:
* Source/WebCore/dom/EventListenerMap.h:
(WebCore::EventListenerMap::clearEntriesForTearDown):
* Source/WebCore/dom/EventSender.h:
(WebCore::Counter&gt;::EventSender):
(WebCore::Counter&gt;::dispatchEventSoon):
(WebCore::Counter&gt;::cancelEvent):
(WebCore::Counter&gt;::dispatchPendingEvents):
(WebCore::EventSender&lt;T&gt;::EventSender): Deleted.
(WebCore::EventSender&lt;T&gt;::dispatchEventSoon): Deleted.
(WebCore::EventSender&lt;T&gt;::cancelEvent): Deleted.
(WebCore::EventSender&lt;T&gt;::dispatchPendingEvents): Deleted.
* Source/WebCore/dom/EventTarget.cpp:
* Source/WebCore/dom/EventTarget.h:
(WebCore::EventTargetData::clear):
(WebCore::EventTargetCounter::increment):
(WebCore::EventTargetCounter::decrement):
(WebCore::EventTarget::eventTargetData const):
(WebCore::EventTarget::eventTargetData):
(WebCore::EventTarget::eventTargetDataConcurrently):
(WebCore::EventTarget::hasEventTargetData const):
(WebCore::EventTarget::setHasEventTargetData const):
(WebCore::EventTarget::ensureEventTargetData):
(): Deleted.
* Source/WebCore/dom/EventTargetConcrete.h:
* Source/WebCore/dom/IdleCallbackController.h:
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::addEventListener):
(WebCore::MessagePort::removeEventListener):
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::liveNodeSet):
(WebCore::ignoreSet):
(WebCore::Node::clearEventTargetData):
(WebCore::eventTargetDataMap): Deleted.
(WebCore::Node::eventTargetData): Deleted.
(WebCore::Node::eventTargetDataConcurrently): Deleted.
(WebCore::Node::ensureEventTargetData): Deleted.
* Source/WebCore/dom/Node.h:
(WebCore::Node::hasEventTargetData const): Deleted.
(WebCore::Node::setHasEventTargetData): Deleted.
* Source/WebCore/dom/NodeRareData.cpp:
* Source/WebCore/dom/NodeRareData.h:
* Source/WebCore/dom/PseudoElement.h:
* Source/WebCore/dom/RadioButtonGroups.cpp:
* Source/WebCore/dom/ScriptedAnimationController.h:
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::slotManualAssignmentDidChange):
(WebCore::ShadowRoot::assignedNodesForSlot):
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::NamedSlotAssignment::slotManualAssignmentDidChange):
(WebCore::NamedSlotAssignment::assignedNodesForSlot):
(WebCore::effectiveAssignedNodes):
(WebCore::ManualSlotAssignment::assignedNodesForSlot):
(WebCore::ManualSlotAssignment::slotManualAssignmentDidChange):
* Source/WebCore/dom/SlotAssignment.h:
* Source/WebCore/dom/TemplateContentDocumentFragment.h:
* Source/WebCore/dom/UserGestureIndicator.h:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::containsEndpoints):
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/editing/TextManipulationController.h:
* Source/WebCore/fileapi/FileReader.h:
* Source/WebCore/html/FormAssociatedElement.h:
* Source/WebCore/html/FormController.cpp:
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::rootEditableElementMap):
* Source/WebCore/html/HTMLDetailsElement.h:
* Source/WebCore/html/HTMLDialogElement.h:
* Source/WebCore/html/HTMLFieldSetElement.h:
* Source/WebCore/html/HTMLFormControlsCollection.cpp:
(WebCore::findFormAssociatedElement):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::unsafeAssociatedElements const):
* Source/WebCore/html/HTMLFormElement.h:
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLInputElement.cpp:
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::updateActiveTextTrackCues):
(WebCore::HTMLMediaElement::speakCueText):
(WebCore::HTMLMediaElement::progressEventTimerFired):
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::HTMLSlotElement::assignedNodes const):
(WebCore::HTMLSlotElement::assign):
* Source/WebCore/html/HTMLSlotElement.h:
* Source/WebCore/html/HTMLStyleElement.h:
* Source/WebCore/html/ImageDocument.h:
* Source/WebCore/html/InputType.h:
* Source/WebCore/html/MediaController.h:
* Source/WebCore/html/MediaDocument.cpp:
* Source/WebCore/html/ModelDocument.cpp:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::DetachedOffscreenCanvas::takePlaceholderCanvas):
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/PluginDocument.cpp:
* Source/WebCore/html/ValidationMessage.h:
* Source/WebCore/html/parser/HTMLScriptRunner.h:
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h:
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/html/track/TrackBase.h:
* Source/WebCore/html/track/TrackListBase.h:
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::removeGridOverlayForNode):
(WebCore::InspectorOverlay::removeFlexOverlayForNode):
* Source/WebCore/inspector/InspectorOverlay.h:
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::enable):
* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::preconnectIfNeeded):
* Source/WebCore/loader/MediaResourceLoader.h:
* Source/WebCore/loader/appcache/ApplicationCacheHost.h:
* Source/WebCore/loader/appcache/DOMApplicationCache.h:
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Source/WebCore/page/AbstractDOMWindow.h:
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::windowsInterestedInStorageEvents):
* Source/WebCore/page/DOMWindowExtension.h:
* Source/WebCore/page/DOMWindowProperty.h:
* Source/WebCore/page/EventSource.h:
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/ImageAnalysisQueue.h:
* Source/WebCore/page/ImageOverlayController.h:
* Source/WebCore/page/IntersectionObserver.h:
(WebCore::IntersectionObserver::observationTargets const):
* Source/WebCore/page/ModalContainerObserver.cpp:
(WebCore::ModalContainerObserver::collectClickableElementsTimerFired):
(WebCore::ModalContainerObserver::collectClickableElements):
* Source/WebCore/page/ModalContainerObserver.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):
(WebCore::Page::doAfterUpdateRendering):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/Performance.h:
* Source/WebCore/page/PointerLockController.h:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/ResizeObservation.h:
* Source/WebCore/page/ResizeObserver.h:
* Source/WebCore/page/UndoItem.h:
* Source/WebCore/page/VisualViewport.h:
* Source/WebCore/page/ios/ContentChangeObserver.h:
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
* Source/WebCore/page/scrolling/ScrollLatchingController.h:
* Source/WebCore/rendering/svg/RenderSVGResource.cpp:
(WebCore::removeFromCacheAndInvalidateDependencies):
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/svg/SVGDocumentExtensions.cpp:
(WebCore::SVGDocumentExtensions::addPendingResource):
* Source/WebCore/svg/SVGDocumentExtensions.h:
(WebCore::SVGDocumentExtensions::svgFontFaceElements const):
(WebCore::SVGDocumentExtensions::removePendingResource):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::instances const):
* Source/WebCore/svg/SVGElement.h:
* Source/WebCore/svg/SVGElementRareData.h:
(WebCore::SVGElementRareData::instances const):
(WebCore::SVGElementRareData::referencingElements const):
(WebCore::SVGElementRareData::takeReferencingElements):
(WebCore::SVGElementRareData::setReferenceTarget):
* Source/WebCore/svg/SVGFontFaceElement.h:
* Source/WebCore/svg/SVGViewElement.h:
* Source/WebCore/svg/SVGViewSpec.h:
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::notifyDependentsIntervalChanged):
* Source/WebCore/svg/animation/SVGSMILElement.h:
* Source/WebCore/testing/WebXRTest.h:
* Source/WebCore/workers/AbstractWorker.h:
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.h:
* Source/WebCore/workers/WorkerRunLoop.h:
* Source/WebCore/workers/service/ServiceWorker.h:
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::addEventListener):
* Source/WebCore/workers/service/ServiceWorkerContainer.h:
* Source/WebCore/workers/service/ServiceWorkerRegistration.h:
* Source/WebCore/worklets/WorkletGlobalScope.h:
* Source/WebCore/xml/DOMParser.h:
* Source/WebCore/xml/XMLHttpRequestEventTarget.h:
* Source/WebCore/xml/XSLStyleSheet.h:
* Source/WebKit/WebProcess/Automation/WebAutomationDOMWindowObserver.h:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/DOMObjectCache.cpp:
* Source/WebKit/WebProcess/Network/WebSocketChannel.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h:

Canonical link: <a href="https://commits.webkit.org/254173@main">https://commits.webkit.org/254173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a7f1af6bc47544ff716bbd4739f3f74e0a47d1b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88307 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97502 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152968 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31190 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26869 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80503 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92158 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24846 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75117 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24823 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67789 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/80043 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28778 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73802 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28778 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14855 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26184 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2930 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37766 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76654 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33990 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17009 "Passed tests") | 
<!--EWS-Status-Bubble-End-->