### PR TITLE
[git-webkit] Accidental overwrite of pull request with similar branch names in Github

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.6.3',
+    version='5.6.4',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 6, 3)
+version = Version(5, 6, 4)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/contributor.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/contributor.py
@@ -210,7 +210,7 @@ class Contributor(object):
         return self.emails[0]
 
     def __repr__(self):
-        return u'{} <{}>'.format(self.name, self.email)
+        return u'{} <{}>'.format(self.name, self.email or '?')
 
     def __hash__(self):
         return hash(self.name)
@@ -224,8 +224,9 @@ class Contributor(object):
             ref_value = ''
         else:
             raise ValueError('Cannot compare {} with {}'.format(Contributor, type(other)))
-        if self.name == ref_value:
-            return 0
+        for part in [self.name, self.emails, self.github, self.bitbucket]:
+            if part == ref_value:
+                return 0
         return 1 if self.name > ref_value else -1
 
     def __eq__(self, other):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -500,7 +500,7 @@ class Git(Scm):
             url = '{}://{}/{}'.format(http_match.group('protocol'), http_match.group('host'), http_match.group('path'))
 
         try:
-            return remote.Scm.from_url(url)
+            return remote.Scm.from_url(url, contributors=self.contributors)
         except OSError:
             pass
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -226,9 +226,12 @@ class PullRequest(Command):
     @classmethod
     def find_existing_pull_request(cls, repository, remote):
         existing_pr = None
+        user, _ = remote.credentials(required=False)
         for pr in remote.pull_requests.find(opened=None, head=repository.branch):
             existing_pr = pr
-            if existing_pr.opened:
+            if not existing_pr.opened:
+                continue
+            if user and existing_pr.author == user:
                 break
         return existing_pr
 
@@ -354,15 +357,48 @@ class PullRequest(Command):
 
         existing_pr = None
         if remote_repo.pull_requests:
+            user, _ = remote_repo.credentials(required=False)
+
             log.info("Checking if PR already exists...")
             existing_pr = cls.find_existing_pull_request(repository, remote_repo)
             log.info("PR #{} found.".format(existing_pr.number) if existing_pr else "PR not found.")
-            if existing_pr and not existing_pr.opened and not args.defaults and (args.defaults is False or Terminal.choose(
-                    "'{}' is already associated with '{}', which is closed.\nWould you like to create a new pull-request?".format(
-                        repository.branch, existing_pr,
-                    ), default='No',
+            if existing_pr and not existing_pr.opened and not args.defaults and (
+                args.defaults is False or Terminal.choose(
+                    "'{}' is already associated with '{}', which is closed.\nWould you like to create a new pull-request?".format(repository.branch, existing_pr),
+                    default='No',
             ) == 'Yes'):
                 existing_pr = None
+
+            if existing_pr and user and existing_pr.author != user and (args.defaults or Terminal.choose(
+                "'{}' is owned by '{}'\nYou can either".format(existing_pr, existing_pr.author),
+                options=('Create a new pull request', 'Overwrite PR-{} and assign to yourself'.format(existing_pr.number)),
+                default='Create a new pull request',
+                numbered=True,
+            ) == 'Create a new pull request'):
+                if target == source_remote:
+                    sys.stderr.write("'{}' already exists on '{}', creating a pull-request would overwrite it\n".format(
+                        repository.branch, target,
+                    ))
+                    return 1
+                existing_pr = None
+
+            if user and existing_pr and isinstance(remote_repo, remote.GitHub) and existing_pr._metadata.get('full_name'):
+                pr_target = existing_pr._metadata['full_name']
+                if not pr_target.startswith('{}/'.format(user)):
+                    target, repo_name = pr_target.split('/')
+                    if '-' in repo_name:
+                        target = '{}-{}'.format(target, repo_name.split('-')[-1])
+                    base_url = repository.url(name=source_remote)
+                    if '://' in base_url:
+                        base_url = '/'.join(base_url.split('/')[:3]) + '/'
+                    else:
+                        base_url = base_url.split(':')[0] + ':'
+                    if target not in repository.source_remotes(personal=True) and run(
+                        [repository.executable(), 'remote', 'add', target, '{}{}.git'.format(base_url, pr_target)],
+                        capture_output=True, cwd=repository.root_path,
+                    ).returncode not in [0, 3]:
+                        sys.stderr.write("Failed to add '{}' remote\n".format(target))
+                        return 1
 
         # Remove any active labels
         if existing_pr and existing_pr._metadata and existing_pr._metadata.get('issue'):
@@ -405,6 +441,7 @@ class PullRequest(Command):
                 repository.executable(), 'push', '-f', target, history_branch,
             ], cwd=repository.root_path).returncode:
                 sys.stderr.write("Failed to create and push '{}' to '{}'\n".format(history_branch, target))
