### PR TITLE
[WGSL] Remove Global prefix from Decls

### DIFF
--- a/Source/WebGPU/WGSL/AST/Decl.h
+++ b/Source/WebGPU/WGSL/AST/Decl.h
@@ -30,24 +30,24 @@
 
 namespace WGSL::AST {
 
-class GlobalDecl : public ASTNode {
+class Decl : public ASTNode {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Kind {
-        GlobalVariable,
+        Variable,
         Struct,
         Function,
     };
 
-    GlobalDecl(SourceSpan span)
+    Decl(SourceSpan span)
         : ASTNode(span)
     {
     }
 
-    virtual ~GlobalDecl() {}
+    virtual ~Decl() { }
 
     virtual Kind kind() const = 0;
-    bool isGlobalVariable() const { return kind() == Kind::GlobalVariable; }
+    bool isVariable() const { return kind() == Kind::Variable; }
     bool isStruct() const { return kind() == Kind::Struct; }
     bool isFunction() const { return kind() == Kind::Function; }
 };
@@ -56,5 +56,5 @@ public:
 
 #define SPECIALIZE_TYPE_TRAITS_WGSL_GLOBAL_DECL(ToValueTypeName, predicate) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(WGSL::AST::ToValueTypeName) \
-    static bool isType(const WGSL::AST::GlobalDecl& decl) { return decl.predicate; } \
+    static bool isType(const WGSL::AST::Decl& decl) { return decl.predicate; } \
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebGPU/WGSL/AST/FunctionDecl.h
+++ b/Source/WebGPU/WGSL/AST/FunctionDecl.h
@@ -28,7 +28,7 @@
 #include "ASTNode.h"
 #include "Attribute.h"
 #include "CompilationMessage.h"
-#include "GlobalDecl.h"
+#include "Decl.h"
 #include "Statements/CompoundStatement.h"
 #include "TypeDecl.h"
 
@@ -55,11 +55,11 @@ private:
     Attributes m_attributes;
 };
 
-class FunctionDecl final : public GlobalDecl {
+class FunctionDecl final : public Decl {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     FunctionDecl(SourceSpan sourceSpan, StringView name, Vector<UniqueRef<Parameter>>&& parameters, std::unique_ptr<TypeDecl>&& returnType, CompoundStatement&& body, Attributes&& attributes, Attributes&& returnAttributes)
-        : GlobalDecl(sourceSpan)
+        : Decl(sourceSpan)
         , m_name(name)
         , m_parameters(WTFMove(parameters))
         , m_attributes(WTFMove(attributes))

--- a/Source/WebGPU/WGSL/AST/ShaderModule.h
+++ b/Source/WebGPU/WGSL/AST/ShaderModule.h
@@ -26,11 +26,11 @@
 #pragma once
 
 #include "ASTNode.h"
+#include "Decl.h"
 #include "FunctionDecl.h"
-#include "GlobalDecl.h"
 #include "GlobalDirective.h"
-#include "GlobalVariableDecl.h"
 #include "StructureDecl.h"
+#include "VariableDecl.h"
 #include <wtf/HashMap.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
@@ -40,7 +40,7 @@ namespace WGSL::AST {
 class ShaderModule final : ASTNode {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ShaderModule(SourceSpan span, Vector<UniqueRef<GlobalDirective>>&& directives, Vector<UniqueRef<GlobalDecl>>&& decls)
+    ShaderModule(SourceSpan span, Vector<UniqueRef<GlobalDirective>>&& directives, Vector<UniqueRef<Decl>>&& decls)
         : ASTNode(span)
         , m_directives(WTFMove(directives))
     {
@@ -48,15 +48,15 @@ public:
             if (is<StructDecl>(decl.get())) {
                 // We want to go from UniqueRef<BaseClass> to UniqueRef<DerivedClass>, but that is not supported by downcast.
                 // So instead we do UniqueRef -> unique_ptr -> raw_pointer -(downcast)-> raw_pointer -> unique_ptr -> UniqueRef...
-                GlobalDecl* rawPtr = decl.moveToUniquePtr().release();
+                Decl* rawPtr = decl.moveToUniquePtr().release();
                 StructDecl* downcastedRawPtr = downcast<StructDecl>(rawPtr);
                 m_structs.append(makeUniqueRefFromNonNullUniquePtr(std::unique_ptr<StructDecl>(downcastedRawPtr)));
-            } else if (is<GlobalVariableDecl>(decl.get())) {
-                GlobalDecl* rawPtr = decl.moveToUniquePtr().release();
-                GlobalVariableDecl* downcastedRawPtr = downcast<GlobalVariableDecl>(rawPtr);
-                m_globalVars.append(makeUniqueRefFromNonNullUniquePtr(std::unique_ptr<GlobalVariableDecl>(downcastedRawPtr)));
+            } else if (is<VariableDecl>(decl.get())) {
+                Decl* rawPtr = decl.moveToUniquePtr().release();
+                VariableDecl* downcastedRawPtr = downcast<VariableDecl>(rawPtr);
+                m_globalVars.append(makeUniqueRefFromNonNullUniquePtr(std::unique_ptr<VariableDecl>(downcastedRawPtr)));
             } else {
-                GlobalDecl* rawPtr = decl.moveToUniquePtr().release();
+                Decl* rawPtr = decl.moveToUniquePtr().release();
                 FunctionDecl* func = downcast<FunctionDecl>(rawPtr);
                 m_functions.append(makeUniqueRefFromNonNullUniquePtr(std::unique_ptr<FunctionDecl>(func)));
             }
@@ -65,14 +65,14 @@ public:
 
     Vector<UniqueRef<GlobalDirective>>& directives() { return m_directives; }
     Vector<UniqueRef<StructDecl>>& structs() { return m_structs; }
-    Vector<UniqueRef<GlobalVariableDecl>>& globalVars() { return m_globalVars; }
+    Vector<UniqueRef<VariableDecl>>& globalVars() { return m_globalVars; }
     Vector<UniqueRef<FunctionDecl>>& functions() { return m_functions; }
 
 private:
     Vector<UniqueRef<GlobalDirective>> m_directives;
 
     Vector<UniqueRef<StructDecl>> m_structs;
-    Vector<UniqueRef<GlobalVariableDecl>> m_globalVars;
+    Vector<UniqueRef<VariableDecl>> m_globalVars;
     Vector<UniqueRef<FunctionDecl>> m_functions;
 };
 

--- a/Source/WebGPU/WGSL/AST/StructureDecl.h
+++ b/Source/WebGPU/WGSL/AST/StructureDecl.h
@@ -28,7 +28,7 @@
 #include "ASTNode.h"
 #include "Attribute.h"
 #include "CompilationMessage.h"
-#include "GlobalDecl.h"
+#include "Decl.h"
 #include "TypeDecl.h"
 #include <wtf/text/StringView.h>
 #include <wtf/FastMalloc.h>
@@ -58,11 +58,11 @@ private:
     UniqueRef<TypeDecl> m_type;
 };
 
-class StructDecl final : public GlobalDecl {
+class StructDecl final : public Decl {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     StructDecl(SourceSpan sourceSpan, StringView name, Vector<UniqueRef<StructMember>>&& members, Attributes&& attributes)
-        : GlobalDecl(sourceSpan)
+        : Decl(sourceSpan)
         , m_name(name)
         , m_attributes(WTFMove(attributes))
         , m_members(WTFMove(members))

--- a/Source/WebGPU/WGSL/AST/VariableDecl.h
+++ b/Source/WebGPU/WGSL/AST/VariableDecl.h
@@ -27,19 +27,19 @@
 
 #include "Attribute.h"
 #include "CompilationMessage.h"
+#include "Decl.h"
 #include "Expression.h"
-#include "GlobalDecl.h"
 #include "TypeDecl.h"
 #include "VariableQualifier.h"
 #include <wtf/text/WTFString.h>
 
 namespace WGSL::AST {
 
-class GlobalVariableDecl final : public GlobalDecl {
+class VariableDecl final : public Decl {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    GlobalVariableDecl(SourceSpan span, StringView name, std::unique_ptr<VariableQualifier>&& qualifier, std::unique_ptr<TypeDecl>&& type, std::unique_ptr<Expression>&& initializer, Attributes&& attributes)
-        : GlobalDecl(span)
+    VariableDecl(SourceSpan span, StringView name, std::unique_ptr<VariableQualifier>&& qualifier, std::unique_ptr<TypeDecl>&& type, std::unique_ptr<Expression>&& initializer, Attributes&& attributes)
+        : Decl(span)
         , m_name(name)
         , m_attributes(WTFMove(attributes))
         , m_qualifier(WTFMove(qualifier))
@@ -49,7 +49,7 @@ public:
         ASSERT(m_type || m_initializer);
     }
 
-    Kind kind() const override { return Kind::GlobalVariable; }
+    Kind kind() const override { return Kind::Variable; }
     const StringView& name() const { return m_name; }
     Attributes& attributes() { return m_attributes; }
     VariableQualifier* maybeQualifier() { return m_qualifier.get(); }
@@ -68,4 +68,4 @@ private:
 
 } // namespace WGSL::AST
 
-SPECIALIZE_TYPE_TRAITS_WGSL_GLOBAL_DECL(GlobalVariableDecl, isGlobalVariable())
+SPECIALIZE_TYPE_TRAITS_WGSL_GLOBAL_DECL(VariableDecl, isVariable())

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -29,12 +29,12 @@
 #include "config.h"
 
 #include "AST/Attribute.h"
+#include "AST/Decl.h"
 #include "AST/Expression.h"
 #include "AST/Expressions/CallableExpression.h"
 #include "AST/Expressions/IdentifierExpression.h"
 #include "AST/Expressions/LiteralExpressions.h"
 #include "AST/Expressions/StructureAccess.h"
-#include "AST/GlobalDecl.h"
 #include "AST/Statement.h"
 #include "AST/Statements/AssignmentStatement.h"
 #include "AST/Statements/CompoundStatement.h"
@@ -153,7 +153,7 @@ Expected<AST::ShaderModule, Error> Parser<Lexer>::parseShader()
     Vector<UniqueRef<AST::GlobalDirective>> directives;
     // FIXME: parse directives here.
 
-    Vector<UniqueRef<AST::GlobalDecl>> decls;
+    Vector<UniqueRef<AST::Decl>> decls;
     while (!m_lexer.isAtEndOfFile()) {
         PARSE(globalDecl, GlobalDecl)
         decls.append(WTFMove(globalDecl));
@@ -163,7 +163,7 @@ Expected<AST::ShaderModule, Error> Parser<Lexer>::parseShader()
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::GlobalDecl>, Error> Parser<Lexer>::parseGlobalDecl()
+Expected<UniqueRef<AST::Decl>, Error> Parser<Lexer>::parseGlobalDecl()
 {
     START_PARSE();
 
@@ -175,9 +175,9 @@ Expected<UniqueRef<AST::GlobalDecl>, Error> Parser<Lexer>::parseGlobalDecl()
         return { makeUniqueRef<AST::StructDecl>(WTFMove(structDecl)) };
     }
     case TokenType::KeywordVar: {
-        PARSE(varDecl, GlobalVariableDecl, WTFMove(attributes));
+        PARSE(varDecl, VariableDecl, WTFMove(attributes));
         CONSUME_TYPE(Semicolon);
-        return { makeUniqueRef<AST::GlobalVariableDecl>(WTFMove(varDecl)) };
+        return { makeUniqueRef<AST::VariableDecl>(WTFMove(varDecl)) };
     }
     case TokenType::KeywordFn: {
         PARSE(fn, FunctionDecl, WTFMove(attributes));
@@ -327,7 +327,7 @@ Expected<UniqueRef<AST::TypeDecl>, Error> Parser<Lexer>::parseTypeDeclAfterIdent
 }
 
 template<typename Lexer>
-Expected<AST::GlobalVariableDecl, Error> Parser<Lexer>::parseGlobalVariableDecl(AST::Attributes&& attributes)
+Expected<AST::VariableDecl, Error> Parser<Lexer>::parseVariableDecl(AST::Attributes&& attributes)
 {
     START_PARSE();
 
@@ -351,7 +351,7 @@ Expected<AST::GlobalVariableDecl, Error> Parser<Lexer>::parseGlobalVariableDecl(
     std::unique_ptr<AST::Expression> maybeInitializer = nullptr;
     // FIXME: initializer
 
-    RETURN_NODE(GlobalVariableDecl, name.m_ident, WTFMove(maybeQualifier), WTFMove(maybeType), WTFMove(maybeInitializer), WTFMove(attributes));
+    RETURN_NODE(VariableDecl, name.m_ident, WTFMove(maybeQualifier), WTFMove(maybeType), WTFMove(maybeInitializer), WTFMove(attributes));
 }
 
 template<typename Lexer>

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -43,14 +43,14 @@ public:
     Expected<AST::ShaderModule, Error> parseShader();
 
     // UniqueRef whenever it can return multiple types.
-    Expected<UniqueRef<AST::GlobalDecl>, Error> parseGlobalDecl();
+    Expected<UniqueRef<AST::Decl>, Error> parseGlobalDecl();
     Expected<AST::Attributes, Error> parseAttributes();
     Expected<UniqueRef<AST::Attribute>, Error> parseAttribute();
     Expected<AST::StructDecl, Error> parseStructDecl(AST::Attributes&&);
     Expected<AST::StructMember, Error> parseStructMember();
     Expected<UniqueRef<AST::TypeDecl>, Error> parseTypeDecl();
     Expected<UniqueRef<AST::TypeDecl>, Error> parseTypeDeclAfterIdentifier(StringView&&, SourcePosition start);
-    Expected<AST::GlobalVariableDecl, Error> parseGlobalVariableDecl(AST::Attributes&&);
+    Expected<AST::VariableDecl, Error> parseVariableDecl(AST::Attributes&&);
     Expected<AST::VariableQualifier, Error> parseVariableQualifier();
     Expected<AST::StorageClass, Error> parseStorageClass();
     Expected<AST::AccessMode, Error> parseAccessMode();

--- a/Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm
+++ b/Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm
@@ -79,7 +79,7 @@
     XCTAssert(shader->structs().isEmpty());
     XCTAssert(shader->globalVars().size() == 1);
     XCTAssert(shader->functions().isEmpty());
-    WGSL::AST::GlobalVariableDecl& var = shader->globalVars()[0];
+    WGSL::AST::VariableDecl& var = shader->globalVars()[0];
     XCTAssert(var.attributes().size() == 2);
     XCTAssert(var.attributes()[0]->isGroup());
     XCTAssert(!downcast<WGSL::AST::GroupAttribute>(var.attributes()[0].get()).group());

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -60,8 +60,8 @@
 		339B7B1E27D816270072BF9A /* CompilationMessage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 33EA186727BC1B1400A1DD52 /* CompilationMessage.cpp */; };
 		33EA185E27BC194F00A1DD52 /* ASTNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA185D27BC194F00A1DD52 /* ASTNode.h */; };
 		33EA186027BC198100A1DD52 /* GlobalDirective.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA185F27BC198100A1DD52 /* GlobalDirective.h */; };
-		33EA186227BC19C100A1DD52 /* GlobalDecl.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA186127BC19C100A1DD52 /* GlobalDecl.h */; };
-		33EA186427BC1A1D00A1DD52 /* GlobalVariableDecl.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA186327BC1A1D00A1DD52 /* GlobalVariableDecl.h */; };
+		33EA186227BC19C100A1DD52 /* Decl.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA186127BC19C100A1DD52 /* Decl.h */; };
+		33EA186427BC1A1D00A1DD52 /* VariableDecl.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA186327BC1A1D00A1DD52 /* VariableDecl.h */; };
 		33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA186527BC1AD500A1DD52 /* CompilationMessage.h */; };
 		33EA186A27BC1BE600A1DD52 /* Attribute.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA186927BC1BE600A1DD52 /* Attribute.h */; };
 		33EA186C27BC1CBC00A1DD52 /* Expression.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA186B27BC1CBC00A1DD52 /* Expression.h */; };
