### PR TITLE
[WebGL] Reinstate const only access to GCGLSpan buffer size

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5235,7 +5235,7 @@ void WebGLRenderingContextBase::texImageArrayBufferViewHelper(TexImageFunctionID
 
     Vector<uint8_t> tempData;
     bool changeUnpackParams = false;
-    if (data->data && width && height
+    if (data->data() && width && height
         && (m_unpackFlipY || m_unpackPremultiplyAlpha)) {
         ASSERT(sourceType == TexImageDimension::Tex2D);
         // Only enter here if width or height is non-zero. Otherwise, call to the
@@ -5357,7 +5357,7 @@ void WebGLRenderingContextBase::texImage2DBase(GCGLenum target, GCGLint level, G
     ASSERT(validateTexFuncParameters("texImage2D", TexImageFunctionType::TexImage, SourceArrayBufferView, target, level, internalFormat, width, height, 1, border, format, type));
     ASSERT(tex);
     ASSERT(validateNPOTTextureLevel(width, height, level, "texImage2D"));
-    if (!pixels.data) {
+    if (!pixels.data()) {
         if (!static_cast<GraphicsContextGLOpenGL*>(m_context.get())->texImage2DResourceSafe(target, level, internalFormat, width, height, border, format, type, m_unpackAlignment))
             return;
     } else {
@@ -6319,7 +6319,7 @@ void WebGLRenderingContextBase::uniform1iv(const WebGLUniformLocation* location,
 
 #if !USE(ANGLE)
     if (location->type() == GraphicsContextGL::SAMPLER_2D || location->type() == GraphicsContextGL::SAMPLER_CUBE) {
-        for (size_t i = 0; i < data.bufSize; ++i) {
+        for (size_t i = 0; i < data.size(); ++i) {
             if (data[i] >= static_cast<int>(m_textureUnits.size())) {
                 LOG(WebGL, "Texture unit size=%zu, v[%zu]=%d. Location type = %04X.", m_textureUnits.size(), i, data[i], location->type());
                 synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "uniform1iv", "invalid texture unit");

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -591,7 +591,7 @@ bool GraphicsContextGL::extractTextureData(unsigned width, unsigned height, GCGL
 
     unsigned imageSizeInBytes, skipSizeInBytes;
     computeImageSizeInBytes(format, type, width, height, 1, unpackParams, &imageSizeInBytes, nullptr, &skipSizeInBytes);
-    const uint8_t* srcData = static_cast<const uint8_t*>(pixels.data);
+    const uint8_t* srcData = static_cast<const uint8_t*>(pixels.data());
     if (skipSizeInBytes)
         srcData += skipSizeInBytes;
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -371,14 +371,14 @@ void GraphicsContextGLANGLE::getIntegerv(GCGLenum pname, GCGLSpan<GCGLint> value
 {
     if (!makeContextCurrent())
         return;
-    GL_GetIntegervRobustANGLE(pname, value.bufSize, nullptr, value.data);
+    GL_GetIntegervRobustANGLE(pname, value.size(), nullptr, value.data());
 }
 
 void GraphicsContextGLANGLE::getIntegeri_v(GCGLenum pname, GCGLuint index, GCGLSpan<GCGLint, 4> value) // NOLINT
 {
     if (!makeContextCurrent())
         return;
-    GL_GetIntegeri_vRobustANGLE(pname, index, value.bufSize, nullptr, value.data);
+    GL_GetIntegeri_vRobustANGLE(pname, index, value.size(), nullptr, value.data());
 }
 
 void GraphicsContextGLANGLE::getShaderPrecisionFormat(GCGLenum shaderType, GCGLenum precisionType, GCGLSpan<GCGLint, 2> range, GCGLint* precision)
@@ -386,7 +386,7 @@ void GraphicsContextGLANGLE::getShaderPrecisionFormat(GCGLenum shaderType, GCGLe
     if (!makeContextCurrent())
         return;
 
-    GL_GetShaderPrecisionFormat(shaderType, precisionType, range.data, precision);
+    GL_GetShaderPrecisionFormat(shaderType, precisionType, range.data(), precision);
 }
 
 void GraphicsContextGLANGLE::texImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, GCGLSpan<const GCGLvoid> pixels)
@@ -395,7 +395,7 @@ void GraphicsContextGLANGLE::texImage2D(GCGLenum target, GCGLint level, GCGLenum
         internalformat = adjustWebGL1TextureInternalFormat(internalformat, format, type);
     if (!makeContextCurrent())
         return;
-    GL_TexImage2DRobustANGLE(target, level, internalformat, width, height, border, format, type, pixels.bufSize, pixels.data);
+    GL_TexImage2DRobustANGLE(target, level, internalformat, width, height, border, format, type, pixels.size(), pixels.data());
     invalidateKnownTextureContent(m_state.currentBoundTexture());
 }
 
@@ -410,7 +410,7 @@ void GraphicsContextGLANGLE::texSubImage2D(GCGLenum target, GCGLint level, GCGLi
         return;
 
     // FIXME: we will need to deal with PixelStore params when dealing with image buffers that differ from the subimage size.
-    GL_TexSubImage2DRobustANGLE(target, level, xoff, yoff, width, height, format, type, pixels.bufSize, pixels.data);
+    GL_TexSubImage2DRobustANGLE(target, level, xoff, yoff, width, height, format, type, pixels.size(), pixels.data());
     invalidateKnownTextureContent(m_state.currentBoundTexture());
 }
 
@@ -424,7 +424,7 @@ void GraphicsContextGLANGLE::compressedTexImage2D(GCGLenum target, int level, GC
     if (!makeContextCurrent())
         return;
 
-    GL_CompressedTexImage2DRobustANGLE(target, level, internalformat, width, height, border, imageSize, data.bufSize, data.data);
+    GL_CompressedTexImage2DRobustANGLE(target, level, internalformat, width, height, border, imageSize, data.size(), data.data());
     invalidateKnownTextureContent(m_state.currentBoundTexture());
 }
 
@@ -438,7 +438,7 @@ void GraphicsContextGLANGLE::compressedTexSubImage2D(GCGLenum target, int level,
     if (!makeContextCurrent())
         return;
 
-    GL_CompressedTexSubImage2DRobustANGLE(target, level, xoffset, yoffset, width, height, format, imageSize, data.bufSize, data.data);
+    GL_CompressedTexSubImage2DRobustANGLE(target, level, xoffset, yoffset, width, height, format, imageSize, data.size(), data.data());
     invalidateKnownTextureContent(m_state.currentBoundTexture());
 }
 
@@ -465,7 +465,7 @@ void GraphicsContextGLANGLE::clearDepth(GCGLclampf depth)
 
 void GraphicsContextGLANGLE::readnPixels(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, GCGLSpan<GCGLvoid> data)
 {
-    readnPixelsImpl(x, y, width, height, format, type, data.bufSize, nullptr, nullptr, nullptr, data.data, false);
+    readnPixelsImpl(x, y, width, height, format, type, data.size(), nullptr, nullptr, nullptr, data.data(), false);
 }
 
 void GraphicsContextGLANGLE::readnPixels(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, GCGLintptr offset)
@@ -815,7 +815,7 @@ void GraphicsContextGLANGLE::bufferData(GCGLenum target, GCGLSpan<const GCGLvoid
     if (!makeContextCurrent())
         return;
 
-    GL_BufferData(target, data.bufSize, data.data, usage);
+    GL_BufferData(target, data.size(), data.data(), usage);
 }
 
 void GraphicsContextGLANGLE::bufferSubData(GCGLenum target, GCGLintptr offset, GCGLSpan<const GCGLvoid> data)
@@ -823,17 +823,17 @@ void GraphicsContextGLANGLE::bufferSubData(GCGLenum target, GCGLintptr offset, G
     if (!makeContextCurrent())
         return;
 
-    GL_BufferSubData(target, offset, data.bufSize, data.data);
+    GL_BufferSubData(target, offset, data.size(), data.data());
 }
 
 void GraphicsContextGLANGLE::getBufferSubData(GCGLenum target, GCGLintptr offset, GCGLSpan<GCGLvoid> data)
 {
     if (!makeContextCurrent())
         return;
-    GCGLvoid* ptr = GL_MapBufferRange(target, offset, data.bufSize, GraphicsContextGL::MAP_READ_BIT);
+    GCGLvoid* ptr = GL_MapBufferRange(target, offset, data.size(), GraphicsContextGL::MAP_READ_BIT);
     if (!ptr)
         return;
-    memcpy(data.data, ptr, data.bufSize);
+    memcpy(data.data(), ptr, data.size());
     if (!GL_UnmapBuffer(target))
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION);
 }
@@ -850,7 +850,7 @@ void GraphicsContextGLANGLE::getInternalformativ(GCGLenum target, GCGLenum inter
 {
     if (!makeContextCurrent())
         return;
-    GL_GetInternalformativRobustANGLE(target, internalformat, pname, data.bufSize, nullptr, data.data);
+    GL_GetInternalformativRobustANGLE(target, internalformat, pname, data.size(), nullptr, data.data());
 }
 
 void GraphicsContextGLANGLE::renderbufferStorageMultisample(GCGLenum target, GCGLsizei samples, GCGLenum internalformat, GCGLsizei width, GCGLsizei height)
@@ -884,7 +884,7 @@ void GraphicsContextGLANGLE::texImage3D(GCGLenum target, int level, int internal
     if (!makeContextCurrent())
         return;
 
-    GL_TexImage3DRobustANGLE(target, level, internalformat, width, height, depth, border, format, type, pixels.bufSize, pixels.data);
+    GL_TexImage3DRobustANGLE(target, level, internalformat, width, height, depth, border, format, type, pixels.size(), pixels.data());
 }
 
 void GraphicsContextGLANGLE::texImage3D(GCGLenum target, int level, int internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, int border, GCGLenum format, GCGLenum type, GCGLintptr offset)
@@ -897,7 +897,7 @@ void GraphicsContextGLANGLE::texSubImage3D(GCGLenum target, int level, int xoffs
     if (!makeContextCurrent())
         return;
 
-    GL_TexSubImage3DRobustANGLE(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels.bufSize, pixels.data);
+    GL_TexSubImage3DRobustANGLE(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels.size(), pixels.data());
 }
 
 void GraphicsContextGLANGLE::texSubImage3D(GCGLenum target, int level, int xoffset, int yoffset, int zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, GCGLintptr offset)
@@ -910,7 +910,7 @@ void GraphicsContextGLANGLE::compressedTexImage3D(GCGLenum target, int level, GC
     if (!makeContextCurrent())
         return;
 
-    GL_CompressedTexImage3DRobustANGLE(target, level, internalformat, width, height, depth, border, imageSize, data.bufSize, data.data);
+    GL_CompressedTexImage3DRobustANGLE(target, level, internalformat, width, height, depth, border, imageSize, data.size(), data.data());
 }
 
 void GraphicsContextGLANGLE::compressedTexImage3D(GCGLenum target, int level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, int border, GCGLsizei imageSize, GCGLintptr offset)
@@ -923,7 +923,7 @@ void GraphicsContextGLANGLE::compressedTexSubImage3D(GCGLenum target, int level,
     if (!makeContextCurrent())
         return;
 
-    GL_CompressedTexSubImage3DRobustANGLE(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data.bufSize, data.data);
+    GL_CompressedTexSubImage3DRobustANGLE(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data.size(), data.data());
 }
 
 void GraphicsContextGLANGLE::compressedTexSubImage3D(GCGLenum target, int level, int xoffset, int yoffset, int zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLsizei imageSize, GCGLintptr offset)
@@ -1540,7 +1540,7 @@ void GraphicsContextGLANGLE::uniform1fv(GCGLint location, GCGLSpan<const GCGLflo
     if (!makeContextCurrent())
         return;
 
-    GL_Uniform1fv(location, array.bufSize, array.data);
+    GL_Uniform1fv(location, array.size(), array.data());
 }
 
 void GraphicsContextGLANGLE::uniform2f(GCGLint location, GCGLfloat v0, GCGLfloat v1)
@@ -1553,11 +1553,11 @@ void GraphicsContextGLANGLE::uniform2f(GCGLint location, GCGLfloat v0, GCGLfloat
 
 void GraphicsContextGLANGLE::uniform2fv(GCGLint location, GCGLSpan<const GCGLfloat> array)
 {
-    ASSERT(!(array.bufSize % 2));
+    ASSERT(!(array.size() % 2));
     if (!makeContextCurrent())
         return;
 
-    GL_Uniform2fv(location, array.bufSize / 2, array.data);
+    GL_Uniform2fv(location, array.size() / 2, array.data());
 }
 
 void GraphicsContextGLANGLE::uniform3f(GCGLint location, GCGLfloat v0, GCGLfloat v1, GCGLfloat v2)
@@ -1570,11 +1570,11 @@ void GraphicsContextGLANGLE::uniform3f(GCGLint location, GCGLfloat v0, GCGLfloat
 
 void GraphicsContextGLANGLE::uniform3fv(GCGLint location, GCGLSpan<const GCGLfloat> array)
 {
-    ASSERT(!(array.bufSize % 3));
+    ASSERT(!(array.size() % 3));
     if (!makeContextCurrent())
         return;
 
-    GL_Uniform3fv(location, array.bufSize / 3, array.data);
+    GL_Uniform3fv(location, array.size() / 3, array.data());
 }
 
 void GraphicsContextGLANGLE::uniform4f(GCGLint location, GCGLfloat v0, GCGLfloat v1, GCGLfloat v2, GCGLfloat v3)
@@ -1587,11 +1587,11 @@ void GraphicsContextGLANGLE::uniform4f(GCGLint location, GCGLfloat v0, GCGLfloat
 
 void GraphicsContextGLANGLE::uniform4fv(GCGLint location, GCGLSpan<const GCGLfloat> array)
 {
-    ASSERT(!(array.bufSize % 4));
+    ASSERT(!(array.size() % 4));
     if (!makeContextCurrent())
         return;
 
-    GL_Uniform4fv(location, array.bufSize / 4, array.data);
+    GL_Uniform4fv(location, array.size() / 4, array.data());
 }
 
 void GraphicsContextGLANGLE::uniform1i(GCGLint location, GCGLint v0)
@@ -1607,7 +1607,7 @@ void GraphicsContextGLANGLE::uniform1iv(GCGLint location, GCGLSpan<const GCGLint
     if (!makeContextCurrent())
         return;
 
-    GL_Uniform1iv(location, array.bufSize, array.data);
+    GL_Uniform1iv(location, array.size(), array.data());
 }
 
 void GraphicsContextGLANGLE::uniform2i(GCGLint location, GCGLint v0, GCGLint v1)
@@ -1620,11 +1620,11 @@ void GraphicsContextGLANGLE::uniform2i(GCGLint location, GCGLint v0, GCGLint v1)
 
 void GraphicsContextGLANGLE::uniform2iv(GCGLint location, GCGLSpan<const GCGLint> array)
 {
-    ASSERT(!(array.bufSize % 2));
+    ASSERT(!(array.size() % 2));
     if (!makeContextCurrent())
         return;
 
-    GL_Uniform2iv(location, array.bufSize / 2, array.data);
+    GL_Uniform2iv(location, array.size() / 2, array.data());
 }
 
 void GraphicsContextGLANGLE::uniform3i(GCGLint location, GCGLint v0, GCGLint v1, GCGLint v2)
@@ -1637,11 +1637,11 @@ void GraphicsContextGLANGLE::uniform3i(GCGLint location, GCGLint v0, GCGLint v1,
 
 void GraphicsContextGLANGLE::uniform3iv(GCGLint location, GCGLSpan<const GCGLint> array)
 {
-    ASSERT(!(array.bufSize % 3));
+    ASSERT(!(array.size() % 3));
     if (!makeContextCurrent())
         return;
 
-    GL_Uniform3iv(location, array.bufSize / 3, array.data);
+    GL_Uniform3iv(location, array.size() / 3, array.data());
 }
 
 void GraphicsContextGLANGLE::uniform4i(GCGLint location, GCGLint v0, GCGLint v1, GCGLint v2, GCGLint v3)
@@ -1654,11 +1654,11 @@ void GraphicsContextGLANGLE::uniform4i(GCGLint location, GCGLint v0, GCGLint v1,
 
 void GraphicsContextGLANGLE::uniform4iv(GCGLint location, GCGLSpan<const GCGLint> array)
 {
-    ASSERT(!(array.bufSize % 4));
+    ASSERT(!(array.size() % 4));
     if (!makeContextCurrent())
         return;
 
-    GL_Uniform4iv(location, array.bufSize / 4, array.data);
+    GL_Uniform4iv(location, array.size() / 4, array.data());
 }
 
 void GraphicsContextGLANGLE::uniformMatrix2fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> array)
@@ -1666,25 +1666,25 @@ void GraphicsContextGLANGLE::uniformMatrix2fv(GCGLint location, GCGLboolean tran
     if (!makeContextCurrent())
         return;
 
-    GL_UniformMatrix2fv(location, array.bufSize / 4, transpose, array.data);
+    GL_UniformMatrix2fv(location, array.size() / 4, transpose, array.data());
 }
 
 void GraphicsContextGLANGLE::uniformMatrix3fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> array)
 {
-    ASSERT(!(array.bufSize % 9));
+    ASSERT(!(array.size() % 9));
     if (!makeContextCurrent())
         return;
 
-    GL_UniformMatrix3fv(location, array.bufSize / 9, transpose, array.data);
+    GL_UniformMatrix3fv(location, array.size() / 9, transpose, array.data());
 }
 
 void GraphicsContextGLANGLE::uniformMatrix4fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> array)
 {
-    ASSERT(!(array.bufSize % 16));
+    ASSERT(!(array.size() % 16));
     if (!makeContextCurrent())
         return;
 
-    GL_UniformMatrix4fv(location, array.bufSize / 16, transpose, array.data);
+    GL_UniformMatrix4fv(location, array.size() / 16, transpose, array.data());
 }
 
 void GraphicsContextGLANGLE::useProgram(PlatformGLObject program)
@@ -1718,7 +1718,7 @@ void GraphicsContextGLANGLE::vertexAttrib1fv(GCGLuint index, GCGLSpan<const GCGL
     if (!makeContextCurrent())
         return;
 
-    GL_VertexAttrib1fv(index, array.data);
+    GL_VertexAttrib1fv(index, array.data());
 }
 
 void GraphicsContextGLANGLE::vertexAttrib2f(GCGLuint index, GCGLfloat v0, GCGLfloat v1)
@@ -1734,7 +1734,7 @@ void GraphicsContextGLANGLE::vertexAttrib2fv(GCGLuint index, GCGLSpan<const GCGL
     if (!makeContextCurrent())
         return;
 
-    GL_VertexAttrib2fv(index, array.data);
+    GL_VertexAttrib2fv(index, array.data());
 }
 
 void GraphicsContextGLANGLE::vertexAttrib3f(GCGLuint index, GCGLfloat v0, GCGLfloat v1, GCGLfloat v2)
@@ -1750,7 +1750,7 @@ void GraphicsContextGLANGLE::vertexAttrib3fv(GCGLuint index, GCGLSpan<const GCGL
     if (!makeContextCurrent())
         return;
 
-    GL_VertexAttrib3fv(index, array.data);
+    GL_VertexAttrib3fv(index, array.data());
 }
 
 void GraphicsContextGLANGLE::vertexAttrib4f(GCGLuint index, GCGLfloat v0, GCGLfloat v1, GCGLfloat v2, GCGLfloat v3)
@@ -1766,7 +1766,7 @@ void GraphicsContextGLANGLE::vertexAttrib4fv(GCGLuint index, GCGLSpan<const GCGL
     if (!makeContextCurrent())
         return;
 
-    GL_VertexAttrib4fv(index, array.data);
+    GL_VertexAttrib4fv(index, array.data());
 }
 
 void GraphicsContextGLANGLE::vertexAttribPointer(GCGLuint index, GCGLint size, GCGLenum type, GCGLboolean normalized, GCGLsizei stride, GCGLintptr offset)
@@ -1845,7 +1845,7 @@ void GraphicsContextGLANGLE::getBooleanv(GCGLenum pname, GCGLSpan<GCGLboolean> v
     if (!makeContextCurrent())
         return;
 
-    GL_GetBooleanvRobustANGLE(pname, value.bufSize, nullptr, value.data);
+    GL_GetBooleanvRobustANGLE(pname, value.size(), nullptr, value.data());
 }
 
 GCGLint GraphicsContextGLANGLE::getBufferParameteri(GCGLenum target, GCGLenum pname)
@@ -1862,7 +1862,7 @@ void GraphicsContextGLANGLE::getFloatv(GCGLenum pname, GCGLSpan<GCGLfloat> value
     if (!makeContextCurrent())
         return;
 
-    GL_GetFloatvRobustANGLE(pname, value.bufSize, nullptr, value.data);
+    GL_GetFloatvRobustANGLE(pname, value.size(), nullptr, value.data());
 }
     
 GCGLint64 GraphicsContextGLANGLE::getInteger64(GCGLenum pname)
@@ -2013,8 +2013,8 @@ void GraphicsContextGLANGLE::getUniformfv(PlatformGLObject program, GCGLint loca
     if (!makeContextCurrent())
         return;
     // FIXME: Bug in ANGLE bufSize validation for uniforms. See https://bugs.webkit.org/show_bug.cgi?id=219069.
-    auto bufSize = value.bufSize * sizeof(*value);
-    GL_GetUniformfvRobustANGLE(program, location, bufSize, nullptr, value.data);
+    auto bufSize = value.size() * sizeof(*value);
+    GL_GetUniformfvRobustANGLE(program, location, bufSize, nullptr, value.data());
 }
 
 void GraphicsContextGLANGLE::getUniformiv(PlatformGLObject program, GCGLint location, GCGLSpan<GCGLint> value)
@@ -2022,8 +2022,8 @@ void GraphicsContextGLANGLE::getUniformiv(PlatformGLObject program, GCGLint loca
     if (!makeContextCurrent())
         return;
     // FIXME: Bug in ANGLE bufSize validation for uniforms. See https://bugs.webkit.org/show_bug.cgi?id=219069.
-    auto bufSize = value.bufSize * sizeof(*value);
-    GL_GetUniformivRobustANGLE(program, location, bufSize, nullptr, value.data);
+    auto bufSize = value.size() * sizeof(*value);
+    GL_GetUniformivRobustANGLE(program, location, bufSize, nullptr, value.data());
 }
 
 void GraphicsContextGLANGLE::getUniformuiv(PlatformGLObject program, GCGLint location, GCGLSpan<GCGLuint> value)
@@ -2031,8 +2031,8 @@ void GraphicsContextGLANGLE::getUniformuiv(PlatformGLObject program, GCGLint loc
     if (!makeContextCurrent())
         return;
     // FIXME: Bug in ANGLE bufSize validation for uniforms. See https://bugs.webkit.org/show_bug.cgi?id=219069.
-    auto bufSize = value.bufSize * sizeof(*value);
-    GL_GetUniformuivRobustANGLE(program, location, bufSize, nullptr, value.data);
+    auto bufSize = value.size() * sizeof(*value);
+    GL_GetUniformuivRobustANGLE(program, location, bufSize, nullptr, value.data());
 }
 
 GCGLint GraphicsContextGLANGLE::getUniformLocation(PlatformGLObject program, const String& name)
@@ -2410,7 +2410,7 @@ void GraphicsContextGLANGLE::invalidateFramebuffer(GCGLenum target, GCGLSpan<con
     if (!makeContextCurrent())
         return;
 
-    GL_InvalidateFramebuffer(target, attachments.bufSize, attachments.data);
+    GL_InvalidateFramebuffer(target, attachments.size(), attachments.data());
 }
 
 void GraphicsContextGLANGLE::invalidateSubFramebuffer(GCGLenum target, GCGLSpan<const GCGLenum> attachments, GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height)
@@ -2418,7 +2418,7 @@ void GraphicsContextGLANGLE::invalidateSubFramebuffer(GCGLenum target, GCGLSpan<
     if (!makeContextCurrent())
         return;
 
-    GL_InvalidateSubFramebuffer(target, attachments.bufSize, attachments.data, x, y, width, height);
+    GL_InvalidateSubFramebuffer(target, attachments.size(), attachments.data(), x, y, width, height);
 }
 
 void GraphicsContextGLANGLE::readBuffer(GCGLenum src)
@@ -2491,88 +2491,88 @@ void GraphicsContextGLANGLE::uniform1uiv(GCGLint location, GCGLSpan<const GCGLui
     if (!makeContextCurrent())
         return;
 
-    GL_Uniform1uiv(location, data.bufSize, data.data);
+    GL_Uniform1uiv(location, data.size(), data.data());
 }
 
 void GraphicsContextGLANGLE::uniform2uiv(GCGLint location, GCGLSpan<const GCGLuint> data)
 {
-    ASSERT(!(data.bufSize % 2));
+    ASSERT(!(data.size() % 2));
     if (!makeContextCurrent())
         return;
 
-    GL_Uniform2uiv(location, data.bufSize / 2, data.data);
+    GL_Uniform2uiv(location, data.size() / 2, data.data());
 }
 
 void GraphicsContextGLANGLE::uniform3uiv(GCGLint location, GCGLSpan<const GCGLuint> data)
 {
-    ASSERT(!(data.bufSize % 3));
+    ASSERT(!(data.size() % 3));
     if (!makeContextCurrent())
         return;
 
-    GL_Uniform3uiv(location, data.bufSize / 3, data.data);
+    GL_Uniform3uiv(location, data.size() / 3, data.data());
 }
 
 void GraphicsContextGLANGLE::uniform4uiv(GCGLint location, GCGLSpan<const GCGLuint> data)
 {
-    ASSERT(!(data.bufSize % 4));
+    ASSERT(!(data.size() % 4));
     if (!makeContextCurrent())
         return;
 
-    GL_Uniform4uiv(location, data.bufSize / 4, data.data);
+    GL_Uniform4uiv(location, data.size() / 4, data.data());
 }
 
 void GraphicsContextGLANGLE::uniformMatrix2x3fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
-    ASSERT(!(data.bufSize % 6));
+    ASSERT(!(data.size() % 6));
     if (!makeContextCurrent())
         return;
 
-    GL_UniformMatrix2x3fv(location, data.bufSize / 6, transpose, data.data);
+    GL_UniformMatrix2x3fv(location, data.size() / 6, transpose, data.data());
 }
 
 void GraphicsContextGLANGLE::uniformMatrix3x2fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
-    ASSERT(!(data.bufSize % 6));
+    ASSERT(!(data.size() % 6));
     if (!makeContextCurrent())
         return;
 
-    GL_UniformMatrix3x2fv(location, data.bufSize / 6, transpose, data.data);
+    GL_UniformMatrix3x2fv(location, data.size() / 6, transpose, data.data());
 }
 
 void GraphicsContextGLANGLE::uniformMatrix2x4fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
-    ASSERT(!(data.bufSize % 8));
+    ASSERT(!(data.size() % 8));
     if (!makeContextCurrent())
         return;
 
-    GL_UniformMatrix2x4fv(location, data.bufSize / 8, transpose, data.data);
+    GL_UniformMatrix2x4fv(location, data.size() / 8, transpose, data.data());
 }
 
 void GraphicsContextGLANGLE::uniformMatrix4x2fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
-    ASSERT(!(data.bufSize % 8));
+    ASSERT(!(data.size() % 8));
     if (!makeContextCurrent())
         return;
 
-    GL_UniformMatrix4x2fv(location, data.bufSize / 8, transpose, data.data);
+    GL_UniformMatrix4x2fv(location, data.size() / 8, transpose, data.data());
 }
 
 void GraphicsContextGLANGLE::uniformMatrix3x4fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
-    ASSERT(!(data.bufSize % 12));
+    ASSERT(!(data.size() % 12));
     if (!makeContextCurrent())
         return;
 
-    GL_UniformMatrix3x4fv(location, data.bufSize / 12, transpose, data.data);
+    GL_UniformMatrix3x4fv(location, data.size() / 12, transpose, data.data());
 }
 
 void GraphicsContextGLANGLE::uniformMatrix4x3fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
-    ASSERT(!(data.bufSize % 12));
+    ASSERT(!(data.size() % 12));
     if (!makeContextCurrent())
         return;
 
-    GL_UniformMatrix4x3fv(location, data.bufSize / 12, transpose, data.data);
+    GL_UniformMatrix4x3fv(location, data.size() / 12, transpose, data.data());
 }
 
 void GraphicsContextGLANGLE::vertexAttribI4i(GCGLuint index, GCGLint x, GCGLint y, GCGLint z, GCGLint w)
@@ -2588,7 +2588,7 @@ void GraphicsContextGLANGLE::vertexAttribI4iv(GCGLuint index, GCGLSpan<const GCG
     if (!makeContextCurrent())
         return;
 
-    GL_VertexAttribI4iv(index, values.data);
+    GL_VertexAttribI4iv(index, values.data());
 }
 
 void GraphicsContextGLANGLE::vertexAttribI4ui(GCGLuint index, GCGLuint x, GCGLuint y, GCGLuint z, GCGLuint w)
@@ -2604,7 +2604,7 @@ void GraphicsContextGLANGLE::vertexAttribI4uiv(GCGLuint index, GCGLSpan<const GC
     if (!makeContextCurrent())
         return;
 
-    GL_VertexAttribI4uiv(index, values.data);
+    GL_VertexAttribI4uiv(index, values.data());
 }
 
 void GraphicsContextGLANGLE::drawRangeElements(GCGLenum mode, GCGLuint start, GCGLuint end, GCGLsizei count, GCGLenum type, GCGLintptr offset)
@@ -2621,7 +2621,7 @@ void GraphicsContextGLANGLE::drawBuffers(GCGLSpan<const GCGLenum> bufs)
     if (!makeContextCurrent())
         return;
 
-    GL_DrawBuffers(bufs.bufSize, bufs.data);
+    GL_DrawBuffers(bufs.size(), bufs.data());
 }
 
 void GraphicsContextGLANGLE::clearBufferiv(GCGLenum buffer, GCGLint drawbuffer, GCGLSpan<const GCGLint> values)
@@ -2629,7 +2629,7 @@ void GraphicsContextGLANGLE::clearBufferiv(GCGLenum buffer, GCGLint drawbuffer, 
     if (!makeContextCurrent())
         return;
 
-    GL_ClearBufferiv(buffer, drawbuffer, values.data);
+    GL_ClearBufferiv(buffer, drawbuffer, values.data());
     checkGPUStatus();
 }
 
@@ -2638,7 +2638,7 @@ void GraphicsContextGLANGLE::clearBufferuiv(GCGLenum buffer, GCGLint drawbuffer,
     if (!makeContextCurrent())
         return;
 
-    GL_ClearBufferuiv(buffer, drawbuffer, values.data);
+    GL_ClearBufferuiv(buffer, drawbuffer, values.data());
     checkGPUStatus();
 }
 
@@ -2647,7 +2647,7 @@ void GraphicsContextGLANGLE::clearBufferfv(GCGLenum buffer, GCGLint drawbuffer, 
     if (!makeContextCurrent())
         return;
 
-    GL_ClearBufferfv(buffer, drawbuffer, values.data);
+    GL_ClearBufferfv(buffer, drawbuffer, values.data());
     checkGPUStatus();
 }
 
@@ -2847,7 +2847,7 @@ void GraphicsContextGLANGLE::getActiveUniformBlockiv(GCGLuint program, GCGLuint 
 {
     if (!makeContextCurrent())
         return;
-    GL_GetActiveUniformBlockivRobustANGLE(program, uniformBlockIndex, pname, params.bufSize, nullptr, params.data);
+    GL_GetActiveUniformBlockivRobustANGLE(program, uniformBlockIndex, pname, params.size(), nullptr, params.data());
 }
 
 void GraphicsContextGLANGLE::multiDrawArraysANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLint, const GCGLsizei> firstsAndCounts)
@@ -2948,7 +2948,7 @@ void GraphicsContextGLANGLE::drawBuffersEXT(GCGLSpan<const GCGLenum> bufs)
     if (!makeContextCurrent())
         return;
 
-    GL_DrawBuffersEXT(bufs.bufSize, bufs.data);
+    GL_DrawBuffersEXT(bufs.size(), bufs.data());
 }
 
 void GraphicsContextGLANGLE::enableiOES(GCGLenum target, GCGLuint index)

--- a/Source/WebCore/platform/graphics/opengl/ExtensionsGLOpenGL.cpp
+++ b/Source/WebCore/platform/graphics/opengl/ExtensionsGLOpenGL.cpp
@@ -171,7 +171,7 @@ void ExtensionsGLOpenGL::drawBuffersEXT(GCGLSpan<const GCGLenum> bufs)
 
     //  FIXME: implement support for other platforms.
 #if PLATFORM(GTK)
-    ::glDrawBuffers(bufs.bufSize, bufs.data);
+    ::glDrawBuffers(bufs.size(), bufs.data());
 #else
     UNUSED_PARAM(n);
     UNUSED_PARAM(bufs);

--- a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGL.cpp
+++ b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGL.cpp
@@ -722,7 +722,7 @@ void GraphicsContextGLOpenGL::bufferData(GCGLenum target, GCGLSpan<const void> d
     if (!makeContextCurrent())
         return;
 
-    ::glBufferData(target, data.bufSize, data.data, usage);
+    ::glBufferData(target, data.size(), data.data(), usage);
 }
 
 void GraphicsContextGLOpenGL::bufferSubData(GCGLenum target, GCGLintptr offset, GCGLSpan<const GCGLvoid> data)
@@ -730,7 +730,7 @@ void GraphicsContextGLOpenGL::bufferSubData(GCGLenum target, GCGLintptr offset, 
     if (!makeContextCurrent())
         return;
 
-    ::glBufferSubData(target, offset, data.bufSize, data.data);
+    ::glBufferSubData(target, offset, data.size(), data.data());
 }
 
 GCGLenum GraphicsContextGLOpenGL::checkFramebufferStatus(GCGLenum target)
@@ -1584,7 +1584,7 @@ void GraphicsContextGLOpenGL::uniform1fv(GCGLint location, GCGLSpan<const GCGLfl
     if (!makeContextCurrent())
         return;
 
-    ::glUniform1fv(location, array.bufSize, array.data);
+    ::glUniform1fv(location, array.size(), array.data());
 }
 
 void GraphicsContextGLOpenGL::uniform2f(GCGLint location, GCGLfloat v0, GCGLfloat v1)
@@ -1597,11 +1597,11 @@ void GraphicsContextGLOpenGL::uniform2f(GCGLint location, GCGLfloat v0, GCGLfloa
 
 void GraphicsContextGLOpenGL::uniform2fv(GCGLint location, GCGLSpan<const GCGLfloat> array)
 {
-    ASSERT(!(array.bufSize % 2));
+    ASSERT(!(array.size() % 2));
     if (!makeContextCurrent())
         return;
 
-    ::glUniform2fv(location, array.bufSize / 2, array.data);
+    ::glUniform2fv(location, array.size() / 2, array.data());
 }
 
 void GraphicsContextGLOpenGL::uniform3f(GCGLint location, GCGLfloat v0, GCGLfloat v1, GCGLfloat v2)
@@ -1614,11 +1614,11 @@ void GraphicsContextGLOpenGL::uniform3f(GCGLint location, GCGLfloat v0, GCGLfloa
 
 void GraphicsContextGLOpenGL::uniform3fv(GCGLint location, GCGLSpan<const GCGLfloat> array)
 {
-    ASSERT(!(array.bufSize % 3));
+    ASSERT(!(array.size() % 3));
     if (!makeContextCurrent())
         return;
 
-    ::glUniform3fv(location, array.bufSize / 3, array.data);
+    ::glUniform3fv(location, array.size() / 3, array.data());
 }
 
 void GraphicsContextGLOpenGL::uniform4f(GCGLint location, GCGLfloat v0, GCGLfloat v1, GCGLfloat v2, GCGLfloat v3)
@@ -1631,11 +1631,11 @@ void GraphicsContextGLOpenGL::uniform4f(GCGLint location, GCGLfloat v0, GCGLfloa
 
 void GraphicsContextGLOpenGL::uniform4fv(GCGLint location, GCGLSpan<const GCGLfloat> array)
 {
-    ASSERT(!(array.bufSize % 4));
+    ASSERT(!(array.size() % 4));
     if (!makeContextCurrent())
         return;
 
-    ::glUniform4fv(location, array.bufSize / 4, array.data);
+    ::glUniform4fv(location, array.size() / 4, array.data());
 }
 
 void GraphicsContextGLOpenGL::uniform1i(GCGLint location, GCGLint v0)
@@ -1651,7 +1651,7 @@ void GraphicsContextGLOpenGL::uniform1iv(GCGLint location, GCGLSpan<const GCGLin
     if (!makeContextCurrent())
         return;
 
-    ::glUniform1iv(location, array.bufSize, array.data);
+    ::glUniform1iv(location, array.size(), array.data());
 }
 
 void GraphicsContextGLOpenGL::uniform2i(GCGLint location, GCGLint v0, GCGLint v1)
@@ -1664,11 +1664,11 @@ void GraphicsContextGLOpenGL::uniform2i(GCGLint location, GCGLint v0, GCGLint v1
 
 void GraphicsContextGLOpenGL::uniform2iv(GCGLint location, GCGLSpan<const GCGLint> array)
 {
-    ASSERT(!(array.bufSize % 2));
+    ASSERT(!(array.size() % 2));
     if (!makeContextCurrent())
         return;
 
-    ::glUniform2iv(location, array.bufSize / 2, array.data);
+    ::glUniform2iv(location, array.size() / 2, array.data());
 }
 
 void GraphicsContextGLOpenGL::uniform3i(GCGLint location, GCGLint v0, GCGLint v1, GCGLint v2)
@@ -1681,11 +1681,11 @@ void GraphicsContextGLOpenGL::uniform3i(GCGLint location, GCGLint v0, GCGLint v1
 
 void GraphicsContextGLOpenGL::uniform3iv(GCGLint location, GCGLSpan<const GCGLint> array)
 {
-    ASSERT(!(array.bufSize % 3));
+    ASSERT(!(array.size() % 3));
     if (!makeContextCurrent())
         return;
 
-    ::glUniform3iv(location, array.bufSize / 3, array.data);
+    ::glUniform3iv(location, array.size() / 3, array.data());
 }
 
 void GraphicsContextGLOpenGL::uniform4i(GCGLint location, GCGLint v0, GCGLint v1, GCGLint v2, GCGLint v3)
@@ -1698,38 +1698,38 @@ void GraphicsContextGLOpenGL::uniform4i(GCGLint location, GCGLint v0, GCGLint v1
 
 void GraphicsContextGLOpenGL::uniform4iv(GCGLint location, GCGLSpan<const GCGLint> array)
 {
-    ASSERT(!(array.bufSize % 4));
+    ASSERT(!(array.size() % 4));
     if (!makeContextCurrent())
         return;
 
-    ::glUniform4iv(location, array.bufSize / 4, array.data);
+    ::glUniform4iv(location, array.size() / 4, array.data());
 }
 
 void GraphicsContextGLOpenGL::uniformMatrix2fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> array)
 {
-    ASSERT(!(array.bufSize % 4));
+    ASSERT(!(array.size() % 4));
     if (!makeContextCurrent())
         return;
 
-    ::glUniformMatrix2fv(location, array.bufSize / 4, transpose, array.data);
+    ::glUniformMatrix2fv(location, array.size() / 4, transpose, array.data());
 }
 
 void GraphicsContextGLOpenGL::uniformMatrix3fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> array)
 {
-    ASSERT(!(array.bufSize % 9));
+    ASSERT(!(array.size() % 9));
     if (!makeContextCurrent())
         return;
 
-    ::glUniformMatrix3fv(location, array.bufSize / 9, transpose, array.data);
+    ::glUniformMatrix3fv(location, array.size() / 9, transpose, array.data());
 }
 
 void GraphicsContextGLOpenGL::uniformMatrix4fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> array)
 {
-    ASSERT(!(array.bufSize % 16));
+    ASSERT(!(array.size() % 16));
     if (!makeContextCurrent())
         return;
 
-    ::glUniformMatrix4fv(location, array.bufSize / 16, transpose, array.data);
+    ::glUniformMatrix4fv(location, array.size() / 16, transpose, array.data());
 }
 
 void GraphicsContextGLOpenGL::useProgram(PlatformGLObject program)
@@ -1763,7 +1763,7 @@ void GraphicsContextGLOpenGL::vertexAttrib1fv(GCGLuint index, GCGLSpan<const GCG
     if (!makeContextCurrent())
         return;
 
-    ::glVertexAttrib1fv(index, array.data);
+    ::glVertexAttrib1fv(index, array.data());
 }
 
 void GraphicsContextGLOpenGL::vertexAttrib2f(GCGLuint index, GCGLfloat v0, GCGLfloat v1)
@@ -1779,7 +1779,7 @@ void GraphicsContextGLOpenGL::vertexAttrib2fv(GCGLuint index, GCGLSpan<const GCG
     if (!makeContextCurrent())
         return;
 
-    ::glVertexAttrib2fv(index, array.data);
+    ::glVertexAttrib2fv(index, array.data());
 }
 
 void GraphicsContextGLOpenGL::vertexAttrib3f(GCGLuint index, GCGLfloat v0, GCGLfloat v1, GCGLfloat v2)
@@ -1795,7 +1795,7 @@ void GraphicsContextGLOpenGL::vertexAttrib3fv(GCGLuint index, GCGLSpan<const GCG
     if (!makeContextCurrent())
         return;
 
-    ::glVertexAttrib3fv(index, array.data);
+    ::glVertexAttrib3fv(index, array.data());
 }
 
 void GraphicsContextGLOpenGL::vertexAttrib4f(GCGLuint index, GCGLfloat v0, GCGLfloat v1, GCGLfloat v2, GCGLfloat v3)
@@ -1811,7 +1811,7 @@ void GraphicsContextGLOpenGL::vertexAttrib4fv(GCGLuint index, GCGLSpan<const GCG
     if (!makeContextCurrent())
         return;
 
-    ::glVertexAttrib4fv(index, array.data);
+    ::glVertexAttrib4fv(index, array.data());
 }
 
 void GraphicsContextGLOpenGL::vertexAttribPointer(GCGLuint index, GCGLint size, GCGLenum type, GCGLboolean normalized, GCGLsizei stride, GCGLintptr offset)
@@ -1855,7 +1855,7 @@ void GraphicsContextGLOpenGL::getBooleanv(GCGLenum pname, GCGLSpan<GCGLboolean> 
     if (!makeContextCurrent())
         return;
 
-    ::glGetBooleanv(pname, value.data);
+    ::glGetBooleanv(pname, value.data());
 }
 
 GCGLint GraphicsContextGLOpenGL::getBufferParameteri(GCGLenum target, GCGLenum pname)
@@ -1873,7 +1873,7 @@ void GraphicsContextGLOpenGL::getFloatv(GCGLenum pname, GCGLSpan<GCGLfloat> valu
     if (!makeContextCurrent())
         return;
 
-    ::glGetFloatv(pname, value.data);
+    ::glGetFloatv(pname, value.data());
 }
 
 void GraphicsContextGLOpenGL::getIntegeri_v(GCGLenum pname, GCGLuint index, GCGLSpan<GCGLint, 4> value) // NOLINT
@@ -1885,7 +1885,7 @@ void GraphicsContextGLOpenGL::getIntegeri_v(GCGLenum pname, GCGLuint index, GCGL
         return;
 
     // FIXME 141178: Before enabling this we must first switch over to using gl3.h and creating and initialing the WebGL2 context using OpenGL ES 3.0.
-    // ::glGetIntegeri_v(pname, index, value.data);
+    // ::glGetIntegeri_v(pname, index, value.data());
 }
 
 GCGLint64 GraphicsContextGLOpenGL::getInteger64(GCGLenum pname)
@@ -2144,7 +2144,7 @@ void GraphicsContextGLOpenGL::getUniformfv(PlatformGLObject program, GCGLint loc
     if (!makeContextCurrent())
         return;
 
-    ::glGetUniformfv(program, location, value.data);
+    ::glGetUniformfv(program, location, value.data());
 }
 
 void GraphicsContextGLOpenGL::getUniformiv(PlatformGLObject program, GCGLint location, GCGLSpan<GCGLint> value)
@@ -2152,7 +2152,7 @@ void GraphicsContextGLOpenGL::getUniformiv(PlatformGLObject program, GCGLint loc
     if (!makeContextCurrent())
         return;
 
-    ::glGetUniformiv(program, location, value.data);
+    ::glGetUniformiv(program, location, value.data());
 }
 
 void GraphicsContextGLOpenGL::getUniformuiv(PlatformGLObject program, GCGLint location, GCGLSpan<GCGLuint> value)
@@ -2212,7 +2212,7 @@ void GraphicsContextGLOpenGL::texSubImage2D(GCGLenum target, GCGLint level, GCGL
     }
 
     // FIXME: we will need to deal with PixelStore params when dealing with image buffers that differ from the subimage size.
-    ::glTexSubImage2D(target, level, xoff, yoff, width, height, format, type, pixels.data);
+    ::glTexSubImage2D(target, level, xoff, yoff, width, height, format, type, pixels.data());
 }
 
 void GraphicsContextGLOpenGL::compressedTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLsizei imageSize, GCGLSpan<const GCGLvoid> data)
@@ -2220,7 +2220,7 @@ void GraphicsContextGLOpenGL::compressedTexImage2D(GCGLenum target, GCGLint leve
     if (!makeContextCurrent())
         return;
 
-    ::glCompressedTexImage2D(target, level, internalformat, width, height, border, imageSize, data.data);
+    ::glCompressedTexImage2D(target, level, internalformat, width, height, border, imageSize, data.data());
 }
 
 void GraphicsContextGLOpenGL::compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLsizei imageSize, GCGLSpan<const GCGLvoid> data)
@@ -2228,7 +2228,7 @@ void GraphicsContextGLOpenGL::compressedTexSubImage2D(GCGLenum target, GCGLint l
     if (!makeContextCurrent())
         return;
 
-    ::glCompressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, data.data);
+    ::glCompressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, data.data());
 }
 
 PlatformGLObject GraphicsContextGLOpenGL::createBuffer()
@@ -2416,10 +2416,10 @@ void GraphicsContextGLOpenGL::getBufferSubData(GCGLenum target, GCGLintptr offse
 #if HAVE(OPENGL_4) || HAVE(OPENGL_ES_3)
     if (!makeContextCurrent())
         return;
-    GCGLvoid* ptr = ::glMapBufferRange(target, offset, data.bufSize, GraphicsContextGL::MAP_READ_BIT);
+    GCGLvoid* ptr = ::glMapBufferRange(target, offset, data.size(), GraphicsContextGL::MAP_READ_BIT);
     if (!ptr)
         return;
-    memcpy(data.data, ptr, data.bufSize);
+    memcpy(data.data(), ptr, data.size());
     if (!::glUnmapBuffer(target))
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION);
 #else
@@ -2482,7 +2482,7 @@ void GraphicsContextGLOpenGL::getInternalformativ(GCGLenum target, GCGLenum inte
     if (!makeContextCurrent())
         return;
 
-    ::glGetInternalformativ(target, internalformat, pname, data.bufSize, data.data);
+    ::glGetInternalformativ(target, internalformat, pname, data.size(), data.data());
 #else
     UNUSED_PARAM(target);
     UNUSED_PARAM(internalformat);

--- a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
+++ b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGLBase.cpp
@@ -247,46 +247,46 @@ void GraphicsContextGLOpenGL::getIntegerv(GCGLenum pname, GCGLSpan<GCGLint> valu
     switch (pname) {
 #if USE(OPENGL)
     case MAX_FRAGMENT_UNIFORM_VECTORS:
-        ::glGetIntegerv(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, value.data);
+        ::glGetIntegerv(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, value.data());
         *value /= 4;
         break;
     case MAX_VERTEX_UNIFORM_VECTORS:
-        ::glGetIntegerv(GL_MAX_VERTEX_UNIFORM_COMPONENTS, value.data);
+        ::glGetIntegerv(GL_MAX_VERTEX_UNIFORM_COMPONENTS, value.data());
         *value /= 4;
         break;
     case MAX_VARYING_VECTORS:
         if (isGLES2Compliant()) {
             ASSERT(::glGetError() == GL_NO_ERROR);
-            ::glGetIntegerv(GL_MAX_VARYING_VECTORS, value.data);
+            ::glGetIntegerv(GL_MAX_VARYING_VECTORS, value.data());
             if (::glGetError() == GL_INVALID_ENUM) {
-                ::glGetIntegerv(GL_MAX_VARYING_COMPONENTS, value.data);
+                ::glGetIntegerv(GL_MAX_VARYING_COMPONENTS, value.data());
                 *value /= 4;
             }
         } else {
-            ::glGetIntegerv(GL_MAX_VARYING_FLOATS, value.data);
+            ::glGetIntegerv(GL_MAX_VARYING_FLOATS, value.data());
             *value /= 4;
         }
         break;
 #endif
     case MAX_TEXTURE_SIZE:
-        ::glGetIntegerv(MAX_TEXTURE_SIZE, value.data);
+        ::glGetIntegerv(MAX_TEXTURE_SIZE, value.data());
         if (getExtensions().requiresRestrictedMaximumTextureSize())
             *value = std::min(4096, *value);
         break;
     case MAX_CUBE_MAP_TEXTURE_SIZE:
-        ::glGetIntegerv(MAX_CUBE_MAP_TEXTURE_SIZE, value.data);
+        ::glGetIntegerv(MAX_CUBE_MAP_TEXTURE_SIZE, value.data());
         if (getExtensions().requiresRestrictedMaximumTextureSize())
             *value = std::min(1024, *value);
         break;
     default:
-        ::glGetIntegerv(pname, value.data);
+        ::glGetIntegerv(pname, value.data());
     }
 }
 
 void GraphicsContextGLOpenGL::getShaderPrecisionFormat(GCGLenum shaderType, GCGLenum precisionType, GCGLSpan<GCGLint, 2> range, GCGLint* precision)
 {
     UNUSED_PARAM(shaderType);
-    ASSERT(range.data);
+    ASSERT(range.data());
     ASSERT(precision);
 
     if (!makeContextCurrent())
@@ -318,7 +318,7 @@ void GraphicsContextGLOpenGL::getShaderPrecisionFormat(GCGLenum shaderType, GCGL
 
 void GraphicsContextGLOpenGL::texImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, GCGLSpan<const GCGLvoid> pixels)
 {
-    if (width && height && !pixels.data) {
+    if (width && height && !pixels.data()) {
         synthesizeGLError(INVALID_VALUE);
         return;
     }
@@ -378,7 +378,7 @@ void GraphicsContextGLOpenGL::texImage2D(GCGLenum target, GCGLint level, GCGLenu
         }
     }
 
-    texImage2DDirect(target, level, openGLInternalFormat, width, height, border, openGLFormat, type, pixels.data);
+    texImage2DDirect(target, level, openGLInternalFormat, width, height, border, openGLFormat, type, pixels.data());
 }
 
 void GraphicsContextGLOpenGL::depthRange(GCGLclampf zNear, GCGLclampf zFar)
@@ -422,7 +422,7 @@ void GraphicsContextGLOpenGL::readnPixels(GCGLint x, GCGLint y, GCGLsizei width,
         ::glBindFramebufferEXT(GraphicsContextGL::FRAMEBUFFER, m_fbo);
         ::glFlush();
     }
-    ::glReadPixels(x, y, width, height, format, type, data.data);
+    ::glReadPixels(x, y, width, height, format, type, data.data());
     if (attrs.antialias && m_state.boundDrawFBO == m_multisampleFBO)
         ::glBindFramebufferEXT(GraphicsContextGL::FRAMEBUFFER, m_multisampleFBO);
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -284,11 +284,11 @@ void RemoteGraphicsContextGLProxy::readnPixels(GCGLint x, GCGLint y, GCGLsizei w
 {
     IPC::ArrayReference<uint8_t> dataReply;
     if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::ReadnPixels0(x, y, width, height, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<uint8_t*>(data.data), data.bufSize)), Messages::RemoteGraphicsContextGL::ReadnPixels0::Reply(dataReply));
+        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::ReadnPixels0(x, y, width, height, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<uint8_t*>(data.data()), data.size())), Messages::RemoteGraphicsContextGL::ReadnPixels0::Reply(dataReply));
         if (!sendResult)
             markContextLost();
         else
-            memcpy(data.data, dataReply.data(), data.bufSize * sizeof(uint8_t));
+            memcpy(data.data(), dataReply.data(), data.size());
     }
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -564,11 +564,11 @@ void RemoteGraphicsContextGLProxy::getFloatv(GCGLenum pname, GCGLSpan<GCGLfloat>
 {
     IPC::ArrayReference<float> valueReply;
     if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFloatv(pname, value.bufSize), Messages::RemoteGraphicsContextGL::GetFloatv::Reply(valueReply));
+        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFloatv(pname, value.size()), Messages::RemoteGraphicsContextGL::GetFloatv::Reply(valueReply));
         if (!sendResult)
             markContextLost();
         else
-            memcpy(value.data, valueReply.data(), value.bufSize * sizeof(float));
+            memcpy(value.data(), valueReply.data(), value.size() * sizeof(float));
     }
 }
 
