### PR TITLE
Web Inspector: Add Media Tab

### DIFF
--- a/Source/JavaScriptCore/DerivedSources-input.xcfilelist
+++ b/Source/JavaScriptCore/DerivedSources-input.xcfilelist
@@ -108,6 +108,7 @@ $(PROJECT_DIR)/inspector/protocol/Heap.json
 $(PROJECT_DIR)/inspector/protocol/IndexedDB.json
 $(PROJECT_DIR)/inspector/protocol/Inspector.json
 $(PROJECT_DIR)/inspector/protocol/LayerTree.json
+$(PROJECT_DIR)/inspector/protocol/Media.json
 $(PROJECT_DIR)/inspector/protocol/Memory.json
 $(PROJECT_DIR)/inspector/protocol/Network.json
 $(PROJECT_DIR)/inspector/protocol/Page.json

--- a/Source/JavaScriptCore/DerivedSources.make
+++ b/Source/JavaScriptCore/DerivedSources.make
@@ -302,6 +302,7 @@ INSPECTOR_DOMAINS := \
     $(JavaScriptCore)/inspector/protocol/IndexedDB.json \
     $(JavaScriptCore)/inspector/protocol/Inspector.json \
     $(JavaScriptCore)/inspector/protocol/LayerTree.json \
+	$(JavaScriptCore)/inspector/protocol/Media.json \
     $(JavaScriptCore)/inspector/protocol/Memory.json \
     $(JavaScriptCore)/inspector/protocol/Network.json \
     $(JavaScriptCore)/inspector/protocol/Page.json \

--- a/Source/JavaScriptCore/inspector/protocol/Media.json
+++ b/Source/JavaScriptCore/inspector/protocol/Media.json
@@ -1,0 +1,123 @@
+{
+    "domain": "Media",
+    "description": "Media domain allows tracking of media elements that have an associated media player. Tracks media elements in the DOM and elements created in JS.",
+    "condition": "defined(ENABLE_VIDEO) && ENABLE_VIDEO",
+    "debuggableTypes": ["page", "web-page"],
+    "targetTypes": ["page"],
+    "types": [
+        {
+            "id": "MediaPlayerId",
+            "type": "string",
+            "description": "Unique media player identifier."
+        },
+        {
+            "id": "MediaPlayer",
+            "type": "object",
+            "description": "Information about a media player.",
+            "properties": [
+                { "name": "playerId", "$ref": "MediaPlayerId", "description": "Media player identifier." },
+                { "name": "originUrl", "type": "string", "description": "Origin url." },
+                { "name": "contentType", "type": "string", "description": "Resource content type." },
+                { "name": "duration", "type": "any", "description": "Media time representing the duration of the content." },
+                { "name": "engine", "type": "string", "description": "The internal engine behind the media player." }
+            ]
+        },
+        {
+            "id": "MediaPlayerEvent",
+            "type": "string",
+            "enum": [
+                "abort",
+                "canplay",
+                "canplaythrough",
+                "durationchange",
+                "emptied",
+                "ended",
+                "error",
+                "loadeddata",
+                "loadedmetadata",
+                "loadstart",
+                "pause",
+                "play",
+                "playing",
+                "progress",
+                "ratechange",
+                "resize",
+                "seeked",
+                "seeking",
+                "stalled",
+                "suspend",
+                "timeupdate",
+                "volumechange",
+                "waiting"
+            ],
+            "description": "Possible events emitted from a media player."
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables media inspection."
+        },
+        {
+            "name": "disable",
+            "description": "Disables media inspection."
+        },
+        {
+            "name": "requestNode",
+            "description": "Gets the NodeId for the player node with the given MediaPlayerId.",
+            "parameters": [
+                { "name": "playerId", "$ref": "MediaPlayerId", "description": "Media player identifier." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Node identifier for given media player." }
+            ]
+        },
+        {
+            "name": "resolveElement",
+            "description": "Resolves JavaScript media element for a given playerId.",
+            "parameters": [
+                { "name": "playerId", "$ref": "MediaPlayerId", "description": "Canvas identifier." },
+                { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
+            ],
+            "returns": [
+                { "name": "object", "$ref": "Runtime.RemoteObject", "description": "JavaScript object wrapper for given media player." }
+            ]
+        },
+        {
+            "name": "play",
+            "description": "Plays the given media player.",
+            "parameters": [
+                { "name": "playerId", "$ref": "MediaPlayerId", "description": "Media player identifier." }
+            ]
+        },
+        {
+            "name": "pause",
+            "description": "Pauses the given media player.",
+            "parameters": [
+                { "name": "playerId", "$ref": "MediaPlayerId", "description": "Media player identifier." }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "playerAdded",
+            "parameters": [
+                { "name": "player", "$ref": "MediaPlayer", "description": "Media player object." }
+            ]
+        },
+        {
+            "name": "playerRemoved",
+            "parameters": [
+                { "name": "playerId", "$ref": "MediaPlayerId", "description": "Removed media player identifier." }
+            ]
+        },
+        {
+            "name": "playerUpdated",
+            "parameters": [
+                { "name": "player", "$ref": "MediaPlayer", "description": "Media player object." },
+                { "name": "event", "$ref": "MediaPlayerEvent", "description": "Media player event." },
+                { "name": "data", "type": "any", "optional": true, "description": "Media player event data." }
+            ]
+        }
+    ]
+}

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1521,6 +1521,7 @@ inspector/InspectorHistory.cpp
 inspector/InspectorInstrumentation.cpp
 inspector/InspectorInstrumentationPublic.cpp
 inspector/InspectorInstrumentationWebKit.cpp
+inspector/InspectorMediaPlayer.cpp
 inspector/InspectorNodeFinder.cpp
 inspector/InspectorOverlay.cpp
 inspector/InspectorOverlayLabel.cpp
@@ -1546,6 +1547,7 @@ inspector/agents/InspectorDOMStorageAgent.cpp
 inspector/agents/InspectorDatabaseAgent.cpp
 inspector/agents/InspectorIndexedDBAgent.cpp
 inspector/agents/InspectorLayerTreeAgent.cpp
+inspector/agents/InspectorMediaAgent.cpp
 inspector/agents/InspectorMemoryAgent.cpp
 inspector/agents/InspectorNetworkAgent.cpp
 inspector/agents/InspectorPageAgent.cpp

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -472,6 +472,7 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
 #endif
 {
     allMediaElements().add(this);
+    InspectorInstrumentation::didCreateMediaPlayer(&document, *this);
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
@@ -546,6 +547,8 @@ void HTMLMediaElement::initializeMediaSession()
 HTMLMediaElement::~HTMLMediaElement()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
+    
+    InspectorInstrumentation::didDestroyMediaPlayer(&document(), *this);
 
     beginIgnoringTrackDisplayUpdateRequests();
 
@@ -972,6 +975,8 @@ void HTMLMediaElement::scheduleEvent(const AtomString& eventName)
 
 void HTMLMediaElement::scheduleEvent(Ref<Event>&& event)
 {
+    if (m_player)
+        InspectorInstrumentation::didUpdateMediaPlayer(&document(), *this, event->type().string());
     queueCancellableTaskToDispatchEvent(*this, TaskSource::MediaElement, m_asyncEventsCancellationGroup, WTFMove(event));
 }
 

--- a/Source/WebCore/inspector/InspectorController.cpp
+++ b/Source/WebCore/inspector/InspectorController.cpp
@@ -52,6 +52,7 @@
 #include "InspectorIndexedDBAgent.h"
 #include "InspectorInstrumentation.h"
 #include "InspectorLayerTreeAgent.h"
+#include "InspectorMediaAgent.h"
 #include "InspectorMemoryAgent.h"
 #include "InspectorPageAgent.h"
 #include "InspectorTimelineAgent.h"
@@ -186,6 +187,7 @@ void InspectorController::createLazyAgents()
     m_agents.append(makeUnique<InspectorCanvasAgent>(pageContext));
     m_agents.append(makeUnique<InspectorTimelineAgent>(pageContext));
     m_agents.append(makeUnique<InspectorAnimationAgent>(pageContext));
+    m_agents.append(makeUnique<InspectorMediaAgent>(pageContext));
 
     if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())
         commandLineAPIHost->init(m_instrumentingAgents.copyRef());

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -1285,6 +1285,24 @@ void InspectorInstrumentation::didFireObserverCallbackImpl(InstrumentingAgents& 
         timelineAgent->didFireObserverCallback();
 }
 
+void InspectorInstrumentation::didCreateMediaPlayerImpl(InstrumentingAgents& instrumentingAgents, HTMLMediaElement& mediaElement)
+{
+    if (auto* mediaAgent = instrumentingAgents.enabledMediaAgent())
+        mediaAgent->didCreateMediaPlayer(mediaElement);
+}
+
+void InspectorInstrumentation::didDestroyMediaPlayerImpl(InstrumentingAgents& instrumentingAgents, HTMLMediaElement& mediaElement)
+{
+    if (auto* mediaAgent = instrumentingAgents.enabledMediaAgent())
+        mediaAgent->didDestroyMediaPlayer(mediaElement);
+}
+
+void InspectorInstrumentation::didUpdateMediaPlayerImpl(InstrumentingAgents& instrumentingAgents, HTMLMediaElement& mediaElement, const String& event)
+{
+    if (auto* mediaAgent = instrumentingAgents.enabledMediaAgent())
+        mediaAgent->didUpdateMediaPlayer(mediaElement, event);
+}
+
 void InspectorInstrumentation::registerInstrumentingAgents(InstrumentingAgents& instrumentingAgents)
 {
     if (!s_instrumentingAgentsSet)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -315,6 +315,10 @@ public:
     static void didCreateWebAnimation(WebAnimation&);
     static void willDestroyWebAnimation(WebAnimation&);
 
+    static void didCreateMediaPlayer(Document*, HTMLMediaElement&);
+    static void didDestroyMediaPlayer(Document*, HTMLMediaElement&);
+    static void didUpdateMediaPlayer(Document*, HTMLMediaElement&, const String&);
+    
     static void networkStateChanged(Page&);
     static void updateApplicationCacheStatus(Frame*);
 
@@ -523,6 +527,10 @@ private:
     static void didCreateWebAnimationImpl(InstrumentingAgents&, WebAnimation&);
     static void willDestroyWebAnimationImpl(InstrumentingAgents&, WebAnimation&);
 
+    static void didCreateMediaPlayerImpl(InstrumentingAgents&, HTMLMediaElement&);
+    static void didDestroyMediaPlayerImpl(InstrumentingAgents&, HTMLMediaElement&);
+    static void didUpdateMediaPlayerImpl(InstrumentingAgents&, HTMLMediaElement&, const String&);
+    
     static void layerTreeDidChangeImpl(InstrumentingAgents&);
     static void renderLayerDestroyedImpl(InstrumentingAgents&, const RenderLayer&);
 
@@ -1543,6 +1551,27 @@ inline void InspectorInstrumentation::willDestroyWebAnimation(WebAnimation& anim
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(animation.scriptExecutionContext()))
         willDestroyWebAnimationImpl(*agents, animation);
+}
+
+inline void InspectorInstrumentation::didCreateMediaPlayer(Document* document, HTMLMediaElement& mediaElement)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (auto* agents = instrumentingAgents(document))
+        didCreateMediaPlayerImpl(*agents, mediaElement);
+}
+
+inline void InspectorInstrumentation::didDestroyMediaPlayer(Document* document, HTMLMediaElement& mediaElement)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (auto* agents = instrumentingAgents(document))
+        didDestroyMediaPlayerImpl(*agents, mediaElement);
+}
+
+inline void InspectorInstrumentation::didUpdateMediaPlayer(Document* document, HTMLMediaElement& mediaElement, const String& event)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (auto* agents = instrumentingAgents(document))
+        didUpdateMediaPlayerImpl(*agents, mediaElement, event);
 }
 
 inline void InspectorInstrumentation::networkStateChanged(Page& page)

