### PR TITLE
[webkitpy] Introduce GLibPort base class

### DIFF
--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -1,0 +1,134 @@
+# Copyright (C) 2010 Google Inc. All rights reserved.
+# Copyright (C) 2013 Samsung Electronics.  All rights reserved.
+# Copyright (C) 2017-2022 Igalia S.L. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the Google name nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import uuid
+
+from webkitpy.port.base import Port
+from webkitpy.port.leakdetector_valgrind import LeakDetectorValgrind
+from webkitpy.port.linux_get_crash_log import GDBCrashLogGenerator
+
+
+class GLibPort(Port):
+
+    def __init__(self, *args, **kwargs):
+        super(GLibPort, self).__init__(*args, **kwargs)
+        self._display_server = self.get_option("display_server")
+
+        if self.get_option("leaks"):
+            self._leakdetector = LeakDetectorValgrind(self._executive, self._filesystem, self.results_directory())
+            if not self.get_option("wrapper"):
+                raise ValueError('use --wrapper=\"valgrind\" for memory leak detection')
+
+        if self._should_use_jhbuild():
+            self._jhbuild_wrapper = [self.path_from_webkit_base('Tools', 'jhbuild', 'jhbuild-wrapper'), self._port_flag_for_scripts(), 'run']
+            if self.get_option('wrapper'):
+                self.set_option('wrapper', ' '.join(self._jhbuild_wrapper) + ' ' + self.get_option('wrapper'))
+            else:
+                self.set_option_default('wrapper', ' '.join(self._jhbuild_wrapper))
+
+    def default_timeout_ms(self):
+        default_timeout = 15000
+        # Starting an application under Valgrind takes a lot longer than normal
+        # so increase the timeout (empirically 10x is enough to avoid timeouts).
+        multiplier = 10 if self.get_option("leaks") else 1
+        # Debug builds are slower (no compiler optimizations are used).
+        if self.get_option('configuration') == 'Debug':
+            multiplier *= 2
+        return multiplier * default_timeout
+
+    def _built_executables_path(self, *path):
+        return self._build_path(*(('bin',) + path))
+
+    def _built_libraries_path(self, *path):
+        return self._build_path(*(('lib',) + path))
+
+    def setup_test_run(self, device_type=None):
+        super(GLibPort, self).setup_test_run(device_type)
+
+        if self.get_option("leaks"):
+            self._leakdetector.clean_leaks_files_from_results_directory()
+
+    def setup_environ_for_server(self, server_name=None):
+        environment = super(GLibPort, self).setup_environ_for_server(server_name)
+        environment['G_DEBUG'] = 'fatal-criticals'
+        environment['GSETTINGS_BACKEND'] = 'memory'
+
+        environment['TEST_RUNNER_INJECTED_BUNDLE_FILENAME'] = self._build_path('lib', 'libTestRunnerInjectedBundle.so')
+        environment['TEST_RUNNER_TEST_PLUGIN_PATH'] = self._build_path('lib', 'plugins')
+        environment['WEBKIT_EXEC_PATH'] = self._build_path('bin')
+        self._copy_value_from_environ_if_set(environment, 'LIBGL_ALWAYS_SOFTWARE')
+        self._copy_value_from_environ_if_set(environment, 'WEBKIT_OUTPUTDIR')
+        self._copy_value_from_environ_if_set(environment, 'WEBKIT_JHBUILD')
+        self._copy_value_from_environ_if_set(environment, 'WEBKIT_TOP_LEVEL')
+        self._copy_value_from_environ_if_set(environment, 'WEBKIT_DEBUG')
+        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_USE_PLAYBIN3')
+        self._copy_value_from_environ_if_set(environment, 'AT_SPI_BUS_ADDRESS')
+        for gst_variable in ('DEBUG', 'DEBUG_DUMP_DOT_DIR', 'DEBUG_FILE', 'DEBUG_NO_COLOR',
+                             'PLUGIN_SCANNER', 'PLUGIN_PATH', 'PLUGIN_SYSTEM_PATH', 'REGISTRY',
+                             'PLUGIN_PATH_1_0'):
+            self._copy_value_from_environ_if_set(environment, 'GST_%s' % gst_variable)
+
+        gst_feature_rank_override = os.environ.get('GST_PLUGIN_FEATURE_RANK')
+        environment['GST_PLUGIN_FEATURE_RANK'] = 'fakeaudiosink:max'
+        if gst_feature_rank_override:
+            environment['GST_PLUGIN_FEATURE_RANK'] += ',%s' % gst_feature_rank_override
+
+        if self.get_option("leaks"):
+            # Turn off GLib memory optimisations https://wiki.gnome.org/Valgrind.
+            environment['G_SLICE'] = 'always-malloc'
+            environment['G_DEBUG'] += ',gc-friendly'
+            # Turn off bmalloc when running under Valgrind, see https://bugs.webkit.org/show_bug.cgi?id=177745
+            environment['Malloc'] = '1'
+            xmlfilename = "".join(("drt-%p-", uuid.uuid1().hex, "-leaks.xml"))
+            xmlfile = os.path.join(self.results_directory(), xmlfilename)
+            suppressionsfile = self.path_from_webkit_base('Tools', 'Scripts', 'valgrind', 'suppressions.txt')
+            environment['VALGRIND_OPTS'] = \
+                "--tool=memcheck " \
+                "--num-callers=40 " \
+                "--demangle=no " \
+                "--trace-children=no " \
+                "--smc-check=all-non-file " \
+                "--leak-check=yes " \
+                "--leak-resolution=high " \
+                "--show-possibly-lost=no " \
+                "--show-reachable=no " \
+                "--leak-check=full " \
+                "--undef-value-errors=no " \
+                "--gen-suppressions=all " \
+                "--xml=yes " \
+                "--xml-file=%s " \
+                "--suppressions=%s" % (xmlfile, suppressionsfile)
+
+        return environment
+
+    def _get_crash_log(self, name, pid, stdout, stderr, newer_than, target_host=None):
+        return GDBCrashLogGenerator(self._executive, name, pid, newer_than,
+                                    self._filesystem, self._path_to_driver, self.port_name, self.get_option('configuration')).generate_crash_log(stdout, stderr)

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -29,7 +29,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
-import uuid
 import logging
 import shlex
 
