### PR TITLE
[GStreamer] WebAudio drums demo makes WebKit GStreamer based ports crash

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -78,6 +78,7 @@ private:
     int m_channels { 0 };
     HashMap<int, GRefPtr<GstBufferList>> m_buffers;
     GRefPtr<GstElement> m_pipeline;
+    std::optional<int> m_firstChannelType;
     unsigned m_channelSize { 0 };
     GRefPtr<GstElement> m_decodebin;
     GRefPtr<GstElement> m_deInterleave;
@@ -141,20 +142,8 @@ AudioFileReader::~AudioFileReader()
     }
 }
 
-GstFlowReturn AudioFileReader::handleSample(GstAppSink* sink)
+static inline std::optional<int> channelTypeFromCaps(GstCaps* caps)
 {
-    auto sample = adoptGRef(gst_app_sink_try_pull_sample(sink, 0));
-    if (!sample)
-        return gst_app_sink_is_eos(sink) ? GST_FLOW_EOS : GST_FLOW_ERROR;
-
-    GstBuffer* buffer = gst_sample_get_buffer(sample.get());
-    if (!buffer)
-        return GST_FLOW_ERROR;
-
-    GstCaps* caps = gst_sample_get_caps(sample.get());
-    if (!caps)
-        return GST_FLOW_ERROR;
-
     int channelId = 0;
     GstAudioInfo info;
     gst_audio_info_from_caps(&info, caps);
@@ -182,14 +171,44 @@ GstFlowReturn AudioFileReader::handleSample(GstAppSink* sink)
         break;
     default:
         GST_WARNING("Unhandled channel: %d", GST_AUDIO_INFO_POSITION(&info, 0));
-        return GST_FLOW_ERROR;
+        return { };
     };
+    return channelId;
+}
 
-    channelId++;
-    if (channelId == 1)
+GstFlowReturn AudioFileReader::handleSample(GstAppSink* sink)
+{
+    auto sample = adoptGRef(gst_app_sink_try_pull_sample(sink, 0));
+    if (!sample)
+        return gst_app_sink_is_eos(sink) ? GST_FLOW_EOS : GST_FLOW_ERROR;
+
+    GstBuffer* buffer = gst_sample_get_buffer(sample.get());
+    if (!buffer)
+        return GST_FLOW_ERROR;
+
+    GstCaps* caps = gst_sample_get_caps(sample.get());
+    if (!caps)
+        return GST_FLOW_ERROR;
+
+    auto channelType = channelTypeFromCaps(caps);
+    if (!channelType)
+        return GST_FLOW_ERROR;
+
+    if (!m_firstChannelType) {
+        ASSERT_NOT_REACHED();
+        return GST_FLOW_ERROR;
+    }
+
+    if (*channelType == *m_firstChannelType) {
+        GstAudioInfo info;
+        gst_audio_info_from_caps(&info, caps);
         m_channelSize += gst_buffer_get_size(buffer) / info.bpf;
+    }
 
-    auto result = m_buffers.ensure(channelId, [] {
+    // Shift hash table key values by one, otherwise we would hit an ASSERT here when channelType is
+    // 0 (Left), which is also KeyTraits::emptyValue() which is not allowed.
+    int keyId = *channelType + 1;
+    auto result = m_buffers.ensure(keyId, [] {
         return adoptGRef(gst_buffer_list_new());
     });
     auto& bufferList = result.iterator->value;
@@ -249,6 +268,12 @@ void AudioFileReader::handleNewDeinterleavePad(GstPad* pad)
     // ... deinterleave ! appsink.
     GstElement* sink = makeGStreamerElement("appsink", nullptr);
 
+    if (!m_firstChannelType) {
+        auto caps = adoptGRef(gst_pad_query_caps(pad, nullptr));
+        auto channelType = channelTypeFromCaps(caps.get());
+        if (channelType)
+            m_firstChannelType = WTFMove(channelType);
+    }
     m_channels++;
 
     static GstAppSinkCallbacks callbacks = {
@@ -395,8 +420,9 @@ RefPtr<AudioBus> AudioFileReader::createBus(float sampleRate, bool mixToMono)
     auto audioBus = AudioBus::create(m_channels, m_channelSize, true);
     audioBus->setSampleRate(m_sampleRate);
 
-    for (auto& it : m_buffers)
-        copyGstreamerBuffersToAudioChannel(it.value, audioBus->channel(it.key - 1));
+    for (auto& [key, buffer] : m_buffers)
+        copyGstreamerBuffersToAudioChannel(buffer, audioBus->channelByType(key - 1));
+
     m_buffers.clear();
 
     if (mixToMono)


### PR DESCRIPTION
#### 2aa13bb90ada0abbfe5ec6e6ad1fcc95c798a361
<pre>
[GStreamer] WebAudio drums demo makes WebKit GStreamer based ports crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=244841">https://bugs.webkit.org/show_bug.cgi?id=244841</a>

Reviewed by Xabier Rodriguez-Calvar.

The main issue was a mix-up between channel index and channel types. The m_buffers hash table stores
buffers by channel type, so when we need to copy the data to the bus, we need to use
AudioBus::channelByType().

* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
(WebCore::channelTypeFromCaps):
(WebCore::AudioFileReader::handleSample):
(WebCore::AudioFileReader::handleNewDeinterleavePad):
(WebCore::AudioFileReader::createBus):

Canonical link: <a href="https://commits.webkit.org/254223@main">https://commits.webkit.org/254223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ff696791b4fb2dfc82a09df70bbc3107da42b3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97626 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153104 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31438 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27056 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80645 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92281 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24987 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75339 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/24948 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79877 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/67911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29046 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/29030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/14985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2974 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32254 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31132 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/34094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->