### PR TITLE
[GStreamer] Introduce workaround for race condition in appsink

### DIFF
--- a/Source/WebCore/platform/GStreamer.cmake
+++ b/Source/WebCore/platform/GStreamer.cmake
@@ -25,6 +25,7 @@ if (ENABLE_VIDEO OR ENABLE_WEB_AUDIO)
 
         Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
 
+        platform/graphics/gstreamer/AppSinkWorkaround.cpp
         platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
         platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
         platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp

--- a/Source/WebCore/platform/graphics/gstreamer/AppSinkWorkaround.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/AppSinkWorkaround.cpp
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (C) 2022 Igalia S.L
+ *  Copyright (C) 2022 Metrological Group B.V.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+
+#include "config.h"
+#include "AppSinkWorkaround.h"
+
+#if USE(GSTREAMER)
+
+#include <gst/gst.h>
+#include <gst/pbutils/gstpluginsbaseversion.h>
+#include <mutex>
+#include <wtf/PrintStream.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/WTFGType.h>
+
+GST_DEBUG_CATEGORY(webkit_app_sink_workaround_debug);
+#define GST_CAT_DEFAULT webkit_app_sink_workaround_debug
+
+namespace WebCore {
+
+static bool checkNeedsAppsinkWorkaround()
+{
+    GRefPtr<GstElementFactory> factory = adoptGRef(gst_element_factory_find("appsink"));
+    if (!factory) {
+        WTFLogAlways("GStreamer element appsink not found. Please install it");
+        return false;
+    }
+
+    GST_DEBUG("gst-plugins-base version is %s", gst_plugins_base_version_string());
+    guint major, minor, micro;
+    gst_plugins_base_version(&major, &minor, &micro, nullptr);
+
+    if (major < 1)
+        return true;
+    if (major > 1)
+        return false;
+
+    if (minor < 20)
+        return true;
+    if (minor >= 22)
+        return false;
+    if (minor == 21)
+        return micro < 1; // Fix landed in 1.21.1 https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/2413
+
+    ASSERT(minor == 20);
+    return micro < 3; // Fix was backported to 1.20.3 https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/2442
+}
+
+static std::once_flag appSinkWorkaroundOnceFlag;
+
+void registerAppsinkWorkaroundIfNeeded()
+{
+    std::call_once(appSinkWorkaroundOnceFlag, [] {
+        bool needsWorkaround = checkNeedsAppsinkWorkaround();
+        GST_DEBUG("appsink workaround will%s be registered.", needsWorkaround ? "" : " NOT");
+        if (!needsWorkaround)
+            return;
+
+        gst_element_register(nullptr, "appsink", GST_RANK_PRIMARY + 100, WEBKIT_TYPE_APP_SINK_WITH_WORKAROUND);
+    });
+}
+
+} // namespace WebCore
+
+struct WebKitAppSinkWithWorkaroundPrivate {
+    // Must only be read and written with the pad lock.
+    bool needsResendCaps { false };
+};
+
+#define webkit_app_sink_with_workaround_parent_class parent_class
+WEBKIT_DEFINE_TYPE(WebKitAppSinkWithWorkaround, webkit_app_sink_with_workaround, GST_TYPE_APP_SINK);
+
+static GstPadProbeReturn appsinkWorkaroundProbe(GstPad* pad, GstPadProbeInfo* info, void* userData)
+{
+    auto priv = static_cast<WebKitAppSinkWithWorkaroundPrivate*>(userData);
+
+    // Changes to the flushing flag of a pad only occur while the pad lock is held.
+    // By holding it, we can reliably prevent the flushing flag from changing during the execution of our code.
+    // The pad lock also ensures there are no data races over `priv->needsResendCaps`.
+    GST_OBJECT_LOCK(pad);
+    bool willResendCaps = false;
+    if ((info->type & GST_PAD_PROBE_TYPE_EVENT_FLUSH) && GST_EVENT_TYPE(info->data) == GST_EVENT_FLUSH_STOP) {
+        GST_TRACE_OBJECT(pad, "Flush event received, setting needsResendCaps = true");
+        priv->needsResendCaps = true;
+    } else if (!GST_PAD_IS_FLUSHING(pad) && (info->type & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM) && GST_EVENT_TYPE(info->data) == GST_EVENT_CAPS) {
+        GST_TRACE_OBJECT(pad, "Caps event received, setting needsResendCaps = false");
+        priv->needsResendCaps = false;
+    } else if (!GST_PAD_IS_FLUSHING(pad) && (info->type & GST_PAD_PROBE_TYPE_BUFFER) && priv->needsResendCaps) {
+        GST_DEBUG_OBJECT(pad, "Buffer received, but first need to resend pad caps to workaround bug. Will resend caps.");
+        willResendCaps = true;
+    }
+    GST_OBJECT_UNLOCK(pad);
+
+    if (willResendCaps) {
+        GRefPtr<GstCaps> caps = adoptGRef(gst_pad_get_current_caps(pad));
+        GST_DEBUG_OBJECT(pad, "Sending stored pad caps to appsink: %" GST_PTR_FORMAT, caps.get());
+        // This will cause a recursive call to appsinkWorkaroundProbe() which will also set `needsResendCaps` to false.
+        bool capsSent = gst_pad_send_event(pad, gst_event_new_caps(caps.get()));
+        GST_DEBUG_OBJECT(pad, "capsSent = %s. Returning from the probe so that the buffer is sent: %" GST_PTR_FORMAT, boolForPrinting(capsSent), info->data);
+    }
+
+    return GST_PAD_PROBE_OK;
+}
+
+static void webkitAppSinkWithWorkAroundConstructed(GObject* object)
+{
+    G_OBJECT_CLASS(webkit_app_sink_with_workaround_parent_class)->constructed(object);
+
+    WebKitAppSinkWithWorkaroundPrivate* priv = WEBKIT_APP_SINK_WITH_WORKAROUND(object)->priv;
+    GstElement* element = GST_ELEMENT(object);
+    GRefPtr<GstPad> pad = adoptGRef(gst_element_get_static_pad(element, "sink"));
+    gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER
+        | GST_PAD_PROBE_TYPE_EVENT_FLUSH | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM),
+        appsinkWorkaroundProbe, priv, nullptr);
+    GST_DEBUG_OBJECT(object, "appsink with workaround probe instantiated.");
+}
+
+static void webkit_app_sink_with_workaround_class_init(WebKitAppSinkWithWorkaroundClass* klass)
+{
+    auto* gobjectClass = G_OBJECT_CLASS(klass);
+    gobjectClass->constructed = webkitAppSinkWithWorkAroundConstructed;
+}
+
+#endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/AppSinkWorkaround.h
+++ b/Source/WebCore/platform/graphics/gstreamer/AppSinkWorkaround.h
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2022 Igalia S.L
+ *  Copyright (C) 2022 Metrological Group B.V.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#pragma once
+
+#if USE(GSTREAMER)
+
+#include <gst/app/gstappsink.h>
+
+namespace WebCore {
+
+void registerAppsinkWorkaroundIfNeeded();
+
+} // namespace WebCore
+
+#define WEBKIT_TYPE_APP_SINK_WITH_WORKAROUND (webkit_app_sink_with_workaround_get_type())
+
+#define WEBKIT_APP_SINK_WITH_WORKAROUND(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_APP_SINK_WITH_WORKAROUND, WebKitAppSinkWithWorkaround))
+#define WEBKIT_APP_SINK_WITH_WORKAROUND_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST((klass), WEBKIT_TYPE_APP_SINK_WITH_WORKAROUND, WebKitAppSinkWithWorkaroundClass))
+#define WEBKIT_IS_APP_SINK_WITH_WORKAROUND(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_APP_SINK_WITH_WORKAROUND))
+#define WEBKIT_IS_APP_SINK_WITH_WORKAROUND_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), WEBKIT_TYPE_APP_SINK_WITH_WORKAROUND))
+#define WEBKIT_APP_SINK_WITH_WORKAROUND_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS((obj), WEBKIT_TYPE_APP_SINK_WITH_WORKAROUND, WebKitAppSinkWithWorkaroundClass))
+
+struct WebKitAppSinkWithWorkaroundPrivate;
+struct WebKitAppSinkWithWorkaround {
+    GstAppSink parent;
+    WebKitAppSinkWithWorkaroundPrivate* priv;
+};
+
+struct WebKitAppSinkWithWorkaroundClass {
+    GstAppSinkClass parent;
+};
+
+GType webkit_app_sink_with_workaround_get_type();
+
+#endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -23,6 +23,7 @@
 
 #if USE(GSTREAMER)
 
