### PR TITLE
[git-webkit] Accidental overwrite of pull request with similar branch names in Github

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py
@@ -86,7 +86,7 @@ class Terminal(object):
         if not isinstance(target, (io.IOBase, file, StringIO)):
             raise ValueError('{} is not an IO object'.format(target))
         if not isinstance(target, StringIO) and not (getattr(target, 'writable', None) and target.writable()) and 'w' not in getattr(target, 'mode', 'r'):
-            raise ValueError('{} is an IO object, but is not writable {}'.format(target, ))
+            raise ValueError('{} is an IO object, but is not writable'.format(target, ))
 
     @classmethod
     def supports_color(cls, file):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/contributor.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/contributor.py
@@ -210,7 +210,7 @@ class Contributor(object):
         return self.emails[0]
 
     def __repr__(self):
-        return u'{} <{}>'.format(self.name, self.email)
+        return u'{} <{}>'.format(self.name, self.email or '?')
 
     def __hash__(self):
         return hash(self.name)
@@ -224,8 +224,9 @@ class Contributor(object):
             ref_value = ''
         else:
             raise ValueError('Cannot compare {} with {}'.format(Contributor, type(other)))
-        if self.name == ref_value:
-            return 0
+        for part in [self.name, self.emails, self.github, self.bitbucket]:
+            if part == ref_value:
+                return 0
         return 1 if self.name > ref_value else -1
 
     def __eq__(self, other):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -500,7 +500,7 @@ class Git(Scm):
             url = '{}://{}/{}'.format(http_match.group('protocol'), http_match.group('host'), http_match.group('path'))
 
         try:
-            return remote.Scm.from_url(url)
+            return remote.Scm.from_url(url, contributors=self.contributors)
         except OSError:
             pass
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -226,9 +226,12 @@ class PullRequest(Command):
     @classmethod
     def find_existing_pull_request(cls, repository, remote):
         existing_pr = None
+        user, _ = remote.credentials(required=False)
         for pr in remote.pull_requests.find(opened=None, head=repository.branch):
             existing_pr = pr
-            if existing_pr.opened:
+            if not existing_pr.opened:
+                continue
+            if user and existing_pr.author == user:
                 break
         return existing_pr
 
@@ -354,15 +357,41 @@ class PullRequest(Command):
 
         existing_pr = None
         if remote_repo.pull_requests:
+            user, _ = remote_repo.credentials(required=False)
+
             log.info("Checking if PR already exists...")
             existing_pr = cls.find_existing_pull_request(repository, remote_repo)
             log.info("PR #{} found.".format(existing_pr.number) if existing_pr else "PR not found.")
-            if existing_pr and not existing_pr.opened and not args.defaults and (args.defaults is False or Terminal.choose(
-                    "'{}' is already associated with '{}', which is closed.\nWould you like to create a new pull-request?".format(
-                        repository.branch, existing_pr,
-                    ), default='No',
+            if existing_pr and not existing_pr.opened and not args.defaults and (
+                args.defaults is False or Terminal.choose(
+                "'{}' is already associated with '{}', which is closed.\nWould you like to create a new pull-request?".format(repository.branch, existing_pr),
+                default='No',
             ) == 'Yes'):
                 existing_pr = None
+
+            if existing_pr and user and existing_pr.author != user and (args.defaults or Terminal.choose(
+                "'{}' is owned by '{}'\nWould you like to take over this pull-request?".format(existing_pr, existing_pr.author),
+                default='No',
+            ) == 'No'):
+                existing_pr = None
+
+            if user and existing_pr and isinstance(remote_repo, remote.GitHub) and existing_pr._metadata.get('full_name'):
+                pr_target = existing_pr._metadata['full_name']
+                if not pr_target.startswith('{}/'.format(user)):
+                    target = pr_target.split('/')[0]
+                    if '-' in pr_target:
+                        target = '{}-{}'.format(target, pr_target.split('-')[-1])
+                    base_url = repository.url(name=source_remote)
+                    if '://' in base_url:
+                        base_url = '/'.join(base_url.split('/')[:3]) + '/'
+                    else:
+                        base_url = base_url.split(':')[0] + ':'
+                    if target not in repository.source_remotes(personal=True) and run(
+                        [repository.executable(), 'remote', 'add', target, '{}{}.git'.format(base_url, pr_target)],
+                        capture_output=True, cwd=repository.root_path,
+                    ).returncode not in [0, 3]:
+                        sys.stderr.write("Failed to add '{}' remote\n".format(target))
+                        return 1
 
         # Remove any active labels
         if existing_pr and existing_pr._metadata and existing_pr._metadata.get('issue'):
@@ -405,6 +434,7 @@ class PullRequest(Command):
                 repository.executable(), 'push', '-f', target, history_branch,
             ], cwd=repository.root_path).returncode:
                 sys.stderr.write("Failed to create and push '{}' to '{}'\n".format(history_branch, target))
+                return 1
 
         if not remote_repo.pull_requests:
             sys.stderr.write("'{}' cannot generate pull-requests\n".format(remote_repo.url))


### PR DESCRIPTION
#### 6d5f387b43594244bcedaaf449035b2c28e225bb
<pre>
[git-webkit] Accidental overwrite of pull request with similar branch names in Github
<a href="https://bugs.webkit.org/show_bug.cgi?id=244660">https://bugs.webkit.org/show_bug.cgi?id=244660</a>
&lt;rdar://problem/99648208&gt;

Reviewed by NOBODY (OOPS!).

WIP

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py:
(Terminal.assert_writeable_stream):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/contributor.py:
(Contributor.__repr__):
(Contributor.__cmp__):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.remote):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.find_existing_pull_request):
(PullRequest.create_pull_request):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75373484ab5ffc1a5e4d046e70ec7ba7e5876434

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88507 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33042 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/19376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/97692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153162 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31536 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/80723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92337 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94110 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/25037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/75428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/80723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/92099 "Found 9 webkitpy python3 test failures: webkitscmpy.test.land_unittest.TestLandGitHub.test_merge_queue, webkitscmpy.test.land_unittest.TestLandGitHub.test_merge_queue_linked_bug, webkitscmpy.test.pull_request_unittest.TestDoPullRequest.test_bitbucket, webkitscmpy.test.pull_request_unittest.TestDoPullRequest.test_bitbucket_append, webkitscmpy.test.pull_request_unittest.TestDoPullRequest.test_bitbucket_draft, webkitscmpy.test.pull_request_unittest.TestDoPullRequest.test_bitbucket_radar, webkitscmpy.test.pull_request_unittest.TestDoPullRequest.test_bitbucket_reopen, webkitscmpy.test.pull_request_unittest.TestDoPullRequest.test_bitbucket_reopen_radar, webkitscmpy.test.pull_request_unittest.TestDoPullRequest.test_bitbucket_update") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/79924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/19376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/80723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29154 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/19376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/87567 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/29110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/19376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32389 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/75428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31187 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/19376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->