### PR TITLE
Expose _overrideDeviceScaleFactor property on iOS (currently macOS only)

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3928,6 +3928,16 @@ static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFind
     });
 }
 
+- (void)_setOverrideDeviceScaleFactor:(CGFloat)deviceScaleFactor
+{
+    _page->setCustomDeviceScaleFactor(deviceScaleFactor);
+}
+
+- (CGFloat)_overrideDeviceScaleFactor
+{
+    return _page->customDeviceScaleFactor().value_or(0);
+}
+
 @end
 
 @implementation WKWebView (WKDeprecated)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -433,6 +433,9 @@ for this property.
 
 - (void)_dataTaskWithRequest:(NSURLRequest *)request completionHandler:(void(^)(_WKDataTask *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
+// Default value is 0. A value of 0 means the window's backing scale factor will be used and automatically update when the window moves screens.
+@property (nonatomic, setter=_setOverrideDeviceScaleFactor:) CGFloat _overrideDeviceScaleFactor WK_API_AVAILABLE(macos(10.11), ios(WK_IOS_TBA));
+
 typedef NS_ENUM(NSInteger, WKDisplayCaptureState) {
     WKDisplayCaptureStateNone,
     WKDisplayCaptureStateActive,
@@ -666,9 +669,6 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 @property (nonatomic, setter=_setTopContentInset:) CGFloat _topContentInset;
 
 @property (nonatomic, setter=_setAutomaticallyAdjustsContentInsets:) BOOL _automaticallyAdjustsContentInsets;
-
-// Default value is 0. A value of 0 means the window's backing scale factor will be used and automatically update when the window moves screens.
-@property (nonatomic, setter=_setOverrideDeviceScaleFactor:) CGFloat _overrideDeviceScaleFactor WK_API_AVAILABLE(macos(10.11));
 
 @property (nonatomic, setter=_setWindowOcclusionDetectionEnabled:) BOOL _windowOcclusionDetectionEnabled;
 

--- a/Source/WebKit/UIProcess/API/mac/WKView.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKView.mm
@@ -1423,12 +1423,12 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(NSUs
 
 - (void)_setOverrideDeviceScaleFactor:(CGFloat)deviceScaleFactor
 {
-    _data->_impl->setOverrideDeviceScaleFactor(deviceScaleFactor);
+    _data->_impl->page().setCustomDeviceScaleFactor(deviceScaleFactor);
 }
 
 - (CGFloat)_overrideDeviceScaleFactor
 {
-    return _data->_impl->overrideDeviceScaleFactor();
+    return _data->_impl->page().customDeviceScaleFactor().value_or(0);
 }
 
 - (WKLayoutMode)_layoutMode

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1379,16 +1379,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return _impl->automaticallyAdjustsContentInsets();
 }
 
-- (void)_setOverrideDeviceScaleFactor:(CGFloat)deviceScaleFactor
-{
-    _impl->setOverrideDeviceScaleFactor(deviceScaleFactor);
-}
-
-- (CGFloat)_overrideDeviceScaleFactor
-{
-    return _impl->overrideDeviceScaleFactor();
-}
-
 - (BOOL)_windowOcclusionDetectionEnabled
 {
     return _impl->windowOcclusionDetectionEnabled();

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1124,6 +1124,7 @@ public:
     
     float deviceScaleFactor() const;
     void setIntrinsicDeviceScaleFactor(float);
+    std::optional<float> customDeviceScaleFactor() const { return m_customDeviceScaleFactor; }
     void setCustomDeviceScaleFactor(float);
 
     void accessibilitySettingsDidChange();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -272,9 +272,6 @@ public:
     void setLayoutMode(WKLayoutMode);
     void updateSupportsArbitraryLayoutModes();
 
-    void setOverrideDeviceScaleFactor(CGFloat);
-    CGFloat overrideDeviceScaleFactor() const { return m_overrideDeviceScaleFactor; }
-
     void windowDidOrderOffScreen();
     void windowDidOrderOnScreen();
     void windowDidBecomeKey(NSWindow *);
@@ -793,7 +790,6 @@ private:
     CGSize m_scrollOffsetAdjustment { 0, 0 };
 
     CGSize m_intrinsicContentSize { 0, 0 };
-    CGFloat m_overrideDeviceScaleFactor { 0 };
 
     RetainPtr<WKViewLayoutStrategy> m_layoutStrategy;
     WKLayoutMode m_lastRequestedLayoutMode { kWKLayoutModeViewSize };

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1928,16 +1928,8 @@ void WebViewImpl::updateSupportsArbitraryLayoutModes()
     }
 }
 
-void WebViewImpl::setOverrideDeviceScaleFactor(CGFloat deviceScaleFactor)
-{
-    m_overrideDeviceScaleFactor = deviceScaleFactor;
-    m_page->setIntrinsicDeviceScaleFactor(intrinsicDeviceScaleFactor());
-}
-
 float WebViewImpl::intrinsicDeviceScaleFactor() const
 {
-    if (m_overrideDeviceScaleFactor)
-        return m_overrideDeviceScaleFactor;
     if (m_targetWindowForMovePreparation)
         return [m_targetWindowForMovePreparation backingScaleFactor];
     if (NSWindow *window = [m_view window])


### PR DESCRIPTION
#### bf2449abf730c6c5e867f52040ab28809b01f6a1
<pre>
Expose _overrideDeviceScaleFactor property on iOS (currently macOS only)
<a href="https://bugs.webkit.org/show_bug.cgi?id=244753">https://bugs.webkit.org/show_bug.cgi?id=244753</a>

Reviewed by Simon Fraser.

Remove our custom implementation of &quot;override the device scale factor&quot;
in WebViewImpl, and make the SPI property call into the &quot;custom device scale factor&quot;
mechanism that GTK folks use on WebPageProxy instead.

Also, expose the property on iOS as well, now that it&apos;s not tied to WebViewImpl!

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setOverrideDeviceScaleFactor:]):
(-[WKWebView _overrideDeviceScaleFactor]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
(-[WKWebView _dataTaskWithRequest:completionHandler:]): Deleted.
* Source/WebKit/UIProcess/API/mac/WKView.mm:
(-[WKView _setOverrideDeviceScaleFactor:]):
(-[WKView _overrideDeviceScaleFactor]):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setOverrideDeviceScaleFactor:]): Deleted.
(-[WKWebView _overrideDeviceScaleFactor]): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
(WebKit::WebViewImpl::overrideDeviceScaleFactor const): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::intrinsicDeviceScaleFactor const):
(WebKit::WebViewImpl::setOverrideDeviceScaleFactor): Deleted.

Canonical link: <a href="https://commits.webkit.org/254126@main">https://commits.webkit.org/254126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6921d00011681d98185af6080a62ea92f733c6c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97272 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30656 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26580 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80242 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91989 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24709 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74759 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24671 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28283 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28375 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14618 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2896 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31409 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30358 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33848 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->