### PR TITLE
Memory allocation performed on the audio thread in AudioSampleDataConverter::updateBufferedAmount

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataConverter.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataConverter.mm
@@ -30,6 +30,8 @@
 #import "DeprecatedGlobalSettings.h"
 #import "Logging.h"
 #import <AudioToolbox/AudioConverter.h>
+#include <wtf/FastMalloc.h>
+
 #import <pal/cf/AudioToolboxSoftLink.h>
 
 namespace WebCore {
@@ -85,6 +87,7 @@ bool AudioSampleDataConverter::updateBufferedAmount(size_t currentBufferedAmount
         return !!m_selectedConverter;
 
     if (currentBufferedAmount) {
+        DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
         if (m_selectedConverter == m_regularConverter) {
             if (currentBufferedAmount <= m_lowBufferSize) {
                 m_selectedConverter = m_lowConverter;


### PR DESCRIPTION
#### b0889f31654424d0c67ac33c8ada7ee033f90a84
<pre>
Memory allocation performed on the audio thread in AudioSampleDataConverter::updateBufferedAmount
<a href="https://bugs.webkit.org/show_bug.cgi?id=243719">https://bugs.webkit.org/show_bug.cgi?id=243719</a>
rdar://problem/98365181

Reviewed by Eric Carlson.

Disable memory allocation check as we do an allocation with the Function creation.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/audio/cocoa/AudioSampleDataConverter.mm:
(WebCore::AudioSampleDataConverter::updateBufferedAmount):

Canonical link: <a href="https://commits.webkit.org/254215@main">https://commits.webkit.org/254215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/386942b95dce95b0a07ce98b883c638c37a87c21

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97532 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153003 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31253 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26916 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92189 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24876 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75173 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24852 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67818 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28850 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28833 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14895 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2967 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37810 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34017 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->