### PR TITLE
[GStreamer] Switch media player to playbin3

### DIFF
--- a/LayoutTests/http/tests/security/resources/reference-movie-cross-origin-allow.py
+++ b/LayoutTests/http/tests/security/resources/reference-movie-cross-origin-allow.py
@@ -15,7 +15,7 @@ sys.stdout.write(
     'ETag: foo\r\n'
     'Last-Modified: Thu, 01 Jan 2000 00:00:00 GMT\r\n'
     'Cache-Control: max-age=0\r\n'
-    'Content-Type: text/html\r\n'
+    'Content-Type: video/mp4\r\n'
     'Content-Length: {}\r\n\r\n'.format(os.path.getsize(os.path.join(os.path.dirname(__file__), '../../media/resources/reference.mov')))
 )
 

--- a/LayoutTests/media/track/audio/audio-track-mkv-vorbis-language-expected.txt
+++ b/LayoutTests/media/track/audio/audio-track-mkv-vorbis-language-expected.txt
@@ -5,8 +5,8 @@ EVENT(canplaythrough)
 
 ** Check in-band kind attributes
 EXPECTED (video.audioTracks.length == '2') OK
-EXPECTED (video.audioTracks.getTrackById('A0').language == 'en') OK
-EXPECTED (video.audioTracks.getTrackById('A1').language == 'la') OK
+EXPECTED (video.audioTracks[0].language == 'en') OK
+EXPECTED (video.audioTracks[1].language == 'la') OK
 
 END OF TEST
 

--- a/LayoutTests/media/track/audio/audio-track-mkv-vorbis-language.html
+++ b/LayoutTests/media/track/audio/audio-track-mkv-vorbis-language.html
@@ -7,7 +7,7 @@
         <script src=../../video-test.js></script>
         <script src=../../in-band-tracks.js></script>
     </head>
-    <body onload="testAttribute('../../content/two-audio-and-video-tracks.mkv', 'audio', 'language', {'A0': 'en', 'A1': 'la'})">
+    <body onload="testAttribute('../../content/two-audio-and-video-tracks.mkv', 'audio', 'language', ['en', 'la'])">
         <video controls></video>
         <p>Check audio tracks' language attributes.</p>
     </body>

--- a/LayoutTests/media/track/video/video-track-mkv-theora-language-expected.txt
+++ b/LayoutTests/media/track/video/video-track-mkv-theora-language-expected.txt
@@ -5,8 +5,8 @@ EVENT(canplaythrough)
 
 ** Check in-band kind attributes
 EXPECTED (video.videoTracks.length == '2') OK
-EXPECTED (video.videoTracks.getTrackById('V0').language == 'zh') OK
-EXPECTED (video.videoTracks.getTrackById('V1').language == 'ru') OK
+EXPECTED (video.videoTracks[0].language == 'zh') OK
+EXPECTED (video.videoTracks[1].language == 'ru') OK
 
 END OF TEST
 

--- a/LayoutTests/media/track/video/video-track-mkv-theora-language.html
+++ b/LayoutTests/media/track/video/video-track-mkv-theora-language.html
@@ -7,7 +7,7 @@
         <script src=../../video-test.js></script>
         <script src=../../in-band-tracks.js></script>
     </head>
-    <body onload="testAttribute('../../content/two-audio-and-video-tracks.mkv', 'video', 'language', {'V0':'zh', 'V1':'ru'})">
+    <body onload="testAttribute('../../content/two-audio-and-video-tracks.mkv', 'video', 'language', ['zh', 'ru'])">
         <video controls></video>
         <p>Check video tracks' language attributes.</p>
     </body>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -270,7 +270,6 @@ http/tests/security/canvas-remote-read-remote-video-blocked-no-crossorigin.html 
 http/tests/security/canvas-remote-read-remote-video-redirect.html [ Pass ]
 http/tests/security/contentSecurityPolicy/audio-redirect-allowed.html [ Pass ]
 http/tests/security/contentSecurityPolicy/video-redirect-allowed.html [ Pass ]
-http/tests/security/video-cross-origin-caching.html [ Pass ]
 media/media-can-play-webm.html [ Pass ]
 media/media-controller-time-constant.html [ Pass ]
 media/media-controller-time.html [ Pass ]
@@ -906,9 +905,6 @@ webkit.org/b/233731 fast/mediastream/getDisplayMedia-size.html [ Failure ]
 
 webkit.org/b/233836 http/tests/media/media-blocked-by-willsendrequest.html [ Timeout ]
 
-# Expected to pass when we enable playbin3 by default and update the SDK to GStreamer 1.20.
-webkit.org/b/234084 media/track/audio-track-configuration.html [ Failure ]
-
 # Even with playbin3 enabled there is still a failure here, h264parse is unable
 # to calculate the framerate of test.mp4 and the calculated bitrate tag is too
 # low, probably because we would need a playing pipeline to have better average
