### PR TITLE
Update spring physics to include overdamped case.

### DIFF
--- a/Source/WebCore/platform/graphics/SpringSolver.h
+++ b/Source/WebCore/platform/graphics/SpringSolver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,10 +39,15 @@ public:
             m_wd = m_w0 * std::sqrt(1 - m_zeta * m_zeta);
             m_A = 1;
             m_B = (m_zeta * m_w0 + -initialVelocity) / m_wd;
-        } else {
-            // Critically damped (ignoring over-damped case for now).
+        } else if (1 == m_zeta) {
+            // Critically damped.
             m_A = 1;
             m_B = -initialVelocity + m_w0;
+        } else {
+            // Over-damped.
+            m_A = -m_zeta * m_w0 + m_w0 * std::sqrt(m_zeta * m_zeta - 1);
+            m_B = -m_zeta * m_w0 - m_w0 * std::sqrt(m_zeta * m_zeta - 1);
+            m_v0 = initialVelocity;
         }
     }
 
@@ -51,9 +56,12 @@ public:
         if (m_zeta < 1) {
             // Under-damped
             t = std::exp(-t * m_zeta * m_w0) * (m_A * std::cos(m_wd * t) + m_B * std::sin(m_wd * t));
-        } else {
-            // Critically damped (ignoring over-damped case for now).
+        } else if (1 == m_zeta) {
+            // Critically damped.
             t = (m_A + m_B * t) * std::exp(-t * m_w0);
+        } else {
+            // Over-damped.
+            t = ((m_B + m_v0) * std::exp(t * m_A) - (m_A + m_v0) * std::exp(t * m_B)) / (m_B - m_A);
         }
 
         // Map range from [1..0] to [0..1].
@@ -66,6 +74,7 @@ private:
     double m_wd;
     double m_A;
     double m_B;
+    double m_v0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/SpringSolverTest.h
+++ b/Source/WebCore/platform/graphics/SpringSolverTest.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "SpringSolver.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+void assertEquals(double expected, double actual)
+{
+    if (fabs(expected - actual) > 0.001) {
+        printf("%g != %g\n", expected, actual);
+        assert(false);
+    }
+}
+
+struct Coordinate {
+    double time;
+    double value;
+};
+
+double settlingTime(std::vector<Coordinate> series)
+{
+    for (auto itr = series.rbegin(); itr != series.rend(); ++itr) {
+        if (itr->value > 1.02 || itr->value < 0.98)
+            return itr->time;
+    }
+    return 0;
+}
+
+Coordinate max(std::vector<Coordinate> series)
+{
+    Coordinate max { 0, 0 };
+    for (auto itr = series.begin(); itr != series.end(); ++itr) {
+        if (itr->value > max.value) {
+            max.value = itr->value;
+            max.time = itr->time;
+        }
+    }
+    return max;
+}
+
+void testUnderDamped()
+{
+    WebCore::SpringSolver subject(1, 150, 12.2, 0);
+    std::vector<Coordinate> series;
+    for (double t = 0; t < 1; t += 0.001) {
+        Coordinate c;
+        c.time = t;
+        c.value = subject.solve(t);
+        series.push_back(c);
+    }
+
+    assertEquals(0.66, settlingTime(series));
+    assertEquals(0.296, max(series).time);
+    assertEquals(1.164, max(series).value);
+}
+
+void testCriticallyDamped()
+{
+    WebCore::SpringSolver subject(1, 150, 2 * std::sqrt(150), 0);
+    std::vector<Coordinate> series;
+    for (double t = 0; t < 1; t += 0.001) {
+        Coordinate c;
+        c.time = t;
+        c.value = subject.solve(t);
+        series.push_back(c);
+    }
+
+    assertEquals(0.476, settlingTime(series));
+    assertEquals(0.999, max(series).time);
+    assertEquals(0.999, max(series).value);
+}
+
+void testOverDamped()
+{
+    WebCore::SpringSolver subject(1, 150, 36, 0);
+    std::vector<Coordinate> series;
+    for (double t = 0; t < 1; t += 0.001) {
+        Coordinate c;
+        c.time = t;
+        c.value = subject.solve(t);
+        series.push_back(c);
+    }
+
+    assertEquals(0.848, settlingTime(series));
+    assertEquals(0.999, max(series).time);
+    assertEquals(0.990, max(series).value);
+}
+
+int main()
+{
+    testUnderDamped();
+    testCriticallyDamped();
+    testOverDamped();
+    return 0;
+}

--- a/Source/WebInspectorUI/UserInterface/Models/Geometry.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Geometry.js
@@ -554,12 +554,23 @@ WI.Spring = class Spring
             wd = w0 * Math.sqrt(1 - zeta * zeta);
             A = 1;
             B = (zeta * w0 + -this.initialVelocity) / wd;