--- a/Source/WebCore/inspector/InspectorMediaPlayer.cpp
+++ b/Source/WebCore/inspector/InspectorMediaPlayer.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InspectorMediaPlayer.h"
+
+#include "HTMLMediaElement.h"
+#include "MediaPlayer.h"
+#include <variant>
+#include <wtf/Function.h>
+#include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+using namespace Inspector;
+
+Ref<InspectorMediaPlayer> InspectorMediaPlayer::create(HTMLMediaElement& mediaElement)
+{
+    return adoptRef(*new InspectorMediaPlayer(mediaElement));
+}
+
+InspectorMediaPlayer::InspectorMediaPlayer(HTMLMediaElement& mediaElement)
+    : m_mediaElement(mediaElement)
+{
+}
+
+String InspectorMediaPlayer::identifier() const
+{
+    return m_mediaElement->identifier().loggingString();
+}
+
+HTMLMediaElement* InspectorMediaPlayer::mediaElement() const
+{
+    return m_mediaElement.get();
+}
+
+MediaPlayer* InspectorMediaPlayer::mediaPlayer() const
+{
+    return m_mediaElement->player().get();
+}
+
+void InspectorMediaPlayer::play()
+{
+    m_mediaElement->play();
+}
+
+void InspectorMediaPlayer::pause()
+{
+    m_mediaElement->pause();
+}
+
+Ref<Inspector::Protocol::Media::MediaPlayer> InspectorMediaPlayer::buildObjectForMediaPlayer()
+{
+    auto player = Protocol::Media::MediaPlayer::create()
+        .setPlayerId(identifier())
+        .setOriginUrl(mediaPlayer()->url().string())
+        .setContentType(mediaPlayer()->contentMIMEType())
+        .setDuration(mediaPlayer()->duration().toJSONObject())
+        .setEngine(mediaPlayer()->engineDescription())
+        .release();;
+    
+    return player;
+}
+
+} // namespace WebCore
+

--- a/Source/WebCore/inspector/InspectorMediaPlayer.h
+++ b/Source/WebCore/inspector/InspectorMediaPlayer.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2017-2018 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class HTMLMediaElement;
+class MediaPlayer;
+class MediaPlayerClient;
+
+class InspectorMediaPlayer final : public RefCounted<InspectorMediaPlayer> {
+public:
+    static Ref<InspectorMediaPlayer> create(HTMLMediaElement&);
+
+    String identifier() const;
+    HTMLMediaElement* mediaElement() const;
+    MediaPlayer* mediaPlayer() const;
+    
+    void play();
+    void pause();
+    
+    Ref<Inspector::Protocol::Media::MediaPlayer> buildObjectForMediaPlayer();
+
+private:
+    InspectorMediaPlayer(HTMLMediaElement&);
+    
+    WeakPtr<HTMLMediaElement> m_mediaElement;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -53,6 +53,7 @@ class InspectorDOMDebuggerAgent;
 class InspectorDOMStorageAgent;
 class InspectorDatabaseAgent;
 class InspectorLayerTreeAgent;
+class InspectorMediaAgent;
 class InspectorMemoryAgent;
 class InspectorNetworkAgent;
 class InspectorPageAgent;
@@ -81,6 +82,7 @@ class WebDebuggerAgent;
 #define DEFINE_INSPECTOR_AGENT_Heap_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, PageHeapAgent, PageHeapAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Inspector(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, Inspector::InspectorAgent, InspectorAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_LayerTree(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorLayerTreeAgent, LayerTreeAgent, Getter, Setter)
+#define DEFINE_INSPECTOR_AGENT_Media(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorMediaAgent, MediaAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Network(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorNetworkAgent, NetworkAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorPageAgent, PageAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Runtime_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, PageRuntimeAgent, PageRuntimeAgent, Getter, Setter)
@@ -126,6 +128,7 @@ class WebDebuggerAgent;
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, DOMStorage) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Heap_Page) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, LayerTree) \
+    DEFINE_ENABLED_INSPECTOR_AGENT(macro, Media) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Memory) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Network) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Page) \

