### PR TITLE
Move out of OnTrack/OnRemoveTrack libwebrtc callbacks

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-rollback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-rollback-expected.txt
@@ -17,7 +17,7 @@ PASS rollback of a local offer to negotiated stable state should enable applying
 PASS rollback a local offer with audio direction change to negotiated stable state and then add video receiver
 PASS two transceivers with same mids
 PASS onremovetrack fires during remote rollback
-FAIL rollback of a remote offer with stream changes assert_equals: expected 2 but got 1
+PASS rollback of a remote offer with stream changes
 PASS removeTrack() with a sender being rolled back does not crash or throw
 PASS Implicit rollback with only a datachannel works
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpSender-setStreams.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpSender-setStreams.https-expected.txt
@@ -1,9 +1,7 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS setStreams causes streams to be reported via ontrack on callee
 PASS setStreams can be used to reconstruct a stream with a track on the remote side
 PASS Adding streams and changing direction causes new streams to be reported via ontrack on callee
-TIMEOUT Adding streams to an active transceiver causes new streams to be reported via ontrack on callee Test timed out
+PASS Adding streams to an active transceiver causes new streams to be reported via ontrack on callee
 PASS setStreams() fires InvalidStateError on a closed peer connection.
 

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -78,6 +78,9 @@ public:
 
     RefPtr<MediaStream> clone();
 
+    using WeakValueType = MediaStreamPrivate::Observer::WeakValueType;
+    using MediaStreamPrivate::Observer::weakPtrFactory;
+
     bool active() const { return m_isActive; }
     bool muted() const { return m_private->muted(); }
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -162,6 +162,8 @@ public:
     const void* logIdentifier() const final { return m_private->logIdentifier(); }
 #endif
 
+    void setShouldFireMuteEventImmediately(bool value) { m_shouldFireMuteEventImmediately = value; }
+
 protected:
     MediaStreamTrack(ScriptExecutionContext&, Ref<MediaStreamTrackPrivate>&&);
 
@@ -211,6 +213,7 @@ private:
     bool m_ended { false };
     const bool m_isCaptureTrack { false };
     bool m_isInterrupted { false };
