### PR TITLE
Account for zoom when computing SVG font size

### DIFF
--- a/LayoutTests/svg/text/lowdpi-zoom-text-expected.txt
+++ b/LayoutTests/svg/text/lowdpi-zoom-text-expected.txt
@@ -1,0 +1,8 @@
+Test: zoom should not affect getComputedTextLength().
+PASS
+PASS
+PASS
+PASS
+PASS
+PASS
+

--- a/LayoutTests/svg/text/lowdpi-zoom-text.html
+++ b/LayoutTests/svg/text/lowdpi-zoom-text.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<html>
+<style>
+   html {
+       zoom: 1.25;
+   }
+</style>
+<body>
+Test: zoom should not affect getComputedTextLength().<br>
+<svg width="400" height="300">
+    <text y="30" class="testLowDPI" font-size="16px">1 regular 16px abcd</text>
+    <text y="60" class="testLowDPI" font-size="16px" text-rendering="geometricPrecision">1 geometric precision 16px abcd</text>
+    <text y="90" class="testLowDPI" font-size="12px">1 regular 12px abcd</text>
+
+    <text y="130" class="testHighDPI" font-size="16px">2 regular 16px abcd</text>
+    <text y="160" class="testHighDPI" font-size="16px" text-rendering="geometricPrecision">2 geometric precision 16px abcd</text>
+    <text y="190" class="testHighDPI" font-size="12px">2 regular 12px abcd</text>
+</svg>
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+        testRunner.setBackingScaleFactor(1, function() {
+            runTest('testLowDPI');
+            testRunner.setBackingScaleFactor(2, function() {
+                runTest('testHighDPI');
+                testRunner.notifyDone();
+            });
+        });
+    }
+
+    function runTest(className) {
+        var textElements = document.getElementsByClassName(className);
+        for (var t = 0; t < textElements.length; t++) {
+            var text = textElements[t];
+            var longerLength = text.getComputedTextLength();
+            // Remove one character from the text so that it is now shorter.
+            text.textContent = text.textContent.substring(0, text.textContent.length - 1);
+            var shorterLength = text.getComputedTextLength();
+
+            if (longerLength > shorterLength)
+                text.textContent = "PASS";
+            else
+                text.textContent = "FAIL, " + longerLength + " should be greater than " + shorterLength;
+        }
+    }
+</script>
+</body>
+</html>

