### PR TITLE
AX: Support VTT-based extended audio descriptions

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4795,6 +4795,7 @@ http/tests/media/hls/hls-hdr-switch.html [ Skip ]
 http/tests/media/video-canplaythrough-webm.html [ Skip ]
 media/media-session/mock-coordinator.html [ Skip ]
 media/track/track-description-cue.html [ Skip ]
+media/track/track-extended-descriptions.html [ Skip ]
 
 # These tests rely on webkit-test-runner flags that aren't implemented for DumpRenderTree, so they will fail under legacy WebKit.
 editing/selection/expando.html [ Failure ]

--- a/LayoutTests/media/track/captions-webvtt/captions-extended-descriptions.vtt
+++ b/LayoutTests/media/track/captions-webvtt/captions-extended-descriptions.vtt
@@ -1,0 +1,10 @@
+WEBVTT
+
+1
+00:00:01.100 --> 00:00:02.000
+1 - The first cue, it is much too long to complete
+
+2
+00:00:03.000 --> 00:00:15.000
+2 - The second cue, from time 3 to 15
+

--- a/LayoutTests/media/track/track-extended-descriptions-expected.txt
+++ b/LayoutTests/media/track/track-extended-descriptions-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS WebVTT extended audio descriptions
+

--- a/LayoutTests/media/track/track-extended-descriptions.html
+++ b/LayoutTests/media/track/track-extended-descriptions.html
@@ -7,10 +7,10 @@
         <script src=../media-file.js></script>
     </head>
     <body>
-        <video controls muted>
+        <video controls>
         </video>
         