--- a/Source/WebCore/inspector/agents/InspectorMediaAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorMediaAgent.cpp
@@ -1,0 +1,269 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InspectorMediaAgent.h"
+
+#include "HTMLMediaElement.h"
+#include "JSHTMLMediaElement.h"
+#include "MediaPlayer.h"
+#include <variant>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+#include <wtf/Lock.h>
+#include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+using namespace Inspector;
+
+InspectorMediaAgent::InspectorMediaAgent(PageAgentContext& context)
+    : InspectorAgentBase("Media"_s, context)
+    , m_frontendDispatcher(makeUnique<Inspector::MediaFrontendDispatcher>(context.frontendRouter))
+    , m_backendDispatcher(Inspector::MediaBackendDispatcher::create(context.backendDispatcher, this))
+    , m_injectedScriptManager(context.injectedScriptManager)
+    , m_inspectedPage(context.inspectedPage)
+    , m_playerDestroyedTimer(*this, &InspectorMediaAgent::playerDestroyedTimerFired)
+{
+}
+
+InspectorMediaAgent::~InspectorMediaAgent() = default;
+
+void InspectorMediaAgent::didCreateFrontendAndBackend(Inspector::FrontendRouter*, Inspector::BackendDispatcher*)
+{
+}
+
+void InspectorMediaAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
+{
+    disable();
+}
+
+void InspectorMediaAgent::discardAgent()
+{
+    reset();
+}
+
+Protocol::ErrorStringOr<void> InspectorMediaAgent::enable()
+{
+    if (m_instrumentingAgents.enabledMediaAgent() == this)
+        return { };
+    
+    m_instrumentingAgents.setEnabledMediaAgent(this);
+    
+    for (auto* mediaElement : HTMLMediaElement::allMediaElements()) {
+        if (mediaElement->document().page() == &m_inspectedPage)
+            bindPlayer(*mediaElement);
+    }
+    
+    return { };
+}
+
+Protocol::ErrorStringOr<void> InspectorMediaAgent::disable()
+{
+    m_instrumentingAgents.setEnabledMediaAgent(nullptr);
+    reset();
+    return { };
+}
+
+Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorMediaAgent::requestNode(const Protocol::Media::MediaPlayerId& playerId)
+{
+    Protocol::ErrorString errorString;
+    
+    auto inspectorPlayer = assertInspectorPlayer(errorString, playerId);
+    if (!inspectorPlayer)
+        return makeUnexpected(errorString);
+    
+    auto* node = inspectorPlayer->mediaElement();
+    if (!node)
+        return makeUnexpected("Missing element of player for given playerId"_s);
+    
+    int documentNodeId = m_instrumentingAgents.persistentDOMAgent()->boundNodeId(&node->document());
+    if (!documentNodeId)
+        return makeUnexpected("Document must have been requested"_s);
+    
+    return m_instrumentingAgents.persistentDOMAgent()->pushNodeToFrontend(errorString, documentNodeId, node);
+}
+
+Inspector::Protocol::ErrorStringOr<Ref<Protocol::Runtime::RemoteObject>> InspectorMediaAgent::resolveElement(const Inspector::Protocol::Media::MediaPlayerId& playerId, const String& objectGroup)
+{
+    Protocol::ErrorString errorString;
+    
+    auto inspectorPlayer = assertInspectorPlayer(errorString, playerId);
+    if (!inspectorPlayer)
+        return makeUnexpected(errorString);
+    
+    auto* node = inspectorPlayer->mediaElement();
+    if (!node)
+        return makeUnexpected("Missing element of player for given playerId"_s);
+    
+    auto* state = node->scriptExecutionContext()->globalObject();
+    auto injectedScript = m_injectedScriptManager.injectedScriptFor(state);
+    ASSERT(!injectedScript.hasNoValue());
+    
+    JSC::JSValue value;
+    {
+        JSC::JSLockHolder lock(state);
+
+        auto* globalObject = deprecatedGlobalObjectForPrototype(state);
+        value = toJS(state, globalObject, node);
+    }
+    
+    if (!value) {
+        ASSERT_NOT_REACHED();
+        return makeUnexpected("Internal error: unknown HTMLMediaElement for given playerId"_s);
+    }
+
+    auto object = injectedScript.wrapObject(value, objectGroup);
+    if (!object)
+        return makeUnexpected("Internal error: unable to cast HTMLMediaElement"_s);
+
+    return object.releaseNonNull();
+}
+
+Protocol::ErrorStringOr<void> InspectorMediaAgent::play(const Protocol::Media::MediaPlayerId& playerId)
+{
+    Protocol::ErrorString errorString;
+    
+    auto inspectorPlayer = assertInspectorPlayer(errorString, playerId);
+    if (!inspectorPlayer)
+        return makeUnexpected(errorString);
+    
+    inspectorPlayer->play();
+    return { };
+}
+
+Protocol::ErrorStringOr<void> InspectorMediaAgent::pause(const Protocol::Media::MediaPlayerId& playerId)
+{
+    Protocol::ErrorString errorString;
+    
+    auto inspectorPlayer = assertInspectorPlayer(errorString, playerId);
+    if (!inspectorPlayer)
+        return makeUnexpected(errorString);
+    
+    inspectorPlayer->pause();
+    return { };
+}
+
+void InspectorMediaAgent::didCreateMediaPlayer(HTMLMediaElement& mediaElement)
+{
+    if (!mediaElement.identifier()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+    
+    bindPlayer(mediaElement);
+}
+
+void InspectorMediaAgent::didDestroyMediaPlayer(HTMLMediaElement& mediaElement)
+{
+    if (!mediaElement.identifier()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+    
+    auto playerId = mediaElement.identifier().loggingString();
+    auto inspectorPlayer = m_identifierToInspectorPlayer.get(playerId);
+    if (!inspectorPlayer)
+        return;
+    
+    unbindPlayer(*inspectorPlayer);
+}
+
+void InspectorMediaAgent::didUpdateMediaPlayer(HTMLMediaElement& mediaElement, const String& eventString)
+{
+    auto event = Protocol::Helpers::parseEnumValueFromString<Protocol::Media::MediaPlayerEvent>(eventString);
+    if (!event || !mediaElement.identifier()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+    
+    auto playerId = mediaElement.identifier().loggingString();
+    auto inspectorPlayer = m_identifierToInspectorPlayer.get(playerId);
+    if (!inspectorPlayer) {
+        bindPlayer(mediaElement);
+        inspectorPlayer = m_identifierToInspectorPlayer.get(playerId);
+    }
+    
+    if (!inspectorPlayer || !inspectorPlayer->mediaPlayer())
+        return;
+    
+    m_frontendDispatcher->playerUpdated(inspectorPlayer->buildObjectForMediaPlayer(), *event, JSON::Value::create(String("hello"_s)));
+}
+
+void InspectorMediaAgent::reset()
+{
+    m_identifierToInspectorPlayer.clear();
+    m_removedPlayerIdentifiers.clear();
+}
+
+void InspectorMediaAgent::bindPlayer(HTMLMediaElement& mediaElement)
+{
+    if (!mediaElement.player())
+        return;
+    
+    auto inspectorPlayer = InspectorMediaPlayer::create(mediaElement);
+    m_identifierToInspectorPlayer.set(inspectorPlayer->identifier(), inspectorPlayer.copyRef());
+    
+    m_frontendDispatcher->playerAdded(inspectorPlayer->buildObjectForMediaPlayer());
+}
+
+void InspectorMediaAgent::unbindPlayer(InspectorMediaPlayer& inspectorPlayer)
+{
+    auto identifier = inspectorPlayer.identifier();
+    m_identifierToInspectorPlayer.remove(identifier);
+    
+    // This can be called in response to GC. Due to the single-process model used in WebKit1, the
+    // event must be dispatched from a timer to prevent the frontend from making JS allocations
+    // while the GC is still active.
+    m_removedPlayerIdentifiers.append(identifier);
+
+    if (!m_playerDestroyedTimer.isActive())
+        m_playerDestroyedTimer.startOneShot(0_s);
+}
+
+RefPtr<InspectorMediaPlayer> InspectorMediaAgent::assertInspectorPlayer(Protocol::ErrorString& errorString, const String& playerId)
+{
+    auto inspectorPlayer = m_identifierToInspectorPlayer.get(playerId);
+    if (!inspectorPlayer) {
+        errorString = "Missing player for given playerId"_s;
+        return nullptr;
+    }
+    return inspectorPlayer;
+}
+
+void InspectorMediaAgent::playerDestroyedTimerFired()
+{
+    if (!m_removedPlayerIdentifiers.size())
+        return;
+
+    for (auto& identifier : m_removedPlayerIdentifiers)
+        m_frontendDispatcher->playerRemoved(identifier);
+
+    m_removedPlayerIdentifiers.clear();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/InspectorMediaAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorMediaAgent.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InspectorMediaPlayer.h"
+#include "InspectorWebAgentBase.h"
+#include <initializer_list>
+#include <wtf/Forward.h>
+#include <wtf/RobinHoodHashMap.h>
+#include <wtf/RobinHoodHashSet.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
+
+namespace Inspector {
+class InjectedScriptManager;
+}
+
+namespace WebCore {
+
+class Page;
+
+class InspectorMediaAgent final : public InspectorAgentBase, public Inspector::MediaBackendDispatcherHandler {
+    WTF_MAKE_NONCOPYABLE(InspectorMediaAgent);
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    InspectorMediaAgent(PageAgentContext&);
+    ~InspectorMediaAgent();
+
+    // InspectorAgentBase
+    void didCreateFrontendAndBackend(Inspector::FrontendRouter*, Inspector::BackendDispatcher*);
+    void willDestroyFrontendAndBackend(Inspector::DisconnectReason);
+    void discardAgent();
+    
+    // MediaBackendDispatcherHandler
+    Inspector::Protocol::ErrorStringOr<void> enable();
+    Inspector::Protocol::ErrorStringOr<void> disable();
+    Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> requestNode(const Inspector::Protocol::Media::MediaPlayerId&);
+    Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObject>> resolveElement(const Inspector::Protocol::Media::MediaPlayerId&, const String& objectGroup);
+    Inspector::Protocol::ErrorStringOr<void> play(const Inspector::Protocol::Media::MediaPlayerId&);
+    Inspector::Protocol::ErrorStringOr<void> pause(const Inspector::Protocol::Media::MediaPlayerId&);
+
+    // InspectorInstrumentation
+    void didCreateMediaPlayer(HTMLMediaElement&);
+    void didDestroyMediaPlayer(HTMLMediaElement&);
+    void didUpdateMediaPlayer(HTMLMediaElement&, const String&);
+
+private:
+    void reset();
+    
+    void bindPlayer(HTMLMediaElement&);
+    void unbindPlayer(InspectorMediaPlayer&);
+    RefPtr<InspectorMediaPlayer> assertInspectorPlayer(Inspector::Protocol::ErrorString&, const String& playerId);
+    
+    void playerDestroyedTimerFired();
+    
+//    InspectorCanvas& bindMediaPlayer(CanvasRenderingContext&, bool captureBacktrace);
+//    void unbindCanvas(InspectorCanvas&);
+//    RefPtr<InspectorCanvas> assertInspectorCanvas(Inspector::Protocol::ErrorString&, const String& canvasId);
+//    RefPtr<InspectorCanvas> findInspectorCanvas(CanvasRenderingContext&);
+
+    std::unique_ptr<Inspector::MediaFrontendDispatcher> m_frontendDispatcher;
+    RefPtr<Inspector::MediaBackendDispatcher> m_backendDispatcher;
+
+    Inspector::InjectedScriptManager& m_injectedScriptManager;
+    Page& m_inspectedPage;
+
+    MemoryCompactRobinHoodHashMap<String, RefPtr<InspectorMediaPlayer>> m_identifierToInspectorPlayer;
+    Vector<String> m_removedPlayerIdentifiers;
+    Timer m_playerDestroyedTimer;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -73,6 +73,7 @@ class DestinationColorSpace;
 class GraphicsContextGL;
 class GraphicsContext;
 class InbandTextTrackPrivate;
+class InspectorMediaPlayer;
 class LegacyCDM;
 class LegacyCDMSession;
 class LegacyCDMSessionClient;
@@ -580,6 +581,7 @@ public:
 
     String referrer() const;
     String userAgent() const;
+    URL url() const { return m_url; }
 
     String engineDescription() const;
     long platformErrorCode() const;
@@ -713,6 +715,7 @@ public:
     void renderVideoWillBeDestroyed();
 
 private:
+    friend class InspectorMediaPlayer;
     MediaPlayer(MediaPlayerClient&);
     MediaPlayer(MediaPlayerClient&, MediaPlayerEnums::MediaEngineIdentifier);
 

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -149,6 +149,7 @@ localizedStrings["All Exceptions @ JavaScript Breakpoint"] = "All Exceptions";
 /* Break (pause) on all intervals */
 localizedStrings["All Intervals @ Event Breakpoint"] = "All Intervals";
 localizedStrings["All Layers"] = "All Layers";
+localizedStrings["All Media Players"] = "All Media Players";
 /* Break (pause) on all microtasks */
 localizedStrings["All Microtasks @ JavaScript Breakpoint"] = "All Microtasks";
 /* Property value for `font-variant-capitals: all-petite-caps`. */
@@ -209,6 +210,7 @@ localizedStrings["Attribute"] = "Attribute";
 /* A submenu item of 'Break On' that breaks (pauses) before DOM attribute is modified */
 localizedStrings["Attribute Modified @ DOM Breakpoint"] = "Attribute Modified";
 localizedStrings["Attributes"] = "Attributes";
+localizedStrings["Audio"] = "Audio";
 localizedStrings["Audit"] = "Audit";
 localizedStrings["Audit Error: %s"] = "Audit Error: %s";
 /* Name of Audit Tab */
@@ -404,6 +406,7 @@ localizedStrings["Console opened at %s"] = "Console opened at %s";
 localizedStrings["Console prompt"] = "Console prompt";
 localizedStrings["Containing"] = "Containing";
 localizedStrings["Content Security Policy violation of directive: %s"] = "Content Security Policy violation of directive: %s";
+localizedStrings["Content Type"] = "Content Type";
 /* Property value for `font-variant-ligatures: contextual`. */
 localizedStrings["Contextual Alternates @ Font Details Sidebar Property Value"] = "Contextual Alternates";
 localizedStrings["Continuation Frame"] = "Continuation Frame";
@@ -610,6 +613,7 @@ localizedStrings["Element overlaps other compositing element"] = "Element overla
 localizedStrings["Elements"] = "Elements";
 /* Name of Elements Tab */
 localizedStrings["Elements Tab Name"] = "Elements";
+localizedStrings["Empty"] = "Empty";
 /* Checkbox shown in the Console to cause future evaluations as though they are in response to user interaction. */
 localizedStrings["Emulate User Gesture @ Console"] = "Emulate User Gesture";
 /* Checkbox shown when configuring log/evaluate/probe breakpoint actions to cause it to be evaluated as though it was in response to user interaction. */
@@ -634,6 +638,7 @@ localizedStrings["Enabled Timelines @ Timelines Tab"] = "Enabled Timelines";
 localizedStrings["Encoded"] = "Encoded";
 localizedStrings["Encoding"] = "Encoding";
 localizedStrings["Energy Impact"] = "Energy Impact";
+localizedStrings["Engine"] = "Engine";
 localizedStrings["Ensure aria-hidden=\u0022%s\u0022 is not used."] = "Ensure aria-hidden=\u0022%s\u0022 is not used.";
 localizedStrings["Ensure that \u0022%s\u0022 is spelled correctly."] = "Ensure that \u0022%s\u0022 is spelled correctly.";
 localizedStrings["Ensure that buttons have accessible labels for assistive technology."] = "Ensure that buttons have accessible labels for assistive technology.";
@@ -939,6 +944,7 @@ localizedStrings["Log Canvas Context"] = "Log Canvas Context";
 localizedStrings["Log Element"] = "Log Element";
 localizedStrings["Log Frame Text"] = "Log Frame Text";
 localizedStrings["Log Frame Value"] = "Log Frame Value";
+localizedStrings["Log MediaPlayer"] = "Log MediaPlayer";
 localizedStrings["Log Message"] = "Log Message";
 /* Log (print) DOM node to Console */
 localizedStrings["Log Node"] = "Log Node";
@@ -974,6 +980,11 @@ localizedStrings["Media & Animations"] = "Media & Animations";
 localizedStrings["Media Element"] = "Media Element";
 localizedStrings["Media Event"] = "Media Event";
 localizedStrings["Media Logging:"] = "Media Logging:";
+localizedStrings["Media Player Details"] = "Media Player Details";
+localizedStrings["Media Player Events"] = "Media Player Events";
+localizedStrings["Media Players"] = "Media Players";
+/* Name of Media Tab */
+localizedStrings["Media Tab Name"] = "Media";
 localizedStrings["MediaSource"] = "MediaSource";
 /* Medium network request priority */
 localizedStrings["Medium @ Network Priority"] = "Medium";
@@ -1385,6 +1396,7 @@ localizedStrings["Selected Element"] = "Selected Element";
 localizedStrings["Selected Frame"] = "Selected Frame";
 localizedStrings["Selected Item"] = "Selected Item";
 localizedStrings["Selected Items"] = "Selected Items";
+localizedStrings["Selected Media Player"] = "Selected Media Player";
 /* Selected DOM node */
 localizedStrings["Selected Node"] = "Selected Node";
 localizedStrings["Selected Symbol"] = "Selected Symbol";
@@ -1688,6 +1700,7 @@ localizedStrings["Ungrouped @ Computed Style variables grouping mode"] = "Ungrou
 localizedStrings["Unicase @ Font Details Sidebar Property Value"] = "Unicase";
 localizedStrings["Unique"] = "Unique";
 localizedStrings["Unknown Location"] = "Unknown Location";
+localizedStrings["Unknown Type"] = "Unknown Type";
 localizedStrings["Unknown error"] = "Unknown error";
 localizedStrings["Unknown node"] = "Unknown node";
 /* Title of icon indicating that the selected audit is not able to be run (i.e. unsupported). */
@@ -1719,6 +1732,7 @@ localizedStrings["Vertex Shader"] = "Vertex Shader";
 localizedStrings["Vertex/Fragment Shader"] = "Vertex/Fragment Shader";
 /* Energy Impact: Very High */
 localizedStrings["Very High @ Timeline Energy Impact"] = "Very High";
+localizedStrings["Video"] = "Video";
 localizedStrings["View Image"] = "View Image";
 localizedStrings["View Recording"] = "View Recording";
 localizedStrings["View Shader"] = "View Shader";

--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -82,6 +82,8 @@ WI.loaded = function()
         InspectorBackend.registerInspectorDispatcher(WI.InspectorObserver);
     if (InspectorBackend.registerLayerTreeDispatcher)
         InspectorBackend.registerLayerTreeDispatcher(WI.LayerTreeObserver);
+    if (InspectorBackend.registerMediaDispatcher)
+        InspectorBackend.registerMediaDispatcher(WI.MediaObserver);
     if (InspectorBackend.registerMemoryDispatcher)
         InspectorBackend.registerMemoryDispatcher(WI.MemoryObserver);
     if (InspectorBackend.registerNetworkDispatcher)
@@ -130,6 +132,7 @@ WI.loaded = function()
         WI.domDebuggerManager = new WI.DOMDebuggerManager,
         WI.canvasManager = new WI.CanvasManager,
         WI.animationManager = new WI.AnimationManager,
+        WI.mediaManager = new WI.MediaManager,
     ];
 
     // Register for events.
@@ -159,6 +162,7 @@ WI.loaded = function()
         WI.GraphicsTabContentView.Type,
         WI.LayersTabContentView.Type,
         WI.AuditTabContentView.Type,
+        WI.MediaTabContentView.Type,
     ]);
     WI._selectedTabIndexSetting = new WI.Setting("selected-tab-index", 0);
 
@@ -503,6 +507,7 @@ WI.contentLoaded = function()
         WI.ConsoleTabContentView,
         WI.SearchTabContentView,
         WI.SettingsTabContentView,
+        WI.MediaTabContentView,
     ];
 
     WI._knownTabClassesByType = new Map;
@@ -1417,6 +1422,9 @@ WI.tabContentViewClassForRepresentedObject = function(representedObject)
         || representedObject instanceof WI.AnimationCollection
         || representedObject instanceof WI.Animation)
         return WI.GraphicsTabContentView;
+
+    if (representedObject instanceof WI.MediaPlayer)
+        return WI.MediaTabContentView;
 
     return null;
 };