+    bool m_shouldFireMuteEventImmediately { false };
 };
 
 typedef Vector<Ref<MediaStreamTrack>> MediaStreamTrackVector;

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -182,25 +182,113 @@ void PeerConnectionBackend::setLocalDescription(const RTCSessionDescription* ses
 {
     ASSERT(!m_peerConnection.isClosed());
 
+    m_isProcessingLocalDescriptionAnswer = sessionDescription && (sessionDescription->type() == RTCSdpType::Answer || sessionDescription->type() == RTCSdpType::Pranswer);
     m_setDescriptionCallback = WTFMove(callback);
     doSetLocalDescription(sessionDescription);
 }
 
-void PeerConnectionBackend::setLocalDescriptionSucceeded(std::optional<DescriptionStates>&& descriptionStates, std::unique_ptr<RTCSctpTransportBackend>&& sctpBackend)
+struct MediaStreamAndTrackItem {
+    Ref<MediaStream> stream;
+    Ref<MediaStreamTrack> track;
+};
+
+// https://w3c.github.io/webrtc-pc/#set-associated-remote-streams
+static void setAssociatedRemoteStreams(RTCRtpReceiver& receiver, const PeerConnectionBackend::TransceiverState& state, Vector<MediaStreamAndTrackItem>& addList, Vector<MediaStreamAndTrackItem>& removeList)
+{
+    for (auto& currentStream : receiver.associatedStreams()) {
+        if (currentStream && !anyOf(state.receiverStreams, [&currentStream](auto& stream) { return stream->id() == currentStream->id(); }))
+            removeList.append({ Ref { *currentStream }, Ref { receiver.track() } });
+    }
+
+    for (auto& stream : state.receiverStreams) {
+        if (!anyOf(receiver.associatedStreams(), [&stream](auto& currentStream) { return stream->id() == currentStream->id(); }))
+            addList.append({ *stream, Ref { receiver.track() } });
+    }
+
+    receiver.setAssociatedStreams(WTF::map(state.receiverStreams, [](auto& stream) { return WeakPtr { stream.get() }; }));
+}
+
+static bool isDirectionReceiving(RTCRtpTransceiverDirection direction)
+{
+    return direction == RTCRtpTransceiverDirection::Sendrecv || direction == RTCRtpTransceiverDirection::Recvonly;
+}
+
+// https://w3c.github.io/webrtc-pc/#process-remote-tracks
+static void processRemoteTracks(RTCRtpTransceiver& transceiver, PeerConnectionBackend::TransceiverState&& state, Vector<MediaStreamAndTrackItem>& addList, Vector<MediaStreamAndTrackItem>& removeList, Vector<Ref<RTCTrackEvent>>& trackEventList, Vector<Ref<MediaStreamTrack>>& muteTrackList)
+{
+    auto addListSize = addList.size();
+    auto& receiver = transceiver.receiver();
+    setAssociatedRemoteStreams(receiver, state, addList, removeList);
+    if ((state.firedDirection && isDirectionReceiving(*state.firedDirection) && (!transceiver.firedDirection() || !isDirectionReceiving(*transceiver.firedDirection()))) || addListSize != addList.size()) {
+        // https://w3c.github.io/webrtc-pc/#process-remote-track-addition
+        trackEventList.append(RTCTrackEvent::create(eventNames().trackEvent, Event::CanBubble::No, Event::IsCancelable::No, &receiver, &receiver.track(), WTFMove(state.receiverStreams), &transceiver));
+    }
+    if (!(state.firedDirection && isDirectionReceiving(*state.firedDirection)) && transceiver.firedDirection() && isDirectionReceiving(*transceiver.firedDirection())) {
+        // https://w3c.github.io/webrtc-pc/#process-remote-track-removal
+        muteTrackList.append(receiver.track());
+    }
+    transceiver.setFiredDirection(state.firedDirection);
+}
+
+void PeerConnectionBackend::setLocalDescriptionSucceeded(std::optional<DescriptionStates>&& descriptionStates, std::optional<TransceiverStates>&& transceiverStates, std::unique_ptr<RTCSctpTransportBackend>&& sctpBackend)
 {
     ASSERT(isMainThread());
     ALWAYS_LOG(LOGIDENTIFIER);
 
     ASSERT(m_setDescriptionCallback);
-    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), descriptionStates = WTFMove(descriptionStates), sctpBackend = WTFMove(sctpBackend)]() mutable {
+    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), descriptionStates = WTFMove(descriptionStates), transceiverStates = WTFMove(transceiverStates), sctpBackend = WTFMove(sctpBackend)]() mutable {
         if (m_peerConnection.isClosed())
             return;
 
-        if (descriptionStates)
-            m_peerConnection.updateDescriptions(WTFMove(*descriptionStates));
         m_peerConnection.updateTransceiversAfterSuccessfulLocalDescription();
         m_peerConnection.updateSctpBackend(WTFMove(sctpBackend));
+
+        if (descriptionStates) {
+            m_peerConnection.updateDescriptions(WTFMove(*descriptionStates));
+            if (m_peerConnection.isClosed())
+                return;
+        }
+
         m_peerConnection.processIceTransportChanges();
+        if (m_peerConnection.isClosed())
+            return;
+
+        if (m_isProcessingLocalDescriptionAnswer && transceiverStates) {
+            // Compute track related events.
+            Vector<MediaStreamAndTrackItem> removeList;
+            Vector<Ref<MediaStreamTrack>> muteTrackList;
+            Vector<MediaStreamAndTrackItem> addListNoOp;
+            for (auto& transceiverState : *transceiverStates) {
+                RefPtr<RTCRtpTransceiver> transceiver;
+                for (auto& item : m_peerConnection.currentTransceivers()) {
+                    if (item->mid() == transceiverState.mid) {
+                        transceiver = item;
+                        break;
+                    }
+                }
+                if (transceiver) {
+                    if (!(transceiverState.firedDirection && isDirectionReceiving(*transceiverState.firedDirection)) && transceiver->firedDirection() && isDirectionReceiving(*transceiver->firedDirection())) {
+                        setAssociatedRemoteStreams(transceiver->receiver(), transceiverState, addListNoOp, removeList);
+                        muteTrackList.append(transceiver->receiver().track());
+                    }
+                }
+                transceiver->setFiredDirection(transceiverState.firedDirection);
+            }
+            for (auto& track : muteTrackList) {
+                track->setShouldFireMuteEventImmediately(true);
+                track->source().setMuted(true);
+                track->setShouldFireMuteEventImmediately(false);
+                if (m_peerConnection.isClosed())
+                    return;
+            }
+
+            for (auto& pair : removeList) {
+                pair.stream->privateStream().removeTrack(pair.track->privateTrack());
+                if (m_peerConnection.isClosed())
+                    return;
+            }
+        }
+
         callback({ });
     });
 }
