### PR TITLE
REGRESSION(254047@main): [ iOS Debug wk2 ] platform/ios/mediastream/video-muted-in-background-tab.html is a near constant crash

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3742,8 +3742,6 @@ webkit.org/b/244619 editing/selection/ios/tap-to-set-selection-in-editable-web-v
 
 webkit.org/b/244740 http/wpt/cross-origin-opener-policy/non-secure-to-secure-context-navigation.https.html [ Pass Failure ]
 
-webkit.org/b/244851 [ Debug ] platform/ios/mediastream/video-muted-in-background-tab.html [ Skip ]
-
 # These tests have similar harness errors and timeouts. See webkit.org/b/244900
 [ Debug ] imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-1.html [ Pass Timeout Failure ]
 [ Debug ] imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-2.html [ Pass Timeout Failure ]

--- a/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm
+++ b/Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm
@@ -119,6 +119,7 @@ using namespace WebCore;
         [m_statusBarStyleOverride invalidate];
         m_statusBarStyleOverride = nil;
     }
+    m_manager = nullptr;
 }
 
 - (BOOL)statusBarCoordinator:(SBSStatusBarStyleOverridesCoordinator *)coordinator receivedTapWithContext:(id<SBSStatusBarTapContext>)tapContext completionBlock:(void (^)(void))completion

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -687,8 +687,10 @@ void CoreAudioSharedUnit::setIsInBackground(bool isInBackground)
             m_statusBarWasTappedCallback(WTFMove(completionHandler));
     }, [this] {
         RELEASE_LOG_ERROR(WebRTC, "CoreAudioSharedUnit status bar failed");
-        captureFailed();
-        ASSERT(!m_statusBarManager);
+        auto statusBarManager = std::exchange(m_statusBarManager, { });
+        statusBarManager->stop();
+        if (isRunning())
+            captureFailed();
     });
     m_statusBarManager->start();
 }


### PR DESCRIPTION
#### 27fd2059f7ada2a28b3834d0c9b739b13ada8db3
<pre>
REGRESSION(254047@main): [ iOS Debug wk2 ] platform/ios/mediastream/video-muted-in-background-tab.html is a near constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=244851">https://bugs.webkit.org/show_bug.cgi?id=244851</a>
rdar://problem/99614035

Reviewed by Eric Carlson.

Make sure to stop the manager when an error happens, since the captureFailed call will not remove it if the AudioUnit is not running.

* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/platform/mediastream/ios/MediaCaptureStatusBarManager.mm:
(-[WebCoreMediaCaptureStatusBarHandler stop]):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::setIsInBackground):

Canonical link: <a href="https://commits.webkit.org/254303@main">https://commits.webkit.org/254303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eac3bc45ce1d1299aadb6d325f5815c228c1c9fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97790 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/153680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31652 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27236 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80823 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92426 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25107 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75541 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25052 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68015 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29319 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14063 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29182 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15077 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3037 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38005 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34186 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->