### PR TITLE
Merge Element::attributeChanged and Element::parseAttribute and avoid base class calls when an attribute is handled

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -366,9 +366,11 @@ bool HTMLModelElement::isInteractive() const
 
 void HTMLModelElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason reason)
 {
-    HTMLElement::attributeChanged(name, oldValue, newValue, reason);
-    if (m_modelPlayer && name == HTMLNames::interactiveAttr)
-        m_modelPlayer->setInteractionEnabled(isInteractive());
+    if (name == HTMLNames::interactiveAttr) {
+        if (m_modelPlayer)
+            m_modelPlayer->setInteractionEnabled(isInteractive());
+    } else
+        HTMLElement::attributeChanged(name, oldValue, newValue, reason);
 }
 
 void HTMLModelElement::defaultEventHandler(Event& event)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -294,10 +294,6 @@ public:
         ModifiedByCloning
     };
 
-    // These functions are called whenever an attribute is added, changed or removed.
-    virtual void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = ModifiedDirectly);
-    virtual void parseAttribute(const QualifiedName&, const AtomString&) { }
-
     // Only called by the parser immediately after element construction.
     void parserSetAttributes(const Vector<Attribute>&);
 
@@ -700,9 +696,14 @@ protected:
     void removeAllEventListeners() final;
     virtual void parserDidSetAttributes();
 
+    // This function is called whenever an attribute is added, changed or removed.
+    virtual void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason);
+
     void setTabIndexExplicitly(std::optional<int>);
 
+    void idAttributeChanged(const AtomString& oldValue, const AtomString& newValue);
     void classAttributeChanged(const AtomString& newClassString);
+    void nameAttributeChanged(const AtomString& newValue);
     void partAttributeChanged(const AtomString& newValue);
 
     void addShadowRoot(Ref<ShadowRoot>&&);
@@ -737,6 +738,7 @@ private:
     void willModifyAttribute(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue);
     void didModifyAttribute(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue);
     void didRemoveAttribute(const QualifiedName&, const AtomString& oldValue);
+    void notifyAttributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = ModifiedDirectly);
 
     void synchronizeAttribute(const QualifiedName&) const;
     void synchronizeAttribute(const AtomString& localName) const;

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -174,18 +174,22 @@ MutableStyleProperties& StyledElement::ensureMutableInlineStyle()
     return downcast<MutableStyleProperties>(*inlineStyle);
 }
 
+void StyledElement::attributeWithPresentationalHintChanged()
+{
+    elementData()->setPresentationalHintStyleIsDirty(true);
+    invalidateStyle();
+}
+
 void StyledElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason reason)
 {
-    if (oldValue != newValue) {
-        if (name == styleAttr)
-            styleAttributeChanged(newValue, reason);
-        else if (hasPresentationalHintsForAttribute(name)) {
-            elementData()->setPresentationalHintStyleIsDirty(true);
-            invalidateStyle();
-        }
-    }
+    if (name == styleAttr)
+        styleAttributeChanged(newValue, reason);
+    else {
+        if (hasPresentationalHintsForAttribute(name))
+            attributeWithPresentationalHintChanged();
 
-    Element::attributeChanged(name, oldValue, newValue, reason);
+        Element::attributeChanged(name, oldValue, newValue, reason);
+    }
 }
 
 PropertySetCSSStyleDeclaration* StyledElement::inlineStyleCSSOMWrapper()

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -74,6 +74,8 @@ protected:
     }
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = ModifiedDirectly) override;
+    void styleAttributeChanged(const AtomString& newStyleString, AttributeModificationReason);
+    void attributeWithPresentationalHintChanged();
 
     virtual bool hasPresentationalHintsForAttribute(const QualifiedName&) const { return false; }
 
@@ -84,7 +86,6 @@ protected:
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const override;
 
 private:
-    void styleAttributeChanged(const AtomString& newStyleString, AttributeModificationReason);
     void synchronizeStyleAttributeInternalImpl();
 
     void inlineStyleChanged();

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -237,7 +237,7 @@ void HTMLAnchorElement::setActive(bool down, Style::InvalidationScope invalidati
     HTMLElement::setActive(down, invalidationScope);
 }
 
-void HTMLAnchorElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLAnchorElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == hrefAttr) {
         bool wasLink = isLink();
@@ -251,8 +251,6 @@ void HTMLAnchorElement::parseAttribute(const QualifiedName& name, const AtomStri
                     document().frame()->loader().client().prefetchDNS(document().completeURL(parsedURL).host().toString());
             }
         }
-    } else if (name == nameAttr || name == titleAttr) {
-        // Do nothing.
     } else if (name == relAttr) {
         // Update HTMLAnchorElement::relList() if more rel attributes values are supported.
         static MainThreadNeverDestroyed<const AtomString> noReferrer("noreferrer"_s);
@@ -269,7 +267,7 @@ void HTMLAnchorElement::parseAttribute(const QualifiedName& name, const AtomStri
             m_relList->associatedAttributeValueChanged(value);
     }
     else
-        HTMLElement::parseAttribute(name, value);
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 bool HTMLAnchorElement::isURLAttribute(const Attribute& attribute) const

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -83,7 +83,7 @@ public:
 protected:
     HTMLAnchorElement(const QualifiedName&, Document&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
 
 private:
     bool supportsFocus() const override;

--- a/Source/WebCore/html/HTMLAreaElement.cpp
+++ b/Source/WebCore/html/HTMLAreaElement.cpp
@@ -53,7 +53,7 @@ Ref<HTMLAreaElement> HTMLAreaElement::create(const QualifiedName& tagName, Docum
     return adoptRef(*new HTMLAreaElement(tagName, document));
 }
 
-void HTMLAreaElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLAreaElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == shapeAttr) {
         if (equalLettersIgnoringASCIICase(value, "default"_s))
@@ -73,7 +73,7 @@ void HTMLAreaElement::parseAttribute(const QualifiedName& name, const AtomString
     } else if (name == altAttr) {
         // Do nothing.
     } else
-        HTMLAnchorElement::parseAttribute(name, value);
+        HTMLAnchorElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void HTMLAreaElement::invalidateCachedRegion()

--- a/Source/WebCore/html/HTMLAreaElement.h
+++ b/Source/WebCore/html/HTMLAreaElement.h
@@ -52,7 +52,7 @@ public:
 private:
     HTMLAreaElement(const QualifiedName&, Document&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool supportsFocus() const final;
     AtomString target() const final;
     bool isKeyboardFocusable(KeyboardEvent*) const final;

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -166,21 +166,20 @@ RefPtr<HTMLImageElement> HTMLAttachmentElement::enclosingImageElement() const
     return { };
 }
 
-void HTMLAttachmentElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLAttachmentElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == progressAttr || name == subtitleAttr || name == titleAttr || name == typeAttr) {
-        if (auto* renderer = this->renderer())
-            renderer->invalidate();
-    }
-
-    HTMLElement::parseAttribute(name, value);
-
 #if ENABLE(SERVICE_CONTROLS)
     if (name == typeAttr && attachmentType() == "application/pdf"_s) {
         setImageMenuEnabled(true);
         ImageControlsMac::updateImageControls(*this);
     }
 #endif
+
+    if (name == progressAttr || name == subtitleAttr || name == titleAttr || name == typeAttr) {
+        if (auto* renderer = this->renderer())
+            renderer->invalidate();
+    } else
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 String HTMLAttachmentElement::attachmentTitle() const

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -95,7 +95,7 @@ private:
 #endif
     }
     bool canContainRangeEndPoint() const final { return false; }
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
 #if ENABLE(SERVICE_CONTROLS)
     bool childShouldCreateRenderer(const Node&) const final;

--- a/Source/WebCore/html/HTMLBaseElement.cpp
+++ b/Source/WebCore/html/HTMLBaseElement.cpp
@@ -47,12 +47,12 @@ Ref<HTMLBaseElement> HTMLBaseElement::create(const QualifiedName& tagName, Docum
     return adoptRef(*new HTMLBaseElement(tagName, document));
 }
 
-void HTMLBaseElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLBaseElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == hrefAttr || name == targetAttr)
         document().processBaseElement();
     else
-        HTMLElement::parseAttribute(name, value);
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 Node::InsertedIntoAncestorResult HTMLBaseElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/html/HTMLBaseElement.h
+++ b/Source/WebCore/html/HTMLBaseElement.h
@@ -39,7 +39,7 @@ private:
 
     AtomString target() const final;
     bool isURLAttribute(const Attribute&) const final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;
 };

--- a/Source/WebCore/html/HTMLBodyElement.h
+++ b/Source/WebCore/html/HTMLBodyElement.h
@@ -39,7 +39,7 @@ public:
 private:
     HTMLBodyElement(const QualifiedName&, Document&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -106,7 +106,7 @@ bool HTMLButtonElement::hasPresentationalHintsForAttribute(const QualifiedName& 
     return HTMLFormControlElement::hasPresentationalHintsForAttribute(name);
 }
 
-void HTMLButtonElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLButtonElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == typeAttr) {
         Type oldType = m_type;
@@ -122,7 +122,7 @@ void HTMLButtonElement::parseAttribute(const QualifiedName& name, const AtomStri
                 form()->resetDefaultButton();
         }
     } else
-        HTMLFormControlElement::parseAttribute(name, value);
+        HTMLFormControlElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void HTMLButtonElement::defaultEventHandler(Event& event)

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -55,7 +55,7 @@ private:
 
     int defaultTabIndex() const final;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void defaultEventHandler(Event&) final;
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -170,11 +170,12 @@ void HTMLCanvasElement::collectPresentationalHintsForAttribute(const QualifiedNa
         HTMLElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
-void HTMLCanvasElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLCanvasElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == widthAttr || name == heightAttr)
         reset();
-    HTMLElement::parseAttribute(name, value);
+    else
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 RenderPtr<RenderElement> HTMLCanvasElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& insertionPosition)

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -153,7 +153,7 @@ private:
     // EventTarget.
     void eventListenersDidChange() final;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -130,7 +130,7 @@ bool HTMLDetailsElement::isActiveSummary(const HTMLSummaryElement& summary) cons
     return slot == m_summarySlot.get();
 }
 
-void HTMLDetailsElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLDetailsElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == openAttr) {
         bool oldValue = m_isOpen;
@@ -154,7 +154,7 @@ void HTMLDetailsElement::parseAttribute(const QualifiedName& name, const AtomStr
             m_isToggleEventTaskQueued = true;
         }
     } else
-        HTMLElement::parseAttribute(name, value);
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -41,7 +41,7 @@ private:
     HTMLDetailsElement(const QualifiedName&, Document&);
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
     bool hasCustomFocusLogic() const final { return true; }

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -161,7 +161,7 @@ protected:
     void applyBorderAttributeToStyle(const AtomString&, MutableStyleProperties&);
 
     bool matchesReadWritePseudoClass() const override;
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     Node::InsertedIntoAncestorResult insertedIntoAncestor(InsertionType , ContainerNode& parentOfInsertedTree) override;
     void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) override;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -95,7 +95,7 @@ static bool hasTypeOrSrc(const HTMLEmbedElement& embed)
     return embed.hasAttributeWithoutSynchronization(typeAttr) || embed.hasAttributeWithoutSynchronization(srcAttr);
 }
 
-void HTMLEmbedElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLEmbedElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == typeAttr) {
         m_serviceType = value.string().left(value.find(';')).convertToASCIILowercase();
@@ -115,7 +115,7 @@ void HTMLEmbedElement::parseAttribute(const QualifiedName& name, const AtomStrin
             invalidateStyle();
         // FIXME: If both code and src attributes are specified, last one parsed/changed wins. That can't be right!
     } else
-        HTMLPlugInImageElement::parseAttribute(name, value);
+        HTMLPlugInImageElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void HTMLEmbedElement::parametersForPlugin(Vector<AtomString>& paramNames, Vector<AtomString>& paramValues)

--- a/Source/WebCore/html/HTMLEmbedElement.h
+++ b/Source/WebCore/html/HTMLEmbedElement.h
@@ -35,7 +35,7 @@ public:
 private:
     HTMLEmbedElement(const QualifiedName&, Document&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 
     bool rendererIsNeeded(const RenderStyle&) final;

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -153,7 +153,7 @@ void HTMLFormControlElement::setAncestorDisabled(bool isDisabled)
     disabledStateChanged();
 }
 
-void HTMLFormControlElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLFormControlElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == formAttr)
         formAttributeChanged();
@@ -182,7 +182,7 @@ void HTMLFormControlElement::parseAttribute(const QualifiedName& name, const Ato
             requiredStateChanged();
         }
     } else
-        HTMLElement::parseAttribute(name, value);
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void HTMLFormControlElement::disabledAttributeChanged()

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -137,7 +137,7 @@ protected:
 
     bool disabledByAncestorFieldset() const { return m_disabledByAncestorFieldset; }
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     virtual void disabledAttributeChanged();
     virtual void disabledStateChanged();
     virtual void readOnlyStateChanged();

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -524,7 +524,7 @@ bool HTMLFormElement::shouldAutocorrect() const
 
 #endif
 
-void HTMLFormElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLFormElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == actionAttr) {
         m_attributes.parseAction(value);
@@ -552,7 +552,7 @@ void HTMLFormElement::parseAttribute(const QualifiedName& name, const AtomString
         if (m_relList)
             m_relList->associatedAttributeValueChanged(value);
     } else
-        HTMLElement::parseAttribute(name, value);
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 unsigned HTMLFormElement::formElementIndexWithFormAttribute(Element* element, unsigned rangeStart, unsigned rangeEnd)

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -137,7 +137,7 @@ private:
     void removedFromAncestor(RemovalType, ContainerNode&) final;
     void finishParsingChildren() final;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool isURLAttribute(const Attribute&) const final;
 
     void resumeFromDocumentSuspension() final;

--- a/Source/WebCore/html/HTMLFrameElement.cpp
+++ b/Source/WebCore/html/HTMLFrameElement.cpp
@@ -81,7 +81,7 @@ int HTMLFrameElement::defaultTabIndex() const
     return 0;
 }
 
-void HTMLFrameElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLFrameElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == frameborderAttr) {
         m_frameBorder = parseHTMLInteger(value).value_or(0);
@@ -91,7 +91,7 @@ void HTMLFrameElement::parseAttribute(const QualifiedName& name, const AtomStrin
         if (auto* renderer = this->renderer())
             renderer->updateFromElement();
     } else
-        HTMLFrameElementBase::parseAttribute(name, value);
+        HTMLFrameElementBase::attributeChanged(name, oldValue, value, reason);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLFrameElement.h
+++ b/Source/WebCore/html/HTMLFrameElement.h
@@ -46,7 +46,7 @@ private:
     bool rendererIsNeeded(const RenderStyle&) final;
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     int defaultTabIndex() const final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     bool m_frameBorder { true };
     bool m_frameBorderSet { false };

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -107,17 +107,18 @@ void HTMLFrameElementBase::openURL(LockHistory lockHistory, LockBackForwardList 
     parentFrame->loader().subframeLoader().requestFrame(*this, m_frameURL, frameName, lockHistory, lockBackForwardList);
 }
 
-void HTMLFrameElementBase::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLFrameElementBase::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == srcdocAttr) {
         if (value.isNull())
             setLocation(stripLeadingAndTrailingHTMLSpaces(attributeWithoutSynchronization(srcAttr)));
         else
             setLocation("about:srcdoc"_s);
-    } else if (name == srcAttr && !hasAttributeWithoutSynchronization(srcdocAttr))
-        setLocation(stripLeadingAndTrailingHTMLSpaces(value));
-    else
-        HTMLFrameOwnerElement::parseAttribute(name, value);
+    } else if (name == srcAttr) {
+        if (!hasAttributeWithoutSynchronization(srcdocAttr))
+            setLocation(stripLeadingAndTrailingHTMLSpaces(value));
+    } else
+        HTMLFrameOwnerElement::attributeChanged(name, oldValue, value, reason);
 }
 
 Node::InsertedIntoAncestorResult HTMLFrameElementBase::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/html/HTMLFrameElementBase.h
+++ b/Source/WebCore/html/HTMLFrameElementBase.h
@@ -49,7 +49,7 @@ protected:
 
     bool canLoad() const;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void didFinishInsertingNode() final;
     void didAttachRenderers() override;

--- a/Source/WebCore/html/HTMLFrameSetElement.cpp
+++ b/Source/WebCore/html/HTMLFrameSetElement.cpp
@@ -84,7 +84,7 @@ void HTMLFrameSetElement::collectPresentationalHintsForAttribute(const Qualified
         HTMLElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
-void HTMLFrameSetElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLFrameSetElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == rowsAttr) {
         // FIXME: What is the right thing to do when removing this attribute?
@@ -94,10 +94,7 @@ void HTMLFrameSetElement::parseAttribute(const QualifiedName& name, const AtomSt
             // FIXME: Would be nice to optimize the case where m_rowLengths did not change.
             invalidateStyleForSubtree();
         }
-        return;
-    }
-
-    if (name == colsAttr) {
+    } else if (name == colsAttr) {
         // FIXME: What is the right thing to do when removing this attribute?
         // Why not treat it the same way we treat setting it to the empty string?
         if (!value.isNull()) {
@@ -105,10 +102,7 @@ void HTMLFrameSetElement::parseAttribute(const QualifiedName& name, const AtomSt
             // FIXME: Would be nice to optimize the case where m_colLengths did not change.
             invalidateStyleForSubtree();
         }
-        return;
-    }
-
-    if (name == frameborderAttr) {
+    } else if (name == frameborderAttr) {
         if (!value.isNull()) {
             if (equalLettersIgnoringASCIICase(value, "no"_s) || value == "0"_s) {
                 m_frameborder = false;
@@ -121,39 +115,29 @@ void HTMLFrameSetElement::parseAttribute(const QualifiedName& name, const AtomSt
             m_frameborderSet = false;
         }
         // FIXME: Do we need to trigger repainting?
-        return;
-    }
-
-    if (name == noresizeAttr) {
+    } else if (name == noresizeAttr) {
         // FIXME: This should set m_noresize to false if the value is null.
         m_noresize = true;
-        return;
-    }
-
-    if (name == borderAttr) {
+    } else if (name == borderAttr) {
         if (!value.isNull()) {
             m_border = parseHTMLInteger(value).value_or(0);
             m_borderSet = true;
         } else
             m_borderSet = false;
         // FIXME: Do we need to trigger repainting?
-        return;
-    }
-
-    if (name == bordercolorAttr) {
+    } else if (name == bordercolorAttr) {
         m_borderColorSet = !value.isEmpty();
         // FIXME: Clearly wrong: This can overwrite the value inherited from the parent frameset.
         // FIXME: Do we need to trigger repainting?
-        return;
-    }
+    } else {
+        auto& eventName = HTMLBodyElement::eventNameForWindowEventHandlerAttribute(name);
+        if (!eventName.isNull()) {
+            document().setWindowAttributeEventListener(eventName, name, value, mainThreadNormalWorld());
+            return;
+        }
 
-    auto& eventName = HTMLBodyElement::eventNameForWindowEventHandlerAttribute(name);
-    if (!eventName.isNull()) {
-        document().setWindowAttributeEventListener(eventName, name, value, mainThreadNormalWorld());
-        return;
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
     }
-
-    HTMLElement::parseAttribute(name, value);
 }
 
 bool HTMLFrameSetElement::rendererIsNeeded(const RenderStyle& style)

--- a/Source/WebCore/html/HTMLFrameSetElement.h
+++ b/Source/WebCore/html/HTMLFrameSetElement.h
@@ -55,7 +55,7 @@ public:
 private:
     HTMLFrameSetElement(const QualifiedName&, Document&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -97,7 +97,7 @@ void HTMLIFrameElement::collectPresentationalHintsForAttribute(const QualifiedNa
         HTMLFrameElementBase::collectPresentationalHintsForAttribute(name, value, style);
 }
 
-void HTMLIFrameElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLIFrameElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == sandboxAttr) {
         if (m_sandbox)
@@ -117,7 +117,7 @@ void HTMLIFrameElement::parseAttribute(const QualifiedName& name, const AtomStri
             loadDeferredFrame();
         }
     } else
-        HTMLFrameElementBase::parseAttribute(name, value);
+        HTMLFrameElementBase::attributeChanged(name, oldValue, value, reason);
 }
 
 bool HTMLIFrameElement::rendererIsNeeded(const RenderStyle& style)

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -58,7 +58,7 @@ private:
     HTMLIFrameElement(const QualifiedName&, Document&);
 
     int defaultTabIndex() const final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -161,8 +161,7 @@ protected:
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) override;
 
 private:
-    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;
     void collectExtraStyleForPresentationalHints(MutableStyleProperties&) override;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -568,11 +568,11 @@ void HTMLInputElement::updateType()
         ASSERT(elementData());
         // FIXME: We don't have the old attribute values so we pretend that we didn't have the old values.
         if (const Attribute* height = findAttributeByName(heightAttr))
-            attributeChanged(heightAttr, nullAtom(), height->value());
+            attributeChanged(heightAttr, nullAtom(), height->value(), ModifiedDirectly);
         if (const Attribute* width = findAttributeByName(widthAttr))
-            attributeChanged(widthAttr, nullAtom(), width->value());
+            attributeChanged(widthAttr, nullAtom(), width->value(), ModifiedDirectly);
         if (const Attribute* align = findAttributeByName(alignAttr))
-            attributeChanged(alignAttr, nullAtom(), align->value());
+            attributeChanged(alignAttr, nullAtom(), align->value(), ModifiedDirectly);
     }
 
     if (auto* form = this->form(); form && wasSuccessfulSubmitButtonCandidate != m_inputType->canBeSuccessfulSubmitButton())
@@ -723,7 +723,7 @@ inline void HTMLInputElement::initializeInputType()
     updateValidity();
 }
 
-void HTMLInputElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     ASSERT(m_inputType);
     Ref protectedInputType { *m_inputType };
@@ -732,7 +732,7 @@ void HTMLInputElement::parseAttribute(const QualifiedName& name, const AtomStrin
         removeFromRadioButtonGroup();
         m_name = value;
         addToRadioButtonGroup();
-        HTMLTextFormControlElement::parseAttribute(name, value);
+        nameAttributeChanged(value);
     } else if (name == autocompleteAttr) {
         if (equalLettersIgnoringASCIICase(value, "off"_s)) {
             m_autocomplete = Off;
@@ -802,7 +802,7 @@ void HTMLInputElement::parseAttribute(const QualifiedName& name, const AtomStrin
     }
 #endif
     else
-        HTMLTextFormControlElement::parseAttribute(name, value);
+        HTMLTextFormControlElement::attributeChanged(name, oldValue, value, reason);
 
     m_inputType->attributeChanged(name);
 }

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -398,7 +398,7 @@ private:
 
     bool accessKeyAction(bool sendMouseEvents) final;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
     void finishParsingChildren() final;

--- a/Source/WebCore/html/HTMLLIElement.cpp
+++ b/Source/WebCore/html/HTMLLIElement.cpp
@@ -83,13 +83,13 @@ void HTMLLIElement::collectPresentationalHintsForAttribute(const QualifiedName& 
         HTMLElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
-void HTMLLIElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLLIElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == valueAttr) {
         if (renderer() && renderer()->isListItem())
             parseValue(value);
     } else
-        HTMLElement::parseAttribute(name, value);
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void HTMLLIElement::didAttachRenderers()

--- a/Source/WebCore/html/HTMLLIElement.h
+++ b/Source/WebCore/html/HTMLLIElement.h
@@ -35,7 +35,7 @@ public:
 private:
     HTMLLIElement(const QualifiedName&, Document&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -163,7 +163,7 @@ void HTMLLinkElement::setDisabledState(bool disabled)
     }
 }
 
-void HTMLLinkElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLLinkElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == relAttr) {
         auto parsedRel = LinkRelAttribute(document(), value);
@@ -173,40 +173,27 @@ void HTMLLinkElement::parseAttribute(const QualifiedName& name, const AtomString
             m_relList->associatedAttributeValueChanged(value);
         if (didMutateRel)
             process();
-        return;
-    }
-    if (name == hrefAttr) {
+    } else if (name == hrefAttr) {
         process();
-        return;
-    }
-    if (name == typeAttr) {
+    } else if (name == typeAttr) {
         m_type = value;
         process();
-        return;
-    }
-    if (name == sizesAttr) {
+    } else if (name == sizesAttr) {
         if (m_sizes)
             m_sizes->associatedAttributeValueChanged(value);
         process();
-        return;
-    }
-    if (name == mediaAttr) {
+    } else if (name == mediaAttr) {
         m_media = value.string().convertToASCIILowercase();
         process();
         if (m_sheet && !isDisabled())
             m_styleScope->didChangeActiveStyleSheetCandidates();
-        return;
-    }
-    if (name == disabledAttr) {
+    } else if (name == disabledAttr) {
         setDisabledState(!value.isNull());
-        return;
-    }
-    if (name == titleAttr) {
+    } else if (name == titleAttr) {
         if (m_sheet && !isInShadowTree())
             m_sheet->setTitle(value);
-        return;
-    }
-    HTMLElement::parseAttribute(name, value);
+    } else
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 bool HTMLLinkElement::shouldLoadLink()

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -91,7 +91,7 @@ public:
     ReferrerPolicy referrerPolicy() const;
 
 private:
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     bool shouldLoadLink() final;
     void process();

--- a/Source/WebCore/html/HTMLMapElement.h
+++ b/Source/WebCore/html/HTMLMapElement.h
@@ -46,7 +46,7 @@ public:
 private:
     HTMLMapElement(const QualifiedName&, Document&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -752,22 +752,12 @@ bool HTMLMediaElement::isInteractiveContent() const
     return controls();
 }
 
-void HTMLMediaElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason reason)
+void HTMLMediaElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    if (name == webkitwirelessvideoplaybackdisabledAttr)
-        mediaSession().setWirelessVideoPlaybackDisabled(newValue != nullAtom());
-    else
-#endif
-        HTMLElement::attributeChanged(name, oldValue, newValue, reason);
-}
-
-void HTMLMediaElement::parseAttribute(const QualifiedName& name, const AtomString& value)
-{
-    if (name == idAttr)
+    if (name == idAttr) {
         m_id = value;
-
-    if (name == srcAttr) {
+        idAttributeChanged(oldValue, value);
+    } else if (name == srcAttr) {
         // https://html.spec.whatwg.org/multipage/embedded-content.html#location-of-the-media-resource
         // Location of the Media Resource
         // 12 February 2017
@@ -803,13 +793,15 @@ void HTMLMediaElement::parseAttribute(const QualifiedName& name, const AtomStrin
     } else if (name == titleAttr) {
         if (m_mediaSession)
             m_mediaSession->clientCharacteristicsChanged(false);
-    }
-    else
-        HTMLElement::parseAttribute(name, value);
-
-    // Changing the "muted" attribue could affect ":muted"
-    if (name == mutedAttr)
+    } if (name == mutedAttr) {
+        // Changing the "muted" attribute could affect ":muted"
         invalidateStyle();
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    } else if (name == webkitwirelessvideoplaybackdisabledAttr) {
+        mediaSession().setWirelessVideoPlaybackDisabled(!value.isNull());
+#endif
+    } else
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void HTMLMediaElement::finishParsingChildren()

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -621,8 +621,7 @@ protected:
     HTMLMediaElement(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLMediaElement();
 
-    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     void finishParsingChildren() override;
     bool isURLAttribute(const Attribute&) const override;
     void willAttachRenderers() override;

--- a/Source/WebCore/html/HTMLMenuElement.h
+++ b/Source/WebCore/html/HTMLMenuElement.h
@@ -38,7 +38,7 @@ private:
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     bool m_isTouchBarMenu;
 };

--- a/Source/WebCore/html/HTMLMetaElement.cpp
+++ b/Source/WebCore/html/HTMLMetaElement.cpp
@@ -91,43 +91,21 @@ const Color& HTMLMetaElement::contentColor()
 
 void HTMLMetaElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason reason)
 {
-    HTMLElement::attributeChanged(name, oldValue, newValue, reason);
-
-    if (!isInDocumentTree())
-        return;
-
     if (name == nameAttr) {
-        if (equalLettersIgnoringASCIICase(oldValue, "theme-color"_s) && !equalLettersIgnoringASCIICase(newValue, "theme-color"_s))
+        nameAttributeChanged(newValue);
+        if (isInDocumentTree() && equalLettersIgnoringASCIICase(oldValue, "theme-color"_s) && !equalLettersIgnoringASCIICase(newValue, "theme-color"_s))
             document().metaElementThemeColorChanged(*this);
-        return;
-    }
-}
-
-void HTMLMetaElement::parseAttribute(const QualifiedName& name, const AtomString& value)
-{
-    if (name == nameAttr) {
         process();
-        return;
-    }
-
-    if (name == contentAttr) {
+    } else if (name == contentAttr) {
         m_contentColor = std::nullopt;
         process();
-        return;
-    }
-
-    if (name == http_equivAttr) {
+    } else if (name == http_equivAttr)
         process();
-        return;
-    }
-
-    if (name == mediaAttr) {
+    else if (name == mediaAttr) {
         m_media = nullptr;
         process();
-        return;
-    }
-
-    HTMLElement::parseAttribute(name, value);
+    } else
+        HTMLElement::attributeChanged(name, oldValue, newValue, reason);
 }
 
 Node::InsertedIntoAncestorResult HTMLMetaElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/html/HTMLMetaElement.h
+++ b/Source/WebCore/html/HTMLMetaElement.h
@@ -46,8 +46,7 @@ public:
 private:
     HTMLMetaElement(const QualifiedName&, Document&);
 
-    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = ModifiedDirectly) final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void didFinishInsertingNode();
     void removedFromAncestor(RemovalType, ContainerNode&) final;

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -70,12 +70,12 @@ bool HTMLMeterElement::childShouldCreateRenderer(const Node& child) const
     return !is<RenderMeter>(renderer()) && HTMLElement::childShouldCreateRenderer(child);
 }
 
-void HTMLMeterElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLMeterElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == valueAttr || name == minAttr || name == maxAttr || name == lowAttr || name == highAttr || name == optimumAttr)
         didElementStateChange();
     else
-        LabelableElement::parseAttribute(name, value);
+        LabelableElement::attributeChanged(name, oldValue, value, reason);
 }
 
 double HTMLMeterElement::min() const

--- a/Source/WebCore/html/HTMLMeterElement.h
+++ b/Source/WebCore/html/HTMLMeterElement.h
@@ -71,7 +71,7 @@ private:
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     bool childShouldCreateRenderer(const Node&) const final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     void didElementStateChange();
     void didAddUserAgentShadowRoot(ShadowRoot&) final;

--- a/Source/WebCore/html/HTMLOListElement.cpp
+++ b/Source/WebCore/html/HTMLOListElement.cpp
@@ -83,7 +83,7 @@ void HTMLOListElement::collectPresentationalHintsForAttribute(const QualifiedNam
         HTMLElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
-void HTMLOListElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLOListElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == startAttr) {
         int oldStart = start();
@@ -98,7 +98,7 @@ void HTMLOListElement::parseAttribute(const QualifiedName& name, const AtomStrin
         m_isReversed = reversed;
         RenderListItem::updateItemValuesForOrderedList(*this);
     } else
-        HTMLElement::parseAttribute(name, value);
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void HTMLOListElement::setStartForBindings(int start)

--- a/Source/WebCore/html/HTMLOListElement.h
+++ b/Source/WebCore/html/HTMLOListElement.h
@@ -48,7 +48,7 @@ private:
         
     WEBCORE_EXPORT unsigned itemCount() const;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -99,7 +99,7 @@ void HTMLObjectElement::collectPresentationalHintsForAttribute(const QualifiedNa
         HTMLPlugInImageElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
-void HTMLObjectElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLObjectElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     bool invalidateRenderer = false;
     bool needsWidgetUpdate = false;
@@ -119,7 +119,7 @@ void HTMLObjectElement::parseAttribute(const QualifiedName& name, const AtomStri
         invalidateRenderer = true;
         needsWidgetUpdate = true;
     } else
-        HTMLPlugInImageElement::parseAttribute(name, value);
+        HTMLPlugInImageElement::attributeChanged(name, oldValue, value, reason);
 
     if (needsWidgetUpdate) {
         setNeedsWidgetUpdate(true);

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -62,7 +62,7 @@ private:
 
     int defaultTabIndex() const final;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -90,9 +90,9 @@ void HTMLOptGroupElement::childrenChanged(const ChildChange& change)
     HTMLElement::childrenChanged(change);
 }
 
-void HTMLOptGroupElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLOptGroupElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    HTMLElement::parseAttribute(name, value);
+    // FIXME: This should only be called if an attribute relevant to the parent select element is changed.
     recalcSelectOptions();
 
     if (name == disabledAttr) {
@@ -106,7 +106,8 @@ void HTMLOptGroupElement::parseAttribute(const QualifiedName& name, const AtomSt
 
             m_isDisabled = newDisabled;
         }
-    }
+    } else
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void HTMLOptGroupElement::recalcSelectOptions()

--- a/Source/WebCore/html/HTMLOptGroupElement.h
+++ b/Source/WebCore/html/HTMLOptGroupElement.h
@@ -44,7 +44,7 @@ private:
 
     const AtomString& formControlType() const;
     bool isFocusable() const final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 
     void childrenChanged(const ChildChange&) final;

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -167,7 +167,7 @@ int HTMLOptionElement::index() const
     return 0;
 }
 
-void HTMLOptionElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLOptionElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
 #if ENABLE(DATALIST_ELEMENT)
     if (name == valueAttr) {
@@ -194,7 +194,7 @@ void HTMLOptionElement::parseAttribute(const QualifiedName& name, const AtomStri
         // has no effect on whether the element is selected.
         setSelectedState(!value.isNull());
     } else
-        HTMLElement::parseAttribute(name, value);
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 String HTMLOptionElement::value() const

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -72,7 +72,7 @@ private:
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
     bool matchesDefaultPseudoClass() const final;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     bool accessKeyAction(bool) final;
 

--- a/Source/WebCore/html/HTMLOutputElement.cpp
+++ b/Source/WebCore/html/HTMLOutputElement.cpp
@@ -69,11 +69,13 @@ bool HTMLOutputElement::supportsFocus() const
     return HTMLElement::supportsFocus();
 }
 
-void HTMLOutputElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLOutputElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == HTMLNames::forAttr && m_forTokens)
-        m_forTokens->associatedAttributeValueChanged(value);
-    HTMLFormControlElement::parseAttribute(name, value);
+    if (name == HTMLNames::forAttr) {
+        if (m_forTokens)
+            m_forTokens->associatedAttributeValueChanged(value);
+    } else
+        HTMLFormControlElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void HTMLOutputElement::reset()

--- a/Source/WebCore/html/HTMLOutputElement.h
+++ b/Source/WebCore/html/HTMLOutputElement.h
@@ -54,7 +54,7 @@ private:
 
     bool canContainRangeEndPoint() const final { return false; }
     bool computeWillValidate() const final { return false; }
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     const AtomString& formControlType() const final;
     bool isEnumeratable() const final { return true; }
     bool supportLabels() const final { return true; }

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -77,7 +77,7 @@ RenderProgress* HTMLProgressElement::renderProgress() const
     return downcast<RenderProgress>(descendantsOfType<Element>(*userAgentShadowRoot()).first()->renderer());
 }
 
-void HTMLProgressElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLProgressElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == valueAttr) {
         updateDeterminateState();
@@ -85,7 +85,7 @@ void HTMLProgressElement::parseAttribute(const QualifiedName& name, const AtomSt
     } else if (name == maxAttr)
         didElementStateChange();
     else
-        LabelableElement::parseAttribute(name, value);
+        LabelableElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void HTMLProgressElement::didAttachRenderers()

--- a/Source/WebCore/html/HTMLProgressElement.h
+++ b/Source/WebCore/html/HTMLProgressElement.h
@@ -54,7 +54,7 @@ private:
     bool childShouldCreateRenderer(const Node&) const final;
     RenderProgress* renderProgress() const;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     void didAttachRenderers() final;
 

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -63,14 +63,14 @@ void HTMLScriptElement::childrenChanged(const ChildChange& change)
     ScriptElement::childrenChanged(change);
 }
 
-void HTMLScriptElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLScriptElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == srcAttr)
         handleSourceAttribute(value);
     else if (name == asyncAttr)
         handleAsyncAttribute();
     else
-        HTMLElement::parseAttribute(name, value);
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 Node::InsertedIntoAncestorResult HTMLScriptElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -56,7 +56,7 @@ public:
 private:
     HTMLScriptElement(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void didFinishInsertingNode() final;
     void childrenChanged(const ChildChange&) final;

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -285,7 +285,7 @@ bool HTMLSelectElement::hasPresentationalHintsForAttribute(const QualifiedName& 
     return HTMLFormControlElementWithState::hasPresentationalHintsForAttribute(name);
 }
 
-void HTMLSelectElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLSelectElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == sizeAttr) {
         unsigned oldSize = m_size;
@@ -305,7 +305,7 @@ void HTMLSelectElement::parseAttribute(const QualifiedName& name, const AtomStri
     } else if (name == multipleAttr)
         parseMultipleAttribute(value);
     else
-        HTMLFormControlElementWithState::parseAttribute(name, value);
+        HTMLFormControlElementWithState::attributeChanged(name, oldValue, value, reason);
 }
 
 int HTMLSelectElement::defaultTabIndex() const

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -132,7 +132,7 @@ private:
     FormControlState saveFormControlState() const final;
     void restoreFormControlState(const FormControlState&) final;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
 
     bool childShouldCreateRenderer(const Node&) const final;

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -93,12 +93,14 @@ void HTMLSlotElement::childrenChanged(const ChildChange& childChange)
 
 void HTMLSlotElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason reason)
 {
-    HTMLElement::attributeChanged(name, oldValue, newValue, reason);
-
-    if (isInShadowTree() && name == nameAttr) {
-        if (RefPtr shadowRoot = containingShadowRoot())
-            shadowRoot->renameSlotElement(*this, oldValue, newValue);
-    }
+    if (name == nameAttr) {
+        if (isInShadowTree()) {
+            if (RefPtr shadowRoot = containingShadowRoot())
+                shadowRoot->renameSlotElement(*this, oldValue, newValue);
+        }
+        nameAttributeChanged(newValue);
+    } else
+        HTMLElement::attributeChanged(name, oldValue, newValue, reason);
 }
 
 const Vector<WeakPtr<Node>>* HTMLSlotElement::assignedNodes() const

--- a/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/Source/WebCore/html/HTMLSourceElement.cpp
@@ -151,9 +151,8 @@ void HTMLSourceElement::stop()
     cancelPendingErrorEvent();
 }
 
