### PR TITLE
REGRESSION (254104@main): [Reporting API] Do not expose TestReportBody as a JS-exposed type

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -835,6 +835,7 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-embed-elemen
 
 # Newly imported WPT tests that are flaky.
 webkit.org/b/227649 imported/w3c/web-platform-tests/beacon/beacon-basic.https.window.html [ Failure Pass ]
+imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-allowed.sub.html [ Failure Pass ]
 imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/worklet-audio.https.html [ Failure Pass ]
 imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/script-tag.http.html [ Failure Pass ]
 imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/script-tag.https.html [ Failure Pass ]

--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -171,6 +171,8 @@ void ReportingScope::generateTestReport(String&& message, String&& group)
 
     // https://w3c.github.io/reporting/#generate-test-report-command, step 7.1.10.
     notifyReportObservers(Report::create(TestReportBody::testReportType(), WTFMove(reportURL), TestReportBody::create(WTFMove(message))));
+
+    // FIXME(244907): We should call sendReportToEndpoints here.
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/reporting/TestReportBody.cpp
+++ b/Source/WebCore/Modules/reporting/TestReportBody.cpp
@@ -61,7 +61,6 @@ const String& TestReportBody::message() const
     return m_bodyMessage;
 }
 
-
 Ref<FormData> TestReportBody::createReportFormDataForViolation(const String& bodyMessage)
 {
     // https://w3c.github.io/reporting/#generate-test-report-command, Step 7.1.10

--- a/Source/WebCore/Modules/reporting/TestReportBody.idl
+++ b/Source/WebCore/Modules/reporting/TestReportBody.idl
@@ -26,7 +26,7 @@
 // https://w3c.github.io/reporting/#reportingobserver
 [
     EnabledBySetting=ReportingEnabled,
-    Exposed=Window
+    LegacyNoInterfaceObject
 ] interface TestReportBody : ReportBody {
     readonly attribute USVString message;
     [Default] object toJSON();


### PR DESCRIPTION
#### 7c5cd05f49f96c9294e344cf8eebee9e97df3f13
<pre>
REGRESSION (254104@main): [Reporting API] Do not expose TestReportBody as a JS-exposed type
<a href="https://bugs.webkit.org/show_bug.cgi?id=244905">https://bugs.webkit.org/show_bug.cgi?id=244905</a>
&lt;rdar://problem/99664743&gt;

Reviewed by Chris Dumez.

I mistakenly treated TestReportBody as a public JS type that could be exposed to the web and created by JS code.
This isn&apos;t correct. TestReportBody is just a class-cluster implementation behind ReportBody, and should not itself
be exposed (just the generic ReportBody type).

This patch fixes that error.

* LayoutTests/TestExpectations: Mark a flaky test (Drive-by fix)
* Source/WebCore/Modules/reporting/ReportingScope.cpp:
(WebCore::ReportingScope::generateTestReport): Add reminder to fix a bug in test reports.
* Source/WebCore/Modules/reporting/TestReportBody.cpp: Drive-by fix (whitespace).
* Source/WebCore/Modules/reporting/TestReportBody.idl: Stop exposing the class to the JS layer.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj: Remove some incorrect generated files,
and add some missed ones.

Canonical link: <a href="https://commits.webkit.org/254261@main">https://commits.webkit.org/254261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/497d02a324810bd693603840258ff37cdec27ddc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97710 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/153179 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31558 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27153 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92351 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25046 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75455 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25004 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67967 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29182 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29123 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15031 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3013 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37959 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34140 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->