### PR TITLE
EventTarget::{ref,deref} should have Node fast path

### DIFF
--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -83,8 +83,8 @@ class EventTarget : public ScriptWrappable, public CanMakeWeakPtr<EventTarget, W
 public:
     static Ref<EventTarget> create(ScriptExecutionContext&);
 
-    void ref() { refEventTarget(); }
-    void deref() { derefEventTarget(); }
+    void ref();
+    void deref();
 
     virtual EventTargetInterface eventTargetInterface() const = 0;
     virtual ScriptExecutionContext* scriptExecutionContext() const = 0;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -840,6 +840,22 @@ ALWAYS_INLINE unsigned Node::refCount() const
     return m_refCountAndParentBit / s_refCountIncrement;
 }
 
+ALWAYS_INLINE void EventTarget::ref()
+{
+    if (isNode())
+        static_cast<Node*>(this)->ref();
+    else
+        refEventTarget();
+}
+
+ALWAYS_INLINE void EventTarget::deref()
+{
+    if (isNode())
+        static_cast<Node*>(this)->deref();
+    else
+        derefEventTarget();
+}
+
 // Used in Node::addSubresourceAttributeURLs() and in addSubresourceStyleURLs()
 inline void addSubresourceURL(ListHashSet<URL>& urls, const URL& url)
 {

--- a/Source/WebCore/dom/TouchEvent.cpp
+++ b/Source/WebCore/dom/TouchEvent.cpp
@@ -31,6 +31,7 @@
 #include "TouchEvent.h"
 
 #include "EventDispatcher.h"
+#include "Node.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/TouchList.cpp
+++ b/Source/WebCore/dom/TouchList.cpp
@@ -29,6 +29,8 @@
 
 #include "TouchList.h"
 
+#include "Node.h"
+
 namespace WebCore {
 
 Touch* TouchList::item(unsigned index)


### PR DESCRIPTION
#### 0d220f2b134bd56334e7604e4fdedd3cb345113c
<pre>
EventTarget::{ref,deref} should have Node fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=244834">https://bugs.webkit.org/show_bug.cgi?id=244834</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/WebCore/dom/EventTarget.h:
(WebCore::EventTarget::ref): Deleted.
(WebCore::EventTarget::deref): Deleted.
* Source/WebCore/dom/Node.h:
(WebCore::EventTarget::ref):
(WebCore::EventTarget::deref):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d220f2b134bd56334e7604e4fdedd3cb345113c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19234 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97576 "Hash 0d220f2b for PR 4049 does not build (failure)") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153049 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31344 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26983 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80591 "Hash 0d220f2b for PR 4049 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92234 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24923 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75250 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/80591 "Hash 0d220f2b for PR 4049 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79943 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/80591 "Hash 0d220f2b for PR 4049 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28956 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13924 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28946 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14945 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37867 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34058 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->