### PR TITLE
Test addition (253931@main): [ macOS wk1 Debug ] media/track/track-description-cue.html consistently hits ASSERTION FAILED: !m_currentSpeechUtterance

### DIFF
--- a/LayoutTests/media/track/track-description-cue.html
+++ b/LayoutTests/media/track/track-description-cue.html
@@ -17,8 +17,10 @@ promise_test(async (t) => {
 
     let descriptionsTrack = document.querySelector("track");
 
-    if (window.internals)
+    if (window.internals) {
         internals.settings.setShouldDisplayTrackKind('TextDescriptions', true);
+        internals.enableMockSpeechSynthesizer();
+    }
 
     video.src = findMediaFile('video', '../content/test');
     await new Promise(resolve => video.oncanplaythrough = resolve);


### PR DESCRIPTION
#### 3cf9c0d666a185b899ec8fa5eeb1dfec3c9ad577
<pre>
Test addition (253931@main): [ macOS wk1 Debug ] media/track/track-description-cue.html consistently hits ASSERTION FAILED: !m_currentSpeechUtterance
<a href="https://bugs.webkit.org/show_bug.cgi?id=244683">https://bugs.webkit.org/show_bug.cgi?id=244683</a>
&lt;rdar://99449962&gt;

Reviewed by NOBODY (OOPS!).

* LayoutTests/media/track/track-description-cue.html: Use the mock speech synthesizer.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cf9c0d666a185b899ec8fa5eeb1dfec3c9ad577

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97570 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153043 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31352 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26976 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92228 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24960 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75239 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24892 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67856 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28942 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13918 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28934 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14940 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37871 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34053 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->