-void HTMLSourceElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLSourceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    HTMLElement::parseAttribute(name, value);
     if (name == srcsetAttr || name == sizesAttr || name == mediaAttr || name == typeAttr) {
         if (name == mediaAttr)
             m_cachedParsedMediaAttribute = std::nullopt;
@@ -162,12 +161,17 @@ void HTMLSourceElement::parseAttribute(const QualifiedName& name, const AtomStri
             downcast<HTMLPictureElement>(*parent).sourcesChanged();
     }
 #if ENABLE(MODEL_ELEMENT)
-    if (name == srcAttr ||  name == typeAttr) {
+    else if (name == srcAttr || name == typeAttr) {
         RefPtr<Element> parent = parentElement();
         if (is<HTMLModelElement>(parent))
             downcast<HTMLModelElement>(*parent).sourcesChanged();
     }
 #endif
+    else if (name == widthAttr || name == heightAttr) {
+        if (RefPtr parent = parentNode(); is<HTMLPictureElement>(parent))
+            downcast<HTMLPictureElement>(*parent).sourceDimensionAttributesChanged(*this);
+    } else
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 const MediaQuerySet* HTMLSourceElement::parsedMediaAttribute(Document& document) const
@@ -180,15 +184,6 @@ const MediaQuerySet* HTMLSourceElement::parsedMediaAttribute(Document& document)
         m_cachedParsedMediaAttribute = WTFMove(parsedAttribute);
     }
     return m_cachedParsedMediaAttribute.value().get();
-}
-
-void HTMLSourceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason reason)
-{
-    if (name == widthAttr || name == heightAttr) {
-        if (RefPtr parent = parentNode(); is<HTMLPictureElement>(parent))
-            downcast<HTMLPictureElement>(*parent).sourceDimensionAttributesChanged(*this);
-    }
-    HTMLElement::attributeChanged(name, oldValue, newValue, reason);
 }
 
 }

--- a/Source/WebCore/html/HTMLSourceElement.h
+++ b/Source/WebCore/html/HTMLSourceElement.h
@@ -55,9 +55,7 @@ private:
     const char* activeDOMObjectName() const final;
     void stop() final;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
-
-    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     TaskCancellationGroup m_errorEventCancellationGroup;
     bool m_shouldCallSourcesChanged { false };

--- a/Source/WebCore/html/HTMLStyleElement.cpp
+++ b/Source/WebCore/html/HTMLStyleElement.cpp
@@ -75,11 +75,12 @@ Ref<HTMLStyleElement> HTMLStyleElement::create(Document& document)
     return adoptRef(*new HTMLStyleElement(styleTag, document, false));
 }
 
-void HTMLStyleElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLStyleElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == titleAttr && sheet() && !isInShadowTree())
-        sheet()->setTitle(value);
-    else if (name == mediaAttr) {
+    if (name == titleAttr) {
+        if (sheet() && !isInShadowTree())
+            sheet()->setTitle(value);
+    } else if (name == mediaAttr) {
         m_styleSheetOwner.setMedia(value);
         if (sheet()) {
             sheet()->setMediaQueries(MediaQuerySet::create(value, MediaQueryParserContext(document())));
@@ -93,7 +94,7 @@ void HTMLStyleElement::parseAttribute(const QualifiedName& name, const AtomStrin
         if (auto* scope = m_styleSheetOwner.styleScope())
             scope->didChangeStyleSheetContents();
     } else
-        HTMLElement::parseAttribute(name, value);
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void HTMLStyleElement::finishParsingChildren()

--- a/Source/WebCore/html/HTMLStyleElement.h
+++ b/Source/WebCore/html/HTMLStyleElement.h
@@ -55,7 +55,7 @@ public:
 private:
     HTMLStyleElement(const QualifiedName&, Document&, bool createdByParser);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;
     void childrenChanged(const ChildChange&) final;

--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -112,7 +112,7 @@ void HTMLTableCellElement::collectPresentationalHintsForAttribute(const Qualifie
         HTMLTablePartElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
-void HTMLTableCellElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLTableCellElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == rowspanAttr) {
         if (is<RenderTableCell>(renderer()))
@@ -121,7 +121,7 @@ void HTMLTableCellElement::parseAttribute(const QualifiedName& name, const AtomS
         if (is<RenderTableCell>(renderer()))
             downcast<RenderTableCell>(*renderer()).colSpanOrRowSpanChanged();
     } else
-        HTMLTablePartElement::parseAttribute(name, value);
+        HTMLTablePartElement::attributeChanged(name, oldValue, value, reason);
 }
 
 const StyleProperties* HTMLTableCellElement::additionalPresentationalHintStyle() const

--- a/Source/WebCore/html/HTMLTableCellElement.h
+++ b/Source/WebCore/html/HTMLTableCellElement.h
@@ -54,7 +54,7 @@ public:
 private:
     HTMLTableCellElement(const QualifiedName&, Document&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;
     const StyleProperties* additionalPresentationalHintStyle() const override;

--- a/Source/WebCore/html/HTMLTableColElement.cpp
+++ b/Source/WebCore/html/HTMLTableColElement.cpp
@@ -72,7 +72,7 @@ void HTMLTableColElement::collectPresentationalHintsForAttribute(const Qualified
         HTMLTablePartElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
-void HTMLTableColElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLTableColElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == spanAttr) {
         m_span = clampHTMLNonNegativeIntegerToRange(value, minSpan, maxSpan, defaultSpan);
@@ -88,7 +88,7 @@ void HTMLTableColElement::parseAttribute(const QualifiedName& name, const AtomSt
             }
         }
     } else
-        HTMLTablePartElement::parseAttribute(name, value);
+        HTMLTablePartElement::attributeChanged(name, oldValue, value, reason);
 }
 
 const StyleProperties* HTMLTableColElement::additionalPresentationalHintStyle() const

--- a/Source/WebCore/html/HTMLTableColElement.h
+++ b/Source/WebCore/html/HTMLTableColElement.h
@@ -42,7 +42,7 @@ public:
 private:
     HTMLTableColElement(const QualifiedName& tagName, Document&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
     const StyleProperties* additionalPresentationalHintStyle() const final;

--- a/Source/WebCore/html/HTMLTableElement.h
+++ b/Source/WebCore/html/HTMLTableElement.h
@@ -71,7 +71,7 @@ public:
 private:
     HTMLTableElement(const QualifiedName&, Document&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
     bool isURLAttribute(const Attribute&) const final;

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -166,7 +166,7 @@ void HTMLTextAreaElement::collectPresentationalHintsForAttribute(const Qualified
         HTMLTextFormControlElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
-void HTMLTextAreaElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLTextAreaElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == rowsAttr) {
         unsigned rows = limitToOnlyHTMLNonNegativeNumbersGreaterThanZero(value, defaultRows);
@@ -202,7 +202,7 @@ void HTMLTextAreaElement::parseAttribute(const QualifiedName& name, const AtomSt
     else if (name == minlengthAttr)
         minLengthAttributeChanged(value);
     else
-        HTMLTextFormControlElement::parseAttribute(name, value);
+        HTMLTextFormControlElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void HTMLTextAreaElement::maxLengthAttributeChanged(const AtomString& newValue)

--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -113,7 +113,7 @@ private:
     bool isTextField() const final { return true; }
 
     void childrenChanged(const ChildChange&) final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -554,13 +554,13 @@ void HTMLTextFormControlElement::scheduleSelectEvent()
     queueTaskToDispatchEvent(TaskSource::UserInteraction, Event::create(eventNames().selectEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
 } 
 
-void HTMLTextFormControlElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLTextFormControlElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == placeholderAttr) {
         updatePlaceholderText();
         updatePlaceholderVisibility();
     } else
-        HTMLFormControlElementWithState::parseAttribute(name, value);
+        HTMLFormControlElementWithState::attributeChanged(name, oldValue, value, reason);
 }
 
 void HTMLTextFormControlElement::disabledStateChanged()

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -111,7 +111,7 @@ protected:
     bool isPlaceholderEmpty() const;
     virtual void updatePlaceholderText() = 0;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
 
     void disabledStateChanged() override;
     void readOnlyStateChanged() override;

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -103,7 +103,7 @@ void HTMLTrackElement::removedFromAncestor(RemovalType removalType, ContainerNod
         downcast<HTMLMediaElement>(oldParentOfRemovedTree).didRemoveTextTrack(*this);
 }
 
-void HTMLTrackElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLTrackElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == srcAttr) {
         scheduleLoad();
@@ -116,8 +116,8 @@ void HTMLTrackElement::parseAttribute(const QualifiedName& name, const AtomStrin
         track().setLabel(value);
     else if (name == srclangAttr)
         track().setLanguage(value);
-
-    HTMLElement::parseAttribute(name, value);
+    else
+        HTMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 const AtomString& HTMLTrackElement::kind()

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -73,7 +73,7 @@ private:
     const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -132,7 +132,7 @@ bool HTMLVideoElement::hasPresentationalHintsForAttribute(const QualifiedName& n
     return HTMLMediaElement::hasPresentationalHintsForAttribute(name);
 }
 
-void HTMLVideoElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLVideoElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == posterAttr) {
         if (shouldDisplayPosterImage()) {
@@ -146,18 +146,16 @@ void HTMLVideoElement::parseAttribute(const QualifiedName& name, const AtomStrin
             }
         }
     }
-    else {
-        HTMLMediaElement::parseAttribute(name, value);    
-
 #if PLATFORM(IOS_FAMILY) && ENABLE(WIRELESS_PLAYBACK_TARGET)
-        if (name == webkitairplayAttr) {
-            bool disabled = false;
-            if (equalLettersIgnoringASCIICase(attributeWithoutSynchronization(HTMLNames::webkitairplayAttr), "deny"_s))
-                disabled = true;
-            mediaSession().setWirelessVideoPlaybackDisabled(disabled);
-        }
-#endif
+    else if (name == webkitairplayAttr) {
+        bool disabled = false;
+        if (equalLettersIgnoringASCIICase(attributeWithoutSynchronization(HTMLNames::webkitairplayAttr), "deny"_s))
+            disabled = true;
+        mediaSession().setWirelessVideoPlaybackDisabled(disabled);
     }
+#endif
+    else
+        HTMLMediaElement::attributeChanged(name, oldValue, value, reason);
 }
 
 bool HTMLVideoElement::supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode) const

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -126,7 +126,7 @@ private:
     void scheduleResizeEventIfSizeChanged() final;
     bool rendererIsNeeded(const RenderStyle&) final;
     void didAttachRenderers() final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
     bool isVideo() const final { return true; }

--- a/Source/WebCore/mathml/MathMLAnnotationElement.cpp
+++ b/Source/WebCore/mathml/MathMLAnnotationElement.cpp
@@ -103,8 +103,8 @@ void MathMLAnnotationElement::attributeChanged(const QualifiedName& name, const 
         auto* parent = parentElement();
         if (is<MathMLElement>(parent) && parent->hasTagName(semanticsTag))
             downcast<MathMLElement>(*parent).updateSelectedChild();
-    }
-    MathMLPresentationElement::attributeChanged(name, oldValue, newValue, reason);
+    } else
+        MathMLPresentationElement::attributeChanged(name, oldValue, newValue, reason);
 }
 
 }

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -78,7 +78,7 @@ unsigned MathMLElement::rowSpan() const
     return std::max(1u, std::min(limitToOnlyHTMLNonNegative(rowSpanValue, 1u), maxRowspan));
 }
 
-void MathMLElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void MathMLElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == hrefAttr) {
         bool wasLink = isLink();
@@ -103,7 +103,7 @@ void MathMLElement::parseAttribute(const QualifiedName& name, const AtomString& 
             return;
         }
 
-        StyledElement::parseAttribute(name, value);
+        StyledElement::attributeChanged(name, oldValue, value, reason);
     }
 }
 

--- a/Source/WebCore/mathml/MathMLElement.h
+++ b/Source/WebCore/mathml/MathMLElement.h
@@ -92,7 +92,7 @@ public:
 protected:
     MathMLElement(const QualifiedName& tagName, Document&, ConstructionType = CreateMathMLElement);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     bool childShouldCreateRenderer(const Node&) const override;
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;

--- a/Source/WebCore/mathml/MathMLFractionElement.cpp
+++ b/Source/WebCore/mathml/MathMLFractionElement.cpp
@@ -109,7 +109,7 @@ MathMLFractionElement::FractionAlignment MathMLFractionElement::denominatorAlign
     return cachedFractionAlignment(denomalignAttr, m_denominatorAlignment);
 }
 
-void MathMLFractionElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void MathMLFractionElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == linethicknessAttr)
         m_lineThickness = std::nullopt;
@@ -117,8 +117,8 @@ void MathMLFractionElement::parseAttribute(const QualifiedName& name, const Atom
         m_numeratorAlignment = std::nullopt;
     else if (name == denomalignAttr)
         m_denominatorAlignment = std::nullopt;
-
-    MathMLElement::parseAttribute(name, value);
+    else
+        MathMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 RenderPtr<RenderElement> MathMLFractionElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)

--- a/Source/WebCore/mathml/MathMLFractionElement.h
+++ b/Source/WebCore/mathml/MathMLFractionElement.h
@@ -47,7 +47,7 @@ public:
 private:
     MathMLFractionElement(const QualifiedName& tagName, Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     FractionAlignment cachedFractionAlignment(const QualifiedName&, std::optional<FractionAlignment>&);
 

--- a/Source/WebCore/mathml/MathMLMathElement.cpp
+++ b/Source/WebCore/mathml/MathMLMathElement.cpp
@@ -56,15 +56,14 @@ RenderPtr<RenderElement> MathMLMathElement::createElementRenderer(RenderStyle&& 
     return createRenderer<RenderMathMLMath>(*this, WTFMove(style));
 }
 
-void MathMLMathElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void MathMLMathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    bool mathVariantAttribute = name == mathvariantAttr;
-    if (mathVariantAttribute)
+    if (name == mathvariantAttr) {
         m_mathVariant = std::nullopt;
-    if ((mathVariantAttribute) && renderer())
-        MathMLStyle::resolveMathMLStyleTree(renderer());
-
-    MathMLElement::parseAttribute(name, value);
+        if (renderer())
+            MathMLStyle::resolveMathMLStyleTree(renderer());
+    } else
+        MathMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void MathMLMathElement::didAttachRenderers()

--- a/Source/WebCore/mathml/MathMLMathElement.h
+++ b/Source/WebCore/mathml/MathMLMathElement.h
@@ -40,7 +40,7 @@ public:
 
 private:
     MathMLMathElement(const QualifiedName& tagName, Document&);
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void didAttachRenderers() final;
 
     bool acceptsMathVariantAttribute() final { return true; }

--- a/Source/WebCore/mathml/MathMLMencloseElement.cpp
+++ b/Source/WebCore/mathml/MathMLMencloseElement.cpp
@@ -133,12 +133,12 @@ bool MathMLMencloseElement::hasNotation(MencloseNotationFlag notationFlag)
     return m_notationFlags.value() & notationFlag;
 }
 
-void MathMLMencloseElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void MathMLMencloseElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == notationAttr)
         m_notationFlags = std::nullopt;
-
-    MathMLRowElement::parseAttribute(name, value);
+    else
+        MathMLRowElement::attributeChanged(name, oldValue, value, reason);
 }
 
 }

--- a/Source/WebCore/mathml/MathMLMencloseElement.h
+++ b/Source/WebCore/mathml/MathMLMencloseElement.h
@@ -59,7 +59,7 @@ public:
 private:
     MathMLMencloseElement(const QualifiedName&, Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void parseNotationAttribute();
     void clearNotations() { m_notationFlags = 0; }
     void addNotation(MencloseNotationFlag notationFlag) { m_notationFlags.value() |= notationFlag; }

--- a/Source/WebCore/mathml/MathMLOperatorElement.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorElement.cpp
@@ -229,28 +229,32 @@ static std::optional<MathMLOperatorDictionary::Flag> attributeNameToPropertyFlag
     return std::nullopt;
 }
 
-void MathMLOperatorElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void MathMLOperatorElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
+    auto updateRendererFromElement = [&] {
+        if (renderer())
+            downcast<RenderMathMLOperator>(*renderer()).updateFromElement();
+    };
+
     if (name == formAttr) {
         m_dictionaryProperty = std::nullopt;
         m_properties.dirtyFlags = MathMLOperatorDictionary::allFlags;
     } else if (auto flag = attributeNameToPropertyFlag(name))
         m_properties.dirtyFlags |= flag.value();
-    else if (name == lspaceAttr)
+    else if (name == lspaceAttr) {
         m_leadingSpace = std::nullopt;
-    else if (name == rspaceAttr)
+        updateRendererFromElement();
+    } else if (name == rspaceAttr) {
         m_trailingSpace = std::nullopt;
-    else if (name == minsizeAttr)
+        updateRendererFromElement();
+    } else if (name == minsizeAttr)
         m_minSize = std::nullopt;
     else if (name == maxsizeAttr)
         m_maxSize = std::nullopt;
-
-    if ((name == stretchyAttr || name == lspaceAttr || name == rspaceAttr || name == movablelimitsAttr) && renderer()) {
-        downcast<RenderMathMLOperator>(*renderer()).updateFromElement();
-        return;
-    }
-
-    MathMLTokenElement::parseAttribute(name, value);
+    else if (name == stretchyAttr || name == movablelimitsAttr)
+        updateRendererFromElement();
+    else
+        MathMLTokenElement::attributeChanged(name, oldValue, value, reason);
 }
 
 RenderPtr<RenderElement> MathMLOperatorElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)

--- a/Source/WebCore/mathml/MathMLOperatorElement.h
+++ b/Source/WebCore/mathml/MathMLOperatorElement.h
@@ -56,7 +56,7 @@ private:
     MathMLOperatorElement(const QualifiedName& tagName, Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     void childrenChanged(const ChildChange&) final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     std::optional<OperatorChar> m_operatorChar;
 

--- a/Source/WebCore/mathml/MathMLPaddedElement.cpp
+++ b/Source/WebCore/mathml/MathMLPaddedElement.cpp
@@ -73,7 +73,7 @@ const MathMLElement::Length& MathMLPaddedElement::voffset()
     return cachedMathMLLength(MathMLNames::voffsetAttr, m_voffset);
 }
 
-void MathMLPaddedElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void MathMLPaddedElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == widthAttr)
         m_width = std::nullopt;
@@ -85,8 +85,8 @@ void MathMLPaddedElement::parseAttribute(const QualifiedName& name, const AtomSt
         m_lspace = std::nullopt;
     else if (name == voffsetAttr)
         m_voffset = std::nullopt;
-
-    MathMLElement::parseAttribute(name, value);
+    else
+        MathMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 RenderPtr<RenderElement> MathMLPaddedElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)

--- a/Source/WebCore/mathml/MathMLPaddedElement.h
+++ b/Source/WebCore/mathml/MathMLPaddedElement.h
@@ -44,7 +44,7 @@ public:
 private:
     MathMLPaddedElement(const QualifiedName& tagName, Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     std::optional<Length> m_width;
     std::optional<Length> m_height;

--- a/Source/WebCore/mathml/MathMLPresentationElement.cpp
+++ b/Source/WebCore/mathml/MathMLPresentationElement.cpp
@@ -357,15 +357,16 @@ std::optional<MathMLElement::MathVariant> MathMLPresentationElement::specifiedMa
     return m_mathVariant.value() == MathVariant::None ? std::nullopt : m_mathVariant;
 }
 
-void MathMLPresentationElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void MathMLPresentationElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    bool mathVariantAttribute = name == mathvariantAttr && acceptsMathVariantAttribute();
-    if (mathVariantAttribute)
+    if (name == mathvariantAttr) {
+        if (!acceptsMathVariantAttribute())
+            return;
         m_mathVariant = std::nullopt;
-    if ((mathVariantAttribute) && renderer())
-        MathMLStyle::resolveMathMLStyleTree(renderer());
-
-    MathMLElement::parseAttribute(name, value);
+        if (renderer())
+            MathMLStyle::resolveMathMLStyleTree(renderer());
+    } else
+        MathMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 }

