### PR TITLE
[GTK] Crash in Nicosia::GC3DLayer::makeContextCurrent, failure to play fullscreen video due to failure in EGL display creation

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLLayer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLLayer.cpp
@@ -43,11 +43,18 @@ namespace Nicosia {
 
 using namespace WebCore;
 
-GCGLLayer::GCGLLayer(GraphicsContextGLOpenGL& context)
+std::unique_ptr<GCGLLayer> GCGLLayer::create(WebCore::GraphicsContextGLOpenGL& context)
+{
+    if (auto glContext = GLContext::createOffscreenContext(&PlatformDisplay::sharedDisplayForCompositing()))
+        return makeUnique<GCGLLayer>(context, WTFMove(glContext));
+    return nullptr;
+}
+
+GCGLLayer::GCGLLayer(GraphicsContextGLOpenGL& context, std::unique_ptr<WebCore::GLContext>&& glContext)
     : m_context(context)
+    , m_glContext(WTFMove(glContext))
     , m_contentLayer(Nicosia::ContentLayer::create(Nicosia::ContentLayerTextureMapperImpl::createFactory(*this)))
 {
-    m_glContext = GLContext::createOffscreenContext(&PlatformDisplay::sharedDisplayForCompositing());
 }
 
 GCGLLayer::~GCGLLayer()

--- a/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLLayer.h
+++ b/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLLayer.h
@@ -43,8 +43,9 @@ namespace Nicosia {
 class GCGLLayer : public ContentLayerTextureMapperImpl::Client {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit GCGLLayer(WebCore::GraphicsContextGLOpenGL&);
+    static std::unique_ptr<GCGLLayer> create(WebCore::GraphicsContextGLOpenGL&);
 
+    GCGLLayer(WebCore::GraphicsContextGLOpenGL&, std::unique_ptr<WebCore::GLContext>&&);
     virtual ~GCGLLayer();
 
     ContentLayer& contentLayer() const { return m_contentLayer; }


### PR DESCRIPTION
#### b7d555805988f56bc97e9ae21014a35a463b1987
<pre>
[GTK] Crash in Nicosia::GC3DLayer::makeContextCurrent, failure to play fullscreen video due to failure in EGL display creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=201507">https://bugs.webkit.org/show_bug.cgi?id=201507</a>

Reviewed by Žan Doberšek.

NicosiaGCGLLayer assumes the creation of the GL context can&apos;t fail and
we end up crashing when that happens for whatever reason.

* Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLLayer.cpp:
(Nicosia::GCGLLayer::create): Create the GL context and return nullptr
if it fails, otherwise pass it to the constructor.
(Nicosia::GCGLLayer::GCGLLayer): Receive the GL context as parameter too.
* Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLLayer.h:
* Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGL.cpp:
(WebCore::GraphicsContextGLOpenGL::GraphicsContextGLOpenGL): Do not
initialize the context here, move it to initialize().
(WebCore::GraphicsContextGLOpenGL::~GraphicsContextGLOpenGL): Return
early if makeContextCurrent() returns false.
(WebCore::GraphicsContextGLOpenGL::initialize): Move initialization
here, returning false if context creation or making the context current fails.
(WebCore::GraphicsContextGLOpenGL::makeContextCurrent): Null check m_nicosiaLayer.

Canonical link: <a href="https://commits.webkit.org/254183@main">https://commits.webkit.org/254183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5efe657924c4e7d903a1d5f2e1c083066ab9fc0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97461 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152928 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31111 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26812 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80450 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92124 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93876 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24809 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75054 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24785 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67752 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28684 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28718 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14811 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2941 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37729 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33962 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->