@@ -37,43 +36,19 @@ import webkitpy
 from webkitpy.common.system import path
 from webkitpy.common.memoized import memoized
 from webkitpy.layout_tests.models.test_configuration import TestConfiguration
-from webkitpy.port.base import Port
+from webkitpy.port.glib import GLibPort
 from webkitpy.port.xvfbdriver import XvfbDriver
 from webkitpy.port.westondriver import WestonDriver
 from webkitpy.port.xorgdriver import XorgDriver
 from webkitpy.port.waylanddriver import WaylandDriver
-from webkitpy.port.linux_get_crash_log import GDBCrashLogGenerator
-from webkitpy.port.leakdetector_valgrind import LeakDetectorValgrind
 
 from webkitcorepy import decorators
 
 _log = logging.getLogger(__name__)
 
 
-class GtkPort(Port):
+class GtkPort(GLibPort):
     port_name = "gtk"
-
-    def __init__(self, *args, **kwargs):
-        super(GtkPort, self).__init__(*args, **kwargs)
-        self._display_server = self.get_option("display_server")
-
-        if self.get_option("leaks"):
-            self._leakdetector = LeakDetectorValgrind(self._executive, self._filesystem, self.results_directory())
-            if not self.get_option("wrapper"):
-                raise ValueError('use --wrapper=\"valgrind\" for memory leak detection on GTK')
-
-        if self._should_use_jhbuild():
-            self._jhbuild_wrapper = [self.path_from_webkit_base('Tools', 'jhbuild', 'jhbuild-wrapper'), '--gtk', 'run']
-            if self.get_option('wrapper'):
-                self.set_option('wrapper', ' '.join(self._jhbuild_wrapper) + ' ' + self.get_option('wrapper'))
-            else:
-                self.set_option_default('wrapper', ' '.join(self._jhbuild_wrapper))
-
-    def _built_executables_path(self, *path):
-        return self._build_path(*(('bin',) + path))
-
-    def _built_libraries_path(self, *path):
-        return self._build_path(*(('lib',) + path))
 
     def _port_flag_for_scripts(self):
         return "--gtk"
@@ -88,50 +63,15 @@ class GtkPort(Port):
             return XorgDriver
         return XvfbDriver
 