--- a/Source/WebCore/mathml/MathMLPresentationElement.h
+++ b/Source/WebCore/mathml/MathMLPresentationElement.h
@@ -40,7 +40,7 @@ public:
 
 protected:
     MathMLPresentationElement(const QualifiedName& tagName, Document&);
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
 
     static bool isPhrasingContent(const Node&);
     static bool isFlowContent(const Node&);

--- a/Source/WebCore/mathml/MathMLScriptsElement.cpp
+++ b/Source/WebCore/mathml/MathMLScriptsElement.cpp
@@ -77,14 +77,14 @@ const MathMLElement::Length& MathMLScriptsElement::superscriptShift()
     return cachedMathMLLength(superscriptshiftAttr, m_superscriptShift);
 }
 
-void MathMLScriptsElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void MathMLScriptsElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == subscriptshiftAttr)
         m_subscriptShift = std::nullopt;
     else if (name == superscriptshiftAttr)
         m_superscriptShift = std::nullopt;
-
-    MathMLElement::parseAttribute(name, value);
+    else
+        MathMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 RenderPtr<RenderElement> MathMLScriptsElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)

--- a/Source/WebCore/mathml/MathMLScriptsElement.h
+++ b/Source/WebCore/mathml/MathMLScriptsElement.h
@@ -46,7 +46,7 @@ protected:
 
 private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
 
     const ScriptType m_scriptType;
     std::optional<Length> m_subscriptShift;

--- a/Source/WebCore/mathml/MathMLSelectElement.cpp
+++ b/Source/WebCore/mathml/MathMLSelectElement.cpp
@@ -103,10 +103,11 @@ void MathMLSelectElement::childrenChanged(const ChildChange& change)
 
 void MathMLSelectElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason reason)
 {
-    if (hasTagName(mactionTag) && (name == MathMLNames::actiontypeAttr || name == MathMLNames::selectionAttr))
-        updateSelectedChild();
-
-    MathMLRowElement::attributeChanged(name, oldValue, newValue, reason);
+    if (name == MathMLNames::actiontypeAttr || name == MathMLNames::selectionAttr) {
+        if (hasTagName(mactionTag))
+            updateSelectedChild();
+    } else
+        MathMLRowElement::attributeChanged(name, oldValue, newValue, reason);
 }
 
 int MathMLSelectElement::getSelectedActionChildAndIndex(Element*& selectedChild)

--- a/Source/WebCore/mathml/MathMLSpaceElement.cpp
+++ b/Source/WebCore/mathml/MathMLSpaceElement.cpp
@@ -63,7 +63,7 @@ const MathMLElement::Length& MathMLSpaceElement::depth()
     return cachedMathMLLength(MathMLNames::depthAttr, m_depth);
 }
 
-void MathMLSpaceElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void MathMLSpaceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == widthAttr)
         m_width = std::nullopt;
@@ -71,8 +71,8 @@ void MathMLSpaceElement::parseAttribute(const QualifiedName& name, const AtomStr
         m_height = std::nullopt;
     else if (name == depthAttr)
         m_depth = std::nullopt;
-
-    MathMLPresentationElement::parseAttribute(name, value);
+    else
+        MathMLPresentationElement::attributeChanged(name, oldValue, value, reason);
 }
 
 RenderPtr<RenderElement> MathMLSpaceElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)

--- a/Source/WebCore/mathml/MathMLSpaceElement.h
+++ b/Source/WebCore/mathml/MathMLSpaceElement.h
@@ -41,7 +41,7 @@ public:
 private:
     MathMLSpaceElement(const QualifiedName& tagName, Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     std::optional<Length> m_width;
     std::optional<Length> m_height;

--- a/Source/WebCore/mathml/MathMLUnderOverElement.cpp
+++ b/Source/WebCore/mathml/MathMLUnderOverElement.cpp
@@ -58,14 +58,14 @@ const MathMLElement::BooleanValue& MathMLUnderOverElement::accentUnder()
     return cachedBooleanAttribute(accentunderAttr, m_accentUnder);
 }
 
-void MathMLUnderOverElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void MathMLUnderOverElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == accentAttr)
         m_accent = std::nullopt;
     else if (name == accentunderAttr)
         m_accentUnder = std::nullopt;
-
-    MathMLElement::parseAttribute(name, value);
+    else
+        MathMLElement::attributeChanged(name, oldValue, value, reason);
 }
 
 RenderPtr<RenderElement> MathMLUnderOverElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)

--- a/Source/WebCore/mathml/MathMLUnderOverElement.h
+++ b/Source/WebCore/mathml/MathMLUnderOverElement.h
@@ -41,7 +41,7 @@ public:
 private:
     MathMLUnderOverElement(const QualifiedName& tagName, Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     std::optional<BooleanValue> m_accent;
     std::optional<BooleanValue> m_accentUnder;

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -78,18 +78,18 @@ String SVGAElement::title() const
     return SVGElement::title();
 }
 
-void SVGAElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGAElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == SVGNames::targetAttr) {
-        m_target->setBaseValInternal(value);
+    if (SVGURIReference::parseAttribute(name, value))
         return;
-    } else if (name == SVGNames::relAttr) {
+
+    if (name == SVGNames::targetAttr)
+        m_target->setBaseValInternal(value);
+    else if (name == SVGNames::relAttr) {
         if (m_relList)
             m_relList->associatedAttributeValueChanged(value);
-    }
-
-    SVGGraphicsElement::parseAttribute(name, value);
-    SVGURIReference::parseAttribute(name, value);
+    } else
+        SVGGraphicsElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGAElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGAElement.h
+++ b/Source/WebCore/svg/SVGAElement.h
@@ -47,7 +47,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGAElement, SVGGraphicsElement, SVGURIReference>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -98,15 +98,13 @@ bool SVGAnimateMotionElement::hasValidAttributeName() const
     return true;
 }
 
-void SVGAnimateMotionElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGAnimateMotionElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::pathAttr) {
         m_path = buildPathFromString(value);
         updateAnimationPath();
-        return;
-    }
-
-    SVGAnimationElement::parseAttribute(name, value);
+    } else
+        SVGAnimationElement::attributeChanged(name, oldValue, value, reason);
 }
     
 SVGAnimateMotionElement::RotateMode SVGAnimateMotionElement::rotateMode() const

--- a/Source/WebCore/svg/SVGAnimateMotionElement.h
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.h
@@ -39,7 +39,7 @@ private:
     bool hasValidAttributeType() const override;
     bool hasValidAttributeName() const override;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     void startAnimation() override;
     void stopAnimation(SVGElement* targetElement) override;

--- a/Source/WebCore/svg/SVGAnimateTransformElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateTransformElement.cpp
@@ -54,16 +54,14 @@ bool SVGAnimateTransformElement::hasValidAttributeType() const
     return SVGAnimateElementBase::hasValidAttributeType();
 }
 
-void SVGAnimateTransformElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGAnimateTransformElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::typeAttr) {
         m_type = SVGTransformable::parseTransformType(value).value_or(SVGTransformValue::SVG_TRANSFORM_UNKNOWN);
         if (m_type == SVGTransformValue::SVG_TRANSFORM_MATRIX)
             m_type = SVGTransformValue::SVG_TRANSFORM_UNKNOWN;
-        return;
-    }
-
-    SVGAnimateElementBase::parseAttribute(name, value);
+    } else
+        SVGAnimateElementBase::attributeChanged(name, oldValue, value, reason);
 }
 
 String SVGAnimateTransformElement::animateRangeString(const String& string) const

--- a/Source/WebCore/svg/SVGAnimateTransformElement.h
+++ b/Source/WebCore/svg/SVGAnimateTransformElement.h
@@ -40,7 +40,7 @@ private:
     SVGAnimateTransformElement(const QualifiedName&, Document&);
     
     bool hasValidAttributeType() const final;
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     String animateRangeString(const String&) const final;
 
     SVGTransformValue::SVGTransformType m_type;

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -163,8 +163,11 @@ bool SVGAnimationElement::attributeContainsJavaScriptURL(const Attribute& attrib
     return Element::attributeContainsJavaScriptURL(attribute);
 }
 
-void SVGAnimationElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGAnimationElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
+    if (SVGTests::parseAttribute(name, value))
+        return;
+
     if (name == SVGNames::valuesAttr) {
         // Per the SMIL specification, leading and trailing white space,
         // and white space before and after semicolon separators, is allowed and will be ignored.
@@ -175,48 +178,27 @@ void SVGAnimationElement::parseAttribute(const QualifiedName& name, const AtomSt
         });
 
         updateAnimationMode();
-        return;
-    }
-
-    if (name == SVGNames::keyTimesAttr) {
+    } else if (name == SVGNames::keyTimesAttr)
         parseKeyTimes(value, m_keyTimesFromAttribute, true);
-        return;
-    }
-
-    if (name == SVGNames::keyPointsAttr) {
+    else if (name == SVGNames::keyPointsAttr) {
         if (hasTagName(SVGNames::animateMotionTag)) {
             // This is specified to be an animateMotion attribute only but it is simpler to put it here 
             // where the other timing calculatations are.
             parseKeyTimes(value, m_keyPoints, false);
         }
-        return;
-    }
-
-    if (name == SVGNames::keySplinesAttr) {
+    } else if (name == SVGNames::keySplinesAttr) {
         if (auto keySplines = parseKeySplines(value))
             m_keySplines = WTFMove(*keySplines);
         else
             m_keySplines.clear();
-        return;
-    }
-
-    if (name == SVGNames::attributeTypeAttr) {
+    } else if (name == SVGNames::attributeTypeAttr)
         setAttributeType(value);
-        return;
-    }
-
-    if (name == SVGNames::calcModeAttr) {
+    else if (name == SVGNames::calcModeAttr)
         setCalcMode(value);
-        return;
-    }
-
-    if (name == SVGNames::fromAttr || name == SVGNames::toAttr || name == SVGNames::byAttr) {
+    else if (name == SVGNames::fromAttr || name == SVGNames::toAttr || name == SVGNames::byAttr)
         updateAnimationMode();
-        return;
-    }
-
-    SVGSMILElement::parseAttribute(name, value);
-    SVGTests::parseAttribute(name, value);
+    else
+        SVGSMILElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGAnimationElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGAnimationElement.h
+++ b/Source/WebCore/svg/SVGAnimationElement.h
@@ -88,7 +88,7 @@ protected:
 
     static bool isSupportedAttribute(const QualifiedName&);
     bool attributeContainsJavaScriptURL(const Attribute&) const final;
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 
     String toValue() const;

--- a/Source/WebCore/svg/SVGCircleElement.cpp
+++ b/Source/WebCore/svg/SVGCircleElement.cpp
@@ -50,7 +50,7 @@ Ref<SVGCircleElement> SVGCircleElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new SVGCircleElement(tagName, document));
 }
 
-void SVGCircleElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGCircleElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     SVGParsingError parseError = NoError;
 
@@ -60,10 +60,10 @@ void SVGCircleElement::parseAttribute(const QualifiedName& name, const AtomStrin
         m_cy->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
     else if (name == SVGNames::rAttr)
         m_r->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, value, parseError, SVGLengthNegativeValuesMode::Forbid));
+    else
+        SVGGeometryElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGGeometryElement::parseAttribute(name, value);
 }
 
 void SVGCircleElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGCircleElement.h
+++ b/Source/WebCore/svg/SVGCircleElement.h
@@ -44,7 +44,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGCircleElement, SVGGeometryElement>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
     bool isValid() const final { return SVGTests::isValid(); }

--- a/Source/WebCore/svg/SVGClipPathElement.cpp
+++ b/Source/WebCore/svg/SVGClipPathElement.cpp
@@ -50,16 +50,14 @@ Ref<SVGClipPathElement> SVGClipPathElement::create(const QualifiedName& tagName,
     return adoptRef(*new SVGClipPathElement(tagName, document));
 }
 
-void SVGClipPathElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGClipPathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::clipPathUnitsAttr) {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(value);
         if (propertyValue > 0)
             m_clipPathUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
-        return;
-    }
-
-    SVGGraphicsElement::parseAttribute(name, value);
+    } else
+        SVGGraphicsElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGClipPathElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGClipPathElement.h
+++ b/Source/WebCore/svg/SVGClipPathElement.h
@@ -41,7 +41,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGClipPathElement, SVGGraphicsElement>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
     void childrenChanged(const ChildChange&) final;
 

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
@@ -46,46 +46,26 @@ SVGComponentTransferFunctionElement::SVGComponentTransferFunctionElement(const Q
     });
 }
 
-void SVGComponentTransferFunctionElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGComponentTransferFunctionElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::typeAttr) {
         ComponentTransferType propertyValue = SVGPropertyTraits<ComponentTransferType>::fromString(value);
         if (propertyValue > 0)
             m_type->setBaseValInternal<ComponentTransferType>(propertyValue);
-        return;
-    }
-
-    if (name == SVGNames::tableValuesAttr) {
+    } else if (name == SVGNames::tableValuesAttr)
         m_tableValues->baseVal()->parse(value);
-        return;
-    }
-
-    if (name == SVGNames::slopeAttr) {
+    else if (name == SVGNames::slopeAttr)
         m_slope->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::interceptAttr) {
+    else if (name == SVGNames::interceptAttr)
         m_intercept->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::amplitudeAttr) {
+    else if (name == SVGNames::amplitudeAttr)
         m_amplitude->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::exponentAttr) {
+    else if (name == SVGNames::exponentAttr)
         m_exponent->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::offsetAttr) {
+    else if (name == SVGNames::offsetAttr)
         m_offset->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    SVGElement::parseAttribute(name, value);
+    else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGComponentTransferFunctionElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
@@ -92,7 +92,7 @@ protected:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGComponentTransferFunctionElement, SVGElement>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool rendererIsNeeded(const RenderStyle&) override { return false; }

--- a/Source/WebCore/svg/SVGCursorElement.cpp
+++ b/Source/WebCore/svg/SVGCursorElement.cpp
@@ -58,20 +58,21 @@ SVGCursorElement::~SVGCursorElement()
         client->cursorElementRemoved(*this);
 }
 
-void SVGCursorElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGCursorElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
+    if (SVGTests::parseAttribute(name, value) || SVGURIReference::parseAttribute(name, value))
+        return;
+
     SVGParsingError parseError = NoError;
 
     if (name == SVGNames::xAttr)
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError));
     else if (name == SVGNames::yAttr)
         m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
+    else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGElement::parseAttribute(name, value);
-    SVGTests::parseAttribute(name, value);
-    SVGURIReference::parseAttribute(name, value);
 }
 
 void SVGCursorElement::addClient(CSSCursorImageValue& value)

--- a/Source/WebCore/svg/SVGCursorElement.h
+++ b/Source/WebCore/svg/SVGCursorElement.h
@@ -50,7 +50,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGCursorElement, SVGElement, SVGTests, SVGURIReference>;
     
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
     bool isValid() const final { return SVGTests::isValid(); }

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -168,10 +168,9 @@ protected:
     virtual ~SVGElement();
 
     bool rendererIsNeeded(const RenderStyle&) override;
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
 
     void finishParsingChildren() override;
-    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = ModifiedDirectly) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     bool childShouldCreateRenderer(const Node&) const override;
 
     SVGElementRareData& ensureSVGRareData();

--- a/Source/WebCore/svg/SVGEllipseElement.cpp
+++ b/Source/WebCore/svg/SVGEllipseElement.cpp
@@ -51,7 +51,7 @@ Ref<SVGEllipseElement> SVGEllipseElement::create(const QualifiedName& tagName, D
     return adoptRef(*new SVGEllipseElement(tagName, document));
 }
 
-void SVGEllipseElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGEllipseElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     SVGParsingError parseError = NoError;
 
@@ -63,10 +63,10 @@ void SVGEllipseElement::parseAttribute(const QualifiedName& name, const AtomStri
         m_rx->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError, SVGLengthNegativeValuesMode::Forbid));
     else if (name == SVGNames::ryAttr)
         m_ry->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError, SVGLengthNegativeValuesMode::Forbid));
+    else
+        SVGGeometryElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGGeometryElement::parseAttribute(name, value);
 }
 
 void SVGEllipseElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGEllipseElement.h
+++ b/Source/WebCore/svg/SVGEllipseElement.h
@@ -46,7 +46,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGEllipseElement, SVGGeometryElement>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
     bool isValid() const final { return SVGTests::isValid(); }

--- a/Source/WebCore/svg/SVGFEBlendElement.cpp
+++ b/Source/WebCore/svg/SVGFEBlendElement.cpp
@@ -49,26 +49,18 @@ Ref<SVGFEBlendElement> SVGFEBlendElement::create(const QualifiedName& tagName, D
     return adoptRef(*new SVGFEBlendElement(tagName, document));
 }
     
-void SVGFEBlendElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFEBlendElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::modeAttr) {
         BlendMode mode = BlendMode::Normal;
         if (parseBlendMode(value, mode))
             m_mode->setBaseValInternal<BlendMode>(mode);
-        return;
-    }
-
-    if (name == SVGNames::inAttr) {
+    } else if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    if (name == SVGNames::in2Attr) {
+    else if (name == SVGNames::in2Attr)
         m_in2->setBaseValInternal(value);
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 bool SVGFEBlendElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEBlendElement.h
+++ b/Source/WebCore/svg/SVGFEBlendElement.h
@@ -65,7 +65,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEBlendElement, SVGFilterPrimitiveStandardAttributes>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName& attrName) override;

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
@@ -58,26 +58,18 @@ bool SVGFEColorMatrixElement::isInvalidValuesLength() const
         || (filterType == FECOLORMATRIX_TYPE_SATURATE  && size != 1);
 }
 
-void SVGFEColorMatrixElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFEColorMatrixElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::typeAttr) {
         auto propertyValue = SVGPropertyTraits<ColorMatrixType>::fromString(value);
         if (propertyValue > 0)
             m_type->setBaseValInternal<ColorMatrixType>(propertyValue);
-        return;
-    }
-
-    if (name == SVGNames::inAttr) {
+    } else if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    if (name == SVGNames::valuesAttr) {
+    else if (name == SVGNames::valuesAttr)
         m_values->baseVal()->parse(value);
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 bool SVGFEColorMatrixElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.h
@@ -83,7 +83,7 @@ private:
 
     bool isInvalidValuesLength() const;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
@@ -52,14 +52,12 @@ Ref<SVGFEComponentTransferElement> SVGFEComponentTransferElement::create(const Q
     return adoptRef(*new SVGFEComponentTransferElement(tagName, document));
 }
 
-void SVGFEComponentTransferElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFEComponentTransferElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == SVGNames::inAttr) {
+    if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGFEComponentTransferElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.h
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.h
@@ -39,7 +39,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEComponentTransferElement, SVGFilterPrimitiveStandardAttributes>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() } }; }

--- a/Source/WebCore/svg/SVGFECompositeElement.cpp
+++ b/Source/WebCore/svg/SVGFECompositeElement.cpp
@@ -52,46 +52,26 @@ Ref<SVGFECompositeElement> SVGFECompositeElement::create(const QualifiedName& ta
     return adoptRef(*new SVGFECompositeElement(tagName, document));
 }
 
