### PR TITLE
Add .serialization.in files for VertexAttribute and VertexBufferLayout

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -523,6 +523,8 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/WebGPU/WebGPUOrigin3D.serialization.in
     Shared/WebGPU/WebGPUSupportedFeatures.serialization.in
     Shared/WebGPU/WebGPUValidationError.serialization.in
+    Shared/WebGPU/WebGPUVertexAttribute.serialization.in
+    Shared/WebGPU/WebGPUVertexBufferLayout.serialization.in
 )
 
 list(APPEND WebKit_DERIVED_SOURCES

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -146,6 +146,8 @@ $(PROJECT_DIR)/Shared/WebCoreArgumentCoders.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUOrigin3D.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUSupportedFeatures.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUValidationError.serialization.in
+$(PROJECT_DIR)/Shared/WebGPU/WebGPUVertexAttribute.serialization.in
+$(PROJECT_DIR)/Shared/WebGPU/WebGPUVertexBufferLayout.serialization.in
 $(PROJECT_DIR)/Shared/WebsiteDataStoreParameters.serialization.in
 $(PROJECT_DIR)/Shared/mac/SecItemResponseData.serialization.in
 $(PROJECT_DIR)/UIProcess/Automation/Automation.json

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -454,6 +454,8 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/WebCoreArgumentCoders.serialization.in \
 	Shared/mac/SecItemResponseData.serialization.in \
 	Shared/WebsiteDataStoreParameters.serialization.in \
+	Shared/WebGPU/WebGPUVertexBufferLayout.serialization.in \
+	Shared/WebGPU/WebGPUVertexAttribute.serialization.in \
 	Shared/WebGPU/WebGPUValidationError.serialization.in \
 	Shared/WebGPU/WebGPUSupportedFeatures.serialization.in \
 	Shared/WebGPU/WebGPUOrigin3D.serialization.in \

--- a/Source/WebKit/Shared/WebGPU/WebGPUVertexAttribute.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUVertexAttribute.h
@@ -38,33 +38,6 @@ struct VertexAttribute {
     PAL::WebGPU::Size64 offset { 0 };
 
     PAL::WebGPU::Index32 shaderLocation { 0 };
-
-    template<class Encoder> void encode(Encoder& encoder) const
-    {
-        encoder << format;
-        encoder << offset;
-        encoder << shaderLocation;
-    }
-
-    template<class Decoder> static std::optional<VertexAttribute> decode(Decoder& decoder)
-    {
-        std::optional<PAL::WebGPU::VertexFormat> format;
-        decoder >> format;
-        if (!format)
-            return std::nullopt;
-
-        std::optional<PAL::WebGPU::Size64> offset;
-        decoder >> offset;
-        if (!offset)
-            return std::nullopt;
-
-        std::optional<PAL::WebGPU::Index32> shaderLocation;
-        decoder >> shaderLocation;
-        if (!shaderLocation)
-            return std::nullopt;
-
-        return { { WTFMove(*format), WTFMove(*offset), WTFMove(*shaderLocation) } };
-    }
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/Shared/WebGPU/WebGPUVertexAttribute.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUVertexAttribute.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: "WebGPUVertexAttribute.h"
+
+#if ENABLE(GPU_PROCESS)
+[AdditionalEncoder=StreamConnectionEncoder] struct WebKit::WebGPU::VertexAttribute {
+    PAL::WebGPU::VertexFormat format
+    PAL::WebGPU::Size64 offset
+    PAL::WebGPU::Index32 shaderLocation
+}
+#endif

--- a/Source/WebKit/Shared/WebGPU/WebGPUVertexBufferLayout.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUVertexBufferLayout.h
@@ -39,33 +39,6 @@ struct VertexBufferLayout {
     PAL::WebGPU::Size64 arrayStride { 0 };
     PAL::WebGPU::VertexStepMode stepMode { PAL::WebGPU::VertexStepMode::Vertex };
     Vector<VertexAttribute> attributes;
-
-    template<class Encoder> void encode(Encoder& encoder) const
-    {
-        encoder << arrayStride;
-        encoder << stepMode;
-        encoder << attributes;
-    }
-
-    template<class Decoder> static std::optional<VertexBufferLayout> decode(Decoder& decoder)
-    {
-        std::optional<PAL::WebGPU::Size64> arrayStride;
-        decoder >> arrayStride;
-        if (!arrayStride)
-            return std::nullopt;
-
-        std::optional<PAL::WebGPU::VertexStepMode> stepMode;
-        decoder >> stepMode;
-        if (!stepMode)
-            return std::nullopt;
-
-        std::optional<Vector<VertexAttribute>> attributes;
-        decoder >> attributes;
-        if (!attributes)
-            return std::nullopt;
-
-        return { { WTFMove(*arrayStride), WTFMove(*stepMode), WTFMove(*attributes) } };
-    }
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/Shared/WebGPU/WebGPUVertexBufferLayout.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUVertexBufferLayout.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: "WebGPUVertexBufferLayout.h"
+
+#if ENABLE(GPU_PROCESS)
+[AdditionalEncoder=StreamConnectionEncoder] struct WebKit::WebGPU::VertexBufferLayout {
+    PAL::WebGPU::Size64 arrayStride
+    PAL::WebGPU::VertexStepMode stepMode
+    Vector<WebKit::WebGPU::VertexAttribute> attributes
+}
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2811,6 +2811,8 @@
 		00B9661718E25AE100CE1F88 /* FindClient.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FindClient.mm; sourceTree = "<group>"; };
 		00B9661818E25AE100CE1F88 /* FindClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FindClient.h; sourceTree = "<group>"; };
 		0237C21428C168D10018A851 /* WebGPUSupportedFeatures.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUSupportedFeatures.serialization.in; sourceTree = "<group>"; };
+		02CDD14628C2A9490015610A /* WebGPUVertexAttribute.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUVertexAttribute.serialization.in; sourceTree = "<group>"; };
+		02CDD14728C2A95E0015610A /* WebGPUVertexBufferLayout.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUVertexBufferLayout.serialization.in; sourceTree = "<group>"; };
 		0701789B23BAE261005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaPlayerMIMETypeCache.cpp; sourceTree = "<group>"; };
 		0701789C23BAE262005F0FAA /* RemoteMediaPlayerMIMETypeCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaPlayerMIMETypeCache.h; sourceTree = "<group>"; };
 		070259BE2522841C00153405 /* UserMediaPermissionRequestManagerProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UserMediaPermissionRequestManagerProxy.mm; sourceTree = "<group>"; };
@@ -8682,8 +8684,10 @@
 				5CD4F01B28B6A20700F9ECEA /* WebGPUValidationError.serialization.in */,
 				1C98C0D027462681002CCB78 /* WebGPUVertexAttribute.cpp */,
 				1CB7467227439CB000F19874 /* WebGPUVertexAttribute.h */,
+				02CDD14628C2A9490015610A /* WebGPUVertexAttribute.serialization.in */,
 				1C98C0AC2746267B002CCB78 /* WebGPUVertexBufferLayout.cpp */,
 				1CB7468F27439CB800F19874 /* WebGPUVertexBufferLayout.h */,
+				02CDD14728C2A95E0015610A /* WebGPUVertexBufferLayout.serialization.in */,
 				1C98C0CD27462681002CCB78 /* WebGPUVertexState.cpp */,
 				1CB7469A27439CBB00F19874 /* WebGPUVertexState.h */,
 			);


### PR DESCRIPTION
#### 2da05c9d432069810da7891ecf332255b19f7d77
<pre>
Add .serialization.in files for VertexAttribute and VertexBufferLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=244730">https://bugs.webkit.org/show_bug.cgi?id=244730</a>

Reviewed by NOBODY (OOPS!).

Add .serialization.in files for WebGPUVertexAttribute and WebGPUVertexBufferLayout.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/WebGPU/WebGPUVertexAttribute.h:
(WebKit::WebGPU::VertexAttribute::encode const): Deleted.
(WebKit::WebGPU::VertexAttribute::decode): Deleted.
* Source/WebKit/Shared/WebGPU/WebGPUVertexAttribute.serialization.in: Added.
* Source/WebKit/Shared/WebGPU/WebGPUVertexBufferLayout.h:
(WebKit::WebGPU::VertexBufferLayout::encode const): Deleted.
(WebKit::WebGPU::VertexBufferLayout::decode): Deleted.
* Source/WebKit/Shared/WebGPU/WebGPUVertexBufferLayout.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2da05c9d432069810da7891ecf332255b19f7d77

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97225 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30618 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26552 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80181 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91963 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24676 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74729 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24641 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67626 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28247 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13612 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28343 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14594 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37484 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33828 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->