-    def default_timeout_ms(self):
-        default_timeout = 15000
-        # Starting an application under Valgrind takes a lot longer than normal
-        # so increase the timeout (empirically 10x is enough to avoid timeouts).
-        multiplier = 10 if self.get_option("leaks") else 1
-        # Debug builds are slower (no compiler optimizations are used).
-        if self.get_option('configuration') == 'Debug':
-            multiplier *= 2
-        return multiplier * default_timeout
-
     def driver_stop_timeout(self):
         if self.get_option("leaks"):
             # Wait the default timeout time before killing the process in driver.stop().
             return self.default_timeout_ms()
         return super(GtkPort, self).driver_stop_timeout()
 
-    def setup_test_run(self, device_type=None):
-        super(GtkPort, self).setup_test_run(device_type)
-
-        if self.get_option("leaks"):
-            self._leakdetector.clean_leaks_files_from_results_directory()
-
     def setup_environ_for_server(self, server_name=None):
         environment = super(GtkPort, self).setup_environ_for_server(server_name)
-        environment['G_DEBUG'] = 'fatal-criticals'
-        environment['GSETTINGS_BACKEND'] = 'memory'
         environment['LIBOVERLAY_SCROLLBAR'] = '0'
-        environment['TEST_RUNNER_INJECTED_BUNDLE_FILENAME'] = self._build_path('lib', 'libTestRunnerInjectedBundle.so')
-        environment['TEST_RUNNER_TEST_PLUGIN_PATH'] = self._build_path('lib', 'plugins')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_OUTPUTDIR')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_JHBUILD')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_TOP_LEVEL')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_DEBUG')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_USE_PLAYBIN3')
-        self._copy_value_from_environ_if_set(environment, 'AT_SPI_BUS_ADDRESS')
-        for gst_variable in ('DEBUG', 'DEBUG_DUMP_DOT_DIR', 'DEBUG_FILE', 'DEBUG_NO_COLOR',
-                             'PLUGIN_SCANNER', 'PLUGIN_PATH', 'PLUGIN_SYSTEM_PATH', 'REGISTRY',
-                             'PLUGIN_PATH_1_0'):
-            self._copy_value_from_environ_if_set(environment, 'GST_%s' % gst_variable)
-
-        gst_feature_rank_override = os.environ.get('GST_PLUGIN_FEATURE_RANK')
-        environment['GST_PLUGIN_FEATURE_RANK'] = 'fakeaudiosink:max'
-        if gst_feature_rank_override:
-            environment['GST_PLUGIN_FEATURE_RANK'] += ',%s' % gst_feature_rank_override
 
         # Configure the software libgl renderer if jhbuild ready and we test inside a virtualized window system
         if self._driver_class() in [XvfbDriver, WestonDriver] and (self._should_use_jhbuild() or self._is_flatpak()):
@@ -151,31 +91,6 @@ class GtkPort(Port):
                 environment['LIBGL_DRIVERS_PATH'] = dri_libgl_path
             else:
                 _log.warning("Can't find Gallium llvmpipe driver. Try to run update-webkitgtk-libs or update-webkit-flatpak")
-        if self.get_option("leaks"):
-            # Turn off GLib memory optimisations https://wiki.gnome.org/Valgrind.
-            environment['G_SLICE'] = 'always-malloc'
-            environment['G_DEBUG'] += ',gc-friendly'
-            # Turn off bmalloc when running under Valgrind, see https://bugs.webkit.org/show_bug.cgi?id=177745
-            environment['Malloc'] = '1'
-            xmlfilename = "".join(("drt-%p-", uuid.uuid1().hex, "-leaks.xml"))
-            xmlfile = os.path.join(self.results_directory(), xmlfilename)
-            suppressionsfile = self.path_from_webkit_base('Tools', 'Scripts', 'valgrind', 'suppressions.txt')
-            environment['VALGRIND_OPTS'] = \
-                "--tool=memcheck " \
-                "--num-callers=40 " \
-                "--demangle=no " \
-                "--trace-children=no " \
-                "--smc-check=all-non-file " \
-                "--leak-check=yes " \
-                "--leak-resolution=high " \
-                "--show-possibly-lost=no " \
-                "--show-reachable=no " \
-                "--leak-check=full " \
-                "--undef-value-errors=no " \
-                "--gen-suppressions=all " \
-                "--xml=yes " \
-                "--xml-file=%s " \
-                "--suppressions=%s" % (xmlfile, suppressionsfile)
         return environment
 
     def _generate_all_test_configurations(self):
@@ -243,10 +158,6 @@ class GtkPort(Port):
 
     def check_sys_deps(self):
         return super(GtkPort, self).check_sys_deps() and self._driver_class().check_driver(self)