-void SVGFECompositeElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFECompositeElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::operatorAttr) {
         CompositeOperationType propertyValue = SVGPropertyTraits<CompositeOperationType>::fromString(value);
         if (propertyValue > 0)
             m_svgOperator->setBaseValInternal<CompositeOperationType>(propertyValue);
-        return;
-    }
-
-    if (name == SVGNames::inAttr) {
+    } else if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    if (name == SVGNames::in2Attr) {
+    else if (name == SVGNames::in2Attr)
         m_in2->setBaseValInternal(value);
-        return;
-    }
-
-    if (name == SVGNames::k1Attr) {
+    else if (name == SVGNames::k1Attr)
         m_k1->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::k2Attr) {
+    else if (name == SVGNames::k2Attr)
         m_k2->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::k3Attr) {
+    else if (name == SVGNames::k3Attr)
         m_k3->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::k4Attr) {
+    else if (name == SVGNames::k4Attr)
         m_k4->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 bool SVGFECompositeElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFECompositeElement.h
+++ b/Source/WebCore/svg/SVGFECompositeElement.h
@@ -101,7 +101,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFECompositeElement, SVGFilterPrimitiveStandardAttributes>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -57,82 +57,53 @@ Ref<SVGFEConvolveMatrixElement> SVGFEConvolveMatrixElement::create(const Qualifi
     return adoptRef(*new SVGFEConvolveMatrixElement(tagName, document));
 }
 
-void SVGFEConvolveMatrixElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == SVGNames::inAttr) {
+    if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    if (name == SVGNames::orderAttr) {
+    else if (name == SVGNames::orderAttr) {
         auto result = parseNumberOptionalNumber(value);
         if (result && result->first >= 1 && result->second >= 1) {
             m_orderX->setBaseValInternal(result->first);
             m_orderY->setBaseValInternal(result->second);
         } else
             document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing order=\"" + value + "\". Filtered element will not be displayed.");
-        return;
-    }
-
-    if (name == SVGNames::edgeModeAttr) {
+    } else if (name == SVGNames::edgeModeAttr) {
         EdgeModeType propertyValue = SVGPropertyTraits<EdgeModeType>::fromString(value);
         if (propertyValue != EdgeModeType::Unknown)
             m_edgeMode->setBaseValInternal<EdgeModeType>(propertyValue);
         else
             document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing edgeMode=\"" + value + "\". Filtered element will not be displayed.");
-        return;
-    }
-
-    if (name == SVGNames::kernelMatrixAttr) {
+    } else if (name == SVGNames::kernelMatrixAttr)
         m_kernelMatrix->baseVal()->parse(value);
-        return;
-    }
-
-    if (name == SVGNames::divisorAttr) {
+    else if (name == SVGNames::divisorAttr) {
         float divisor = value.toFloat();
         if (divisor)
             m_divisor->setBaseValInternal(divisor);
         else
             document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing divisor=\"" + value + "\". Filtered element will not be displayed.");
-        return;
-    }
-    
-    if (name == SVGNames::biasAttr) {
+    } else if (name == SVGNames::biasAttr)
         m_bias->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::targetXAttr) {
+    else if (name == SVGNames::targetXAttr)
         m_targetX->setBaseValInternal(parseInteger<unsigned>(value).value_or(0));
-        return;
-    }
-
-    if (name == SVGNames::targetYAttr) {
+    else if (name == SVGNames::targetYAttr)
         m_targetY->setBaseValInternal(parseInteger<unsigned>(value).value_or(0));
-        return;
-    }
-
-    if (name == SVGNames::kernelUnitLengthAttr) {
+    else if (name == SVGNames::kernelUnitLengthAttr) {
         auto result = parseNumberOptionalNumber(value);
         if (result && result->first > 0 && result->second > 0) {
             m_kernelUnitLengthX->setBaseValInternal(result->first);
             m_kernelUnitLengthY->setBaseValInternal(result->second);
         } else
             document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing kernelUnitLength=\"" + value + "\". Filtered element will not be displayed.");
-        return;
-    }
-
-    if (name == SVGNames::preserveAlphaAttr) {
+    } else if (name == SVGNames::preserveAlphaAttr) {
         if (value == trueAtom())
             m_preserveAlpha->setBaseValInternal(true);
         else if (value == falseAtom())
             m_preserveAlpha->setBaseValInternal(false);
         else
             document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing preserveAlphaAttr=\"" + value  + "\". Filtered element will not be displayed.");
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    } else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 bool SVGFEConvolveMatrixElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
@@ -99,7 +99,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEConvolveMatrixElement, SVGFilterPrimitiveStandardAttributes>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
@@ -51,32 +51,21 @@ Ref<SVGFEDiffuseLightingElement> SVGFEDiffuseLightingElement::create(const Quali
     return adoptRef(*new SVGFEDiffuseLightingElement(tagName, document));
 }
 
-void SVGFEDiffuseLightingElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFEDiffuseLightingElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == SVGNames::inAttr) {
+    if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    if (name == SVGNames::surfaceScaleAttr) {
+    else if (name == SVGNames::surfaceScaleAttr)
         m_surfaceScale->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::diffuseConstantAttr) {
+    else if (name == SVGNames::diffuseConstantAttr)
         m_diffuseConstant->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::kernelUnitLengthAttr) {
+    else if (name == SVGNames::kernelUnitLengthAttr) {
         if (auto result = parseNumberOptionalNumber(value)) {
             m_kernelUnitLengthX->setBaseValInternal(result->first);
             m_kernelUnitLengthY->setBaseValInternal(result->second);
         }
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    } else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 bool SVGFEDiffuseLightingElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.h
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.h
@@ -53,7 +53,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDiffuseLightingElement, SVGFilterPrimitiveStandardAttributes>;
     
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
@@ -49,38 +49,24 @@ Ref<SVGFEDisplacementMapElement> SVGFEDisplacementMapElement::create(const Quali
     return adoptRef(*new SVGFEDisplacementMapElement(tagName, document));
 }
 
-void SVGFEDisplacementMapElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFEDisplacementMapElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::xChannelSelectorAttr) {
         auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(value);
         if (propertyValue > 0)
             m_xChannelSelector->setBaseValInternal<ChannelSelectorType>(propertyValue);
-        return;
-    }
-
-    if (name == SVGNames::yChannelSelectorAttr) {
+    } else if (name == SVGNames::yChannelSelectorAttr) {
         auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(value);
         if (propertyValue > 0)
             m_yChannelSelector->setBaseValInternal<ChannelSelectorType>(propertyValue);
-        return;
-    }
-
-    if (name == SVGNames::inAttr) {
+    } else if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    if (name == SVGNames::in2Attr) {
+    else if (name == SVGNames::in2Attr)
         m_in2->setBaseValInternal(value);
-        return;
-    }
-
-    if (name == SVGNames::scaleAttr) {
+    else if (name == SVGNames::scaleAttr)
         m_scale->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 bool SVGFEDisplacementMapElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.h
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.h
@@ -86,7 +86,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDisplacementMapElement, SVGFilterPrimitiveStandardAttributes>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName& attrName) override;

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -57,32 +57,21 @@ void SVGFEDropShadowElement::setStdDeviation(float x, float y)
     updateSVGRendererForElementChange();
 }
 
-void SVGFEDropShadowElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFEDropShadowElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::stdDeviationAttr) {
         if (auto result = parseNumberOptionalNumber(value)) {
             m_stdDeviationX->setBaseValInternal(result->first);
             m_stdDeviationY->setBaseValInternal(result->second);
         }
-        return;
-    }
-
-    if (name == SVGNames::inAttr) {
+    } else if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    if (name == SVGNames::dxAttr) {
+    else if (name == SVGNames::dxAttr)
         m_dx->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::dyAttr) {
+    else if (name == SVGNames::dyAttr)
         m_dy->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGFEDropShadowElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEDropShadowElement.h
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.h
@@ -49,7 +49,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDropShadowElement, SVGFilterPrimitiveStandardAttributes>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -56,31 +56,23 @@ void SVGFEGaussianBlurElement::setStdDeviation(float x, float y)
     updateSVGRendererForElementChange();
 }
 
-void SVGFEGaussianBlurElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFEGaussianBlurElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::stdDeviationAttr) {
         if (auto result = parseNumberOptionalNumber(value)) {
             m_stdDeviationX->setBaseValInternal(result->first);
             m_stdDeviationY->setBaseValInternal(result->second);
         }
-        return;
-    }
-
-    if (name == SVGNames::inAttr) {
+    } else if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    if (name == SVGNames::edgeModeAttr) {
+    else if (name == SVGNames::edgeModeAttr) {
         auto propertyValue = SVGPropertyTraits<EdgeModeType>::fromString(value);
         if (propertyValue != EdgeModeType::Unknown)
             m_edgeMode->setBaseValInternal<EdgeModeType>(propertyValue);
         else
             document().accessSVGExtensions().reportWarning("feGaussianBlur: problem parsing edgeMode=\"" + value + "\". Filtered element will not be displayed.");
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    } else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGFEGaussianBlurElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.h
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.h
@@ -49,7 +49,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEGaussianBlurElement, SVGFilterPrimitiveStandardAttributes>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -114,15 +114,15 @@ void SVGFEImageElement::buildPendingResource()
     updateSVGRendererForElementChange();
 }
 
-void SVGFEImageElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFEImageElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == SVGNames::preserveAspectRatioAttr) {
-        m_preserveAspectRatio->setBaseValInternal(SVGPreserveAspectRatioValue { value });
+    if (SVGURIReference::parseAttribute(name, value))
         return;
-    }
 
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
-    SVGURIReference::parseAttribute(name, value);
+    if (name == SVGNames::preserveAspectRatioAttr)
+        m_preserveAspectRatio->setBaseValInternal(SVGPreserveAspectRatioValue { value });
+    else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGFEImageElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -45,7 +45,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEImageElement, SVGFilterPrimitiveStandardAttributes, SVGURIReference>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;

--- a/Source/WebCore/svg/SVGFELightElement.cpp
+++ b/Source/WebCore/svg/SVGFELightElement.cpp
@@ -68,59 +68,30 @@ SVGFELightElement* SVGFELightElement::findLightElement(const SVGElement* svgElem
     return nullptr;
 }
 
-void SVGFELightElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFELightElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == SVGNames::azimuthAttr) {
+    if (name == SVGNames::azimuthAttr)
         m_azimuth->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::elevationAttr) {
+    else if (name == SVGNames::elevationAttr)
         m_elevation->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::xAttr) {
+    else if (name == SVGNames::xAttr)
         m_x->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::yAttr) {
+    else if (name == SVGNames::yAttr)
         m_y->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::zAttr) {
+    else if (name == SVGNames::zAttr)
         m_z->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::pointsAtXAttr) {
+    else if (name == SVGNames::pointsAtXAttr)
         m_pointsAtX->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::pointsAtYAttr) {
+    else if (name == SVGNames::pointsAtYAttr)
         m_pointsAtY->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::pointsAtZAttr) {
+    else if (name == SVGNames::pointsAtZAttr)
         m_pointsAtZ->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::specularExponentAttr) {
+    else if (name == SVGNames::specularExponentAttr)
         m_specularExponent->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::limitingConeAngleAttr) {
+    else if (name == SVGNames::limitingConeAngleAttr)
         m_limitingConeAngle->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    SVGElement::parseAttribute(name, value);
+    else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGFELightElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFELightElement.h
+++ b/Source/WebCore/svg/SVGFELightElement.h
@@ -65,7 +65,7 @@ protected:
 private:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFELightElement, SVGElement>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
     void childrenChanged(const ChildChange&) override;
 

--- a/Source/WebCore/svg/SVGFEMergeNodeElement.cpp
+++ b/Source/WebCore/svg/SVGFEMergeNodeElement.cpp
@@ -48,14 +48,12 @@ Ref<SVGFEMergeNodeElement> SVGFEMergeNodeElement::create(const QualifiedName& ta
     return adoptRef(*new SVGFEMergeNodeElement(tagName, document));
 }
 
-void SVGFEMergeNodeElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFEMergeNodeElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == SVGNames::inAttr) {
+    if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    SVGElement::parseAttribute(name, value);
+    else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGFEMergeNodeElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEMergeNodeElement.h
+++ b/Source/WebCore/svg/SVGFEMergeNodeElement.h
@@ -38,7 +38,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMergeNodeElement, SVGElement>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -55,29 +55,21 @@ void SVGFEMorphologyElement::setRadius(float x, float y)
     updateSVGRendererForElementChange();
 }
 
-void SVGFEMorphologyElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFEMorphologyElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::operatorAttr) {
         MorphologyOperatorType propertyValue = SVGPropertyTraits<MorphologyOperatorType>::fromString(value);
         if (propertyValue != MorphologyOperatorType::Unknown)
             m_svgOperator->setBaseValInternal<MorphologyOperatorType>(propertyValue);
-        return;
-    }
-
-    if (name == SVGNames::inAttr) {
+    } else if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    if (name == SVGNames::radiusAttr) {
+    else if (name == SVGNames::radiusAttr) {
         if (auto result = parseNumberOptionalNumber(value)) {
             m_radiusX->setBaseValInternal(result->first);
             m_radiusY->setBaseValInternal(result->second);
         }
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    } else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 bool SVGFEMorphologyElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEMorphologyElement.h
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.h
@@ -76,7 +76,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMorphologyElement, SVGFilterPrimitiveStandardAttributes>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEOffsetElement.cpp
+++ b/Source/WebCore/svg/SVGFEOffsetElement.cpp
@@ -48,24 +48,16 @@ Ref<SVGFEOffsetElement> SVGFEOffsetElement::create(const QualifiedName& tagName,
     return adoptRef(*new SVGFEOffsetElement(tagName, document));
 }
 
-void SVGFEOffsetElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFEOffsetElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == SVGNames::dxAttr) {
+    if (name == SVGNames::dxAttr)
         m_dx->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::dyAttr) {
+    else if (name == SVGNames::dyAttr)
         m_dy->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::inAttr) {
+    else if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGFEOffsetElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEOffsetElement.h
+++ b/Source/WebCore/svg/SVGFEOffsetElement.h
@@ -43,7 +43,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEOffsetElement, SVGFilterPrimitiveStandardAttributes>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
@@ -54,37 +54,23 @@ Ref<SVGFESpecularLightingElement> SVGFESpecularLightingElement::create(const Qua
     return adoptRef(*new SVGFESpecularLightingElement(tagName, document));
 }
 
-void SVGFESpecularLightingElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFESpecularLightingElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == SVGNames::inAttr) {
+    if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    if (name == SVGNames::surfaceScaleAttr) {
+    else if (name == SVGNames::surfaceScaleAttr)
         m_surfaceScale->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::specularConstantAttr) {
+    else if (name == SVGNames::specularConstantAttr)
         m_specularConstant->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::specularExponentAttr) {
+    else if (name == SVGNames::specularExponentAttr)
         m_specularExponent->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::kernelUnitLengthAttr) {
+    else if (name == SVGNames::kernelUnitLengthAttr) {
         if (auto result = parseNumberOptionalNumber(value)) {
             m_kernelUnitLengthX->setBaseValInternal(result->first);
             m_kernelUnitLengthY->setBaseValInternal(result->second);
         }
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    } else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 bool SVGFESpecularLightingElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.h
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.h
@@ -53,7 +53,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFESpecularLightingElement, SVGFilterPrimitiveStandardAttributes>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFETileElement.cpp
+++ b/Source/WebCore/svg/SVGFETileElement.cpp
@@ -46,14 +46,12 @@ Ref<SVGFETileElement> SVGFETileElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new SVGFETileElement(tagName, document));
 }
 
-void SVGFETileElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFETileElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == SVGNames::inAttr) {
+    if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(value);
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGFETileElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFETileElement.h
+++ b/Source/WebCore/svg/SVGFETileElement.h
@@ -38,7 +38,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFETileElement, SVGFilterPrimitiveStandardAttributes>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() } }; }

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -51,41 +51,27 @@ Ref<SVGFETurbulenceElement> SVGFETurbulenceElement::create(const QualifiedName& 
     return adoptRef(*new SVGFETurbulenceElement(tagName, document));
 }
 
-void SVGFETurbulenceElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFETurbulenceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::typeAttr) {
         TurbulenceType propertyValue = SVGPropertyTraits<TurbulenceType>::fromString(value);
         if (propertyValue != TurbulenceType::Unknown)
             m_type->setBaseValInternal<TurbulenceType>(propertyValue);
-        return;
-    }
-
-    if (name == SVGNames::stitchTilesAttr) {
+    } else if (name == SVGNames::stitchTilesAttr) {
         SVGStitchOptions propertyValue = SVGPropertyTraits<SVGStitchOptions>::fromString(value);
         if (propertyValue > 0)
             m_stitchTiles->setBaseValInternal<SVGStitchOptions>(propertyValue);
-        return;
-    }
-
-    if (name == SVGNames::baseFrequencyAttr) {
+    } else if (name == SVGNames::baseFrequencyAttr) {
         if (auto result = parseNumberOptionalNumber(value)) {
             m_baseFrequencyX->setBaseValInternal(result->first);
             m_baseFrequencyY->setBaseValInternal(result->second);
         }
-        return;
-    }
-
-    if (name == SVGNames::seedAttr) {
+    } else if (name == SVGNames::seedAttr)
         m_seed->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::numOctavesAttr) {
+    else if (name == SVGNames::numOctavesAttr)
         m_numOctaves->setBaseValInternal(parseInteger<unsigned>(value).value_or(0));
-        return;
-    }
-
-    SVGFilterPrimitiveStandardAttributes::parseAttribute(name, value);
+    else
+        SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, value, reason);
 }
 
 bool SVGFETurbulenceElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFETurbulenceElement.h
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.h
@@ -114,7 +114,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFETurbulenceElement, SVGFilterPrimitiveStandardAttributes>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName& attrName) override;

--- a/Source/WebCore/svg/SVGFilterElement.cpp
+++ b/Source/WebCore/svg/SVGFilterElement.cpp
@@ -62,8 +62,11 @@ Ref<SVGFilterElement> SVGFilterElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new SVGFilterElement(tagName, document));
 }
 
-void SVGFilterElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFilterElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
+    if (SVGURIReference::parseAttribute(name, value))
+        return;
+
     SVGParsingError parseError = NoError;
 
     if (name == SVGNames::filterUnitsAttr) {
@@ -82,11 +85,10 @@ void SVGFilterElement::parseAttribute(const QualifiedName& name, const AtomStrin
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError));
     else if (name == SVGNames::heightAttr)
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
+    else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGElement::parseAttribute(name, value);
-    SVGURIReference::parseAttribute(name, value);
 }
 
 void SVGFilterElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFilterElement.h
+++ b/Source/WebCore/svg/SVGFilterElement.h
@@ -53,7 +53,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFilterElement, SVGElement, SVGURIReference>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
     void childrenChanged(const ChildChange&) final;
 

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
@@ -46,7 +46,7 @@ SVGFilterPrimitiveStandardAttributes::SVGFilterPrimitiveStandardAttributes(const
     });
 }
 
-void SVGFilterPrimitiveStandardAttributes::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFilterPrimitiveStandardAttributes::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     SVGParsingError parseError = NoError;
 
