### PR TITLE
[Reporting API] WebDriver: Add support for generateTestReport

### DIFF
--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -160,8 +160,10 @@ String ReportingScope::endpointURIForToken(const String& reportTo) const
     return m_reportingEndpoints.get(reportTo);
 }
 
-void ReportingScope::generateTestReport(String&& message)
+void ReportingScope::generateTestReport(String&& message, String&& group)
 {
+    UNUSED_PARAM(group);
+
     String reportURL { ""_s };
     if (auto* document = dynamicDowncast<Document>(scriptExecutionContext()))
         reportURL = document->url().strippedForUseAsReferrer();

--- a/Source/WebCore/Modules/reporting/ReportingScope.h
+++ b/Source/WebCore/Modules/reporting/ReportingScope.h
@@ -61,7 +61,7 @@ public:
 
     String endpointURIForToken(const String&) const;
 
-    void generateTestReport(String&& message);
+    void generateTestReport(String&& message, String&& group);
 
 private:
     explicit ReportingScope(ScriptExecutionContext&);

--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -854,6 +854,15 @@
                 { "name": "authenticatorId", "type": "string", "description": "The virtual authenticator id to fetch all credentials for." },
                 { "name": "isUserVerified", "type": "boolean", "description": "The isUserVerified value to set on the given virtual authenticator"}
             ]
+        },
+        {
+            "name": "generateTestReport",
+            "description": "generate a test report for the specified browsing context",
+            "parameters": [
+                { "name": "browsingContextHandle", "$ref": "BrowsingContextHandle", "description": "The handle for the browsing context." },
+                { "name": "message", "type": "string", "description": "The body message for the generated test report." },
+                { "name": "group", "type": "string", "description": "The group value to use when sending a test report."}
+            ]
         }
     ],
     "events": [

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1680,6 +1680,17 @@ Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::setVirtualAuthent
     SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(NotImplemented, "This method is not yet implemented.");
 }
 
+Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::generateTestReport(const String& browsingContextHandle, const String& message, const String& group)
+{
+    WebPageProxy* page = webPageProxyForHandle(browsingContextHandle);
+    if (!page)
+        SYNC_FAIL_WITH_PREDEFINED_ERROR(WindowNotFound);
+
+    page->generateTestReport(message, group);
+
+    return { };
+}
+
 bool WebAutomationSession::shouldAllowGetUserMediaForPage(const WebPageProxy&) const
 {
     return m_permissionForGetUserMedia;

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -213,6 +213,7 @@ public:
     Inspector::Protocol::ErrorStringOr<void> removeVirtualAuthenticatorCredential(const String& browsingContextHandle, const String& authenticatorId, const String& credentialId);
     Inspector::Protocol::ErrorStringOr<void> removeAllVirtualAuthenticatorCredentials(const String& browsingContextHandle, const String& authenticatorId);
     Inspector::Protocol::ErrorStringOr<void> setVirtualAuthenticatorUserVerified(const String& browsingContextHandle, const String& authenticatorId, bool isUserVerified);
+    Inspector::Protocol::ErrorStringOr<void> generateTestReport(const String& browsingContextHandle, const String& message, const String& group);
 
 #if PLATFORM(MAC)
     void inspectBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, std::optional<bool>&& enableAutoCapturing, Ref<InspectBrowsingContextCallback>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11654,6 +11654,11 @@ bool WebPageProxy::shouldAvoidSynchronouslyWaitingToPreventDeadlock() const
     return false;
 }
 
+void WebPageProxy::generateTestReport(const String& message, const String& group)
+{
+    send(Messages::WebPage::GenerateTestReport(message, group));
+}
+
 } // namespace WebKit
 
 #undef WEBPAGEPROXY_RELEASE_LOG

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2146,6 +2146,8 @@ public:
 
     void queryPermission(const WebCore::ClientOrigin&, const WebCore::PermissionDescriptor&, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&&);
 
+    void generateTestReport(const String& message, const String& group);
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -290,12 +290,12 @@ void WKBundleFrameFocus(WKBundleFrameRef frameRef)
     CheckedRef(coreFrame->page()->focusController())->setFocusedFrame(coreFrame.get());
 }
 