+#include "AppSinkWorkaround.h"
 #include "ApplicationGLib.h"
 #include "DMABufVideoSinkGStreamer.h"
 #include "GLVideoSinkGStreamer.h"
@@ -304,6 +305,9 @@ bool ensureGStreamerInitialized()
         if (isGStreamerInitialized)
             gst_mpegts_initialize();
 #endif
+
+        // Workaround for https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/2413
+        registerAppsinkWorkaroundIfNeeded();
 #endif
     });
     return isGStreamerInitialized;

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -227,6 +227,8 @@ _PATH_RULES_SPECIFIER = [
     ([
       # These files define GObjects, which implies some definitions of
       # variables and functions containing underscores.
+      os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'AppSinkWorkaround.cpp'),
+      os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'AppSinkWorkaround.h'),
       os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'GLVideoSinkGStreamer.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'GLVideoSinkGStreamer.h'),
       os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'DMABufVideoSinkGStreamer.cpp'),


### PR DESCRIPTION
#### 840480537fe23ae2745ce76212b60c6c20a37a82
<pre>
[GStreamer] Introduce workaround for race condition in appsink

Reviewed by Philippe Normand.

This patch introduces a WebKit-side workaround for this GStreamer bug:
<a href="https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/2413">https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/2413</a>
appsink: Fix race condition on caps handling

That race condition causes occasional crashes on MSE flushes following
quality changes.

The workaround consists in registering an element that is a subclass of
appsink with a probe that pushes a redundant caps event if a buffer is
received after a flush. This ensures appsink processes the caps so that
the GstSample later pulled from appsink contains the right caps.

The workaround is only installed if the version of gst-plugins-base is
known to have this bug.

Canonical link: <a href="https://commits.webkit.org/255431@main">https://commits.webkit.org/255431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e01e06c625c405d3dc3f4ba85c6ff10f69b8afc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101981 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162222 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1419 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29817 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84634 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98147 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/923 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78716 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27867 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/95765 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70906 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36240 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16463 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33997 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17624 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3766 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40261 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36758 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->