### PR TITLE
Fancy Quotes and Apostrophes are not matched to Scroll To Text Fragment fragments.

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/start-text-quote-expected.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/start-text-quote-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - highlight simple start reference</title>
+<style>
+  span {
+    background-color: rgb(255, 238, 190);
+  }
+</style>
+
+<p>The test passes if the following word has a yellow background.</p>
+<div>Select <span>“isn’t”</span> to pass.</div>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/start-text-quote.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/start-text-quote.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
+<meta charset="utf-8" />
+<title>Scroll to text fragment - highlight simple start text</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<meta name="assert" content="This test checks that a fragment directive with quotes and apostrophes is correctly highlighted.">
+
+<p>The test passes if the following word has a yellow background.</p>
+<div>Select <span>“isn’t”</span> to pass.</div>
+
+<script>
+  location.href = "#:~:text=\"isn't\"";
+</script>
+</html>

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -145,6 +145,8 @@ static std::optional<SimpleRange> findRangeFromNodeList(const String& query, con
     // FIXME: try to use SearchBuffer in TextIterator.h instead.
     searchBuffer = searchBufferBuilder.toString();
     
+    searchBuffer = foldQuoteMarks(searchBuffer);
+    
     unsigned searchStart = 0;
     
     if (nodes[0].ptr() == &searchRange.startContainer())


### PR DESCRIPTION
#### c79c0dc354f2430992eebd89c515da6bc39406ea
<pre>
Fancy Quotes and Apostrophes are not matched to Scroll To Text Fragment fragments.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244918">https://bugs.webkit.org/show_bug.cgi?id=244918</a>

Reviewed by Wenson Hsieh.

Leverage existing quote folding code to match non-ascii quote marks for more accurate
fragment matching.

* LayoutTests/http/tests/scroll-to-text-fragment/start-text-quote-expected.html: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/start-text-quote.html: Added.
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::findRangeFromNodeList):

Canonical link: <a href="https://commits.webkit.org/254275@main">https://commits.webkit.org/254275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7079599edac80182abf158c4515c96947a97a28e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97739 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/153422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31592 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27172 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80773 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92379 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25061 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75473 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25016 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67979 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29222 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29136 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15042 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3019 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37970 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34151 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->