@@ -576,11 +576,11 @@ void RemoteGraphicsContextGLProxy::getIntegerv(GCGLenum pname, GCGLSpan<GCGLint>
 {
     IPC::ArrayReference<int32_t> valueReply;
     if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetIntegerv(pname, value.bufSize), Messages::RemoteGraphicsContextGL::GetIntegerv::Reply(valueReply));
+        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetIntegerv(pname, value.size()), Messages::RemoteGraphicsContextGL::GetIntegerv::Reply(valueReply));
         if (!sendResult)
             markContextLost();
         else
-            memcpy(value.data, valueReply.data(), value.bufSize * sizeof(int32_t));
+            memcpy(value.data(), valueReply.data(), value.size() * sizeof(int32_t));
     }
 }
 
@@ -593,7 +593,7 @@ void RemoteGraphicsContextGLProxy::getIntegeri_v(GCGLenum pname, GCGLuint index,
         if (!sendResult)
             markContextLost();
         else
-            memcpy(value.data, valueReply.data(), value.bufSize * sizeof(int32_t));
+            memcpy(value.data(), valueReply.data(), value.size() * sizeof(int32_t));
     }
 }
 
@@ -634,11 +634,11 @@ void RemoteGraphicsContextGLProxy::getBooleanv(GCGLenum pname, GCGLSpan<GCGLbool
 {
     IPC::ArrayReference<bool> valueReply;
     if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBooleanv(pname, value.bufSize), Messages::RemoteGraphicsContextGL::GetBooleanv::Reply(valueReply));
+        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBooleanv(pname, value.size()), Messages::RemoteGraphicsContextGL::GetBooleanv::Reply(valueReply));
         if (!sendResult)
             markContextLost();
         else
