### PR TITLE
[GTK4] Allow non-composited mode in the web process

### DIFF
--- a/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp
+++ b/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp
@@ -46,11 +46,6 @@ HardwareAccelerationManager::HardwareAccelerationManager()
     return;
 #endif
 
-#if USE(GTK4)
-    RELEASE_ASSERT(AcceleratedBackingStore::checkRequirements());
-    m_forceHardwareAcceleration = true;
-#endif
-
     const char* disableCompositing = getenv("WEBKIT_DISABLE_COMPOSITING_MODE");
     if (disableCompositing && strcmp(disableCompositing, "0")) {
         m_canUseHardwareAcceleration = false;


### PR DESCRIPTION
#### 5b10b791568f0659729002423138068a70767f1e
<pre>
[GTK4] Allow non-composited mode in the web process
<a href="https://bugs.webkit.org/show_bug.cgi?id=244835">https://bugs.webkit.org/show_bug.cgi?id=244835</a>

Reviewed by Michael Catanzaro.

GTK4 requires GL in the UI process, but it&apos;s still useful to allow
disabling compositing mode in the web process to reduce memory usage and
debugging purposes.

* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseSnapshot): Use gtk_snapshot_append_cairo() for non
accelerated content.
* Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp:
(WebKit::HardwareAccelerationManager::HardwareAccelerationManager):
Always compositing is now the default, so we don&apos;t need to force it here
for GTK4.

Canonical link: <a href="https://commits.webkit.org/254221@main">https://commits.webkit.org/254221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e9d0be121a3382775c373217a116185d8ce1daa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97531 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31250 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26914 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80537 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92188 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24875 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75171 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24849 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67815 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28847 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28831 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14894 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2973 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37808 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31011 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34016 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->