-
-    def _get_crash_log(self, name, pid, stdout, stderr, newer_than, target_host=None):
-        return GDBCrashLogGenerator(self._executive, name, pid, newer_than,
-                                    self._filesystem, self._path_to_driver, self.port_name, self.get_option('configuration')).generate_crash_log(stdout, stderr)
 
     def test_expectations_file_position(self):
         # GTK port baseline search path is gtk -> glib -> wk2 -> generic (as gtk-wk2 and gtk baselines are merged), so port test expectations file is at third to last position.

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -33,42 +33,21 @@ import shlex
 from webkitpy.common.system import path
 from webkitpy.common.memoized import memoized
 from webkitpy.layout_tests.models.test_configuration import TestConfiguration
-from webkitpy.port.base import Port
+from webkitpy.port.glib import GLibPort
 from webkitpy.port.headlessdriver import HeadlessDriver
-from webkitpy.port.linux_get_crash_log import GDBCrashLogGenerator
 
 from webkitcorepy import decorators
 
 
-class WPEPort(Port):
+class WPEPort(GLibPort):
     port_name = "wpe"
 
     def __init__(self, *args, **kwargs):
         super(WPEPort, self).__init__(*args, **kwargs)
 
-        self._display_server = self.get_option("display_server")
         if self._display_server == 'xvfb':
             # While not supported by WPE, xvfb is used as the default value in the main scripts
             self._display_server = 'headless'
-        if self._should_use_jhbuild():
-            self._jhbuild_wrapper = [self.path_from_webkit_base('Tools', 'jhbuild', 'jhbuild-wrapper'), '--wpe', 'run']
-            self.set_option_default('wrapper', ' '.join(self._jhbuild_wrapper))
-
-    def default_timeout_ms(self):
-        default_timeout = 15000
-        # Starting an application under Valgrind takes a lot longer than normal
-        # so increase the timeout (empirically 10x is enough to avoid timeouts).
-        multiplier = 10 if self.get_option("leaks") else 1
-        # Debug builds are slower (no compiler optimizations are used).
-        if self.get_option('configuration') == 'Debug':
-            multiplier *= 2
-        return multiplier * default_timeout
-
-    def _built_executables_path(self, *path):
-        return self._build_path(*(('bin',) + path))
-
-    def _built_libraries_path(self, *path):
-        return self._build_path(*(('lib',) + path))
 
     def _port_flag_for_scripts(self):
         return "--wpe"
@@ -79,32 +58,8 @@ class WPEPort(Port):
 
     def setup_environ_for_server(self, server_name=None):
         environment = super(WPEPort, self).setup_environ_for_server(server_name)
-        environment['G_DEBUG'] = 'fatal-criticals'
-        environment['GSETTINGS_BACKEND'] = 'memory'
-        environment['TEST_RUNNER_INJECTED_BUNDLE_FILENAME'] = self._build_path('lib', 'libTestRunnerInjectedBundle.so')
-        environment['TEST_RUNNER_TEST_PLUGIN_PATH'] = self._build_path('lib', 'plugins')
-        environment['WEBKIT_EXEC_PATH'] = self._build_path('bin')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_OUTPUTDIR')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_JHBUILD')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_TOP_LEVEL')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_DEBUG')
-        self._copy_value_from_environ_if_set(environment, 'AT_SPI_BUS_ADDRESS')
-        self._copy_value_from_environ_if_set(environment, 'LIBGL_ALWAYS_SOFTWARE')
-        self._copy_value_from_environ_if_set(environment, 'PULSE_SERVER')
-        self._copy_value_from_environ_if_set(environment, 'PULSE_CLIENTCONFIG')
         self._copy_value_from_environ_if_set(environment, 'XR_RUNTIME_JSON')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_USE_PLAYBIN3')
         self._copy_value_from_environ_if_set(environment, 'BREAKPAD_MINIDUMP_DIR')
-        for gst_variable in ('DEBUG', 'DEBUG_DUMP_DOT_DIR', 'DEBUG_FILE', 'DEBUG_NO_COLOR',
-                             'PLUGIN_SCANNER', 'PLUGIN_PATH', 'PLUGIN_SYSTEM_PATH', 'REGISTRY',
-                             'PLUGIN_PATH_1_0'):
-            self._copy_value_from_environ_if_set(environment, 'GST_%s' % gst_variable)
-
-        gst_feature_rank_override = os.environ.get('GST_PLUGIN_FEATURE_RANK')
-        environment['GST_PLUGIN_FEATURE_RANK'] = 'fakeaudiosink:max'
-        if gst_feature_rank_override:
-            environment['GST_PLUGIN_FEATURE_RANK'] += ',%s' % gst_feature_rank_override
-
         return environment
 
     def show_results_html_file(self, results_filename):
