### PR TITLE
[OpenSSL] Use AES_wrap_key/AES_unwrap_key directly to wrap/unwrap keys

### DIFF
--- a/Source/WebCore/crypto/openssl/OpenSSLUtilities.cpp
+++ b/Source/WebCore/crypto/openssl/OpenSSLUtilities.cpp
@@ -105,6 +105,33 @@ BIGNUMPtr convertToBigNumber(const Vector<uint8_t>& bytes)
     return BIGNUMPtr(BN_bin2bn(bytes.data(), bytes.size(), nullptr));
 }
 
+bool AESKey::setKey(const Vector<uint8_t>& key, int enc)
+{
+    size_t keySize = key.size() * 8;
+    if (keySize != 128 && keySize != 192 && keySize != 256)
+        return false;
+
+    if (enc == AES_ENCRYPT) {
+        if (AES_set_encrypt_key(key.data(), keySize, &m_key) < 0)
+            return false;
+        return true;
+    }
+
+    if (enc == AES_DECRYPT) {
+        if (AES_set_decrypt_key(key.data(), keySize, &m_key) < 0)
+            return false;
+        return true;
+    }
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
+AESKey::~AESKey()
+{
+    memset(&m_key, 0, sizeof m_key);
+}
+
 } // namespace WebCore
 
 

--- a/Source/WebCore/crypto/openssl/OpenSSLUtilities.h
+++ b/Source/WebCore/crypto/openssl/OpenSSLUtilities.h
@@ -27,8 +27,10 @@
 
 #include "CryptoAlgorithmIdentifier.h"
 #include "OpenSSLCryptoUniquePtr.h"
+#include <openssl/aes.h>
 #include <openssl/evp.h>
 #include <stdint.h>
+#include <wtf/NonCopyable.h>
 #include <wtf/Vector.h>
 
 #if ENABLE(WEB_CRYPTO)
@@ -44,6 +46,19 @@ Vector<uint8_t> convertToBytes(const BIGNUM*);
 Vector<uint8_t> convertToBytesExpand(const BIGNUM*, size_t bufferSize);
 
 BIGNUMPtr convertToBigNumber(const Vector<uint8_t>& bytes);
+
+class AESKey {
+    WTF_MAKE_NONCOPYABLE(AESKey);
+public:
+    AESKey() = default;
+    ~AESKey();
+
+    bool setKey(const Vector<uint8_t>& key, int enc /* AES_ENCRYPT or AES_DECRYPT */);
+
+    AES_KEY* key() { return &m_key; }
+private:
+    AES_KEY m_key;
+};
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 5eeccd33fb42f133005c6a210eefcb3492233ec3
<pre>
[OpenSSL] Use AES_wrap_key/AES_unwrap_key directly to wrap/unwrap keys
<a href="https://bugs.webkit.org/show_bug.cgi?id=244784">https://bugs.webkit.org/show_bug.cgi?id=244784</a>

Reviewed by Don Olmstead.

EVP_aes_*_wrap functions are not present in boringssl. Use
AES_wrap_key/AES_unwrap_key directly to compile this with boringssl.

AESKey OpenSSL utility class is introduced to wrap the AES_KEY struct
to force clear the memory in its destructor.

* Source/WebCore/crypto/openssl/CryptoAlgorithmAES_KWOpenSSL.cpp:
(WebCore::cryptWrapKey):
(WebCore::cryptUnwrapKey):
(WebCore::aesAlgorithm): Deleted.
* Source/WebCore/crypto/openssl/OpenSSLUtilities.cpp:
(WebCore::AESKey::setKey):
(WebCore::AESKey::~AESKey):
* Source/WebCore/crypto/openssl/OpenSSLUtilities.h:
(WebCore::AESKey::key):

Canonical link: <a href="https://commits.webkit.org/254171@main">https://commits.webkit.org/254171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ddee9717c7c303eafce99710d1d15981df8b7b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97503 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152969 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31191 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26871 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80504 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92159 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24844 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75118 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24817 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67783 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28779 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28781 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14857 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2929 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37767 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33991 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->