### PR TITLE
Unreviewed, non-unified build fixes after 254173@main

### DIFF
--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -37,6 +37,7 @@ class CachedFont;
 class FontLoadRequest;
 class SVGFontFaceElement;
 class ScriptExecutionContext;
+class WeakPtrImplWithEventTargetData;
 
 class CSSFontFaceSrcValue final : public CSSValue {
 public:

--- a/Source/WebCore/css/MediaQueryMatcher.h
+++ b/Source/WebCore/css/MediaQueryMatcher.h
@@ -32,6 +32,7 @@ class MediaQueryList;
 class MediaQueryEvaluator;
 class MediaQuerySet;
 class RenderStyle;
+class WeakPtrImplWithEventTargetData;
 
 // MediaQueryMatcher class is responsible for evaluating the queries whenever it
 // is needed and dispatch "change" event on MediaQueryLists if the corresponding

--- a/Source/WebCore/css/StyleSheetList.h
+++ b/Source/WebCore/css/StyleSheetList.h
@@ -33,6 +33,7 @@ class Node;
 class ShadowRoot;
 class StyleSheet;
 class CSSStyleSheet;
+class WeakPtrImplWithEventTargetData;
 
 class StyleSheetList final : public RefCounted<StyleSheetList> {
 public:

--- a/Source/WebCore/dom/ScriptedAnimationController.h
+++ b/Source/WebCore/dom/ScriptedAnimationController.h
@@ -40,6 +40,7 @@ class Document;
 class Page;
 class RequestAnimationFrameCallback;
 class UserGestureToken;
+class WeakPtrImplWithEventTargetData;
 
 class ScriptedAnimationController : public RefCounted<ScriptedAnimationController>
 {

--- a/Source/WebCore/html/parser/HTMLScriptRunner.h
+++ b/Source/WebCore/html/parser/HTMLScriptRunner.h
@@ -37,6 +37,7 @@ class Document;
 class Frame;
 class HTMLScriptRunnerHost;
 class ScriptSourceCode;
+class WeakPtrImplWithEventTargetData;
 
 class HTMLScriptRunner {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -58,6 +58,7 @@ class NodeList;
 class RenderObject;
 class Settings;
 class StyleRule;
+class WeakPtrImplWithEventTargetData;
 
 namespace Style {
 class Resolver;

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
@@ -42,6 +42,7 @@ class Node;
 class PseudoElement;
 class RenderElement;
 class RenderLayer;
+class WeakPtrImplWithEventTargetData;
 
 class InspectorLayerTreeAgent final : public InspectorAgentBase, public Inspector::LayerTreeBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorLayerTreeAgent);

--- a/Source/WebCore/loader/MediaResourceLoader.h
+++ b/Source/WebCore/loader/MediaResourceLoader.h
@@ -44,6 +44,7 @@ class CachedRawResource;
 class Document;
 class Element;
 class MediaResource;
+class WeakPtrImplWithEventTargetData;
 
 class MediaResourceLoader final : public PlatformMediaResourceLoader, public CanMakeWeakPtr<MediaResourceLoader>, public ContextDestructionObserver {
 public:

--- a/Source/WebCore/loader/appcache/ApplicationCacheHost.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheHost.h
@@ -51,6 +51,7 @@ class ResourceLoader;
 class ResourceRequest;
 class ResourceResponse;
 class SubstituteData;
+class WeakPtrImplWithEventTargetData;
 
 class ApplicationCacheHost {
     WTF_MAKE_NONCOPYABLE(ApplicationCacheHost); WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/page/ImageOverlayController.h
+++ b/Source/WebCore/page/ImageOverlayController.h
@@ -46,6 +46,7 @@ class IntRect;
 class FloatQuad;
 class Page;
 class RenderElement;
+class WeakPtrImplWithEventTargetData;
 struct GapRects;
 
 class ImageOverlayController final : private PageOverlay::Client

--- a/Source/WebCore/page/ModalContainerObserver.h
+++ b/Source/WebCore/page/ModalContainerObserver.h
@@ -41,6 +41,7 @@ class Element;
 class FrameView;
 class HTMLElement;
 class HTMLFrameOwnerElement;
+class WeakPtrImplWithEventTargetData;
 
 class ModalContainerObserver {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -38,6 +38,7 @@ class HTMLElement;
 class HTMLVideoElement;
 class LayoutUnit;
 class PlatformMouseEvent;
+class WeakPtrImplWithEventTargetData;
 struct SecurityOriginData;
 
 #if ENABLE(INTELLIGENT_TRACKING_PREVENTION)

--- a/Source/WebCore/page/ResizeObservation.h
+++ b/Source/WebCore/page/ResizeObservation.h
@@ -39,6 +39,7 @@ class TextStream;
 namespace WebCore {
 
 class Element;
+class WeakPtrImplWithEventTargetData;
 
 class ResizeObservation : public RefCounted<ResizeObservation> {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/page/UndoItem.h
+++ b/Source/WebCore/page/UndoItem.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "EventTarget.h"
 #include "VoidCallback.h"
 #include <wtf/IsoMalloc.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -38,6 +38,7 @@ class SVGResourcesCache;
 class SVGSMILElement;
 class SVGSVGElement;
 class SVGUseElement;
+class WeakPtrImplWithEventTargetData;
 
 class SVGDocumentExtensions {
     WTF_MAKE_NONCOPYABLE(SVGDocumentExtensions); WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/svg/SVGViewSpec.h
+++ b/Source/WebCore/svg/SVGViewSpec.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class SVGElement;
 class SVGTransformList;
+class WeakPtrImplWithEventTargetData;
 
 class SVGViewSpec final : public RefCounted<SVGViewSpec>, public SVGFitToViewBox, public SVGZoomAndPan {
 public:


### PR DESCRIPTION
#### 4ed47973ce0216db077e943cec65b64e09ebed65
<pre>
Unreviewed, non-unified build fixes after 254173@main

* Source/WebCore/css/CSSFontFaceSrcValue.h: Add missing WeakPtrImplWithEventTargetData forward decl.
* Source/WebCore/css/MediaQueryMatcher.h: Ditto.
* Source/WebCore/css/StyleSheetList.h: Ditto.
* Source/WebCore/dom/ScriptedAnimationController.h: Ditto.
* Source/WebCore/html/parser/HTMLScriptRunner.h: Ditto.
* Source/WebCore/inspector/agents/InspectorCSSAgent.h: Ditto.
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h: Ditto.
* Source/WebCore/loader/MediaResourceLoader.h: Ditto.
* Source/WebCore/loader/appcache/ApplicationCacheHost.h: Ditto.
* Source/WebCore/page/ImageOverlayController.h: Ditto.
* Source/WebCore/page/ModalContainerObserver.h: Ditto.
* Source/WebCore/page/Quirks.h: Ditto.
* Source/WebCore/page/ResizeObservation.h: Ditto.
* Source/WebCore/page/UndoItem.h: Include missing EventTarget.h.
* Source/WebCore/svg/SVGDocumentExtensions.h: Add missing WeakPtrImplWithEventTargetData forward decl.
* Source/WebCore/svg/SVGViewSpec.h: Ditto.

Canonical link: <a href="https://commits.webkit.org/254249@main">https://commits.webkit.org/254249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6719e7e362bd497c60c20d28242f45a3d1b26af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97605 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153083 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31397 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27032 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80624 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92261 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24973 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75308 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24933 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67896 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29010 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28992 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14968 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2988 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37896 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34077 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->