### PR TITLE
Import x-frame-options WPT tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -477,6 +477,11 @@ imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audionode-interface/a
 imported/w3c/web-platform-tests/workers/same-origin-check.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/mixed-content [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/upgrade-insecure-requests [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/x-frame-options/deny.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/x-frame-options/get-decode-split.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/x-frame-options/invalid.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/x-frame-options/multiple.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/x-frame-options/sameorigin.sub.html [ DumpJSConsoleLogInStdErr ]
 
 # Skip some WPT that require cross-origin testrunner features we don't yet support, causing timeouts.
 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic.http-rp/opt-in/xhr.https.html [ Skip ]

--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -479,7 +479,7 @@
     "web-platform-tests/webxr": "import", 
     "web-platform-tests/workers": "import", 
     "web-platform-tests/worklets": "import", 
-    "web-platform-tests/x-frame-options": "skip", 
+    "web-platform-tests/x-frame-options": "import", 
     "web-platform-tests/xhr": "import", 
     "web-platform-testscss/css-transforms/": "import", 
     "web-platform/test/html/infrastructure": "import", 

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/META.yml
@@ -1,0 +1,5 @@
+spec: https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-x-frame-options-header
+suggested_reviewers:
+  - annevk
+  - mikewest
+  - domenic

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/README.md
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/README.md
@@ -1,0 +1,3 @@
+This directory contains tests for [`X-Frame-Options`](https://html.spec.whatwg.org/#the-x-frame-options-header).
+
+Currently it only tests `<iframe>`. It would be nice to test `<embed>` and `<object>` as well.

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/deny-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/deny-expected.txt
@@ -1,0 +1,12 @@
+
+PASS `DENY` blocks same-origin framing
+PASS `DENY` blocks cross-origin framing
+PASS `denY` blocks same-origin framing
+PASS `denY` blocks cross-origin framing
+PASS `  DENY ` blocks same-origin framing
+PASS `  DENY ` blocks cross-origin framing
+PASS `DENY` blocks same-origin framing with CSP default-src 'self'
+PASS `DENY` blocks cross-origin framing with CSP default-src 'self'
+PASS `DENY` allows same-origin framing with CSP frame-ancestors 'self'
+PASS `DENY` blocks cross-origin framing with CSP frame-ancestors 'self'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/deny.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/deny.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>X-Frame-Options variations of DENY</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./support/helper.sub.js"></script>
+
+<body>
+<script>
+"use strict";
+
+xfo_simple_tests({
+  headerValue: `DENY`,
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `denY`,
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `  DENY `,
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `DENY`,
+  cspValue: `default-src 'self'`,
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `DENY`,
+  cspValue: `frame-ancestors 'self'`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: false
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/get-decode-split-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/get-decode-split-expected.txt
@@ -1,0 +1,6 @@
+
+PASS `,SAMEORIGIN,,DENY,` blocks same-origin framing
+PASS `,SAMEORIGIN,,DENY,` blocks cross-origin framing
+PASS `  SAMEORIGIN,    DENY` blocks same-origin framing
+PASS `  SAMEORIGIN,    DENY` blocks cross-origin framing
+

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/get-decode-split.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/get-decode-split.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>X-Frame-Options headers use the get, decode, and split algorithm</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/helper.sub.js"></script>
+
+<body>
+<script>
+"use strict";
+
+xfo_simple_tests({
+  headerValue: `,SAMEORIGIN,,DENY,`,
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `  SAMEORIGIN,    DENY`,
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/invalid-expected.txt
@@ -1,0 +1,18 @@
+
+PASS `INVALID` allows same-origin framing
+PASS `INVALID` allows cross-origin framing
+PASS `ALLOW-FROM https://example.com/` allows same-origin framing
+PASS `ALLOW-FROM https://example.com/` allows cross-origin framing
+PASS `ALLOW-FROM=https://example.com/` allows same-origin framing
+PASS `ALLOW-FROM=https://example.com/` allows cross-origin framing
+PASS `ALLOWALL` allows same-origin framing
+PASS `ALLOWALL` allows cross-origin framing
+PASS `"DENY"` allows same-origin framing
+PASS `"DENY"` allows cross-origin framing
+PASS `"SAMEORIGIN"` allows same-origin framing
+PASS `"SAMEORIGIN"` allows cross-origin framing
+PASS `"SAMEORIGIN,DENY"` allows same-origin framing
+PASS `"SAMEORIGIN,DENY"` allows cross-origin framing
+PASS `(the empty string)` allows same-origin framing
+PASS `(the empty string)` allows cross-origin framing
+

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/invalid.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>X-Frame-Options invalid values</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./support/helper.sub.js"></script>
+
+<body>
+<script>
+"use strict";
+
+xfo_simple_tests({
+  headerValue: `INVALID`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
+
+xfo_simple_tests({
+  headerValue: `ALLOW-FROM https://example.com/`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
+
+xfo_simple_tests({
+  headerValue: `ALLOW-FROM=https://example.com/`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
+
+xfo_simple_tests({
+  headerValue: `ALLOWALL`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
+
+xfo_simple_tests({
+  headerValue: `"DENY"`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
+
+xfo_simple_tests({
+  headerValue: `"SAMEORIGIN"`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
+
+xfo_simple_tests({
+  headerValue: `"SAMEORIGIN,DENY"`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
+
+xfo_simple_tests({
+  headerValue: ``,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/multiple-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/multiple-expected.txt
@@ -1,0 +1,112 @@
+
+PASS `SAMEORIGIN;SAMEORIGIN` allows same-origin framing
+PASS `SAMEORIGIN;SAMEORIGIN` blocks cross-origin framing
+PASS `SAMEORIGIN;sameOrigin` allows same-origin framing
+PASS `sameOrigin;SAMEORIGIN` allows same-origin framing
+PASS `SAMEORIGIN,sameOrigin` allows same-origin framing
+PASS `sameOrigin,SAMEORIGIN` allows same-origin framing
+PASS `SAMEORIGIN;sameOrigin` blocks cross-origin framing
+PASS `sameOrigin;SAMEORIGIN` blocks cross-origin framing
+PASS `SAMEORIGIN,sameOrigin` blocks cross-origin framing
+PASS `sameOrigin,SAMEORIGIN` blocks cross-origin framing
+PASS `SAMEORIGIN;DENY` blocks same-origin framing
+PASS `DENY;SAMEORIGIN` blocks same-origin framing
+PASS `SAMEORIGIN,DENY` blocks same-origin framing
+PASS `DENY,SAMEORIGIN` blocks same-origin framing
+PASS `SAMEORIGIN;DENY` blocks cross-origin framing
+PASS `DENY;SAMEORIGIN` blocks cross-origin framing
+PASS `SAMEORIGIN,DENY` blocks cross-origin framing
+PASS `DENY,SAMEORIGIN` blocks cross-origin framing
+PASS `SAMEORIGIN;INVALID` blocks same-origin framing
+PASS `INVALID;SAMEORIGIN` blocks same-origin framing
+PASS `SAMEORIGIN,INVALID` blocks same-origin framing
+PASS `INVALID,SAMEORIGIN` blocks same-origin framing
+PASS `SAMEORIGIN;INVALID` blocks cross-origin framing
+PASS `INVALID;SAMEORIGIN` blocks cross-origin framing
+PASS `SAMEORIGIN,INVALID` blocks cross-origin framing
+PASS `INVALID,SAMEORIGIN` blocks cross-origin framing
+PASS `SAMEORIGIN;ALLOWALL` blocks same-origin framing
+PASS `ALLOWALL;SAMEORIGIN` blocks same-origin framing
+PASS `SAMEORIGIN,ALLOWALL` blocks same-origin framing
+PASS `ALLOWALL,SAMEORIGIN` blocks same-origin framing
+PASS `SAMEORIGIN;ALLOWALL` blocks cross-origin framing
+PASS `ALLOWALL;SAMEORIGIN` blocks cross-origin framing
+PASS `SAMEORIGIN,ALLOWALL` blocks cross-origin framing
+PASS `ALLOWALL,SAMEORIGIN` blocks cross-origin framing
+PASS `SAMEORIGIN;"DENY"` blocks same-origin framing
+PASS `"DENY";SAMEORIGIN` blocks same-origin framing
+PASS `SAMEORIGIN,"DENY"` blocks same-origin framing
+PASS `"DENY",SAMEORIGIN` blocks same-origin framing
+PASS `SAMEORIGIN;"DENY"` blocks cross-origin framing
+PASS `"DENY";SAMEORIGIN` blocks cross-origin framing
+PASS `SAMEORIGIN,"DENY"` blocks cross-origin framing
+PASS `"DENY",SAMEORIGIN` blocks cross-origin framing
+PASS `SAMEORIGIN;` blocks same-origin framing
+FAIL `(the empty string);SAMEORIGIN` blocks same-origin framing assert_equals: expected null but got Document node with 2 children
+FAIL `SAMEORIGIN,(the empty string)` blocks same-origin framing assert_equals: expected null but got Document node with 2 children
+FAIL `(the empty string),SAMEORIGIN` blocks same-origin framing assert_equals: expected null but got Document node with 2 children
+PASS `SAMEORIGIN;` blocks cross-origin framing
+PASS `(the empty string);SAMEORIGIN` blocks cross-origin framing
+PASS `SAMEORIGIN,(the empty string)` blocks cross-origin framing
+PASS `(the empty string),SAMEORIGIN` blocks cross-origin framing
+PASS `DENY;DENY` blocks same-origin framing
+PASS `DENY;DENY` blocks cross-origin framing
+PASS `DENY;INVALID` blocks same-origin framing
+PASS `INVALID;DENY` blocks same-origin framing
+PASS `DENY,INVALID` blocks same-origin framing
+PASS `INVALID,DENY` blocks same-origin framing
+PASS `DENY;INVALID` blocks cross-origin framing
+PASS `INVALID;DENY` blocks cross-origin framing
+PASS `DENY,INVALID` blocks cross-origin framing
+PASS `INVALID,DENY` blocks cross-origin framing
+PASS `DENY;ALLOWALL` blocks same-origin framing
+PASS `ALLOWALL;DENY` blocks same-origin framing
+PASS `DENY,ALLOWALL` blocks same-origin framing
+PASS `ALLOWALL,DENY` blocks same-origin framing
+PASS `DENY;ALLOWALL` blocks cross-origin framing
+PASS `ALLOWALL;DENY` blocks cross-origin framing
+PASS `DENY,ALLOWALL` blocks cross-origin framing
+PASS `ALLOWALL,DENY` blocks cross-origin framing
+PASS `DENY;"SAMEORIGIN"` blocks same-origin framing
+PASS `"SAMEORIGIN";DENY` blocks same-origin framing
+PASS `DENY,"SAMEORIGIN"` blocks same-origin framing
+PASS `"SAMEORIGIN",DENY` blocks same-origin framing
+PASS `DENY;"SAMEORIGIN"` blocks cross-origin framing
+PASS `"SAMEORIGIN";DENY` blocks cross-origin framing
+PASS `DENY,"SAMEORIGIN"` blocks cross-origin framing
+PASS `"SAMEORIGIN",DENY` blocks cross-origin framing
+PASS `ALLOWALL;INVALID` blocks same-origin framing
+PASS `INVALID;ALLOWALL` blocks same-origin framing
+PASS `ALLOWALL,INVALID` blocks same-origin framing
+PASS `INVALID,ALLOWALL` blocks same-origin framing
+PASS `ALLOWALL;INVALID` blocks cross-origin framing
+PASS `INVALID;ALLOWALL` blocks cross-origin framing
+PASS `ALLOWALL,INVALID` blocks cross-origin framing
+PASS `INVALID,ALLOWALL` blocks cross-origin framing
+PASS `ALLOWALL;` blocks same-origin framing
+FAIL `(the empty string);ALLOWALL` blocks same-origin framing assert_equals: expected null but got Document node with 2 children
+FAIL `ALLOWALL,(the empty string)` blocks same-origin framing assert_equals: expected null but got Document node with 2 children
+FAIL `(the empty string),ALLOWALL` blocks same-origin framing assert_equals: expected null but got Document node with 2 children
+PASS `ALLOWALL;` blocks cross-origin framing
+PASS `(the empty string);ALLOWALL` blocks cross-origin framing
+PASS `ALLOWALL,(the empty string)` blocks cross-origin framing
+PASS `(the empty string),ALLOWALL` blocks cross-origin framing
+PASS `allowAll;INVALID` blocks same-origin framing
+PASS `INVALID;allowAll` blocks same-origin framing
+PASS `allowAll,INVALID` blocks same-origin framing
+PASS `INVALID,allowAll` blocks same-origin framing
+PASS `allowAll;INVALID` blocks cross-origin framing
+PASS `INVALID;allowAll` blocks cross-origin framing
+PASS `allowAll,INVALID` blocks cross-origin framing
+PASS `INVALID,allowAll` blocks cross-origin framing
+PASS `INVALID;INVALID` allows same-origin framing
+PASS `INVALID;INVALID` allows cross-origin framing
+PASS `INVALID;` allows same-origin framing
+PASS `(the empty string);INVALID` allows same-origin framing
+PASS `INVALID,(the empty string)` allows same-origin framing
+PASS `(the empty string),INVALID` allows same-origin framing
+PASS `INVALID;` allows cross-origin framing
+PASS `(the empty string);INVALID` allows cross-origin framing
+PASS `INVALID,(the empty string)` allows cross-origin framing
+PASS `(the empty string),INVALID` allows cross-origin framing
+

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/multiple.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/multiple.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>X-Frame-Options headers sent multiple times</title>
+
+<!--
+  This test is creating and navigating >90 iframes. This can exceed the
+  "short" timeout".
+-->
+<meta name="timeout" content="long">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/helper.sub.js"></script>
+
+<body>
+<script>
+"use strict";
+
+xfo_simple_tests({
+  headerValue: `SAMEORIGIN`,
+  headerValue2: `SAMEORIGIN`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `SAMEORIGIN`,
+  headerValue2: `sameOrigin`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `SAMEORIGIN`,
+  headerValue2: `DENY`,
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `SAMEORIGIN`,
+  headerValue2: `INVALID`,
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `SAMEORIGIN`,
+  headerValue2: `ALLOWALL`, // same as INVALID
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `SAMEORIGIN`,
+  headerValue2: `"DENY"`, // same as INVALID
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `SAMEORIGIN`,
+  headerValue2: ``, // same as INVALID
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `DENY`,
+  headerValue2: `DENY`,
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `DENY`,
+  headerValue2: `INVALID`,
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `DENY`,
+  headerValue2: `ALLOWALL`, // same as INVALID
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `DENY`,
+  headerValue2: `"SAMEORIGIN"`, // same as INVALID
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `ALLOWALL`,
+  headerValue2: `INVALID`,
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `ALLOWALL`,
+  headerValue2: ``,
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `allowAll`,
+  headerValue2: `INVALID`,
+  sameOriginAllowed: false,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `INVALID`,
+  headerValue2: `INVALID`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
+
+xfo_simple_tests({
+  headerValue: `INVALID`,
+  headerValue2: ``,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/redirect-expected.txt
@@ -1,0 +1,3 @@
+
+PASS XFO on redirect responses is ignored
+

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/redirect.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/redirect.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>X-Frame-Options headers sent along with a redirect</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/helper.sub.js"></script>
+
+<body>
+<script>
+"use strict";
+
+xfo_test({
+  url: `./support/redirect.py?value=DENY&url=/x-frame-options/support/xfo.py%3Fvalue%3DALLOWALL`,
+  check: "loaded message",
+  message: `XFO on redirect responses is ignored`
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/sameorigin.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/sameorigin.sub-expected.txt
@@ -1,0 +1,12 @@
+
+PASS `SAMEORIGIN` allows same-origin framing
+PASS `SAMEORIGIN` blocks cross-origin framing
+PASS `sameOriGin` allows same-origin framing
+PASS `sameOriGin` blocks cross-origin framing
+PASS `  SAMEORIGIN ` allows same-origin framing
+PASS `  SAMEORIGIN ` blocks cross-origin framing
+PASS SAMEORIGIN allows same-origin nested in same-origin framing
+PASS SAMEORIGIN blocks cross-origin nested in same-origin framing
+PASS SAMEORIGIN blocks same-origin nested in cross-origin framing
+PASS SAMEORIGIN blocks cross-origin nested in cross-origin framing
+

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/sameorigin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/sameorigin.sub.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>X-Frame-Options variations of SAMEORIGIN</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./support/helper.sub.js"></script>
+
+<body>
+<script>
+"use strict";
+
+xfo_simple_tests({
+  headerValue: `SAMEORIGIN`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `sameOriGin`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: false
+});
+
+xfo_simple_tests({
+  headerValue: `  SAMEORIGIN `,
+  sameOriginAllowed: true,
+  crossOriginAllowed: false
+});
+
+xfo_test({
+  url: `./support/nested.py?origin=http://{{host}}:{{ports[http][0]}}&value=SAMEORIGIN&loadShouldSucceed=true`,
+  check: "loaded message",
+  message: `SAMEORIGIN allows same-origin nested in same-origin framing`
+});
+
+xfo_test({
+  url: `./support/nested.py?origin=http://{{hosts[alt][]}}:{{ports[http][0]}}&value=SAMEORIGIN`,
+  check: "failed message",
+  message: `SAMEORIGIN blocks cross-origin nested in same-origin framing`
+});
+
+xfo_test({
+  url: `http://{{hosts[alt][]}}:{{ports[http][0]}}/x-frame-options/support/nested.py?origin=http://{{host}}:{{ports[http][0]}}&value=SAMEORIGIN`,
+  check: "failed message",
+  message: `SAMEORIGIN blocks same-origin nested in cross-origin framing`
+});
+
+xfo_test({
+  url: `http://{{hosts[alt][]}}:{{ports[http][0]}}/x-frame-options/support/nested.py?origin=http://{{hosts[alt][]}}:{{ports[http][0]}}&value=SAMEORIGIN`,
+  check: "failed message",
+  message: `SAMEORIGIN blocks cross-origin nested in cross-origin framing`
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/helper.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/helper.sub.js
@@ -1,0 +1,104 @@
+function xfo_simple_tests({ headerValue, headerValue2, cspValue, sameOriginAllowed, crossOriginAllowed }) {
+  simpleXFOTestsInner({
+    urlPrefix: "",
+    allowed: sameOriginAllowed,
+    headerValue,
+    headerValue2,
+    cspValue,
+    sameOrCross: "same-origin"
+  });
+
+  simpleXFOTestsInner({
+    urlPrefix: "http://{{hosts[alt][]}}:{{ports[http][0]}}",
+    allowed: crossOriginAllowed,
+    headerValue,
+    headerValue2,
+    cspValue,
+    sameOrCross: "cross-origin"
+  });
+}
+
+function simpleXFOTestsInner({ urlPrefix, allowed, headerValue, headerValue2, cspValue, sameOrCross }) {
+  const value2QueryString = headerValue2 !== undefined ? `&value2=${headerValue2}` : ``;
+  const cspQueryString = cspValue !== undefined ? `&csp_value=${cspValue}` : ``;
+
+  const valueMessageString = headerValue === "" ? "(the empty string)" : headerValue;
+  const value2MessageString = headerValue2 === "" ? "(the empty string)" : headerValue2;
+  const value2MaybeMessageString = headerValue2 !== undefined ? `;${headerValue2}` : ``;
+  const cspMessageString = cspValue !== undefined ? ` with CSP ${cspValue}` : ``;
+
+  // This will test the multi-header variant, if headerValue2 is not undefined.
+  xfo_test({
+    url: `${urlPrefix}/x-frame-options/support/xfo.py?value=${headerValue}${value2QueryString}${cspQueryString}`,
+    check: allowed ? "loaded message" : "no message",
+    message: `\`${valueMessageString}${value2MaybeMessageString}\` ${allowed ? "allows" : "blocks"} ${sameOrCross} framing${cspMessageString}`
+  });
+
+  if (headerValue2 !== undefined && headerValue2 !== headerValue) {
+    // Reversed variant
+    xfo_test({
+      url: `${urlPrefix}/x-frame-options/support/xfo.py?value=${headerValue2}&value2=${headerValue}${cspQueryString}`,
+      check: allowed ? "loaded message" : "no message",
+      message: `\`${value2MessageString};${valueMessageString}\` ${allowed ? "allows" : "blocks"} ${sameOrCross} framing${cspMessageString}`
+    });
+
+    // Comma variant
+    xfo_test({
+      url: `${urlPrefix}/x-frame-options/support/xfo.py?value=${headerValue},${headerValue2}${cspQueryString}`,
+      check: allowed ? "loaded message" : "no message",
+      message: `\`${valueMessageString},${value2MessageString}\` ${allowed ? "allows" : "blocks"} ${sameOrCross} framing${cspMessageString}`
+    });
+
+    // Comma + reversed variant
+    xfo_test({
+      url: `${urlPrefix}/x-frame-options/support/xfo.py?value=${headerValue2},${headerValue}${cspQueryString}`,
+      check: allowed ? "loaded message" : "no message",
+      message: `\`${value2MessageString},${valueMessageString}\` ${allowed ? "allows" : "blocks"} ${sameOrCross} framing${cspMessageString}`
+    });
+  }
+}
+
+function xfo_test({ url, check, message }) {
+  async_test(t => {
+    const i = document.createElement("iframe");
+    i.src = url;
+
+    switch (check) {
+      case "loaded message": {
+        waitForMessageFrom(i, t).then(t.step_func_done(e => {
+          assert_equals(e.data, "Loaded");
+        }));
+        break;
+      }
+      case "failed message": {
+        waitForMessageFrom(i, t).then(t.step_func_done(e => {
+          assert_equals(e.data, "Failed");
+        }));
+        break;
+      }
+      case "no message": {
+        waitForMessageFrom(i, t).then(t.unreached_func("Frame should not have sent a message."));
+        i.onload = t.step_func_done(() => {
+          assert_equals(i.contentDocument, null);
+        });
+        break;
+      }
+      default: {
+        throw new Error("Bad test");
+      }
+    }
+
+    document.body.append(i);
+    t.add_cleanup(() => i.remove());
+  }, message);
+}
+
+function waitForMessageFrom(frame, test) {
+  return new Promise(resolve => {
+    window.addEventListener("message", test.step_func(e => {
+      if (e.source == frame.contentWindow) {
+        resolve(e);
+      }
+    }));
+  });
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/nested.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/nested.py
@@ -1,0 +1,39 @@
+def main(request, response):
+    origin = request.GET.first(b"origin");
+    value = request.GET.first(b"value");
+    # This is used to solve the race condition we have for postMessages
+    shouldSucceed = request.GET.first(b"loadShouldSucceed", b"false");
+    return ([(b"Content-Type", b"text/html")],
+            b"""<!DOCTYPE html>
+<title>XFO.</title>
+<body>
+<script>
+  var gotMessage = false;
+  window.addEventListener("message", e => {
+    gotMessage = true;
+    window.parent.postMessage(e.data, "*");
+  });
+
+  var i = document.createElement("iframe");
+  i.src = "%s/x-frame-options/support/xfo.py?value=%s";
+  i.onload = _ => {
+    // Why two rAFs? Because that seems to be enough to stop the
+    // load event from racing with the onmessage event.
+    requestAnimationFrame(_ => {
+      requestAnimationFrame(_ => {
+        // The race condition problem we have is it is possible
+        // that the sub iframe is loaded before the postMessage is
+        // dispatched, as a result, the "Failed" message is sent
+        // out. So the way we fixed is we simply let the timeout
+        // to happen if we expect the "Loaded" postMessage to be
+        // sent
+        if (!gotMessage && %s != true) {
+          window.parent.postMessage("Failed", "*");
+        }
+      });
+    });
+  };
+  document.body.appendChild(i);
+</script>
+            """ % (origin, value, shouldSucceed))
+

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/redirect.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/redirect.py
@@ -1,0 +1,4 @@
+def main(request, response):
+    response.status = 302
+    response.headers.set(b"X-Frame-Options", request.GET.first(b"value"))
+    response.headers.set(b"Location", request.GET.first(b"url"))

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/w3c-import.log
@@ -1,0 +1,20 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/helper.sub.js
+/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/nested.py
+/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/redirect.py
+/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/xfo.py

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/xfo.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/xfo.py
@@ -1,0 +1,21 @@
+def main(request, response):
+    headers = [(b"Content-Type", b"text/html"), (b"X-Frame-Options", request.GET.first(b"value"))]
+
+    if b"value2" in request.GET:
+        headers.append((b"X-Frame-Options", request.GET.first(b"value2")))
+
+    if b"csp_value" in request.GET:
+        headers.append((b"Content-Security-Policy", request.GET.first(b"csp_value")))
+
+    body = u"""<!DOCTYPE html>
+        <html>
+        <head>
+          <title>XFO.</title>
+          <script>window.parent.postMessage('Loaded', '*');</script>
+        </head>
+        <body>
+          Loaded
+        </body>
+        </html>
+    """
+    return (headers, body)

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/w3c-import.log
@@ -1,0 +1,24 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/README.md
+/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/deny.html
+/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/get-decode-split.html
+/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/multiple.html
+/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/redirect.html
+/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/sameorigin.sub.html

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -5990,6 +5990,9 @@
     "imported/w3c/web-platform-tests/worklets/paint-worklet-referrer.https.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/x-frame-options/multiple.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/xhr/overridemimetype-blob.html": [
         "slow"
     ],


### PR DESCRIPTION
#### c596955c9ffdb44149c410ef2eeb2e2ab7d60cbe
<pre>
Import x-frame-options WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=244865">https://bugs.webkit.org/show_bug.cgi?id=244865</a>

Reviewed by Brent Fulgham.

Import x-frame-options WPT tests from upstream fb6750aa0a21d75e8.

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/META.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/README.md: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/deny-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/deny.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/get-decode-split-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/get-decode-split.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/multiple-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/multiple.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/redirect-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/redirect.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/sameorigin.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/sameorigin.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/helper.sub.js: Added.
(xfo_simple_tests):
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/nested.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/redirect.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/support/xfo.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/x-frame-options/w3c-import.log: Added.
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/254231@main">https://commits.webkit.org/254231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f2fde50f78d245e3388c07bdfd7b7f45efa1cfa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88408 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97589 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153063 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31367 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27000 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92245 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24937 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75272 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24915 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67878 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/28977 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/28966 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14961 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37882 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1209 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34070 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->