### PR TITLE
imported/w3c/web-platform-tests/FileAPI/url/url-reload.window.html is timing out in WebKit

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-reload.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-reload.window-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Reloading a blob URL succeeds.
-TIMEOUT Reloading a blob URL succeeds even if the URL was revoked. Test timed out
+PASS Reloading a blob URL succeeds even if the URL was revoked.
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3502,6 +3502,11 @@ void Document::setURL(const URL& url)
     if (SecurityOrigin::shouldIgnoreHost(m_url))
         m_url.setHostAndPort({ });
 
+    if (m_url.protocolIsBlob())
+        m_blobURLLifetimeExtension = m_url;
+    else
+        m_blobURLLifetimeExtension.clear();
+
     m_documentURI = m_url.string();
     updateBaseURL();
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "BlobURL.h"
 #include "CSSPropertyNames.h"
 #include "CSSRegisteredCustomProperty.h"
 #include "CanvasBase.h"
@@ -1848,6 +1849,7 @@ private:
 
     // Document URLs.
     URL m_url; // Document.URL: The URL from which this document was retrieved.
+    BlobURLHandle m_blobURLLifetimeExtension; // Keep the Document's blob alive so it can be reloaded.
     URL m_creationURL; // https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url.
     URL m_baseURL; // Node.baseURI: The URL to use when resolving relative URLs.
     URL m_baseURLOverride; // An alternative base URL that takes precedence over m_baseURL (but not m_baseElementURL).


### PR DESCRIPTION
#### e295563ee5ae3226673799a8ec66672ed6080473
<pre>
imported/w3c/web-platform-tests/FileAPI/url/url-reload.window.html is timing out in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=244864">https://bugs.webkit.org/show_bug.cgi?id=244864</a>

Reviewed by Geoffrey Garen.

imported/w3c/web-platform-tests/FileAPI/url/url-reload.window.html is timing
out in WebKit but passing in Gecko.

The test is reloading a frame with a Blob URL after revoking that URL,
expecting the reload to succeed. To support this, the Document now keeps its
blob URL alive using a BlobURLHandle.

* LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-reload.window-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setURL):
* Source/WebCore/dom/Document.h:

Canonical link: <a href="https://commits.webkit.org/254254@main">https://commits.webkit.org/254254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/226d984830c7db85a5a5d67313a89d303e18b09f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97587 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153060 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31362 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26998 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92243 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24935 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75269 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24913 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67876 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28973 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28963 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14953 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2991 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37881 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34066 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->