-void _WKBundleFrameGenerateTestReport(WKBundleFrameRef frameRef, WKStringRef message)
+void _WKBundleFrameGenerateTestReport(WKBundleFrameRef frameRef, WKStringRef message, WKStringRef group)
 {
     RefPtr coreFrame = WebKit::toImpl(frameRef)->coreFrame();
     if (!coreFrame)
         return;
 
     if (RefPtr document = coreFrame->document())
-        document->reportingScope().generateTestReport(WebKit::toWTFString(message));
+        document->reportingScope().generateTestReport(WebKit::toWTFString(message), WebKit::toWTFString(group));
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
@@ -56,7 +56,7 @@ WK_EXPORT bool WKBundleFrameHandlesPageScaleGesture(WKBundleFrameRef frame);
 
 WK_EXPORT void WKBundleFrameFocus(WKBundleFrameRef frame);
 
-WK_EXPORT void _WKBundleFrameGenerateTestReport(WKBundleFrameRef, WKStringRef message);
+WK_EXPORT void _WKBundleFrameGenerateTestReport(WKBundleFrameRef, WKStringRef message, WKStringRef group);
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8250,6 +8250,12 @@ void WebPage::clearNotificationPermissionState()
 }
 #endif
 
+void WebPage::generateTestReport(String&& message, String&& group)
+{
+    if (RefPtr document = m_page->mainFrame().document())
+        document->reportingScope().generateTestReport(WTFMove(message), WTFMove(group));
+}
+
 } // namespace WebKit
 
 #undef WEBPAGE_RELEASE_LOG

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1563,6 +1563,8 @@ public:
     void setInteractionRegionsEnabled(bool);
 #endif
 
+    void generateTestReport(String&& message, String&& group);
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -704,4 +704,6 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     SetInteractionRegionsEnabled(bool enable)
 #endif
+
+    GenerateTestReport(String message, String group);
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -434,5 +434,5 @@ interface TestRunner {
     undefined takeViewPortSnapshot(object callback);
 
     // Reporting API
-    undefined generateTestReport(DOMString message);
+    undefined generateTestReport(DOMString message, DOMString group);
 };

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -2234,9 +2234,9 @@ void TestRunner::viewPortSnapshotTaken(WKStringRef value)
     m_takeViewPortSnapshot = false;
 }
 
-void TestRunner::generateTestReport(JSStringRef message)
+void TestRunner::generateTestReport(JSStringRef message, JSStringRef group)
 {
-    _WKBundleFrameGenerateTestReport(mainFrame(), toWK(message).get());
+    _WKBundleFrameGenerateTestReport(mainFrame(), toWK(message).get(), toWK(group).get());
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_END

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -549,7 +549,7 @@ public:
     void viewPortSnapshotTaken(WKStringRef);
 
     // Reporting API
-    void generateTestReport(JSStringRef message);
+    void generateTestReport(JSStringRef message, JSStringRef group);
 
 private:
     TestRunner();


### PR DESCRIPTION
#### 9b7b0a6ad68383e5623c51681ce914bfdfc85d44
<pre>
[Reporting API] WebDriver: Add support for generateTestReport
<a href="https://bugs.webkit.org/show_bug.cgi?id=244719">https://bugs.webkit.org/show_bug.cgi?id=244719</a>
&lt;rdar://problem/99496290&gt;

Reviewed by Patrick Angle.

Add a new Automation interface to support &apos;generate_test_report&apos; in WPT when
run by WebDriver. This involves the following changes to comply with
<a href="https://w3c.github.io/reporting/#generate-test-report-command">https://w3c.github.io/reporting/#generate-test-report-command</a>:

(1) Update ReportingScope to accept a &apos;group&apos; argument, which will be used in
a future patch (once WPT starts using it).
(2) Update WKTR to accept an optional &apos;group&apos; argument to generateTestReport,
passing &apos;default&apos; if not provided.
(3) Provide a UIProcess method to accept generateTestReport from the Automation
interface.
(4) Add a new IPC message for the WebContent Process to generate a test report
at the request of the UIProcess.

* Source/WebCore/Modules/reporting/ReportingScope.cpp:
(WebCore::ReportingScope::generateTestReport): Add &apos;group&apos; argument.
* Source/WebCore/Modules/reporting/ReportingScope.h:
* Source/WebKit/UIProcess/Automation/Automation.json: Add new method.
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::generateTestReport): Added.
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::generateTestReport): Added.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(_WKBundleFrameGenerateTestReport): Accept the &apos;group&apos; argument.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::generateTestReport): Added.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::generateTestReport): Update to accept an optional
&apos;group&apos; argument, passing &quot;default&quot; if none is provided.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:

Canonical link: <a href="https://commits.webkit.org/254122@main">https://commits.webkit.org/254122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b7eec2a2f9be43fedcdd12e7fa7ec53efdb788a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32263 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/18804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97234 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152734 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30630 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80191 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/91971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93708 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74739 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24650 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/18804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28259 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/18804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28353 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/18804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2892 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31384 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30333 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/18804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->