### PR TITLE
[GTK][WPE] Use a single xdg-dbus-proxy process

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h
+++ b/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h
@@ -28,29 +28,34 @@
 #if ENABLE(BUBBLEWRAP_SANDBOX)
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/Vector.h>
 #include <wtf/text/CString.h>
+#include <wtf/unix/UnixFileDescriptor.h>
 
 namespace WebKit {
 
 class XDGDBusProxy {
     WTF_MAKE_NONCOPYABLE(XDGDBusProxy); WTF_MAKE_FAST_ALLOCATED;
 public:
-    enum class Type { SessionBus, AccessibilityBus };
-    XDGDBusProxy(Type, bool = false);
-    ~XDGDBusProxy();
+    XDGDBusProxy() = default;
+    ~XDGDBusProxy() = default;
 
-    const CString& proxyPath() const { return m_proxyPath; }
-    const CString& path() const { return m_path; }
+    enum class AllowPortals : bool { No, Yes };
+    std::optional<std::pair<CString, CString>> dbusSessionProxy(AllowPortals);
+    std::optional<std::pair<CString, CString>> accessibilityProxy();
+
+    bool launch();
 
 private:
-    CString makeProxy() const;
-    int launch(bool) const;
+    static CString makePath(const char* dbusAddress);
+    static CString makeProxy(const char* proxyTemplate);
 
-    Type m_type;
-    CString m_dbusAddress;
-    CString m_proxyPath;
-    CString m_path;
-    int m_syncFD { -1 };
+    Vector<CString> m_args;
+    CString m_dbusSessionProxyPath;
+    CString m_dbusSessionPath;
+    CString m_accessibilityProxyPath;
+    CString m_accessibilityPath;
+    UnixFileDescriptor m_syncFD;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### f6198cdad380b68e02c7a135b18fcf7e387078ea
<pre>
[GTK][WPE] Use a single xdg-dbus-proxy process
<a href="https://bugs.webkit.org/show_bug.cgi?id=244930">https://bugs.webkit.org/show_bug.cgi?id=244930</a>

Reviewed by Michael Catanzaro.

We currently spawn two xdg-dbus-proxy processes, one for the session bus
and one for the atspi bus, but we can do both with a single process.

* Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp:
(WebKit::bindDBusSession): Receive the XDGDBusProxy as argument. Use the
new api to get the proxy paths.
(WebKit::bindA11y): Ditto.
(WebKit::bubblewrapSpawn): Create a single XDGDBusProxy and pass it to bindDBusSession() and bindA11y().
* Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp:
(WebKit::XDGDBusProxy::makePath): Helper to create a path for the given DBus address.
(WebKit::XDGDBusProxy::makeProxy): Helper to create the proxy file using the given template.
(WebKit::XDGDBusProxy::dbusSessionProxy): Return the proxy paths for DBus session.
(WebKit::XDGDBusProxy::accessibilityProxy): Return the proxy paths for atspi.
(WebKit::XDGDBusProxy::launch): Return falseif we don&apos;t need to spawn xdg-dbus-proxy at all.
(WebKit::XDGDBusProxy::XDGDBusProxy): Deleted.
(WebKit::XDGDBusProxy::~XDGDBusProxy): Deleted.
(WebKit::XDGDBusProxy::makeProxy const): Deleted.
(WebKit::XDGDBusProxy::launch const): Deleted.
* Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h:
(WebKit::XDGDBusProxy::proxyPath const): Deleted.
(WebKit::XDGDBusProxy::path const): Deleted.
(): Deleted.

Canonical link: <a href="https://commits.webkit.org/254293@main">https://commits.webkit.org/254293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fca670bdad02b2758f8c74faf2f1caee2b84b314

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97786 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31648 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27229 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80819 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92422 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25104 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75533 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25045 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68008 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29307 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29178 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15072 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3035 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38003 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34181 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->