### PR TITLE
[GLib] Fix build with CMake < 3.17

### DIFF
--- a/Source/WebKit/PdfJSGResources.cmake
+++ b/Source/WebKit/PdfJSGResources.cmake
@@ -5,7 +5,7 @@ macro(WEBKIT_BUILD_PDFJS_GRESOURCES _derived_sources_dir)
     add_custom_command(
         OUTPUT ${_derived_sources_dir}/PdfJSGResourceBundle.xml
         DEPENDS ${TOOLS_DIR}/glib/generate-pdfjs-resource-manifest.py ${PdfJSFiles}
-        COMMAND ${CMAKE_COMMAND} -E rm -f ${_derived_sources_dir}/PdfJSGResourceBundle.deps
+        COMMAND ${CMAKE_COMMAND} -E remove -f ${_derived_sources_dir}/PdfJSGResourceBundle.deps
         COMMAND ${PYTHON_EXECUTABLE} ${TOOLS_DIR}/glib/generate-pdfjs-resource-manifest.py --gresource --input=${THIRDPARTY_DIR}/pdfjs --output=${_derived_sources_dir}/PdfJSGResourceBundle.xml
         VERBATIM
     )
@@ -21,7 +21,7 @@ macro(WEBKIT_BUILD_PDFJS_GRESOURCES _derived_sources_dir)
     add_custom_command(
         OUTPUT ${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml
         DEPENDS ${TOOLS_DIR}/glib/generate-pdfjs-resource-manifest.py ${PdfJSExtraFiles}
-        COMMAND ${CMAKE_COMMAND} -E rm -f ${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps
+        COMMAND ${CMAKE_COMMAND} -E remove -f ${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps
         COMMAND ${PYTHON_EXECUTABLE} ${TOOLS_DIR}/glib/generate-pdfjs-resource-manifest.py --gresource --input=${WEBCORE_DIR}/Modules/pdfjs-extras --output=${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml
         VERBATIM
     )


### PR DESCRIPTION
#### 6be2817af1e115abc5e26cc670cd3d20a27609ae
<pre>
[GLib] Fix build with CMake &lt; 3.17
<a href="https://bugs.webkit.org/show_bug.cgi?id=244728">https://bugs.webkit.org/show_bug.cgi?id=244728</a>

Reviewed by Adrian Perez de Castro.

* Source/WebKit/PdfJSGResources.cmake:

Canonical link: <a href="https://commits.webkit.org/254121@main">https://commits.webkit.org/254121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66f0d1e0c846435a62773a8f151ea6a7dd01f03c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97219 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30612 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26547 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80175 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/91958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93691 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74723 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/24644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28241 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28337 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/14588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2891 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31367 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30315 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/33823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->