@@ -313,8 +313,8 @@
 		339B7B1C27D80A1C0072BF9A /* WGSLParserTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WGSLParserTests.mm; sourceTree = "<group>"; };
 		33EA185D27BC194F00A1DD52 /* ASTNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ASTNode.h; path = WGSL/ASTNode.h; sourceTree = SOURCE_ROOT; };
 		33EA185F27BC198100A1DD52 /* GlobalDirective.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GlobalDirective.h; sourceTree = "<group>"; };
-		33EA186127BC19C100A1DD52 /* GlobalDecl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GlobalDecl.h; sourceTree = "<group>"; };
-		33EA186327BC1A1D00A1DD52 /* GlobalVariableDecl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GlobalVariableDecl.h; sourceTree = "<group>"; };
+		33EA186127BC19C100A1DD52 /* Decl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Decl.h; sourceTree = "<group>"; };
+		33EA186327BC1A1D00A1DD52 /* VariableDecl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VariableDecl.h; sourceTree = "<group>"; };
 		33EA186527BC1AD500A1DD52 /* CompilationMessage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompilationMessage.h; sourceTree = "<group>"; };
 		33EA186727BC1B1400A1DD52 /* CompilationMessage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CompilationMessage.cpp; sourceTree = "<group>"; };
 		33EA186927BC1BE600A1DD52 /* Attribute.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Attribute.h; sourceTree = "<group>"; };
@@ -695,15 +695,15 @@
 				33EA187727BC229A00A1DD52 /* Statements */,
 				33EA185D27BC194F00A1DD52 /* ASTNode.h */,
 				33EA186927BC1BE600A1DD52 /* Attribute.h */,
