### PR TITLE
EventTarget::isNode uses bit in weakPtrFactory

### DIFF
--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -73,11 +73,6 @@ EventTarget::~EventTarget()
     }
 }
 
-bool EventTarget::isNode() const
-{
-    return false;
-}
-
 bool EventTarget::isPaymentRequest() const
 {
     return false;

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -89,7 +89,6 @@ public:
     virtual EventTargetInterface eventTargetInterface() const = 0;
     virtual ScriptExecutionContext* scriptExecutionContext() const = 0;
 
-    WEBCORE_EXPORT virtual bool isNode() const;
     WEBCORE_EXPORT virtual bool isPaymentRequest() const;
 
     using AddEventListenerOptionsOrBoolean = std::variant<AddEventListenerOptions, bool>;
@@ -153,11 +152,24 @@ public:
         return weakPtrFactory().bitfield() & static_cast<uint16_t>(EventTargetFlag::HasEventTargetData);
     }
 
+    bool isNode() const
+    {
+        return weakPtrFactory().bitfield() & static_cast<uint16_t>(EventTargetFlag::IsNode);
+    }
+
 protected:
+    enum ConstructNodeTag { ConstructNode };
+    EventTarget() = default;
+    EventTarget(ConstructNodeTag)
+    {
+        weakPtrFactory().setBitfield(weakPtrFactory().bitfield() | static_cast<uint16_t>(EventTargetFlag::IsNode));
+    }
+
     WEBCORE_EXPORT virtual ~EventTarget();
 
     enum class EventTargetFlag : uint16_t {
         HasEventTargetData = 1 << 0,
+        IsNode = 1 << 1,
     };
 
     void setHasEventTargetData(bool flag) const

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -351,7 +351,8 @@ inline void NodeRareData::operator delete(NodeRareData* nodeRareData, std::destr
 }
 
 Node::Node(Document& document, ConstructionType type)
-    : m_nodeFlags(type)
+    : EventTarget(ConstructNode)
+    , m_nodeFlags(type)
     , m_treeScope(&document)
 {
     ASSERT(isMainThread());
@@ -434,11 +435,6 @@ void Node::clearRareData()
     ASSERT(!transientMutationObserverRegistry() || transientMutationObserverRegistry()->isEmpty());
 
     m_rareDataWithBitfields.setPointer(nullptr);
-}
-
-bool Node::isNode() const
-{
-    return true;
 }
 
 String Node::nodeValue() const

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -725,7 +725,6 @@ private:
 
     void refEventTarget() final;
     void derefEventTarget() final;
-    bool isNode() const final;
 
     void trackForDebugging();
     void materializeRareData();


### PR DESCRIPTION
#### 939f75513ba340050b356025b9fd601f30776375
<pre>
EventTarget::isNode uses bit in weakPtrFactory
<a href="https://bugs.webkit.org/show_bug.cgi?id=244823">https://bugs.webkit.org/show_bug.cgi?id=244823</a>

Reviewed by Ryosuke Niwa.

We leverage weakPtrFactory&apos;s bit to optimize EventTarget::isNode.

* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::isNode const): Deleted.
* Source/WebCore/dom/EventTarget.h:
(WebCore::EventTarget::isNode const):
(WebCore::EventTarget::setIsNode const):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::Node):
(WebCore::Node::isNode const): Deleted.
* Source/WebCore/dom/Node.h:

Canonical link: <a href="https://commits.webkit.org/254180@main">https://commits.webkit.org/254180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1deea765dea1ca8f41fd1d190a7c0c7c8210cb34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97514 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152980 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31213 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26886 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92170 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24856 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75141 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24829 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67795 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28806 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28798 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14870 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2940 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/31970 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37781 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34000 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->