### PR TITLE
BlobURLHandle doesn't work as intended for opaque origin Blob URLs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/sandboxed-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/sandboxed-iframe-expected.txt
@@ -21,7 +21,7 @@ PASS XHR with method "OPTIONS" should fail
 PASS XHR with method "PUT" should fail
 PASS XHR with method "CUSTOM" should fail
 PASS XHR should return Content-Type from Blob
-FAIL Revoke blob URL after open(), will fetch assert_unreached: Got unexpected error event Reached unreachable code
+PASS Revoke blob URL after open(), will fetch
 PASS Blob URLs can be used in fetch
 PASS fetch with a fragment should succeed
 PASS fetch of a revoked URL should fail
@@ -35,7 +35,7 @@ PASS fetch with method "OPTIONS" should fail
 PASS fetch with method "PUT" should fail
 PASS fetch with method "CUSTOM" should fail
 PASS fetch should return Content-Type from Blob
-FAIL Revoke blob URL after creating Request, will fetch promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Revoke blob URL after creating Request, then clone Request, will fetch promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Revoke blob URL after creating Request, will fetch
+PASS Revoke blob URL after creating Request, then clone Request, will fetch
 PASS Revoke blob URL after calling fetch, fetch should succeed
 


### PR DESCRIPTION
#### 2953e9903dd4e68d615bdcd2047d1adbcbe2c816
<pre>
BlobURLHandle doesn&apos;t work as intended for opaque origin Blob URLs
<a href="https://bugs.webkit.org/show_bug.cgi?id=244862">https://bugs.webkit.org/show_bug.cgi?id=244862</a>

Reviewed by Darin Adler.

BlobURLHandle doesn&apos;t work as intended for opaque origin Blob URLs. This is
causing some of the subtests in imported/w3c/web-platform-tests/FileAPI/url/sandboxed-iframe.html
to fail in WebKit.

The issue is that the SecurityOrigin of an opaque-origin blob URL gets stored
in a OriginMap inside ThreadableBlobOrigin. When the blob URL would later get
revoked, we would remove its origin from the OriginMap, without checking if
there are any BlobURLHandles keeping the blob alive.

* LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/sandboxed-iframe-expected.txt:
* Source/WebCore/fileapi/ThreadableBlobRegistry.cpp:
(WebCore::blobURLReferencesMap):
(WebCore::unregisterBlobURLOriginIfNecessary):
(WebCore::ThreadableBlobRegistry::registerBlobURL):
(WebCore::ThreadableBlobRegistry::unregisterBlobURL):
(WebCore::ThreadableBlobRegistry::registerBlobURLHandle):
(WebCore::ThreadableBlobRegistry::unregisterBlobURLHandle):

Canonical link: <a href="https://commits.webkit.org/254238@main">https://commits.webkit.org/254238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c7de52d74bb4b8581b44fe7993c0f84c520a11a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97585 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153058 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31358 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26995 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80601 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92241 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24934 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75266 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24911 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67874 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28970 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28957 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14952 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2980 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37880 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34065 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->