### PR TITLE
IPC::Attachment is used as an encoded type on Unix

### DIFF
--- a/Source/WebKit/Platform/IPC/Attachment.h
+++ b/Source/WebKit/Platform/IPC/Attachment.h
@@ -55,12 +55,10 @@ public:
 
     enum Type {
         Uninitialized,
-        SocketType,
-        MappedMemoryType,
+        FileDescriptorType,
         CustomWriterType,
     };
 
-    explicit Attachment(UnixFileDescriptor&&, size_t);
     explicit Attachment(UnixFileDescriptor&&);
 
     Attachment(Attachment&&);
@@ -75,7 +73,6 @@ public:
     Type type() const { return m_type; }
 
     bool isNull() const { return !m_fd; }
-    size_t size() const { return m_size; }
 
     const UnixFileDescriptor& fd() const { return m_fd; }
     UnixFileDescriptor release() { return std::exchange(m_fd, UnixFileDescriptor { }); }
@@ -88,7 +85,6 @@ private:
     Type m_type;
 
     UnixFileDescriptor m_fd;
-    size_t m_size;
     CustomWriter m_customWriter;
 };
 #endif

--- a/Source/WebKit/Platform/IPC/unix/AttachmentUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/AttachmentUnix.cpp
@@ -38,33 +38,22 @@ Attachment::Attachment()
 {
 }
 
-Attachment::Attachment(UnixFileDescriptor&& fd, size_t size)
-    : m_type(MappedMemoryType)
-    , m_fd(WTFMove(fd))
-    , m_size(size)
-{
-}
-
 Attachment::Attachment(UnixFileDescriptor&& fd)
-    : m_type(SocketType)
+    : m_type(FileDescriptorType)
     , m_fd(WTFMove(fd))
-    , m_size(0)
 {
 }
 
 Attachment::Attachment(Attachment&& attachment)
     : m_type(attachment.m_type)
     , m_fd(WTFMove(attachment.m_fd))
-    , m_size(attachment.m_size)
     , m_customWriter(WTFMove(attachment.m_customWriter))
 {
     attachment.m_type = Uninitialized;
-    attachment.m_size = 0;
 }
 
 Attachment::Attachment(CustomWriter&& writer)
     : m_type(CustomWriterType)
-    , m_size(0)
     , m_customWriter(WTFMove(writer))
 {
 }
@@ -74,8 +63,6 @@ Attachment& Attachment::operator=(Attachment&& attachment)
     m_type = attachment.m_type;
     attachment.m_type = Uninitialized;
     m_fd = WTFMove(attachment.m_fd);
-    m_size = attachment.m_size;
-    attachment.m_size = 0;
     m_customWriter = WTFMove(attachment.m_customWriter);
 
     return *this;

--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -27,21 +27,24 @@
 #pragma once
 
 #include <wtf/Forward.h>
-#include <wtf/MachSendRight.h>
-#include <wtf/Noncopyable.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 #if USE(UNIX_DOMAIN_SOCKETS)
-#include "Attachment.h"
+#include <wtf/unix/UnixFileDescriptor.h>
 #endif
 
 #if OS(WINDOWS)
 #include <wtf/win/Win32Handle.h>
 #endif
 
+#if OS(DARWIN)
+#include <wtf/MachSendRight.h>
+#endif
+
 namespace IPC {
 class Decoder;
 class Encoder;
+class Connection;
 }
 
 namespace WebCore {
@@ -49,12 +52,6 @@ class FragmentedSharedBuffer;
 class ProcessIdentity;
 class SharedBuffer;
 }
-
-#if OS(DARWIN)
-namespace WTF {
-class MachSendRight;
-}
-#endif
 
 namespace WebKit {
 
@@ -85,22 +82,25 @@ public:
 
         void clear();
 
-#if USE(UNIX_DOMAIN_SOCKETS)
-        IPC::Attachment releaseAttachment() const;
-        void adoptAttachment(IPC::Attachment&&);
-#endif
         void encode(IPC::Encoder&) const;
         static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, Handle&);