@@ -141,10 +96,6 @@ class WPEPort(Port):
     def test_expectations_file_position(self):
         # WPE port baseline search path is wpe -> glib -> wk2 -> generic, so port test expectations file is at third to last position.
         return 3
-
-    def _get_crash_log(self, name, pid, stdout, stderr, newer_than, target_host=None):
-        return GDBCrashLogGenerator(self._executive, name, pid, newer_than,
-                                    self._filesystem, self._path_to_driver, self.port_name, self.get_option('configuration')).generate_crash_log(stdout, stderr)
 
     def configuration_for_upload(self, host=None):
         configuration = super(WPEPort, self).configuration_for_upload(host=host)

--- a/Tools/Scripts/webkitpy/port/wpe_unittest.py
+++ b/Tools/Scripts/webkitpy/port/wpe_unittest.py
@@ -62,8 +62,8 @@ class WPEPortTest(port_testcase.PortTestCase):
     def test_default_timeout_ms(self):
         self.assertEqual(self.make_port(options=MockOptions(configuration='Release')).default_timeout_ms(), 15000)
         self.assertEqual(self.make_port(options=MockOptions(configuration='Debug')).default_timeout_ms(), 30000)
-        self.assertEqual(self.make_port(options=MockOptions(configuration='Release', leaks=True)).default_timeout_ms(), 150000)
-        self.assertEqual(self.make_port(options=MockOptions(configuration='Debug', leaks=True)).default_timeout_ms(), 300000)
+        self.assertEqual(self.make_port(options=MockOptions(configuration='Release', leaks=True, wrapper="valgrind")).default_timeout_ms(), 150000)
+        self.assertEqual(self.make_port(options=MockOptions(configuration='Debug', leaks=True, wrapper="valgrind")).default_timeout_ms(), 300000)
 
     def test_get_crash_log(self):
         # This function tested in linux_get_crash_log_unittest.py


### PR DESCRIPTION
#### 4aba78c2c8ad2e6943e915da68a129c9d50d26ec
<pre>
[webkitpy] Introduce GLibPort base class
<a href="https://bugs.webkit.org/show_bug.cgi?id=244773">https://bugs.webkit.org/show_bug.cgi?id=244773</a>

Reviewed by Jonathan Bedard.

Code shared between the WPE/GTK webkitpy ports is now de-duplicated. Rejoice. And with this patch
WPE gained support for running tests in valgrind, but that wasn&apos;t tested in years I&apos;m afraid, so it
might need a follow-up revamp.

* Tools/Scripts/webkitpy/port/glib.py: Added.
(GLibPort):
(GLibPort.__init__):
(GLibPort.default_timeout_ms):
(GLibPort._built_executables_path):
(GLibPort._built_libraries_path):
(GLibPort.setup_test_run):
(GLibPort.setup_environ_for_server):
(GLibPort._get_crash_log):
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort):
(GtkPort._driver_class):
(GtkPort.driver_stop_timeout):
(GtkPort.setup_environ_for_server):
(GtkPort.check_sys_deps):
(GtkPort.__init__): Deleted.
(GtkPort._built_executables_path): Deleted.
(GtkPort._built_libraries_path): Deleted.
(GtkPort.default_timeout_ms): Deleted.
(GtkPort.setup_test_run): Deleted.
(GtkPort._get_crash_log): Deleted.
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort):
(WPEPort.__init__):
(WPEPort.setup_environ_for_server):
(WPEPort.test_expectations_file_position):
(WPEPort.default_timeout_ms): Deleted.
(WPEPort._built_executables_path): Deleted.
(WPEPort._built_libraries_path): Deleted.
(WPEPort._get_crash_log): Deleted.

Canonical link: <a href="https://commits.webkit.org/254212@main">https://commits.webkit.org/254212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1967286ff221e6a1cbcd0c9066f091186f6c07a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97379 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152845 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30814 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26689 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92047 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24760 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74905 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24712 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/91997 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67688 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28474 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13733 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28548 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14720 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2964 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37624 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33902 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->