--- a/LayoutTests/svg/text/zoom-text-and-geometry-expected.html
+++ b/LayoutTests/svg/text/zoom-text-and-geometry-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    font-size : 16px;
+    font-family : "Times New Roman";
+    zoom: 2;
+}
+rect {
+    fill : green;
+    stroke: green;
+}
+</style>
+</head>
+<body>
+    Text should zoom like geometry.<br/>
+    This test passes if there is no red.<br/>
+    <svg version="1.1" width="32px" height="32px">
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em">
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em" viewbox="0 0 32 32">
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="32px" height="32px">
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em">
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em" viewbox="0 0 32 32">
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/text/zoom-text-and-geometry.html
+++ b/LayoutTests/svg/text/zoom-text-and-geometry.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    font-size : 16px;
+    font-family : "Times New Roman";
+    zoom: 2;
+}
+rect {
+    fill : green;
+    stroke: green;
+}
+text {
+    fill : red;
+}
+.geometricPrecision {
+    text-rendering: geometricPrecision;
+}
+</style>
+</head>
+<body>
+    Text should zoom like geometry.<br/>
+    This test passes if there is no red.<br/>
+    <svg version="1.1" width="32px" height="32px">
+        <text x="10" y="22">F</text>
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em">
+        <text x="10" y="22">A</text>
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em" viewbox="0 0 32 32">
+        <text x="10" y="22">I</text>
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="32px" height="32px">
+        <text class="geometricPrecision" x="10" y="22">L</text>
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em">
+        <text class="geometricPrecision" x="10" y="22">F</text>
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em" viewbox="0 0 32 32">
+        <text class="geometricPrecision" x="10" y="22">F</text>
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/zoom/text/zoom-em-units-expected.html
+++ b/LayoutTests/svg/zoom/text/zoom-em-units-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+	zoom: 2;
+}
+div {
+    width: 3em;
+    height: 3em;
+    display: inline-block;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+This test passes if<br/>
+there are two green squares of the same size.<br/>
+<div></div>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/svg/zoom/text/zoom-em-units.html
+++ b/LayoutTests/svg/zoom/text/zoom-em-units.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+	zoom: 2;
+}
+rect {
+	fill : green;
+}
+div {
+    width: 3em;
+    height: 3em;
+    display: inline-block;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+This test passes if<br/>
+there are two green squares of the same size.<br/>
+<div></div>
+<svg width="3em" height="3em">
+<rect x="0" y="0" width="100%" height="100%"/>
+</svg>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -219,18 +219,21 @@ void RenderSVGInlineText::computeNewScaledFontForStyle(const RenderObject& rende
         return SVGRenderingContext::calculateScreenFontSizeScalingFactor(renderer);
     };
 
-    // Alter font-size to the right on-screen value to avoid scaling the glyphs themselves, except when GeometricPrecision is specified
+    // Alter font-size to the right on-screen value to avoid scaling the glyphs themselves, except when GeometricPrecision is specified.
     scalingFactor = computeScalingFactor();
-    if (!scalingFactor || style.fontDescription().textRenderingMode() == TextRenderingMode::GeometricPrecision) {
+    if (style.effectiveZoom() == 1 && (scalingFactor == 1 || !scalingFactor)) {
         scalingFactor = 1;
         scaledFont = style.fontCascade();
         return;
     }
 
+    if (style.fontDescription().textRenderingMode() == TextRenderingMode::GeometricPrecision)
+        scalingFactor = 1;
+
     auto fontDescription = style.fontDescription();
 
     // FIXME: We need to better handle the case when we compute very small fonts below (below 1pt).
-    fontDescription.setComputedSize(Style::computedFontSizeFromSpecifiedSizeForSVGInlineText(fontDescription.computedSize(), fontDescription.isAbsoluteSize(), scalingFactor, renderer.document()));
+    fontDescription.setComputedSize(Style::computedFontSizeFromSpecifiedSizeForSVGInlineText(fontDescription.specifiedSize(), fontDescription.isAbsoluteSize(), scalingFactor, renderer.document()));
 
     // SVG controls its own glyph orientation, so don't allow writing-mode
     // to affect it.

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -241,7 +241,7 @@ ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEMS(float value)
     if (!style)
         return Exception { NotSupportedError };
 
-    float fontSize = style->computedFontPixelSize();
+    float fontSize = style->specifiedFontSize();
     if (!fontSize)
         return Exception { NotSupportedError };
 
@@ -254,7 +254,7 @@ ExceptionOr<float> SVGLengthContext::convertValueFromEMSToUserUnits(float value)
     if (!style)
         return Exception { NotSupportedError };
 
-    return value * style->computedFontPixelSize();
+    return value * style->specifiedFontSize();
 }
 
 ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEXS(float value) const


### PR DESCRIPTION
<pre>
Account for zoom when computing SVG font size

<a href="https://bugs.webkit.org/show_bug.cgi?id=118818">https://bugs.webkit.org/show_bug.cgi?id=118818</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/5624c6e475af92d541edc8a3394602e320d00323">https://chromium.googlesource.com/chromium/blink/+/5624c6e475af92d541edc8a3394602e320d00323</a> & <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=180995">https://src.chromium.org/viewvc/blink?view=revision&revision=180995</a> & <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=154004">https://src.chromium.org/viewvc/blink?view=revision&revision=154004</a>

Previously, text that was zoomed appeared larger than geometry under the same zoom value. This was caused by two bugs:
1) When setting the computed font size, we incorrectly referenced the computedTextSize instead of the specified size.
2) Text with GeometricPrecision did not set a computed size but instead relied on the text size being correct.

Further, it also fixes an issue about optimization in RenderSVGInlineText::computeNewScaledFontForStyle would skip updating the font size on lowdpi devices while zooming. The computed font size calculation depends on zoom and the font scaling factor depends on the device's scaling factor. Previously, we would skip updating the font when the scaling factor was 1 which would fail to account for zoom. This patch updates the optimization to only be used when both the scaling factor and zoom are 1.

This change addresses both of these issues and adds a test to prove correctness.

SVG doesn't scale zoomed font units so zooming should not affect font sizes. This patch fixes a bug where em lengths were resolved against the style's font size (with zoom) instead of the specified font size (without zoom).

* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(RenderSVGInlineText::computedNewScaledFontForStyle) - Updated Scaling factor to be accounted into two buckets: 1) GeometricPrecision 2) computedTextSize being referred 3) Use DoNotUseSmartMinimumForFontSize 4) Also fix low DPI issue
* Source/WebCore/svg/SVGLengthContext.cpp: Update "convertValueFromUserUnitsToEMS" and "convertValueFromEMSToUserUnits" to use "specifiedFontSize" rather than "computedFontPixelSize"
* LayoutTests/svg/zoom/text/zoom-text-geometry.html: Added Test Case
* LayoutTests/svg/zoom/text/zoom-text-geometry-expected.html: Added Test Case Expectations
* LayoutTests/svg/zoom/text/lowdpi-zoom-text.html: Added Test Case
* LayoutTests/svg/texst/lowdpi-zoom-text-expected.txt: Added Test Case Expectations
* LayoutTets/svg/zoom/text/zoom-em-units.html: Added Test Case
* LayoutTets/svg/zoom/text/zoom-em-units-expected.html: Added Test Case Expectations

</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/488e2ebfd562800b5237959a981be11375ca5167

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91019 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100399 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/159063 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95025 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29094 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83366 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97148 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96675 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77804 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26978 "Passed tests") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70014 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35169 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15649 "Found 1 new test failure: svg/text/font-small-enlarged-minimum-larger.svg (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32967 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16636 "Found 1 new test failure: svg/text/font-small-enlarged-minimum-larger.svg (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36747 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39606 "Found 1 new test failure: svg/text/font-small-enlarged-minimum-larger.svg (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35720 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->