+				33EA186127BC19C100A1DD52 /* Decl.h */,
 				33EA186B27BC1CBC00A1DD52 /* Expression.h */,
 				33EA187527BC216B00A1DD52 /* FunctionDecl.h */,
-				33EA186127BC19C100A1DD52 /* GlobalDecl.h */,
 				33EA185F27BC198100A1DD52 /* GlobalDirective.h */,
-				33EA186327BC1A1D00A1DD52 /* GlobalVariableDecl.h */,
 				33EA186F27BC1E8A00A1DD52 /* ShaderModule.h */,
 				33EA187827BC22AA00A1DD52 /* Statement.h */,
 				33EA187327BC204900A1DD52 /* StructureDecl.h */,
 				33EA186D27BC1D4C00A1DD52 /* TypeDecl.h */,
+				33EA186327BC1A1D00A1DD52 /* VariableDecl.h */,
 				33EA187127BC1FE100A1DD52 /* VariableQualifier.h */,
 			);
 			path = AST;
@@ -765,11 +765,10 @@
 				33EA188627BC26DF00A1DD52 /* CallableExpression.h in Headers */,
 				33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */,
 				33EA187B27BC230E00A1DD52 /* CompoundStatement.h in Headers */,
+				33EA186227BC19C100A1DD52 /* Decl.h in Headers */,
 				33EA186C27BC1CBC00A1DD52 /* Expression.h in Headers */,
 				33EA187627BC216B00A1DD52 /* FunctionDecl.h in Headers */,