@@ -931,6 +927,17 @@ webkit.org/b/239750 media/media-source/media-mp4-xhe-aac.html [ Skip ]
 # bad colorimetry handling, our baseline looks a bit greyish compared to the
 # Apple baseline.
 media/media-hevc-video-as-img.html [ ImageOnlyFailure ]
+
+# https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/1418
+imported/w3c/web-platform-tests/paint-timing/fcp-only/fcp-video-frame.html [ Failure ]
+imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-enter-seeking.html [ Failure ]
+imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-cuechange-dynamically-created-track-element.html [ Failure ]
+
+# https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/1419
+http/tests/media/video-play-stall-seek.html [ Timeout ]
+
+# playbin3 doesn't handle URI redirects yet, see https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/1562
+http/tests/security/video-cross-origin-caching.html [ Timeout ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of GStreamer-related bugs
@@ -2042,22 +2049,14 @@ media/unsupported-rtsp.html [ WontFix Skip ]
 # This test is specific to QuickTime media engine.
 media/video-does-not-loop.html [ WontFix Timeout Crash ]
 
-# Requires media engine closed caption support.
-media/media-captions.html [ WontFix Failure ]
-
 # No support for MPEG-4 caption support
 webkit.org/b/131546 media/track/track-forced-subtitles-in-band.html [ Timeout Failure Crash ]
-webkit.org/b/131546 media/track/track-in-band-cues-added-once.html [ Timeout Crash ]
-webkit.org/b/131546 webkit.org/b/198830 media/track/track-in-band-legacy-api.html [ Failure Crash ]
-webkit.org/b/131546 media/track/track-in-band-mode.html [ Skip ]
 media/track/track-in-band-chapters.html [ Skip ]
 
 # DataCue.value not enabled
 http/tests/media/track-in-band-hls-metadata.html [ Skip ]
 
-# ENABLE(WEBVTT_REGIONS) is disabled
-webkit.org/b/109570 media/track/regions-webvtt [ Skip ]
-webkit.org/b/109570 media/track/w3c [ Skip ]
+media/track/w3c/interfaces/TextTrackCue/align.html [ Failure ]
 
 # Modern-media-controls support expected to pass, excepted for Apple-specific tests.
 media/modern-media-controls [ Pass ]
@@ -2709,7 +2708,6 @@ webkit.org/b/108925 http/tests/media/video-play-stall.html [ Failure Timeout ]
 
 webkit.org/b/137698 media/video-controls-drag.html [ Timeout ]
 webkit.org/b/141959 http/tests/media/clearkey/clear-key-hls-aes128.html [ Crash Timeout ]
-webkit.org/b/130971 media/track/track-remove-track.html [ Timeout ]
 webkit.org/b/113127 media/track/track-prefer-captions.html [ Timeout ]
 
 webkit.org/b/168373 http/tests/media/track-in-band-hls-metadata-crash.html [ Timeout ]

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -442,6 +442,8 @@ private:
     void fillTimerFired();
     void didEnd();
 
+    void maybeNotifyClientOfReadyAndNetworkChanges(MediaPlayerEnums::NetworkState, MediaPlayerEnums::ReadyState);
+
     GstElement* createVideoSink();
     GstElement* createAudioSink();
     GstElement* audioSink() const;

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
@@ -97,10 +97,6 @@ private:
     bool getTag(GstTagList* tags, const gchar* tagName, StringType& value);
 
     void streamChanged();
-
-    static void activeChangedCallback(TrackPrivateBaseGStreamer*);
-    static void tagsChangedCallback(TrackPrivateBaseGStreamer*);
-
     void tagsChanged();
 
     TrackType m_type;

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -89,7 +89,7 @@ class GLibPort(Port):
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_JHBUILD')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_TOP_LEVEL')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_DEBUG')
-        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_USE_PLAYBIN3')
+        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_USE_PLAYBIN2')
         self._copy_value_from_environ_if_set(environment, 'AT_SPI_BUS_ADDRESS')
         for gst_variable in ('DEBUG', 'DEBUG_DUMP_DOT_DIR', 'DEBUG_FILE', 'DEBUG_NO_COLOR',
                              'PLUGIN_SCANNER', 'PLUGIN_PATH', 'PLUGIN_SYSTEM_PATH', 'REGISTRY',


### PR DESCRIPTION
#### 771e7c4c156bf3b4816f8009b7a52437d6852b66
<pre>
[GStreamer] Switch media player to playbin3
<a href="https://bugs.webkit.org/show_bug.cgi?id=236884">https://bugs.webkit.org/show_bug.cgi?id=236884</a>
&lt;<a href="https://rdar.apple.com/problem/89307315">rdar://problem/89307315</a>&gt;

Reviewed by NOBODY (OOPS!).

With GStreamer 1.24 playbin3 is quite usable now, so give it a try as default playback engine during
the 2.44 cycle. If one wants to opt out, set the WEBKIT_GST_USE_PLAYBIN2 environment variable to 1.

No new tests, covered by existing media layout tests.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::ensureGStreamerInitialized):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin):
* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort.setup_environ_for_server):
</pre>