### PR TITLE
Web Inspector: Make frontend engineering settings available behind a debug runtime flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesDebug.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesDebug.yaml
@@ -185,3 +185,13 @@ VisibleDebugOverlayRegions:
     WebCore:
       default: 0
 
+WebInspectorEngineeringSettingsAllowed:
+  type: bool
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -75,6 +75,10 @@
 #include <wtf/persistence/PersistentDecoder.h>
 #include <wtf/text/Base64.h>
 
+#if PLATFORM(COCOA)
+#include <wtf/spi/darwin/OSVariantSPI.h>
+#endif
+
 namespace WebCore {
 
 using namespace Inspector;
@@ -634,6 +638,21 @@ void InspectorFrontendHost::setAllowsInspectingInspector(bool allow)
     m_frontendPage->settings().setDeveloperExtrasEnabled(allow);
     if (m_client)
         m_client->setInspectorPageDeveloperExtrasEnabled(m_frontendPage->settings().developerExtrasEnabled());
+}
+
+bool InspectorFrontendHost::engineeringSettingsAllowed()
+{
+    if (!m_frontendPage)
+        return false;
+
+    if (!m_frontendPage->settings().webInspectorEngineeringSettingsAllowed())
+        return false;
+#if PLATFORM(COCOA)
+    static bool allowsInternalSecurityPolicies = os_variant_allows_internal_security_policies("com.apple.WebKit");
+    if (!allowsInternalSecurityPolicies)
+        return false;
+#endif
+    return true;
 }
 
 bool InspectorFrontendHost::supportsShowCertificate() const

--- a/Source/WebCore/inspector/InspectorFrontendHost.h
+++ b/Source/WebCore/inspector/InspectorFrontendHost.h
@@ -145,6 +145,8 @@ public:
     bool isBeingInspected();
     void setAllowsInspectingInspector(bool);
 
+    bool engineeringSettingsAllowed();
+
     bool supportsDiagnosticLogging();
 #if ENABLE(INSPECTOR_TELEMETRY)
     bool diagnosticLoggingAvailable();

--- a/Source/WebCore/inspector/InspectorFrontendHost.idl
+++ b/Source/WebCore/inspector/InspectorFrontendHost.idl
@@ -98,6 +98,8 @@
     boolean isBeingInspected();
     undefined setAllowsInspectingInspector(boolean allow);
 
+    boolean engineeringSettingsAllowed();
+
     readonly attribute boolean supportsDiagnosticLogging;
     [Conditional=INSPECTOR_TELEMETRY] undefined logDiagnosticEvent(DOMString eventName, DOMString content);
 

--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -3579,6 +3579,11 @@ WI.reset = async function()
 };
 
 WI.isEngineeringBuild = false;
+WI.inspectorFrontendHostAllowsEngineeringSettings = InspectorFrontendHost.engineeringSettingsAllowed();
+
+WI.engineeringSettingsAllowed = function() {
+    return WI.isEngineeringBuild || WI.inspectorFrontendHostAllowsEngineeringSettings;
+}
 
 // OpenResourceDialog delegate
 

--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -153,15 +153,15 @@ WI.EngineeringSetting = class EngineeringSetting extends WI.Setting
 {
     get value()
     {
-        if (WI.isEngineeringBuild)
+        if (WI.engineeringSettingsAllowed())
             return super.value;
         return this.defaultValue;
     }
 
     set value(value)
     {
-        console.assert(WI.isEngineeringBuild);
-        if (WI.isEngineeringBuild)
+        console.assert(WI.engineeringSettingsAllowed());
+        if (WI.engineeringSettingsAllowed())
             super.value = value;
     }
 };
@@ -248,7 +248,6 @@ WI.settings = {
     engineeringShowInternalObjectsInHeapSnapshot: new WI.EngineeringSetting("engineering-show-internal-objects-in-heap-snapshot", false),
     engineeringShowPrivateSymbolsInHeapSnapshot: new WI.EngineeringSetting("engineering-show-private-symbols-in-heap-snapshot", false),
     engineeringAllowEditingUserAgentShadowTrees: new WI.EngineeringSetting("engineering-allow-editing-user-agent-shadow-trees", false),
-    engineeringShowMockWebExtensionTab: new WI.EngineeringSetting("engineering-show-mock-web-extension-tab", false),
 
     // Debug
     debugShowConsoleEvaluations: new WI.DebugSetting("debug-show-console-evaluations", false),
@@ -259,4 +258,5 @@ WI.settings = {
     debugEnableDiagnosticLogging: new WI.DebugSetting("debug-enable-diagnostic-logging", true),
     debugAutoLogDiagnosticEvents: new WI.DebugSetting("debug-auto-log-diagnostic-events", false),
     debugLayoutDirection: new WI.DebugSetting("debug-layout-direction-override", "system"),
+    debugShowMockWebExtensionTab: new WI.DebugSetting("debug-show-mock-web-extension-tab", false),
 };

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -73,7 +73,7 @@ WI.DOMManager = class DOMManager extends WI.Object
                 this.ensureDocument();
             });
 
