### PR TITLE
[JSC] Use destroying_delete for Watchpoint

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.h
@@ -47,7 +47,7 @@ public:
     void fireInternal(VM&, const FireDetail&);
 
 private:
-    JSC_WATCHPOINT_FIELD(PackedCellPtr<CodeBlock>, m_codeBlock);
+    PackedCellPtr<CodeBlock> m_codeBlock;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.h
@@ -50,9 +50,9 @@ public:
 
 private:
     // Own destructor may not be called. Keep members trivially destructible.
-    JSC_WATCHPOINT_FIELD(PackedCellPtr<CodeBlock>, m_owner);
-    JSC_WATCHPOINT_FIELD(Packed<BytecodeIndex>, m_bytecodeIndex);
-    JSC_WATCHPOINT_FIELD(ObjectPropertyCondition, m_key);
+    PackedCellPtr<CodeBlock> m_owner;
+    Packed<BytecodeIndex> m_bytecodeIndex;
+    ObjectPropertyCondition m_key;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
@@ -55,8 +55,8 @@ public:
 
 private:
     // Own destructor may not be called. Keep members trivially destructible.
-    JSC_WATCHPOINT_FIELD(PackedPtr<WatchpointsOnStructureStubInfo>, m_holder);
-    JSC_WATCHPOINT_FIELD(ObjectPropertyCondition, m_key);
+    PackedPtr<WatchpointsOnStructureStubInfo> m_holder;
+    ObjectPropertyCondition m_key;
 };
 
 class AdaptiveValueStructureStubClearingWatchpoint final : public AdaptiveInferredPropertyValueWatchpointBase {

--- a/Source/JavaScriptCore/bytecode/Watchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.cpp
@@ -50,6 +50,28 @@ void StringFireDetail::dump(PrintStream& out) const
     out.print(m_string);
 }
 
+template<typename Func>
+inline void Watchpoint::runWithDowncast(const Func& func)
+{
+    switch (m_type) {
+#define JSC_DEFINE_WATCHPOINT_DISPATCH(type, cast) \
+    case Type::type: \
+        func(static_cast<cast*>(this)); \
+        break;
+    JSC_WATCHPOINT_TYPES(JSC_DEFINE_WATCHPOINT_DISPATCH)
+#undef JSC_DEFINE_WATCHPOINT_DISPATCH
+    }
+}
+
+void Watchpoint::operator delete(Watchpoint* watchpoint, std::destroying_delete_t)
+{
+    watchpoint->runWithDowncast([](auto* derived) {
+        using T = std::decay_t<decltype(*derived)>;
+        derived->~T();
+    });
+    Watchpoint::freeAfterDestruction(watchpoint);
+}
+
 Watchpoint::~Watchpoint()
 {
     if (isOnList()) {
@@ -65,14 +87,9 @@ Watchpoint::~Watchpoint()
 void Watchpoint::fire(VM& vm, const FireDetail& detail)
 {
     RELEASE_ASSERT(!isOnList());
-    switch (m_type) {
-#define JSC_DEFINE_WATCHPOINT_DISPATCH(type, cast) \
-    case Type::type: \
-        static_cast<cast*>(this)->fireInternal(vm, detail); \
-        break;
-    JSC_WATCHPOINT_TYPES(JSC_DEFINE_WATCHPOINT_DISPATCH)
-#undef JSC_DEFINE_WATCHPOINT_DISPATCH
-    }
+    runWithDowncast([&](auto* derived) {
+        derived->fireInternal(vm, detail);
+    });
 }
 
 WatchpointSet::WatchpointSet(WatchpointState state)

--- a/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.h
+++ b/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.h
@@ -49,8 +49,8 @@ public:
 
 private:
     // Own destructor may not be called. Keep members trivially destructible.
-    JSC_WATCHPOINT_FIELD(PackedCellPtr<CodeBlock>, m_codeBlock);
-    JSC_WATCHPOINT_FIELD(ObjectPropertyCondition, m_key);
+    PackedCellPtr<CodeBlock> m_codeBlock;
+    ObjectPropertyCondition m_key;
 };
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/runtime/CachedSpecialPropertyAdaptiveStructureWatchpoint.h
+++ b/Source/JavaScriptCore/runtime/CachedSpecialPropertyAdaptiveStructureWatchpoint.h
@@ -46,8 +46,8 @@ public:
     
 private:
     // Own destructor may not be called. Keep members trivially destructible.
-    JSC_WATCHPOINT_FIELD(PackedCellPtr<StructureRareData>, m_structureRareData);
-    JSC_WATCHPOINT_FIELD(ObjectPropertyCondition, m_key);
+    PackedCellPtr<StructureRareData> m_structureRareData;
+    ObjectPropertyCondition m_key;
 };
 
 }