@@ -60,10 +60,10 @@ void SVGFilterPrimitiveStandardAttributes::parseAttribute(const QualifiedName& n
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
     else if (name == SVGNames::resultAttr)
         m_result->setBaseValInternal(value);
+    else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGElement::parseAttribute(name, value);
 }
 
 OptionSet<FilterEffectGeometry::Flags> SVGFilterPrimitiveStandardAttributes::effectGeometryFlags() const

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
@@ -66,7 +66,7 @@ public:
 protected:
     SVGFilterPrimitiveStandardAttributes(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
     void childrenChanged(const ChildChange&) override;
 

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -70,10 +70,9 @@ Ref<SVGFontFaceElement> SVGFontFaceElement::create(const QualifiedName& tagName,
     return adoptRef(*new SVGFontFaceElement(tagName, document));
 }
 
-void SVGFontFaceElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFontFaceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {    
-    CSSPropertyID propertyId = cssPropertyIdForSVGAttributeName(name);
-    if (propertyId > 0) {
+    if (auto propertyId = cssPropertyIdForSVGAttributeName(name)) {
         // FIXME: Parse using the @font-face descriptor grammars, not the property grammars.
         auto& properties = m_fontFaceRule->mutableProperties();
         bool valueChanged = properties.setProperty(propertyId, value);
@@ -89,10 +88,8 @@ void SVGFontFaceElement::parseAttribute(const QualifiedName& name, const AtomStr
         }
 
         rebuildFontFace();
-        return;
-    }
-    
-    SVGElement::parseAttribute(name, value);
+    } else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 unsigned SVGFontFaceElement::unitsPerEm() const

--- a/Source/WebCore/svg/SVGFontFaceElement.h
+++ b/Source/WebCore/svg/SVGFontFaceElement.h
@@ -55,7 +55,7 @@ private:
     SVGFontFaceElement(const QualifiedName&, Document&);
     ~SVGFontFaceElement();
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
 
     void childrenChanged(const ChildChange&) final;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;

--- a/Source/WebCore/svg/SVGFontFaceUriElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.cpp
@@ -64,12 +64,12 @@ Ref<CSSFontFaceSrcValue> SVGFontFaceUriElement::srcValue() const
     return src;
 }
 
-void SVGFontFaceUriElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGFontFaceUriElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::hrefAttr || name == XLinkNames::hrefAttr)
         loadFont();
     else
-        SVGElement::parseAttribute(name, value);
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGFontFaceUriElement::childrenChanged(const ChildChange& change)

--- a/Source/WebCore/svg/SVGFontFaceUriElement.h
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.h
@@ -39,7 +39,7 @@ public:
 private:
     SVGFontFaceUriElement(const QualifiedName&, Document&);
     
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void childrenChanged(const ChildChange&) final;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     bool rendererIsNeeded(const RenderStyle&) final { return false; }

--- a/Source/WebCore/svg/SVGForeignObjectElement.cpp
+++ b/Source/WebCore/svg/SVGForeignObjectElement.cpp
@@ -55,7 +55,7 @@ Ref<SVGForeignObjectElement> SVGForeignObjectElement::create(const QualifiedName
     return adoptRef(*new SVGForeignObjectElement(tagName, document));
 }
 
-void SVGForeignObjectElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGForeignObjectElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     SVGParsingError parseError = NoError;
 
@@ -67,10 +67,10 @@ void SVGForeignObjectElement::parseAttribute(const QualifiedName& name, const At
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError));
     else if (name == SVGNames::heightAttr)
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
+    else
+        SVGGraphicsElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGGraphicsElement::parseAttribute(name, value);
 }
 
 void SVGForeignObjectElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGForeignObjectElement.h
+++ b/Source/WebCore/svg/SVGForeignObjectElement.h
@@ -45,7 +45,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGForeignObjectElement, SVGGraphicsElement>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
     bool rendererIsNeeded(const RenderStyle&) final;

--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -133,16 +133,14 @@ bool SVGGeometryElement::isPointInStroke(DOMPointInit&& pointInit)
     return false;
 }
 
-void SVGGeometryElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGGeometryElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::pathLengthAttr) {
         m_pathLength->setBaseValInternal(value.toFloat());
         if (m_pathLength->baseVal() < 0)
             document().accessSVGExtensions().reportError("A negative value for path attribute <pathLength> is not allowed"_s);
-        return;
-    }
-
-    SVGGraphicsElement::parseAttribute(name, value);
+    } else
+        SVGGraphicsElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGGeometryElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGGeometryElement.h
+++ b/Source/WebCore/svg/SVGGeometryElement.h
@@ -48,7 +48,7 @@ public:
 protected:
     SVGGeometryElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 
 private:

--- a/Source/WebCore/svg/SVGGlyphRefElement.cpp
+++ b/Source/WebCore/svg/SVGGlyphRefElement.cpp
@@ -60,8 +60,11 @@ static float parseFloat(const AtomString& value)
     return parseNumber(value).value_or(0);
 }
 
-void SVGGlyphRefElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGGlyphRefElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
+    if (SVGURIReference::parseAttribute(name, value))
+        return;
+
     // FIXME: Is the error handling in parseFloat correct for these attributes?
     if (name == SVGNames::xAttr)
         m_x = parseFloat(value);
@@ -71,10 +74,8 @@ void SVGGlyphRefElement::parseAttribute(const QualifiedName& name, const AtomStr
         m_dx = parseFloat(value);
     else if (name == SVGNames::dyAttr)
         m_dy = parseFloat(value);
-    else {
-        SVGURIReference::parseAttribute(name, value);
-        SVGElement::parseAttribute(name, value);
-    }
+    else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGGlyphRefElement::setX(float x)

--- a/Source/WebCore/svg/SVGGlyphRefElement.h
+++ b/Source/WebCore/svg/SVGGlyphRefElement.h
@@ -46,7 +46,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGlyphRefElement, SVGElement, SVGURIReference>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 
     float m_x { 0 };

--- a/Source/WebCore/svg/SVGGradientElement.cpp
+++ b/Source/WebCore/svg/SVGGradientElement.cpp
@@ -49,29 +49,23 @@ SVGGradientElement::SVGGradientElement(const QualifiedName& tagName, Document& d
     });
 }
 
-void SVGGradientElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGGradientElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
+    if (SVGURIReference::parseAttribute(name, value))
+        return;
+
     if (name == SVGNames::gradientUnitsAttr) {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(value);
         if (propertyValue > 0)
             m_gradientUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
-        return;
-    }
-
-    if (name == SVGNames::gradientTransformAttr) {
+    } else if (name == SVGNames::gradientTransformAttr)
         m_gradientTransform->baseVal()->parse(value);
-        return;
-    }
-
-    if (name == SVGNames::spreadMethodAttr) {
+    else if (name == SVGNames::spreadMethodAttr) {
         auto propertyValue = SVGPropertyTraits<SVGSpreadMethodType>::fromString(value);
         if (propertyValue > 0)
             m_spreadMethod->setBaseValInternal<SVGSpreadMethodType>(propertyValue);
-        return;
-    }
-
-    SVGElement::parseAttribute(name, value);
-    SVGURIReference::parseAttribute(name, value);
+    } else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGGradientElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGGradientElement.h
+++ b/Source/WebCore/svg/SVGGradientElement.h
@@ -94,7 +94,7 @@ public:
 protected:
     SVGGradientElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 
 private:

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -129,15 +129,15 @@ AffineTransform* SVGGraphicsElement::supplementalTransform()
     return m_supplementalTransform.get();
 }
 
-void SVGGraphicsElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGGraphicsElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == SVGNames::transformAttr) {
-        m_transform->baseVal()->parse(value);
+    if (SVGTests::parseAttribute(name, value))
         return;
-    }
 
-    SVGElement::parseAttribute(name, value);
-    SVGTests::parseAttribute(name, value);
+    if (name == SVGNames::transformAttr)
+        m_transform->baseVal()->parse(value);
+    else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGGraphicsElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -72,7 +72,7 @@ public:
 protected:
     SVGGraphicsElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
     void didAttachRenderers() override;
 

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -78,16 +78,16 @@ bool SVGImageElement::hasSingleSecurityOrigin() const
     return !image || image->hasSingleSecurityOrigin();
 }
 
-void SVGImageElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGImageElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == SVGNames::preserveAspectRatioAttr) {
-        m_preserveAspectRatio->setBaseValInternal(SVGPreserveAspectRatioValue { value });
+    if (SVGURIReference::parseAttribute(name, value))
         return;
-    }
 
     SVGParsingError parseError = NoError;
 
-    if (name == SVGNames::xAttr)
+    if (name == SVGNames::preserveAspectRatioAttr)
+        m_preserveAspectRatio->setBaseValInternal(SVGPreserveAspectRatioValue { value });
+    else if (name == SVGNames::xAttr)
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError));
     else if (name == SVGNames::yAttr)
         m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
@@ -95,11 +95,10 @@ void SVGImageElement::parseAttribute(const QualifiedName& name, const AtomString
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError, SVGLengthNegativeValuesMode::Forbid));
     else if (name == SVGNames::heightAttr)
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError, SVGLengthNegativeValuesMode::Forbid));
+    else
+        SVGGraphicsElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGGraphicsElement::parseAttribute(name, value);
-    SVGURIReference::parseAttribute(name, value);
 }
 
 void SVGImageElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -52,7 +52,7 @@ private:
     
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGImageElement, SVGGraphicsElement, SVGURIReference>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
     void didAttachRenderers() final;

--- a/Source/WebCore/svg/SVGLineElement.cpp
+++ b/Source/WebCore/svg/SVGLineElement.cpp
@@ -51,7 +51,7 @@ Ref<SVGLineElement> SVGLineElement::create(const QualifiedName& tagName, Documen
     return adoptRef(*new SVGLineElement(tagName, document));
 }
 
-void SVGLineElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGLineElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     SVGParsingError parseError = NoError;
 
@@ -63,10 +63,10 @@ void SVGLineElement::parseAttribute(const QualifiedName& name, const AtomString&
         m_x2->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError));
     else if (name == SVGNames::y2Attr)
         m_y2->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
+    else
+        SVGGeometryElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGGeometryElement::parseAttribute(name, value);
 }
 
 void SVGLineElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGLineElement.h
+++ b/Source/WebCore/svg/SVGLineElement.h
@@ -46,7 +46,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGLineElement, SVGGeometryElement>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
     bool isValid() const final { return SVGTests::isValid(); }

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -60,7 +60,7 @@ Ref<SVGLinearGradientElement> SVGLinearGradientElement::create(const QualifiedNa
     return adoptRef(*new SVGLinearGradientElement(tagName, document));
 }
 
-void SVGLinearGradientElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGLinearGradientElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     SVGParsingError parseError = NoError;
 
@@ -72,10 +72,10 @@ void SVGLinearGradientElement::parseAttribute(const QualifiedName& name, const A
         m_x2->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError));
     else if (name == SVGNames::y2Attr)
         m_y2->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
+    else
+        SVGGradientElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGGradientElement::parseAttribute(name, value);
 }
 
 void SVGLinearGradientElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGLinearGradientElement.h
+++ b/Source/WebCore/svg/SVGLinearGradientElement.h
@@ -50,7 +50,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGLinearGradientElement, SVGGradientElement>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;

--- a/Source/WebCore/svg/SVGMPathElement.cpp
+++ b/Source/WebCore/svg/SVGMPathElement.cpp
@@ -98,10 +98,12 @@ void SVGMPathElement::removedFromAncestor(RemovalType removalType, ContainerNode
         clearResourceReferences();
 }
 
-void SVGMPathElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGMPathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    SVGElement::parseAttribute(name, value);
-    SVGURIReference::parseAttribute(name, value);
+    if (SVGURIReference::parseAttribute(name, value))
+        return;
+
+    SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGMPathElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGMPathElement.h
+++ b/Source/WebCore/svg/SVGMPathElement.h
@@ -44,7 +44,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGMPathElement, SVGElement, SVGURIReference>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
     void buildPendingResource() final;

--- a/Source/WebCore/svg/SVGMarkerElement.cpp
+++ b/Source/WebCore/svg/SVGMarkerElement.cpp
@@ -59,25 +59,22 @@ AffineTransform SVGMarkerElement::viewBoxToViewTransform(float viewWidth, float 
     return SVGFitToViewBox::viewBoxToViewTransform(viewBox(), preserveAspectRatio(), viewWidth, viewHeight);
 }
 
-void SVGMarkerElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGMarkerElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
+    SVGParsingError parseError = NoError;
+
+    if (SVGFitToViewBox::parseAttribute(name, value))
+        return;
+
     if (name == SVGNames::markerUnitsAttr) {
         auto propertyValue = SVGPropertyTraits<SVGMarkerUnitsType>::fromString(value);
         if (propertyValue > 0)
             m_markerUnits->setBaseValInternal<SVGMarkerUnitsType>(propertyValue);
-        return;
-    }
-
-    if (name == SVGNames::orientAttr) {
+    } else if (name == SVGNames::orientAttr) {
         auto pair = SVGPropertyTraits<std::pair<SVGAngleValue, SVGMarkerOrientType>>::fromString(value);
         m_orientAngle->setBaseValInternal(pair.first);
         m_orientType->setBaseValInternal(pair.second);
-        return;
-    }
-
-    SVGParsingError parseError = NoError;
-
-    if (name == SVGNames::refXAttr)
+    } else if (name == SVGNames::refXAttr)
         m_refX->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError));
     else if (name == SVGNames::refYAttr)
         m_refY->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
@@ -85,11 +82,10 @@ void SVGMarkerElement::parseAttribute(const QualifiedName& name, const AtomStrin
         m_markerWidth->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError));
     else if (name == SVGNames::markerHeightAttr)
         m_markerHeight->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
+    else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGElement::parseAttribute(name, value);
-    SVGFitToViewBox::parseAttribute(name, value);
 }
 
 void SVGMarkerElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGMarkerElement.h
+++ b/Source/WebCore/svg/SVGMarkerElement.h
@@ -74,7 +74,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGMarkerElement, SVGElement, SVGFitToViewBox>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
     void childrenChanged(const ChildChange&) override;
 

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -64,24 +64,22 @@ Ref<SVGMaskElement> SVGMaskElement::create(const QualifiedName& tagName, Documen
     return adoptRef(*new SVGMaskElement(tagName, document));
 }
 
-void SVGMaskElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGMaskElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
+    if (SVGTests::parseAttribute(name, value))
+        return;
+
+    SVGParsingError parseError = NoError;
+
     if (name == SVGNames::maskUnitsAttr) {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(value);
         if (propertyValue > 0)
             m_maskUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
-        return;
-    }
-    if (name == SVGNames::maskContentUnitsAttr) {
+    } else if (name == SVGNames::maskContentUnitsAttr) {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(value);
         if (propertyValue > 0)
             m_maskContentUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
-        return;
-    }
-
-    SVGParsingError parseError = NoError;
-
-    if (name == SVGNames::xAttr)
+    } else if (name == SVGNames::xAttr)
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError));
     else if (name == SVGNames::yAttr)
         m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
@@ -89,11 +87,10 @@ void SVGMaskElement::parseAttribute(const QualifiedName& name, const AtomString&
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError));
     else if (name == SVGNames::heightAttr)
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
+    else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGElement::parseAttribute(name, value);
-    SVGTests::parseAttribute(name, value);
 }
 
 void SVGMaskElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGMaskElement.h
+++ b/Source/WebCore/svg/SVGMaskElement.h
@@ -51,7 +51,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGMaskElement, SVGElement, SVGTests>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
     void childrenChanged(const ChildChange&) final;
 

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -53,15 +53,13 @@ Ref<SVGPathElement> SVGPathElement::create(const QualifiedName& tagName, Documen
     return adoptRef(*new SVGPathElement(tagName, document));
 }
 
-void SVGPathElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGPathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::dAttr) {
         if (!m_pathSegList->baseVal()->parse(value))
             document().accessSVGExtensions().reportError("Problem parsing d=\"" + value + "\"");
-        return;
-    }
-
-    SVGGeometryElement::parseAttribute(name, value);
+    } else
+        SVGGeometryElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGPathElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -109,7 +109,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGPathElement, SVGGeometryElement>;
     
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
     bool isValid() const final { return SVGTests::isValid(); }

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -70,28 +70,24 @@ Ref<SVGPatternElement> SVGPatternElement::create(const QualifiedName& tagName, D
     return adoptRef(*new SVGPatternElement(tagName, document));
 }
 
-void SVGPatternElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGPatternElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
+    if (SVGURIReference::parseAttribute(name, value) || SVGTests::parseAttribute(name, value) || SVGFitToViewBox::parseAttribute(name, value))
+        return;
+
+    SVGParsingError parseError = NoError;
+
     if (name == SVGNames::patternUnitsAttr) {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(value);
         if (propertyValue > 0)
             m_patternUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
-        return;
-    }
-    if (name == SVGNames::patternContentUnitsAttr) {
+    } else if (name == SVGNames::patternContentUnitsAttr) {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(value);
         if (propertyValue > 0)
             m_patternContentUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
-        return;
-    }
-    if (name == SVGNames::patternTransformAttr) {
+    } else if (name == SVGNames::patternTransformAttr) {
         m_patternTransform->baseVal()->parse(value);
-        return;
-    }
-
-    SVGParsingError parseError = NoError;
-
-    if (name == SVGNames::xAttr)
+    } else if (name == SVGNames::xAttr)
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError));
     else if (name == SVGNames::yAttr)
         m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
@@ -99,13 +95,10 @@ void SVGPatternElement::parseAttribute(const QualifiedName& name, const AtomStri
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError, SVGLengthNegativeValuesMode::Forbid));
     else if (name == SVGNames::heightAttr)
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError, SVGLengthNegativeValuesMode::Forbid));
+    else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGElement::parseAttribute(name, value);
-    SVGURIReference::parseAttribute(name, value);
-    SVGTests::parseAttribute(name, value);
-    SVGFitToViewBox::parseAttribute(name, value);
 }
 
 void SVGPatternElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -62,7 +62,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGPatternElement, SVGElement, SVGFitToViewBox, SVGTests, SVGURIReference>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
     void childrenChanged(const ChildChange&) final;
 

--- a/Source/WebCore/svg/SVGPolyElement.cpp
+++ b/Source/WebCore/svg/SVGPolyElement.cpp
@@ -43,15 +43,13 @@ SVGPolyElement::SVGPolyElement(const QualifiedName& tagName, Document& document)
     });
 }
 
-void SVGPolyElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGPolyElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::pointsAttr) {
         if (!m_points->baseVal()->parse(value))
             document().accessSVGExtensions().reportError("Problem parsing points=\"" + value + "\"");
-        return;
-    }
-
-    SVGGeometryElement::parseAttribute(name, value);
+    } else
+        SVGGeometryElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGPolyElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGPolyElement.h
+++ b/Source/WebCore/svg/SVGPolyElement.h
@@ -42,7 +42,7 @@ protected:
 private:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGPolyElement, SVGGeometryElement>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override; 
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool isValid() const override { return SVGTests::isValid(); }

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -62,7 +62,7 @@ Ref<SVGRadialGradientElement> SVGRadialGradientElement::create(const QualifiedNa
     return adoptRef(*new SVGRadialGradientElement(tagName, document));
 }
 
-void SVGRadialGradientElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGRadialGradientElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     SVGParsingError parseError = NoError;
 
@@ -78,10 +78,10 @@ void SVGRadialGradientElement::parseAttribute(const QualifiedName& name, const A
         m_fy->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError));
     else if (name == SVGNames::frAttr)
         m_fr->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, value, parseError, SVGLengthNegativeValuesMode::Forbid));
+    else
+        SVGGradientElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGGradientElement::parseAttribute(name, value);
 }
 
 void SVGRadialGradientElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGRadialGradientElement.h
+++ b/Source/WebCore/svg/SVGRadialGradientElement.h
@@ -54,7 +54,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGRadialGradientElement, SVGGradientElement>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;

--- a/Source/WebCore/svg/SVGRectElement.cpp
+++ b/Source/WebCore/svg/SVGRectElement.cpp
@@ -54,7 +54,7 @@ Ref<SVGRectElement> SVGRectElement::create(const QualifiedName& tagName, Documen
     return adoptRef(*new SVGRectElement(tagName, document));
 }
 
-void SVGRectElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGRectElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     SVGParsingError parseError = NoError;
 
