### PR TITLE
[MSE][GStreamer] Actually do flushes, unify m_hasAllTracks

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -281,7 +281,7 @@ void MediaPlayerPrivateGStreamerMSE::sourceSetup(GstElement* sourceElement)
     GST_DEBUG_OBJECT(pipeline(), "Source %p setup (old was: %p)", sourceElement, m_source.get());
     m_source = sourceElement;
 
-    if (m_hasAllTracks)
+    if (m_mediaSourcePrivate->hasAllTracks())
         webKitMediaSrcEmitStreams(WEBKIT_MEDIA_SRC(m_source.get()), m_tracks);
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -82,7 +82,6 @@ public:
 
     void asyncStateChangeDone() override;
 
-    bool hasAllTracks() const { return m_hasAllTracks; }
     void startSource(const Vector<RefPtr<MediaSourceTrackGStreamer>>& tracks);
     WebKitMediaSrc* webKitMediaSrc() { return reinterpret_cast<WebKitMediaSrc*>(m_source.get()); }
 
@@ -112,7 +111,6 @@ private:
     RefPtr<MediaSourcePrivateGStreamer> m_mediaSourcePrivate;
     MediaTime m_mediaTimeDuration { MediaTime::invalidTime() };
     bool m_isPipelinePlaying = true;
-    bool m_hasAllTracks = false;
     Vector<RefPtr<MediaSourceTrackGStreamer>> m_tracks;
 
     bool m_isWaitingForPreroll = true;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -84,7 +84,7 @@ MediaSourcePrivateGStreamer::AddStatus MediaSourcePrivateGStreamer::addSourceBuf
     DEBUG_LOG(LOGIDENTIFIER, contentType);
 
     // Once every SourceBuffer has had an initialization segment appended playback starts and it's too late to add new SourceBuffers.
-    if (m_playerPrivate.hasAllTracks())
+    if (m_hasAllTracks)
         return MediaSourcePrivateGStreamer::AddStatus::ReachedIdLimit;
 
     if (!SourceBufferPrivateGStreamer::isContentTypeSupported(contentType))

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -75,6 +75,7 @@ public:
 
     void sourceBufferPrivateDidChangeActiveState(SourceBufferPrivateGStreamer*, bool);
     void startPlaybackIfHasAllTracks();
+    bool hasAllTracks() const { return m_hasAllTracks; }
 
     const PlatformTimeRanges& buffered();
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -138,7 +138,7 @@ void SourceBufferPrivateGStreamer::flush(const AtomString& trackId)
 
     // This is only for on-the-fly reenqueues after appends. When seeking, the seek will do its own flush.
 
-    if (!m_playerPrivate.hasAllTracks()) {
+    if (!m_mediaSource->hasAllTracks()) {
         GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Source element has not emitted tracks yet, so we only need to clear the queue. trackId = '%s'", trackId.string().utf8().data());
         MediaSourceTrackGStreamer* track = m_tracks.get(trackId);
         track->clearQueue();


### PR DESCRIPTION
#### 3e5ad5ea060bfc76de9b71e81a4f4cde51a871e9
<pre>
[MSE][GStreamer] Actually do flushes, unify m_hasAllTracks
<a href="https://bugs.webkit.org/show_bug.cgi?id=257035">https://bugs.webkit.org/show_bug.cgi?id=257035</a>

Reviewed by Xabier Rodriguez-Calvar.

Before this patch, there were two classes having a m_hasAllTracks field:
MediaSourcePrivateGStreamer and MediaPlayerPrivateGStreamerMSE.

This redundancy lead to non-synchronization, and in consequence this was
making flushes not occur on MSE, as
SourceBufferPrivateGStreamer::flush() checked for the one in
MediaPlayerPrivateGStreamerMSE which no code ever set to true.

A visible consequence of this was video was being repeated on quality
changes, due to the lack of flush of old frames.

This patch fixes the issue by keeping the `hasAllTracks` state in one
single place, in MediaSourcePrivateGStreamer.

Note:

The triggering of MSE flushes exposed several bugs on the handling of
flushes in other parts of the code. It&apos;s important these are addressed
to avoid regressions in behavior when incorporating this patch:

(1) <a href="https://github.com/WebKit/WebKit/pull/3802">https://github.com/WebKit/WebKit/pull/3802</a>
    [GStreamer] MediaPlayerPrivateGStreamer: Abort stale tasks on flushes

    Without this patch, MSE flushes can deadlock.

(2) <a href="https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/2413">https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/2413</a>
    appsink: Fix race condition on caps handling

    appsink used to have a race condition on the handling of caps after
    a flush that can cause crashes. A fix is present in GStreamer 1.20.3+.

    A workaround in the WebKit side is possible and desirable to avoid
    headaches in Linux distros, and has been uploaded as:

    <a href="https://github.com/WebKit/WebKit/pull/3965">https://github.com/WebKit/WebKit/pull/3965</a>
    [GStreamer] Introduce workaround for race condition in appsink

(3) <a href="https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/3471">https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/3471</a>
    basesink: Support position queries after non-resetting flushes

    basesink doesn&apos;t answer position queries between a FLUSH_STOP with
    reset_time=FALSE and a SEGMENT event until GStreamer 1.24.0, which
    incorporates that patch.

    For backwards-compatibility -- and present-compatibility for that matter
    since GStreamer 1.24.0 has not been released yet, a workaround has been
    Proposed for WebKit:

    <a href="https://github.com/WebKit/WebKit/pull/14082">https://github.com/WebKit/WebKit/pull/14082</a>
    [MSE][GStreamer] Workaround basesink&apos;s lack of support for position queries
    between a non-resetting flush and a pre-roll

* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::sourceSetup):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
(WebCore::MediaPlayerPrivateGStreamerMSE::hasAllTracks const): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::addSourceBuffer):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::flush):

Canonical link: <a href="https://commits.webkit.org/264510@main">https://commits.webkit.org/264510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0837706bbd8f3e52b4c90f8c00bd33a33608010

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7411 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10770 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7318 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/9137 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8915 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14286 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9528 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5826 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6487 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1876 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6871 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->