### PR TITLE
[JSC] TypedArray can stop [[Prototype]] lookup chain

### DIFF
--- a/JSTests/stress/poly-proto-typed-array-case.js
+++ b/JSTests/stress/poly-proto-typed-array-case.js
@@ -1,0 +1,18 @@
+const typedArray = new Uint8Array();
+let key = '0.1';
+Object.prototype[key] = undefined;
+
+function bar() {
+  function Foo() {}
+
+  for (let i = 0; i < 100; i++) {
+    let foo = new Foo();
+    typedArray.__proto__ = foo;
+    let {x} = foo;
+  }
+  typedArray[key];
+}
+
+for (let i = 0; i < 100; i++) {
+  bar();
+}

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h
@@ -194,8 +194,8 @@ struct PrototypeChainCachingStatus {
     bool flattenedDictionary;
 };
 
-std::optional<PrototypeChainCachingStatus> prepareChainForCaching(JSGlobalObject*, JSCell* base, const PropertySlot&);
-std::optional<PrototypeChainCachingStatus> prepareChainForCaching(JSGlobalObject*, JSCell* base, JSObject* target);
-std::optional<PrototypeChainCachingStatus> prepareChainForCaching(JSGlobalObject*, Structure* base, JSObject* target);
+std::optional<PrototypeChainCachingStatus> prepareChainForCaching(JSGlobalObject*, JSCell* base, UniquedStringImpl*, const PropertySlot&);
+std::optional<PrototypeChainCachingStatus> prepareChainForCaching(JSGlobalObject*, JSCell* base, UniquedStringImpl*, JSObject* target);
+std::optional<PrototypeChainCachingStatus> prepareChainForCaching(JSGlobalObject*, Structure* base, UniquedStringImpl*, JSObject* target);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/PolyProtoAccessChain.h
+++ b/Source/JavaScriptCore/bytecode/PolyProtoAccessChain.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CacheableIdentifier.h"
 #include "StructureID.h"
 #include "VM.h"
 #include <wtf/FixedVector.h>
@@ -41,8 +42,8 @@ class Structure;
 class PolyProtoAccessChain final : public ThreadSafeRefCounted<PolyProtoAccessChain> {
 public:
     // Returns nullptr when invalid.
-    static RefPtr<PolyProtoAccessChain> tryCreate(JSGlobalObject*, JSCell* base, const PropertySlot&);
-    static RefPtr<PolyProtoAccessChain> tryCreate(JSGlobalObject*, JSCell* base, JSObject* target);
+    static RefPtr<PolyProtoAccessChain> tryCreate(JSGlobalObject*, JSCell* base, CacheableIdentifier, const PropertySlot&);
+    static RefPtr<PolyProtoAccessChain> tryCreate(JSGlobalObject*, JSCell* base, CacheableIdentifier, JSObject* target);
 
     const FixedVector<StructureID>& chain() const { return m_chain; }
 

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -450,7 +450,7 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
                 // need to be informed if the custom goes away since we cache the
                 // constant function pointer.
 
-                if (!prepareChainForCaching(globalObject, slot.slotBase(), slot.slotBase()))
+                if (!prepareChainForCaching(globalObject, slot.slotBase(), propertyName.uid(), slot.slotBase()))
                     return GiveUpOnCache;
             }
 
@@ -471,7 +471,7 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
                 // If a kind is GetByKind::ByIdDirect or GetByKind::PrivateName, we do not need to investigate prototype chains further.
                 // Cacheability just depends on the head structure.
                 if (kind != GetByKind::ByIdDirect && !isPrivate) {
-                    auto cacheStatus = prepareChainForCaching(globalObject, baseCell, slot);
+                    auto cacheStatus = prepareChainForCaching(globalObject, baseCell, propertyName.uid(), slot);
                     if (!cacheStatus)
                         return GiveUpOnCache;
 
@@ -481,10 +481,10 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
                     }
 
                     if (cacheStatus->usesPolyProto) {
-                        prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, slot);
+                        prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, propertyName, slot);
                         if (!prototypeAccessChain)
                             return GiveUpOnCache;
