### PR TITLE
Unreviewed, build fix after 254159@main

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1672,7 +1672,7 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
 
     [self _cancelInteraction];
 
-    BOOL shouldDeactivateSelection = [&] -> BOOL {
+    BOOL shouldDeactivateSelection = [&]() -> BOOL {
 #if PLATFORM(MACCATALYST)
         if (reason == EndEditingReasonResigningFirstResponder) {
             // This logic is based on a similar check on macOS (in WebViewImpl::resignFirstResponder()) to


### PR DESCRIPTION
#### 9c73247b538cfda816b528f7d927e8cdfedbfa06
<pre>
mediaSession API not showing artwork
<a href="https://bugs.webkit.org/show_bug.cgi?id=247043">https://bugs.webkit.org/show_bug.cgi?id=247043</a>
rdar://101597398

Reviewed by NOBODY (OOPS!).

When we send an artwork image to MediaRemote, recent versions now check if the dimensions of
that image are valid by calling CGImageSourceCreateWithData with the provided image
and looking at the dimensions. However, in the GPU process, CoreGraphic&apos;s decoders are disabled by default and the creation of the CGImage fails.
Adopt new MediaRemote entitlement: com.apple.mediaremote.external-artwork-validation
which will skip this check provided the dimensions are also provided to MediaRemote via the kMRMediaRemoteNowPlayingInfoArtworkDataWidth and kMRMediaRemoteNowPlayingInfoArtworkDataHeight key.

Additionally, we will now properly decode the image in the content process to
ensure its validity. This is automatically done by the RefPtr&lt;Image&gt; IPC encoder.
We then reencode that decoded image into a TIFF as MediaRemote does require a valid comppressed image.

Manually tested by temporarily removing the CG&apos;s decoders restriction until a version with the MediaRemote fix is available.

* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::ArtworkImageLoader::notifyFinished):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::nowPlayingInfo const):
* Source/WebCore/platform/NowPlayingManager.cpp:
(WebCore::NowPlayingManager::setNowPlayingInfo):
(WebCore::NowPlayingManager::setNowPlayingInfoPrivate):
* Source/WebCore/platform/NowPlayingManager.h:
* Source/WebCore/platform/audio/NowPlayingInfo.h:
(WebCore::NowPlayingInfoArtwork::encode const):
(WebCore::NowPlayingInfoArtwork::decode):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::setNowPlayingInfo):
* Source/WebCore/platform/mac/MediaRemoteSoftLink.h:
* Source/WebCore/platform/mac/MediaRemoteSoftLink.mm:
* Source/WebKit/Scripts/process-entitlements.sh:
* Tools/TestWebKitAPI/Tests/WebCore/NowPlayingInfoTests.cpp:
(TestWebKitAPI::testEmptyArtwork):
</pre>