+                return 1
 
         if not remote_repo.pull_requests:
             sys.stderr.write("'{}' cannot generate pull-requests\n".format(remote_repo.url))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -286,7 +286,7 @@ class BitBucket(Scm):
 
         self.pull_requests = self.PRGenerator(self)
 
-    def credentials(self):
+    def credentials(self, required=True, validate=False, save_in_keyring=None):
         return None, None
 
     @property

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
@@ -365,8 +365,8 @@ class TestLandGitHub(testing.PathTestCase):
         os.mkdir(os.path.join(self.path, '.svn'))
 
     @classmethod
-    def webserver(cls, approved=None, labels=None):
-        result = mocks.remote.GitHub(labels=labels)
+    def webserver(cls, approved=None, labels=None, environment=None):
+        result = mocks.remote.GitHub(labels=labels, environment=environment)
         result.users.create('Ricky Reviewer', 'rreviewer', ['rreviewer@webkit.org'])
         result.users.create('Tim Contributor', 'tcontributor', ['tcontributor@webkit.org'])
         result.issues = {
@@ -490,6 +490,10 @@ class TestLandGitHub(testing.PathTestCase):
     def test_merge_queue(self):
         with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('y', 'n'), self.webserver(
             approved=True, labels={'merge-queue': dict(color='3AE653', description="Send PR to merge-queue")},
+            environment=Environment(
+                GITHUB_EXAMPLE_COM_USERNAME='tcontributor',
+                GITHUB_EXAMPLE_COM_TOKEN='token',
+            ),
         ) as remote, mocks.local.Svn(), repository(
             self.path, has_oops=True,
             remote='https://{}'.format(remote.remote),
@@ -532,6 +536,10 @@ class TestLandGitHub(testing.PathTestCase):
         self.maxDiff = None
         with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('y', 'n'), self.webserver(
             approved=True, labels={'merge-queue': dict(color='3AE653', description="Send PR to merge-queue")},
+            environment=Environment(
+                GITHUB_EXAMPLE_COM_USERNAME='tcontributor',
+                GITHUB_EXAMPLE_COM_TOKEN='token',
+            ),
         ) as remote, mocks.local.Svn(), repository(
             self.path, has_oops=True,
             issue_url='{}/show_bug.cgi?id=1'.format(self.BUGZILLA),


### PR DESCRIPTION
#### 9eedf00c442768bab889b5e7ca6bc3e24c07bb53
<pre>
[git-webkit] Accidental overwrite of pull request with similar branch names in Github
<a href="https://bugs.webkit.org/show_bug.cgi?id=244660">https://bugs.webkit.org/show_bug.cgi?id=244660</a>
&lt;rdar://problem/99648208&gt;

Reviewed by Elliott Williams and Ryan Haddad.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/contributor.py:
(Contributor.__repr__): Print ? if &apos;email&apos; is &apos;None&apos;.
(Contributor.__cmp__): Consider other string representations of a Contributor when comparing against a string.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.remote): Pass contributors object so that Contributors have their actual names.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.find_existing_pull_request): Prefer pull-requests owned by the current user if branch names collide.
(PullRequest.create_pull_request): If the user provides a branch name already used by another user, offer to
push to that user&apos;s branch instead of the current user&apos;s branch. If the user opts out of this, create a new pull-request.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.credentials): Accept options GitHub&apos;s credential&apos;s function accepts.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py:
(TestLandGitHub): Specify current user.

Canonical link: <a href="https://commits.webkit.org/254478@main">https://commits.webkit.org/254478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d7d0d2622c816a5fa3603bc43ae6e9b75e3db48

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33757 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/20016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/98515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93205 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/64/builds/32265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/81558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/92984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94843 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/64/builds/32265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/76121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/81558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/92783 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/64/builds/32265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/20016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/81558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/30044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/20016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/88252 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/29768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/20016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/33215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/76121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1319 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/31916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/20016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->