### PR TITLE
[git-webkit] Add trace command

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.6.10',
+    version='5.6.11',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 6, 10)
+version = Version(5, 6, 11)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -45,6 +45,7 @@ from .pull_request import PullRequest
 from .revert import Revert
 from .setup_git_svn import SetupGitSvn
 from .setup import Setup
+from .trace import Trace
 from .track import Track
 
 from webkitbugspy import log as webkitbugspy_log
@@ -85,7 +86,7 @@ def main(
         Clean, Find, Info, Land, Log, Pull,
         PullRequest, Revert, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,
-        Pickable, CherryPick, Track,
+        Pickable, CherryPick, Trace, Track,
     ]
     if subversion:
         programs.append(SetupGitSvn)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py
@@ -1,0 +1,276 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import re
+import sys
+
+from .command import Command
+from webkitscmpy import Commit, local, log, remote
+from webkitbugspy import Tracker
+
+
+COMMIT_REF_BASE = r'r?R?[a-f0-9A-F]+.?\d*@?[0-9a-zA-z\-/]*'
+COMPOUND_COMMIT_REF = r'(?P<primary>{})(?P<secondary> \({}\))?'.format(COMMIT_REF_BASE, COMMIT_REF_BASE)
+CHERRY_PICK_RE = re.compile(r'[Cc]herry[- ][Pp]ick {}'.format(COMPOUND_COMMIT_REF))
+REVERT_RE = re.compile(r'Reverts? {}'.format(COMPOUND_COMMIT_REF))
+FOLLOW_UP_FIXES_RE = [
+    re.compile(r'Fix following {}'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'Follow-? ?up fix {}'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'Follow-? ?up {}'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'\[?[Gg]ardening\]?:? REGRESSION \(?{}\)?'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'REGRESSION ?\(?{}\)?'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'\[?[Gg]ardening\]?:? [Tt]est-? ?[Aa]ddition \(?{}\)?'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'[Tt]est-? ?[Aa]ddition \(?{}\)?'.format(COMPOUND_COMMIT_REF)),
+]
+UNPACK_SECONDARY_RE = re.compile(r' \(({})\)'.format(COMMIT_REF_BASE))
+
+
+class Relationship(object):
+    TYPES = (
+        'references', 'referenced by',
+        'cherry-picked', 'original',
+        'reverts', 'reverted by',
+        'follow-up', 'follow-up by',
+    )
+    REFERENCES, REFERENCED_BY, \
+        CHERRY_PICK, ORIGINAL, \
+        REVERTS, REVERTED_BY, \
+        FOLLOW_UP, FOLLOW_UP_BY = TYPES
+
+    PAIRED = [FOLLOW_UP, FOLLOW_UP_BY]
+    IDENTITY = [CHERRY_PICK, ORIGINAL]
+    UNDO = [REVERTS, REVERTED_BY]
+
+    @classmethod
+    def reversed(cls, type):
+        return {
+            cls.REFERENCES: cls.REFERENCED_BY,
+            cls.REFERENCED_BY: cls.REFERENCES,
+            cls.CHERRY_PICK: cls.ORIGINAL,
+            cls.ORIGINAL: cls.CHERRY_PICK,
+            cls.REVERTS: cls.REVERTED_BY,
+            cls.REVERTED_BY: cls.REVERTS,
+            cls.FOLLOW_UP: cls.FOLLOW_UP_BY,
+            cls.FOLLOW_UP_BY: cls.FOLLOW_UP,
+        }.get(type, type)
+
+    @classmethod
+    def parse(cls, commit):
+        lines = commit.message.splitlines()
+
+        for type, regexes in {
+            cls.ORIGINAL: [CHERRY_PICK_RE],
+            cls.REVERTS: [REVERT_RE],
+            cls.FOLLOW_UP: FOLLOW_UP_FIXES_RE,
+        }.items():
+            for regex in regexes:
+                match = regex.match(lines[0])
+                if not match:
+                    continue
+                primary = match.group('primary')
+                secondary = match.group('secondary')
+                if secondary:
+                    secondary = UNPACK_SECONDARY_RE.match(secondary).groups()[0]
+                return type, [ref.rstrip('.').rstrip() for ref in [primary, secondary] if ref]
+        return None, []
+
+    def __init__(self, commit, type=None):
+        self.commit = commit
+        self.type = type or self.REFERENCES
+
+    def __repr__(self):
+        return '{} {}'.format(self.commit, self.type)
+
+
+class CommitsStory(object):
+    @classmethod
+    def issues_for(cls, commit):
+        filter = set()
+        result = []
+        line_count = 0
+        for line in commit.message.splitlines():
+            if not line and line_count >= 2:
+                break
+            if not line:
+                continue
+            line_count += 1
+            for word in line.split(' '):
+                bug = Tracker.from_string(word)
+                if bug and bug.link not in filter:
+                    filter.add(bug.link)
+                    result.append(bug)
+        return result
+
+    def __init__(self, commits=None):
+        self.commits = []
+        self.by_ref = {}
+        self.by_issue = {}
+        self.relations = {}
+        for commit in commits or []:
+            self.add(commit)
+
+    def add(self, commit):
+        if str(commit) in self.by_ref:
+            return True
+        self.commits.append(commit)
+        self.by_ref[str(commit)] = commit
+        if commit.hash:
+            self.by_ref[commit.hash[:Commit.HASH_LABEL_SIZE]] = commit
+        if commit.revision:
+            self.by_ref['r{}'.format(commit.revision)] = commit
+
+        for issue in self.issues_for(commit):
+            if issue.link not in self.by_issue:
+                self.by_issue[issue.link] = []
+            self.by_issue[issue.link].append(commit)
+
+        type, refs = Relationship.parse(commit)
+        if type:
+            for ref in refs:
+                if ref not in self.relations:
+                    self.relations[ref] = []
+                self.relations[ref].append(Relationship(commit, Relationship.reversed(type)))
+        return False
+
+
+class Trace(Command):
+    name = 'trace'
+    aliases = ['follow']
+    help = "Given an identifier, revision, or hash, find related commits"
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            'argument', nargs=1,
+            type=str, default=None,
+            help='String representation of a commit to trace relationships of',
+        )
+        parser.add_argument(
+            '--limit',
+            type=int, default=500,
+            help='Search commit messages around the specified commit for relationships',
+        )
+
+    @classmethod
+    def relationships(cls, commit, repository, commits_story=None):
+        tracked = set([str(commit)])
+        result = []
+        type, refs = Relationship.parse(commit)
+        if type and refs:
+            for ref in refs:
+                found = None
+                if commits_story:
+                    found = commits_story.by_ref.get(ref, None)
+                if not found:
+                    found = repository.find(ref)
+                if not found:
+                    continue
+                if commits_story:
+                    commits_story.add(found)
+
+                tracked.add(str(found))
+                result.append(Relationship(found, type))
+                for relation in cls.relationships(found, repository):
+                    if str(relation.commit) in tracked:
+                        continue
+                    tracked.add(str(relation.commit))
+                    result.append(relation)
+                break
+
+            else:
+                sys.stderr.write("'{}' {} something we can't find, continuing\n".format(commit, type))
+
+        if not commits_story:
+            return result
+
+        type = Relationship.REFERENCES
+        for issue in CommitsStory.issues_for(commit):
+            for candidate in commits_story.by_issue.get(issue.link, []):
+                if str(candidate) in tracked:
+                    continue
+                tracked.add(str(candidate))
+                result.append(Relationship(candidate, type))
+
+        references = [str(commit)]
+        if commit.hash:
+            references.append(commit.hash[:Commit.HASH_LABEL_SIZE])
+        if commit.revision:
+            references.append('r{}'.format(commit.revision))
+        for reference in references:
+            for candidate in commits_story.relations.get(reference, []):
+                if str(candidate.commit) in tracked:
+                    continue
+                tracked.add(str(candidate.commit))
+                result.append(candidate)
+        return result
+
+    @classmethod
+    def summary(cls, commit):
+        return '{identifier} | {hash}{revision}{title}'.format(
+            identifier=commit,
+            hash=commit.hash[:Commit.HASH_LABEL_SIZE] if commit.hash else '',
+            revision='{}r{}'.format(', ' if commit.hash else '', commit.revision) if commit.revision else '',
+            title=' | {}'.format(commit.message.splitlines()[0]) if commit.message else ''
+        )
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        if not repository:
+            sys.stderr.write('No repository provided\n')
+            return 1
+
+        try:
+            commit = repository.find(args.argument[0], include_log=True)
+        except (local.Scm.Exception, TypeError, ValueError) as exception:
+            # ValueErrors and Scm exceptions usually contain enough information to be displayed
+            # to the user as an error
+            sys.stderr.write(str(exception) + '\n')
+            return 1
+
+        print(cls.summary(commit))
+
+        story = CommitsStory()
+        if args.limit:
+            head = repository.commit()
+            if head.branch != commit.branch:
+                for c in repository.commits(
+                    begin=dict(argument='{}~{}'.format(head.hash, args.limit)),
+                    end=dict(argument=head.hash),
+                ):
+                    story.add(c)
+                head = repository.commit(branch=commit.branch)
+
+            for c in repository.commits(
+                begin=dict(argument='{}~{}'.format(commit.hash, args.limit)),
+                end=dict(argument=head.hash),
+            ):
+                story.add(c)
+
+        relationship = cls.relationships(commit, repository, commits_story=story)
+        if not relationship:
+            sys.stderr.write('No relationships found\n')
+            return 1
+
+        for relationship in relationship:
+            print('    {} {}'.format(relationship.type, cls.summary(relationship.commit)))
+
+        return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
@@ -1,0 +1,180 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+import os
+import sys
+import time
+
+from mock import patch
+from unittest import TestCase
+from webkitbugspy import radar, mocks as bmocks
+from webkitcorepy import OutputCapture, Terminal, testing
+from webkitscmpy import local, mocks, Commit, program
+from webkitscmpy.program.trace import Relationship, CommitsStory
+
+
+class TestRelationship(TestCase):
+    def test_cherry_pick(self):
+        self.assertEqual(
+            ('original', ['0123456789ab']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Cherry-pick 0123456789ab <rdar://54321>',
+            ))
+        )
+        self.assertEqual(
+            ('original', ['123@main', '0123456789ab']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Cherry-pick 123@main (0123456789ab). <rdar://54321>',
+            ))
+        )
+        self.assertEqual(
+            ('original', ['123@main', 'r120']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Cherry-pick 123@main (r120). <rdar://54321>',
+            ))
+        )
+
+    def test_revert(self):
+        self.assertEqual(
+            ('reverts', ['1230@main', '0123456789ab']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Reverts 1230@main (0123456789ab)',
+            ))
+        )
+        self.assertEqual(
+            ('reverts', ['1230@main']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Revert 1230@main, it broke the build',
+            ))
+        )
+
+    def test_follow_up(self):
+        self.assertEqual(
+            ('follow-up', ['1230@main', '0123456789ab']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Fix following 1230@main (0123456789ab)',
+            ))
+        )
+        self.assertEqual(
+            ('follow-up', ['1230@main']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Follow-up 1230@main, it broke the build',
+            ))
+        )
+        self.assertEqual(
+            ('follow-up', ['1230@main']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='REGRESSION 1230@main',
+            ))
+        )
+        self.assertEqual(
+            ('follow-up', ['1230@main']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Test-addition (1230@main)',
+            ))
+        )
+
+
+class TestCommitsStory(TestCase):
+    def test_cherry_pick(self):
+        with bmocks.Radar(issues=bmocks.ISSUES), patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+            commit = Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Cherry-pick 123@main (0123456789ab). <rdar://54321>',
+            )
+            story = CommitsStory([commit])
+            self.assertEqual(story.by_issue.get('<rdar://54321>', []), [commit])
+            self.assertEqual(
+                [str(rel) for rel in story.relations.get('123@main', [])],
+                ['1234@main cherry-picked'],
+            )
+            self.assertEqual(
+                [str(rel) for rel in story.relations.get('0123456789ab', [])],
+                ['1234@main cherry-picked'],
+            )
+
+    def test_revert(self):
+        story = CommitsStory([Commit(
+            hash='deadbeef1234', revision=1234, identifier='1234@main',
+            message='Reverts 1230@main (0123456789ab)',
+        )])
+        self.assertEqual(story.by_issue, {})
+        self.assertEqual(
+            [str(rel) for rel in story.relations.get('1230@main', [])],
+            ['1234@main reverted by'],
+        )
+        self.assertEqual(
+            [str(rel) for rel in story.relations.get('0123456789ab', [])],
+            ['1234@main reverted by'],
+        )
+
+    def test_follow_up(self):
+        story = CommitsStory([Commit(
+            hash='deadbeef1234', revision=1234, identifier='1234@main',
+            message='Fix following 1230@main (0123456789ab)',
+        )])
+        self.assertEqual(story.by_issue, {})
+        self.assertEqual(
+            [str(rel) for rel in story.relations.get('1230@main', [])],
+            ['1234@main follow-up by'],
+        )
+        self.assertEqual(
+            [str(rel) for rel in story.relations.get('0123456789ab', [])],
+            ['1234@main follow-up by'],
+        )
+
+
+class TestTrace(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def setUp(self):
+        super(TestTrace, self).setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    def test_none(self):
+        with OutputCapture() as captured, mocks.local.Git(), mocks.local.Svn(), Terminal.override_atty(sys.stdin, isatty=False):
+            self.assertEqual(1, program.main(
+                args=('trace', '6@main'),
+                path=self.path,
+            ))
+        self.assertEqual(captured.stderr.getvalue(), 'No repository provided\n')
+
+    def test_revert(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), Terminal.override_atty(sys.stdin, isatty=False):
+            repo.head = Commit(
+                hash='deadbeef1234', revision=10, identifier='6@main',
+                message='Reverts 5@main', timestamp=int(time.time()),
+                author=repo.head.author,
+            )
+            repo.commits['main'].append(repo.head)
+
+            self.assertEqual(0, program.main(
+                args=('trace', '6@main', '--limit', '1'),
+                path=self.path,
+            ))
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            '6@main | deadbeef1234 | Reverts 5@main\n    reverts 5@main | d8bce26fa65c | Patch Series\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')


