### PR TITLE
Remove logs added by error in RealtimeMediaSourceCenter::shouldInterruptAudioOnPageVisibilityChange

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/RealtimeMediaSourceCenterMac.mm
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeMediaSourceCenterMac.mm
@@ -39,13 +39,11 @@ bool RealtimeMediaSourceCenter::shouldInterruptAudioOnPageVisibilityChange()
     if (!modes)
         return true;
     
-    RELEASE_LOG_ERROR(WebRTC, "RealtimeMediaSourceCenter::shouldInterruptAudioOnPageVisibilityChange2");
     int modesCount = [modes count];
     for (int i = 0; i < modesCount; i++) {
         if ([[modes objectAtIndex:i] isEqual: @"audio"])
             return false;
     }
-    RELEASE_LOG_ERROR(WebRTC, "RealtimeMediaSourceCenter::shouldInterruptAudioOnPageVisibilityChange3");
     return true;
 #else
     return false;


### PR DESCRIPTION
#### 768cdfe9d4d6eae46640275bbee70625ee670d84
<pre>
Remove logs added by error in RealtimeMediaSourceCenter::shouldInterruptAudioOnPageVisibilityChange
<a href="https://bugs.webkit.org/show_bug.cgi?id=244897">https://bugs.webkit.org/show_bug.cgi?id=244897</a>
rdar://problem/99652250

Reviewed by Eric Carlson.

* Source/WebCore/platform/mediastream/mac/RealtimeMediaSourceCenterMac.mm:
(WebCore::RealtimeMediaSourceCenter::shouldInterruptAudioOnPageVisibilityChange):

Canonical link: <a href="https://commits.webkit.org/254274@main">https://commits.webkit.org/254274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2226856f3eb3a71273a8a6085677a412fb4a6019

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97659 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153137 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31495 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27101 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92312 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25014 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75390 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24975 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79902 "analyze-api-test-results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67938 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29114 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13989 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29075 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15008 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3018 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37933 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34117 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->