-    private:
-        friend class SharedMemory;
 #if USE(UNIX_DOMAIN_SOCKETS)
-        mutable IPC::Attachment m_attachment;
+        UnixFileDescriptor releaseHandle();
+#endif
+
+    private:
+#if USE(UNIX_DOMAIN_SOCKETS)
+        mutable UnixFileDescriptor m_handle;
 #elif OS(DARWIN)
         mutable MachSendRight m_handle;
 #elif OS(WINDOWS)
         mutable Win32Handle m_handle;
 #endif
         size_t m_size { 0 };
+        friend class SharedMemory;
+#if USE(UNIX_DOMAIN_SOCKETS)
+        friend class IPC::Connection;
+#endif
     };
 
     // FIXME: Change these factory functions to return Ref<SharedMemory> and crash on failure.
@@ -149,7 +149,7 @@ private:
 #endif
 
 #if USE(UNIX_DOMAIN_SOCKETS)
-    std::optional<int> m_fileDescriptor;
+    UnixFileDescriptor m_fileDescriptor;
     bool m_isWrappingMap { false };
 #elif OS(DARWIN)
     MachSendRight m_sendRight;

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "Attachment.h"
 #include "PageClient.h"
 #include "WebFullScreenManagerProxy.h"
 


### PR DESCRIPTION
#### bd0da08a754582fb65d029cdbbd6268de8e16a68
<pre>
IPC::Attachment is used as an encoded type on Unix
<a href="https://bugs.webkit.org/show_bug.cgi?id=244925">https://bugs.webkit.org/show_bug.cgi?id=244925</a>
rdar://problem/99684383

Reviewed by Žan Doberšek.

IPC::Attachment is an attachment to the encoded and decoded data.
The attachment itself should not be encoded or decoded.
This causes problems:
 - SharedMemory implementations of other platforms are harder
   to maintain
 - General IPC code related to attachments are harder to
   implement
 - Unix connection implementation is more complex than it should
   be.

The SharedMemory::Handle should encode the size of the underlying
memory object, pointed by the file descriptor. The file descriptor
is the attachment that should be sent via domain sockets.
Removes the size from the IPC::Attachment, and make the IPC file
descriptor message structures. Simplifies the implementation
because the IPC::Attachment transfers only file descriptor type,
where as before it would transfer socket type and shared memory type.

* Source/WebKit/Platform/IPC/Attachment.h:
(IPC::Attachment::Attachment::isNull const):
(IPC::Attachment::Attachment::size const): Deleted.
* Source/WebKit/Platform/IPC/unix/AttachmentUnix.cpp:
(IPC::Attachment::Attachment):
(IPC::Attachment::operator=):
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::AttachmentInfo::type const):
(IPC::Connection::processMessage):
(IPC::Connection::sendOutputMessage):
(IPC::AttachmentInfo::setSize): Deleted.
(IPC::AttachmentInfo::size const): Deleted.
* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Platform/unix/SharedMemoryUnix.cpp:
(WebKit::SharedMemory::Handle::clear):
(WebKit::SharedMemory::Handle::isNull const):
(WebKit::SharedMemory::Handle::encode const):
(WebKit::SharedMemory::Handle::decode):
(WebKit::createSharedMemory):
(WebKit::SharedMemory::allocate):
(WebKit::SharedMemory::map):
(WebKit::SharedMemory::wrapMap):
(WebKit::SharedMemory::~SharedMemory):
(WebKit::SharedMemory::createHandle):

Canonical link: <a href="https://commits.webkit.org/254512@main">https://commits.webkit.org/254512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c90ac5965ea372941d68f539a67e4ef8df3dc96f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89284 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98592 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32348 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81645 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93048 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25689 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/76222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25631 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80557 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68607 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30122 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29849 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15532 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3169 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33296 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/76222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34623 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->