### PR TITLE
[WGSL] Implement parsing for ArrayAccess postfix expression.

### DIFF
--- a/Source/WebGPU/WGSL/AST/Expression.h
+++ b/Source/WebGPU/WGSL/AST/Expression.h
@@ -41,6 +41,7 @@ public:
         AbstractIntLiteral,
         AbstractFloatLiteral,
         Identifier,
+        ArrayAccess,
         StructureAccess,
         CallableExpression,
         UnaryExpression,
@@ -61,6 +62,7 @@ public:
     bool isAbstractIntLiteral() const { return kind() == Kind::AbstractIntLiteral; }
     bool isAbstractFloatLiteral() const { return kind() == Kind::AbstractFloatLiteral; }
     bool isIdentifier() const { return kind() == Kind::Identifier; }
+    bool isArrayAccess() const { return kind() == Kind::ArrayAccess; }
     bool isStructureAccess() const { return kind() == Kind::StructureAccess; }
     bool isCallableExpression() const { return kind() == Kind::CallableExpression; }
     bool isUnaryExpression() const { return kind() == Kind::UnaryExpression; }

--- a/Source/WebGPU/WGSL/AST/Expressions/ArrayAccess.h
+++ b/Source/WebGPU/WGSL/AST/Expressions/ArrayAccess.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Expression.h"
+#include <wtf/text/StringView.h>
+
+namespace WGSL::AST {
+
+class ArrayAccess final : public Expression {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    ArrayAccess(SourceSpan span, UniqueRef<Expression>&& base, UniqueRef<Expression>&& index)
+        : Expression(span)
+        , m_base(WTFMove(base))
+        , m_index(WTFMove(index))
+    {
+    }
+
+    Kind kind() const override { return Kind::ArrayAccess; }
+    UniqueRef<Expression>& base() { return m_base; }
+    UniqueRef<Expression>& index() { return m_index; }
+
+private:
+    UniqueRef<Expression> m_base;
+    UniqueRef<Expression> m_index;
+};
+
+} // namespace WGSL::AST
+
+SPECIALIZE_TYPE_TRAITS_WGSL_EXPRESSION(ArrayAccess, isArrayAccess())

--- a/Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm
+++ b/Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "Parser.h"
 
+#import "ArrayAccess.h"
 #import "AssignmentStatement.h"
 #import "CallableExpression.h"
 #import "IdentifierExpression.h"
@@ -209,6 +210,9 @@
     }
 }
 
+#pragma mark -
+#pragma mark Declarations
+
 - (void) testParsingLocalVariable {
     auto shader = WGSL::parseLChar(
         "@vertex\n"
@@ -264,6 +268,45 @@
         XCTAssert(retStmt.maybeExpression()->isIdentifier());
         WGSL::AST::IdentifierExpression retExpr = downcast<WGSL::AST::IdentifierExpression>(*retStmt.maybeExpression());
         XCTAssert(retExpr.identifier() == "x"_s);
+    }
+}
+
+#pragma mark -
+#pragma mark Expressions
+
+- (void) testParsingArrayAccess {
+    auto shader = WGSL::parseLChar("fn test() { return x[42i]; }"_s);
+
+    if (!shader.has_value())
+        dataLogLn(shader.error());
+    XCTAssertTrue(shader.has_value());
+    XCTAssertTrue(shader->directives().isEmpty());
+    XCTAssertTrue(shader->structs().isEmpty());
+    XCTAssertTrue(shader->globalVars().isEmpty());
+    XCTAssertEqual(shader->functions().size(), 1u);
+
+    {
+        WGSL::AST::FunctionDecl& func = shader->functions()[0];
+
+        // fn test() { ... }
+        XCTAssert(func.name() == "test"_s);
+        XCTAssertEqual(func.parameters().size(), 0u);
+        XCTAssertEqual(func.returnAttributes().size(), 0u);
+        XCTAssertFalse(func.maybeReturnType());
+
+        XCTAssertEqual(func.body().statements().size(), 1u);
+        // return x[42];
+        XCTAssert(func.body().statements()[0]->isReturn());
+        WGSL::AST::ReturnStatement& retStmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0].get());
+        XCTAssert(retStmt.maybeExpression());
+        XCTAssert(retStmt.maybeExpression()->isArrayAccess());
+        WGSL::AST::ArrayAccess& arrayAccess = downcast<WGSL::AST::ArrayAccess>(*retStmt.maybeExpression());
+        XCTAssertTrue(arrayAccess.base()->isIdentifier());
+        WGSL::AST::IdentifierExpression& base = downcast<WGSL::AST::IdentifierExpression>(arrayAccess.base().get());
+        XCTAssert(base.identifier() == "x"_s);
+        XCTAssertTrue(arrayAccess.index()->isInt32Literal());
+        WGSL::AST::Int32Literal& index = downcast<WGSL::AST::Int32Literal>(arrayAccess.index().get());
+        XCTAssertEqual(index.value(), 42);
     }
 }
 

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		33EA188427BC268600A1DD52 /* StructureAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188327BC268600A1DD52 /* StructureAccess.h */; };
 		33EA188627BC26DF00A1DD52 /* CallableExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188527BC26DF00A1DD52 /* CallableExpression.h */; };
 		33EA188827BC361E00A1DD52 /* LiteralExpressions.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188727BC361E00A1DD52 /* LiteralExpressions.h */; };
