### PR TITLE
Wheel event does not stop macOS smooth keyboard scroll

### DIFF
--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll-expected.txt
@@ -1,0 +1,5 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Successful.
+

--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
+
+<html>
+
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <meta name="viewport" content="initial-scale=1.5, user-scalable=no">
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+        
+        async function runTest()
+        {
+            if (!window.testRunner || !testRunner.runUIScript)
+                return;
+
+            await UIHelper.rawKeyDown("downArrow");
+            
+            setTimeout(async () => {
+                await UIHelper.rawKeyUp("downArrow");
+                await UIHelper.mouseWheelScrollAt(10, 10, 0, 1, 0, 10);
+
+                const position = window.scrollY;
+                if (position <= 1) 
+                    debug("Successful.");
+                else
+                    debug("Unsuccessful. window.scrollY == " + position);
+
+                testRunner.notifyDone();
+            }, 100);
+        }
+    </script>
+</head>
+
+<body onload="runTest()">
+    <div style="height: 5000px;">
+    </div>
+</body>
+
+</html>

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -270,9 +270,7 @@ bool KeyboardScrollingAnimator::beginKeyboardScrollGesture(ScrollDirection direc
 
     auto scrollableDirections = scrollableDirectionsFromPosition(m_scrollAnimator.currentPosition());
     if (!scrollableDirections.at(boxSideForDirection(direction))) {
-        m_scrollTriggeringKeyIsPressed = false;
-        m_scrollController.didStopKeyboardScrolling();
-        m_velocity = { };
+        stopScrollingImmediately();
         return false;
     }
 
@@ -345,7 +343,13 @@ void KeyboardScrollingAnimator::handleKeyUpEvent()
         return;
 
     stopKeyboardScrollAnimation();
+}
+
+void KeyboardScrollingAnimator::stopScrollingImmediately()
+{
     m_scrollTriggeringKeyIsPressed = false;
+    m_scrollController.didStopKeyboardScrolling();
+    m_velocity = { };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.h
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.h
@@ -57,6 +57,7 @@ public:
     bool beginKeyboardScrollGesture(ScrollDirection, ScrollGranularity);
     void handleKeyUpEvent();
     void updateKeyboardScrollPosition(MonotonicTime);
+    WEBCORE_EXPORT void stopScrollingImmediately();
 
 private:
     void stopKeyboardScrollAnimation();


### PR DESCRIPTION
#### 8c822fa15adbdecd22d0c3ece07c9e9aa2260af1
<pre>
Wheel event does not stop macOS smooth keyboard scroll
<a href="https://bugs.webkit.org/show_bug.cgi?id=244303">https://bugs.webkit.org/show_bug.cgi?id=244303</a>
rdar://99101109

Reviewed by Tim Horton.

Currently, if you enable EventHandlerDrivenSmoothKeyboardScrolling,
scroll using the keyboard, then immediately after use the trackpad to
scroll, the webpage will scroll back to the position where the keyboard
scroll left off. This patch improves the smooth scroll setting so that a
wheel event tells the KeyboardScrollingAnimator to stop scrolling.

This adds a method to KeyboardScrollingAnimator, stopScrollingImmediately
 that can be called to stop the animation without taking the time
To decelerate, which is what should happen when a wheel event
Interrupts the keyboard scroll.

* LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html:
* Source/WebCore/platform/KeyboardScrollingAnimator.cpp
(WebCore::KeyboardScrollingAnimator::stopScrollingImmediately):
* Source/WebCore/platform/KeyboardScrollingAnimator.h
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp

Canonical link: <a href="https://commits.webkit.org/254561@main">https://commits.webkit.org/254561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25435827d6e73b37d5a9daa6912d7d5f8373b64a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98665 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154971 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32393 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27916 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81694 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93090 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25733 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76272 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25675 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68652 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30167 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14615 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29894 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15564 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3201 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38521 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32046 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34655 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->