--- a/Source/WebInspectorUI/UserInterface/Controllers/MediaManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/MediaManager.js
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.MediaManager = class MediaManager extends WI.Object
+{
+    constructor()
+    {
+        super();
+
+        this._enabled = false;
+        this._mediaPlayerIdentifierMap = new Map;
+
+        WI.Frame.addEventListener(WI.Frame.Event.MainResourceDidChange, this._mainResourceDidChange, this);
+    }
+
+    // Agent
+
+    get domains() { return ["Media"]; }
+
+    activateExtraDomain(domain)
+    {
+        // COMPATIBILITY (iOS 14.0): Inspector.activateExtraDomains was removed in favor of a declared debuggable type
+
+        console.assert(domain === "Media");
+
+        for (let target of WI.targets)
+            this.initializeTarget(target);
+    }
+
+    // Target
+
+    initializeTarget(target)
+    {
+        if (!this._enabled)
+            return;
+
+        if (target.hasDomain("Media"))
+            target.MediaAgent.enable();
+    }
+
+    // Public
+
+    get mediaPlayerIdentifierMap() { return this._mediaPlayerIdentifierMap; }
+
+    enable()
+    {
+        console.assert(!this._enabled);
+
+        this._enabled = true;
+
+        for (let target of WI.targets)
+            this.initializeTarget(target);
+    }
+
+    disable()
+    {
+        console.assert(this._enabled);
+
+        for (let target of WI.targets) {
+            if (target.hasDomain("Media"))
+                target.MediaAgent.disable();
+        }
+
+        this._clearPlayers();
+
+        this._enabled = false;
+    }
+
+    // MediaObserver
+    
+    playerAdded(playerPayload)
+    {
+        let player = WI.MediaPlayer.fromPayload(playerPayload);
+        if (this._mediaPlayerIdentifierMap.has(player.identifier))
+            return;
+        this._mediaPlayerIdentifierMap.set(player.identifier, player);
+        this.dispatchEventToListeners(WI.MediaManager.Event.MediaPlayerAdded, player);
+    }
+
+    playerRemoved(playerIdentifier)
+    {
+        let player = this._mediaPlayerIdentifierMap.take(playerIdentifier);
+        if (!player)
+            return;
+        console.assert(player);
+        this.dispatchEventToListeners(WI.MediaManager.Event.MediaPlayerRemoved, player);
+    }
+
+    playerUpdated(playerPayload, event, data)
+    {
+        let player = this._mediaPlayerIdentifierMap.take(playerPayload.playerId);
+        if (!player)
+            return;
+        const newPlayer = WI.MediaPlayer.fromPayload(playerPayload);
+        const difference = this._calculatePlayerDifference(player.properties(), newPlayer.properties());
+        player.updateFromPayload(playerPayload);
+        player.pushEvent({event, data: difference /* data */});
+        this._mediaPlayerIdentifierMap.set(player.identifier, player)
+        this.dispatchEventToListeners(WI.MediaManager.Event.MediaPlayerUpdated, player);
+    }
+
+    // Private
+
+    _mainResourceDidChange(event)
+    {
+        console.assert(event.target instanceof WI.Frame);
+        if (!event.target.isMainFrame())
+            return;
+        
+        this._clearPlayers();
+    }
+
+    _clearPlayers()
+    {
+        for (let player of this._mediaPlayerIdentifierMap.values())
+            this.dispatchEventToListeners(WI.MediaManager.Event.MediaPlayerRemoved, player);
+        this._mediaPlayerIdentifierMap.clear();
+    }
+
+    _calculatePlayerDifference(oldPlayer, newPlayer)
+    {
+        let difference = {old: {}, new: {}};
+        for (let key of WI.MediaPlayer.Properties) {
+            const oldData = JSON.stringify(oldPlayer[key]);
+            const newData = JSON.stringify(newPlayer[key]);
+            if (oldData != newData) {
+                difference.old[key] = oldData;
+                difference.new[key] = newData;
+            }
+        }
+        
+        if (this._isEmpty(difference.old))
+            delete difference.old;
+
+        if (this._isEmpty(difference.new))
+            delete difference.new;
+
+        return !this._isEmpty(difference) ? JSON.stringify(difference) : '';
+    }
+
+    _isEmpty(object)
+    {
+        for (let _ in object) { return false; }
+        return true;
+    }
+};
+
+WI.MediaManager.Event = {
+    MediaPlayerAdded: "media-player-added",
+    MediaPlayerRemoved: "media-player-removed",
+    MediaPlayerUpdated: "media-player-updated"
+}

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -157,6 +157,8 @@
     <link rel="stylesheet" href="Views/LocalResourceOverrideWarningView.css">
     <link rel="stylesheet" href="Views/LogContentView.css">
     <link rel="stylesheet" href="Views/LogIcon.css">
+    <link rel="stylesheet" href="Views/MediaPlayerContentView.css">
+    <link rel="stylesheet" href="Views/MediaSidebarPanel.css">
     <link rel="stylesheet" href="Views/MediaTimelineOverviewGraph.css">
     <link rel="stylesheet" href="Views/MediaTimelineView.css">
     <link rel="stylesheet" href="Views/MemoryCategoryView.css">
@@ -371,6 +373,7 @@
     <script src="Protocol/HeapObserver.js"></script>
     <script src="Protocol/InspectorObserver.js"></script>
     <script src="Protocol/LayerTreeObserver.js"></script>
+    <script src="Protocol/MediaObserver.js"></script>
     <script src="Protocol/MemoryObserver.js"></script>
     <script src="Protocol/NetworkObserver.js"></script>
     <script src="Protocol/PageObserver.js"></script>
@@ -463,6 +466,7 @@
     <script src="Models/LogObject.js"></script>
     <script src="Models/LoggingChannel.js"></script>
     <script src="Models/MediaInstrument.js"></script>
+    <script src="Models/MediaPlayer.js"></script>
     <script src="Models/MediaTimeline.js"></script>
     <script src="Models/MediaTimelineRecord.js"></script>
     <script src="Models/MemoryCategory.js"></script>
@@ -613,6 +617,7 @@
     <script src="Views/ElementsTabContentView.js"></script>
     <script src="Views/GraphicsTabContentView.js"></script>
     <script src="Views/LayersTabContentView.js"></script>
+    <script src="Views/MediaTabContentView.js"></script>
     <script src="Views/ResourceTreeElement.js"></script>
     <script src="Views/ScriptTreeElement.js"></script>
     <script src="Views/SearchTabContentView.js"></script>
@@ -794,6 +799,9 @@
     <script src="Views/LocalResourceOverrideTreeElement.js"></script>
     <script src="Views/LocalResourceOverrideWarningView.js"></script>
     <script src="Views/LogContentView.js"></script>
