### PR TITLE
CoordinatedGraphics: fix includes when COORDINATED_GRAPHICS is not set

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -37,9 +37,6 @@
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RunLoop.h>
-#if PLATFORM(GTK)
-#include <WebCore/CoordinatedGraphicsLayer.h>
-#endif
 
 #if USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
 
@@ -48,6 +45,7 @@
 #else // USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
 
 namespace WebCore {
+class CoordinatedGraphicsLayer;
 class IntRect;
 class IntSize;
 class GraphicsLayer;
@@ -234,6 +232,7 @@ inline void LayerTreeHost::scrollNonCompositedContents(const WebCore::IntRect&) 
 inline void LayerTreeHost::forceRepaint() { }
 inline void LayerTreeHost::forceRepaintAsync(CompletionHandler<void()>&&) { }
 inline void LayerTreeHost::sizeDidChange(const WebCore::IntSize&) { }
+inline void LayerTreeHost::targetRefreshRateDidChange(unsigned) { }
 inline void LayerTreeHost::pauseRendering() { }
 inline void LayerTreeHost::resumeRendering() { }
 inline WebCore::GraphicsLayerFactory* LayerTreeHost::graphicsLayerFactory() { return nullptr; }
@@ -242,6 +241,10 @@ inline void LayerTreeHost::didChangeViewportAttributes(WebCore::ViewportAttribut
 inline void LayerTreeHost::setIsDiscardable(bool) { }
 inline void LayerTreeHost::deviceOrPageScaleFactorChanged() { }
 inline RefPtr<WebCore::DisplayRefreshMonitor> LayerTreeHost::createDisplayRefreshMonitor(WebCore::PlatformDisplayID) { return nullptr; }
+#if PLATFORM(GTK)
+inline void LayerTreeHost::adjustTransientZoom(double, WebCore::FloatPoint) { }
+inline void LayerTreeHost::commitTransientZoom(double, WebCore::FloatPoint) { }
+#endif
 #endif
 
 } // namespace WebKit


### PR DESCRIPTION
#### f06201ca85137bd3dbfdc52ccc475d18ed2332e4
<pre>
CoordinatedGraphics: fix includes when COORDINATED_GRAPHICS is not set

<a href="https://bugs.webkit.org/show_bug.cgi?id=244811">https://bugs.webkit.org/show_bug.cgi?id=244811</a>

Reviewed by Fujii Hironori.

COORDINATED_GRAPHICS is not set if USE_OPENGL_OR_ES=OFF

- Forward declare CoordinatedGraphicsLayer, the header will be
  included in CompositingCoordinator if COORDINATED_GRAPHICS is set.

- The LayerTreeHost.cpp is not compiled if the COORDINATED_GRAPHICS
  flag is not set, so extend the mocked function list.

Signed-off-by: Thomas Devoogdt &lt;thomas.devoogdt@barco.com&gt;

Canonical link: <a href="https://commits.webkit.org/254220@main">https://commits.webkit.org/254220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46379f5b58524162015fdae096d5a8afe2a134ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97620 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31427 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27048 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80639 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92275 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24983 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75330 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24942 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67905 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29035 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/29019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/14979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2972 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32237 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31126 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/34088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->