### PR TITLE
[Reporting API] Refactor network send logic to Report-related code

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -330,6 +330,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/reporting/ReportingObserverCallback.h
     Modules/reporting/ReportingScope.h
     Modules/reporting/TestReportBody.h
+    Modules/reporting/ViolationReportType.h
 
     Modules/speech/SpeechRecognitionCaptureSource.h
     Modules/speech/SpeechRecognitionCaptureSourceImpl.h

--- a/Source/WebCore/Modules/reporting/ReportBody.cpp
+++ b/Source/WebCore/Modules/reporting/ReportBody.cpp
@@ -32,13 +32,13 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ReportBody);
 
-ReportBody::ReportBody(ReportBodyType type)
+ReportBody::ReportBody(ViolationReportType type)
     : m_reportBodyType(type)
 { }
 
 ReportBody::~ReportBody() = default;
 
-ReportBodyType ReportBody::reportBodyType() const
+ViolationReportType ReportBody::reportBodyType() const
 {
     return m_reportBodyType;
 }

--- a/Source/WebCore/Modules/reporting/ReportingClient.h
+++ b/Source/WebCore/Modules/reporting/ReportingClient.h
@@ -31,7 +31,9 @@
 
 namespace WebCore {
 
+class FormData;
 class Report;
+enum class ViolationReportType : uint8_t;
 
 struct WEBCORE_EXPORT ReportingClient {
 
@@ -39,6 +41,7 @@ struct WEBCORE_EXPORT ReportingClient {
 
     virtual void notifyReportObservers(Ref<Report>&&) = 0;
     virtual String endpointURIForToken(const String&) const = 0;
+    virtual void sendReportToEndpoints(const URL& baseURL, Vector<String>&& endPoints, Ref<FormData>&& report, ViolationReportType) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/reporting/TestReportBody.cpp
+++ b/Source/WebCore/Modules/reporting/TestReportBody.cpp
@@ -40,7 +40,7 @@ const AtomString& TestReportBody::testReportType()
 }
 
 TestReportBody::TestReportBody(String&& message)
-    : ReportBody(ReportBodyType::Test)
+    : ReportBody(ViolationReportType::Test)
     , m_bodyMessage(WTFMove(message))
 {
 }

--- a/Source/WebCore/Modules/reporting/TestReportBody.h
+++ b/Source/WebCore/Modules/reporting/TestReportBody.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ReportBody.h"
+#include "ViolationReportType.h"
 #include <wtf/IsoMalloc.h>
 #include <wtf/text/WTFString.h>
 
@@ -78,5 +79,5 @@ std::optional<RefPtr<TestReportBody>> TestReportBody::decode(Decoder& decoder)
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::TestReportBody)
-    static bool isType(const WebCore::ReportBody& reportBody) { return reportBody.reportBodyType() == WebCore::ReportBodyType::Test; }
+    static bool isType(const WebCore::ReportBody& reportBody) { return reportBody.reportBodyType() == WebCore::ViolationReportType::Test; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/reporting/ViolationReportType.h
+++ b/Source/WebCore/Modules/reporting/ViolationReportType.h
@@ -25,26 +25,26 @@
 
 #pragma once
 
-#include <wtf/IsoMalloc.h>
-#include <wtf/RefCounted.h>
-
 namespace WebCore {
 
-enum class ViolationReportType : uint8_t;
-
-class WEBCORE_EXPORT ReportBody : public RefCounted<ReportBody> {
-    WTF_MAKE_ISO_ALLOCATED(ReportBody);
-public:
-    virtual ~ReportBody();
-
-    virtual const AtomString& type() const = 0;
-    ViolationReportType reportBodyType() const;
-
-protected:
-    ReportBody(ViolationReportType);
-
-private:
-    ViolationReportType m_reportBodyType;
+enum class ViolationReportType : uint8_t {
+    ContentSecurityPolicy,
+    StandardReportingAPIViolation, // https://www.w3.org/TR/reporting/#try-delivery
+    Test, // https://www.w3.org/TR/reporting-1/#generate-test-report-command
+    // More to come
 };
 
 } // namespace WebCore
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::ViolationReportType> {
+    using values = EnumValues<
+    WebCore::ViolationReportType,
+    WebCore::ViolationReportType::ContentSecurityPolicy,
+    WebCore::ViolationReportType::StandardReportingAPIViolation,
+    WebCore::ViolationReportType::Test
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebCore/bindings/js/JSReportBodyCustom.cpp
+++ b/Source/WebCore/bindings/js/JSReportBodyCustom.cpp
@@ -32,6 +32,7 @@
 #include "JSTestReportBody.h"
 #include "ReportBody.h"
 #include "TestReportBody.h"
+#include "ViolationReportType.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -170,6 +170,7 @@
 #include "PaintWorkletGlobalScope.h"
 #include "Performance.h"
 #include "PerformanceNavigationTiming.h"
+#include "PingLoader.h"
 #include "PlatformLocale.h"
 #include "PlatformMediaSessionManager.h"
 #include "PlatformScreen.h"
@@ -255,6 +256,7 @@
 #include "UndoManager.h"
 #include "UserGestureIndicator.h"
 #include "ValidationMessageClient.h"
+#include "ViolationReportType.h"
 #include "VisibilityChangeClient.h"
 #include "VisitedLinkState.h"
 #include "VisualViewport.h"
@@ -9267,6 +9269,12 @@ void Document::notifyReportObservers(Ref<Report>&& reports)
 String Document::endpointURIForToken(const String& token) const
 {
     return reportingScope().endpointURIForToken(token);
+}
+
+void Document::sendReportToEndpoints(const URL& baseURL, Vector<String>&& endPoints, Ref<FormData>&& report, ViolationReportType reportType)
+{
+    for (const auto& url : endPoints)
+        PingLoader::sendViolationReport(*frame(), URL { baseURL, url }, report.copyRef(), reportType);    
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -270,6 +270,7 @@ enum class ShouldOpenExternalURLsPolicy : uint8_t;
 enum class RenderingUpdateStep : uint32_t;
 enum class StyleColorOptions : uint8_t;
 enum class MutationObserverOptionType : uint8_t;
+enum class ViolationReportType : uint8_t;
 
 using MediaProducerMediaStateFlags = OptionSet<MediaProducerMediaState>;
 using MediaProducerMutedStateFlags = OptionSet<MediaProducerMutedState>;
@@ -1831,6 +1832,7 @@ private:
 
     void notifyReportObservers(Ref<Report>&&) final;
     String endpointURIForToken(const String&) const final;
+    void sendReportToEndpoints(const URL& baseURL, Vector<String>&& endPoints, Ref<FormData>&& report, ViolationReportType) final;
 
     const Ref<const Settings> m_settings;
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -93,6 +93,7 @@
 #include "TextResourceDecoder.h"
 #include "UserContentProvider.h"
 #include "UserContentURLPattern.h"
+#include "ViolationReportType.h"
 #include <wtf/Assertions.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/NeverDestroyed.h>
@@ -2471,11 +2472,6 @@ PreviewConverter* DocumentLoader::previewConverter() const
 void DocumentLoader::addConsoleMessage(MessageSource messageSource, MessageLevel messageLevel, const String& message, unsigned long requestIdentifier)
 {
     static_cast<ScriptExecutionContext*>(m_frame->document())->addConsoleMessage(messageSource, messageLevel, message, requestIdentifier);
-}
-
-void DocumentLoader::sendCSPViolationReport(URL&& reportURL, Ref<FormData>&& report)
-{
-    PingLoader::sendViolationReport(*m_frame, WTFMove(reportURL), WTFMove(report), ViolationReportType::ContentSecurityPolicy);
 }
 
 void DocumentLoader::enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventInit&& eventInit)

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -563,7 +563,6 @@ private:
 
     // ContentSecurityPolicyClient
     WEBCORE_EXPORT void addConsoleMessage(MessageSource, MessageLevel, const String&, unsigned long requestIdentifier) final;
-    WEBCORE_EXPORT void sendCSPViolationReport(URL&&, Ref<FormData>&&) final;
     WEBCORE_EXPORT void enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventInit&&) final;
 
     bool disallowWebArchive() const;

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -57,6 +57,7 @@
 #include "SecurityOrigin.h"
 #include "SecurityPolicy.h"
 #include "UserContentController.h"
+#include "ViolationReportType.h"
 #include <wtf/text/CString.h>
 
 namespace WebCore {
@@ -172,6 +173,7 @@ void PingLoader::sendViolationReport(Frame& frame, const URL& reportURL, Ref<For
         request.setHTTPContentType("application/csp-report"_s);
         break;
     case ViolationReportType::StandardReportingAPIViolation:
+    case ViolationReportType::Test:
         request.setHTTPContentType("application/reports+json"_s);
         break;
     }
@@ -184,7 +186,7 @@ void PingLoader::sendViolationReport(Frame& frame, const URL& reportURL, Ref<For
 
     HTTPHeaderMap originalRequestHeader = request.httpHeaderFields();
 
-    if (reportType != ViolationReportType::StandardReportingAPIViolation)
+    if (reportType != ViolationReportType::StandardReportingAPIViolation && reportType != ViolationReportType::Test)
         frame.loader().updateRequestAndAddExtraFields(request, IsMainResource::No);
 
     String referrer = SecurityPolicy::generateReferrerHeader(document.referrerPolicy(), reportURL, frame.loader().outgoingReferrer());
@@ -213,7 +215,7 @@ void PingLoader::startPingLoad(Frame& frame, ResourceRequest& request, HTTPHeade
     options.cache = FetchOptions::Cache::NoCache;
 
     // https://www.w3.org/TR/reporting/#try-delivery
-    if (violationReportType == ViolationReportType::StandardReportingAPIViolation) {
+    if (violationReportType == ViolationReportType::StandardReportingAPIViolation || violationReportType == ViolationReportType::Test) {
         options.credentials = FetchOptions::Credentials::SameOrigin;
         options.mode = FetchOptions::Mode::Cors;
         options.serviceWorkersMode = ServiceWorkersMode::None;

--- a/Source/WebCore/loader/PingLoader.h
+++ b/Source/WebCore/loader/PingLoader.h
@@ -45,12 +45,8 @@ class Frame;
 class HTTPHeaderMap;
 class ResourceRequest;
 
-enum class ViolationReportType : uint8_t {
-    ContentSecurityPolicy,
-    StandardReportingAPIViolation // https://www.w3.org/TR/reporting/#try-delivery
-};
-
 enum class ContentSecurityPolicyImposition : uint8_t;
+enum class ViolationReportType : uint8_t;
 
 class PingLoader {
 public:

--- a/Source/WebCore/page/csp/CSPViolationReportBody.cpp
+++ b/Source/WebCore/page/csp/CSPViolationReportBody.cpp
@@ -44,7 +44,7 @@ const AtomString& CSPViolationReportBody::cspReportType()
 }
 
 CSPViolationReportBody::CSPViolationReportBody(Init&& init)
-    : ReportBody(ReportBodyType::CSPViolation)
+    : ReportBody(ViolationReportType::ContentSecurityPolicy)
     , m_documentURL(WTFMove(init.documentURI))
     , m_referrer(init.referrer.isNull() ? emptyString() : WTFMove(init.referrer))
     , m_blockedURL(WTFMove(init.blockedURI))

--- a/Source/WebCore/page/csp/CSPViolationReportBody.h
+++ b/Source/WebCore/page/csp/CSPViolationReportBody.h
@@ -27,6 +27,7 @@
 
 #include "ReportBody.h"
 #include "SecurityPolicyViolationEvent.h"
+#include "ViolationReportType.h"
 #include <wtf/IsoMalloc.h>
 
 namespace WebCore {
@@ -114,5 +115,5 @@ std::optional<RefPtr<CSPViolationReportBody>> CSPViolationReportBody::decode(Dec
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::CSPViolationReportBody)
-    static bool isType(const WebCore::ReportBody& reportBody) { return reportBody.reportBodyType() == WebCore::ReportBodyType::CSPViolation; }
+    static bool isType(const WebCore::ReportBody& reportBody) { return reportBody.reportBodyType() == WebCore::ViolationReportType::ContentSecurityPolicy; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/page/csp/ContentSecurityPolicyClient.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyClient.h
@@ -51,7 +51,6 @@ struct WEBCORE_EXPORT ContentSecurityPolicyClient {
     virtual ~ContentSecurityPolicyClient() = default;
 
     virtual void addConsoleMessage(MessageSource, MessageLevel, const String&, unsigned long requestIdentifier = 0) = 0;
-    virtual void sendCSPViolationReport(URL&&, Ref<FormData>&&) = 0;
     virtual void enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventInit&&) = 0;
 };
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -42,6 +42,7 @@
 #include "ImageBitmapOptions.h"
 #include "InspectorInstrumentation.h"
 #include "JSDOMExceptionHandling.h"
+#include "NotImplemented.h"
 #include "Performance.h"
 #include "RTCDataChannelRemoteHandlerConnection.h"
 #include "ReportingScope.h"
@@ -53,6 +54,7 @@
 #include "ServiceWorkerClientData.h"
 #include "ServiceWorkerGlobalScope.h"
 #include "SocketProvider.h"
+#include "ViolationReportType.h"
 #include "WorkerCacheStorageConnection.h"
 #include "WorkerFileSystemStorageConnection.h"
 #include "WorkerFontLoadRequest.h"
@@ -694,5 +696,11 @@ String WorkerGlobalScope::endpointURIForToken(const String& token) const
 {
     return reportingScope().endpointURIForToken(token);
 }
+
+void WorkerGlobalScope::sendReportToEndpoints(const URL&, Vector<String>&&, Ref<FormData>&&, ViolationReportType)
+{
+    notImplemented();
+}
+
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -71,6 +71,8 @@ class WorkerStorageConnection;
 class WorkerThread;
 struct WorkerParameters;
 
+enum class ViolationReportType : uint8_t;
+
 namespace IDBClient {
 class IDBConnectionProxy;
 }
@@ -204,7 +206,7 @@ private:
 
     void notifyReportObservers(Ref<Report>&&) final;
     String endpointURIForToken(const String&) const final;
-
+    void sendReportToEndpoints(const URL& baseURL, Vector<String>&& endPoints, Ref<FormData>&& report, ViolationReportType) final;
 
     URL m_url;
     URL m_ownerURL;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -61,6 +61,7 @@
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityPolicy.h>
 #include <WebCore/SharedBuffer.h>
+#include <WebCore/ViolationReportType.h>
 #include <wtf/Expected.h>
 #include <wtf/RunLoop.h>
 
@@ -1738,11 +1739,6 @@ void NetworkResourceLoader::addConsoleMessage(MessageSource messageSource, Messa
     send(Messages::WebPage::AddConsoleMessage { m_parameters.webFrameID,  messageSource, messageLevel, message, coreIdentifier() }, m_parameters.webPageID);
 }
 
-void NetworkResourceLoader::sendCSPViolationReport(URL&& reportURL, Ref<FormData>&& report)
-{
-    send(Messages::WebPage::SendCSPViolationReport { m_parameters.webFrameID, WTFMove(reportURL), IPC::FormDataReference { WTFMove(report) } }, m_parameters.webPageID);
-}
-
 void NetworkResourceLoader::enqueueSecurityPolicyViolationEvent(WebCore::SecurityPolicyViolationEventInit&& eventInit)
 {
     send(Messages::WebPage::EnqueueSecurityPolicyViolationEvent { m_parameters.webFrameID, WTFMove(eventInit) }, m_parameters.webPageID);
@@ -1845,6 +1841,11 @@ void NetworkResourceLoader::notifyReportObservers(Ref<Report>&& report)
 String NetworkResourceLoader::endpointURIForToken(const String& reportTo) const
 {
     return m_reportingEndpoints.get(reportTo);
+}
+
+void NetworkResourceLoader::sendReportToEndpoints(const URL& baseURL, Vector<String>&& endPoints, Ref<FormData>&& report, WebCore::ViolationReportType reportType)
+{
+    send(Messages::WebPage::SendReportToEndpoints { m_parameters.webFrameID, baseURL, WTFMove(endPoints), IPC::FormDataReference { WTFMove(report) }, reportType }, m_parameters.webPageID);
 }
 
 #if ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -66,6 +66,7 @@ class ServiceWorkerFetchTask;
 class WebSWServerConnection;
 
 enum class NegotiatedLegacyTLS : bool;
+enum class ViolationReportType : uint8_t;
 
 struct ResourceLoadInfo;
 
@@ -240,7 +241,6 @@ private:
 
     // ContentSecurityPolicyClient
     void addConsoleMessage(MessageSource, MessageLevel, const String&, unsigned long requestIdentifier = 0) final;
-    void sendCSPViolationReport(URL&&, Ref<WebCore::FormData>&&) final;
     void enqueueSecurityPolicyViolationEvent(WebCore::SecurityPolicyViolationEventInit&&) final;
 
     void logSlowCacheRetrieveIfNeeded(const NetworkCache::Cache::RetrieveInfo&);
@@ -256,6 +256,7 @@ private:
     // ReportingClient
     void notifyReportObservers(Ref<WebCore::Report>&&) final;
     String endpointURIForToken(const String&) const final;
+    void sendReportToEndpoints(const URL& baseURL, Vector<String>&& endPoints, Ref<WebCore::FormData>&& report, WebCore::ViolationReportType) final;
 
     enum class IsFromServiceWorker : bool { No, Yes };
     void willSendRedirectedRequestInternal(WebCore::ResourceRequest&&, WebCore::ResourceRequest&& redirectRequest, WebCore::ResourceResponse&&, IsFromServiceWorker);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -3084,11 +3084,14 @@ void ArgumentCoder<RefPtr<WebCore::ReportBody>>::encode(Encoder& encoder, const 
     encoder << reportBody->reportBodyType();
 
     switch (reportBody->reportBodyType()) {
-    case ReportBodyType::CSPViolation:
+    case ViolationReportType::ContentSecurityPolicy:
         downcast<CSPViolationReportBody>(reportBody.get())->encode(encoder);
         return;
-    case ReportBodyType::Test:
+    case ViolationReportType::Test:
         downcast<TestReportBody>(reportBody.get())->encode(encoder);
+        return;
+    case ViolationReportType::StandardReportingAPIViolation:
+        ASSERT_NOT_REACHED();
         return;
     }
 
@@ -3105,16 +3108,19 @@ std::optional<RefPtr<WebCore::ReportBody>> ArgumentCoder<RefPtr<WebCore::ReportB
     if (!hasReportBody)
         return { result };
 
-    std::optional<ReportBodyType> reportBodyType;
+    std::optional<ViolationReportType> reportBodyType;
     decoder >> reportBodyType;
     if (!reportBodyType)
         return std::nullopt;
 
     switch (*reportBodyType) {
-    case ReportBodyType::CSPViolation:
+    case ViolationReportType::ContentSecurityPolicy:
         return CSPViolationReportBody::decode(decoder);
-    case ReportBodyType::Test:
+    case ViolationReportType::Test:
         return TestReportBody::decode(decoder);
+    case ViolationReportType::StandardReportingAPIViolation:
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -240,6 +240,7 @@ enum class TextIndicatorPresentationTransition : uint8_t;
 enum class TextGranularity : uint8_t;
 enum class WheelEventProcessingSteps : uint8_t;
 enum class WritingDirection : uint8_t;
+enum class ViolationReportType : uint8_t;
 
 using PlatformDisplayID = uint32_t;
 
@@ -450,10 +451,10 @@ public:
 #endif
 
     void addConsoleMessage(WebCore::FrameIdentifier, MessageSource, MessageLevel, const String&, std::optional<WebCore::ResourceLoaderIdentifier> = std::nullopt);
-    void sendCSPViolationReport(WebCore::FrameIdentifier, const URL& reportURL, IPC::FormDataReference&&);
     void enqueueSecurityPolicyViolationEvent(WebCore::FrameIdentifier, WebCore::SecurityPolicyViolationEventInit&&);
 
     void notifyReportObservers(WebCore::FrameIdentifier, Ref<WebCore::Report>&&);
+    void sendReportToEndpoints(WebCore::FrameIdentifier, URL&& baseURL, Vector<String>&& endPoints, IPC::FormDataReference&&, WebCore::ViolationReportType);
 
     // -- Called by the DrawingArea.
     // FIXME: We could genericize these into a DrawingArea client interface. Would that be beneficial?

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -28,8 +28,8 @@ messages -> WebPage LegacyReceiver {
     SetBackgroundColor(std::optional<WebCore::Color> color)
 
     AddConsoleMessage(WebCore::FrameIdentifier frameID, enum:uint8_t JSC::MessageSource messageSource, enum:uint8_t JSC::MessageLevel messageLevel, String message, std::optional<WebCore::ResourceLoaderIdentifier> requestID)
-    SendCSPViolationReport(WebCore::FrameIdentifier frameID, URL reportURL, IPC::FormDataReference reportData)
     EnqueueSecurityPolicyViolationEvent(WebCore::FrameIdentifier frameID, struct WebCore::SecurityPolicyViolationEventInit eventInit)
+    SendReportToEndpoints(WebCore::FrameIdentifier frameID, URL baseURL, Vector<String> endPoints, IPC::FormDataReference reportData, enum:uint8_t WebCore::ViolationReportType reportType);
 
     NotifyReportObservers(WebCore::FrameIdentifier frameID, Ref<WebCore::Report> report)
 


### PR DESCRIPTION
#### 2e2acc4000997cddc8be168ae8f79fc4517b3c79
<pre>
[Reporting API] Refactor network send logic to Report-related code
<a href="https://bugs.webkit.org/show_bug.cgi?id=244855">https://bugs.webkit.org/show_bug.cgi?id=244855</a>
&lt;rdar://problem/99618219&gt;

Reviewed by Chris Dumez.

Bits of logic about how to distribute reports to endpoints is spread around the ContentSecurityObject, PingLoader, (COEP/COOP reporting before it was reverted), and now the Reporting module. This patch consolidates the behavior in the Reporting code where it can be used for all report types.

1. Rather than use a new &apos;ReportBodyType&apos; type, it uses the existing &apos;ViolationReportType&apos;, since ReportBodies are 1:1 associated with ViolationReport types.
2. Remove the single-purpose &apos;sendCSPViolationReport&apos; method and replace with a more generic &apos;sendReportToEndpoints&apos;.
3. Modify the ReportingClient to present a signature for sending reports.
4. Modify the ContentSecurityPolicy code to use the new &apos;sendReportToEndpoints&apos; client method.
5. Modify Document and NetworkLoader to implement a &apos;sendReportToEndpoints&apos; method.
6. Add a stub implementation to WorkerGlobalScope to send reports. This will be done in a separate change.

* Source/WebCore/Headers.cmake: Add new ViolationReportType.h header.
* Source/WebCore/Modules/reporting/ReportBody.cpp:
(WebCore::ReportBody::ReportBody): Switch from ReportBodyType to ViolationReportType.
(WebCore::ReportBody::reportBodyType const): Ditto.
* Source/WebCore/Modules/reporting/ReportBody.h:
* Source/WebCore/Modules/reporting/ReportingClient.h: Add new &apos;sendReportToEndpoints&apos; method.
* Source/WebCore/Modules/reporting/TestReportBody.cpp:
(WebCore::TestReportBody::TestReportBody): Switch from ReportBodyType to ViolationReportType.
* Source/WebCore/Modules/reporting/TestReportBody.h:
(isType): Switch from ReportBodyType to ViolationReportType.
* Source/WebCore/Modules/reporting/ViolationReportType.h: Copied from Source/WebCore/Modules/reporting/ReportBody.h.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj: Add new ViolationReportType.h header.
* Source/WebCore/bindings/js/JSReportBodyCustom.cpp: Ditto.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::sendReportToEndpoints): Added.
* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::sendCSPViolationReport): Deleted.
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::sendViolationReport): Recognize the &apos;Test&apos; ViolationReportType.
(WebCore::PingLoader::startPingLoad): Ditto.
* Source/WebCore/loader/PingLoader.h:
* Source/WebCore/page/csp/CSPViolationReportBody.cpp:
(WebCore::CSPViolationReportBody::CSPViolationReportBody): Switch from ReportBodyType to ViolationReportType.
* Source/WebCore/page/csp/CSPViolationReportBody.h:
(isType): Ditto.
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::reportViolation const): Update to use the new ReportingClient mechanism
to send violation reports (rather than special casing for NetworkLoader and Document explicitly).
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::sendReportToEndpoints): Added stub (for future work).
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::sendCSPViolationReport): Replaced with &apos;sendReportToEndpoints&apos;.
(WebKit::NetworkResourceLoader::sendReportToEndpoints): Added new implementation to support the ReportingClient API.
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ReportBody&gt;&gt;::encode): Switch from ReportBodyType to ViolationReportType.
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ReportBody&gt;&gt;::decode): Ditto.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::sendCSPViolationReport): Deleted.
(WebKit::WebPage::sendReportToEndpoints): Added.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/254208@main">https://commits.webkit.org/254208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6a7b19c931cb13f5748233106022f36d89169ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32870 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/19253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97590 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153065 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31369 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80606 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/92246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94017 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/24948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/75274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/24914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/19253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67877 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28978 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/19253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/28968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/19253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2961 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32170 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/75274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31091 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/19253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->