-            memcpy(value.data, valueReply.data(), value.bufSize * sizeof(bool));
+            memcpy(value.data(), valueReply.data(), value.size() * sizeof(bool));
     }
 }
 
@@ -707,7 +707,7 @@ void RemoteGraphicsContextGLProxy::getShaderPrecisionFormat(GCGLenum shaderType,
         if (!sendResult)
             markContextLost();
         else {
-            memcpy(range.data, rangeReply.data(), range.bufSize * sizeof(int32_t));
+            memcpy(range.data(), rangeReply.data(), range.size() * sizeof(int32_t));
             if (precision)
                 *precision = precisionReply;
         }
@@ -751,11 +751,11 @@ void RemoteGraphicsContextGLProxy::getUniformfv(PlatformGLObject program, GCGLin
 {
     IPC::ArrayReference<float> valueReply;
     if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformfv(program, location, value.bufSize), Messages::RemoteGraphicsContextGL::GetUniformfv::Reply(valueReply));
+        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformfv(program, location, value.size()), Messages::RemoteGraphicsContextGL::GetUniformfv::Reply(valueReply));
         if (!sendResult)
             markContextLost();
         else
-            memcpy(value.data, valueReply.data(), value.bufSize * sizeof(float));
+            memcpy(value.data(), valueReply.data(), value.size() * sizeof(float));
     }
 }
 