+        } else if (zeta > 1) {
+            // Over-damped.
+            A = -zeta * w0 + w0 * Math.sqrt(zeta * zeta - 1);
+            B = -zeta * w0 - w0 * Math.sqrt(zeta * zeta - 1);
         }
 
-        if (zeta < 1) // Under-damped
+        if (zeta < 1) {
+            // Under-damped
             t = Math.exp(-t * zeta * w0) * (A * Math.cos(wd * t) + B * Math.sin(wd * t));
-        else // Critically damped (ignoring over-damped case).
+        } else if (zeta == 1) {
+            // Critically damped.
             t = (A + B * t) * Math.exp(-t * w0);
+        } else {
+            // Over-damped.
+            t = ((B + this.initialVelocity) * Math.exp(t * A) - 
+                    (A + this.initialVelocity) * Math.exp(t * B)) / (B - A);
+        }
 
         return 1 - t; // Map range from [1..0] to [0..1].
     }

--- a/Websites/webkit.org/demos/spring/spring.js
+++ b/Websites/webkit.org/demos/spring/spring.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,11 +33,16 @@ function SpringSolver(mass, stiffness, damping, initialVelocity)
         this.m_wd = this.m_w0 * Math.sqrt(1 - this.m_zeta * this.m_zeta);
         this.m_A = 1;
         this.m_B = (this.m_zeta * this.m_w0 + -initialVelocity) / this.m_wd;
-    } else {
-        // Critically damped (ignoring over-damped case for now).
+    } else if (this.m_zeta == 1) {
+        // Critically damped.
         this.m_wd = 0;
         this.m_A = 1;
         this.m_B = -initialVelocity + this.m_w0;
+    } else {
+        // Over-damped.
+        this.m_A = -this.m_zeta * this.m_w0 + this.m_w0 * Math.sqrt(this.m_zeta * this.m_zeta - 1);
+        this.m_B = -this.m_zeta * this.m_w0 - this.m_w0 * Math.sqrt(this.m_zeta * this.m_zeta - 1);
+        this.m_v0 = initialVelocity;
     }
 }
 
@@ -46,9 +51,12 @@ SpringSolver.prototype.solve = function (t)
     if (this.m_zeta < 1) {
         // Under-damped
         t = Math.exp(-t * this.m_zeta * this.m_w0) * (this.m_A * Math.cos(this.m_wd * t) + this.m_B * Math.sin(this.m_wd * t));
-    } else {
-        // Critically damped (ignoring over-damped case for now).
+    } else if (this.m_zeta == 1) {
+        // Critically damped.
         t = (this.m_A + this.m_B * t) * Math.exp(-t * this.m_w0);
+    } else {
+        // Over-damped.
+        t = ((this.m_B + this.m_v0) * Math.exp(t * this.m_A) - (this.m_A + this.m_v0) * Math.exp(t * this.m_B)) / (this.m_B - this.m_A);
     }
 
     // Map range from [1..0] to [0..1].


### PR DESCRIPTION
#### 2c6aad716fe6e0893fdf80a0b290730568a1af6c
<pre>
Update spring physics to include overdamped case.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244873">https://bugs.webkit.org/show_bug.cgi?id=244873</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/SpringSolver.h:
(WebCore::SpringSolver::SpringSolver):
(WebCore::SpringSolver::solve):
* Source/WebInspectorUI/UserInterface/Models/Geometry.js:
(WI.Spring.prototype.solve):
* Websites/webkit.org/demos/spring/spring.js:
(SpringSolver):
(SpringSolver.prototype.solve):

Implemented overdamped case.

References:
<a href="https://www.tutorialspoint.com/control_systems/control_systems_response_second_order.htm">https://www.tutorialspoint.com/control_systems/control_systems_response_second_order.htm</a>
<a href="http://lpsa.swarthmore.edu/Transient/TransInputs/TransStep.html#Case_1">http://lpsa.swarthmore.edu/Transient/TransInputs/TransStep.html#Case_1</a>
<a href="https://android.googlesource.com/platform/frameworks/support/+/7091d83302abf98539aec9d89e10723bdf1267a5/dynamicanimation/dynamicanimation/src/main/java/androidx/dynamicanimation/animation/SpringForce.java">https://android.googlesource.com/platform/frameworks/support/+/7091d83302abf98539aec9d89e10723bdf1267a5/dynamicanimation/dynamicanimation/src/main/java/androidx/dynamicanimation/animation/SpringForce.java</a>

* Source/WebCore/platform/graphics/SpringSolverTest.h: Added.

Sample test.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c6aad716fe6e0893fdf80a0b290730568a1af6c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98062 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154544 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31931 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28163 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81104 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92683 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25341 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75843 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25291 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68255 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29727 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14267 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29457 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15270 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38205 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34375 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->