+    <script src="Views/MediaPlayerContentView.js"></script>
+    <script src="Views/MediaPlayerTreeElement.js"></script>
+    <script src="Views/MediaSidebarPanel.js"></script>
     <script src="Views/MediaTimelineDataGridNode.js"></script>
     <script src="Views/MediaTimelineOverviewGraph.js"></script>
     <script src="Views/MediaTimelineView.js"></script>
@@ -950,6 +958,7 @@
     <script src="Controllers/JavaScriptLogViewController.js"></script>
     <script src="Controllers/JavaScriptRuntimeCompletionProvider.js"></script>
     <script src="Controllers/LayerTreeManager.js"></script>
+    <script src="Controllers/MediaManager.js"></script>
     <script src="Controllers/MemoryManager.js"></script>
     <script src="Controllers/NetworkManager.js"></script>
     <script src="Controllers/CSSQueryController.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Models/MediaPlayer.js
+++ b/Source/WebInspectorUI/UserInterface/Models/MediaPlayer.js
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.MediaPlayer = class MediaPlayer extends WI.Object
+{
+    constructor(identifier, originUrl, contentType, duration, engine)
+    {
+        super();
+
+        console.assert(identifier);
+        
+        this._identifier = identifier;
+        this._originUrl = originUrl;
+        this._contentType = contentType;
+        this._duration = duration;
+        this._engine = engine;
+        this._mediaType = 'video';
+
+        this._events = [];
+    }
+
+    // Static
+
+    static fromPayload(payload)
+    {
+        return new WI.MediaPlayer(
+            payload.playerId,
+            payload.originUrl,
+            payload.contentType,
+            payload.duration,
+            payload.engine);
+    }
+
+    static parseMediaTime(time)
+    {
+        if (typeof time.value == 'number')
+            return new Date(+time.value * 1000).toISOString().substring(11, 23);
+        
+        if (time.invalid || !time.value)
+            return 'Invalid Time.'
+
+        return time.value;
+    }
+
+    // Public
+
+    get identifier() { return this._identifier; }
+    get originUrl() { return this._originUrl; }
+    get contentType() { return this._contentType; }
+    get duration() { return this._duration; }
+    get engine() { return this._engine; }
+    get mediaType() { return this._mediaType; }
+
+    get events() { return this._events; }
+
+    properties()
+    {
+        let props = {};
+        for (let key of WI.MediaPlayer.Properties)
+            props[key] = this[key];
+        return props;
+    }
+
+    updateFromPayload(payload)
+    {
+        this._originUrl = payload.originUrl;
+        this._contentType = payload.contentType;
+        this._duration = payload.duration;
+        this._engine = payload.engine;
+
+        this.dispatchEventToListeners(WI.MediaPlayer.Event.PlayerDidUpdate);
+    }
+
+    saveIdentityToCookie(cookie)
+    {
+        cookie[WI.MediaPlayer.PlayerIdentifierCookieKey] = this._identifier;
+    }
+
+    requestNode()
+    {
+        if (!this._requestNodePromise) {
+            this._requestNodePromise = new Promise((resolve, reject) => {
+                WI.domManager.ensureDocument();
+
+                let target = WI.assumingMainTarget();
+                target.MediaAgent.requestNode(this._identifier, (error, nodeId) => {
+                    if (error) {
+                        resolve(null);
+                        return;
+                    }
+
+                    this._domNode = WI.domManager.nodeForId(nodeId);
+                    if (!this._domNode) {
+                        resolve(null);
+                        return;
+                    }
+
+                    resolve(this._domNode);
+                });
+            });
+        }
+        return this._requestNodePromise;
+    }
+
+    play(callback)
+    {
+        let target = WI.assumingMainTarget();
+        target.MediaAgent.play(this._identifier, callback);
+    }
+
+    pause(callback)
+    {
+        let target = WI.assumingMainTarget();
+        target.MediaAgent.pause(this._identifier, callback);
+    }
+
+    pushEvent({event, data})
+    {
+        switch (event) {
+            case "play":
+                this.dispatchEventToListeners(WI.MediaPlayer.Event.PlayerDidPlay);
+                break;
+            case "pause":
+                this.dispatchEventToListeners(WI.MediaPlayer.Event.PlayerDidPause);
+                break;
+        }
+        const eventObject = {"time": new Date(), "playerEvent": event, "playerData": data};
+        this._events.push(eventObject);
+        this.dispatchEventToListeners(WI.MediaPlayer.Event.EventsDidChange, eventObject);
+    }
+};
+
+WI.MediaPlayer.Properties = [
+    "identifier",
+    "originUrl",
+    "contentType",
+    "duration",
+    "engine"
+];
+
+WI.MediaPlayer.PlayerIdentifierCookieKey = "media-player-identifier";
+
+WI.MediaPlayer.Event = {
+    PlayerDidUpdate: "media-player-did-update",
+    EventsDidChange: "media-player-events-did-change",
+    PlayerDidPlay: "media-player-did-play",
+    PlayerDidPause: "media-player-did-pause",
+};

--- a/Source/WebInspectorUI/UserInterface/Protocol/MediaObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/MediaObserver.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.MediaObserver = class MediaObserver extends InspectorBackend.Dispatcher
+{
+    // Events defined by the "Media" domain.
+    
+    playerAdded(mediaPlayer)
+    {
+        WI.mediaManager.playerAdded(mediaPlayer);
+    }
+
+    playerRemoved(mediaPlayerId)
+    {
+        WI.mediaManager.playerRemoved(mediaPlayerId);
+    }
+
+    playerUpdated(mediaPlayer, event, data)
+    {
+        WI.mediaManager.playerUpdated(mediaPlayer, event, data);
+    }
+};

--- a/Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js
@@ -187,6 +187,25 @@ WI.RemoteObject = class RemoteObject
         target.AnimationAgent.resolveAnimation(animation.animationId, objectGroup, wrapCallback);
     }
 
+    static resolveMediaElement(player, objectGroup, callback)
+    {
+        console.assert(typeof callback === "function");
+
+        function wrapCallback(error, object) {
+            if (error || !object)
+                callback(null);
+            else
+                callback(WI.RemoteObject.fromPayload(object, WI.mainTarget));
+        }
+
+        let target = WI.assumingMainTarget();
+
+        // COMPATIBILITY (iOS 13.1): Media.resolveMediaElement did not exist yet.
+        console.assert(target.hasCommand("Media.resolveMediaElement"));
+
+        target.MediaAgent.resolveElement(player.identifier, objectGroup, wrapCallback);
+    }
+
     // Public
 
     get target()

--- a/Source/WebInspectorUI/UserInterface/Protocol/Target.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/Target.js
@@ -145,6 +145,7 @@ WI.Target = class Target extends WI.Object
     get IndexedDBAgent() { return this._agents.IndexedDB; }
     get InspectorAgent() { return this._agents.Inspector; }
     get LayerTreeAgent() { return this._agents.LayerTree; }
+    get MediaAgent() { return this._agents.Media; }
     get MemoryAgent() { return this._agents.Memory; }
     get NetworkAgent() { return this._agents.Network; }
     get PageAgent() { return this._agents.Page; }

--- a/Source/WebInspectorUI/UserInterface/Test.html
+++ b/Source/WebInspectorUI/UserInterface/Test.html
@@ -99,6 +99,7 @@
     <script src="Protocol/HeapObserver.js"></script>
     <script src="Protocol/InspectorObserver.js"></script>
     <script src="Protocol/LayerTreeObserver.js"></script>
+    <script src="Protocol/MediaObserver.js"></script>
     <script src="Protocol/MemoryObserver.js"></script>
     <script src="Protocol/NetworkObserver.js"></script>
     <script src="Protocol/PageObserver.js"></script>
@@ -182,6 +183,7 @@
     <script src="Models/LocalResourceOverride.js"></script>
     <script src="Models/LoggingChannel.js"></script>
     <script src="Models/MediaInstrument.js"></script>
+    <script src="Models/MediaPlayer.js"></script>
     <script src="Models/MediaTimeline.js"></script>
     <script src="Models/MediaTimelineRecord.js"></script>
     <script src="Models/MemoryCategory.js"></script>
@@ -274,6 +276,7 @@
     <script src="Controllers/HeapManager.js"></script>
     <script src="Controllers/IndexedDBManager.js"></script>
     <script src="Controllers/LayerTreeManager.js"></script>
+    <script src="Controllers/MediaManager.js"></script>
     <script src="Controllers/MemoryManager.js"></script>
     <script src="Controllers/NetworkManager.js"></script>
     <script src="Controllers/RuntimeManager.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Test/Test.js
+++ b/Source/WebInspectorUI/UserInterface/Test/Test.js
@@ -41,6 +41,7 @@ WI.loaded = function()
     InspectorBackend.registerHeapDispatcher(WI.HeapObserver);
     InspectorBackend.registerInspectorDispatcher(WI.InspectorObserver);
     InspectorBackend.registerLayerTreeDispatcher(WI.LayerTreeObserver);
+    InspectorBackend.registerMediaDispatcher(WI.MediaObserver);
     InspectorBackend.registerMemoryDispatcher(WI.MemoryObserver);
     InspectorBackend.registerNetworkDispatcher(WI.NetworkObserver);
     InspectorBackend.registerPageDispatcher(WI.PageObserver);
@@ -73,6 +74,7 @@ WI.loaded = function()
         WI.domDebuggerManager = new WI.DOMDebuggerManager,
         WI.canvasManager = new WI.CanvasManager,
         WI.animationManager = new WI.AnimationManager,
+        WI.mediaManager = new WI.MediaManager,
     ];
 
     // Register for events.
@@ -102,6 +104,7 @@ WI.contentLoaded = function()
     WI.domStorageManager.enable();
     WI.heapManager.enable();
     WI.indexedDBManager.enable();
+    WI.mediaManager.enable();
     WI.memoryManager.enable();
     WI.timelineManager.enable();
 
@@ -202,6 +205,7 @@ WI.updateFindString = () => {};
     makeAgentGetter("IndexedDB");
     makeAgentGetter("Inspector");
     makeAgentGetter("LayerTree");
+    makeAgentGetter("Media");
     makeAgentGetter("Memory");
     makeAgentGetter("Network");
     makeAgentGetter("Page");

--- a/Source/WebInspectorUI/UserInterface/Views/ContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ContentView.js
@@ -197,6 +197,9 @@ WI.ContentView = class ContentView extends WI.View
         if (representedObject instanceof WI.Animation)
             return new WI.AnimationContentView(representedObject, extraArguments);
 
+        if (representedObject instanceof WI.MediaPlayer)
+            return new WI.MediaPlayerContentView(representedObject, extraArguments);
+
         if (representedObject instanceof WI.Collection)
             return new WI.CollectionContentView(representedObject, extraArguments);
 
@@ -338,6 +341,8 @@ WI.ContentView = class ContentView extends WI.View
             || representedObject instanceof WI.AuditTestCaseResult || representedObject instanceof WI.AuditTestGroupResult)
             return true;
         if (representedObject instanceof WI.Animation)