@@ -227,28 +315,92 @@ void PeerConnectionBackend::setRemoteDescription(const RTCSessionDescription& se
     doSetRemoteDescription(sessionDescription);
 }
 
-void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<DescriptionStates>&& descriptionStates, std::unique_ptr<RTCSctpTransportBackend>&& sctpBackend)
+void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<DescriptionStates>&& descriptionStates, std::optional<TransceiverStates>&& transceiverStates, std::unique_ptr<RTCSctpTransportBackend>&& sctpBackend)
 {
     ASSERT(isMainThread());
     ALWAYS_LOG(LOGIDENTIFIER, "Set remote description succeeded");
     ASSERT(m_setDescriptionCallback);
 
-    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), descriptionStates = WTFMove(descriptionStates), sctpBackend = WTFMove(sctpBackend), events = WTFMove(m_pendingTrackEvents)]() mutable {
+    m_peerConnection.queueTaskKeepingObjectAlive(m_peerConnection, TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), descriptionStates = WTFMove(descriptionStates), transceiverStates = WTFMove(transceiverStates), sctpBackend = WTFMove(sctpBackend), events = WTFMove(m_pendingTrackEvents)]() mutable {
         if (m_peerConnection.isClosed())
             return;
 
-        if (descriptionStates)
-            m_peerConnection.updateDescriptions(WTFMove(*descriptionStates));
-
-        for (auto& event : events)
-            dispatchTrackEvent(event);
-
-        if (m_peerConnection.isClosed())
-            return;
+        Vector<MediaStreamAndTrackItem> removeList;
+        if (transceiverStates) {
+            for (auto& transceiver : m_peerConnection.currentTransceivers()) {
+                if (!anyOf(*transceiverStates, [&transceiver](auto& state) { return state.mid == transceiver->mid(); })) {
+                    for (auto& stream : transceiver->receiver().associatedStreams()) {
+                        if (stream)
+                            removeList.append({ Ref { *stream }, Ref { transceiver->receiver().track() } });
+                    }
+                }
+            }
+        }
 
         m_peerConnection.updateTransceiversAfterSuccessfulRemoteDescription();
         m_peerConnection.updateSctpBackend(WTFMove(sctpBackend));
+
+        if (descriptionStates) {
+            m_peerConnection.updateDescriptions(WTFMove(*descriptionStates));
+            if (m_peerConnection.isClosed())
+                return;
+        }
+
         m_peerConnection.processIceTransportChanges();
+        if (m_peerConnection.isClosed())
+            return;
+
+        if (transceiverStates) {
+            // Compute track related events.
+            Vector<Ref<MediaStreamTrack>> muteTrackList;
+            Vector<MediaStreamAndTrackItem> addList;
+            Vector<Ref<RTCTrackEvent>> trackEventList;
+            for (auto& transceiverState : *transceiverStates) {
+                RefPtr<RTCRtpTransceiver> transceiver;
+                for (auto& item : m_peerConnection.currentTransceivers()) {
+                    if (item->mid() == transceiverState.mid) {
+                        transceiver = item;
+                        break;
+                    }
+                }
+                if (transceiver)
+                    processRemoteTracks(*transceiver, WTFMove(transceiverState), addList, removeList, trackEventList, muteTrackList);
+            }
+
+            for (auto& track : muteTrackList) {
+                track->setShouldFireMuteEventImmediately(true);
+                track->source().setMuted(true);
+                track->setShouldFireMuteEventImmediately(false);
+                if (m_peerConnection.isClosed())
+                    return;
+            }
+
+            for (auto& pair : removeList) {
+                pair.stream->privateStream().removeTrack(pair.track->privateTrack());
+                if (m_peerConnection.isClosed())
+                    return;
+            }
+
+            for (auto& pair : addList) {
+                pair.stream->addTrackFromPlatform(pair.track.copyRef());
+                if (m_peerConnection.isClosed())
+                    return;
+            }
+
+            for (auto& event : trackEventList) {
+                RefPtr track = event->track();
+                m_peerConnection.dispatchEvent(event);
+                if (m_peerConnection.isClosed())
+                    return;
+
+                track->source().setMuted(false);
+            }
+        } else {
+            // FIXME: Move ports out of m_pendingTrackEvents.
+            for (auto& event : events)
+                dispatchTrackEvent(event);
+        }
+
         callback({ });
     });
 }

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
@@ -32,7 +32,7 @@
 
 #if ENABLE(WEB_RTC)
 
