### PR TITLE
REGRESSION (253865@main): Fixed elements jiggle when scrolling youtube.com

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4206,7 +4206,7 @@ webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/transform
 webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/transform3d-translate3d-001.html [ ImageOnlyFailure ]
 webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/ttwf-css-3d-polygon-cycle.html [ ImageOnlyFailure ]
 webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/individual-transform/animation/individual-transform-ordering.html [ ImageOnlyFailure ]
-webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/preserve3d-and-flattening-001.html [ ImageOnlyFailure ]
+webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/preserve3d-and-flattening-001.html [ Pass ImageOnlyFailure ]
 webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/transform-fixed-bg-008.tentative.html [ ImageOnlyFailure ]
 
 # writing-modes: sideways-lr/sideways-rl support

--- a/LayoutTests/compositing/absolute-inside-out-of-view-fixed-expected.txt
+++ b/LayoutTests/compositing/absolute-inside-out-of-view-fixed-expected.txt
@@ -8,11 +8,9 @@
       (children 1
         (GraphicsLayer
           (position 0.00 200.00)
-          (bounds origin 0.00 200.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 200.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
               (drawsContent 1)

--- a/LayoutTests/compositing/backing/backing-store-columns-inside-position-fixed-expected.txt
+++ b/LayoutTests/compositing/backing/backing-store-columns-inside-position-fixed-expected.txt
@@ -10,12 +10,10 @@
       (children 1
         (GraphicsLayer
           (position 8.00 0.00)
-          (bounds origin 8.00 0.00)
           (preserves3D 1)
           (backingStoreAttached 0)
           (children 1
             (GraphicsLayer
-              (position 8.00 0.00)
               (bounds 600.00 600.00)
               (drawsContent 1)
               (backingStoreAttached 1)

--- a/LayoutTests/compositing/contents-opaque/hidden-with-visible-child-expected.txt
+++ b/LayoutTests/compositing/contents-opaque/hidden-with-visible-child-expected.txt
@@ -9,11 +9,9 @@ Inner
       (children 1
         (GraphicsLayer
           (position 8.00 13.00)
-          (bounds origin 8.00 13.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 8.00 13.00)
               (bounds 200.00 100.00)
               (drawsContent 1)
             )

--- a/LayoutTests/compositing/contents-opaque/hidden-with-visible-text-expected.txt
+++ b/LayoutTests/compositing/contents-opaque/hidden-with-visible-text-expected.txt
@@ -8,11 +8,9 @@
       (children 1
         (GraphicsLayer
           (position 8.00 13.00)
-          (bounds origin 8.00 13.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 8.00 13.00)
               (bounds 200.00 100.00)
               (contentsVisible 0)
             )

--- a/LayoutTests/compositing/fixed-positioned-pseudo-content-no-compositing-expected.txt
+++ b/LayoutTests/compositing/fixed-positioned-pseudo-content-no-compositing-expected.txt
@@ -17,11 +17,9 @@
         )
         (GraphicsLayer
           (position 0.00 100.00)
-          (bounds origin 0.00 100.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 100.00)
               (bounds 127.00 18.00)
               (drawsContent 1)
             )

--- a/LayoutTests/compositing/fixed-with-fixed-layout-expected.txt
+++ b/LayoutTests/compositing/fixed-with-fixed-layout-expected.txt
@@ -20,11 +20,9 @@ Top Left Right bottom
         )
         (GraphicsLayer
           (position 0.00 200.00)
-          (bounds origin 0.00 200.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 200.00)
               (bounds 100.00 100.00)
               (drawsContent 1)
             )
@@ -32,11 +30,9 @@ Top Left Right bottom
         )
         (GraphicsLayer
           (position 900.00 200.00)
-          (bounds origin 900.00 200.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 900.00 200.00)
               (bounds 100.00 100.00)
               (drawsContent 1)
             )
@@ -44,11 +40,9 @@ Top Left Right bottom
         )
         (GraphicsLayer
           (position 0.00 1900.00)
-          (bounds origin 0.00 1900.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 1900.00)
               (bounds 1000.00 100.00)
               (drawsContent 1)
             )

--- a/LayoutTests/compositing/geometry/fixed-position-flipped-writing-mode-expected.txt
+++ b/LayoutTests/compositing/geometry/fixed-position-flipped-writing-mode-expected.txt
@@ -10,11 +10,9 @@
       (children 2
         (GraphicsLayer
           (position 4308.00 0.00)
-          (bounds origin 4308.00 0.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 4308.00 0.00)
               (bounds 200.00 585.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/compositing/geometry/fixed-transformed-expected.txt
+++ b/LayoutTests/compositing/geometry/fixed-transformed-expected.txt
@@ -8,11 +8,9 @@
       (children 1
         (GraphicsLayer
           (position -100.00 100.00)
-          (bounds origin -100.00 100.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position -100.00 100.00)
               (bounds 220.00 120.00)
               (contentsOpaque 1)
               (drawsContent 1)

--- a/LayoutTests/compositing/geometry/limit-layer-bounds-fixed-expected.txt
+++ b/LayoutTests/compositing/geometry/limit-layer-bounds-fixed-expected.txt
@@ -13,12 +13,10 @@
         )
         (GraphicsLayer
           (position 0.00 3000.00)
-          (bounds origin 0.00 3000.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
               (offsetFromRenderer width=-100 height=-100)
-              (position 0.00 3000.00)
               (bounds 300.00 200.00)
             )
           )

--- a/LayoutTests/compositing/geometry/limit-layer-bounds-fixed-positioned-expected.txt
+++ b/LayoutTests/compositing/geometry/limit-layer-bounds-fixed-positioned-expected.txt
@@ -18,12 +18,10 @@ Text here
         )
         (GraphicsLayer
           (position 0.00 113.00)
-          (bounds origin 0.00 113.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
               (offsetFromRenderer width=-8 height=0)
-              (position 0.00 113.00)
               (bounds 150.00 142.00)
               (drawsContent 1)
             )

--- a/LayoutTests/compositing/iframes/overlapped-nested-iframes-expected.txt
+++ b/LayoutTests/compositing/iframes/overlapped-nested-iframes-expected.txt
@@ -159,11 +159,9 @@
         )
         (GraphicsLayer
           (position 0.00 100.00)
-          (bounds origin 0.00 100.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 100.00)
               (bounds 785.00 120.00)
             )
           )

--- a/LayoutTests/compositing/layer-creation/fixed-overlap-extent-expected.txt
+++ b/LayoutTests/compositing/layer-creation/fixed-overlap-extent-expected.txt
@@ -9,12 +9,10 @@ Fixed layer.
       (children 869
         (GraphicsLayer
           (position 46.00 106.00)
-          (bounds origin 46.00 106.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
               (offsetFromRenderer width=-14 height=-14)
-              (position 46.00 106.00)
               (bounds 228.00 178.00)
               (drawsContent 1)
             )

--- a/LayoutTests/compositing/layer-creation/fixed-overlap-extent-rtl-expected.txt
+++ b/LayoutTests/compositing/layer-creation/fixed-overlap-extent-rtl-expected.txt
@@ -11,12 +11,10 @@ Fixed layer.
       (children 869
         (GraphicsLayer
           (position 369.00 106.00)
-          (bounds origin 369.00 106.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
               (offsetFromRenderer width=-14 height=-14)
-              (position 369.00 106.00)
               (bounds 228.00 178.00)
               (drawsContent 1)
             )

--- a/LayoutTests/compositing/layer-creation/fixed-position-and-transform-expected.txt
+++ b/LayoutTests/compositing/layer-creation/fixed-position-and-transform-expected.txt
@@ -8,11 +8,9 @@
       (children 2
         (GraphicsLayer
           (position 100.00 1100.00)
-          (bounds origin 100.00 1100.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 100.00 1100.00)
               (bounds 256.00 256.00)
               (contentsOpaque 1)
             )
@@ -20,11 +18,9 @@
         )
         (GraphicsLayer
           (position 0.00 1000.00)
-          (bounds origin 0.00 1000.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 1000.00)
               (bounds 500.00 500.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/compositing/layer-creation/fixed-position-change-out-of-view-in-view-expected.txt
+++ b/LayoutTests/compositing/layer-creation/fixed-position-change-out-of-view-in-view-expected.txt
@@ -10,11 +10,9 @@ Layer tree when the fixed elements are in-view (both fixed elements should have 
       (children 2
         (GraphicsLayer
           (position 100.00 50.00)
-          (bounds origin 100.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 100.00 50.00)
               (bounds 10.00 10.00)
               (contentsOpaque 1)
             )
@@ -22,11 +20,9 @@ Layer tree when the fixed elements are in-view (both fixed elements should have 
         )
         (GraphicsLayer
           (position 100.00 100.00)
-          (bounds origin 100.00 100.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 100.00 100.00)
               (bounds 10.00 10.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/compositing/layer-creation/fixed-position-descendants-out-of-view-expected.txt
+++ b/LayoutTests/compositing/layer-creation/fixed-position-descendants-out-of-view-expected.txt
@@ -10,12 +10,10 @@
       (children 3
         (GraphicsLayer
           (position 8.00 13.00)
-          (bounds origin 8.00 13.00)
           (preserves3D 1)
           (backingStoreAttached 0)
           (children 1
             (GraphicsLayer
-              (position 8.00 13.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
               (backingStoreAttached 1)
@@ -31,12 +29,10 @@
         )
         (GraphicsLayer
           (position 8.00 120.00)
-          (bounds origin 8.00 120.00)
           (preserves3D 1)
           (backingStoreAttached 0)
           (children 1
             (GraphicsLayer
-              (position 8.00 120.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
               (backingStoreAttached 0)
@@ -53,12 +49,10 @@
         )
         (GraphicsLayer
           (position 8.00 240.00)
-          (bounds origin 8.00 240.00)
           (preserves3D 1)
           (backingStoreAttached 0)
           (children 1
             (GraphicsLayer
-              (position 8.00 240.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
               (backingStoreAttached 0)

--- a/LayoutTests/compositing/layer-creation/fixed-position-transformed-into-view-expected.txt
+++ b/LayoutTests/compositing/layer-creation/fixed-position-transformed-into-view-expected.txt
@@ -9,11 +9,9 @@ This should be visibleThis should be visible
       (children 2
         (GraphicsLayer
           (position -200.00 0.00)
-          (bounds origin -200.00 0.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position -200.00 0.00)
               (anchor 1.00 0.00)
               (bounds 200.00 50.00)
               (contentsOpaque 1)
@@ -24,11 +22,9 @@ This should be visibleThis should be visible
         )
         (GraphicsLayer
           (position -250.00 210.00)
-          (bounds origin -250.00 210.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position -250.00 210.00)
               (anchor 1.00 0.00)
               (bounds 200.00 200.00)
               (contentsOpaque 1)

--- a/LayoutTests/compositing/layer-creation/fixed-position-under-transform-expected.txt
+++ b/LayoutTests/compositing/layer-creation/fixed-position-under-transform-expected.txt
@@ -17,11 +17,9 @@
         )
         (GraphicsLayer
           (position 0.00 1000.00)
-          (bounds origin 0.00 1000.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 1000.00)
               (bounds 500.00 500.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/compositing/layer-creation/zoomed-clip-intersection-expected.txt
+++ b/LayoutTests/compositing/layer-creation/zoomed-clip-intersection-expected.txt
@@ -11,11 +11,9 @@ Image
       (children 2
         (GraphicsLayer
           (position 8.00 8.00)
-          (bounds origin 8.00 8.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 8.00 8.00)
               (bounds 1024.00 1042.00)
             )
           )

--- a/LayoutTests/compositing/transforms/3d-transformed-fixed-expected.html
+++ b/LayoutTests/compositing/transforms/3d-transformed-fixed-expected.html
@@ -5,8 +5,9 @@
         body {
             perspective: 500px;
             perspective-origin: 100px 150px;
+            height: 1000px;
         }
-        
+
         .box {
             position: absolute;
             left: 100px;
@@ -17,6 +18,11 @@
             background-color: blue;
         }
     </style>
+    <script>
+        window.addEventListener('load', () => {
+            window.scrollTo(0, 200);
+        }, false);
+    </script>
 </head>
 <body>
     <div class="fixed box" style="transform: rotateY(45deg)"></div>

--- a/LayoutTests/compositing/transforms/3d-transformed-fixed.html
+++ b/LayoutTests/compositing/transforms/3d-transformed-fixed.html
@@ -5,6 +5,7 @@
         body {
             perspective: 500px;
             perspective-origin: 100px 150px;
+            height: 1000px;
         }
 
         .box {
@@ -17,6 +18,11 @@
             background-color: blue;
         }
     </style>
+    <script>
+        window.addEventListener('load', () => {
+            window.scrollTo(0, 200);
+        }, false);
+    </script>
 </head>
 <body>
     <div class="box" style="transform: rotateY(45deg)"></div>

--- a/LayoutTests/editing/editable-region/fixed-and-absolute-contenteditable-scrolled-expected.txt
+++ b/LayoutTests/editing/editable-region/fixed-and-absolute-contenteditable-scrolled-expected.txt
@@ -13,11 +13,9 @@
       (children 2
         (GraphicsLayer
           (position 8.00 1037.00)
-          (bounds origin 8.00 1037.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 8.00 1037.00)
               (bounds 792.00 42.00)
               (drawsContent 1)
               (event region

--- a/LayoutTests/editing/editable-region/relative-inside-fixed-contenteditable-scrolled-expected.txt
+++ b/LayoutTests/editing/editable-region/relative-inside-fixed-contenteditable-scrolled-expected.txt
@@ -13,11 +13,9 @@
       (children 1
         (GraphicsLayer
           (position 8.00 1037.00)
-          (bounds origin 8.00 1037.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 8.00 1037.00)
               (bounds 792.00 143.00)
               (drawsContent 1)
               (event region

--- a/LayoutTests/editing/editable-region/transformed-scrolled-on-top-of-fixed-contenteditables-expected.txt
+++ b/LayoutTests/editing/editable-region/transformed-scrolled-on-top-of-fixed-contenteditables-expected.txt
@@ -13,11 +13,9 @@
       (children 2
         (GraphicsLayer
           (position 8.00 128.00)
-          (bounds origin 8.00 128.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 8.00 128.00)
               (bounds 792.00 42.00)
               (drawsContent 1)
               (event region

--- a/LayoutTests/fast/scrolling/mac/negative-z-index-overflow-scroll-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/negative-z-index-overflow-scroll-expected.txt
@@ -14,11 +14,9 @@
           (children 2
             (GraphicsLayer
               (position 8.00 10.00)
-              (bounds origin 8.00 10.00)
               (preserves3D 1)
               (children 1
                 (GraphicsLayer
-                  (position 8.00 10.00)
                   (bounds 792.00 402.00)
                   (drawsContent 1)
                   (event region

--- a/LayoutTests/fast/visual-viewport/tiled-drawing/zoomed-fixed-scrolled-down-expected.txt
+++ b/LayoutTests/fast/visual-viewport/tiled-drawing/zoomed-fixed-scrolled-down-expected.txt
@@ -53,44 +53,36 @@
       (children 4
         (GraphicsLayer
           (position 0.00 207.00)
-          (bounds origin 0.00 207.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 207.00)
               (bounds 785.00 101.00)
             )
           )
         )
         (GraphicsLayer
           (position 0.00 692.00)
-          (bounds origin 0.00 692.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 692.00)
               (bounds 785.00 101.00)
             )
           )
         )
         (GraphicsLayer
           (position 0.00 207.00)
-          (bounds origin 0.00 207.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 207.00)
               (bounds 100.00 586.00)
             )
           )
         )
         (GraphicsLayer
           (position 685.00 207.00)
-          (bounds origin 685.00 207.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 685.00 207.00)
               (bounds 100.00 586.00)
             )
           )

--- a/LayoutTests/fast/visual-viewport/tiled-drawing/zoomed-fixed-scrolled-down-then-up-expected.txt
+++ b/LayoutTests/fast/visual-viewport/tiled-drawing/zoomed-fixed-scrolled-down-then-up-expected.txt
@@ -53,11 +53,9 @@
       (children 4
         (GraphicsLayer
           (position 0.00 230.00)
-          (bounds origin 0.00 230.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 230.00)
               (bounds 785.00 100.00)
               (contentsOpaque 1)
             )
@@ -65,11 +63,9 @@
         )
         (GraphicsLayer
           (position 0.00 715.00)
-          (bounds origin 0.00 715.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 715.00)
               (bounds 785.00 100.00)
               (contentsOpaque 1)
             )
@@ -77,11 +73,9 @@
         )
         (GraphicsLayer
           (position 0.00 230.00)
-          (bounds origin 0.00 230.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 230.00)
               (bounds 100.00 585.00)
               (contentsOpaque 1)
             )
@@ -89,11 +83,9 @@
         )
         (GraphicsLayer
           (position 685.00 230.00)
-          (bounds origin 685.00 230.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 685.00 230.00)
               (bounds 100.00 585.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/fast/visual-viewport/tiled-drawing/zoomed-fixed-scrolling-layers-state-expected.txt
+++ b/LayoutTests/fast/visual-viewport/tiled-drawing/zoomed-fixed-scrolling-layers-state-expected.txt
@@ -57,11 +57,9 @@
         )
         (GraphicsLayer
           (position 0.00 485.00)
-          (bounds origin 0.00 485.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 485.00)
               (bounds 785.00 100.00)
               (contentsOpaque 1)
             )
@@ -78,11 +76,9 @@
         )
         (GraphicsLayer
           (position 685.00 0.00)
-          (bounds origin 685.00 0.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 685.00 0.00)
               (bounds 100.00 585.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/platform/ios-wk2/compositing/contents-opaque/body-background-painted-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/contents-opaque/body-background-painted-expected.txt
@@ -13,11 +13,9 @@
           (children 2
             (GraphicsLayer
               (position 8.00 8.00)
-              (bounds origin 8.00 8.00)
               (preserves3D 1)
               (children 1
                 (GraphicsLayer
-                  (position 8.00 8.00)
                   (bounds 200.00 200.00)
                   (contentsOpaque 1)
                 )

--- a/LayoutTests/platform/ios-wk2/compositing/contents-opaque/body-background-skipped-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/contents-opaque/body-background-skipped-expected.txt
@@ -13,11 +13,9 @@
           (children 2
             (GraphicsLayer
               (position 8.00 8.00)
-              (bounds origin 8.00 8.00)
               (preserves3D 1)
               (children 1
                 (GraphicsLayer
-                  (position 8.00 8.00)
                   (bounds 200.00 200.00)
                   (contentsOpaque 1)
                 )

--- a/LayoutTests/platform/ios-wk2/compositing/fixed-image-loading-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/fixed-image-loading-expected.txt
@@ -9,11 +9,9 @@
       (children 1
         (GraphicsLayer
           (position 8.00 13.00)
-          (bounds origin 8.00 13.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 8.00 13.00)
               (bounds 214.00 232.00)
               (drawsContent 1)
             )

--- a/LayoutTests/platform/ios-wk2/compositing/geometry/fixed-position-composited-switch-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/geometry/fixed-position-composited-switch-expected.txt
@@ -9,11 +9,9 @@ Before (should be empty):
       (children 1
         (GraphicsLayer
           (position 495.00 30.00)
-          (bounds origin 495.00 30.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 495.00 30.00)
               (bounds 300.00 100.00)
               (contentsOpaque 1)
             )
@@ -35,11 +33,9 @@ After (should not be empty):
       (children 1
         (GraphicsLayer
           (position 495.00 30.00)
-          (bounds origin 495.00 30.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 495.00 30.00)
               (bounds 300.00 100.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/platform/ios-wk2/compositing/geometry/limit-layer-bounds-fixed-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/geometry/limit-layer-bounds-fixed-expected.txt
@@ -13,12 +13,10 @@
         )
         (GraphicsLayer
           (position 0.00 3000.00)
-          (bounds origin 0.00 3000.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
               (offsetFromRenderer width=-100 height=-100)
-              (position 0.00 3000.00)
               (bounds 300.00 200.00)
             )
           )

--- a/LayoutTests/platform/ios-wk2/compositing/geometry/limit-layer-bounds-fixed-positioned-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/geometry/limit-layer-bounds-fixed-positioned-expected.txt
@@ -18,12 +18,10 @@ Text here
         )
         (GraphicsLayer
           (position 0.00 113.00)
-          (bounds origin 0.00 113.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
               (offsetFromRenderer width=-8 height=0)
-              (position 0.00 113.00)
               (bounds 150.00 142.00)
               (drawsContent 1)
             )

--- a/LayoutTests/platform/ios-wk2/compositing/layer-creation/fixed-position-transformed-into-view-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/layer-creation/fixed-position-transformed-into-view-expected.txt
@@ -9,11 +9,9 @@ This should be visibleThis should be visible
       (children 2
         (GraphicsLayer
           (position -200.00 0.00)
-          (bounds origin -200.00 0.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position -200.00 0.00)
               (anchor 1.00 0.00)
               (bounds 200.00 50.00)
               (contentsOpaque 1)
@@ -24,11 +22,9 @@ This should be visibleThis should be visible
         )
         (GraphicsLayer
           (position -250.00 210.00)
-          (bounds origin -250.00 210.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position -250.00 210.00)
               (anchor 1.00 0.00)
               (bounds 200.00 200.00)
               (contentsOpaque 1)

--- a/LayoutTests/platform/ios-wk2/compositing/layer-creation/fixed-position-under-transform-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/layer-creation/fixed-position-under-transform-expected.txt
@@ -17,11 +17,9 @@
         )
         (GraphicsLayer
           (position 0.00 1000.00)
-          (bounds origin 0.00 1000.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 1000.00)
               (bounds 500.00 500.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/platform/ios-wk2/compositing/layer-creation/no-compositing-for-sticky-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/layer-creation/no-compositing-for-sticky-expected.txt
@@ -11,11 +11,9 @@ Left sticky Right sticky Left % sticky Right % sticky Left and Right Left and Ri
       (children 6
         (GraphicsLayer
           (position 820.00 61.00)
-          (bounds origin 820.00 61.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 820.00 61.00)
               (bounds 300.00 60.00)
               (contentsOpaque 1)
               (drawsContent 1)
@@ -24,11 +22,9 @@ Left sticky Right sticky Left % sticky Right % sticky Left and Right Left and Ri
         )
         (GraphicsLayer
           (position 812.00 129.00)
-          (bounds origin 812.00 129.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 812.00 129.00)
               (bounds 300.00 60.00)
               (contentsOpaque 1)
               (drawsContent 1)
@@ -37,11 +33,9 @@ Left sticky Right sticky Left % sticky Right % sticky Left and Right Left and Ri
         )
         (GraphicsLayer
           (position 960.00 197.00)
-          (bounds origin 960.00 197.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 960.00 197.00)
               (bounds 300.00 60.00)
               (contentsOpaque 1)
               (drawsContent 1)
@@ -50,11 +44,9 @@ Left sticky Right sticky Left % sticky Right % sticky Left and Right Left and Ri
         )
         (GraphicsLayer
           (position 812.00 265.00)
-          (bounds origin 812.00 265.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 812.00 265.00)
               (bounds 300.00 60.00)
               (contentsOpaque 1)
               (drawsContent 1)
@@ -63,11 +55,9 @@ Left sticky Right sticky Left % sticky Right % sticky Left and Right Left and Ri
         )
         (GraphicsLayer
           (position 820.00 333.00)
-          (bounds origin 820.00 333.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 820.00 333.00)
               (bounds 300.00 60.00)
               (contentsOpaque 1)
               (drawsContent 1)
@@ -76,11 +66,9 @@ Left sticky Right sticky Left % sticky Right % sticky Left and Right Left and Ri
         )
         (GraphicsLayer
           (position 960.00 401.00)
-          (bounds origin 960.00 401.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 960.00 401.00)
               (bounds 300.00 60.00)
               (contentsOpaque 1)
               (drawsContent 1)

--- a/LayoutTests/platform/ios-wk2/compositing/rtl/rtl-fixed-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/rtl/rtl-fixed-expected.txt
@@ -9,11 +9,9 @@
       (children 2
         (GraphicsLayer
           (position 50.00 50.00)
-          (bounds origin 50.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 50.00 50.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
             )
@@ -21,11 +19,9 @@
         )
         (GraphicsLayer
           (position 50.00 50.00)
-          (bounds origin 50.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 50.00 50.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/platform/ios-wk2/compositing/rtl/rtl-fixed-overflow-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/rtl/rtl-fixed-overflow-expected.txt
@@ -11,11 +11,9 @@
       (children 2
         (GraphicsLayer
           (position 250.00 50.00)
-          (bounds origin 250.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 250.00 50.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
             )
@@ -23,11 +21,9 @@
         )
         (GraphicsLayer
           (position 250.00 50.00)
-          (bounds origin 250.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 250.00 50.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/platform/ios-wk2/compositing/rtl/rtl-iframe-fixed-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/rtl/rtl-iframe-fixed-expected.txt
@@ -29,11 +29,9 @@
                               (children 2
                                 (GraphicsLayer
                                   (position 50.00 50.00)
-                                  (bounds origin 50.00 50.00)
                                   (preserves3D 1)
                                   (children 1
                                     (GraphicsLayer
-                                      (position 50.00 50.00)
                                       (bounds 100.00 100.00)
                                       (contentsOpaque 1)
                                     )
@@ -41,11 +39,9 @@
                                 )
                                 (GraphicsLayer
                                   (position 50.00 50.00)
-                                  (bounds origin 50.00 50.00)
                                   (preserves3D 1)
                                   (children 1
                                     (GraphicsLayer
-                                      (position 50.00 50.00)
                                       (bounds 100.00 100.00)
                                       (contentsOpaque 1)
                                     )

--- a/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/fixed-inside-frame-expected.txt
+++ b/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/fixed-inside-frame-expected.txt
@@ -76,11 +76,9 @@
                               (children 1
                                 (GraphicsLayer
                                   (position 10.00 130.00)
-                                  (bounds origin 10.00 130.00)
                                   (preserves3D 1)
                                   (children 1
                                     (GraphicsLayer
-                                      (position 10.00 130.00)
                                       (bounds 470.00 100.00)
                                       (contentsOpaque 1)
                                       (drawsContent 1)

--- a/LayoutTests/platform/ios/compositing/absolute-inside-out-of-view-fixed-expected.txt
+++ b/LayoutTests/platform/ios/compositing/absolute-inside-out-of-view-fixed-expected.txt
@@ -8,11 +8,9 @@
       (children 1
         (GraphicsLayer
           (position 0.00 200.00)
-          (bounds origin 0.00 200.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 200.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
               (drawsContent 1)

--- a/LayoutTests/platform/ios/compositing/geometry/fixed-position-flipped-writing-mode-expected.txt
+++ b/LayoutTests/platform/ios/compositing/geometry/fixed-position-flipped-writing-mode-expected.txt
@@ -10,11 +10,9 @@
       (children 2
         (GraphicsLayer
           (position 4308.00 0.00)
-          (bounds origin 4308.00 0.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 4308.00 0.00)
               (bounds 200.00 600.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/platform/ios/compositing/iframes/overlapped-nested-iframes-expected.txt
+++ b/LayoutTests/platform/ios/compositing/iframes/overlapped-nested-iframes-expected.txt
@@ -159,11 +159,9 @@
         )
         (GraphicsLayer
           (position 0.00 100.00)
-          (bounds origin 0.00 100.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 100.00)
               (bounds 800.00 120.00)
             )
           )

--- a/LayoutTests/platform/ios/compositing/layer-creation/fixed-position-and-transform-expected.txt
+++ b/LayoutTests/platform/ios/compositing/layer-creation/fixed-position-and-transform-expected.txt
@@ -8,11 +8,9 @@
       (children 2
         (GraphicsLayer
           (position 100.00 1100.00)
-          (bounds origin 100.00 1100.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 100.00 1100.00)
               (bounds 256.00 256.00)
               (contentsOpaque 1)
             )
@@ -20,11 +18,9 @@
         )
         (GraphicsLayer
           (position 0.00 1000.00)
-          (bounds origin 0.00 1000.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 0.00 1000.00)
               (bounds 500.00 500.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/platform/ios/compositing/rtl/rtl-fixed-overflow-scrolled-expected.txt
+++ b/LayoutTests/platform/ios/compositing/rtl/rtl-fixed-overflow-scrolled-expected.txt
@@ -11,11 +11,9 @@
       (children 2
         (GraphicsLayer
           (position 51.00 50.00)
-          (bounds origin 51.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 51.00 50.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
             )
@@ -23,11 +21,9 @@
         )
         (GraphicsLayer
           (position 51.00 50.00)
-          (bounds origin 51.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 51.00 50.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/platform/ios/scrollingcoordinator/ios/fixed-in-frame-layer-reconcile-layer-position-expected.txt
+++ b/LayoutTests/platform/ios/scrollingcoordinator/ios/fixed-in-frame-layer-reconcile-layer-position-expected.txt
@@ -31,11 +31,9 @@
                               (children 1
                                 (GraphicsLayer
                                   (position 8.00 10.00)
-                                  (bounds origin 8.00 10.00)
                                   (preserves3D 1)
                                   (children 1
                                     (GraphicsLayer
-                                      (position 8.00 10.00)
                                       (bounds 200.00 140.00)
                                       (contentsOpaque 1)
                                     )

--- a/LayoutTests/platform/mac-wk2/compositing/contents-opaque/body-background-painted-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/contents-opaque/body-background-painted-expected.txt
@@ -13,11 +13,9 @@
           (children 2
             (GraphicsLayer
               (position 8.00 8.00)
-              (bounds origin 8.00 8.00)
               (preserves3D 1)
               (children 1
                 (GraphicsLayer
-                  (position 8.00 8.00)
                   (bounds 200.00 200.00)
                   (contentsOpaque 1)
                 )

--- a/LayoutTests/platform/mac-wk2/compositing/contents-opaque/body-background-skipped-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/contents-opaque/body-background-skipped-expected.txt
@@ -13,11 +13,9 @@
           (children 2
             (GraphicsLayer
               (position 8.00 8.00)
-              (bounds origin 8.00 8.00)
               (preserves3D 1)
               (children 1
                 (GraphicsLayer
-                  (position 8.00 8.00)
                   (bounds 200.00 200.00)
                   (contentsOpaque 1)
                 )

--- a/LayoutTests/platform/mac-wk2/compositing/fixed-image-loading-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/fixed-image-loading-expected.txt
@@ -9,11 +9,9 @@
       (children 1
         (GraphicsLayer
           (position 8.00 13.00)
-          (bounds origin 8.00 13.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 8.00 13.00)
               (bounds 214.00 232.00)
             )
           )

--- a/LayoutTests/platform/mac-wk2/compositing/rtl/rtl-fixed-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/rtl/rtl-fixed-expected.txt
@@ -9,11 +9,9 @@
       (children 2
         (GraphicsLayer
           (position 50.00 50.00)
-          (bounds origin 50.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 50.00 50.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
             )
@@ -21,11 +19,9 @@
         )
         (GraphicsLayer
           (position 50.00 50.00)
-          (bounds origin 50.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 50.00 50.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/platform/mac-wk2/compositing/rtl/rtl-fixed-overflow-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/rtl/rtl-fixed-overflow-expected.txt
@@ -11,11 +11,9 @@
       (children 2
         (GraphicsLayer
           (position 265.00 50.00)
-          (bounds origin 265.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 265.00 50.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
             )
@@ -23,11 +21,9 @@
         )
         (GraphicsLayer
           (position 265.00 50.00)
-          (bounds origin 265.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 265.00 50.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/platform/mac/compositing/geometry/fixed-position-composited-switch-expected.txt
+++ b/LayoutTests/platform/mac/compositing/geometry/fixed-position-composited-switch-expected.txt
@@ -9,11 +9,9 @@ Before (should be empty):
       (children 1
         (GraphicsLayer
           (position 495.00 30.00)
-          (bounds origin 495.00 30.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 495.00 30.00)
               (bounds 300.00 100.00)
               (contentsOpaque 1)
             )
@@ -35,11 +33,9 @@ After (should not be empty):
       (children 1
         (GraphicsLayer
           (position 495.00 30.00)
-          (bounds origin 495.00 30.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 495.00 30.00)
               (bounds 300.00 100.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/platform/mac/compositing/rtl/rtl-fixed-overflow-scrolled-expected.txt
+++ b/LayoutTests/platform/mac/compositing/rtl/rtl-fixed-overflow-scrolled-expected.txt
@@ -11,11 +11,9 @@
       (children 2
         (GraphicsLayer
           (position 51.00 50.00)
-          (bounds origin 51.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 51.00 50.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
             )
@@ -23,11 +21,9 @@
         )
         (GraphicsLayer
           (position 51.00 50.00)
-          (bounds origin 51.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 51.00 50.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
             )

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-frame-expected.txt
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-frame-expected.txt
@@ -79,11 +79,9 @@
                               (children 1
                                 (GraphicsLayer
                                   (position 10.00 130.00)
-                                  (bounds origin 10.00 130.00)
                                   (preserves3D 1)
                                   (children 1
                                     (GraphicsLayer
-                                      (position 10.00 130.00)
                                       (bounds 455.00 100.00)
                                       (contentsOpaque 1)
                                       (drawsContent 1)

--- a/LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-fixed-child-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-fixed-child-expected.txt
@@ -14,11 +14,9 @@
       (children 1
         (GraphicsLayer
           (position 50.00 50.00)
-          (bounds origin 50.00 50.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 50.00 50.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
               (event region

--- a/LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-inside-fixed-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-inside-fixed-expected.txt
@@ -14,11 +14,9 @@
       (children 1
         (GraphicsLayer
           (position 10.00 10.00)
-          (bounds origin 10.00 10.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 10.00 10.00)
               (bounds 150.00 150.00)
               (drawsContent 1)
               (event region

--- a/LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-on-fixed-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-on-fixed-expected.txt
@@ -14,11 +14,9 @@
       (children 1
         (GraphicsLayer
           (position 10.00 10.00)
-          (bounds origin 10.00 10.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 10.00 10.00)
               (bounds 100.00 100.00)
               (contentsOpaque 1)
               (event region

--- a/LayoutTests/tiled-drawing/scrolling/sticky/sticky-layers-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/sticky/sticky-layers-expected.txt
@@ -9,11 +9,9 @@ Left sticky Right sticky Left % sticky Right % sticky Left and Right Left and Ri
       (children 6
         (GraphicsLayer
           (position 820.00 25.00)
-          (bounds origin 820.00 25.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 820.00 25.00)
               (bounds 300.00 60.00)
               (contentsOpaque 1)
               (drawsContent 1)
@@ -22,11 +20,9 @@ Left sticky Right sticky Left % sticky Right % sticky Left and Right Left and Ri
         )
         (GraphicsLayer
           (position 812.00 93.00)
-          (bounds origin 812.00 93.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 812.00 93.00)
               (bounds 300.00 60.00)
               (contentsOpaque 1)
               (drawsContent 1)
@@ -35,11 +31,9 @@ Left sticky Right sticky Left % sticky Right % sticky Left and Right Left and Ri
         )
         (GraphicsLayer
           (position 960.00 161.00)
-          (bounds origin 960.00 161.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 960.00 161.00)
               (bounds 300.00 60.00)
               (contentsOpaque 1)
               (drawsContent 1)
@@ -48,11 +42,9 @@ Left sticky Right sticky Left % sticky Right % sticky Left and Right Left and Ri
         )
         (GraphicsLayer
           (position 812.00 229.00)
-          (bounds origin 812.00 229.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 812.00 229.00)
               (bounds 300.00 60.00)
               (contentsOpaque 1)
               (drawsContent 1)
@@ -61,11 +53,9 @@ Left sticky Right sticky Left % sticky Right % sticky Left and Right Left and Ri
         )
         (GraphicsLayer
           (position 820.00 297.00)
-          (bounds origin 820.00 297.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 820.00 297.00)
               (bounds 300.00 60.00)
               (contentsOpaque 1)
               (drawsContent 1)
@@ -74,11 +64,9 @@ Left sticky Right sticky Left % sticky Right % sticky Left and Right Left and Ri
         )
         (GraphicsLayer
           (position 960.00 365.00)
-          (bounds origin 960.00 365.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
-              (position 960.00 365.00)
               (bounds 300.00 60.00)
               (contentsOpaque 1)
               (drawsContent 1)

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1355,8 +1355,7 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
 
     if (m_viewportAnchorLayer) {
         m_viewportAnchorLayer->setPosition(primaryLayerPosition);
-        // Setting boundsOrigin on this layer allows us to keep the position on m_graphicsLayer, which is necessary to preserve the propagation of the correct perspective transform to fixed layers.
-        m_viewportAnchorLayer->setBoundsOrigin(primaryLayerPosition);
+        primaryLayerPosition = { };
     }
 
     if (m_contentsContainmentLayer) {


### PR DESCRIPTION
#### 99677e63f83398f621acad2e766fedf40d3e5fc9
<pre>
REGRESSION (253865@main): Fixed elements jiggle when scrolling youtube.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=244767">https://bugs.webkit.org/show_bug.cgi?id=244767</a>
&lt;rdar://99495036&gt;

Reviewed by Alan Bujtas.

Part of the fix in 253865@main was based on the false premise that `perspective` on some
ancestor could affect the 3D transform on a layer with `position:fixed` behavior; that
patch fiddled with boundsOrigin on the anchor layer to allow the perspective
sublayerTransform to influence the fixed layer.

However, per spec[1], `perspective` creates a containing block for fixed position, and
indeed this was fixed in the compositing code path in 253809@main (the lack of this fix
confused my testing when writing the original patch). So it turns out that the anchor
layer used for fixed and sticky layers doesn&apos;t need any boundsOrigin adjustment.
Removing the boundsOrigin adjustment fixes some scrolling thread jiggles that I didn&apos;t
fully debug. The anchor layer still uses `GraphicsLayer::Type::Structural` to allow
perspective to affect a `position:sticky` element and to avoid flattening by
`preserve-3d`, as tested by the
`css/css-transforms/3dtransform-and-position-sticky-002.html` WPT.

[1] <a href="https://www.w3.org/TR/css-transforms-2/#perspective-property">https://www.w3.org/TR/css-transforms-2/#perspective-property</a>

* LayoutTests/compositing/absolute-inside-out-of-view-fixed-expected.txt:
* LayoutTests/compositing/absolute-inside-out-of-view-fixed-expected.txt:
* LayoutTests/compositing/backing/backing-store-columns-inside-position-fixed-expected.txt:
* LayoutTests/compositing/backing/backing-store-columns-inside-position-fixed-expected.txt:
* LayoutTests/compositing/backing/no-backing-for-offscreen-children-of-position-fixed-expected.txt:
* LayoutTests/compositing/backing/no-backing-for-offscreen-children-of-position-fixed-expected.txt:
* LayoutTests/compositing/contents-opaque/hidden-with-visible-child-expected.txt:
* LayoutTests/compositing/contents-opaque/hidden-with-visible-child-expected.txt:
* LayoutTests/compositing/contents-opaque/hidden-with-visible-text-expected.txt:
* LayoutTests/compositing/contents-opaque/hidden-with-visible-text-expected.txt:
* LayoutTests/compositing/fixed-positioned-pseudo-content-no-compositing-expected.txt:
* LayoutTests/compositing/fixed-positioned-pseudo-content-no-compositing-expected.txt:
* LayoutTests/compositing/fixed-with-fixed-layout-expected.txt:
* LayoutTests/compositing/fixed-with-fixed-layout-expected.txt:
* LayoutTests/compositing/geometry/fixed-position-flipped-writing-mode-expected.txt:
* LayoutTests/compositing/geometry/fixed-position-flipped-writing-mode-expected.txt:
* LayoutTests/compositing/geometry/fixed-transformed-expected.txt:
* LayoutTests/compositing/geometry/fixed-transformed-expected.txt:
* LayoutTests/compositing/geometry/limit-layer-bounds-fixed-expected.txt:
* LayoutTests/compositing/geometry/limit-layer-bounds-fixed-expected.txt:
* LayoutTests/compositing/geometry/limit-layer-bounds-fixed-positioned-expected.txt:
* LayoutTests/compositing/geometry/limit-layer-bounds-fixed-positioned-expected.txt:
* LayoutTests/compositing/iframes/overlapped-nested-iframes-expected.txt:
* LayoutTests/compositing/iframes/overlapped-nested-iframes-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-overlap-extent-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-overlap-extent-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-overlap-extent-rtl-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-overlap-extent-rtl-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-position-and-transform-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-position-and-transform-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-position-change-out-of-view-in-view-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-position-change-out-of-view-in-view-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-position-descendants-out-of-view-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-position-descendants-out-of-view-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-position-out-of-view-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-position-out-of-view-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-position-transformed-into-view-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-position-transformed-into-view-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-position-under-transform-expected.txt:
* LayoutTests/compositing/layer-creation/fixed-position-under-transform-expected.txt:
* LayoutTests/compositing/layer-creation/zoomed-clip-intersection-expected.txt:
* LayoutTests/compositing/layer-creation/zoomed-clip-intersection-expected.txt:
* LayoutTests/compositing/no-compositing-when-fulll-screen-is-present-expected.txt:
* LayoutTests/compositing/no-compositing-when-fulll-screen-is-present-expected.txt:
* LayoutTests/compositing/transforms/3d-transformed-fixed-expected.html:
* LayoutTests/compositing/transforms/3d-transformed-fixed.html:
* LayoutTests/compositing/visibility/visibility-change-in-subframe-expected.txt:
* LayoutTests/compositing/visibility/visibility-change-in-subframe-expected.txt:
* LayoutTests/editing/editable-region/fixed-and-absolute-contenteditable-scrolled-expected.txt:
* LayoutTests/editing/editable-region/fixed-and-absolute-contenteditable-scrolled-expected.txt:
* LayoutTests/editing/editable-region/relative-inside-fixed-contenteditable-scrolled-expected.txt:
* LayoutTests/editing/editable-region/relative-inside-fixed-contenteditable-scrolled-expected.txt:
* LayoutTests/editing/editable-region/transformed-scrolled-on-top-of-fixed-contenteditables-expected.txt:
* LayoutTests/editing/editable-region/transformed-scrolled-on-top-of-fixed-contenteditables-expected.txt:
* LayoutTests/fast/repaint/iframe-on-subpixel-position-expected.txt:
* LayoutTests/fast/scrolling/mac/negative-z-index-overflow-scroll-expected.txt:
* LayoutTests/fast/scrolling/mac/negative-z-index-overflow-scroll-expected.txt:
* LayoutTests/fast/visual-viewport/tiled-drawing/zoomed-fixed-scrolled-down-expected.txt:
* LayoutTests/fast/visual-viewport/tiled-drawing/zoomed-fixed-scrolled-down-then-up-expected.txt:
* LayoutTests/fast/visual-viewport/tiled-drawing/zoomed-fixed-scrolling-layers-state-expected.txt:
* LayoutTests/fullscreen/full-screen-layer-dump-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/contents-opaque/body-background-painted-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/contents-opaque/body-background-painted-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/contents-opaque/body-background-skipped-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/contents-opaque/body-background-skipped-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/fixed-image-loading-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/fixed-image-loading-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/geometry/fixed-position-composited-switch-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/geometry/fixed-position-composited-switch-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/geometry/limit-layer-bounds-fixed-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/geometry/limit-layer-bounds-fixed-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/geometry/limit-layer-bounds-fixed-positioned-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/geometry/limit-layer-bounds-fixed-positioned-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/layer-creation/fixed-position-transformed-into-view-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/layer-creation/fixed-position-transformed-into-view-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/layer-creation/fixed-position-under-transform-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/layer-creation/fixed-position-under-transform-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/layer-creation/no-compositing-for-sticky-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/layer-creation/no-compositing-for-sticky-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/rtl/rtl-fixed-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/rtl/rtl-fixed-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/rtl/rtl-fixed-overflow-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/rtl/rtl-fixed-overflow-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/rtl/rtl-iframe-fixed-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/rtl/rtl-iframe-fixed-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/visibility/visibility-change-in-subframe-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/visibility/visibility-change-in-subframe-expected.txt:
* LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/fixed-inside-frame-expected.txt:
* LayoutTests/platform/ios/compositing/absolute-inside-out-of-view-fixed-expected.txt:
* LayoutTests/platform/ios/compositing/absolute-inside-out-of-view-fixed-expected.txt:
* LayoutTests/platform/ios/compositing/geometry/fixed-position-flipped-writing-mode-expected.txt:
* LayoutTests/platform/ios/compositing/geometry/fixed-position-flipped-writing-mode-expected.txt:
* LayoutTests/platform/ios/compositing/iframes/overlapped-nested-iframes-expected.txt:
* LayoutTests/platform/ios/compositing/iframes/overlapped-nested-iframes-expected.txt:
* LayoutTests/platform/ios/compositing/layer-creation/fixed-position-and-transform-expected.txt:
* LayoutTests/platform/ios/compositing/layer-creation/fixed-position-and-transform-expected.txt:
* LayoutTests/platform/ios/compositing/rtl/rtl-fixed-overflow-scrolled-expected.txt:
* LayoutTests/platform/ios/compositing/rtl/rtl-fixed-overflow-scrolled-expected.txt:
* LayoutTests/platform/ios/scrollingcoordinator/ios/fixed-in-frame-layer-reconcile-layer-position-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/contents-opaque/body-background-painted-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/contents-opaque/body-background-painted-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/contents-opaque/body-background-skipped-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/contents-opaque/body-background-skipped-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/fixed-image-loading-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/fixed-image-loading-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/rtl/rtl-fixed-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/rtl/rtl-fixed-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/rtl/rtl-fixed-overflow-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/rtl/rtl-fixed-overflow-expected.txt:
* LayoutTests/platform/mac/compositing/geometry/fixed-position-composited-switch-expected.txt:
* LayoutTests/platform/mac/compositing/geometry/fixed-position-composited-switch-expected.txt:
* LayoutTests/platform/mac/compositing/rtl/rtl-fixed-overflow-scrolled-expected.txt:
* LayoutTests/platform/mac/compositing/rtl/rtl-fixed-overflow-scrolled-expected.txt:
* LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-frame-expected.txt:
* LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-frame-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-fixed-child-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-fixed-child-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-inside-fixed-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-inside-fixed-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-on-fixed-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-on-fixed-expected.txt:
* LayoutTests/tiled-drawing/scrolling/sticky/sticky-layers-expected.txt:
* LayoutTests/tiled-drawing/scrolling/sticky/sticky-layers-expected.txt:

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateGeometry):
(WebCore::RenderLayerBacking::updateViewportConstrainedAnchorLayer):

Canonical link: <a href="https://commits.webkit.org/254304@main">https://commits.webkit.org/254304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3363b3e2bc9c594edf942319207711300918c29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97846 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31711 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27310 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80878 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92482 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25159 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75621 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25094 "Found 2 new test failures: compositing/contents-opaque/body-background-painted.html, compositing/contents-opaque/body-background-skipped.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68058 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29416 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29237 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15123 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3038 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38053 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34234 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->