-        <script>            
+        <script>
 
 promise_test(async (t) => {
 
@@ -18,8 +18,9 @@ promise_test(async (t) => {
 
     if (window.internals) {
         internals.settings.setShouldDisplayTrackKind('TextDescriptions', true);
-        internals.settings.setAudioDescriptionsEnabled(true);
+        internals.settings.setExtendedAudioDescriptionsEnabled(true);
         internals.enableMockSpeechSynthesizerForMediaElement(video);
+        internals.setSpeechUtteranceDuration(2);
     }
 
     video.src = findMediaFile('video', '../content/test');
@@ -27,15 +28,15 @@ promise_test(async (t) => {
 
     let descriptionsTrack = document.createElement('track');
     descriptionsTrack.setAttribute('kind', 'descriptions');
-    descriptionsTrack.setAttribute('src', 'captions-webvtt/captions-descriptions.vtt');
+    descriptionsTrack.setAttribute('src', 'captions-webvtt/captions-extended-descriptions.vtt');
     video.appendChild(descriptionsTrack);
     await new Promise(resolve => descriptionsTrack.onload = resolve);
 
     let cues = descriptionsTrack.track.cues;
-    assert_equals(cues.length, 3);
+    assert_equals(cues.length, 2);
 
-    let checkCue = (cue, expectedText) => {
-        assert_equals(cue.text, expectedText);
+    let checkCue = (cue, expectedId) => {
+        assert_equals(cue.id, expectedId);
         if (!window.internals)
             return;
         
@@ -49,23 +50,29 @@ promise_test(async (t) => {
 
         let utterance = window.internals.speechSynthesisUtteranceForCue(spokenCue);
         assert_not_equals(utterance, null, 'cue utterance is not null');
-        assert_equals(utterance.text, expectedText, 'correct text is being spoken');
+        assert_equals(utterance.text, cue.text, 'correct text is being spoken');
     }
 
-    // Seek into the range for the first cue.
-    video.currentTime = 1.1;
+    // Play into the range of the first cue...
+    video.currentTime = 1;
+    video.play();
     await new Promise(resolve => cues[0].onenter = resolve);
-    checkCue(cues[0], '1 - The first cue');
+    checkCue(cues[0], '1');
 
-    video.currentTime = 2.9;
-    await new Promise(resolve => video.onseeked = resolve);
+    // playback should pause...
+    await new Promise(resolve => video.onpause = resolve);
+    
+    // and resume.
+    await new Promise(resolve => video.onplay = resolve);
 
     // Play into the range of the second cue.
+    video.currentTime = 2.9;
+    await new Promise(resolve => video.onseeked = resolve);
     video.play();
     await new Promise(resolve => cues[1].onenter = (e) => { video.pause(); resolve() });
-    checkCue(cues[1], '2 - The second cue, from time 3 to 15');
+    checkCue(cues[1], '2');
     
-}, "WebVTT audio descriptions");
+}, "WebVTT extended audio descriptions");
 
         </script>
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -59,6 +59,7 @@ imported/w3c/web-platform-tests/speech-api/ [ Pass ]
 
 http/tests/media/fairplay [ Pass ]
 media/track/track-description-cue.html [ Pass ]
+media/track/track-extended-descriptions.html [ Pass ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -88,6 +88,7 @@ imported/w3c/web-platform-tests/speech-api [ Pass ]
 
 http/tests/media/fairplay [ Pass ]
 media/track/track-description-cue.html [ Pass ]
+media/track/track-extended-descriptions.html [ Pass ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.

--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -132,8 +132,8 @@ AsyncClipboardAPIEnabled:
 AudioDescriptionsEnabled:
   type: bool
   condition: ENABLE(VIDEO)
-  humanReadableName: "Audio descriptions for video"
-  humanReadableDescription: "Enable audio descriptions for video"
+  humanReadableName: "Audio descriptions for video - Standard"
+  humanReadableDescription: "Enable standard audio descriptions for video"
   defaultValue:
     WebKitLegacy:
       default: false
@@ -637,6 +637,19 @@ ExposeSpeakersEnabled:
   humanReadableName: "Allow speaker device selection"
   humanReadableDescription: "Allow speaker device selection"
   condition: ENABLE(MEDIA_STREAM)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
+ExtendedAudioDescriptionsEnabled:
+  type: bool
+  condition: ENABLE(VIDEO)
+  humanReadableName: "Audio descriptions for video - Extended"
+  humanReadableDescription: "Enable extended audio descriptions for video"
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -74,9 +74,9 @@ SpeechSynthesis::SpeechSynthesis(ScriptExecutionContext& context)
 
 SpeechSynthesis::~SpeechSynthesis() = default;
 
-void SpeechSynthesis::setPlatformSynthesizer(std::unique_ptr<PlatformSpeechSynthesizer> synthesizer)
+void SpeechSynthesis::setPlatformSynthesizer(Ref<PlatformSpeechSynthesizer>&& synthesizer)
 {
-    m_platformSpeechSynthesizer = WTFMove(synthesizer);
+    m_platformSpeechSynthesizer = synthesizer.ptr();
     m_voiceList.clear();
     m_currentSpeechUtterance = nullptr;
     m_utteranceQueue.clear();
@@ -93,7 +93,7 @@ void SpeechSynthesis::voicesDidChange()
 PlatformSpeechSynthesizer& SpeechSynthesis::ensurePlatformSpeechSynthesizer()
 {
     if (!m_platformSpeechSynthesizer)
-        m_platformSpeechSynthesizer = makeUnique<PlatformSpeechSynthesizer>(this);
+        m_platformSpeechSynthesizer = PlatformSpeechSynthesizer::create(*this);
     return *m_platformSpeechSynthesizer;
 }
 

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -63,7 +63,7 @@ public:
     const Vector<Ref<SpeechSynthesisVoice>>& getVoices();
 
     // Used in testing to use a mock platform synthesizer
-    WEBCORE_EXPORT void setPlatformSynthesizer(std::unique_ptr<PlatformSpeechSynthesizer>);
+    WEBCORE_EXPORT void setPlatformSynthesizer(Ref<PlatformSpeechSynthesizer>&&);
 
     // Restrictions to change default behaviors.
     enum BehaviorRestrictionFlags {
@@ -106,7 +106,7 @@ private:
     
     PlatformSpeechSynthesizer& ensurePlatformSpeechSynthesizer();
     
-    std::unique_ptr<PlatformSpeechSynthesizer> m_platformSpeechSynthesizer;
+    RefPtr<PlatformSpeechSynthesizer> m_platformSpeechSynthesizer;
     Vector<Ref<SpeechSynthesisVoice>> m_voiceList;
     RefPtr<SpeechSynthesisUtterance> m_currentSpeechUtterance;
     Deque<Ref<SpeechSynthesisUtterance>> m_utteranceQueue;

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -39,7 +39,6 @@
 #include "Document.h"
 #include "Event.h"
 #include "SourceBuffer.h"
-#include "SpeechSynthesis.h"
 #include "TextTrackClient.h"
 #include "TextTrackCueList.h"
 #include "TextTrackList.h"
@@ -654,18 +653,6 @@ void TextTrack::newCuesAvailable(const TextTrackCueList& list)
         client.textTrackAddCues(*this, list);
     });
 }
-
-#if ENABLE(SPEECH_SYNTHESIS)
-SpeechSynthesis& TextTrack::speechSynthesis()
-{
-    if (!m_speechSynthesis) {
-        m_speechSynthesis = SpeechSynthesis::create(document());
-        m_speechSynthesis->removeBehaviorRestriction(SpeechSynthesis::RequireUserGestureForSpeechStartRestriction);
-    }
-
-    return *m_speechSynthesis;
-}
-#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -37,7 +37,6 @@
 namespace WebCore {
 
 class ScriptExecutionContext;
-class SpeechSynthesis;
 class TextTrack;
 class TextTrackList;
 class TextTrackClient;
@@ -137,10 +136,6 @@ public:
 
     Document& document() const;
 
-#if ENABLE(SPEECH_SYNTHESIS)
-    SpeechSynthesis& speechSynthesis();
-#endif
-    
 protected:
     TextTrack(ScriptExecutionContext*, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language, TextTrackType);
 
@@ -181,9 +176,6 @@ private:
     ReadinessState m_readinessState { NotLoaded };
     std::optional<int> m_trackIndex;
     std::optional<int> m_renderedTrackIndex;
-#if ENABLE(SPEECH_SYNTHESIS)
-    RefPtr<SpeechSynthesis> m_speechSynthesis;
-#endif
     bool m_hasBeenConfigured { false };
 };
 

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -126,7 +126,10 @@ public:
     unsigned cueIndex() const;
 
     using SpeakCueCompletionHandler = Function<void(const TextTrackCue&)>;
-    virtual void speak(double, double, SpeakCueCompletionHandler&&) { }
+    virtual void prepareToSpeak(SpeechSynthesis&, double, double, SpeakCueCompletionHandler&&) { }
+    virtual void beginSpeaking() { }
+    virtual void pauseSpeaking() { }
+    virtual void cancelSpeaking() { }
 
 protected:
     TextTrackCue(Document&, const MediaTime& start, const MediaTime& end);

--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -226,7 +226,10 @@ private:
     };
     CueSetting settingName(VTTScanner&);
 
-    void speak(double, double, SpeakCueCompletionHandler&&) final;
+    void prepareToSpeak(SpeechSynthesis&, double, double, SpeakCueCompletionHandler&&) final;
+    void beginSpeaking() final;
+    void pauseSpeaking() final;
+    void cancelSpeaking() final;
 
     String m_content;
     String m_settings;
@@ -246,6 +249,7 @@ private:
     RefPtr<HTMLDivElement> m_cueBackdropBox;
     RefPtr<VTTCueBox> m_displayTree;
 #if ENABLE(SPEECH_SYNTHESIS)
+    RefPtr<SpeechSynthesis> m_speechSynthesis;
     RefPtr<SpeechSynthesisUtterance> m_speechUtterance;
 #endif
 

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -152,7 +152,11 @@ void CaptionUserPreferences::setUserPrefersSubtitles(bool preference)
 bool CaptionUserPreferences::userPrefersTextDescriptions() const
 {
     auto* page = currentPage();
-    return page && page->settings().audioDescriptionsEnabled() && page->settings().shouldDisplayTextDescriptions();
+    if (!page)
+        return false;
+
+    auto& settings = page->settings();
+    return settings.shouldDisplayTextDescriptions() && (settings.audioDescriptionsEnabled() || settings.extendedAudioDescriptionsEnabled());
 }
 
 void CaptionUserPreferences::setUserPrefersTextDescriptions(bool preference)

--- a/Source/WebCore/platform/PlatformSpeechSynthesizer.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesizer.h
@@ -29,6 +29,7 @@
 #if ENABLE(SPEECH_SYNTHESIS)
 
 #include "PlatformSpeechSynthesisVoice.h"
+#include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
 
 #if PLATFORM(COCOA)
@@ -58,10 +59,10 @@ protected:
     virtual ~PlatformSpeechSynthesizerClient() = default;
 };
 
-class WEBCORE_EXPORT PlatformSpeechSynthesizer {
+class WEBCORE_EXPORT PlatformSpeechSynthesizer : public RefCounted<PlatformSpeechSynthesizer> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WEBCORE_EXPORT explicit PlatformSpeechSynthesizer(PlatformSpeechSynthesizerClient*);
+    WEBCORE_EXPORT static Ref<PlatformSpeechSynthesizer> create(PlatformSpeechSynthesizerClient&);
 
     // FIXME: We have multiple virtual functions just so we can support a mock for testing.
     // Seems wasteful. Would be nice to find a better way.
@@ -74,16 +75,17 @@ public:
     virtual void cancel();
     virtual void resetState();
 
-    PlatformSpeechSynthesizerClient* client() const { return m_speechSynthesizerClient; }
+    PlatformSpeechSynthesizerClient& client() const { return m_speechSynthesizerClient; }
 
 protected:
+    explicit PlatformSpeechSynthesizer(PlatformSpeechSynthesizerClient&);
     Vector<RefPtr<PlatformSpeechSynthesisVoice>> m_voiceList;
 
 private:
     virtual void initializeVoiceList();
 
     bool m_voiceListIsInitialized { false };
-    PlatformSpeechSynthesizerClient* m_speechSynthesizerClient;
+    PlatformSpeechSynthesizerClient& m_speechSynthesizerClient;
 
 #if PLATFORM(COCOA)
     RetainPtr<WebSpeechSynthesisWrapper> m_platformSpeechWrapper;

--- a/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
@@ -148,7 +148,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     // macOS won't send a did start speaking callback for empty strings.
 #if !HAVE(UNIFIED_SPEECHSYNTHESIS_FIX_FOR_81465164)
     if (!m_utterance->text().length())
-        m_synthesizerObject->client()->didStartSpeaking(*m_utterance);
+        m_synthesizerObject->client().didStartSpeaking(*m_utterance);
 #endif
 
     [m_synthesizer speakUtterance:avUtterance];
@@ -198,7 +198,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     if (!m_utterance || m_utterance->wrapper() != utterance)
         return;
 
-    m_synthesizerObject->client()->didStartSpeaking(*m_utterance);
+    m_synthesizerObject->client().didStartSpeaking(*m_utterance);
 }
 
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didFinishSpeechUtterance:(AVSpeechUtterance *)utterance
@@ -211,7 +211,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     RefPtr<WebCore::PlatformSpeechSynthesisUtterance> protectedUtterance = m_utterance;
     m_utterance = nullptr;
 
-    m_synthesizerObject->client()->didFinishSpeaking(*protectedUtterance);
+    m_synthesizerObject->client().didFinishSpeaking(*protectedUtterance);
 }
 
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didPauseSpeechUtterance:(AVSpeechUtterance *)utterance
@@ -220,7 +220,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     if (!m_utterance || m_utterance->wrapper() != utterance)
         return;
 
-    m_synthesizerObject->client()->didPauseSpeaking(*m_utterance);
+    m_synthesizerObject->client().didPauseSpeaking(*m_utterance);
 }
 
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didContinueSpeechUtterance:(AVSpeechUtterance *)utterance
@@ -229,7 +229,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     if (!m_utterance || m_utterance->wrapper() != utterance)
         return;
 
-    m_synthesizerObject->client()->didResumeSpeaking(*m_utterance);
+    m_synthesizerObject->client().didResumeSpeaking(*m_utterance);
 }
 
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didCancelSpeechUtterance:(AVSpeechUtterance *)utterance
@@ -242,7 +242,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     RefPtr<WebCore::PlatformSpeechSynthesisUtterance> protectedUtterance = m_utterance;
     m_utterance = nullptr;
 
-    m_synthesizerObject->client()->didFinishSpeaking(*protectedUtterance);
+    m_synthesizerObject->client().didFinishSpeaking(*protectedUtterance);
 }
 
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer willSpeakRangeOfSpeechString:(NSRange)characterRange utterance:(AVSpeechUtterance *)utterance
@@ -252,14 +252,19 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
         return;
 
     // AVSpeechSynthesizer only supports word boundaries.
