### PR TITLE
[JSC] better compilation defaults for arm 32-bit

### DIFF
--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -440,6 +440,15 @@ static void overrideDefaults()
     Options::numberOfFTLCompilerThreads() = 3;
 #endif
 
+#if OS(LINUX) && CPU(ARM)
+    Options::maximumFunctionForCallInlineCandidateBytecodeCost() = 77;
+    Options::maximumOptimizationCandidateBytecodeCost() = 42403;
+    Options::maximumFunctionForClosureCallInlineCandidateBytecodeCost() = 68;
+    Options::maximumInliningCallerBytecodeCost() = 9912;
+    Options::maximumInliningDepth() = 8;
+    Options::maximumInliningRecursion() = 3;
+#endif
+
 #if USE(BMALLOC_MEMORY_FOOTPRINT_API)
     // On iOS and conditionally Linux, we control heap growth using process memory footprint. Therefore these values can be agressive.
     Options::smallHeapRAMFraction() = 0.8;


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=244253

The defaults for various compilation parameters are not optimal for arm
32-bit, especially considering that compilation happens in the main
thread on that platform, thus making big compilations more costly.

This change introduces new default for arm, found using
scikit-optimize's gp_minimize()[1] and running watch-cli.js from
JetStream2 with jsc compiled in 32-bit.

On an average of 5 runs, these parameters provide a score improvement of
1.60% on a raspberry pi 3, and 1.56% on a raspberry pi 4 with similar
conditions.

[1] https://scikit-optimize.github.io/stable/modules/generated/skopt.gp_minimize.html

* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::overrideDefaults): new defaults of various parameters for CPU(ARM)

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d737095618425a5d1c71bf8ee2722fe083f2eaa9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88140 "15 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/69/builds/33043 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/19497 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97370 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152824 "Hash d7370956 for PR 3991 does not build (failure)") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/64/builds/31543 "Build was cancelled. Recent messages:Failed to print configuration") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27402 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80496 "Failed to checkout and rebase branch from PR 3991") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92002 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93748 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/64/builds/31543 "Build was cancelled. Recent messages:Failed to print configuration") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75684 "Build is being retried. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Reverted pull request changes; Failed to compile WebKit; Unable to build WebKit without PR, retrying build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/80496 "Failed to checkout and rebase branch from PR 3991") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/64/builds/31543 "Build was cancelled. Recent messages:Failed to print configuration") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/19497 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/80496 "Failed to checkout and rebase branch from PR 3991") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79890 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/29629 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/19497 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73644 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29320 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Running unapply-patch; Reverted pull request changes; Failed to compile WebKit; Unable to build WebKit without PR, retrying build (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/19497 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26147 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32663 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Reverted pull request changes; Failed to compile WebKit; Unable to build WebKit without PR, retrying build (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/75684 "Build is being retried. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Reverted pull request changes; Failed to compile WebKit; Unable to build WebKit without PR, retrying build (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76487 "Built successfully") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31032 "Failed to checkout and rebase branch from PR 3991") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/19497 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16970 "Passed tests") | 
<!--EWS-Status-Bubble-End-->