### PR TITLE
Stop calling NSDisableScreenUpdates()/NSEnableScreenUpdates()

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -243,8 +243,6 @@ static RetainPtr<CGImageRef> createImageWithCopiedData(CGImageRef sourceImage)
     webViewContents = createImageWithCopiedData(webViewContents.get());
 
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // Screen updates to be re-enabled in _startEnterFullScreenAnimationWithDuration:
-    NSDisableScreenUpdates();
     [[self window] setAutodisplay:NO];
     ALLOW_DEPRECATED_DECLARATIONS_END
 
@@ -314,9 +312,6 @@ static RetainPtr<CGImageRef> createImageWithCopiedData(CGImageRef sourceImage)
     [[self window] setAutodisplay:YES];
     ALLOW_DEPRECATED_DECLARATIONS_END
     [[self window] displayIfNeeded];
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSEnableScreenUpdates();
-    ALLOW_DEPRECATED_DECLARATIONS_END
 
     [CATransaction commit];
 
@@ -333,10 +328,6 @@ static const float minVideoWidth = 468; // Keep in sync with `--controls-bar-wid
     if (completed) {
         _fullScreenState = InFullScreen;
 
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        // Screen updates to be re-enabled ta the end of the current block.
-        NSDisableScreenUpdates();
-        ALLOW_DEPRECATED_DECLARATIONS_END
         [self _manager]->didEnterFullScreen();
         [self _manager]->setAnimatingFullScreen(false);
 
@@ -391,10 +382,6 @@ static const float minVideoWidth = 468; // Keep in sync with `--controls-bar-wid
         _page->handleMouseEvent(webEvent);
     }
 
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSEnableScreenUpdates();
-    ALLOW_DEPRECATED_DECLARATIONS_END
-
     if (_requestedExitFullScreen) {
         _requestedExitFullScreen = NO;
         [self exitFullScreen];
@@ -424,8 +411,6 @@ static const float minVideoWidth = 468; // Keep in sync with `--controls-bar-wid
     [_webViewPlaceholder setExitWarningVisible:NO];
 
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // Screen updates to be re-enabled in _startExitFullScreenAnimationWithDuration: or beganExitFullScreenWithInitialFrame:finalFrame:
-    NSDisableScreenUpdates();
     [[self window] setAutodisplay:NO];
     ALLOW_DEPRECATED_DECLARATIONS_END
 
@@ -465,13 +450,6 @@ static const float minVideoWidth = 468; // Keep in sync with `--controls-bar-wid
         // If the full screen window is not in the active space, the NSWindow full screen animation delegate methods
         // will never be called. So call finishedExitFullScreenAnimationAndExitImmediately explicitly.
         [self finishedExitFullScreenAnimationAndExitImmediately:NO];
-
-        // Because we are breaking the normal animation pattern, re-enable screen updates
-        // as exitFullScreen has disabled them, but _startExitFullScreenAnimationWithDuration:
-        // will never be called.
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        NSEnableScreenUpdates();
-        ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     [[self window] exitFullScreenMode:self];
@@ -857,9 +835,6 @@ static CAAnimation *fadeAnimation(CFTimeInterval duration, AnimationDirection di
     [[self window] setAutodisplay:YES];
     ALLOW_DEPRECATED_DECLARATIONS_END
     [[self window] displayIfNeeded];
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSEnableScreenUpdates();
-    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 - (void)_watchdogTimerFired:(NSTimer *)timer

--- a/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
@@ -207,7 +207,6 @@ static NSRect convertRectToScreen(NSWindow *window, NSRect rect)
     
     // Screen updates to be re-enabled in beganEnterFullScreenWithInitialFrame:finalFrame:
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSDisableScreenUpdates();
     [[self window] setAutodisplay:NO];
     ALLOW_DEPRECATED_DECLARATIONS_END
 
@@ -266,10 +265,6 @@ static void setClipRectForWindow(NSWindow *window, NSRect clipRect)
     _isEnteringFullScreen = NO;
     
     if (completed) {
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        // Screen updates to be re-enabled at the end of this block
-        NSDisableScreenUpdates();
-        ALLOW_DEPRECATED_DECLARATIONS_END
         [self _manager]->setAnimatingFullscreen(false);
         [self _manager]->didEnterFullscreen();
         
@@ -291,9 +286,6 @@ static void setClipRectForWindow(NSWindow *window, NSRect clipRect)
         
         [_backgroundWindow.get() orderOut:self];
         [_backgroundWindow.get() setFrame:NSZeroRect display:YES];
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        NSEnableScreenUpdates();
-        ALLOW_DEPRECATED_DECLARATIONS_END
     } else
         [_scaleAnimation.get() stopAnimation];
 }
@@ -312,8 +304,6 @@ static void setClipRectForWindow(NSWindow *window, NSRect clipRect)
     _isFullScreen = NO;
 
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // Screen updates to be re-enabled in beganExitFullScreenWithInitialFrame:finalFrame:
-    NSDisableScreenUpdates();
     [[self window] setAutodisplay:NO];
     ALLOW_DEPRECATED_DECLARATIONS_END
 
@@ -355,11 +345,6 @@ static void setClipRectForWindow(NSWindow *window, NSRect clipRect)
     
     [self _updateMenuAndDockForFullScreen];
 
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // Screen updates to be re-enabled at the end of this function
-    NSDisableScreenUpdates();
-    ALLOW_DEPRECATED_DECLARATIONS_END
-
     [self _manager]->setAnimatingFullscreen(false);
     [self _manager]->didExitFullscreen();
     [_webView _scaleWebView:_savedScale atOrigin:NSMakePoint(0, 0)];
@@ -384,10 +369,6 @@ static void setClipRectForWindow(NSWindow *window, NSRect clipRect)
     [_backgroundWindow.get() setFrame:NSZeroRect display:YES];
 
     [[_webView window] makeKeyAndOrderFront:self];
-
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSEnableScreenUpdates();
-    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 - (void)performClose:(id)sender
@@ -544,10 +525,6 @@ static NSRect windowFrameFromApparentFrames(NSRect screenFrame, NSRect initialFr
     [[self window] setAutodisplay:YES];
     ALLOW_DEPRECATED_DECLARATIONS_END
     [[self window] displayIfNeeded];
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // Screen updates disabled in enterFullScreen:
-    NSEnableScreenUpdates();
-    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 - (void)_startExitFullScreenAnimationWithDuration:(NSTimeInterval)duration
@@ -595,11 +572,6 @@ static NSRect windowFrameFromApparentFrames(NSRect screenFrame, NSRect initialFr
     [[self window] setAutodisplay:YES];
     ALLOW_DEPRECATED_DECLARATIONS_END
     [[self window] displayIfNeeded];
-
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // Screen updates disabled in exitFullScreen:
-    NSEnableScreenUpdates();
-    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 @end


### PR DESCRIPTION
#### 0ddb0cb7d5bb36bdfc89e6078c18094ccd583c62
<pre>
Stop calling NSDisableScreenUpdates()/NSEnableScreenUpdates()
<a href="https://bugs.webkit.org/show_bug.cgi?id=244755">https://bugs.webkit.org/show_bug.cgi?id=244755</a>

Reviewed by Tim Horton.

NSDisableScreenUpdates()/NSEnableScreenUpdates() are no-ops for applications linked on Catalina or later.

We call these when showing/hiding the fullscreen window, which is UI that webkit controls, so it should be safe to remove
calls to these functions.

* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:]):
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
(-[WKFullScreenWindowController exitFullScreen]):
(-[WKFullScreenWindowController beganExitFullScreenWithInitialFrame:finalFrame:]):
(-[WKFullScreenWindowController _startExitFullScreenAnimationWithDuration:]):
* Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm:
(-[WebFullScreenController enterFullScreen:]):
(-[WebFullScreenController finishedEnterFullScreenAnimation:]):
(-[WebFullScreenController exitFullScreen]):
(-[WebFullScreenController finishedExitFullScreenAnimation:]):
(-[WebFullScreenController _startEnterFullScreenAnimationWithDuration:]):
(-[WebFullScreenController _startExitFullScreenAnimationWithDuration:]):

Canonical link: <a href="https://commits.webkit.org/254239@main">https://commits.webkit.org/254239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7bfda81fece3caedacaee9505c6b68579928c95

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97604 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153081 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31396 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27030 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80622 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92260 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24969 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75306 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24926 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67889 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29009 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14969 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2981 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32202 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37894 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34078 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->