-#include "MediaStreamTrack.h"
+#include "MediaStream.h"
 #include "RTCDtlsTransport.h"
 #include "RTCRtpReceiverBackend.h"
 #include "RTCRtpSynchronizationSource.h"
@@ -79,6 +79,8 @@ public:
     std::optional<RTCRtpTransform::Internal> transform();
     ExceptionOr<void> setTransform(std::unique_ptr<RTCRtpTransform>&&);
 
+    const Vector<WeakPtr<MediaStream>>& associatedStreams() const { return m_associatedStreams; }
+    void setAssociatedStreams(Vector<WeakPtr<MediaStream>>&& streams) { m_associatedStreams = WTFMove(streams); }
 private:
     RTCRtpReceiver(PeerConnectionBackend&, Ref<MediaStreamTrack>&&, std::unique_ptr<RTCRtpReceiverBackend>&&);
 
@@ -94,6 +96,7 @@ private:
     std::unique_ptr<RTCRtpReceiverBackend> m_backend;
     WeakPtr<PeerConnectionBackend> m_connection;
     std::unique_ptr<RTCRtpTransform> m_transform;
+    Vector<WeakPtr<MediaStream>> m_associatedStreams;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
     const void* m_logIdentifier { nullptr };

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
@@ -72,10 +72,14 @@ public:
     RTCRtpTransceiverBackend* backend() { return m_backend.get(); }
     void setConnection(RTCPeerConnection&);
 
+    std::optional<RTCRtpTransceiverDirection> firedDirection() const { return m_firedDirection; }
+    void setFiredDirection(std::optional<RTCRtpTransceiverDirection> firedDirection) { m_firedDirection = firedDirection; }
+
 private:
     RTCRtpTransceiver(Ref<RTCRtpSender>&&, Ref<RTCRtpReceiver>&&, std::unique_ptr<RTCRtpTransceiverBackend>&&);
 
     RTCRtpTransceiverDirection m_direction;
