### PR TITLE
[Nicosia] Improve build guards in NicosiaGCGLANGLELayer

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.cpp
@@ -29,7 +29,7 @@
 #include "config.h"
 #include "NicosiaGCGLANGLELayer.h"
 
-#if USE(NICOSIA) && USE(TEXTURE_MAPPER) && USE(LIBGBM) && USE(ANGLE)
+#if USE(NICOSIA) && USE(TEXTURE_MAPPER) && USE(ANGLE)
 
 #include "GraphicsContextGLFallback.h"
 #include "GraphicsContextGLGBM.h"
@@ -115,12 +115,14 @@ GCGLANGLELayer::GCGLANGLELayer(GraphicsContextGLFallback& context)
 {
 }
 
+#if USE(LIBGBM)
 GCGLANGLELayer::GCGLANGLELayer(GraphicsContextGLGBM& context)
     : m_contextType(ContextType::Gbm)
     , m_context(context)
     , m_contentLayer(Nicosia::ContentLayer::create(Nicosia::ContentLayerTextureMapperImpl::createFactory(*this, adoptRef(*new TextureMapperPlatformLayerProxyDMABuf))))
 {
 }
+#endif
 
 GCGLANGLELayer::~GCGLANGLELayer()
 {

--- a/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.h
+++ b/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#if USE(NICOSIA) && USE(TEXTURE_MAPPER) && USE(LIBGBM) && USE(ANGLE)
+#if USE(NICOSIA) && USE(TEXTURE_MAPPER) && USE(ANGLE)
 
 #include "NicosiaContentLayerTextureMapperImpl.h"
 
@@ -41,7 +41,9 @@ namespace WebCore {
 class IntSize;
 class GraphicsContextGLANGLE;
 class GraphicsContextGLFallback;
+#if USE(LIBGBM)
 class GraphicsContextGLGBM;
+#endif
 class PlatformDisplay;
 }
 
@@ -51,7 +53,9 @@ class GCGLANGLELayer final : public ContentLayerTextureMapperImpl::Client {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     GCGLANGLELayer(WebCore::GraphicsContextGLFallback&);
+#if USE(LIBGBM)
     GCGLANGLELayer(WebCore::GraphicsContextGLGBM&);
+#endif
     virtual ~GCGLANGLELayer();
 
     ContentLayer& contentLayer() const { return m_contentLayer; }


### PR DESCRIPTION
#### 813972dfeabee821dfafdc3ffd7551b00dfec262
<pre>
[Nicosia] Improve build guards in NicosiaGCGLANGLELayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=244832">https://bugs.webkit.org/show_bug.cgi?id=244832</a>

Reviewed by Adrian Perez de Castro.

Nicosia::GCGLANGLELayer files shouldn&apos;t be completely guarded by USE(LIBGBM).
Instead, this specific guard should only wrap the GraphicsContextGLGBM-related
constructor.

This should (in the future) allow libgbm-less builds of ANGLE functionality.

* Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.cpp:
* Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.h:

Canonical link: <a href="https://commits.webkit.org/254181@main">https://commits.webkit.org/254181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e58eb43b3e77e502a89a9aa1ca5ebc5380d5eb1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97526 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/152997 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31238 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26907 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92183 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24869 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75161 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/24846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79772 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28833 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28819 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14886 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2939 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32005 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/30996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34011 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->