-                        RELEASE_ASSERT(slot.isCacheableCustom() || prototypeAccessChain->slotBaseStructure(vm, structure)->get(vm, propertyName.uid()) == offset);
+                        ASSERT(slot.isCacheableCustom() || prototypeAccessChain->slotBaseStructure(vm, structure)->get(vm, propertyName.uid()) == offset);
                     } else {
                         // We use ObjectPropertyConditionSet instead for faster accesses.
                         prototypeAccessChain = nullptr;
@@ -695,7 +695,7 @@ static InlineCacheAction tryCacheArrayGetByVal(JSGlobalObject* globalObject, Cod
                     return GiveUpOnCache;
 
                 // FIXME: prepareChainForCaching is conservative. We should have another function which only cares about information related to this IC.
-                auto cacheStatus = prepareChainForCaching(globalObject, base, nullptr);
+                auto cacheStatus = prepareChainForCaching(globalObject, base, nullptr, nullptr);
                 if (!cacheStatus)
                     return GiveUpOnCache;
 
@@ -938,12 +938,12 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
                 RefPtr<PolyProtoAccessChain> prototypeAccessChain;
                 ObjectPropertyConditionSet conditionSet;
                 if (putKind == PutKind::NotDirect) {
-                    auto cacheStatus = prepareChainForCaching(globalObject, baseCell, nullptr);
+                    auto cacheStatus = prepareChainForCaching(globalObject, baseCell, propertyName.uid(), nullptr);
                     if (!cacheStatus)
                         return GiveUpOnCache;
 
                     if (cacheStatus->usesPolyProto) {
-                        prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, nullptr);
+                        prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, propertyName, nullptr);
                         if (!prototypeAccessChain)
                             return GiveUpOnCache;
                     } else {
@@ -972,13 +972,13 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
                 // We need to do this even if we're a self custom, since we must disallow dictionaries
                 // because we need to be informed if the custom goes away since we cache the constant
                 // function pointer.
-                auto cacheStatus = prepareChainForCaching(globalObject, baseCell, slot.base());
+                auto cacheStatus = prepareChainForCaching(globalObject, baseCell, propertyName.uid(), slot.base());
                 if (!cacheStatus)
                     return GiveUpOnCache;
 
                 if (slot.base() != baseValue) {
                     if (cacheStatus->usesPolyProto) {
-                        prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, slot.base());
+                        prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, propertyName, slot.base());
                         if (!prototypeAccessChain)
                             return GiveUpOnCache;
                     } else {
@@ -1000,14 +1000,14 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
                 PropertyOffset offset = slot.cachedOffset();
 
                 if (slot.base() != baseValue) {
-                    auto cacheStatus = prepareChainForCaching(globalObject, baseCell, slot.base());
+                    auto cacheStatus = prepareChainForCaching(globalObject, baseCell, propertyName.uid(), slot.base());
                     if (!cacheStatus)
                         return GiveUpOnCache;
                     if (cacheStatus->flattenedDictionary)
                         return RetryCacheLater;
 
                     if (cacheStatus->usesPolyProto) {
-                        prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, slot.base());
+                        prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, baseCell, propertyName, slot.base());
                         if (!prototypeAccessChain)
                             return GiveUpOnCache;
                         unsigned attributes;
@@ -1303,33 +1303,33 @@ static InlineCacheAction tryCacheInBy(
             }
 
             if (slot.slotBase() != base) {
-                auto cacheStatus = prepareChainForCaching(globalObject, base, slot);
+                auto cacheStatus = prepareChainForCaching(globalObject, base, propertyName.uid(), slot);
                 if (!cacheStatus)
                     return GiveUpOnCache;
                 if (cacheStatus->flattenedDictionary)
                     return RetryCacheLater;
 
                 if (cacheStatus->usesPolyProto) {
-                    prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, base, slot);
+                    prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, base, propertyName, slot);
                     if (!prototypeAccessChain)
                         return GiveUpOnCache;
-                    RELEASE_ASSERT(slot.isCacheableCustom() || prototypeAccessChain->slotBaseStructure(vm, structure)->get(vm, propertyName.uid()) == slot.cachedOffset());
+                    ASSERT(slot.isCacheableCustom() || prototypeAccessChain->slotBaseStructure(vm, structure)->get(vm, propertyName.uid()) == slot.cachedOffset());
                 } else {
                     prototypeAccessChain = nullptr;
                     conditionSet = generateConditionsForPrototypePropertyHit(
                         vm, codeBlock, globalObject, structure, slot.slotBase(), ident.impl());
                     if (!conditionSet.isValid())
                         return GiveUpOnCache;
-                    RELEASE_ASSERT(slot.isCacheableCustom() || conditionSet.slotBaseCondition().offset() == slot.cachedOffset());
+                    ASSERT(slot.isCacheableCustom() || conditionSet.slotBaseCondition().offset() == slot.cachedOffset());
                 }
             }
         } else {
-            auto cacheStatus = prepareChainForCaching(globalObject, base, nullptr);
+            auto cacheStatus = prepareChainForCaching(globalObject, base, propertyName.uid(), nullptr);
             if (!cacheStatus)
                 return GiveUpOnCache;
 
             if (cacheStatus->usesPolyProto) {
-                prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, base, slot);
+                prototypeAccessChain = PolyProtoAccessChain::tryCreate(globalObject, base, propertyName, slot);
                 if (!prototypeAccessChain)
                     return GiveUpOnCache;
             } else {
@@ -1552,7 +1552,7 @@ static InlineCacheAction tryCacheInstanceOf(
             } else if (structure->prototypeQueriesAreCacheable()) {
                 // FIXME: Teach this to do poly proto.
                 // https://bugs.webkit.org/show_bug.cgi?id=185663
-                prepareChainForCaching(globalObject, value, wasFound ? prototype : nullptr);
+                prepareChainForCaching(globalObject, value, nullptr, wasFound ? prototype : nullptr);
                 ObjectPropertyConditionSet conditionSet = generateConditionsForInstanceOf(
                     vm, codeBlock, globalObject, structure, prototype, wasFound);
 

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -763,7 +763,7 @@ static void setupGetByIdPrototypeCache(JSGlobalObject* globalObject, VM& vm, Cod
         structure->flattenDictionaryStructure(vm, jsCast<JSObject*>(baseCell));
     }
 
-    prepareChainForCaching(globalObject, baseCell, slot);
+    prepareChainForCaching(globalObject, baseCell, ident.impl(), slot);
 
     ObjectPropertyConditionSet conditions;
     if (slot.isUnset())

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -377,7 +377,7 @@ bool JSGenericTypedArrayView<Adaptor>::getOwnPropertySlot(
         return getOwnPropertySlotByIndex(thisObject, globalObject, index.value(), slot);
     }
 
-    if (isCanonicalNumericIndexString(propertyName))
+    if (isCanonicalNumericIndexString(propertyName.uid()))
         return false;
 
     return Base::getOwnPropertySlot(thisObject, globalObject, propertyName, slot);
@@ -395,7 +395,7 @@ bool JSGenericTypedArrayView<Adaptor>::put(
         return putByIndex(thisObject, globalObject, index.value(), value, slot.isStrictMode());
     }
 
-    if (isCanonicalNumericIndexString(propertyName)) {
+    if (isCanonicalNumericIndexString(propertyName.uid())) {
         // Cases like '-0', '1.1', etc. are still obliged to give the RHS a chance to throw.
         toNativeFromValue<Adaptor>(globalObject, value);
         return true;
@@ -445,7 +445,7 @@ bool JSGenericTypedArrayView<Adaptor>::defineOwnProperty(
         return true;
     }
 
-    if (isCanonicalNumericIndexString(propertyName))
+    if (isCanonicalNumericIndexString(propertyName.uid()))
         return typeError(globalObject, scope, shouldThrow, "Attempting to store canonical numeric string property on a typed array"_s);
 
     RELEASE_AND_RETURN(scope, Base::defineOwnProperty(thisObject, globalObject, propertyName, descriptor, shouldThrow));
@@ -462,7 +462,7 @@ bool JSGenericTypedArrayView<Adaptor>::deleteProperty(
         return deletePropertyByIndex(thisObject, globalObject, index.value());
     }
 
-    if (isCanonicalNumericIndexString(propertyName))
+    if (isCanonicalNumericIndexString(propertyName.uid()))
         return true;
 
     return Base::deleteProperty(thisObject, globalObject, propertyName, slot);

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -165,7 +165,7 @@ ALWAYS_INLINE bool JSObject::getNonIndexPropertySlot(JSGlobalObject* globalObjec
                 return false;
             if (object->type() == ProxyObjectType && slot.internalMethodType() == PropertySlot::InternalMethodType::HasProperty)
                 return false;
-            if (isTypedArrayType(object->type()) && isCanonicalNumericIndexString(propertyName))
+            if (isTypedArrayType(object->type()) && isCanonicalNumericIndexString(propertyName.uid()))
                 return false;
         }
         JSValue prototype;

--- a/Source/JavaScriptCore/runtime/PropertyName.h
+++ b/Source/JavaScriptCore/runtime/PropertyName.h
@@ -132,19 +132,18 @@ ALWAYS_INLINE std::optional<uint32_t> parseIndex(PropertyName propertyName)
 }
 
 // https://www.ecma-international.org/ecma-262/9.0/index.html#sec-canonicalnumericindexstring
-ALWAYS_INLINE bool isCanonicalNumericIndexString(const PropertyName& propertyName)
+ALWAYS_INLINE bool isCanonicalNumericIndexString(UniquedStringImpl* propertyName)
 {
-    StringImpl* property = propertyName.uid();
-    if (!property)
+    if (!propertyName)
         return false;
-    if (property->isSymbol())
+    if (propertyName->isSymbol())
         return false;
-    if (equal(property, "-0"_s))
+    if (equal(propertyName, "-0"_s))
         return true;
-    double index = jsToNumber(property);
+    double index = jsToNumber(propertyName);
     NumberToStringBuffer buffer;
     const char* indexString = WTF::numberToString(index, buffer);
-    if (!equal(property, indexString))
+    if (!equal(propertyName, indexString))
         return false;
     return true;
 }

--- a/Source/JavaScriptCore/runtime/StructureRareData.cpp
+++ b/Source/JavaScriptCore/runtime/StructureRareData.cpp
@@ -27,6 +27,7 @@
 #include "StructureRareData.h"
 
 #include "AdaptiveInferredPropertyValueWatchpointBase.h"
+#include "CacheableIdentifierInlines.h"
 #include "CachedSpecialPropertyAdaptiveStructureWatchpoint.h"
 #include "JSImmutableButterfly.h"
 #include "JSObjectInlines.h"
@@ -155,7 +156,7 @@ void StructureRareData::cacheSpecialPropertySlow(JSGlobalObject* globalObject, V
 
         // This will not create a condition for the current structure but that is good because we know that property
         // is not on the ownStructure so we will transisition if one is added and this cache will no longer be used.
-        auto cacheStatus = prepareChainForCaching(globalObject, ownStructure, slot.slotBase());
+        auto cacheStatus = prepareChainForCaching(globalObject, ownStructure, uid, slot.slotBase());
         if (!cacheStatus) {
             giveUpOnSpecialPropertyCache(key);
             return;
@@ -168,7 +169,7 @@ void StructureRareData::cacheSpecialPropertySlow(JSGlobalObject* globalObject, V
             return;
         }
 
-        auto cacheStatus = prepareChainForCaching(globalObject, ownStructure, nullptr);
+        auto cacheStatus = prepareChainForCaching(globalObject, ownStructure, uid, nullptr);
         if (!cacheStatus) {
             giveUpOnSpecialPropertyCache(key);
             return;


### PR DESCRIPTION
#### db8a1fe47e0e2fce54a4d48a7f1fcc0ffbef5cf6
<pre>
[JSC] TypedArray can stop [[Prototype]] lookup chain
<a href="https://bugs.webkit.org/show_bug.cgi?id=244903">https://bugs.webkit.org/show_bug.cgi?id=244903</a>
rdar://99644213

Reviewed by Alexey Shvayka and Justin Michaud.

According to the spec[1], TypedArray has an ability to stop [[Prototype]] traversing for numeric index string (e.g. &quot;0.1&quot;).
Thus we should align IC&apos;s traversing to this behavior, which is already implemented in JSObject::getPropertySlot.
This patch threads property name and we check this abruption in prototype traversing code for IC if structure is TypedArray.

[1]: <a href="https://262.ecma-international.org/9.0/#_ref_2826">https://262.ecma-international.org/9.0/#_ref_2826</a>

* JSTests/stress/poly-proto-typed-array-case.js: Added.
(bar.Foo):
(bar):
* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp:
(JSC::generateConditionsForPropertyMiss):
(JSC::generateConditionsForPropertySetterMiss):
(JSC::generateConditionsForIndexedMiss):
(JSC::generateConditionsForPrototypePropertyHit):
(JSC::generateConditionsForPrototypePropertyHitCustom):
(JSC::generateConditionsForInstanceOf):
(JSC::generateConditionsForPrototypeEquivalenceConcurrently):
(JSC::generateConditionsForPropertyMissConcurrently):
(JSC::generateConditionsForPropertySetterMissConcurrently):
(JSC::prepareChainForCaching):
* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h:
* Source/JavaScriptCore/bytecode/PolyProtoAccessChain.cpp:
(JSC::PolyProtoAccessChain::tryCreate):
* Source/JavaScriptCore/bytecode/PolyProtoAccessChain.h:
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheGetBy):
(JSC::tryCacheArrayGetByVal):
(JSC::tryCachePutBy):
(JSC::tryCacheInBy):
(JSC::tryCacheInstanceOf):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::setupGetByIdPrototypeCache):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::getOwnPropertySlot):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::put):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::defineOwnProperty):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::deleteProperty):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::getNonIndexPropertySlot):
* Source/JavaScriptCore/runtime/PropertyName.h:
(JSC::isCanonicalNumericIndexString):
* Source/JavaScriptCore/runtime/StructureRareData.cpp:
(JSC::StructureRareData::cacheSpecialPropertySlow):

Canonical link: <a href="https://commits.webkit.org/254264@main">https://commits.webkit.org/254264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14397306f9e2023894cf4727f9f62d4fe8d03d66

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97730 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/153312 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31581 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27168 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80760 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92367 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25058 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75469 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25013 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79944 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67976 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/80256 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29216 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74027 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29133 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15040 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26226 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3015 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32459 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76883 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31237 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34149 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17050 "Passed tests") | 
<!--EWS-Status-Bubble-End-->