### PR TITLE
Modernize MotionMark plan files.

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark.plan
@@ -1,12 +1,1 @@
-{
-    "timeout": 1800,
-    "count": 1,
-    "svn_source": "https://svn.webkit.org/repository/webkit/trunk/PerformanceTests/MotionMark/@r210459",
-    "webserver_benchmark_patch": "data/patches/webserver/MotionMark.patch",
-    "webdriver_benchmark_patch": "data/patches/webdriver/MotionMark.patch",
-    "entry_point": "index.html",
-    "config": {
-        "orientation": "landscape"
-    },
-    "output_file": "motionmark.result"
-}
+motionmark1.2.1.plan

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.0.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.0.plan
@@ -1,0 +1,12 @@
+{
+    "timeout": 1800,
+    "count": 1,
+    "svn_source": "https://svn.webkit.org/repository/webkit/trunk/PerformanceTests/MotionMark/@r210459",
+    "webserver_benchmark_patch": "data/patches/webserver/MotionMark.patch",
+    "webdriver_benchmark_patch": "data/patches/webdriver/MotionMark.patch",
+    "entry_point": "index.html",
+    "config": {
+        "orientation": "landscape"
+    },
+    "output_file": "motionmark.result"
+}


### PR DESCRIPTION
#### 2ea6e9027a4bdd86e084030d280b762af0047f3c
<pre>
Modernize MotionMark plan files.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244747">https://bugs.webkit.org/show_bug.cgi?id=244747</a>
rdar://87990380

Reviewed by Stephanie Lewis.

Move &apos;motionmark.plan&apos; to &apos;motionmark1.0.plan&apos;.
Symlink &apos;motionmark.plan&apos; to &apos;motionmark1.2.1.plan&apos;.

* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.0.plan: Copied from Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark.plan.

Canonical link: <a href="https://commits.webkit.org/254277@main">https://commits.webkit.org/254277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50a4497a070b57cc2effcefcdeee2d7b507754ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97804 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31666 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27254 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80837 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92440 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25122 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75559 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25058 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/92204 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80007 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68021 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29345 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29196 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/15088 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3021 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32622 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34197 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->