@@ -763,11 +763,11 @@ void RemoteGraphicsContextGLProxy::getUniformiv(PlatformGLObject program, GCGLin
 {
     IPC::ArrayReference<int32_t> valueReply;
     if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformiv(program, location, value.bufSize), Messages::RemoteGraphicsContextGL::GetUniformiv::Reply(valueReply));
+        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformiv(program, location, value.size()), Messages::RemoteGraphicsContextGL::GetUniformiv::Reply(valueReply));
         if (!sendResult)
             markContextLost();
         else
-            memcpy(value.data, valueReply.data(), value.bufSize * sizeof(int32_t));
+            memcpy(value.data(), valueReply.data(), value.size() * sizeof(int32_t));
     }
 }
 
@@ -775,11 +775,11 @@ void RemoteGraphicsContextGLProxy::getUniformuiv(PlatformGLObject program, GCGLi
 {
     IPC::ArrayReference<uint32_t> valueReply;
     if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformuiv(program, location, value.bufSize), Messages::RemoteGraphicsContextGL::GetUniformuiv::Reply(valueReply));
+        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformuiv(program, location, value.size()), Messages::RemoteGraphicsContextGL::GetUniformuiv::Reply(valueReply));
         if (!sendResult)
             markContextLost();
         else
-            memcpy(value.data, valueReply.data(), value.bufSize * sizeof(uint32_t));
+            memcpy(value.data(), valueReply.data(), value.size() * sizeof(uint32_t));
     }
 }
 
