### PR TITLE
[GTK4] -Wunused-function warnings from TestContextMenu.cpp

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
@@ -25,7 +25,9 @@
 #include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
 
+#if !USE(GTK4)
 static WebKitTestServer* kServer;
+#endif
 
 class ContextMenuTest: public WebViewTest {
 public:
@@ -482,6 +484,7 @@ public:
     DefaultMenuType m_expectedMenuType;
 };
 
+#if !USE(GTK4)
 static void prepareContextMenuTestView(ContextMenuDefaultTest* test)
 {
     GUniquePtr<char> baseDir(g_strdup_printf("file://%s/", Test::getResourcesDir().data()));
@@ -570,6 +573,7 @@ static void testContextMenuKey(ContextMenuDefaultTest* test, gconstpointer)
     test->m_expectedMenuType = ContextMenuDefaultTest::Selection;
     test->showContextMenuTriggeredByContextMenuKeyAndWaitUntilFinished();
 }
+#endif
 
 class ContextMenuCustomTest: public ContextMenuTest {
 public:
@@ -613,11 +617,11 @@ public:
     void activateMenuItem()
     {
         g_assert_nonnull(m_itemToActivateLabel);
-        auto* menu = getContextMenuWidget();
-        auto* item = getMenuItem(menu, m_itemToActivateLabel);
 #if USE(GTK4)
 
 #else
+        auto* menu = getContextMenuWidget();
+        auto* item = getMenuItem(menu, m_itemToActivateLabel);
         // GTK3 uses a menu, which contains menu items.
         gtk_menu_shell_activate_item(GTK_MENU_SHELL(menu), GTK_WIDGET(item), TRUE);
 #endif // USE(GTK4)
@@ -701,6 +705,7 @@ public:
     bool m_toggled { false };
 };
 
+#if !USE(GTK4)
 static void testContextMenuPopulateMenu(ContextMenuCustomTest* test, gconstpointer)
 {
     test->showInWindow();
@@ -750,6 +755,7 @@ static void testContextMenuPopulateMenu(ContextMenuCustomTest* test, gconstpoint
     test->activateCustomMenuItemAndWaitUntilActivated("Custom _GAction With Target");
     g_assert_true(test->m_activated);
 }
+#endif
 
 class ContextMenuCustomFullTest: public ContextMenuTest {
 public:
@@ -827,6 +833,7 @@ public:
     }
 };
 
+#if !USE(GTK4)
 static void testContextMenuCustomMenu(ContextMenuCustomFullTest* test, gconstpointer)
 {
     test->showInWindow();
@@ -835,6 +842,7 @@ static void testContextMenuCustomMenu(ContextMenuCustomFullTest* test, gconstpoi
 
     test->showContextMenuAndWaitUntilFinished();
 }
+#endif
 
 class ContextMenuSubmenuTest: public ContextMenuTest {
 public:
@@ -875,6 +883,7 @@ public:
     }
 };
 
+#if !USE(GTK4)
 static void testContextMenuSubMenu(ContextMenuSubmenuTest* test, gconstpointer)
 {
     test->showInWindow();
@@ -883,6 +892,7 @@ static void testContextMenuSubMenu(ContextMenuSubmenuTest* test, gconstpointer)
 
     test->showContextMenuAndWaitUntilFinished();
 }
+#endif
 
 class ContextMenuDismissedTest: public ContextMenuTest {
 public:
@@ -915,6 +925,7 @@ public:
     bool m_dismissed;
 };
 
+#if !USE(GTK4)
 static void testContextMenuDismissed(ContextMenuDismissedTest* test, gconstpointer)
 {
     test->showInWindow();
@@ -924,6 +935,7 @@ static void testContextMenuDismissed(ContextMenuDismissedTest* test, gconstpoint
     test->showContextMenuAndWaitUntilDismissed();
     g_assert_true(test->m_dismissed);
 }
+#endif
 
 class ContextMenuWebExtensionTest: public ContextMenuTest {
 public:
@@ -964,6 +976,7 @@ public:
     Vector<WebKitContextMenuAction> m_actions;
 };
 
+#if !USE(GTK4)
 static void testContextMenuWebExtensionMenu(ContextMenuWebExtensionTest* test, gconstpointer)
 {
     test->showInWindow();
@@ -1004,6 +1017,7 @@ static void testContextMenuWebExtensionMenu(ContextMenuWebExtensionTest* test, g
     test->showContextMenuAndWaitUntilFinished();
     g_assert_cmpuint(test->m_actions.size(), ==, 0);
 }
+#endif
 
 class ContextMenuWebExtensionNodeTest: public ContextMenuTest {
 public:
@@ -1054,6 +1068,7 @@ public:
     Node m_node;
 };
 
+#if !USE(GTK4)
 static void testContextMenuWebExtensionNode(ContextMenuWebExtensionNodeTest* test, gconstpointer)
 {
     test->showInWindow();
@@ -1143,12 +1158,14 @@ static void testContextMenuLiveStream(ContextMenuDefaultTest* test, gconstpointe
     test->showContextMenuAtPositionAndWaitUntilFinished(1, 1);
 }
 
+#endif // !USE(GTK4)
+
 void beforeAll()
 {
+#if !USE(GTK4)
     kServer = new WebKitTestServer();
     kServer->run(serverCallback);
 
-#if !USE(GTK4)
     // FIXME: Rework context menu API in GTK4 to not expose GdkEvent.
     ContextMenuDefaultTest::add("WebKitWebView", "default-menu", testContextMenuDefaultMenu);
     ContextMenuDefaultTest::add("WebKitWebView", "context-menu-key", testContextMenuKey);
@@ -1165,5 +1182,7 @@ void beforeAll()
 
 void afterAll()
 {
+#if !USE(GTK4)
     delete kServer;
+#endif
 }


### PR DESCRIPTION
#### 881a95924a0bece5346f923ab6e163d8ebf05b08
<pre>
[GTK4] -Wunused-function warnings from TestContextMenu.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=244892">https://bugs.webkit.org/show_bug.cgi?id=244892</a>

Reviewed by Carlos Alberto Lopez Perez.

* Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp:
(beforeAll):
(afterAll):

Canonical link: <a href="https://commits.webkit.org/254296@main">https://commits.webkit.org/254296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/308e35e6f8993a8f9e61202a1669f898be67e017

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/32994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97654 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153132 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31489 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27096 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80671 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92308 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25009 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75384 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24969 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67932 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29107 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13982 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29067 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15002 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3036 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37929 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31157 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34111 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->