@@ -70,10 +70,10 @@ void SVGRectElement::parseAttribute(const QualifiedName& name, const AtomString&
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError, SVGLengthNegativeValuesMode::Forbid));
     else if (name == SVGNames::heightAttr)
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError, SVGLengthNegativeValuesMode::Forbid));
+    else
+        SVGGeometryElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGGeometryElement::parseAttribute(name, value);
 }
 
 void SVGRectElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGRectElement.h
+++ b/Source/WebCore/svg/SVGRectElement.h
@@ -50,7 +50,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGRectElement, SVGGeometryElement>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
     bool isValid() const final { return SVGTests::isValid(); }

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -124,7 +124,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGSVGElement, SVGGraphicsElement, SVGFitToViewBox>;
     
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
     bool selfHasRelativeLengths() const override;
     bool isValid() const override;

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -44,10 +44,12 @@ Ref<SVGScriptElement> SVGScriptElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new SVGScriptElement(tagName, document, insertedByParser, false));
 }
 
-void SVGScriptElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGScriptElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    SVGElement::parseAttribute(name, value);
-    SVGURIReference::parseAttribute(name, value);
+    if (SVGURIReference::parseAttribute(name, value))
+        return;
+
+    SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGScriptElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -41,7 +41,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGScriptElement, SVGElement, SVGURIReference>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;

--- a/Source/WebCore/svg/SVGStopElement.cpp
+++ b/Source/WebCore/svg/SVGStopElement.cpp
@@ -49,17 +49,15 @@ Ref<SVGStopElement> SVGStopElement::create(const QualifiedName& tagName, Documen
     return adoptRef(*new SVGStopElement(tagName, document));
 }
 
-void SVGStopElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGStopElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::offsetAttr) {
         if (value.endsWith('%'))
             m_offset->setBaseValInternal(value.string().left(value.length() - 1).toFloat() / 100.0f);
         else
             m_offset->setBaseValInternal(value.toFloat());
-        return;
-    }
-
-    SVGElement::parseAttribute(name, value);
+    } else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGStopElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGStopElement.h
+++ b/Source/WebCore/svg/SVGStopElement.h
@@ -40,7 +40,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGStopElement, SVGElement>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 
     bool isGradientStop() const final { return true; }

--- a/Source/WebCore/svg/SVGStyleElement.cpp
+++ b/Source/WebCore/svg/SVGStyleElement.cpp
@@ -92,23 +92,17 @@ String SVGStyleElement::title() const
     return attributeWithoutSynchronization(SVGNames::titleAttr);
 }
 
-void SVGStyleElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGStyleElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::titleAttr) {
         if (sheet() && !isInShadowTree())
             sheet()->setTitle(value);
-        return;
-    }
-    if (name == SVGNames::typeAttr) {
+    } else if (name == SVGNames::typeAttr)
         m_styleSheetOwner.setContentType(value);
-        return;
-    }
-    if (name == SVGNames::mediaAttr) {
+    else if (name == SVGNames::mediaAttr)
         m_styleSheetOwner.setMedia(value);
-        return;
-    }
-
-    SVGElement::parseAttribute(name, value);
+    else
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGStyleElement::finishParsingChildren()

--- a/Source/WebCore/svg/SVGStyleElement.h
+++ b/Source/WebCore/svg/SVGStyleElement.h
@@ -47,7 +47,7 @@ public:
 private:
     SVGStyleElement(const QualifiedName&, Document&, bool createdByParser);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;
     void childrenChanged(const ChildChange&) final;

--- a/Source/WebCore/svg/SVGSymbolElement.cpp
+++ b/Source/WebCore/svg/SVGSymbolElement.cpp
@@ -44,10 +44,12 @@ Ref<SVGSymbolElement> SVGSymbolElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new SVGSymbolElement(tagName, document));
 }
 
-void SVGSymbolElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGSymbolElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    SVGGraphicsElement::parseAttribute(name, value);
-    SVGFitToViewBox::parseAttribute(name, value);
+    if (SVGFitToViewBox::parseAttribute(name, value))
+        return;
+
+    SVGGraphicsElement::attributeChanged(name, oldValue, value, reason);
 }
 
 bool SVGSymbolElement::selfHasRelativeLengths() const

--- a/Source/WebCore/svg/SVGSymbolElement.h
+++ b/Source/WebCore/svg/SVGSymbolElement.h
@@ -36,7 +36,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGSymbolElement, SVGGraphicsElement, SVGFitToViewBox>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
 
     bool selfHasRelativeLengths() const override;

--- a/Source/WebCore/svg/SVGTRefElement.cpp
+++ b/Source/WebCore/svg/SVGTRefElement.cpp
@@ -172,10 +172,12 @@ void SVGTRefElement::detachTarget()
         document().accessSVGExtensions().addPendingResource(target.identifier, *this);
 }
 
-void SVGTRefElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGTRefElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    SVGTextPositioningElement::parseAttribute(name, value);
-    SVGURIReference::parseAttribute(name, value);
+    if (SVGURIReference::parseAttribute(name, value))
+        return;
+
+    SVGTextPositioningElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGTRefElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGTRefElement.h
+++ b/Source/WebCore/svg/SVGTRefElement.h
@@ -41,7 +41,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTRefElement, SVGTextPositioningElement, SVGURIReference>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;

--- a/Source/WebCore/svg/SVGTests.cpp
+++ b/Source/WebCore/svg/SVGTests.cpp
@@ -131,14 +131,17 @@ bool SVGTests::isValid() const
     return true;
 }
 
-void SVGTests::parseAttribute(const QualifiedName& attributeName, const AtomString& value)
+bool SVGTests::parseAttribute(const QualifiedName& attributeName, const AtomString& value)
 {
     if (attributeName == SVGNames::requiredFeaturesAttr)
         m_requiredFeatures->reset(value);
-    if (attributeName == SVGNames::requiredExtensionsAttr)
+    else if (attributeName == SVGNames::requiredExtensionsAttr)
         m_requiredExtensions->reset(value);
-    if (attributeName == SVGNames::systemLanguageAttr)
+    else if (attributeName == SVGNames::systemLanguageAttr)
         m_systemLanguage->reset(value);
+    else
+        return false;
+    return true;
 }
 
 void SVGTests::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGTests.h
+++ b/Source/WebCore/svg/SVGTests.h
@@ -41,7 +41,7 @@ public:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTests>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&);
+    bool parseAttribute(const QualifiedName&, const AtomString&);
     void svgAttributeChanged(const QualifiedName&);
 
     static void addSupportedAttributes(MemoryCompactLookupOnlyRobinHoodHashSet<QualifiedName>&);

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -161,7 +161,7 @@ void SVGTextContentElement::collectPresentationalHintsForAttribute(const Qualifi
     SVGGraphicsElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
-void SVGTextContentElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGTextContentElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     SVGParsingError parseError = NoError;
 
@@ -171,10 +171,10 @@ void SVGTextContentElement::parseAttribute(const QualifiedName& name, const Atom
             m_lengthAdjust->setBaseValInternal<SVGLengthAdjustType>(propertyValue);
     } else if (name == SVGNames::textLengthAttr)
         m_textLength->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, value, parseError, SVGLengthNegativeValuesMode::Forbid));
+    else
+        SVGGraphicsElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGGraphicsElement::parseAttribute(name, value);
 }
 
 void SVGTextContentElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGTextContentElement.h
+++ b/Source/WebCore/svg/SVGTextContentElement.h
@@ -96,7 +96,7 @@ protected:
 
     bool isValid() const override { return SVGTests::isValid(); }
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -63,8 +63,11 @@ void SVGTextPathElement::clearResourceReferences()
     removeElementReference();
 }
 
-void SVGTextPathElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGTextPathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
+    if (SVGURIReference::parseAttribute(name, value))
+        return;
+
     SVGParsingError parseError = NoError;
 
     if (name == SVGNames::startOffsetAttr)
@@ -77,12 +80,10 @@ void SVGTextPathElement::parseAttribute(const QualifiedName& name, const AtomStr
         SVGTextPathSpacingType propertyValue = SVGPropertyTraits<SVGTextPathSpacingType>::fromString(value);
         if (propertyValue > 0)
             m_spacing->setBaseValInternal<SVGTextPathSpacingType>(propertyValue);
-    }
+    } else
+        SVGTextContentElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGTextContentElement::parseAttribute(name, value);
-    SVGURIReference::parseAttribute(name, value);
 }
 
 void SVGTextPathElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGTextPathElement.h
+++ b/Source/WebCore/svg/SVGTextPathElement.h
@@ -128,7 +128,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTextPathElement, SVGTextContentElement, SVGURIReference>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;

--- a/Source/WebCore/svg/SVGTextPositioningElement.cpp
+++ b/Source/WebCore/svg/SVGTextPositioningElement.cpp
@@ -51,34 +51,20 @@ SVGTextPositioningElement::SVGTextPositioningElement(const QualifiedName& tagNam
     });
 }
 
-void SVGTextPositioningElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGTextPositioningElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    if (name == SVGNames::xAttr) {
+    if (name == SVGNames::xAttr)
         m_x->baseVal()->parse(value);
-        return;
-    }
-
-    if (name == SVGNames::yAttr) {
+    else if (name == SVGNames::yAttr)
         m_y->baseVal()->parse(value);
-        return;
-    }
-
-    if (name == SVGNames::dxAttr) {
+    else if (name == SVGNames::dxAttr)
         m_dx->baseVal()->parse(value);
-        return;
-    }
-
-    if (name == SVGNames::dyAttr) {
+    else if (name == SVGNames::dyAttr)
         m_dy->baseVal()->parse(value);
-        return;
-    }
-
-    if (name == SVGNames::rotateAttr) {
+    else if (name == SVGNames::rotateAttr)
         m_rotate->baseVal()->parse(value);
-        return;
-    }
-
-    SVGTextContentElement::parseAttribute(name, value);
+    else
+        SVGTextContentElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGTextPositioningElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)

--- a/Source/WebCore/svg/SVGTextPositioningElement.h
+++ b/Source/WebCore/svg/SVGTextPositioningElement.h
@@ -47,7 +47,7 @@ public:
 protected:
     SVGTextPositioningElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&);
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 
 private:

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -52,12 +52,16 @@ SVGElement& SVGURIReference::contextElement() const
     return *m_href->contextElement();
 }
 
-void SVGURIReference::parseAttribute(const QualifiedName& name, const AtomString& value)
+bool SVGURIReference::parseAttribute(const QualifiedName& name, const AtomString& value)
 {
     if (name.matches(SVGNames::hrefAttr))
         m_href->setBaseValInternal(value.isNull() ? contextElement().getAttribute(XLinkNames::hrefAttr) : value);
-    else if (name.matches(XLinkNames::hrefAttr) && !contextElement().hasAttribute(SVGNames::hrefAttr))
-        m_href->setBaseValInternal(value);
+    else if (name.matches(XLinkNames::hrefAttr)) {
+        if (!contextElement().hasAttribute(SVGNames::hrefAttr))
+            m_href->setBaseValInternal(value);
+    } else
+        return false;
+    return true;
 }
 
 AtomString SVGURIReference::fragmentIdentifierFromIRIString(const String& url, const Document& document)

--- a/Source/WebCore/svg/SVGURIReference.h
+++ b/Source/WebCore/svg/SVGURIReference.h
@@ -34,7 +34,7 @@ class SVGURIReference {
 public:
     virtual ~SVGURIReference() = default;
 
-    void parseAttribute(const QualifiedName&, const AtomString&);
+    bool parseAttribute(const QualifiedName&, const AtomString&);
 
     static AtomString fragmentIdentifierFromIRIString(const String&, const Document&);
 

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -77,8 +77,11 @@ SVGUseElement::~SVGUseElement()
         m_externalDocument->removeClient(*this);
 }
 
-void SVGUseElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGUseElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
+    if (SVGURIReference::parseAttribute(name, value))
+        return;
+
     SVGParsingError parseError = NoError;
 
     if (name == SVGNames::xAttr)
@@ -89,11 +92,10 @@ void SVGUseElement::parseAttribute(const QualifiedName& name, const AtomString& 
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, value, parseError, SVGLengthNegativeValuesMode::Forbid));
     else if (name == SVGNames::heightAttr)
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, value, parseError, SVGLengthNegativeValuesMode::Forbid));
+    else
+        SVGGraphicsElement::attributeChanged(name, oldValue, value, reason);
 
     reportAttributeParsingError(parseError, name, value);
-
-    SVGGraphicsElement::parseAttribute(name, value);
-    SVGURIReference::parseAttribute(name, value);
 }
 
 Node::InsertedIntoAncestorResult SVGUseElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -61,7 +61,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGUseElement, SVGGraphicsElement, SVGURIReference>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;

--- a/Source/WebCore/svg/SVGViewElement.cpp
+++ b/Source/WebCore/svg/SVGViewElement.cpp
@@ -45,11 +45,12 @@ Ref<SVGViewElement> SVGViewElement::create(const QualifiedName& tagName, Documen
     return adoptRef(*new SVGViewElement(tagName, document));
 }
 
-void SVGViewElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGViewElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
-    SVGElement::parseAttribute(name, value);
-    SVGFitToViewBox::parseAttribute(name, value);
-    SVGZoomAndPan::parseAttribute(name, value);
+    if (SVGFitToViewBox::parseAttribute(name, value) || SVGZoomAndPan::parseAttribute(name, value))
+        return;
+
+    SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGViewElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGViewElement.h
+++ b/Source/WebCore/svg/SVGViewElement.h
@@ -46,7 +46,7 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGViewElement, SVGElement, SVGFitToViewBox>;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }

--- a/Source/WebCore/svg/SVGZoomAndPan.cpp
+++ b/Source/WebCore/svg/SVGZoomAndPan.cpp
@@ -51,11 +51,13 @@ std::optional<SVGZoomAndPanType> SVGZoomAndPan::parseZoomAndPan(StringParsingBuf
     return parseZoomAndPanGeneric(buffer);
 }
 
-void SVGZoomAndPan::parseAttribute(const QualifiedName& attributeName, const AtomString& value)
+bool SVGZoomAndPan::parseAttribute(const QualifiedName& attributeName, const AtomString& value)
 {
-    if (attributeName != SVGNames::zoomAndPanAttr)
-        return;
-    m_zoomAndPan = SVGPropertyTraits<SVGZoomAndPanType>::fromString(value);
+    if (attributeName == SVGNames::zoomAndPanAttr) {
+        m_zoomAndPan = SVGPropertyTraits<SVGZoomAndPanType>::fromString(value);
+        return true;
+    }
+    return false;
 }
 
 }

--- a/Source/WebCore/svg/SVGZoomAndPan.h
+++ b/Source/WebCore/svg/SVGZoomAndPan.h
@@ -43,7 +43,7 @@ public:
     ExceptionOr<void> setZoomAndPan(unsigned) { return Exception { NoModificationAllowedError }; }
     void reset() { m_zoomAndPan = SVGPropertyTraits<SVGZoomAndPanType>::initialValue(); }
 
-    void parseAttribute(const QualifiedName&, const AtomString&);
+    bool parseAttribute(const QualifiedName&, const AtomString&);
 
 protected:
     SVGZoomAndPan() = default;

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -480,7 +480,7 @@ bool SVGSMILElement::isSupportedAttribute(const QualifiedName& attrName)
     return supportedAttributes.get().contains<SVGAttributeHashTranslator>(attrName);
 }
 
