### PR TITLE
REGRESSION(254047@main): [ iOS Debug wk2 ] platform/ios/mediastream/video-muted-in-background-tab.html is a near constant crash

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3742,4 +3742,4 @@ webkit.org/b/244619 editing/selection/ios/tap-to-set-selection-in-editable-web-v
 
 webkit.org/b/244740 http/wpt/cross-origin-opener-policy/non-secure-to-secure-context-navigation.https.html [ Pass Failure ]
 
-webkit.org/b/244851 platform/ios/mediastream/video-muted-in-background-tab.html [ Pass Crash ]
+webkit.org/b/244851 [ Debug ] platform/ios/mediastream/video-muted-in-background-tab.html [ Skip ]


### PR DESCRIPTION
#### 689fb3ae6c657e1bfa14fda02ea6e92302b17b12
<pre>
REGRESSION(254047@main): [ iOS Debug wk2 ] platform/ios/mediastream/video-muted-in-background-tab.html is a near constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=244851">https://bugs.webkit.org/show_bug.cgi?id=244851</a>
rdar://problem/99614035
Need a short description (OOPS!).
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Make sure to stop the manager when an error happens, since the captureFailed call will not remove it if the AudioUnit is not running.

* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm:
(-[WebCoreMediaCaptureStatusBarHandler stop]):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::setIsInBackground):
</pre>