@@ -1047,7 +1047,7 @@ void RemoteGraphicsContextGLProxy::uniform1f(GCGLint location, GCGLfloat x)
 void RemoteGraphicsContextGLProxy::uniform1fv(GCGLint location, GCGLSpan<const GCGLfloat> v)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data), v.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1065,7 +1065,7 @@ void RemoteGraphicsContextGLProxy::uniform1i(GCGLint location, GCGLint x)
 void RemoteGraphicsContextGLProxy::uniform1iv(GCGLint location, GCGLSpan<const GCGLint> v)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data), v.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1083,7 +1083,7 @@ void RemoteGraphicsContextGLProxy::uniform2f(GCGLint location, GCGLfloat x, GCGL
 void RemoteGraphicsContextGLProxy::uniform2fv(GCGLint location, GCGLSpan<const GCGLfloat> v)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data), v.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1101,7 +1101,7 @@ void RemoteGraphicsContextGLProxy::uniform2i(GCGLint location, GCGLint x, GCGLin
 void RemoteGraphicsContextGLProxy::uniform2iv(GCGLint location, GCGLSpan<const GCGLint> v)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data), v.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1119,7 +1119,7 @@ void RemoteGraphicsContextGLProxy::uniform3f(GCGLint location, GCGLfloat x, GCGL
 void RemoteGraphicsContextGLProxy::uniform3fv(GCGLint location, GCGLSpan<const GCGLfloat> v)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data), v.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1137,7 +1137,7 @@ void RemoteGraphicsContextGLProxy::uniform3i(GCGLint location, GCGLint x, GCGLin
 void RemoteGraphicsContextGLProxy::uniform3iv(GCGLint location, GCGLSpan<const GCGLint> v)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data), v.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1155,7 +1155,7 @@ void RemoteGraphicsContextGLProxy::uniform4f(GCGLint location, GCGLfloat x, GCGL
 void RemoteGraphicsContextGLProxy::uniform4fv(GCGLint location, GCGLSpan<const GCGLfloat> v)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data), v.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1173,7 +1173,7 @@ void RemoteGraphicsContextGLProxy::uniform4i(GCGLint location, GCGLint x, GCGLin
 void RemoteGraphicsContextGLProxy::uniform4iv(GCGLint location, GCGLSpan<const GCGLint> v)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data), v.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1182,7 +1182,7 @@ void RemoteGraphicsContextGLProxy::uniform4iv(GCGLint location, GCGLSpan<const G
 void RemoteGraphicsContextGLProxy::uniformMatrix2fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> value)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data), value.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1191,7 +1191,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2fv(GCGLint location, GCGLboolea
 void RemoteGraphicsContextGLProxy::uniformMatrix3fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> value)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data), value.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1200,7 +1200,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3fv(GCGLint location, GCGLboolea
 void RemoteGraphicsContextGLProxy::uniformMatrix4fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> value)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data), value.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1236,7 +1236,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib1f(GCGLuint index, GCGLfloat x)
 void RemoteGraphicsContextGLProxy::vertexAttrib1fv(GCGLuint index, GCGLSpan<const GCGLfloat, 1> values)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1fv(index, IPC::ArrayReference<float, 1>(reinterpret_cast<const float*>(values.data), values.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1fv(index, IPC::ArrayReference<float, 1>(reinterpret_cast<const float*>(values.data()), values.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1254,7 +1254,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib2f(GCGLuint index, GCGLfloat x, G
 void RemoteGraphicsContextGLProxy::vertexAttrib2fv(GCGLuint index, GCGLSpan<const GCGLfloat, 2> values)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2fv(index, IPC::ArrayReference<float, 2>(reinterpret_cast<const float*>(values.data), values.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2fv(index, IPC::ArrayReference<float, 2>(reinterpret_cast<const float*>(values.data()), values.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1272,7 +1272,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib3f(GCGLuint index, GCGLfloat x, G
 void RemoteGraphicsContextGLProxy::vertexAttrib3fv(GCGLuint index, GCGLSpan<const GCGLfloat, 3> values)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3fv(index, IPC::ArrayReference<float, 3>(reinterpret_cast<const float*>(values.data), values.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3fv(index, IPC::ArrayReference<float, 3>(reinterpret_cast<const float*>(values.data()), values.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1290,7 +1290,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib4f(GCGLuint index, GCGLfloat x, G
 void RemoteGraphicsContextGLProxy::vertexAttrib4fv(GCGLuint index, GCGLSpan<const GCGLfloat, 4> values)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4fv(index, IPC::ArrayReference<float, 4>(reinterpret_cast<const float*>(values.data), values.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4fv(index, IPC::ArrayReference<float, 4>(reinterpret_cast<const float*>(values.data()), values.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1326,7 +1326,7 @@ void RemoteGraphicsContextGLProxy::bufferData(GCGLenum target, GCGLsizeiptr arg1
 void RemoteGraphicsContextGLProxy::bufferData(GCGLenum target, GCGLSpan<const GCGLvoid> data, GCGLenum usage)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData1(target, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data), data.bufSize), usage));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData1(target, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()), usage));
         if (!sendResult)
             markContextLost();
     }
@@ -1335,7 +1335,7 @@ void RemoteGraphicsContextGLProxy::bufferData(GCGLenum target, GCGLSpan<const GC
 void RemoteGraphicsContextGLProxy::bufferSubData(GCGLenum target, GCGLintptr offset, GCGLSpan<const GCGLvoid> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferSubData(target, static_cast<uint64_t>(offset), IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferSubData(target, static_cast<uint64_t>(offset), IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1344,7 +1344,7 @@ void RemoteGraphicsContextGLProxy::bufferSubData(GCGLenum target, GCGLintptr off
 void RemoteGraphicsContextGLProxy::texImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, GCGLSpan<const GCGLvoid> pixels)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D0(target, level, internalformat, width, height, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data), pixels.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D0(target, level, internalformat, width, height, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1362,7 +1362,7 @@ void RemoteGraphicsContextGLProxy::texImage2D(GCGLenum target, GCGLint level, GC
 void RemoteGraphicsContextGLProxy::texSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, GCGLSpan<const GCGLvoid> pixels)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D0(target, level, xoffset, yoffset, width, height, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data), pixels.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D0(target, level, xoffset, yoffset, width, height, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1380,7 +1380,7 @@ void RemoteGraphicsContextGLProxy::texSubImage2D(GCGLenum target, GCGLint level,
 void RemoteGraphicsContextGLProxy::compressedTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLsizei imageSize, GCGLSpan<const GCGLvoid> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D0(target, level, internalformat, width, height, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D0(target, level, internalformat, width, height, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1398,7 +1398,7 @@ void RemoteGraphicsContextGLProxy::compressedTexImage2D(GCGLenum target, GCGLint
 void RemoteGraphicsContextGLProxy::compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLsizei imageSize, GCGLSpan<const GCGLvoid> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D0(target, level, xoffset, yoffset, width, height, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D0(target, level, xoffset, yoffset, width, height, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1493,11 +1493,11 @@ void RemoteGraphicsContextGLProxy::getBufferSubData(GCGLenum target, GCGLintptr 
 {
     IPC::ArrayReference<uint8_t> dataReply;
     if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBufferSubData(target, static_cast<uint64_t>(offset), data.bufSize), Messages::RemoteGraphicsContextGL::GetBufferSubData::Reply(dataReply));
+        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBufferSubData(target, static_cast<uint64_t>(offset), data.size()), Messages::RemoteGraphicsContextGL::GetBufferSubData::Reply(dataReply));
         if (!sendResult)
             markContextLost();
         else
-            memcpy(data.data, dataReply.data(), data.bufSize * sizeof(uint8_t));
+            memcpy(data.data(), dataReply.data(), data.size() * sizeof(uint8_t));
     }
 }
 
@@ -1522,7 +1522,7 @@ void RemoteGraphicsContextGLProxy::framebufferTextureLayer(GCGLenum target, GCGL
 void RemoteGraphicsContextGLProxy::invalidateFramebuffer(GCGLenum target, GCGLSpan<const GCGLenum> attachments)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data), attachments.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1531,7 +1531,7 @@ void RemoteGraphicsContextGLProxy::invalidateFramebuffer(GCGLenum target, GCGLSp
 void RemoteGraphicsContextGLProxy::invalidateSubFramebuffer(GCGLenum target, GCGLSpan<const GCGLenum> attachments, GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateSubFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data), attachments.bufSize), x, y, width, height));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateSubFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size()), x, y, width, height));
         if (!sendResult)
             markContextLost();
     }
@@ -1576,7 +1576,7 @@ void RemoteGraphicsContextGLProxy::texStorage3D(GCGLenum target, GCGLsizei level
 void RemoteGraphicsContextGLProxy::texImage3D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, GCGLSpan<const GCGLvoid> pixels)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D0(target, level, internalformat, width, height, depth, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data), pixels.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D0(target, level, internalformat, width, height, depth, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1594,7 +1594,7 @@ void RemoteGraphicsContextGLProxy::texImage3D(GCGLenum target, GCGLint level, GC
 void RemoteGraphicsContextGLProxy::texSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, GCGLSpan<const GCGLvoid> pixels)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data), pixels.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1621,7 +1621,7 @@ void RemoteGraphicsContextGLProxy::copyTexSubImage3D(GCGLenum target, GCGLint le
 void RemoteGraphicsContextGLProxy::compressedTexImage3D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLsizei imageSize, GCGLSpan<const GCGLvoid> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D0(target, level, internalformat, width, height, depth, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D0(target, level, internalformat, width, height, depth, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1639,7 +1639,7 @@ void RemoteGraphicsContextGLProxy::compressedTexImage3D(GCGLenum target, GCGLint
 void RemoteGraphicsContextGLProxy::compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLsizei imageSize, GCGLSpan<const GCGLvoid> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1704,7 +1704,7 @@ void RemoteGraphicsContextGLProxy::uniform4ui(GCGLint location, GCGLuint v0, GCG
 void RemoteGraphicsContextGLProxy::uniform1uiv(GCGLint location, GCGLSpan<const GCGLuint> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1713,7 +1713,7 @@ void RemoteGraphicsContextGLProxy::uniform1uiv(GCGLint location, GCGLSpan<const 
 void RemoteGraphicsContextGLProxy::uniform2uiv(GCGLint location, GCGLSpan<const GCGLuint> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1722,7 +1722,7 @@ void RemoteGraphicsContextGLProxy::uniform2uiv(GCGLint location, GCGLSpan<const 
 void RemoteGraphicsContextGLProxy::uniform3uiv(GCGLint location, GCGLSpan<const GCGLuint> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1731,7 +1731,7 @@ void RemoteGraphicsContextGLProxy::uniform3uiv(GCGLint location, GCGLSpan<const 
 void RemoteGraphicsContextGLProxy::uniform4uiv(GCGLint location, GCGLSpan<const GCGLuint> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1740,7 +1740,7 @@ void RemoteGraphicsContextGLProxy::uniform4uiv(GCGLint location, GCGLSpan<const 
 void RemoteGraphicsContextGLProxy::uniformMatrix2x3fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1749,7 +1749,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2x3fv(GCGLint location, GCGLbool
 void RemoteGraphicsContextGLProxy::uniformMatrix3x2fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1758,7 +1758,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3x2fv(GCGLint location, GCGLbool
 void RemoteGraphicsContextGLProxy::uniformMatrix2x4fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1767,7 +1767,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2x4fv(GCGLint location, GCGLbool
 void RemoteGraphicsContextGLProxy::uniformMatrix4x2fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1776,7 +1776,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix4x2fv(GCGLint location, GCGLbool
 void RemoteGraphicsContextGLProxy::uniformMatrix3x4fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1785,7 +1785,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3x4fv(GCGLint location, GCGLbool
 void RemoteGraphicsContextGLProxy::uniformMatrix4x3fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data), data.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1803,7 +1803,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4i(GCGLuint index, GCGLint x, GC
 void RemoteGraphicsContextGLProxy::vertexAttribI4iv(GCGLuint index, GCGLSpan<const GCGLint, 4> values)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4iv(index, IPC::ArrayReference<int32_t, 4>(reinterpret_cast<const int32_t*>(values.data), values.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4iv(index, IPC::ArrayReference<int32_t, 4>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1821,7 +1821,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4ui(GCGLuint index, GCGLuint x, 
 void RemoteGraphicsContextGLProxy::vertexAttribI4uiv(GCGLuint index, GCGLSpan<const GCGLuint, 4> values)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4uiv(index, IPC::ArrayReference<uint32_t, 4>(reinterpret_cast<const uint32_t*>(values.data), values.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4uiv(index, IPC::ArrayReference<uint32_t, 4>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1848,7 +1848,7 @@ void RemoteGraphicsContextGLProxy::drawRangeElements(GCGLenum mode, GCGLuint sta
 void RemoteGraphicsContextGLProxy::drawBuffers(GCGLSpan<const GCGLenum> bufs)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffers(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data), bufs.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffers(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1857,7 +1857,7 @@ void RemoteGraphicsContextGLProxy::drawBuffers(GCGLSpan<const GCGLenum> bufs)
 void RemoteGraphicsContextGLProxy::clearBufferiv(GCGLenum buffer, GCGLint drawbuffer, GCGLSpan<const GCGLint> values)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferiv(buffer, drawbuffer, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(values.data), values.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferiv(buffer, drawbuffer, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1866,7 +1866,7 @@ void RemoteGraphicsContextGLProxy::clearBufferiv(GCGLenum buffer, GCGLint drawbu
 void RemoteGraphicsContextGLProxy::clearBufferuiv(GCGLenum buffer, GCGLint drawbuffer, GCGLSpan<const GCGLuint> values)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferuiv(buffer, drawbuffer, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(values.data), values.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferuiv(buffer, drawbuffer, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -1875,7 +1875,7 @@ void RemoteGraphicsContextGLProxy::clearBufferuiv(GCGLenum buffer, GCGLint drawb
 void RemoteGraphicsContextGLProxy::clearBufferfv(GCGLenum buffer, GCGLint drawbuffer, GCGLSpan<const GCGLfloat> values)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfv(buffer, drawbuffer, IPC::ArrayReference<float>(reinterpret_cast<const float*>(values.data), values.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfv(buffer, drawbuffer, IPC::ArrayReference<float>(reinterpret_cast<const float*>(values.data()), values.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -2272,11 +2272,11 @@ void RemoteGraphicsContextGLProxy::getActiveUniformBlockiv(GCGLuint program, GCG
 {
     IPC::ArrayReference<int32_t> paramsReply;
     if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniformBlockiv(program, uniformBlockIndex, pname, params.bufSize), Messages::RemoteGraphicsContextGL::GetActiveUniformBlockiv::Reply(paramsReply));
+        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniformBlockiv(program, uniformBlockIndex, pname, params.size()), Messages::RemoteGraphicsContextGL::GetActiveUniformBlockiv::Reply(paramsReply));
         if (!sendResult)
             markContextLost();
         else
-            memcpy(params.data, paramsReply.data(), params.bufSize * sizeof(int32_t));
+            memcpy(params.data(), paramsReply.data(), params.size() * sizeof(int32_t));
     }
 }
 
@@ -2294,7 +2294,7 @@ String RemoteGraphicsContextGLProxy::getTranslatedShaderSourceANGLE(PlatformGLOb
 void RemoteGraphicsContextGLProxy::drawBuffersEXT(GCGLSpan<const GCGLenum> bufs)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffersEXT(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data), bufs.bufSize)));
+        auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffersEXT(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
         if (!sendResult)
             markContextLost();
     }
@@ -2385,11 +2385,11 @@ void RemoteGraphicsContextGLProxy::getInternalformativ(GCGLenum target, GCGLenum
 {
     IPC::ArrayReference<int32_t> paramsReply;
     if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInternalformativ(target, internalformat, pname, params.bufSize), Messages::RemoteGraphicsContextGL::GetInternalformativ::Reply(paramsReply));
+        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInternalformativ(target, internalformat, pname, params.size()), Messages::RemoteGraphicsContextGL::GetInternalformativ::Reply(paramsReply));
         if (!sendResult)
             markContextLost();
         else
-            memcpy(params.data, paramsReply.data(), params.bufSize * sizeof(int32_t));
+            memcpy(params.data(), paramsReply.data(), params.size() * sizeof(int32_t));
     }
 }
 

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -360,7 +360,7 @@ def cpp_array_reinterpret_cast_conversion(expr: cpp_expr, type: cpp_type_contain
 
 def webkit_ipc_span_transfer_type_reinterpret_cast_conversion(expr: cpp_expr, type: cpp_type_container) -> cpp_expr:
     element_pointer_type = type.get_contained_type().get_pointer_type()
-    return cpp_expr(type, f"{str(type)}(reinterpret_cast<const {element_pointer_type}>({str(expr)}.data), {str(expr)}.bufSize)")
+    return cpp_expr(type, f"{str(type)}(reinterpret_cast<const {element_pointer_type}>({str(expr)}.data()), {str(expr)}.size())")
 
 def cpp_move_expr(expr: cpp_expr) -> cpp_expr:
     return cpp_expr(expr.type.get_rvalue_type(), f"WTFMove({str(expr)})")
@@ -665,9 +665,9 @@ class webkit_ipc_cpp_proxy_impl(object):
                     ]
                 self.out_exprs += [cpp_expr(v.type, v.name)]
                 if o.type.is_dynamic_span():
-                    self.in_exprs += [cpp_expr(get_cpp_type("size_t"), f"{o.name}.bufSize")]
+                    self.in_exprs += [cpp_expr(get_cpp_type("size_t"), f"{o.name}.size()")]
                 self.post_call_stmts += [
-                    f"    memcpy({o.name}.data, {v.name}.data(), {o.name}.bufSize * sizeof({str(webkit_ipc_type.get_contained_type())}));"
+                    f"    memcpy({o.name}.data(), {v.name}.data(), {o.name}.size() * sizeof({str(webkit_ipc_type.get_contained_type())}));"
                 ]
             else:
                 self.out_exprs += [cpp_expr(o.type, o.name)]


### PR DESCRIPTION
#### dc198777974b4d9893369328efda40c4aa578454
<pre>
[WebGL] Reinstate const only access to GCGLSpan buffer size
<a href="https://bugs.webkit.org/show_bug.cgi?id=244752">https://bugs.webkit.org/show_bug.cgi?id=244752</a>
rdar://problem/99514068

Reviewed by Kimmo Kinnunen.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageArrayBufferViewHelper):
- data -&gt; data()
* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::GraphicsContextGL::extractTextureData):
- data -&gt; data()
* Source/WebCore/platform/graphics/GraphicsTypesGL.h:
(GCGLSpan::GCGLSpan):
- struct -&gt; class
- Make public members data &amp; bufSize private and prepend m_
- Add data() and size() accesssors
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
- data -&gt; data()
- bufSize -&gt; size()
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
Regenerated
* Tools/Scripts/generate-gpup-webgl:
Update code generator to access GCGLSpan members via accessors data() &amp; size().

Canonical link: <a href="https://commits.webkit.org/254207@main">https://commits.webkit.org/254207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02f500a0f6d73411c0914d59e04dc0d87e1f5a84

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97528 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152999 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92305 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31246 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26910 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80534 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92185 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24874 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75166 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24848 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67814 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28842 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28825 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14889 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2960 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37804 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34013 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->