### PR TITLE
[WGSL] Implement local var statement parsing

### DIFF
--- a/Source/WebGPU/WGSL/AST/Statements/VariableStatement.h
+++ b/Source/WebGPU/WGSL/AST/Statements/VariableStatement.h
@@ -25,39 +25,28 @@
 
 #pragma once
 
-#include "ASTNode.h"
-#include <wtf/TypeCasts.h>
+#include "Decl.h"
+#include "Statement.h"
+#include <wtf/UniqueRef.h>
 
 namespace WGSL::AST {
 
-class Statement : public ASTNode {
+class VariableStatement final : public Statement {
     WTF_MAKE_FAST_ALLOCATED;
-
 public:
-    enum class Kind : uint8_t {
-        Compound,
-        Return,
-        Assignment,
-        Variable,
-    };
-
-    Statement(SourceSpan span)
-        : ASTNode(span)
+    VariableStatement(SourceSpan span, VariableDecl&& decl)
+        : Statement(span)
+        , m_decl(makeUniqueRef<VariableDecl>(WTFMove(decl)))
     {
     }
 
-    virtual ~Statement() {}
+    Kind kind() const override { return Kind::Variable; }
+    Decl& declaration() { return m_decl.get(); }
 
-    virtual Kind kind() const = 0;
-    bool isCompound() const { return kind() == Kind::Compound; }
-    bool isReturn() const { return kind() == Kind::Return; }
-    bool isAssignment() const { return kind() == Kind::Assignment; }
-    bool isVariable() const { return kind() == Kind::Variable; }
+private:
+    UniqueRef<Decl> m_decl;
 };
 
 } // namespace WGSL::AST
 
-#define SPECIALIZE_TYPE_TRAITS_WGSL_STATEMENT(ToValueTypeName, predicate) \
-SPECIALIZE_TYPE_TRAITS_BEGIN(WGSL::AST::ToValueTypeName) \
-    static bool isType(const WGSL::AST::Statement& statement) { return statement.predicate; } \
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_WGSL_STATEMENT(VariableStatement, isVariable())

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -50,7 +50,8 @@ public:
     Expected<AST::StructMember, Error> parseStructMember();
     Expected<UniqueRef<AST::TypeDecl>, Error> parseTypeDecl();
     Expected<UniqueRef<AST::TypeDecl>, Error> parseTypeDeclAfterIdentifier(StringView&&, SourcePosition start);
-    Expected<AST::VariableDecl, Error> parseVariableDecl(AST::Attributes&&);
+    Expected<AST::VariableDecl, Error> parseVariableDecl();
+    Expected<AST::VariableDecl, Error> parseVariableDeclWithAttributes(AST::Attributes&&);
     Expected<AST::VariableQualifier, Error> parseVariableQualifier();
     Expected<AST::StorageClass, Error> parseStorageClass();
     Expected<AST::AccessMode, Error> parseAccessMode();

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		33EA188427BC268600A1DD52 /* StructureAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188327BC268600A1DD52 /* StructureAccess.h */; };
 		33EA188627BC26DF00A1DD52 /* CallableExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188527BC26DF00A1DD52 /* CallableExpression.h */; };
 		33EA188827BC361E00A1DD52 /* LiteralExpressions.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188727BC361E00A1DD52 /* LiteralExpressions.h */; };
+		3AE27DB528C1BA480043A8E0 /* VariableStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE27DB428C1BA480043A8E0 /* VariableStatement.h */; };
 		6634666B285F0140002ABE8E /* ConstLiteralTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6634666A285F0140002ABE8E /* ConstLiteralTests.mm */; };
 		664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 664C92FC286A66090008D143 /* IOSurface.framework */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
@@ -332,6 +333,7 @@
 		33EA188327BC268600A1DD52 /* StructureAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StructureAccess.h; sourceTree = "<group>"; };
 		33EA188527BC26DF00A1DD52 /* CallableExpression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CallableExpression.h; sourceTree = "<group>"; };
 		33EA188727BC361E00A1DD52 /* LiteralExpressions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LiteralExpressions.h; sourceTree = "<group>"; };
+		3AE27DB428C1BA480043A8E0 /* VariableStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VariableStatement.h; sourceTree = "<group>"; };
 		6634666A285F0140002ABE8E /* ConstLiteralTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ConstLiteralTests.mm; sourceTree = "<group>"; };
 		664C92FC286A66090008D143 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
@@ -715,6 +717,7 @@
 				33EA187F27BC24E200A1DD52 /* AssignmentStatement.h */,
 				33EA187A27BC230E00A1DD52 /* CompoundStatement.h */,
 				33EA187D27BC249000A1DD52 /* ReturnStatement.h */,
+				3AE27DB428C1BA480043A8E0 /* VariableStatement.h */,
 			);
 			path = Statements;
 			sourceTree = "<group>";
@@ -784,6 +787,7 @@
 				33EA186E27BC1D4C00A1DD52 /* TypeDecl.h in Headers */,
 				33EA186427BC1A1D00A1DD52 /* VariableDecl.h in Headers */,
 				33EA187227BC1FE100A1DD52 /* VariableQualifier.h in Headers */,
+				3AE27DB528C1BA480043A8E0 /* VariableStatement.h in Headers */,
 				1CEBD7F82716B34400A5254D /* WGSL.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
#### 250024bc727642812cf7e5067006871d238ac4fc
<pre>
[WGSL] Implement local var statement parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=244760">https://bugs.webkit.org/show_bug.cgi?id=244760</a>
rdar://problem/99521231

Reviewed by Myles C. Maxfield.

Make use of existing VariableDecl to implement VariableStatement nodes
representing local variable declaration statements beginning with &apos;var&apos; keyword.

* Source/WebGPU/WGSL/AST/Statement.h:
Add Variable to Statement::Kind
(WGSL::AST::Statement::isVariable const):
Predicate for new VariableStatement node
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseVariableDecl):
(WGSL::Parser&lt;Lexer&gt;::parseVariableDeclWithAttributes):
Only global variables can have attributes. Split parsing into parseVariable that
passes an empty list of Attributes for local variable decls and
parseVariableDeclWithAttributes for global variable decls.
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
Handle parsing of variable statements beginning with &apos;var&apos; keyword.
* Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm:
(-[WGSLParserTests testParsingLocalVariable]):
Simple test of a function with a local variable.
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
Add VariableStatement.h

Canonical link: <a href="https://commits.webkit.org/254140@main">https://commits.webkit.org/254140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7a4f9ac549df8db2d97518d20cc6afe87439347

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97350 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30751 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26653 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80305 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92036 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24749 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74842 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/24703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79667 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28395 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28474 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/14692 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2909 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31541 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33892 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->