-            if (WI.isEngineeringBuild) {
+            if (WI.engineeringSettingsAllowed()) {
                 if (DOMManager.supportsEditingUserAgentShadowTrees({target}))
                     target.DOMAgent.setAllowEditingUserAgentShadowTrees(WI.settings.engineeringAllowEditingUserAgentShadowTrees.value);
             }

--- a/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
@@ -51,7 +51,7 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
         WI.settings.blackboxBreakpointEvaluations.addEventListener(WI.Setting.Event.Changed, this._handleBlackboxBreakpointEvaluationsChange, this);
 
-        if (WI.isEngineeringBuild) {
+        if (WI.engineeringSettingsAllowed()) {
             WI.settings.engineeringShowInternalScripts.addEventListener(WI.Setting.Event.Changed, this._handleEngineeringShowInternalScriptsSettingChanged, this);
             WI.settings.engineeringPauseForInternalScripts.addEventListener(WI.Setting.Event.Changed, this._handleEngineeringPauseForInternalScriptsSettingChanged, this);
         }
@@ -259,7 +259,7 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
         this._setBlackboxBreakpointEvaluations(target);
 
-        if (WI.isEngineeringBuild) {
+        if (WI.engineeringSettingsAllowed()) {
             // COMPATIBILITY (iOS 12): DebuggerAgent.setPauseForInternalScripts did not exist yet.
             if (target.hasCommand("Debugger.setPauseForInternalScripts"))
                 target.DebuggerAgent.setPauseForInternalScripts(WI.settings.engineeringPauseForInternalScripts.value);

--- a/Source/WebInspectorUI/UserInterface/Debug/Bootstrap.js
+++ b/Source/WebInspectorUI/UserInterface/Debug/Bootstrap.js
@@ -151,7 +151,7 @@ WI.runBootstrapOperations = function() {
         };
 
         // Simulates the steps taken by WebInspectorUIExtensionController to create an extension tab in WebInspectorUI.
-        if (!WI.settings.engineeringShowMockWebExtensionTab.value) {
+        if (!WI.settings.debugShowMockWebExtensionTab.value) {
             if (WI.sharedApp.extensionController.registeredExtensionIDs.has(mockData.extensionID))
                 InspectorFrontendAPI.unregisterExtension(mockData.extensionID);
 
@@ -170,7 +170,7 @@ WI.runBootstrapOperations = function() {
             return;
         }
     }
-    WI.settings.engineeringShowMockWebExtensionTab.addEventListener(WI.Setting.Event.Changed, updateMockWebExtensionTab, WI.settings.engineeringShowMockWebExtensionTab);
+    WI.settings.debugShowMockWebExtensionTab.addEventListener(WI.Setting.Event.Changed, updateMockWebExtensionTab, WI.settings.debugShowMockWebExtensionTab);
     updateMockWebExtensionTab();
 
     WI.showDebugUISetting.addEventListener(WI.Setting.Event.Changed, function(event) {

--- a/Source/WebInspectorUI/UserInterface/Test/Test.js
+++ b/Source/WebInspectorUI/UserInterface/Test/Test.js
@@ -159,6 +159,8 @@ WI.isDebugUIEnabled = () => false;
 
 WI.isEngineeringBuild = false;
 
+WI.engineeringSettingsAllowed = () => WI.isEngineeringBuild;
+
 WI.unlocalizedString = (string) => string;
 WI.UIString = (string, key, comment) => string;
 

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -187,9 +187,10 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
 
         this._createExperimentalSettingsView();
 
-        if (WI.isEngineeringBuild) {
+        if (WI.engineeringSettingsAllowed())
             this._createEngineeringSettingsView();
 
+        if (WI.isEngineeringBuild) {
             WI.showDebugUISetting.addEventListener(WI.Setting.Event.Changed, this._updateDebugSettingsViewVisibility, this);
             this._updateDebugSettingsViewVisibility();
         }
@@ -447,7 +448,7 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
 
     _createEngineeringSettingsView()
     {
-        // These settings are only ever shown in engineering builds, so the strings are unlocalized.
+        // These settings are only ever shown when engineering tools are enabled or in engineering builds, so the strings are unlocalized.
 
         let engineeringSettingsView = new WI.SettingsView("engineering", WI.unlocalizedString("Engineering"));
 
@@ -466,9 +467,6 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         let heapSnapshotGroup = engineeringSettingsView.addGroup(WI.unlocalizedString("Heap Snapshot:"));
         heapSnapshotGroup.addSetting(WI.settings.engineeringShowInternalObjectsInHeapSnapshot, WI.unlocalizedString("Show Internal Objects"));
         heapSnapshotGroup.addSetting(WI.settings.engineeringShowPrivateSymbolsInHeapSnapshot, WI.unlocalizedString("Show Private Symbols"));
-
-        let extensionsGroup = engineeringSettingsView.addGroup(WI.unlocalizedString("Web Extensions:"));
-        extensionsGroup.addSetting(WI.settings.engineeringShowMockWebExtensionTab, WI.unlocalizedString("Show Mock Web Extension tab"));
 
         this.addSettingsView(engineeringSettingsView);
     }
@@ -526,6 +524,11 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         layoutDirectionEditor.addEventListener(WI.SettingEditor.Event.ValueDidChange, function(event) {
             WI.setLayoutDirection(this.value);
         }, layoutDirectionEditor);
+
+        this._debugSettingsView.addSeparator();
+
+        let extensionsGroup = this._debugSettingsView.addGroup(WI.unlocalizedString("Web Extensions:"));
+        extensionsGroup.addSetting(WI.settings.debugShowMockWebExtensionTab, WI.unlocalizedString("Show Mock Web Extension tab"));
 
         this._debugSettingsView.addSeparator();
 


### PR DESCRIPTION
#### 2326b1146886546de0d44f6aa85415b2e1257b8a
<pre>
Web Inspector: Make frontend engineering settings available behind a debug runtime flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=244819">https://bugs.webkit.org/show_bug.cgi?id=244819</a>
rdar://98957031

Reviewed by Devin Rousso.

Make it slightly easier to use the engineering settings by allowing platforms to define various additional circumstances
under which engineering settings are available.

This is not done as additional functionality behind `DeveloperExtrasEnabled`, as that setting is currently used in some
applications to enable the &quot;Inspect Element&quot; context menu item, but these settings are not generally useful for the
users of those applications.

&quot;Debug&quot; settings and functionality remain limited to local engineering builds.

* Source/WTF/Scripts/Preferences/WebPreferencesDebug.yaml:
- Add a runtime preference to control engineering setting availability.

* Source/WebCore/inspector/InspectorFrontendHost.cpp:
(WebCore::InspectorFrontendHost::engineeringSettingsAllowed):
* Source/WebCore/inspector/InspectorFrontendHost.h:
* Source/WebCore/inspector/InspectorFrontendHost.idl:

* Source/WebInspectorUI/UserInterface/Base/Main.js:
* Source/WebInspectorUI/UserInterface/Test/Test.js:
* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.prototype.initializeTarget):
* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype.async initializeTarget):
- Add helper to determine if engineering settings should be available based on both the preference and the actual build.

* Source/WebInspectorUI/UserInterface/Base/Setting.js:
(WI.EngineeringSetting.prototype.get value):
(WI.EngineeringSetting.prototype.set value):
(WI.EngineeringSetting):
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype.initialLayout):
(WI.SettingsTabContentView.prototype._createEngineeringSettingsView):
(WI.SettingsTabContentView.prototype._createDebugSettingsView):
* Source/WebInspectorUI/UserInterface/Debug/Bootstrap.js:
(updateMockWebExtensionTab):
(WI.runBootstrapOperations):
- Move the mock inspector extension tab setting to the Debug section, since it relies on Debug/Bootstrap.js being in the
build.

Canonical link: <a href="https://commits.webkit.org/254676@main">https://commits.webkit.org/254676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d07e8dd5a63c1cb189ceda20c0dbe999b4e5899e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99123 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155940 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32837 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28285 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82148 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93473 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26093 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76626 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26025 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69023 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81452 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30589 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14897 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76319 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30334 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15834 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26440 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3284 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33788 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38786 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-toggle-in-inactive-document-crash.html (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/78905 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34922 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17286 "Passed tests") | 
<!--EWS-Status-Bubble-End-->