+            return true;
+        if (representedObject instanceof WI.MediaPlayer)
             return true;
         if (representedObject instanceof WI.Collection)
             return true;

--- a/Source/WebInspectorUI/UserInterface/Views/MediaPlayerContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/MediaPlayerContentView.css
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+.content-view.media {
+    background-color: hsl(0, 0%, 90%);
+}
+
+.content-view.media > .preview {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    padding: 15px;
+}
+
+.content-view.media {
+    display: flex;
+    flex-direction: column;
+}
+
+.content-view.media > .preview > img {
+    max-width: 100%;
+    max-height: 100%;
+}
+
+.content-view.media .icon {
+    content: url(../Images/IdentifierIcons.svg#MediaInstrument-dark)
+}
+
+.content-view.media > :matches(header, footer) {
+    display: none;
+}
+
+.content-view.media > .media-player-events {
+    overflow: scroll;
+}
+
+@media (prefers-color-scheme: dark) {
+    .content-view.media {
+        background-color: unset;
+    }
+}

--- a/Source/WebInspectorUI/UserInterface/Views/MediaPlayerContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/MediaPlayerContentView.js
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.MediaPlayerContentView = class MediaPlayerContentView extends WI.ContentView
+{
+    constructor(player)
+    {
+        console.assert(player instanceof WI.MediaPlayer);
+
+        super(player);
+
+        this.element.classList.add("media");
+
+        this._sortComparator = null;
+        this._table = null;
+
+        this._playerIdentifierRow = new WI.DetailsSectionSimpleRow(WI.UIString("Identifier"));
+        this._playerURLRow = new WI.DetailsSectionSimpleRow(WI.UIString("URL"));
+        this._playerContentType = new WI.DetailsSectionSimpleRow(WI.UIString("Content Type"));
+        this._playerDuration = new WI.DetailsSectionSimpleRow(WI.UIString("Duration"));
+        this._playerEngine = new WI.DetailsSectionSimpleRow(WI.UIString("Engine"));
+        this._playerGroup = new WI.DetailsSectionGroup([this._playerIdentifierRow, this._playerURLRow, this._playerContentType, this._playerDuration, this._playerEngine]);
+        this._playerSection = new WI.DetailsSection("media-player-details", WI.UIString("Media Player Details"), [this._playerGroup]);
+        this.element.append(this._playerSection.element);
+
+        this._updateDetails();
+        this.representedObject.addEventListener(WI.MediaPlayer.Event.PlayerDidUpdate, this._updateDetails, this);
+
+        this._refreshButtonNavigationItem = new WI.ButtonNavigationItem("refresh", WI.UIString("Refresh"), "Images/ReloadFull.svg", 13, 13);
+        this._refreshButtonNavigationItem.visibilityPriority = WI.NavigationItem.VisibilityPriority.Low;
+        this._refreshButtonNavigationItem.addEventListener(WI.ButtonNavigationItem.Event.Clicked, this.handleRefreshButtonClicked, this);
+
+        this.representedObject.addEventListener(WI.MediaPlayer.Event.EventsDidChange, this._pushEvent, this);
+    }
+
+    // Public
+
+    get scrollableElements()
+    {
+        if (!this._table)
+            return [];
+        return [this._table.scrollContainer];
+    }
+
+    get navigationItems()
+    {
+        // The toggle recording NavigationItem isn't added to the ContentBrowser's NavigationBar.
+        // It's added to the "quick access" NavigationBar shown when hovering the canvas in the overview.
+        return [this._refreshButtonNavigationItem];
+    }
+
+    refreshPreview()
+    {
+        this.needsLayout();
+    }
+
+    handleRefreshButtonClicked()
+    {
+        this.refreshPreview();
+    }
+
+    // Table dataSource
+
+    tableIndexForRepresentedObject(table, object)
+    {
+        let index = this.representedObject.events.indexOf(object);
+        console.assert(index >= 0);
+        return index;
+    }
+
+    tableRepresentedObjectForIndex(table, index)
+    {
+        console.assert(index >= 0 && index < this.representedObject.events.length);
+        return this.representedObject.events[index];
+    }
+
+    tableNumberOfRows(table)
+    {
+        return this.representedObject.events.length;
+    }
+
+    tableSortChanged(table)
+    {
+        this._generateSortComparator();
+
+        if (!this._sortComparator)
+            return;
+
+        this._updateSort();
+        this._table.reloadData();
+    }
+
+    // Table delegate
+
+    tablePopulateCell(table, cell, column, rowIndex)
+    {
+        const eventObject = this.representedObject.events[rowIndex];
+
+        if (column.identifier === 'time')
+            cell.textContent = eventObject['time'].toISOString().substring(11, 23);
+        else
+            cell.textContent = eventObject[column.identifier];
+        return cell;
+    }
+
+    // Protected
+
+    initialLayout()
+    {
+        super.initialLayout();
+
+        this._table = new WI.Table("media-events-table", this, this, 20);
+        this._table.allowsMultipleSelection = true;
+
+        this._timeColumn = new WI.TableColumn("time", WI.UIString("Time"), {
+            minWidth: 70,
+            maxWidth: 200,
+            initialWidth: 100,
+            resizeType: WI.TableColumn.ResizeType.Locked,
+        });
+
+        this._eventColumn = new WI.TableColumn("playerEvent", WI.UIString("Event"), {
+            minWidth: 70,
+            maxWidth: 200,
+            initialWidth: 100,
+            hideable: false,
+            resizeType: WI.TableColumn.ResizeType.Locked,
+        });
+
+        this._dataColumn = new WI.TableColumn("playerData", WI.UIString("Data"), {
+            minWidth: 100,
+            maxWidth: 600,
+            initialWidth: 200,
+            hideable: true,
+        });
+
+        this._table.addColumn(this._timeColumn);
+        this._table.addColumn(this._eventColumn);
+        this._table.addColumn(this._dataColumn);
+
+        if (!this._table.sortColumnIdentifier) {
+            this._table.sortOrder = WI.Table.SortOrder.Ascending;
+            this._table.sortColumnIdentifier = "time";
+        }
+
+        this.addSubview(this._table);
+
+        this._updateEvents();
+        this.tableSortChanged();
+    }
+
+    layout()
+    {
+        super.layout();
+    }
+
+    attached()
+    {
+        super.attached();
+
+        this.refreshPreview();
+    }
+
+    detached()
+    {
+        super.detached();
+    }
+
+    // Private
+
+    _generateSortComparator()
+    {
+        let sortColumnIdentifier = this._table.sortColumnIdentifier;
+        if (!sortColumnIdentifier) {
+            this._sortComparator = null;
+            return;
+        }
+
+        let comparator = null;
+
+        if (sortColumnIdentifier == 'time')
+            comparator = (a, b) => ((a['time'] > b['time']) - (a['time'] < b['time']));
+        else
+            comparator = (a, b) => (a[sortColumnIdentifier] || "").extendedLocaleCompare(b[sortColumnIdentifier] || "");
+
+        let reverseFactor = this._table.sortOrder === WI.Table.SortOrder.Ascending ? 1 : -1;
+        this._sortComparator = (a, b) => reverseFactor * comparator(a, b);
+    }
+
+    _updateSort()
+    {
+        if (!this._sortComparator)
+            return;
+
+        this.representedObject.events.sort(this._sortComparator);
+    }
+
+    _showError()
+    {
+        // if (this._previewImageElement)
+        //     this._previewImageElement.remove();
+
+        // if (!this._errorElement)
+        //     this._errorElement = WI.createMessageTextView(WI.UIString("No Preview Available"), isError);
+
+        // if (this._previewContainerElement)
+        //     this._previewContainerElement.appendChild(this._errorElement);
+    }
+
+    _updateDetails()
+    {
+        const player = this.representedObject;
+        this._playerIdentifierRow.value = player.identifier;
+        this._playerURLRow.value = player.originUrl ? WI.linkifyStringAsFragment(player.originUrl) : '';
+        this._playerContentType.value = player.contentType;
+        this._playerDuration.value = WI.MediaPlayer.parseMediaTime(player.duration);
+        this._playerEngine.value = player.engine;
+    }
+
+    _pushEvent(event)
+    {
+        this._updateEvents();
+    }
+
+    _updateEvents()
+    {
+        this._updateSort();
+        this._table.reloadData();
+    }
+};

--- a/Source/WebInspectorUI/UserInterface/Views/MediaPlayerTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/MediaPlayerTreeElement.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.MediaPlayerTreeElement = class MediaPlayerTreeElement extends WI.FolderizedTreeElement
+{
+    constructor(representedObject)
+    {
+        console.assert(representedObject instanceof WI.MediaPlayer);
+
+        let title = representedObject.originUrl.split('/').slice(-1)[0] || WI.UIString("Empty");
+        let subtitle = representedObject.contentType || WI.UIString("Unknown Type");
+        super("media", title, subtitle, representedObject);
+    }
+
+    // Public
+
+    updateTitles()
+    {
+        this.mainTitle = this.representedObject.originUrl.split('/').slice(-1)[0] || WI.UIString("Empty");
+        this.subtitle = this.representedObject.contentType || WI.UIString("Unknown Type");
+    }
+
+    // Protected
+
+    onattach()
+    {
+        super.onattach();
+
+        this.element.addEventListener("mouseover", this._handleMouseOver.bind(this));
+        this.element.addEventListener("mouseout", this._handleMouseOut.bind(this));
+
+        this.representedObject.addEventListener(WI.MediaPlayer.Event.PlayerDidPlay, this._handlePlay, this);
+        this.representedObject.addEventListener(WI.MediaPlayer.Event.PlayerDidPause, this._handlePause, this);
+
+        this.onpopulate();
+    }
+
+    ondetach()
+    {
+        this.element.removeEventListener("mouseover", this._handleMouseOver.bind(this));
+        this.element.removeEventListener("mouseout", this._handleMouseOut.bind(this));
+
+        this.iconElement.removeEventListener('click', this._handleIconClick.bind(this));
+
+        this.representedObject.removeEventListener(WI.MediaPlayer.Event.PlayerDidPlay, this._handlePlay, this);
+        this.representedObject.removeEventListener(WI.MediaPlayer.Event.PlayerDidPause, this._handlePause, this);
+
+        super.ondetach();
+    }
+
+    onpopulate()
+    {
+        super.onpopulate();
+
+        if (this.children.length && !this.shouldRefreshChildren)
+            return;
+
+        this.shouldRefreshChildren = false;
+
+        this.removeChildren();
+
+        this.iconElement.classList.add('paused');
+        this.iconElement.addEventListener('click', this._handleIconClick.bind(this));
+    }
+
+    populateContextMenu(contextMenu, event)
+    {
+        super.populateContextMenu(contextMenu, event);
+
+        contextMenu.appendItem(WI.UIString("Log MediaPlayer"), () => {
+            WI.RemoteObject.resolveMediaElement(this.representedObject, WI.RuntimeManager.ConsoleObjectGroup, (remoteObject) => {
+                if (!remoteObject)
+                    return;
+
+                const text = WI.UIString("Selected Media Player");
+                const addSpecialUserLogClass = true;
+                WI.consoleLogViewController.appendImmediateExecutionWithResult(text, remoteObject, addSpecialUserLogClass);
+            });
+        });
+
+        contextMenu.appendSeparator();
+    }
+
+    // Private
+
+    _handleItemAdded(event)
+    {
+        this.addChildForRepresentedObject(event.data.item);
+    }
+
+    _handleItemRemoved(event)
+    {
+        this.removeChildForRepresentedObject(event.data.item);
+    }
+
+    _handleMouseOver(event)
+    {
+        this.representedObject.requestNode().then((node) => {
+            if (!node || !node.ownerDocument)
+                return;
+            node.highlight();
+        });
+    }
+
+    _handleMouseOut(event)
+    {
+        WI.domManager.hideDOMNodeHighlight();
+    }
+
+    _handleIconClick(event)
+    {
+        const callback = (error) => {
+            if (error) console.error(error);
+        }
+        if (this.iconElement.classList.contains('paused'))
+            this.representedObject.play(callback);
+        else
+            this.representedObject.pause(callback);
+    }
+
+    _handlePlay()
+    {
+        this.iconElement.classList.remove('paused');
+        this.iconElement.classList.add('playing');
+    }
+
+    _handlePause()
+    {
+        this.iconElement.classList.remove('playing');
+        this.iconElement.classList.add('paused');
+    }
+
+    _updateStatus()
+    {
+    }
+};

--- a/Source/WebInspectorUI/UserInterface/Views/MediaSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/MediaSidebarPanel.css
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+.sidebar > .panel.navigation.media > .content {
+    top: var(--navigation-bar-height);
+}
+
+.sidebar > .panel.navigation.media .icon.paused {
+    content: url(../Images/Resume.svg)
+}
+
+.sidebar > .panel.navigation.media .icon.playing {
+    content: url(../Images/Pause.svg)
+}
+
+.sidebar > .panel.navigation.media > .navigation-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+}