-				33EA186227BC19C100A1DD52 /* GlobalDecl.h in Headers */,
 				33EA186027BC198100A1DD52 /* GlobalDirective.h in Headers */,
-				33EA186427BC1A1D00A1DD52 /* GlobalVariableDecl.h in Headers */,
 				33EA188227BC25D000A1DD52 /* IdentifierExpression.h in Headers */,
 				338BB2D427B6B66C00E066AB /* Lexer.h in Headers */,
 				33EA188827BC361E00A1DD52 /* LiteralExpressions.h in Headers */,
@@ -783,6 +782,7 @@
 				33EA187427BC204900A1DD52 /* StructureDecl.h in Headers */,
 				338BB2CE27B6B60200E066AB /* Token.h in Headers */,
 				33EA186E27BC1D4C00A1DD52 /* TypeDecl.h in Headers */,
+				33EA186427BC1A1D00A1DD52 /* VariableDecl.h in Headers */,
 				33EA187227BC1FE100A1DD52 /* VariableQualifier.h in Headers */,
 				1CEBD7F82716B34400A5254D /* WGSL.h in Headers */,
 			);


### PR DESCRIPTION
#### ab2583628d5f4e1cc2bf1e1428e0b1da7f962f31
<pre>
[WGSL] Remove Global prefix from Decls
<a href="https://bugs.webkit.org/show_bug.cgi?id=244759">https://bugs.webkit.org/show_bug.cgi?id=244759</a>
rdar://problem/99521000

Reviewed by Myles C. Maxfield.

Code gardening in preparation for implementing local variable statements.

* Source/WebGPU/WGSL/AST/Decl.h: Renamed from Source/WebGPU/WGSL/AST/GlobalDecl.h.
* Source/WebGPU/WGSL/AST/FunctionDecl.h:
* Source/WebGPU/WGSL/AST/ShaderModule.h:
* Source/WebGPU/WGSL/AST/StructureDecl.h:
* Source/WebGPU/WGSL/AST/VariableDecl.h: Renamed from Source/WebGPU/WGSL/AST/GlobalVariableDecl.h.
* Source/WebGPU/WGSL/Parser.cpp:
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
Rename:
GlobalDecl -&gt; Decl
GlobalVariable -&gt; Variable

Canonical link: <a href="https://commits.webkit.org/254137@main">https://commits.webkit.org/254137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc219c2c147547704a731de2e329c7ba5cf9328c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97282 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30670 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26591 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91999 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24717 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74770 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24675 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79743 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28296 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28388 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14634 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2906 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37531 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33857 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->