### PR TITLE
Page numbers not printed when using WKWebView.

### DIFF
--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -545,6 +545,7 @@ public:
 
     virtual void pinnedStateWillChange() { }
     virtual void pinnedStateDidChange() { }
+    virtual void drawPageBorderForPrinting(WebCore::FloatSize&& size) { }
     virtual bool scrollingUpdatesDisabledForTesting() { return false; }
 
     virtual bool hasSafeBrowsingWarning() const { return false; }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9180,6 +9180,13 @@ void WebPageProxy::drawFooterForPrinting(WebFrameProxy& frame, FloatRect&& rect)
     m_uiClient->drawFooter(*this, frame, WTFMove(rect));
 }
 
+void WebPageProxy::drawPageBorderForPrinting(WebFrameProxy& frame, WebCore::FloatSize&& size)
+{
+    if (frame.isDisplayingPDFDocument())
+        return;
+    pageClient().drawPageBorderForPrinting(WTFMove(size));
+}
+
 void WebPageProxy::runModal()
 {
     // Since runModal() can (and probably will) spin a nested run loop we need to turn off the responsiveness timer.

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1288,6 +1288,7 @@ public:
     float footerHeightForPrinting(WebFrameProxy&);
     void drawHeaderForPrinting(WebFrameProxy&, WebCore::FloatRect&&);
     void drawFooterForPrinting(WebFrameProxy&, WebCore::FloatRect&&);
+    void drawPageBorderForPrinting(WebFrameProxy&, WebCore::FloatSize&&);
 
 #if PLATFORM(COCOA)
     // Dictionary.

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -125,6 +125,8 @@ private:
 
     void pinnedStateWillChange() final;
     void pinnedStateDidChange() final;
+        
+    void drawPageBorderForPrinting(WebCore::FloatSize&&) final;
 
     CGRect boundsOfLayerInLayerBackedWindowCoordinates(CALayer *) const override;
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -445,6 +445,11 @@ void PageClientImpl::pinnedStateDidChange()
 {
     [m_webView didChangeValueForKey:@"_pinnedState"];
 }
+
+void PageClientImpl::drawPageBorderForPrinting(WebCore::FloatSize&& size)
+{
+    [m_webView drawPageBorderWithSize:size];
+}
     
 IntPoint PageClientImpl::screenToRootView(const IntPoint& point)
 {

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -677,6 +677,10 @@ static NSString *linkDestinationName(PDFDocument *document, PDFDestination *dest
     NSRectClip(footerRect);
     _webFrame->page()->drawFooterForPrinting(*_webFrame, footerRect);
     [currentContext restoreGraphicsState];
+    
+    [currentContext saveGraphicsState];
+    _webFrame->page()->drawPageBorderForPrinting(*_webFrame, static_cast<WebCore::FloatSize>(borderSize));
+    [currentContext restoreGraphicsState];
 }
 
 - (NSRect)rectForPage:(NSInteger)page


### PR DESCRIPTION
#### 2b0e8042741ba22bd408aaf764c273064647193b
<pre>
Page numbers not printed when using WKWebView.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244911">https://bugs.webkit.org/show_bug.cgi?id=244911</a>
rdar://85438043

Reviewed by Tim Horton.

In AppKit, there is an API method `drawPageBorderWithSize:` that can be
overriden to be used to arbitrarily draw contents on a page&apos;s border. In
legacy WebKit, this method was called when printing. However, in WKWebView,
the behavior differs because this method is no longer called.

This PR resolves this discrepency by ensuring this method does get called
and so the behavior remains consistent with how it works with legacy web
views.

* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::drawPageBorderForPrinting):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::drawPageBorderForPrinting):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::drawPageBorderForPrinting):
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView drawPageBorderWithSize:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.mm:
(-[WKPrintPageBordersWebView drawPageBorderWithSize:]):
(-[WKPrintPageBordersWebView _waitUntilPrintingDone]):
(-[PrintPageBordersUIDelegate _webView:printFrame:pdfFirstPageSize:completionHandler:]):
(TEST):
(-[PrintUIDelegate callBlockAsync:]): Deleted.
(-[PrintUIDelegate _webView:printFrame:pdfFirstPageSize:completionHandler:]): Deleted.
(-[PrintUIDelegate waitForPagination]): Deleted.

Canonical link: <a href="https://commits.webkit.org/254392@main">https://commits.webkit.org/254392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b2d772ea9fcb1414f2f42d0a570c1621f3e6c9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97954 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31819 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27438 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92579 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25241 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75740 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25197 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80118 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68158 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29611 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14193 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29353 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15195 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3080 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38119 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31472 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34302 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->