--- a/Source/WebInspectorUI/UserInterface/Views/MediaSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/MediaSidebarPanel.js
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2013, 2015 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.MediaSidebarPanel = class MediaSidebarPanel extends WI.NavigationSidebarPanel
+{
+    constructor()
+    {
+        super("media", WI.UIString("Media"));
+
+        this._navigationBar = new WI.NavigationBar;
+        this.addSubview(this._navigationBar);
+
+        let scopeItemPrefix = "media-sidebar-";
+        let scopeBarItems = [];
+
+        scopeBarItems.push(new WI.ScopeBarItem(scopeItemPrefix + "type-all", WI.UIString("All Media Players"), {exclusive: true}));
+
+        let mediaTypes = [
+            {identifier: "audio", title: WI.UIString("Audio"), classes: [WI.MediaPlayerTreeElement]},
+            {identifier: "video", title: WI.UIString("Video"), classes: [WI.MediaPlayerTreeElement]},
+        ];
+
+        mediaTypes.sort(function(a, b) { return a.title.extendedLocaleCompare(b.title); });
+
+        for (let info of mediaTypes) {
+            let scopeBarItem = new WI.ScopeBarItem(scopeItemPrefix + info.identifier, info.title);
+            scopeBarItem.__mediaTypeInfo = info;
+            scopeBarItems.push(scopeBarItem);
+        }
+
+        this._scopeBar = new WI.ScopeBar("media-sidebar-scope-bar", scopeBarItems, scopeBarItems[0], true);
+        this._scopeBar.addEventListener(WI.ScopeBar.Event.SelectionChanged, this._scopeBarSelectionDidChange, this);
+
+        this._navigationBar.addNavigationItem(this._scopeBar);
+
+        WI.mediaManager.addEventListener(WI.MediaManager.Event.MediaPlayerAdded, this._handlePlayerAdded, this);
+        WI.mediaManager.addEventListener(WI.MediaManager.Event.MediaPlayerRemoved, this._handlePlayerRemoved, this);
+        WI.mediaManager.addEventListener(WI.MediaManager.Event.MediaPlayerUpdated, this._handlePlayerUpdated, this);
+
+        this.contentTreeOutline.addEventListener(WI.TreeOutline.Event.SelectionDidChange, this._treeSelectionDidChange, this);
+
+        for (let player of WI.mediaManager.mediaPlayerIdentifierMap.values())
+            this._addPlayer(player);
+    }
+
+    // Public
+
+    get minimumWidth()
+    {
+        return this._navigationBar.minimumWidth;
+    }
+
+    showDefaultContentView()
+    {
+        // Don't show anything by default. It doesn't make a whole lot of sense here.
+    }
+
+    closed()
+    {
+        super.closed();
+
+        WI.mediaManager.removeEventListener(WI.MediaManager.Event.MediaPlayerAdded, this._handlePlayerAdded, this);
+        WI.mediaManager.removeEventListener(WI.MediaManager.Event.MediaPlayerRemoved, this._handlePlayerRemoved, this);
+        WI.mediaManager.removeEventListener(WI.MediaManager.Event.MediaPlayerUpdated, this._handlePlayerUpdated, this);
+    }
+
+    // Protected
+
+    resetFilter()
+    {
+        this._scopeBar.resetToDefault();
+
+        super.resetFilter();
+    }
+
+    hasCustomFilters()
+    {
+        console.assert(this._scopeBar.selectedItems.length === 1);
+        let selectedScopeBarItem = this._scopeBar.selectedItems[0];
+        return selectedScopeBarItem && !selectedScopeBarItem.exclusive;
+    }
+
+    // Private
+
+    _treeSelectionDidChange(event)
+    {
+        if (!this.selected)
+            return;
+
+        let treeElement = this.contentTreeOutline.selectedTreeElement;
+        if (!treeElement)
+            return;
+
+        if (treeElement instanceof WI.MediaPlayerTreeElement) {
+            WI.showRepresentedObject(treeElement.representedObject);
+            return;
+        }
+
+        console.error("Unknown tree element", treeElement);
+    }
+
+    _addMediaChild(childElement)
+    {
+        childElement.flattened = true;
+
+        this.contentTreeOutline.insertChild(childElement, insertionIndexForObjectInListSortedByFunction(childElement, this.contentTreeOutline.children, this._compareTreeElements));
+
+        return childElement;
+    }
+
+    _addPlayer(player)
+    {
+        console.assert(player instanceof WI.MediaPlayer);
+        this._addMediaChild(new WI.MediaPlayerTreeElement(player));
+    }
+
+    _removePlayer(player)
+    {
+        let treeElement = this.treeElementForRepresentedObject(player);
+        console.assert(treeElement, "Missing tree element for player.", player);
+
+        this._closeContentViewForTreeElement(treeElement);
+        this.contentTreeOutline.removeChild(treeElement);
+    }
+
+    _updatePlayer(player)
+    {
+        let treeElement = this.treeElementForRepresentedObject(player);
+        console.assert(treeElement, "Missing tree element for player.", player);
+
+        treeElement.updateTitles();
+    }
+
+    _handlePlayerAdded(event)
+    {
+        this._addPlayer(event.data);
+    }
+
+    _handlePlayerRemoved(event)
+    {
+        this._removePlayer(event.data);
+    }
+
+    _handlePlayerUpdated(event)
+    {
+        this._updatePlayer(event.data);
+    }
+
+    _compareTreeElements(a, b)
+    {
+        console.assert(a.mainTitle);
+        console.assert(b.mainTitle);
+
+        return (a.mainTitle || "").extendedLocaleCompare(b.mainTitle || "");
+    }
+
+    _closeContentViewForTreeElement(treeElement)
+    {
+        const onlyExisting = true;
+        let contentView = this.contentBrowser.contentViewForRepresentedObject(treeElement.representedObject, onlyExisting);
+        if (contentView)
+            this.contentBrowser.contentViewContainer.closeContentView(contentView);
+    }
+
+    _scopeBarSelectionDidChange(event)
+    {
+        this.updateFilter();
+    }
+};

--- a/Source/WebInspectorUI/UserInterface/Views/MediaTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/MediaTabContentView.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.MediaTabContentView = class MediaTabContentView extends WI.ContentBrowserTabContentView
+{
+    constructor()
+    {
+        super(MediaTabContentView.tabInfo(), {
+            navigationSidebarPanelConstructor: WI.MediaSidebarPanel,
+        });
+
+        WI.mediaManager.enable();
+    }
+
+    static tabInfo()
+    {
+        return {
+            identifier: MediaTabContentView.Type,
+            image: "Images/IdentifierIcons.svg#MediaInstrument-dark",
+            displayName: WI.UIString("Media", "Media Tab Name", "Name of Media Tab"),
+        };
+    }
+
+    static isTabAllowed()
+    {
+        return InspectorBackend.hasDomain("Media");
+    }
+
+    // Public
+
+    get type()
+    {
+        return WI.MediaTabContentView.Type;
+    }
+
+    get supportsSplitContentBrowser()
+    {
+        return true;
+    }
+
+    canShowRepresentedObject(representedObject)
+    {
+        return representedObject instanceof WI.MediaPlayer;
+    }
+
+    get canHandleFindEvent()
+    {
+        return this.contentBrowser.currentContentView.canFocusFilterBar;
+    }
+
+    handleFindEvent(event)
+    {
+        this.contentBrowser.currentContentView.focusFilterBar();
+    }
+
+    closed()
+    {
+        WI.mediaManager.disable();
+
+        super.closed();
+    }
+};
+
+WI.MediaTabContentView.Type = "media";


### PR DESCRIPTION
#### 57e7f2025d14c255b2c5b6794d25ab9612e631d6
<pre>
Web Inspector: Add Media Tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=244738">https://bugs.webkit.org/show_bug.cgi?id=244738</a>

Reviewed by NOBODY (OOPS!).

This patch adds experimental feature support for a new Media Tab.
Currently, the tab provides basic information about the active media
elements on a given page and captures all events emitted from each element.