--- a/Source/JavaScriptCore/runtime/FunctionRareData.h
+++ b/Source/JavaScriptCore/runtime/FunctionRareData.h
@@ -178,7 +178,7 @@ public:
 
 private:
     // Own destructor may not be called. Keep members trivially destructible.
-    JSC_WATCHPOINT_FIELD(PackedCellPtr<FunctionRareData>, m_rareData);
+    PackedCellPtr<FunctionRareData> m_rareData;
 };
 
 inline Watchpoint* FunctionRareData::createAllocationProfileClearingWatchpoint()

--- a/Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h
+++ b/Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h
@@ -35,8 +35,8 @@ class ObjectAdaptiveStructureWatchpoint final : public Watchpoint {
 public:
     ObjectAdaptiveStructureWatchpoint(JSCell* owner, const ObjectPropertyCondition& key, InlineWatchpointSet& watchpointSet)
         : Watchpoint(Watchpoint::Type::ObjectAdaptiveStructure)
-        , m_key(key)
         , m_owner(owner)
+        , m_key(key)
         , m_watchpointSet(watchpointSet)
     {
         RELEASE_ASSERT(key.kind() != PropertyCondition::Equivalence);
@@ -53,9 +53,9 @@ public:
 
 private:
     // Own destructor may not be called. Keep members trivially destructible.
-    JSC_WATCHPOINT_FIELD(ObjectPropertyCondition, m_key);
-    JSC_WATCHPOINT_FIELD(JSCell*, m_owner);
-    JSC_WATCHPOINT_FIELD(InlineWatchpointSet&, m_watchpointSet);
+    PackedCellPtr<JSCell> m_owner;
+    ObjectPropertyCondition m_key;
+    InlineWatchpointSet& m_watchpointSet;
 };
 
 inline void ObjectAdaptiveStructureWatchpoint::install(VM&)

--- a/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
@@ -60,7 +60,7 @@ public:
 
 private:
     // Own destructor may not be called. Keep members trivially destructible.
-    JSC_WATCHPOINT_FIELD(PackedCellPtr<StructureRareData>, m_structureRareData);
+    PackedCellPtr<StructureRareData> m_structureRareData;
 };
 
 inline void StructureRareData::setPreviousID(VM& vm, Structure* structure)


### PR DESCRIPTION
#### 1afd5ee3eea2282c161e15f6728e15c2c2ef877b
<pre>
[JSC] Use destroying_delete for Watchpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=244923">https://bugs.webkit.org/show_bug.cgi?id=244923</a>

Reviewed by Mark Lam.

We use C++20 destroying_delete for Watchpoint so that we do not need to have JSC_WATCHPOINT_FIELD macro etc.

* Source/JavaScriptCore/bytecode/CodeBlockJettisoningWatchpoint.h:
* Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.h:
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h:
* Source/JavaScriptCore/bytecode/Watchpoint.cpp:
(JSC::Watchpoint::runWithDowncast):
(JSC::Watchpoint::operator delete):
(JSC::Watchpoint::fire):
* Source/JavaScriptCore/bytecode/Watchpoint.h:
* Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.h:
* Source/JavaScriptCore/runtime/CachedSpecialPropertyAdaptiveStructureWatchpoint.h:
* Source/JavaScriptCore/runtime/FunctionRareData.h:
* Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h:
* Source/JavaScriptCore/runtime/StructureRareDataInlines.h:

Canonical link: <a href="https://commits.webkit.org/254265@main">https://commits.webkit.org/254265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa91042e1f8cc3a44cd25b41c3adb98ee5e1c4fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88553 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97750 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/153466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31608 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27184 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80784 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92390 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25072 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75485 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25025 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79957 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67988 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/80273 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29240 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74044 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29146 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15048 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26227 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3016 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32482 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/37980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76900 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34157 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17051 "Passed tests") | 
<!--EWS-Status-Bubble-End-->