### PR TITLE
Run-benchmark should be able to checkout out a fixed version of benchmark from Git/GitHub. (Follow-up)

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
@@ -104,7 +104,7 @@ class BenchmarkBuilder(object):
             raise Exception('Cannot checkout the benchmark - Error: %s' % error_code)
 
     def _download_from_github(self, github_source, github_subtree):
-        _log.info(f'Downloading content from {github_source}')
+        _log.info('Downloading content from {}'.format(github_source))
         GithubDownloadTask(github_source, github_subtree).execute(self._dest)
 
     def _local_git_archive_eligible(self):


### PR DESCRIPTION
#### a87f9a49dcc4fdce679b140ab24aa33c1acdfdf7
<pre>
Run-benchmark should be able to checkout out a fixed version of benchmark from Git/GitHub. (Follow-up)
<a href="https://bugs.webkit.org/show_bug.cgi?id=244704">https://bugs.webkit.org/show_bug.cgi?id=244704</a>
rdar://99465558

Unreviewed test fix.

F-string broke Python 2 unit tests.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py:
(BenchmarkBuilder._download_from_github):
* Tools/Scripts/webkitpy/benchmark_runner/github_downloader.py:
(GithubDownloadTask.__init__):
(retry_on_exception.decorator.wrapped):
(GithubDownloader.subtree_for_path_with_commit):
(GithubDownloader._download_subtree_multiprocessing):
(GithubDownloader._commit):
(GithubDownloader._raw_content_url):
(GithubDownloader._request):

Canonical link: <a href="https://commits.webkit.org/254149@main">https://commits.webkit.org/254149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/244bb7f616bc0c2fe2b62d10b167078bda7ed4db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88203 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/69/builds/32480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97398 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152865 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92171 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30846 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26721 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80360 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92066 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24774 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74949 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/24729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/91806 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79802 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28524 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28593 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/14741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2912 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31695 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33915 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->