-void SVGSMILElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void SVGSMILElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& value, AttributeModificationReason reason)
 {
     if (name == SVGNames::beginAttr) {
         if (!m_conditions.isEmpty()) {
@@ -505,7 +505,7 @@ void SVGSMILElement::parseAttribute(const QualifiedName& name, const AtomString&
     else if (name == SVGNames::onbeginAttr)
         setAttributeEventListener(eventNames().beginEventEvent, name, value);
     else
-        SVGElement::parseAttribute(name, value);
+        SVGElement::attributeChanged(name, oldValue, value, reason);
 }
 
 void SVGSMILElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -46,7 +46,7 @@ public:
     SVGSMILElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&);
     virtual ~SVGSMILElement();
 
-    void parseAttribute(const QualifiedName&, const AtomString&) override;
+    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& value, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
     void removedFromAncestor(RemovalType, ContainerNode&) override;


### PR DESCRIPTION
#### 03a5c1dee63e3365b6df614c4fca7c16d29acc17
<pre>
Merge Element::attributeChanged and Element::parseAttribute and avoid base class calls when an attribute is handled
<a href="https://bugs.webkit.org/show_bug.cgi?id=244822">https://bugs.webkit.org/show_bug.cgi?id=244822</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::idAttributeChanged):
(WebCore::Element::attributeChanged):
(WebCore::Element::notifyAttributeChanged):
(WebCore::Element::parserSetAttributes):
(WebCore::Element::didMoveToNewDocument):
(WebCore::Element::didAddAttribute):
(WebCore::Element::didModifyAttribute):
(WebCore::Element::didRemoveAttribute):
(WebCore::Element::cloneAttributesFromElement):
* Source/WebCore/dom/Element.h:
(WebCore::Element::parseAttribute): Deleted.
* Source/WebCore/dom/StyledElement.h:
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::attributeChanged):
(WebCore::HTMLAnchorElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLAnchorElement.h:
* Source/WebCore/html/HTMLAreaElement.cpp:
(WebCore::HTMLAreaElement::attributeChanged):
(WebCore::HTMLAreaElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLAreaElement.h:
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::attributeChanged):
(WebCore::HTMLAttachmentElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/HTMLBaseElement.cpp:
(WebCore::HTMLBaseElement::attributeChanged):
(WebCore::HTMLBaseElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLBaseElement.h:
* Source/WebCore/html/HTMLBodyElement.cpp:
(WebCore::HTMLBodyElement::attributeChanged):
(WebCore::HTMLBodyElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLBodyElement.h:
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::attributeChanged):
(WebCore::HTMLButtonElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLButtonElement.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::attributeChanged):
(WebCore::HTMLCanvasElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::attributeChanged):
(WebCore::HTMLDetailsElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLDetailsElement.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::attributeChanged):
(WebCore::HTMLElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLEmbedElement.cpp:
(WebCore::HTMLEmbedElement::attributeChanged):
(WebCore::HTMLEmbedElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLEmbedElement.h:
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::attributeChanged):
(WebCore::HTMLFormControlElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::attributeChanged):
(WebCore::HTMLFormElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLFormElement.h:
* Source/WebCore/html/HTMLFrameElement.cpp:
(WebCore::HTMLFrameElement::attributeChanged):
(WebCore::HTMLFrameElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLFrameElement.h:
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::attributeChanged):
(WebCore::HTMLFrameElementBase::parseAttribute): Deleted.
* Source/WebCore/html/HTMLFrameElementBase.h:
* Source/WebCore/html/HTMLFrameSetElement.cpp:
(WebCore::HTMLFrameSetElement::attributeChanged):
(WebCore::HTMLFrameSetElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLFrameSetElement.h:
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::attributeChanged):
(WebCore::HTMLIFrameElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLIFrameElement.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::attributeChanged):
(WebCore::HTMLImageElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateType):
(WebCore::HTMLInputElement::attributeChanged):
(WebCore::HTMLInputElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLLIElement.cpp:
(WebCore::HTMLLIElement::attributeChanged):
(WebCore::HTMLLIElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLLIElement.h:
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::attributeChanged):
(WebCore::HTMLLinkElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/HTMLMapElement.cpp:
(WebCore::HTMLMapElement::attributeChanged):
(WebCore::HTMLMapElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLMapElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::attributeChanged):
(WebCore::HTMLMediaElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLMenuElement.cpp:
(WebCore::HTMLMenuElement::attributeChanged):
(WebCore::HTMLMenuElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLMenuElement.h:
* Source/WebCore/html/HTMLMetaElement.cpp:
(WebCore::HTMLMetaElement::attributeChanged):
(WebCore::HTMLMetaElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLMetaElement.h:
* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::attributeChanged):
(WebCore::HTMLMeterElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLMeterElement.h:
* Source/WebCore/html/HTMLOListElement.cpp:
(WebCore::HTMLOListElement::attributeChanged):
(WebCore::HTMLOListElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLOListElement.h:
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::attributeChanged):
(WebCore::HTMLObjectElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLObjectElement.h:
* Source/WebCore/html/HTMLOptGroupElement.cpp:
(WebCore::HTMLOptGroupElement::attributeChanged):
(WebCore::HTMLOptGroupElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLOptGroupElement.h:
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::attributeChanged):
(WebCore::HTMLOptionElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLOptionElement.h:
* Source/WebCore/html/HTMLOutputElement.cpp:
(WebCore::HTMLOutputElement::attributeChanged):
(WebCore::HTMLOutputElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLOutputElement.h:
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::attributeChanged):
(WebCore::HTMLProgressElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLProgressElement.h:
* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::attributeChanged):
(WebCore::HTMLScriptElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::attributeChanged):
(WebCore::HTMLSelectElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebCore/html/HTMLSourceElement.cpp:
(WebCore::HTMLSourceElement::attributeChanged):
(WebCore::HTMLSourceElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLSourceElement.h:
* Source/WebCore/html/HTMLStyleElement.cpp:
(WebCore::HTMLStyleElement::attributeChanged):
(WebCore::HTMLStyleElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLStyleElement.h:
* Source/WebCore/html/HTMLTableCellElement.cpp:
(WebCore::HTMLTableCellElement::attributeChanged):
(WebCore::HTMLTableCellElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLTableCellElement.h:
* Source/WebCore/html/HTMLTableColElement.cpp:
(WebCore::HTMLTableColElement::attributeChanged):
(WebCore::HTMLTableColElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLTableColElement.h:
* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::HTMLTableElement::attributeChanged):
(WebCore::HTMLTableElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLTableElement.h:
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::attributeChanged):
(WebCore::HTMLTextAreaElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLTextAreaElement.h:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::attributeChanged):
(WebCore::HTMLTextFormControlElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLTextFormControlElement.h:
* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::attributeChanged):
(WebCore::HTMLTrackElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLTrackElement.h:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::attributeChanged):
(WebCore::HTMLVideoElement::parseAttribute): Deleted.
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::attributeChanged):
(WebCore::MathMLElement::parseAttribute): Deleted.
* Source/WebCore/mathml/MathMLElement.h:
* Source/WebCore/mathml/MathMLFractionElement.cpp:
(WebCore::MathMLFractionElement::attributeChanged):
(WebCore::MathMLFractionElement::parseAttribute): Deleted.
* Source/WebCore/mathml/MathMLFractionElement.h:
* Source/WebCore/mathml/MathMLMathElement.cpp:
(WebCore::MathMLMathElement::attributeChanged):
(WebCore::MathMLMathElement::parseAttribute): Deleted.
* Source/WebCore/mathml/MathMLMathElement.h:
* Source/WebCore/mathml/MathMLMencloseElement.cpp:
(WebCore::MathMLMencloseElement::attributeChanged):
(WebCore::MathMLMencloseElement::parseAttribute): Deleted.
* Source/WebCore/mathml/MathMLMencloseElement.h:
* Source/WebCore/mathml/MathMLOperatorElement.cpp:
(WebCore::MathMLOperatorElement::attributeChanged):
(WebCore::MathMLOperatorElement::parseAttribute): Deleted.
* Source/WebCore/mathml/MathMLOperatorElement.h:
* Source/WebCore/mathml/MathMLPaddedElement.cpp:
(WebCore::MathMLPaddedElement::attributeChanged):
(WebCore::MathMLPaddedElement::parseAttribute): Deleted.
* Source/WebCore/mathml/MathMLPaddedElement.h:
* Source/WebCore/mathml/MathMLPresentationElement.cpp:
(WebCore::MathMLPresentationElement::attributeChanged):
(WebCore::MathMLPresentationElement::parseAttribute): Deleted.
* Source/WebCore/mathml/MathMLPresentationElement.h:
* Source/WebCore/mathml/MathMLScriptsElement.cpp:
(WebCore::MathMLScriptsElement::attributeChanged):
(WebCore::MathMLScriptsElement::parseAttribute): Deleted.
* Source/WebCore/mathml/MathMLScriptsElement.h:
* Source/WebCore/mathml/MathMLSpaceElement.cpp:
(WebCore::MathMLSpaceElement::attributeChanged):
(WebCore::MathMLSpaceElement::parseAttribute): Deleted.
* Source/WebCore/mathml/MathMLSpaceElement.h:
* Source/WebCore/mathml/MathMLUnderOverElement.cpp:
(WebCore::MathMLUnderOverElement::attributeChanged):
(WebCore::MathMLUnderOverElement::parseAttribute): Deleted.
* Source/WebCore/mathml/MathMLUnderOverElement.h:
* Source/WebCore/svg/SVGAElement.cpp:
(WebCore::SVGAElement::attributeChanged):
(WebCore::SVGAElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGAElement.h:
* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::attributeChanged):
(WebCore::SVGAnimateMotionElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGAnimateMotionElement.h:
* Source/WebCore/svg/SVGAnimateTransformElement.cpp:
(WebCore::SVGAnimateTransformElement::attributeChanged):
(WebCore::SVGAnimateTransformElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGAnimateTransformElement.h:
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::attributeChanged):
(WebCore::SVGAnimationElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGAnimationElement.h:
* Source/WebCore/svg/SVGCircleElement.cpp:
(WebCore::SVGCircleElement::attributeChanged):
(WebCore::SVGCircleElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGCircleElement.h:
* Source/WebCore/svg/SVGClipPathElement.cpp:
(WebCore::SVGClipPathElement::attributeChanged):
(WebCore::SVGClipPathElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGClipPathElement.h:
* Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp:
(WebCore::SVGComponentTransferFunctionElement::attributeChanged):
(WebCore::SVGComponentTransferFunctionElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGComponentTransferFunctionElement.h:
* Source/WebCore/svg/SVGCursorElement.cpp:
(WebCore::SVGCursorElement::attributeChanged):
(WebCore::SVGCursorElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGCursorElement.h:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::attributeChanged):
(WebCore::SVGElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGElement.h:
* Source/WebCore/svg/SVGEllipseElement.cpp:
(WebCore::SVGEllipseElement::attributeChanged):
(WebCore::SVGEllipseElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGEllipseElement.h:
* Source/WebCore/svg/SVGFEBlendElement.cpp:
(WebCore::SVGFEBlendElement::attributeChanged):
(WebCore::SVGFEBlendElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFEBlendElement.h:
* Source/WebCore/svg/SVGFEColorMatrixElement.cpp:
(WebCore::SVGFEColorMatrixElement::attributeChanged):
(WebCore::SVGFEColorMatrixElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFEColorMatrixElement.h:
* Source/WebCore/svg/SVGFEComponentTransferElement.cpp:
(WebCore::SVGFEComponentTransferElement::attributeChanged):
(WebCore::SVGFEComponentTransferElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFEComponentTransferElement.h:
* Source/WebCore/svg/SVGFECompositeElement.cpp:
(WebCore::SVGFECompositeElement::attributeChanged):
(WebCore::SVGFECompositeElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFECompositeElement.h:
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::attributeChanged):
(WebCore::SVGFEConvolveMatrixElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFEConvolveMatrixElement.h:
* Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp:
(WebCore::SVGFEDiffuseLightingElement::attributeChanged):
(WebCore::SVGFEDiffuseLightingElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFEDiffuseLightingElement.h:
* Source/WebCore/svg/SVGFEDisplacementMapElement.cpp:
(WebCore::SVGFEDisplacementMapElement::attributeChanged):
(WebCore::SVGFEDisplacementMapElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFEDisplacementMapElement.h:
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::attributeChanged):
(WebCore::SVGFEDropShadowElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFEDropShadowElement.h:
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
(WebCore::SVGFEGaussianBlurElement::attributeChanged):
(WebCore::SVGFEGaussianBlurElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFEGaussianBlurElement.h:
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::attributeChanged):
(WebCore::SVGFEImageElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFEImageElement.h:
* Source/WebCore/svg/SVGFELightElement.cpp:
(WebCore::SVGFELightElement::attributeChanged):
(WebCore::SVGFELightElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFELightElement.h:
* Source/WebCore/svg/SVGFEMergeNodeElement.cpp:
(WebCore::SVGFEMergeNodeElement::attributeChanged):
(WebCore::SVGFEMergeNodeElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFEMergeNodeElement.h:
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
(WebCore::SVGFEMorphologyElement::attributeChanged):
(WebCore::SVGFEMorphologyElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFEMorphologyElement.h:
* Source/WebCore/svg/SVGFEOffsetElement.cpp:
(WebCore::SVGFEOffsetElement::attributeChanged):
(WebCore::SVGFEOffsetElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFEOffsetElement.h:
* Source/WebCore/svg/SVGFESpecularLightingElement.cpp:
(WebCore::SVGFESpecularLightingElement::attributeChanged):
(WebCore::SVGFESpecularLightingElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFESpecularLightingElement.h:
* Source/WebCore/svg/SVGFETileElement.cpp:
(WebCore::SVGFETileElement::attributeChanged):
(WebCore::SVGFETileElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFETileElement.h:
* Source/WebCore/svg/SVGFETurbulenceElement.cpp:
(WebCore::SVGFETurbulenceElement::attributeChanged):
(WebCore::SVGFETurbulenceElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFETurbulenceElement.h:
* Source/WebCore/svg/SVGFilterElement.cpp:
(WebCore::SVGFilterElement::attributeChanged):
(WebCore::SVGFilterElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFilterElement.h:
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp:
(WebCore::SVGFilterPrimitiveStandardAttributes::attributeChanged):
(WebCore::SVGFilterPrimitiveStandardAttributes::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h:
* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::attributeChanged):
(WebCore::SVGFontFaceElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFontFaceElement.h:
* Source/WebCore/svg/SVGFontFaceUriElement.cpp:
(WebCore::SVGFontFaceUriElement::attributeChanged):
(WebCore::SVGFontFaceUriElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGFontFaceUriElement.h:
* Source/WebCore/svg/SVGForeignObjectElement.cpp:
(WebCore::SVGForeignObjectElement::attributeChanged):
(WebCore::SVGForeignObjectElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGForeignObjectElement.h:
* Source/WebCore/svg/SVGGeometryElement.cpp:
(WebCore::SVGGeometryElement::attributeChanged):
(WebCore::SVGGeometryElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGGeometryElement.h:
* Source/WebCore/svg/SVGGlyphRefElement.cpp:
(WebCore::SVGGlyphRefElement::attributeChanged):
(WebCore::SVGGlyphRefElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGGlyphRefElement.h:
* Source/WebCore/svg/SVGGradientElement.cpp:
(WebCore::SVGGradientElement::attributeChanged):
(WebCore::SVGGradientElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGGradientElement.h:
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::attributeChanged):
(WebCore::SVGGraphicsElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGGraphicsElement.h:
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::attributeChanged):
(WebCore::SVGImageElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGImageElement.h:
* Source/WebCore/svg/SVGLineElement.cpp:
(WebCore::SVGLineElement::attributeChanged):
(WebCore::SVGLineElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGLineElement.h:
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::SVGLinearGradientElement::attributeChanged):
(WebCore::SVGLinearGradientElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGLinearGradientElement.h:
* Source/WebCore/svg/SVGMPathElement.cpp:
(WebCore::SVGMPathElement::attributeChanged):
(WebCore::SVGMPathElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGMPathElement.h:
* Source/WebCore/svg/SVGMarkerElement.cpp:
(WebCore::SVGMarkerElement::attributeChanged):
(WebCore::SVGMarkerElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGMarkerElement.h:
* Source/WebCore/svg/SVGMaskElement.cpp:
(WebCore::SVGMaskElement::attributeChanged):
(WebCore::SVGMaskElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGMaskElement.h:
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::attributeChanged):
(WebCore::SVGPathElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGPathElement.h:
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::attributeChanged):
(WebCore::SVGPatternElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGPatternElement.h:
* Source/WebCore/svg/SVGPolyElement.cpp:
(WebCore::SVGPolyElement::attributeChanged):
(WebCore::SVGPolyElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGPolyElement.h:
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::SVGRadialGradientElement::attributeChanged):
(WebCore::SVGRadialGradientElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGRadialGradientElement.h:
* Source/WebCore/svg/SVGRectElement.cpp:
(WebCore::SVGRectElement::attributeChanged):
(WebCore::SVGRectElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGRectElement.h:
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::eventNameForOutermostSVGSVGElementAttribute):
(WebCore::SVGSVGElement::attributeChanged):
(WebCore::SVGSVGElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGSVGElement.h:
* Source/WebCore/svg/SVGScriptElement.cpp:
(WebCore::SVGScriptElement::attributeChanged):
(WebCore::SVGScriptElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGScriptElement.h:
* Source/WebCore/svg/SVGStopElement.cpp:
(WebCore::SVGStopElement::attributeChanged):
(WebCore::SVGStopElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGStopElement.h:
* Source/WebCore/svg/SVGStyleElement.cpp:
(WebCore::SVGStyleElement::attributeChanged):
(WebCore::SVGStyleElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGStyleElement.h:
* Source/WebCore/svg/SVGSymbolElement.cpp:
(WebCore::SVGSymbolElement::attributeChanged):
(WebCore::SVGSymbolElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGSymbolElement.h:
* Source/WebCore/svg/SVGTRefElement.cpp:
(WebCore::SVGTRefElement::attributeChanged):
(WebCore::SVGTRefElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGTRefElement.h:
* Source/WebCore/svg/SVGTests.cpp:
(WebCore::SVGTests::parseAttribute):
* Source/WebCore/svg/SVGTests.h:
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::attributeChanged):
(WebCore::SVGTextContentElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGTextContentElement.h:
* Source/WebCore/svg/SVGTextPathElement.cpp:
(WebCore::SVGTextPathElement::attributeChanged):
(WebCore::SVGTextPathElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGTextPathElement.h:
* Source/WebCore/svg/SVGTextPositioningElement.cpp:
(WebCore::SVGTextPositioningElement::attributeChanged):
(WebCore::SVGTextPositioningElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGTextPositioningElement.h:
* Source/WebCore/svg/SVGURIReference.cpp:
(WebCore::SVGURIReference::parseAttribute):
* Source/WebCore/svg/SVGURIReference.h:
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::attributeChanged):
(WebCore::SVGUseElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGUseElement.h:
* Source/WebCore/svg/SVGViewElement.cpp:
(WebCore::SVGViewElement::attributeChanged):
(WebCore::SVGViewElement::parseAttribute): Deleted.
* Source/WebCore/svg/SVGViewElement.h:
* Source/WebCore/svg/SVGZoomAndPan.cpp:
(WebCore::SVGZoomAndPan::parseAttribute):
* Source/WebCore/svg/SVGZoomAndPan.h:
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::attributeChanged):
(WebCore::SVGSMILElement::parseAttribute): Deleted.
* Source/WebCore/svg/animation/SVGSMILElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03a5c1dee63e3365b6df614c4fca7c16d29acc17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97586 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153059 "Found 30 new test failures: css3/filters/effect-reference-after.html, css3/filters/svg-blur-filter-clipped.html, css3/masking/clip-path-reference-2.html, css3/masking/clip-path-reference-local-url-with-base.html, css3/masking/clip-path-reference-painted-mask-zoom.html, css3/masking/clip-path-reference-restore.html, css3/masking/clip-path-reference-userSpaceOnUse.html, css3/masking/clip-path-reference-zoom-objectBoundingBox.html, css3/masking/clip-path-reference-zoom.html, css3/masking/clip-path-reference.html ... (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31360 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26996 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80602 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92242 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94011 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24933 "Found 30 new test failures: accessibility/ios-simulator/svg-group-element-with-title.html, compositing/rtl/rtl-scrolling-with-transformed-descendants.html, compositing/scrolling/async-overflow-scrolling/position-inside-rtl-overflow.html, css3/blending/svg-blend-layer-clip-path.html, css3/filters/effect-reference-after.html, css3/filters/effect-reference-composite-hw.html, css3/filters/effect-reference-composite.html, css3/filters/effect-reference-hw.html, css3/filters/effect-reference-ordering-hw.html, css3/filters/effect-reference-ordering.html ... (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75267 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24910 "Failure limit exceed. At least found 331 new test failures: compositing/layer-creation/fixed-overlap-extent-rtl.html, css3/blending/svg-blend-layer-clip-path.html, css3/filters/effect-reference-after.html, css3/filters/reference-filter-change-repaint.html, css3/filters/svg-blur-filter-clipped.html, css3/masking/clip-path-reference-2.html, css3/masking/clip-path-reference-local-url-with-base.html, css3/masking/clip-path-reference-painted-mask-zoom.html, css3/masking/clip-path-reference-restore.html, css3/masking/clip-path-reference-userSpaceOnUse.html ... (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79844 "Found 3 new API test failures: TestWebKitAPI.FontAttributes.FontAttributesAfterChangingSelection, TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText, TestWebKitAPI.FontAttributes.NestedTextListsWithHorizontalAlignment (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79952 "Found 4 new API test failures: TestWebKitAPI.FontAttributes.FontAttributesAfterChangingSelection, TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText, TestWebKitAPI.AttributedSubstringForProposedRange.TextAlignmentParagraphStyles, TestWebKitAPI.FontAttributes.NestedTextListsWithHorizontalAlignment (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67873 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28971 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13934 "Found 30 new test failures: accessibility/svg-bounds.html, compositing/rtl/rtl-scrolling-with-transformed-descendants.html, css3/blending/svg-blend-layer-clip-path.html, css3/filters/effect-reference-after.html, css3/filters/effect-reference-composite-hw.html, css3/filters/effect-reference-composite.html, css3/filters/effect-reference-hw.html, css3/filters/effect-reference-ordering-hw.html, css3/filters/effect-reference-ordering.html, css3/filters/effect-reference.html ... (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28960 "Failed to checkout and rebase branch from PR 4040") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14959 "Found 30 new test failures: accessibility/svg-bounds.html, compositing/layer-creation/fixed-overlap-extent-rtl.html, compositing/overflow/rtl-scrollbar-layer-positioning.html, compositing/rtl/rtl-scrolling-with-transformed-descendants.html, compositing/scrolling/async-overflow-scrolling/position-inside-rtl-overflow.html, css3/blending/svg-blend-layer-clip-path.html, css3/filters/effect-reference-after.html, css3/filters/effect-reference-composite-hw.html, css3/filters/effect-reference-composite.html, css3/filters/effect-reference-hw.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32159 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37879 "Found 30 new test failures: accessibility/svg-bounds.html, compositing/layer-creation/fixed-overlap-extent-rtl.html, compositing/overflow/rtl-scrollbar-layer-positioning.html, compositing/rtl/rtl-scrolling-with-transformed-descendants.html, compositing/scrolling/async-overflow-scrolling/position-inside-rtl-overflow.html, css3/blending/svg-blend-layer-clip-path.html, css3/filters/effect-reference-after.html, css3/filters/effect-reference-composite-hw.html, css3/filters/effect-reference-composite.html, css3/filters/effect-reference-hw.html ... (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34067 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->