+		3A7E164C28C57BB8003F49C9 /* ArrayAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A7E164B28C57BB7003F49C9 /* ArrayAccess.h */; };
 		3AAE4EB428C56E9A00DA484B /* UnaryExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AAE4EB328C56E9A00DA484B /* UnaryExpression.h */; };
 		3AE27DB528C1BA480043A8E0 /* VariableStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE27DB428C1BA480043A8E0 /* VariableStatement.h */; };
 		6634666B285F0140002ABE8E /* ConstLiteralTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6634666A285F0140002ABE8E /* ConstLiteralTests.mm */; };
@@ -334,6 +335,7 @@
 		33EA188327BC268600A1DD52 /* StructureAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StructureAccess.h; sourceTree = "<group>"; };
 		33EA188527BC26DF00A1DD52 /* CallableExpression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CallableExpression.h; sourceTree = "<group>"; };
 		33EA188727BC361E00A1DD52 /* LiteralExpressions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LiteralExpressions.h; sourceTree = "<group>"; };
+		3A7E164B28C57BB7003F49C9 /* ArrayAccess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayAccess.h; sourceTree = "<group>"; };
 		3AAE4EB328C56E9A00DA484B /* UnaryExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UnaryExpression.h; sourceTree = "<group>"; };
 		3AE27DB428C1BA480043A8E0 /* VariableStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VariableStatement.h; sourceTree = "<group>"; };
 		6634666A285F0140002ABE8E /* ConstLiteralTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ConstLiteralTests.mm; sourceTree = "<group>"; };
@@ -727,6 +729,7 @@
 		33EA187C27BC246000A1DD52 /* Expressions */ = {
 			isa = PBXGroup;
 			children = (
+				3A7E164B28C57BB7003F49C9 /* ArrayAccess.h */,
 				33EA188527BC26DF00A1DD52 /* CallableExpression.h */,
 				33EA188127BC25D000A1DD52 /* IdentifierExpression.h */,
 				33EA188727BC361E00A1DD52 /* LiteralExpressions.h */,
@@ -765,6 +768,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3A7E164C28C57BB8003F49C9 /* ArrayAccess.h in Headers */,
 				33EA188027BC24E200A1DD52 /* AssignmentStatement.h in Headers */,
 				33EA185E27BC194F00A1DD52 /* ASTNode.h in Headers */,
 				33EA186A27BC1BE600A1DD52 /* Attribute.h in Headers */,


### PR DESCRIPTION
#### 8ee6f731f76e42891521ff404a1303305679104b
<pre>
[WGSL] Implement parsing for ArrayAccess postfix expression.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244789">https://bugs.webkit.org/show_bug.cgi?id=244789</a>
rdar://99557326

Reviewed by Myles Maxfield.

* Source/WebGPU/WGSL/AST/Expression.h:
(WGSL::AST::Expression::isArrayAccess const):
Add kind and predicate for ArrayAccess.
* Source/WebGPU/WGSL/AST/Expressions/ArrayAccess.h: Added.
Implementation of AST::ArrayAccess node.
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parsePostfixExpression):
Implement parsing of a sequence of StructureAccess or ArrayAccess postfix to an
expression.
* Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm:
(-[WGSLParserTests testParsingArrayAccess]):
Test parsing of `x[42]`
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
Add &apos;ArrayAccess.h&apos;

Canonical link: <a href="https://commits.webkit.org/254182@main">https://commits.webkit.org/254182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e92fe0677cb11bece8d2b7f24da8afce075fe70c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97525 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31237 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26905 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80530 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92182 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24870 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75159 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24844 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67810 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28832 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28817 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2942 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32003 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34010 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->