### PR TITLE
Expose MediaStreamTrack displaySurface setting

### DIFF
--- a/LayoutTests/fast/mediastream/getDisplayMedia-displaySurface-expected.txt
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-displaySurface-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Validate displaySurface settings and capabilities
+

--- a/LayoutTests/fast/mediastream/getDisplayMedia-displaySurface.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-displaySurface.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>video track created with getDisplayMedia should return correct settings</title>
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+        <script src="resources/getDisplayMedia-utils.js"></script>
+    </head>
+    <body>
+
+        <script>
+            promise_test(async () => {
+                assert_true(navigator.mediaDevices.getSupportedConstraints().displaySurface, "displaySurface constraint");
+
+                stream = await callGetDisplayMedia({ video: true });
+
+                const settings = stream.getVideoTracks()[0].getSettings();
+                assert_equals(settings.displaySurface, "monitor", "displaySurface settings");
+
+                const capabilities = stream.getVideoTracks()[0].getCapabilities();
+                assert_equals(capabilities.displaySurface, "monitor", "displaySurface capabilities");
+            }, "Validate displaySurface settings and capabilities");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -818,6 +818,7 @@ webkit.org/b/79203 fast/mediastream/RTCRtpSender-replaceTrack.html [ Failure ]
 webkit.org/b/187603 fast/mediastream/media-stream-track-source-failure.html [ Timeout Failure Pass ]
 
 fast/mediastream/mediastreamtrack-configurationchange.html [ Failure ]
+fast/mediastream/getDisplayMedia-displaySurface.html [ Failure ]
 
 webkit.org/b/223508 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-MediaElement-srcObject.https.html [ Failure Pass ]
 

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -363,6 +363,7 @@ MediaTrackSupportedConstraints MediaDevices::getSupportedConstraints()
     result.echoCancellation = supported.supportsEchoCancellation();
     result.deviceId = supported.supportsDeviceId();
     result.groupId = supported.supportsGroupId();
+    result.displaySurface = supported.supportsDisplaySurface();
 
     return result;
 }

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -273,8 +273,10 @@ MediaStreamTrack::TrackSettings MediaStreamTrack::getSettings() const
         result.deviceId = settings.deviceId();
     if (settings.supportsGroupId())
         result.groupId = settings.groupId();
+    if (settings.supportsDisplaySurface() && settings.displaySurface() != RealtimeMediaSourceSettings::DisplaySurfaceType::Invalid)
+        result.displaySurface = RealtimeMediaSourceSettings::displaySurface(settings.displaySurface());
 
-    // FIXME: shouldn't this include displaySurface and logicalSurface?
+    // FIXME: shouldn't this include logicalSurface?
 
     return result;
 }
@@ -362,6 +364,11 @@ MediaStreamTrack::TrackCapabilities MediaStreamTrack::getCapabilities() const
         result.deviceId = capabilities.deviceId();
     if (capabilities.supportsGroupId())
         result.groupId = capabilities.groupId();
+
+    auto settings = m_private->settings();
+    if (settings.supportsDisplaySurface() && settings.displaySurface() != RealtimeMediaSourceSettings::DisplaySurfaceType::Invalid)
+        result.displaySurface = RealtimeMediaSourceSettings::displaySurface(settings.displaySurface());
+
     return result;
 }
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -113,8 +113,8 @@ public:
         std::optional<int> sampleRate;
         std::optional<int> sampleSize;
         std::optional<bool> echoCancellation;
-        std::optional<bool> displaySurface;
-        String logicalSurface;
+        String displaySurface;
+        std::optional<bool> logicalSurface;
         String deviceId;
         String groupId;
     };
@@ -132,6 +132,7 @@ public:
         std::optional<Vector<bool>> echoCancellation;
         String deviceId;
         String groupId;
+        String displaySurface;
     };
     TrackCapabilities getCapabilities() const;
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
@@ -72,6 +72,7 @@ enum MediaStreamTrackState { "live", "ended" };
     // FIXME 169871: add channelCount
     DOMString deviceId;
     DOMString groupId;
+    DOMString displaySurface;
 };
 
 [
@@ -91,4 +92,5 @@ enum MediaStreamTrackState { "live", "ended" };
     // FIXME 169871: add channelCount
     DOMString deviceId;
     DOMString groupId;
+    DOMString displaySurface;
 };

--- a/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h
@@ -46,6 +46,7 @@ struct MediaTrackSupportedConstraints {
     bool echoCancellation;
     bool deviceId;
     bool groupId;
+    bool displaySurface;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl
+++ b/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl
@@ -45,4 +45,5 @@
     // FIXME 169871: add channelCount
     boolean deviceId = true;
     boolean groupId = true;
+    boolean displaySurface = true;
 };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -63,6 +63,7 @@ RealtimeMediaSourceCenter::RealtimeMediaSourceCenter()
     m_supportedConstraints.setSupportsFacingMode(true);
     m_supportedConstraints.setSupportsVolume(true);
     m_supportedConstraints.setSupportsDeviceId(true);
+    m_supportedConstraints.setSupportsDisplaySurface(true);
 }
 
 RealtimeMediaSourceCenter::~RealtimeMediaSourceCenter() = default;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
@@ -183,6 +183,25 @@ String convertEnumerationToString(RealtimeMediaSourceSettings::VideoFacingMode e
     return values[static_cast<size_t>(enumerationValue)];
 }
 
