### PR TITLE
Enable -autoDisplay in DumpRenderTree's window

### DIFF
--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -765,7 +765,6 @@ RetainPtr<WebView> createWebViewAndOffscreenWindow()
         [mainWindow orderFront:nil];
     else
         [mainWindow orderBack:nil];
-    [mainWindow setAutodisplay:NO];
 
     [(DumpRenderTreeWindow *)mainWindow.get() startListeningForAcceleratedCompositingChanges];
 #else
@@ -1752,9 +1751,6 @@ static void resetWebViewToConsistentState(const WTR::TestOptions& options, Reset
     [webView _clearMainFrameName];
     [[webView undoManager] removeAllActions];
     [WebView _removeAllUserContentFromGroup:[webView groupName]];
-#if !PLATFORM(IOS_FAMILY)
-    [[webView window] setAutodisplay:NO];
-#endif
     [webView setTracksRepaints:NO];
 
     [WebCache clearCachedCredentials];


### PR DESCRIPTION
#### c91e8567a6dd007fb8f318343cdf0679216a65c1
<pre>
Enable -autoDisplay in DumpRenderTree&apos;s window
<a href="https://bugs.webkit.org/show_bug.cgi?id=244756">https://bugs.webkit.org/show_bug.cgi?id=244756</a>

Reviewed by NOBODY (OOPS!).

DumpRenderTree&apos;s calls -setAutoDisplay:NO on its window, unless there are compositing
layers. Historically I think this was done to allow tests to control when painting
happens, and to improve performance, but it would be better if DRT behaved more like
WebKitTestRunner and had normal, rendering-update-drive repaint behavior.

-setAutoDisplay:NO even makes the window never appear on the screen (with
--show-webview) so it hinders debugging, and makes it harder to adapt DRT to allow
repaint testing via ref tests.

* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(createWebViewAndOffscreenWindow):
(resetWebViewToConsistentState):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c91e8567a6dd007fb8f318343cdf0679216a65c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97276 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152763 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92097 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30662 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26584 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80246 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91993 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24711 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74763 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24668 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79631 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67650 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28288 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13654 "Found 16 new test failures: fast/animation/request-animation-frame-throttle-subframe.html, fast/animation/request-animation-frame-throttling-outside-viewport.html, fast/dom/timer-throttling-subframe.html, fast/frames/lots-of-iframes.html, fast/frames/lots-of-objects.html, fast/repaint/no-animation-outside-viewport-subframe.html, fast/repaint/no-animation-outside-viewport.html, imported/w3c/web-platform-tests/content-security-policy/script-src/scripthash-changed-1.html, imported/w3c/web-platform-tests/content-security-policy/script-src/scripthash-changed-2.html, imported/w3c/web-platform-tests/content-security-policy/script-src/scriptnonce-changed-1.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28380 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14622 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37523 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33853 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->