+    std::optional<RTCRtpTransceiverDirection> m_firedDirection;
 
     Ref<RTCRtpSender> m_sender;
     Ref<RTCRtpReceiver> m_receiver;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -362,7 +362,7 @@ void GStreamerMediaEndpoint::doSetLocalDescription(const RTCSessionDescription* 
 
         GRefPtr<GstWebRTCSCTPTransport> transport;
         g_object_get(m_webrtcBin.get(), "sctp-transport", &transport.outPtr(), nullptr);
-        m_peerConnectionBackend.setLocalDescriptionSucceeded(WTFMove(descriptions), transport ? makeUnique<GStreamerSctpTransportBackend>(WTFMove(transport)) : nullptr);
+        m_peerConnectionBackend.setLocalDescriptionSucceeded(WTFMove(descriptions), { }, transport ? makeUnique<GStreamerSctpTransportBackend>(WTFMove(transport)) : nullptr);
     }, [protectedThis = Ref(*this), this](const GError* error) {
         if (protectedThis->isStopped())
             return;
@@ -430,7 +430,7 @@ void GStreamerMediaEndpoint::doSetRemoteDescription(const RTCSessionDescription&
 
         GRefPtr<GstWebRTCSCTPTransport> transport;
         g_object_get(m_webrtcBin.get(), "sctp-transport", &transport.outPtr(), nullptr);
-        m_peerConnectionBackend.setRemoteDescriptionSucceeded(WTFMove(descriptions), transport ? makeUnique<GStreamerSctpTransportBackend>(WTFMove(transport)) : nullptr);
+        m_peerConnectionBackend.setRemoteDescriptionSucceeded(WTFMove(descriptions), { }, transport ? makeUnique<GStreamerSctpTransportBackend>(WTFMove(transport)) : nullptr);
     }, [protectedThis = Ref(*this), this](const GError* error) {
         if (protectedThis->isStopped())
             return;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -126,8 +126,6 @@ private:
     // webrtc::PeerConnectionObserver API
     void OnSignalingChange(webrtc::PeerConnectionInterface::SignalingState) final;
     void OnDataChannel(rtc::scoped_refptr<webrtc::DataChannelInterface>) final;
-    void OnTrack(rtc::scoped_refptr<webrtc::RtpTransceiverInterface>) final;
-    void OnRemoveTrack(rtc::scoped_refptr<webrtc::RtpReceiverInterface>) final;
 
     void OnNegotiationNeededEvent(uint32_t) final;
     void OnStandardizedIceConnectionChange(webrtc::PeerConnectionInterface::IceConnectionState) final;
@@ -141,10 +139,6 @@ private:
     void setLocalSessionDescriptionFailed(ExceptionCode, const char*);
     void setRemoteSessionDescriptionSucceeded();
     void setRemoteSessionDescriptionFailed(ExceptionCode, const char*);
-    void newTransceiver(rtc::scoped_refptr<webrtc::RtpTransceiverInterface>&&);
-    void removeRemoteTrack(rtc::scoped_refptr<webrtc::RtpReceiverInterface>&&);
-
-    void addPendingTrackEvent(Ref<RTCRtpReceiver>&&, MediaStreamTrack&, const std::vector<rtc::scoped_refptr<webrtc::MediaStreamInterface>>&, RefPtr<RTCRtpTransceiver>&&);
 
     template<typename T>
     ExceptionOr<Backends> createTransceiverBackends(T&&, webrtc::RtpTransceiverInit&&, LibWebRTCRtpSenderBackend::Source&&);
@@ -156,7 +150,7 @@ private:
 
     rtc::scoped_refptr<LibWebRTCStatsCollector> createStatsCollector(Ref<DeferredPromise>&&);
 
-    MediaStream& mediaStreamFromRTCStream(webrtc::MediaStreamInterface&);
+    MediaStream& mediaStreamFromRTCStreamId(const String&);
 
     void AddRef() const { ref(); }
     rtc::RefCountReleaseStatus Release() const


### PR DESCRIPTION
#### 704f5d6f10f8c0208e685fbd8203c0cd834f5e4f
<pre>
Move out of OnTrack/OnRemoveTrack libwebrtc callbacks
<a href="https://bugs.webkit.org/show_bug.cgi?id=244709">https://bugs.webkit.org/show_bug.cgi?id=244709</a>
rdar://problem/99481570

Reviewed by Eric Carlson.

OnTrack/OnRemoveTrack are not standard compliant.
We miss some cases where these should be called (say rollback).
The timing of these callbacks is also not well aligned with the specification.

Instead, everytime a description is applied successfully, we store the current transceiver states from the backend.
We then compute the corresponding events from the transceiver states.

Covered by existing and rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-rollback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpSender-setStreams.https-expected.txt:
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::trackMutedChanged):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
(WebCore::MediaStreamTrack::setShouldFireMuteEventImmediately):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::setLocalDescription):
(WebCore::setAssociatedRemoteStreams):
(WebCore::isDirectionReceiving):
(WebCore::processRemoteTracks):
(WebCore::PeerConnectionBackend::setLocalDescriptionSucceeded):
(WebCore::PeerConnectionBackend::setRemoteDescriptionSucceeded):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.h:
(WebCore::PeerConnectionBackend::DescriptionStates::isolatedCopy):
* Source/WebCore/Modules/mediastream/RTCRtpReceiver.h:
* Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::doSetRemoteDescription):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::mediaStreamFromRTCStreamId):
(WebCore::LibWebRTCMediaEndpoint::addPendingTrackEvent):
(WebCore::LibWebRTCMediaEndpoint::collectTransceivers):
(WebCore::LibWebRTCMediaEndpoint::addIceCandidate):
(WebCore::LibWebRTCMediaEndpoint::OnIceCandidate):
(WebCore::LibWebRTCMediaEndpointTransceiverState::isolatedCopy):
(WebCore::toLibWebRTCMediaEndpointTransceiverState):
(WebCore::transceiverStatesFromPeerConnection):
(WebCore::LibWebRTCMediaEndpoint::setLocalSessionDescriptionSucceeded):
(WebCore::LibWebRTCMediaEndpoint::setLocalSessionDescriptionFailed):
(WebCore::LibWebRTCMediaEndpoint::setRemoteSessionDescriptionSucceeded):
(WebCore::LibWebRTCMediaEndpoint::mediaStreamFromRTCStream): Deleted.
(WebCore::LibWebRTCMediaEndpoint::newTransceiver): Deleted.
(WebCore::LibWebRTCMediaEndpoint::removeRemoteTrack): Deleted.
(WebCore::LibWebRTCMediaEndpoint::OnTrack): Deleted.
(WebCore::LibWebRTCMediaEndpoint::OnRemoveTrack): Deleted.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h:

Canonical link: <a href="https://commits.webkit.org/254128@main">https://commits.webkit.org/254128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40dc990d13496597fc082838e3dbba31f5c1aaa5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88024 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97170 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152663 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30558 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26502 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80127 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91916 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24621 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74675 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24598 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79682 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28187 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28289 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14547 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2897 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37424 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33792 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->