### PR DESCRIPTION
#### d3e19e632f184c36329139ac86089f604afc477d
<pre>
[git-webkit] Add trace command
<a href="https://bugs.webkit.org/show_bug.cgi?id=244859">https://bugs.webkit.org/show_bug.cgi?id=244859</a>
&lt;rdar://97455957&gt;

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py: Add Trace command.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py:
(Pickable.pickable): Create a CommitsStory object to track more commit relationships.
(Pickable.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py: Added.
(Relationship.reversed): Reverse the relationship type (ie, the reverse of &quot;reverted&quot; is &quot;reverted by&quot;).
(Relationship.parse): Parse a commit message and return relationships.
(Relationship.__init__):
(Relationship.__repr__):
(CommitsStory.issues_for): Parse a commit message for embedded issue references.
(CommitsStory.__init__):
(CommitsStory.add): Add a commit to the story.
(Trace.parser):
(Trace.relationships): Find all relationships for the specified commit.
(Trace.summary): Sumarize a commit.
(Trace.main): Find all relationships for the specified commit and print them.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py: Added.
(TestRelationship):
(TestCommitsStory):
(TestTrace):

Canonical link: <a href="https://commits.webkit.org/254997@main">https://commits.webkit.org/254997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2837aed3c668d320b8b54a09bbd142e02745e543

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35540 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/100312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/34041 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83313 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96625 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/26928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/94548 "webkitpy-tests (failure)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/69963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35121 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/90035 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32921 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36699 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1528 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38626 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->