* Source/JavaScriptCore/DerivedSources-input.xcfilelist:
* Source/JavaScriptCore/DerivedSources.make:
* Source/JavaScriptCore/inspector/protocol/Media.json: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::m_logIdentifier):
(WebCore::HTMLMediaElement::~HTMLMediaElement):
(WebCore::HTMLMediaElement::scheduleEvent):
* Source/WebCore/inspector/InspectorController.cpp:
(WebCore::InspectorController::createLazyAgents):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didCreateMediaPlayerImpl):
(WebCore::InspectorInstrumentation::didDestroyMediaPlayerImpl):
(WebCore::InspectorInstrumentation::didUpdateMediaPlayerImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didCreateMediaPlayer):
(WebCore::InspectorInstrumentation::didDestroyMediaPlayer):
(WebCore::InspectorInstrumentation::didUpdateMediaPlayer):
* Source/WebCore/inspector/InspectorMediaPlayer.cpp: Added.
(WebCore::InspectorMediaPlayer::create):
(WebCore::InspectorMediaPlayer::InspectorMediaPlayer):
(WebCore::InspectorMediaPlayer::identifier const):
(WebCore::InspectorMediaPlayer::mediaElement const):
(WebCore::InspectorMediaPlayer::mediaPlayer const):
(WebCore::InspectorMediaPlayer::play):
(WebCore::InspectorMediaPlayer::pause):
(WebCore::InspectorMediaPlayer::buildObjectForMediaPlayer):
* Source/WebCore/inspector/InspectorMediaPlayer.h: Added.
* Source/WebCore/inspector/InstrumentingAgents.h:
* Source/WebCore/inspector/agents/InspectorMediaAgent.cpp: Added.
(WebCore::InspectorMediaAgent::InspectorMediaAgent):
(WebCore::InspectorMediaAgent::didCreateFrontendAndBackend):
(WebCore::InspectorMediaAgent::willDestroyFrontendAndBackend):
(WebCore::InspectorMediaAgent::discardAgent):
(WebCore::InspectorMediaAgent::enable):
(WebCore::InspectorMediaAgent::disable):
(WebCore::InspectorMediaAgent::requestNode):
(WebCore::InspectorMediaAgent::resolveElement):
(WebCore::InspectorMediaAgent::play):
(WebCore::InspectorMediaAgent::pause):
(WebCore::InspectorMediaAgent::didCreateMediaPlayer):
(WebCore::InspectorMediaAgent::didDestroyMediaPlayer):
(WebCore::InspectorMediaAgent::didUpdateMediaPlayer):
(WebCore::InspectorMediaAgent::reset):
(WebCore::InspectorMediaAgent::bindPlayer):
(WebCore::InspectorMediaAgent::unbindPlayer):
(WebCore::InspectorMediaAgent::assertInspectorPlayer):
(WebCore::InspectorMediaAgent::playerDestroyedTimerFired):
* Source/WebCore/inspector/agents/InspectorMediaAgent.h: Added.
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Base/Main.js:
(WI.loaded):
* Source/WebInspectorUI/UserInterface/Controllers/MediaManager.js: Added.
(WI.MediaManager):
(WI.MediaManager.prototype.get domains):
(WI.MediaManager.prototype.activateExtraDomain):
(WI.MediaManager.prototype.initializeTarget):
(WI.MediaManager.prototype.get mediaPlayerIdentifierMap):
(WI.MediaManager.prototype.enable):
(WI.MediaManager.prototype.disable):
(WI.MediaManager.prototype.playerAdded):
(WI.MediaManager.prototype.playerRemoved):
(WI.MediaManager.prototype.playerUpdated):
(WI.MediaManager.prototype._mainResourceDidChange):
(WI.MediaManager.prototype._clearPlayers):
(WI.MediaManager.prototype._calculatePlayerDifference):
(WI.MediaManager.prototype._isEmpty):
* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Models/MediaPlayer.js: Added.
(WI.MediaPlayer):
(WI.MediaPlayer.fromPayload):
(WI.MediaPlayer.parseMediaTime):
(WI.MediaPlayer.prototype.get identifier):
(WI.MediaPlayer.prototype.get originUrl):
(WI.MediaPlayer.prototype.get contentType):
(WI.MediaPlayer.prototype.get duration):
(WI.MediaPlayer.prototype.get engine):
(WI.MediaPlayer.prototype.get mediaType):
(WI.MediaPlayer.prototype.get events):
(WI.MediaPlayer.prototype.properties):
(WI.MediaPlayer.prototype.updateFromPayload):
(WI.MediaPlayer.prototype.saveIdentityToCookie):
(WI.MediaPlayer.prototype.requestNode):
(WI.MediaPlayer.prototype.play):
(WI.MediaPlayer.prototype.pause):
(WI.MediaPlayer.prototype.pushEvent):
* Source/WebInspectorUI/UserInterface/Protocol/MediaObserver.js: Added.
(WI.MediaObserver.prototype.playerAdded):
(WI.MediaObserver.prototype.playerRemoved):
(WI.MediaObserver.prototype.playerUpdated):
(WI.MediaObserver):
* Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js:
(WI.RemoteObject.resolveMediaElement):
* Source/WebInspectorUI/UserInterface/Protocol/Target.js:
(WI.Target.prototype.get MediaAgent):
* Source/WebInspectorUI/UserInterface/Test.html:
* Source/WebInspectorUI/UserInterface/Test/Test.js:
(WI.loaded):
(WI.contentLoaded):
* Source/WebInspectorUI/UserInterface/Views/ContentView.js:
(WI.ContentView.createFromRepresentedObject):
(WI.ContentView.isViewable):
* Source/WebInspectorUI/UserInterface/Views/MediaPlayerContentView.css: Added.
(.content-view.media):
(.content-view.media &gt; .preview):
(.content-view.media &gt; .preview &gt; img):
(.content-view.media .icon):
(.content-view.media &gt; :matches(header, footer)):
(.content-view.media &gt; .media-player-events):
(@media (prefers-color-scheme: dark) .content-view.media):
* Source/WebInspectorUI/UserInterface/Views/MediaPlayerContentView.js: Added.
(WI.MediaPlayerContentView):
(WI.MediaPlayerContentView.prototype.get scrollableElements):
(WI.MediaPlayerContentView.prototype.get navigationItems):
(WI.MediaPlayerContentView.prototype.refreshPreview):
(WI.MediaPlayerContentView.prototype.handleRefreshButtonClicked):
(WI.MediaPlayerContentView.prototype.tableIndexForRepresentedObject):
(WI.MediaPlayerContentView.prototype.tableRepresentedObjectForIndex):
(WI.MediaPlayerContentView.prototype.tableNumberOfRows):
(WI.MediaPlayerContentView.prototype.tableSortChanged):
(WI.MediaPlayerContentView.prototype.tablePopulateCell):
(WI.MediaPlayerContentView.prototype.initialLayout):
(WI.MediaPlayerContentView.prototype.layout):
(WI.MediaPlayerContentView.prototype.attached):
(WI.MediaPlayerContentView.prototype.detached):
(WI.MediaPlayerContentView.prototype._generateSortComparator):
(WI.MediaPlayerContentView.prototype._updateSort):
(WI.MediaPlayerContentView.prototype._showError):
(WI.MediaPlayerContentView.prototype._updateDetails):
(WI.MediaPlayerContentView.prototype._pushEvent):
(WI.MediaPlayerContentView.prototype._updateEvents):
* Source/WebInspectorUI/UserInterface/Views/MediaPlayerTreeElement.js: Added.
(WI.MediaPlayerTreeElement):
(WI.MediaPlayerTreeElement.prototype.updateTitles):
(WI.MediaPlayerTreeElement.prototype.onattach):
(WI.MediaPlayerTreeElement.prototype.ondetach):
(WI.MediaPlayerTreeElement.prototype.onpopulate):
(WI.MediaPlayerTreeElement.prototype.populateContextMenu):
(WI.MediaPlayerTreeElement.prototype._handleItemAdded):
(WI.MediaPlayerTreeElement.prototype._handleItemRemoved):
(WI.MediaPlayerTreeElement.prototype._handleMouseOver):
(WI.MediaPlayerTreeElement.prototype._handleMouseOut):
(WI.MediaPlayerTreeElement.prototype._handleIconClick):
(WI.MediaPlayerTreeElement.prototype._handlePlay):
(WI.MediaPlayerTreeElement.prototype._handlePause):
(WI.MediaPlayerTreeElement.prototype._updateStatus):
* Source/WebInspectorUI/UserInterface/Views/MediaSidebarPanel.css: Added.
(.sidebar &gt; .panel.navigation.media &gt; .content):
(.sidebar &gt; .panel.navigation.media .icon.paused):
(.sidebar &gt; .panel.navigation.media .icon.playing):
(.sidebar &gt; .panel.navigation.media &gt; .navigation-bar):
* Source/WebInspectorUI/UserInterface/Views/MediaSidebarPanel.js: Added.
(WI.MediaSidebarPanel):
(WI.MediaSidebarPanel.prototype.get minimumWidth):
(WI.MediaSidebarPanel.prototype.showDefaultContentView):
(WI.MediaSidebarPanel.prototype.closed):
(WI.MediaSidebarPanel.prototype.resetFilter):
(WI.MediaSidebarPanel.prototype.hasCustomFilters):
(WI.MediaSidebarPanel.prototype._treeSelectionDidChange):
(WI.MediaSidebarPanel.prototype._addMediaChild):
(WI.MediaSidebarPanel.prototype._addPlayer):
(WI.MediaSidebarPanel.prototype._removePlayer):
(WI.MediaSidebarPanel.prototype._updatePlayer):
(WI.MediaSidebarPanel.prototype._handlePlayerAdded):
(WI.MediaSidebarPanel.prototype._handlePlayerRemoved):
(WI.MediaSidebarPanel.prototype._handlePlayerUpdated):
(WI.MediaSidebarPanel.prototype._compareTreeElements):
(WI.MediaSidebarPanel.prototype._closeContentViewForTreeElement):
(WI.MediaSidebarPanel.prototype._scopeBarSelectionDidChange):
* Source/WebInspectorUI/UserInterface/Views/MediaTabContentView.js: Added.
(WI.MediaTabContentView):
(WI.MediaTabContentView.tabInfo):
(WI.MediaTabContentView.isTabAllowed):
(WI.MediaTabContentView.prototype.get type):
(WI.MediaTabContentView.prototype.get supportsSplitContentBrowser):
(WI.MediaTabContentView.prototype.canShowRepresentedObject):
(WI.MediaTabContentView.prototype.get canHandleFindEvent):
(WI.MediaTabContentView.prototype.handleFindEvent):
(WI.MediaTabContentView.prototype.closed):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57e7f2025d14c255b2c5b6794d25ab9612e631d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88097 "21 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18802 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97232 "Hash 57e7f202 for PR 3975 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152732 "Hash 57e7f202 for PR 3975 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30628 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26558 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80189 "Hash 57e7f202 for PR 3975 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91969 "Hash 57e7f202 for PR 3975 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24684 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74737 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/80189 "Hash 57e7f202 for PR 3975 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79721 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/80189 "Hash 57e7f202 for PR 3975 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79848 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28257 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13621 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73601 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28351 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14598 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26140 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31382 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37492 "Found 2 new test failures: http/tests/inspector/dom/didFireEvent.html, inspector/console/webcore-logging.html (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76445 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30331 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33832 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16963 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode (failure)") | 
<!--EWS-Status-Bubble-End-->