### PR TITLE
Optimize SpaceSplitString creation in classAttributeChanged() & partAttributeChanged()

### DIFF
--- a/Source/WebCore/dom/SpaceSplitString.h
+++ b/Source/WebCore/dom/SpaceSplitString.h
@@ -101,7 +101,7 @@ public:
     SpaceSplitString() = default;
 
     enum class ShouldFoldCase : bool { No, Yes };
-    SpaceSplitString(const AtomString& string, ShouldFoldCase shouldFoldCase) { set(string, shouldFoldCase); }
+    SpaceSplitString(const AtomString&, ShouldFoldCase);
 
     bool operator!=(const SpaceSplitString& other) const { return m_data != other.m_data; }
 
@@ -124,5 +124,10 @@ public:
 private:
     RefPtr<SpaceSplitStringData> m_data;
 };
+
+inline SpaceSplitString::SpaceSplitString(const AtomString& string, ShouldFoldCase shouldFoldCase)
+    : m_data(!string.isEmpty() ? SpaceSplitStringData::create(shouldFoldCase == ShouldFoldCase::Yes ? string.convertToASCIILowercase() : string) : nullptr)
+{
+}
 
 } // namespace WebCore


### PR DESCRIPTION
#### 8f13bfc6fbc08932f5acb5e47f063c39dd79cee4
<pre>
Optimize SpaceSplitString creation in classAttributeChanged() &amp; partAttributeChanged()
<a href="https://bugs.webkit.org/show_bug.cgi?id=244765">https://bugs.webkit.org/show_bug.cgi?id=244765</a>

Reviewed by Ryosuke Niwa.

Optimize SpaceSplitString creation in classAttributeChanged() &amp; partAttributeChanged().
These functions were calling isNonEmptyTokenList() which would iterate the class
attribute string to check if it contains any token or not, in order to decide if it
should construct an empty SpaceSplitString or not.

However, the SpaceSplitString constructor already does the right thing when passed
in such a string. It actually has to count the number of tokens in the string in other
to allocate the right amount of memory for the SpaceSplitStringData.

Getting rid of the isNonEmptyTokenList() check thus doesn&apos;t change behavior but is a
0.41% progression on Speedometer 2.1 on Apple Silicon.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::classAttributeChanged):
(WebCore::Element::partAttributeChanged):
(WebCore::isNonEmptyTokenList): Deleted.
* Source/WebCore/dom/SpaceSplitString.h:
(WebCore::SpaceSplitString::SpaceSplitString):

Canonical link: <a href="https://commits.webkit.org/254139@main">https://commits.webkit.org/254139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b484213ee3d2f8cfefc5048c7db4eaab890624c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97320 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152806 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30717 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26628 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80282 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92019 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24733 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74813 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24689 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79763 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28356 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28447 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14669 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2908 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37565 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33876 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->