-    m_synthesizerObject->client()->boundaryEventOccurred(*m_utterance, WebCore::SpeechBoundary::SpeechWordBoundary, characterRange.location, characterRange.length);
+    m_synthesizerObject->client().boundaryEventOccurred(*m_utterance, WebCore::SpeechBoundary::SpeechWordBoundary, characterRange.location, characterRange.length);
 }
 
 @end
 
 namespace WebCore {
 
-PlatformSpeechSynthesizer::PlatformSpeechSynthesizer(PlatformSpeechSynthesizerClient* client)
+Ref<PlatformSpeechSynthesizer> PlatformSpeechSynthesizer::create(PlatformSpeechSynthesizerClient& client)
+{
+    return adoptRef(*new PlatformSpeechSynthesizer(client));
+}
+
+PlatformSpeechSynthesizer::PlatformSpeechSynthesizer(PlatformSpeechSynthesizerClient& client)
     : m_speechSynthesizerClient(client)
 {
 }

--- a/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
+++ b/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc.  All rights reserved.
+ * Copyright (C) 2013-2022 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,7 +31,12 @@
 
 namespace WebCore {
 
-PlatformSpeechSynthesizerMock::PlatformSpeechSynthesizerMock(PlatformSpeechSynthesizerClient* client)
+Ref<PlatformSpeechSynthesizer> PlatformSpeechSynthesizerMock::create(PlatformSpeechSynthesizerClient& client)
+{
+    return adoptRef(*new PlatformSpeechSynthesizerMock(client));
+}
+
+PlatformSpeechSynthesizerMock::PlatformSpeechSynthesizerMock(PlatformSpeechSynthesizerClient& client)
     : PlatformSpeechSynthesizer(client)
     , m_speakingFinishedTimer(*this, &PlatformSpeechSynthesizerMock::speakingFinished)
 {
@@ -45,7 +50,7 @@ void PlatformSpeechSynthesizerMock::speakingFinished()
     RefPtr<PlatformSpeechSynthesisUtterance> protect(m_utterance);
     m_utterance = nullptr;
 
-    client()->didFinishSpeaking(*protect);
+    client().didFinishSpeaking(*protect);
 }
 
 void PlatformSpeechSynthesizerMock::initializeVoiceList()
@@ -59,14 +64,14 @@ void PlatformSpeechSynthesizerMock::speak(RefPtr<PlatformSpeechSynthesisUtteranc
 {
     ASSERT(!m_utterance);
     m_utterance = WTFMove(utterance);
-    client()->didStartSpeaking(*m_utterance);
+    client().didStartSpeaking(*m_utterance);
 
     // Fire a fake word and then sentence boundary event. Since the entire sentence is the full length, pick arbitrary (3) length for the word.
-    client()->boundaryEventOccurred(*m_utterance, SpeechBoundary::SpeechWordBoundary, 0, 3);
-    client()->boundaryEventOccurred(*m_utterance, SpeechBoundary::SpeechSentenceBoundary, 0, m_utterance->text().length());
+    client().boundaryEventOccurred(*m_utterance, SpeechBoundary::SpeechWordBoundary, 0, 3);
+    client().boundaryEventOccurred(*m_utterance, SpeechBoundary::SpeechSentenceBoundary, 0, m_utterance->text().length());
 
     // Give the fake speech job some time so that pause and other functions have time to be called.
-    m_speakingFinishedTimer.startOneShot(100_ms);
+    m_speakingFinishedTimer.startOneShot(m_utteranceDuration);
 }
 
 void PlatformSpeechSynthesizerMock::cancel()
@@ -75,18 +80,24 @@ void PlatformSpeechSynthesizerMock::cancel()
         return;
 
     m_speakingFinishedTimer.stop();
-    client()->speakingErrorOccurred(*m_utterance);
-    m_utterance = nullptr;
+    auto utterance = std::exchange(m_utterance, nullptr);
+    client().speakingErrorOccurred(*utterance);
 }
 
 void PlatformSpeechSynthesizerMock::pause()
 {
-    client()->didPauseSpeaking(*m_utterance);
+    if (!m_utterance)
+        return;
+
+    client().didPauseSpeaking(*m_utterance);
 }
 
 void PlatformSpeechSynthesizerMock::resume()
 {
-    client()->didResumeSpeaking(*m_utterance);
+    if (!m_utterance)
+        return;
+
+    client().didResumeSpeaking(*m_utterance);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.h
+++ b/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc.  All rights reserved.
+ * Copyright (C) 2013-2022 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class PlatformSpeechSynthesizerMock : public PlatformSpeechSynthesizer {
 public:
-    WEBCORE_EXPORT explicit PlatformSpeechSynthesizerMock(PlatformSpeechSynthesizerClient*);
+    WEBCORE_EXPORT static Ref<PlatformSpeechSynthesizer> create(PlatformSpeechSynthesizerClient&);
 
     virtual ~PlatformSpeechSynthesizerMock();
     virtual void speak(RefPtr<PlatformSpeechSynthesisUtterance>&&);
@@ -43,12 +43,17 @@ public:
     virtual void resume();
     virtual void cancel();
 
+    void setUtteranceDuration(Seconds duration) { m_utteranceDuration = duration; }
+
 private:
+    explicit PlatformSpeechSynthesizerMock(PlatformSpeechSynthesizerClient&);
+
     virtual void initializeVoiceList();
     void speakingFinished();
 
     Timer m_speakingFinishedTimer;
     RefPtr<PlatformSpeechSynthesisUtterance> m_utterance;
+    Seconds m_utteranceDuration { 100_ms };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -165,6 +165,10 @@ class MockMediaSessionCoordinator;
 class HTMLModelElement;
 #endif
 
+#if ENABLE(SPEECH_SYNTHESIS)
+class PlatformSpeechSynthesizerMock;
+#endif
+
 template<typename IDLType> class DOMPromiseDeferred;
 
 struct MockWebAuthenticationConfiguration;
@@ -657,6 +661,8 @@ public:
 
 #if ENABLE(SPEECH_SYNTHESIS)
     void enableMockSpeechSynthesizer();
+    void enableMockSpeechSynthesizerForMediaElement(HTMLMediaElement&);
+    ExceptionOr<void> setSpeechUtteranceDuration(double);
 #endif
 
 #if ENABLE(MEDIA_STREAM)
@@ -1386,6 +1392,9 @@ private:
     RefPtr<WebXRTest> m_xrTest;
 #endif
 
+#if ENABLE(SPEECH_SYNTHESIS)
+    RefPtr<PlatformSpeechSynthesizerMock> m_platformSpeechSynthesizer;
+#endif
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
     RefPtr<MockMediaSessionCoordinator> m_mockMediaSessionCoordinator;
 #endif

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -787,6 +787,8 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     undefined enableMockMediaCapabilities();
 
     [Conditional=SPEECH_SYNTHESIS] undefined enableMockSpeechSynthesizer();
+    [Conditional=SPEECH_SYNTHESIS] undefined enableMockSpeechSynthesizerForMediaElement(HTMLMediaElement element);
+    [Conditional=SPEECH_SYNTHESIS] undefined setSpeechUtteranceDuration(double duration);
 
     DOMString getImageSourceURL(Element element);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10979,14 +10979,13 @@ void WebPageProxy::resetSpeechSynthesizer()
     synthesisData.speakingStartedCompletionHandler = nullptr;
     synthesisData.speakingPausedCompletionHandler = nullptr;
     synthesisData.speakingResumedCompletionHandler = nullptr;
-    if (synthesisData.synthesizer)
-        synthesisData.synthesizer->resetState();
+    synthesisData.synthesizer->resetState();
 }
 
 WebPageProxy::SpeechSynthesisData& WebPageProxy::speechSynthesisData()
 {
     if (!m_speechSynthesisData)
-        m_speechSynthesisData = SpeechSynthesisData { makeUnique<PlatformSpeechSynthesizer>(this), nullptr, nullptr, nullptr, nullptr, nullptr };
+        m_speechSynthesisData = SpeechSynthesisData { PlatformSpeechSynthesizer::create(*this), nullptr, nullptr, nullptr, nullptr, nullptr };
     return *m_speechSynthesisData;
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3231,7 +3231,7 @@ private:
 
 #if ENABLE(SPEECH_SYNTHESIS)
     struct SpeechSynthesisData {
-        std::unique_ptr<WebCore::PlatformSpeechSynthesizer> synthesizer;
+        Ref<WebCore::PlatformSpeechSynthesizer> synthesizer;
         RefPtr<WebCore::PlatformSpeechSynthesisUtterance> utterance;
         CompletionHandler<void()> speakingStartedCompletionHandler;
         CompletionHandler<void()> speakingFinishedCompletionHandler;


### PR DESCRIPTION
#### c2f7594742ab1169aa5e66097a2a4de8f928a746
<pre>
AX: Support VTT-based extended audio descriptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=244931">https://bugs.webkit.org/show_bug.cgi?id=244931</a>
&lt;rdar://99697422&gt;

Reviewed by Jer Noble.

* LayoutTests/media/track/captions-webvtt/captions-extended-descriptions.vtt: Added.
* LayoutTests/media/track/track-description-cue.html:
* LayoutTests/media/track/track-extended-descriptions-expected.txt: Added.
* LayoutTests/media/track/track-extended-descriptions.html: Added.
* LayoutTests/TestExpectations: Feature is Cocoa-specific so far, skip test globally.
* LayoutTests/platform/ios/TestExpectations: Enable test on iOS.
* LayoutTests/platform/mac/TestExpectations: Enable test on macOS.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml: Add &apos;ExtendedAudioDescriptionsEnabled&apos;
setting.

* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::setPlatformSynthesizer): Take a Ref&lt;&gt; synthesizer instead of a
unique_ptr.
(WebCore::SpeechSynthesis::ensurePlatformSpeechSynthesizer): Use PlatformSpeechSynthesizer::create.
* Source/WebCore/Modules/speech/SpeechSynthesis.h:

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::convertEnumerationToString): Added.
(WebCore::HTMLMediaElement::unregisterWithDocument): Cancel speech, clear synthesize.
(WebCore::HTMLMediaElement::updateActiveTextTrackCues): Cleanup for readability.
(WebCore::HTMLMediaElement::setSpeechSynthesisState): Update for extended descriptions.
(WebCore::HTMLMediaElement::speakCueText): Call cue.prepareToSpeak as we don&apos;t always want
a cue to begin speaking immediately.
(WebCore::HTMLMediaElement::pauseSpeakingCueText): Support completing an extended description.
(WebCore::HTMLMediaElement::resumeSpeakingCueText): Ditto.
(WebCore::HTMLMediaElement::pausePlaybackForExtendedTextDescription): New, pause playback
to allow an extended description to complete.
(WebCore::HTMLMediaElement::speechSynthesis): Have the media element own the synthesizer
since the logic for managing it is here.
(WebCore::HTMLMediaElement::executeCueEnterOrExitActionForTime): Support extended descriptions.
(WebCore::HTMLMediaElement::addTextTrack): Set m_userPrefersExtendedDescriptions.
(WebCore::HTMLMediaElement::configureTextTrackGroup): Use m_userPrefersTextDescriptions.
(WebCore::HTMLMediaElement::updatePlayState): Pause and resume speaking here, not in `playPlayer`
and `pausePlayer`.
(WebCore::HTMLMediaElement::playPlayer): Ditto.
(WebCore::HTMLMediaElement::pausePlayer): Ditto.
(WebCore::HTMLMediaElement::captionPreferencesChanged): set m_userPrefersExtendedDescriptions.
(WebCore::HTMLMediaElement::executeCueEnterOrLeaveAction): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
(WTF::LogArgument&lt;WebCore::HTMLMediaElement::SpeechSynthesisState&gt;::toString):

* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::speechSynthesis): Deleted.
* Source/WebCore/html/track/TextTrack.h:

* Source/WebCore/html/track/TextTrackCue.h:
(WebCore::TextTrackCue::prepareToSpeak): Renamed from `speak`.
(WebCore::TextTrackCue::beginSpeaking): Added.
(WebCore::TextTrackCue::pauseSpeaking): Added.
(WebCore::TextTrackCue::cancelSpeaking): Added.
(WebCore::TextTrackCue::speak): Deleted.

* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::mapVideoRateToSpeechRate): Convert playback rate to web speech rate.
(WebCore::VTTCue::prepareToSpeak): Call completion handler when there is nothing to speak
or when the track is null. Stash `speechSynthesis` for future use.
(WebCore::VTTCue::beginSpeaking): Begin or resume speaking.
(WebCore::VTTCue::pauseSpeaking):
(WebCore::VTTCue::cancelSpeaking):
(WebCore::VTTCue::speak): Deleted.
* Source/WebCore/html/track/VTTCue.h:

* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::CaptionUserPreferences::userPrefersTextDescriptions const): Consider setting for
extended descriptions.
* Source/WebCore/platform/PlatformSpeechSynthesizer.h: Make refcounted.

* Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm:
(-[WebSpeechSynthesisWrapper speakUtterance:]): `client()` is a ref, not a pointer.
(-[WebSpeechSynthesisWrapper speechSynthesizer:didStartSpeechUtterance:]): Ditto.
(-[WebSpeechSynthesisWrapper speechSynthesizer:didFinishSpeechUtterance:]): Ditto.
(-[WebSpeechSynthesisWrapper speechSynthesizer:didPauseSpeechUtterance:]): Ditto.
(-[WebSpeechSynthesisWrapper speechSynthesizer:didContinueSpeechUtterance:]): Ditto.
(-[WebSpeechSynthesisWrapper speechSynthesizer:didCancelSpeechUtterance:]): Ditto.
(-[WebSpeechSynthesisWrapper speechSynthesizer:willSpeakRangeOfSpeechString:utterance:]): Ditto.
(WebCore::PlatformSpeechSynthesizer::create): Client can never be null so take ref, not a pointer.
(WebCore::PlatformSpeechSynthesizer::PlatformSpeechSynthesizer):

* Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp:
(WebCore::PlatformSpeechSynthesizerMock::create): Client can never be null so take ref, not a pointer.
(WebCore::PlatformSpeechSynthesizerMock::PlatformSpeechSynthesizerMock):
(WebCore::PlatformSpeechSynthesizerMock::speakingFinished): `client()` is a ref, not a pointer.
(WebCore::PlatformSpeechSynthesizerMock::speak): Ditto. Use configurable utterance duration.
(WebCore::PlatformSpeechSynthesizerMock::cancel): Ditto.
(WebCore::PlatformSpeechSynthesizerMock::pause): Ditto. Null-check `m_utterance`.
(WebCore::PlatformSpeechSynthesizerMock::resume): Ditto.
* Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.h:
(WebCore::PlatformSpeechSynthesizerMock::setUtteranceDuration):

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::enableMockSpeechSynthesizer):
(WebCore::Internals::enableMockSpeechSynthesizerForMediaElement):
(WebCore::Internals::setSpeechUtteranceDuration):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::resetSpeechSynthesizer): PlatformSpeechSynthesizer is a Ref, not
a unique_ptr.
(WebKit::WebPageProxy::speechSynthesisData): Ditto.
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/254502@main">https://commits.webkit.org/254502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebfd896d22b5e55c471932977b0d92b96a922cb1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89211 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98525 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154839 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32278 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27822 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92994 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25638 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76130 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25572 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68546 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/80915 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30055 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14538 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74712 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29780 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15500 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26329 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3159 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38458 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/77577 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34591 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17165 "Passed tests") | 
<!--EWS-Status-Bubble-End-->