### PR TITLE
Make MediaStreamTrack Document agnostic

### DIFF
--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -101,8 +101,6 @@ public:
 
     void addTrackFromPlatform(Ref<MediaStreamTrack>&&);
 
-    Document* document() const;
-
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const final { return m_private->logIdentifier(); }
 #endif
@@ -147,6 +145,8 @@ private:
     void statusDidChange();
 
     MediaStreamTrackVector filteredTracks(const Function<bool(const MediaStreamTrack&)>&) const;
+
+    Document* document() const;
 
     Ref<MediaStreamPrivate> m_private;
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -82,7 +82,7 @@ MediaStreamTrack::MediaStreamTrack(ScriptExecutionContext& context, Ref<MediaStr
     : ActiveDOMObject(&context)
     , m_private(WTFMove(privateTrack))
     , m_muted(m_private->muted())
-    , m_isCaptureTrack(m_private->isCaptureTrack())
+    , m_isCaptureTrack(is<Document>(context) && m_private->isCaptureTrack())
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
@@ -90,6 +90,9 @@ MediaStreamTrack::MediaStreamTrack(ScriptExecutionContext& context, Ref<MediaStr
 
     if (!isCaptureTrack())
         return;
+
+    ASSERT(isMainThread());
+    ASSERT(is<Document>(context));
 
     m_isInterrupted = m_private->source().interrupted();
     allCaptureTracks().add(this);
@@ -410,8 +413,8 @@ MediaProducerMediaStateFlags MediaStreamTrack::mediaState() const
     if (m_ended || !isCaptureTrack())
         return MediaProducer::IsNotPlaying;
 
-    auto* document = this->document();
-    if (!document || !document->page())
+    auto* context = scriptExecutionContext();
+    if (!context || !is<Document>(context) || !downcast<Document>(context)->page())
         return MediaProducer::IsNotPlaying;
 
     return sourceCaptureState(source());
@@ -465,7 +468,7 @@ MediaProducerMediaStateFlags MediaStreamTrack::captureState(Document& document)
 {
     MediaProducerMediaStateFlags state;
     for (auto* captureTrack : allCaptureTracks()) {
-        if (captureTrack->document() != &document || captureTrack->ended())
+        if (captureTrack->scriptExecutionContext() != &document || captureTrack->ended())
             continue;
         state.add(sourceCaptureState(captureTrack->source()));
     }
@@ -475,16 +478,17 @@ MediaProducerMediaStateFlags MediaStreamTrack::captureState(Document& document)
 void MediaStreamTrack::updateCaptureAccordingToMutedState(Document& document)
 {
     for (auto* captureTrack : allCaptureTracks()) {
-        if (captureTrack->document() == &document && !captureTrack->ended())
+        if (captureTrack->scriptExecutionContext() == &document && !captureTrack->ended())
             captureTrack->updateToPageMutedState();
     }
 }
 
-static void updateVideoCaptureAccordingMicrophoneInterruption(Document& document, bool isMicrophoneInterrupted)
+void MediaStreamTrack::updateVideoCaptureAccordingMicrophoneInterruption(Document& document, bool isMicrophoneInterrupted)
 {
     auto* page = document.page();
     for (auto* captureTrack : allCaptureTracks()) {
-        if (!captureTrack->document() || captureTrack->document()->page() != page)
+        auto* context = captureTrack->scriptExecutionContext();
+        if (!context || downcast<Document>(context)->page() != page)
             continue;
         auto& source = captureTrack->source();
         if (!source.isEnded() && source.deviceType() == CaptureDevice::DeviceType::Camera)
@@ -495,7 +499,13 @@ static void updateVideoCaptureAccordingMicrophoneInterruption(Document& document
 void MediaStreamTrack::updateToPageMutedState()
 {
     ASSERT(isCaptureTrack());
-    auto& document = *this->document();
+    auto* context = scriptExecutionContext();
+
+    if (!context)
+        return;
+
+    ASSERT(is<Document>(context));
+    auto& document = downcast<Document>(*context);
     auto* page = document.page();
     if (!page)
         return;
@@ -551,7 +561,8 @@ void MediaStreamTrack::endCapture(Document& document, MediaProducerMediaCaptureK
 {
     bool didEndCapture = false;
     for (auto* captureTrack : allCaptureTracks()) {
-        if (captureTrack->document() != &document)
+        auto* trackDocument = downcast<Document>(captureTrack->scriptExecutionContext());
+        if (trackDocument != &document)
             continue;
         if (kind != MediaProducerMediaCaptureKind::EveryKind && kind != trackTypeForMediaProducerCaptureKind(captureTrack->privateTrack().deviceType()))
             continue;
@@ -606,12 +617,13 @@ void MediaStreamTrack::trackEnded(MediaStreamTrackPrivate&)
     
 void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
 {
-    auto* document = this->document();
-    if (document->activeDOMObjectsAreStopped() || m_ended)
+    auto* context = scriptExecutionContext();
+    if (scriptExecutionContext()->activeDOMObjectsAreStopped() || m_ended)
         return;
 
     Function<void()> updateMuted = [this, muted = m_private->muted()] {
-        if (!scriptExecutionContext() || scriptExecutionContext()->activeDOMObjectsAreStopped())
+        auto* context = scriptExecutionContext();
+        if (!context || context ->activeDOMObjectsAreStopped())
             return;
 
         if (m_muted == muted)
@@ -629,8 +641,8 @@ void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
 
     bool wasInterrupted = m_isInterrupted;
     m_isInterrupted = m_private->source().interrupted();
-    if (wasInterrupted != m_isInterrupted && m_private->source().type() == RealtimeMediaSource::Type::Audio && document->settings().muteCameraOnMicrophoneInterruptionEnabled())
-        updateVideoCaptureAccordingMicrophoneInterruption(*document, m_isInterrupted);
+    if (isCaptureTrack() && wasInterrupted != m_isInterrupted && m_private->source().type() == RealtimeMediaSource::Type::Audio && context->settingsValues().muteCameraOnMicrophoneInterruptionEnabled)
+        updateVideoCaptureAccordingMicrophoneInterruption(*downcast<Document>(context), m_isInterrupted);
 }
 
 void MediaStreamTrack::trackSettingsChanged(MediaStreamTrackPrivate&)
@@ -655,8 +667,11 @@ void MediaStreamTrack::trackEnabledChanged(MediaStreamTrackPrivate&)
 
 void MediaStreamTrack::configureTrackRendering()
 {
-    if (auto document = this->document())
-        document->updateIsPlayingMedia();
+    auto* context = scriptExecutionContext();
+    if (!context || !is<Document>(context))
+        return;
+
+    downcast<Document>(context)->updateIsPlayingMedia();
 
     // 4.3.1
     // ... media from the source only flows when a MediaStreamTrack object is both unmuted and enabled
@@ -689,11 +704,6 @@ bool MediaStreamTrack::virtualHasPendingActivity() const
 RefPtr<WebAudioSourceProvider> MediaStreamTrack::createAudioSourceProvider()
 {
     return m_private->createAudioSourceProvider();
-}
-
-Document* MediaStreamTrack::document() const
-{
-    return downcast<Document>(scriptExecutionContext());
 }
 
 bool MediaStreamTrack::isCapturingAudio() const

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -156,8 +156,6 @@ public:
 
     void setIdForTesting(String&& id) { m_private->setIdForTesting(WTFMove(id)); }
 
-    Document* document() const;
-
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_private->logger(); }
     const void* logIdentifier() const final { return m_private->logIdentifier(); }
@@ -199,6 +197,8 @@ private:
 
     // PlatformMediaSession::AudioCaptureSource
     bool isCapturingAudio() const final;
+
+    void updateVideoCaptureAccordingMicrophoneInterruption(Document&, bool);
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const final { return "MediaStreamTrack"; }

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -190,7 +190,7 @@ void UserMediaRequest::allow(CaptureDevice&& audioDevice, CaptureDevice&& videoD
             }
 
             ASSERT(document.isCapturing());
-            stream->document()->setHasCaptureMediaStreamTrack();
+            document.setHasCaptureMediaStreamTrack();
             m_promise->resolve(WTFMove(stream));
         };
 


### PR DESCRIPTION
#### a966c840dd95725bc155a3b90be0ac59d39e7bc6
<pre>
Make MediaStreamTrack Document agnostic
<a href="https://bugs.webkit.org/show_bug.cgi?id=244803">https://bugs.webkit.org/show_bug.cgi?id=244803</a>
rdar://problem/99566115

Small refactoring in case we want to allow MediaStreamTrack in worker contexts.
We explicitly check for the track context to be a Document before using it.
Capture track should always be restricted to document&apos;s context (even though they might be transferred).

Reviewed by Eric Carlson.

* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::MediaStreamTrack):
(WebCore::MediaStreamTrack::ended const):
(WebCore::MediaStreamTrack::mediaState const):
(WebCore::MediaStreamTrack::captureState):
(WebCore::MediaStreamTrack::updateCaptureAccordingToMutedState):
(WebCore::MediaStreamTrack::updateVideoCaptureAccordingMicrophoneInterruption):
(WebCore::MediaStreamTrack::updateToPageMutedState):
(WebCore::MediaStreamTrack::endCapture):
(WebCore::MediaStreamTrack::trackMutedChanged):
(WebCore::MediaStreamTrack::configureTrackRendering):
(WebCore::updateVideoCaptureAccordingMicrophoneInterruption): Deleted.
(WebCore::MediaStreamTrack::document const): Deleted.
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::allow):

Canonical link: <a href="https://commits.webkit.org/254218@main">https://commits.webkit.org/254218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af8ab5c91c5aaea69abde660657c4b4a05b48c8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97457 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152924 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31103 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26808 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92120 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24806 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75047 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24783 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67750 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28680 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13813 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28715 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14805 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2969 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37721 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33958 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->