### PR TITLE
Debug assertion under `ImageOverlay::updateWithTextRecognitionResult` when hovering over certain images

### DIFF
--- a/LayoutTests/fast/images/text-recognition/image-overlay-reversed-range-expected.txt
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-reversed-range-expected.txt
@@ -1,0 +1,6 @@
+
+PASS getSelection().toString() is "foo bar"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/images/text-recognition/image-overlay-reversed-range.html
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-reversed-range.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    margin: 0;
+}
+img {
+    width: 300px;
+    height: 300px;
+}
+</style>
+</head>
+<body>
+<textarea></textarea>
+<img src="../resources/green-400x400.png"></img>
+<pre id="console"></pre>
+<script>
+addEventListener("load", () => {
+    const image = document.querySelector("img");
+    internals.installImageOverlay(image, [
+        {
+            topLeft : new DOMPointReadOnly(0, 0),
+            topRight : new DOMPointReadOnly(1, 0),
+            bottomRight : new DOMPointReadOnly(1, 0.3),
+            bottomLeft : new DOMPointReadOnly(0, 0.3),
+            hasTrailingNewline: false,
+            children: [
+                {
+                    text : "foo",
+                    topLeft : new DOMPointReadOnly(0, 0),
+                    topRight : new DOMPointReadOnly(0.5, 0),
+                    bottomRight : new DOMPointReadOnly(0.5, 0.3),
+                    bottomLeft : new DOMPointReadOnly(0, 0.3),
+                },
+                {
+                    text : " ",
+                    topLeft : new DOMPointReadOnly(0.51, 0),
+                    topRight : new DOMPointReadOnly(0.5, 0),
+                    bottomRight : new DOMPointReadOnly(0.5, 0.3),
+                    bottomLeft : new DOMPointReadOnly(0.51, 0.3),
+                },
+                {
+                    text : "bar",
+                    topLeft : new DOMPointReadOnly(0.51, 0),
+                    topRight : new DOMPointReadOnly(1, 0),
+                    bottomRight : new DOMPointReadOnly(1, 0.3),
+                    bottomLeft : new DOMPointReadOnly(0.51, 0.3),
+                }
+            ],
+        }
+    ]);
+
+    getSelection().selectAllChildren(internals.shadowRoot(image).getElementById("image-overlay"));
+    shouldBeEqualToString("getSelection().toString()", "foo bar")
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -510,10 +510,9 @@ void updateWithTextRecognitionResult(HTMLElement& element, const TextRecognition
 
         auto offsetsAlongHorizontalAxis = line.children.map([&](auto& child) -> WTF::Range<float> {
             auto textQuad = convertToContainerCoordinates(child.normalizedQuad);
-            return {
-                offsetAlongHorizontalAxis(textQuad.p1(), textQuad.p4()),
-                offsetAlongHorizontalAxis(textQuad.p2(), textQuad.p3())
-            };
+            auto startOffset = offsetAlongHorizontalAxis(textQuad.p1(), textQuad.p4());
+            auto endOffset = offsetAlongHorizontalAxis(textQuad.p2(), textQuad.p3());
+            return { std::min(startOffset, endOffset), std::max(startOffset, endOffset) };
         });
 
         for (size_t childIndex = 0; childIndex < line.children.size(); ++childIndex) {


### PR DESCRIPTION
#### e9e6c7937d2c3fe4d737709cbf546d68155150cc
<pre>
Debug assertion under `ImageOverlay::updateWithTextRecognitionResult` when hovering over certain images
<a href="https://bugs.webkit.org/show_bug.cgi?id=244721">https://bugs.webkit.org/show_bug.cgi?id=244721</a>

Reviewed by Ryosuke Niwa.

It&apos;s possible for VisionKit to return word quads that are flipped about the y-axis in some
scenarios when analyzing images for Live Text. In this case, we end up asserting due to the fact
that we attempt to create `WTF::Range`s corresponding to these flipped word ranges, for which the
starting offset is after the end.

Fix this by making `updateWithTextRecognitionResult` robust against this possibility, by ensuring
that the start offset is always before or equal to the end offset.

Test: fast/images/text-recognition/image-overlay-reversed-range.html

* LayoutTests/fast/images/text-recognition/image-overlay-reversed-range-expected.txt: Added.
* LayoutTests/fast/images/text-recognition/image-overlay-reversed-range.html: Added.
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::updateWithTextRecognitionResult):

Canonical link: <a href="https://commits.webkit.org/254115@main">https://commits.webkit.org/254115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbae007911c859b0eb5fc63406479a12fbba4927

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97197 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152689 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30583 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26527 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80151 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91940 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24645 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74698 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24614 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79567 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28212 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28314 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14569 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2887 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31338 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33807 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->