### PR TITLE
[JSC] Reduce cost of ValueProfile

### DIFF
--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -514,11 +514,12 @@ SpeculatedType speculationFromClassInfoInheritance(const ClassInfo* classInfo)
     if (classInfo->isSubClassOf(JSArray::info()))
         return SpecArray | SpecDerivedArray;
 
-    if (classInfo->isSubClassOf(JSFunction::info())) {
-        if (classInfo == JSBoundFunction::info())
-            return SpecFunctionWithNonDefaultHasInstance;
+    static_assert(std::is_final_v<JSBoundFunction>);
+    if (classInfo == JSBoundFunction::info())
+        return SpecFunctionWithNonDefaultHasInstance;
+
+    if (classInfo->isSubClassOf(JSFunction::info()))
         return SpecFunctionWithDefaultHasInstance;
-    }
 
     if (classInfo->isSubClassOf(JSPromise::info()))
         return SpecPromiseObject;
@@ -540,7 +541,8 @@ SpeculatedType speculationFromClassInfoInheritance(const ClassInfo* classInfo)
 SpeculatedType speculationFromStructure(Structure* structure)
 {
     SpeculatedType filteredResult = SpecNone;
-    switch (structure->typeInfo().type()) {
+    JSType type = structure->typeInfo().type();
+    switch (type) {
     case StringType:
         filteredResult = SpecString;
         break;
@@ -549,6 +551,39 @@ SpeculatedType speculationFromStructure(Structure* structure)
         break;
     case HeapBigIntType:
         filteredResult = SpecHeapBigInt;
+        break;
+    case FinalObjectType:
+        filteredResult = SpecFinalObject;
+        break;
+    case DirectArgumentsType:
+        filteredResult = SpecDirectArguments;
+        break;
+    case ScopedArgumentsType:
+        filteredResult = SpecScopedArguments;
+        break;
+    case RegExpObjectType:
+        filteredResult = SpecRegExpObject;
+        break;
+    case JSDateType:
+        filteredResult = SpecDateObject;
+        break;
+    case JSMapType:
+        filteredResult = SpecMapObject;
+        break;
+    case JSSetType:
+        filteredResult = SpecSetObject;
+        break;
+    case JSWeakMapType:
+        filteredResult = SpecWeakMapObject;
+        break;
+    case JSWeakSetType:
+        filteredResult = SpecWeakSetObject;
+        break;
+    case ProxyObjectType:
+        filteredResult = SpecProxyObject;
+        break;
+    case DataViewType:
+        filteredResult = SpecDataViewObject;
         break;
     case DerivedArrayType:
         filteredResult = SpecDerivedArray;
@@ -563,7 +598,27 @@ SpeculatedType speculationFromStructure(Structure* structure)
     case DerivedStringObjectType:
         filteredResult = SpecObjectOther;
         break;
+    case JSPromiseType:
+        filteredResult = SpecPromiseObject;
+        break;
+    case JSFunctionType:
+        static_assert(std::is_final_v<JSBoundFunction>);
+        if (structure->classInfoForCells() == JSBoundFunction::info())
+            filteredResult = SpecFunctionWithNonDefaultHasInstance;
+        else
+            filteredResult = SpecFunctionWithDefaultHasInstance;
+        break;
+
+#define JSC_TYPED_ARRAY_CHECK(type) \
+    case type##ArrayType: \
+        filteredResult = Spec ## type ## Array; \
+        break;
+    FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(JSC_TYPED_ARRAY_CHECK)
+#undef JSC_TYPED_ARRAY_CHECK
+
     default:
+        if (!isObjectType(type))
+            return SpecCellOther;
         return speculationFromClassInfoInheritance(structure->classInfoForCells());
     }
     ASSERT(filteredResult);

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -372,7 +372,7 @@ inline bool jitCompileAndSetHeuristics(VM& vm, CodeBlock* codeBlock, BytecodeInd
     DeferGCForAWhile deferGC(vm); // My callers don't set top callframe, so we don't want to GC here at all.
     ASSERT(Options::useJIT());
     
-    codeBlock->updateAllValueProfilePredictions();
+    codeBlock->updateAllValueProfilePredictions(ConcurrentJSLocker(codeBlock->m_lock));
 
     if (codeBlock->jitType() != JITType::BaselineJIT) {
         if (RefPtr<BaselineJITCode> baselineRef = codeBlock->unlinkedCodeBlock()->m_unlinkedBaselineCode) {

--- a/Source/JavaScriptCore/runtime/JSType.h
+++ b/Source/JavaScriptCore/runtime/JSType.h
@@ -155,6 +155,8 @@ inline constexpr bool isTypedArrayType(JSType type)
     return (static_cast<uint32_t>(type) - FirstTypedArrayType) < NumberOfTypedArrayTypesExcludingDataView;
 }
 
+inline constexpr bool isObjectType(JSType type) { return type >= ObjectType; }
+
 } // namespace JSC
 
 namespace WTF {


### PR DESCRIPTION
#### a9590d7d9907dd267f35109c2783a54cd5dd346e
<pre>
[JSC] Reduce cost of ValueProfile
<a href="https://bugs.webkit.org/show_bug.cgi?id=244722">https://bugs.webkit.org/show_bug.cgi?id=244722</a>

Reviewed by Mark Lam.

Speedometer2.1 showed that prediction computation from ValueProfile&apos;s captured JSValue is a bit costly,
which can be called from CodeBlock::finalizeUnconditionally, operationOptimize etc. This patch attempts
to make it cheap by,

1. Dropping unused arguments value profiles in non LLInt / Baseline CodeBlock. We are always using them
   in LLInt / Baseline CodeBlock, so the other CodeBlocks (DFG / FTL) do not need to have them.
2. speculationFromStructure gets fast path for more JSTypes. Avoiding going through speculationFromClassInfoInheritance,
   which is more costly.
3. CodeBlock::finalizeUnconditionally do not need to call updateAllPredictions for all CodeBlocks. Only
   calling it for Baseline / LLInt is enough since DFG / FTL&apos;s ValueProfiles are the same to the corresponding
   Baseline / LLInt CodeBlocks&apos; one.
4. Reduce lock-and-unlock.

AppleSilicon is neutral. Speedometer2.1 in Intel shows 0.21% improvement.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::CodeBlock):
(JSC::CodeBlock::setNumParameters):
(JSC::CodeBlock::finalizeUnconditionally):
(JSC::CodeBlock::updateAllValueProfilePredictionsAndCountLiveness):
(JSC::CodeBlock::updateAllValueProfilePredictions):
(JSC::CodeBlock::updateAllArrayPredictions):
(JSC::CodeBlock::updateAllPredictions):
(JSC::CodeBlock::shouldOptimizeNow):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
(JSC::CodeBlock::numberOfArgumentValueProfiles):
(JSC::CodeBlock::valueProfileForArgument):
* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
(JSC::speculationFromClassInfoInheritance):
(JSC::speculationFromStructure):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::jitCompileAndSetHeuristics):
* Source/JavaScriptCore/runtime/JSType.h:
(JSC::isObjectType):

Canonical link: <a href="https://commits.webkit.org/254129@main">https://commits.webkit.org/254129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10aa4246c82c56f741a394eac436391bc41c6f3d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88062 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97206 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152699 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30593 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26535 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80160 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91946 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24655 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74707 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24627 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79703 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79814 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28222 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73567 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28322 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14576 "Found 1 new test failure: imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26135 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2898 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37457 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76410 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33814 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16958 "Passed tests") | 
<!--EWS-Status-Bubble-End-->