### PR TITLE
Switch FontCache to use ThreadSpecific instead of ThreadGlobalData

### DIFF
--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -99,7 +99,7 @@ CSSFontSelector::~CSSFontSelector()
 
     clearFonts();
 
-    if (auto fontCache = FontCache::forCurrentThreadIfNotDestroyed())
+    if (auto fontCache = FontCache::forCurrentThreadIfExists())
         fontCache->removeClient(*this);
 }
 

--- a/Source/WebCore/platform/ThreadGlobalData.cpp
+++ b/Source/WebCore/platform/ThreadGlobalData.cpp
@@ -29,7 +29,6 @@
 
 #include "CachedResourceRequestInitiators.h"
 #include "EventNames.h"
-#include "FontCache.h"
 #include "MIMETypeRegistry.h"
 #include "QualifiedNameCache.h"
 #include "ThreadTimers.h"
@@ -125,12 +124,6 @@ void ThreadGlobalData::initializeMimeTypeRegistryThreadGlobalData()
 {
     ASSERT(!m_MIMETypeRegistryThreadGlobalData);
     m_MIMETypeRegistryThreadGlobalData = MIMETypeRegistry::createMIMETypeRegistryThreadGlobalData();
-}
-
-void ThreadGlobalData::initializeFontCache()
-{
-    ASSERT(!m_fontCache);
-    m_fontCache = makeUnique<FontCache>();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ThreadGlobalData.h
+++ b/Source/WebCore/platform/ThreadGlobalData.h
@@ -37,7 +37,6 @@ class JSGlobalObject;
 
 namespace WebCore {
 
-class FontCache;
 class QualifiedNameCache;
 class ThreadTimers;
 
@@ -94,17 +93,6 @@ public:
     bool isInRemoveAllEventListeners() const { return m_isInRemoveAllEventListeners; }
     void setIsInRemoveAllEventListeners(bool value) { m_isInRemoveAllEventListeners = value; }
 
-    FontCache& fontCache()
-    {
-        ASSERT(!m_destroyed);
-        if (UNLIKELY(!m_fontCache))
-            initializeFontCache();
-        return *m_fontCache;
-    }
-
-    FontCache* fontCacheIfExists() { return m_fontCache.get(); }
-    FontCache* fontCacheIfNotDestroyed() { return m_destroyed ? nullptr : &fontCache(); }
-
 private:
     WEBCORE_EXPORT void initializeCachedResourceRequestInitiators();
     WEBCORE_EXPORT void initializeEventNames();
@@ -118,7 +106,6 @@ private:
     std::unique_ptr<QualifiedNameCache> m_qualifiedNameCache;
     JSC::JSGlobalObject* m_currentState { nullptr };
     std::unique_ptr<MIMETypeRegistryThreadGlobalData> m_MIMETypeRegistryThreadGlobalData;
-    std::unique_ptr<FontCache> m_fontCache;
 
 #ifndef NDEBUG
     bool m_isMainThread;

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -97,7 +97,7 @@ class FontCache {
 public:
     WEBCORE_EXPORT static FontCache& forCurrentThread();
     static FontCache* forCurrentThreadIfExists();
-    static FontCache* forCurrentThreadIfNotDestroyed();
+    static void destroy();
 
     FontCache();
     ~FontCache();

--- a/Source/WebCore/workers/WorkerOrWorkletThread.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WorkerOrWorkletThread.h"
 
+#include "FontCache.h"
 #include "ThreadGlobalData.h"
 #include "WorkerEventLoop.h"
 #include "WorkerOrWorkletGlobalScope.h"
@@ -239,8 +240,11 @@ void WorkerOrWorkletThread::destroyWorkerGlobalScope(Ref<WorkerOrWorkletThread>&
     if (stoppedCallback)
         callOnMainThread(WTFMove(stoppedCallback));
 
-    // Clean up WebCore::ThreadGlobalData before WTF::Thread goes away!
+    // Clean up any TLS data that contains AtomStrings before WTF::Thread goes
+    // away, otherwise AtomStrings would be destroyed after the thread's atom
+    // string table is destroyed.
     threadGlobalData().destroy();
+    FontCache::destroy();
 
     // Send the last WorkerThread Ref to be Deref'ed on the main thread.
     callOnMainThread([protectedThis = WTFMove(protectedThis)] { });


### PR DESCRIPTION
#### 21308fa925b845ce1d059459879ff397e611bb65
<pre>
Switch FontCache to use ThreadSpecific instead of ThreadGlobalData
<a href="https://bugs.webkit.org/show_bug.cgi?id=244919">https://bugs.webkit.org/show_bug.cgi?id=244919</a>

Reviewed by Youenn Fablet.

ThreadGlobalData doesn&apos;t handle the case where we try to access it while it&apos;s being shut down, and
the font code tries to do that.

ThreadSpecific should be faster, and safe for this case.

* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::~CSSFontSelector):
* Source/WebCore/platform/ThreadGlobalData.cpp:
(WebCore::ThreadGlobalData::initializeFontCache): Deleted.
* Source/WebCore/platform/ThreadGlobalData.h:
(WebCore::ThreadGlobalData::fontCache): Deleted.
(WebCore::ThreadGlobalData::fontCacheIfExists): Deleted.
(WebCore::ThreadGlobalData::fontCacheIfNotDestroyed): Deleted.
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::fontCacheForCurrentThread):
(WebCore::FontCache::forCurrentThread):
(WebCore::FontCache::forCurrentThreadIfExists):
(WebCore::FontCache::destroy):
(WebCore::FontCache::forCurrentThreadIfNotDestroyed): Deleted.
* Source/WebCore/platform/graphics/FontCache.h:
* Source/WebCore/workers/WorkerOrWorkletThread.cpp:
(WebCore::WorkerOrWorkletThread::workerOrWorkletThread):

Canonical link: <a href="https://commits.webkit.org/256048@main">https://commits.webkit.org/256048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6466a0c501532e84d4c7fe75cfedb7f4cd37afea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104068 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164345 "Found 1 new test failure: http/wpt/webcodecs/videoFrame-serialization.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3639 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31790 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86742 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100063 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2613 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80805 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29651 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84535 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72543 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38188 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17947 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36058 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19220 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4179 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39950 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38449 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->