### PR TITLE
Resync COEP WPT tests from upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-credentialless.tentative.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-credentialless.tentative.https.any.js
@@ -1,2 +1,2 @@
-// META: global=window,worker,sharedworker-module
+// META: global=window,worker,sharedworker-module,serviceworker-module
 test(t => assert_equals(crossOriginEmbedderPolicy, "credentialless"));

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-credentialless.tentative.https.any.serviceworker-module-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-credentialless.tentative.https.any.serviceworker-module-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL reflection-credentialless Can't find variable: crossOriginEmbedderPolicy
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-credentialless.tentative.https.any.serviceworker-module.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-credentialless.tentative.https.any.serviceworker-module.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-require-corp.tentative.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-require-corp.tentative.https.any.js
@@ -1,2 +1,2 @@
-// META: global=window,worker,sharedworker-module
+// META: global=window,worker,sharedworker-module,serviceworker-module
 test(t => assert_equals(crossOriginEmbedderPolicy, "require-corp"));

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-require-corp.tentative.https.any.serviceworker-module-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-require-corp.tentative.https.any.serviceworker-module-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL reflection-require-corp Can't find variable: crossOriginEmbedderPolicy
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-require-corp.tentative.https.any.serviceworker-module.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-require-corp.tentative.https.any.serviceworker-module.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-unsafe-none.tentative.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-unsafe-none.tentative.https.any.js
@@ -1,2 +1,2 @@
-// META: global=window,worker,sharedworker-module
+// META: global=window,worker,sharedworker-module,serviceworker-module
 test(t => assert_equals(crossOriginEmbedderPolicy, "unsafe-none"));

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-unsafe-none.tentative.https.any.serviceworker-module-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-unsafe-none.tentative.https.any.serviceworker-module-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL reflection-unsafe-none Can't find variable: crossOriginEmbedderPolicy
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-unsafe-none.tentative.https.any.serviceworker-module.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-unsafe-none.tentative.https.any.serviceworker-module.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->


### PR DESCRIPTION
#### 01cbf5d176bc826043ede0fd1512c7e46bee0b12
<pre>
Resync COEP WPT tests from upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=244850">https://bugs.webkit.org/show_bug.cgi?id=244850</a>

Reviewed by Geoffrey Garen.

Resync COEP WPT tests from upstream fb6750aa0a21d75e8a.

* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-credentialless.tentative.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-credentialless.tentative.https.any.serviceworker-module-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-credentialless.tentative.https.any.serviceworker-module.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-require-corp.tentative.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-require-corp.tentative.https.any.serviceworker-module-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-require-corp.tentative.https.any.serviceworker-module.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-unsafe-none.tentative.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-unsafe-none.tentative.https.any.serviceworker-module-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-unsafe-none.tentative.https.any.serviceworker-module.html: Added.

Canonical link: <a href="https://commits.webkit.org/254205@main">https://commits.webkit.org/254205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f5b79221162f34d459e7c79793a7c5531dbf625

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97568 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153041 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31327 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26973 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80589 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92226 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24916 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75236 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24899 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79816 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67863 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28938 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/28930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14938 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2958 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32119 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31068 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34051 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->