+String RealtimeMediaSourceSettings::displaySurface(RealtimeMediaSourceSettings::DisplaySurfaceType surface)
+{
+    static const NeverDestroyed<String> values[] = {
+        MAKE_STATIC_STRING_IMPL("monitor"),
+        MAKE_STATIC_STRING_IMPL("window"),
+        MAKE_STATIC_STRING_IMPL("application"),
+        MAKE_STATIC_STRING_IMPL("browser"),
+        MAKE_STATIC_STRING_IMPL("invalid"),
+    };
+
+    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Monitor) == 0, "RealtimeMediaSourceSettings::DisplaySurface::Monitor is not 0 as expected");
+    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Window) == 1, "RealtimeMediaSourceSettings::DisplaySurface::Window is not 1 as expected");
+    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Application) == 2, "RealtimeMediaSourceSettings::DisplaySurface::Application is not 0 as expected");
+    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Browser) == 3, "RealtimeMediaSourceSettings::DisplaySurface::Browser is not 1 as expected");
+    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Invalid) == 4, "RealtimeMediaSourceSettings::DisplaySurface::Invalid is not 0 as expected");
+    ASSERT(static_cast<size_t>(surface) < WTF_ARRAY_LENGTH(values));
+    return values[static_cast<size_t>(surface)];
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
@@ -38,9 +38,18 @@ namespace WebCore {
 class RealtimeMediaSourceSettings {
 public:
     enum VideoFacingMode { Unknown, User, Environment, Left, Right };
+    enum class DisplaySurfaceType {
+        Monitor,
+        Window,
+        Application,
+        Browser,
+        Invalid,
+    };
+
 
     static String facingMode(RealtimeMediaSourceSettings::VideoFacingMode);
     static RealtimeMediaSourceSettings::VideoFacingMode videoFacingModeEnum(const String&);
+    static String displaySurface(RealtimeMediaSourceSettings::DisplaySurfaceType);
 
     enum Flag {
         Width = 1 << 0,
@@ -109,14 +118,6 @@ public:
     const AtomString& groupId() const { return m_groupId; }
     void setGroupId(const AtomString& groupId) { m_groupId = groupId; }
 
-    enum class DisplaySurfaceType {
-        Monitor,
-        Window,
-        Application,
-        Browser,
-        Invalid,
-    };
-
     bool supportsDisplaySurface() const { return m_supportedConstraints.supportsDisplaySurface(); }
     DisplaySurfaceType displaySurface() const { return m_displaySurface; }
     void setDisplaySurface(DisplaySurfaceType displaySurface) { m_displaySurface = displaySurface; }
@@ -170,6 +171,8 @@ void RealtimeMediaSourceSettings::encode(Encoder& encoder) const
         << m_echoCancellation
         << m_deviceId
         << m_groupId
+        << m_displaySurface
+        << m_logicalSurface
         << m_label
         << m_supportedConstraints;
     encoder << m_facingMode;
@@ -188,6 +191,8 @@ bool RealtimeMediaSourceSettings::decode(Decoder& decoder, RealtimeMediaSourceSe
         && decoder.decode(settings.m_echoCancellation)
         && decoder.decode(settings.m_deviceId)
         && decoder.decode(settings.m_groupId)
+        && decoder.decode(settings.m_displaySurface)
+        && decoder.decode(settings.m_logicalSurface)
         && decoder.decode(settings.m_label)
         && decoder.decode(settings.m_supportedConstraints)
         && decoder.decode(settings.m_facingMode);
@@ -207,6 +212,17 @@ template <> struct EnumTraits<WebCore::RealtimeMediaSourceSettings::VideoFacingM
         WebCore::RealtimeMediaSourceSettings::VideoFacingMode::Environment,
         WebCore::RealtimeMediaSourceSettings::VideoFacingMode::Left,
         WebCore::RealtimeMediaSourceSettings::VideoFacingMode::Right
+    >;
+};
+
+template <> struct EnumTraits<WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType> {
+    using values = EnumValues<
+        WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType,
+        WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType::Monitor,
+        WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType::Window,
+        WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType::Application,
+        WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType::Browser,
+        WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType::Invalid
     >;
 };
 


### PR DESCRIPTION
#### be6fd53362dbf2fe352c8db59b7f4568742c95d1
<pre>
Expose MediaStreamTrack displaySurface setting
<a href="https://bugs.webkit.org/show_bug.cgi?id=244809">https://bugs.webkit.org/show_bug.cgi?id=244809</a>
rdar://problem/99568246

Expose in WebIDL displaySurface as per <a href="https://w3c.github.io/mediacapture-screen-share/#extensions-to-mediatrackconstraintset.">https://w3c.github.io/mediacapture-screen-share/#extensions-to-mediatrackconstraintset.</a>
Add necesary IPC encoding/decoding code.

Reviewed by Eric Carlson.

* LayoutTests/fast/mediastream/getDisplayMedia-displaySurface-expected.txt: Added.
* LayoutTests/fast/mediastream/getDisplayMedia-displaySurface.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::getSupportedConstraints):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::getSettings const):
(WebCore::MediaStreamTrack::getCapabilities const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.idl:
* Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h:
* Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp:
(WebCore::RealtimeMediaSourceCenter::RealtimeMediaSourceCenter):
(WebCore::RealtimeMediaSourceSettings::displaySurface):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h:
(WebCore::RealtimeMediaSourceSettings::encode const):
(WebCore::RealtimeMediaSourceSettings::decode):

Canonical link: <a href="https://commits.webkit.org/254216@main">https://commits.webkit.org/254216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c604012894a13f5a6882eded144fd18fd97a447

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88346 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97536 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153007 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31264 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26926 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80553 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92193 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24881 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75181 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24864 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67828 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28865 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28848 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14902 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2968 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37817 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34021 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->