### PR TITLE
Rename unique origin to opaque origin to match the naming in the specification

### DIFF
--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -50,7 +50,7 @@ static std::optional<ClientOrigin> clientOriginFromContext(ScriptExecutionContex
     if (!context)
         return std::nullopt;
     auto* origin = context->securityOrigin();
-    if (!origin || origin->isUnique())
+    if (!origin || origin->isOpaque())
         return std::nullopt;
     return { { context->topOrigin().data(), origin->data() } };
 }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6372,7 +6372,7 @@ void Document::initSecurityContext()
         // No source for a security context.
         // This can occur via document.implementation.createDocument().
         setCookieURL(URL({ }, emptyString()));
-        setSecurityOriginPolicy(SecurityOriginPolicy::create(SecurityOrigin::createUnique()));
+        setSecurityOriginPolicy(SecurityOriginPolicy::create(SecurityOrigin::createOpaque()));
         setContentSecurityPolicy(makeUnique<ContentSecurityPolicy>(URL { emptyString() }, *this));
         return;
     }
@@ -6391,7 +6391,7 @@ void Document::initSecurityContext()
     if (!isSecurityOriginUnique)
         isSecurityOriginUnique = documentLoader && documentLoader->response().tainting() == ResourceResponse::Tainting::Opaque;
 
-    setSecurityOriginPolicy(SecurityOriginPolicy::create(isSecurityOriginUnique ? SecurityOrigin::createUnique() : SecurityOrigin::create(m_url)));
+    setSecurityOriginPolicy(SecurityOriginPolicy::create(isSecurityOriginUnique ? SecurityOrigin::createOpaque() : SecurityOrigin::create(m_url)));
     setContentSecurityPolicy(makeUnique<ContentSecurityPolicy>(URL { m_url }, *this));
 
     String overrideContentSecurityPolicy = m_frame->loader().client().overrideContentSecurityPolicy();
@@ -6422,7 +6422,7 @@ void Document::initSecurityContext()
         } else if (!settings().allowFileAccessFromFileURLs()) {
             // Some clients want local URLs to have even tighter restrictions by default, and not be able to access other local files.
             // FIXME 81578: The naming of this is confusing. Files with restricted access to other local files
-            // still can have other privileges that can be remembered, thereby not making them unique origins.
+            // still can have other privileges that can be remembered, thereby not making them opaque origins.
             securityOrigin().setEnforcesFilePathSeparation();
         }
     }

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -83,7 +83,7 @@ std::optional<bool> DocumentStorageAccess::hasStorageAccessQuickCheck()
         return true;
 
     auto& securityOrigin = m_document.securityOrigin();
-    if (!frame || securityOrigin.isUnique())
+    if (!frame || securityOrigin.isOpaque())
         return false;
 
     if (frame->isMainFrame())
@@ -153,7 +153,7 @@ std::optional<StorageAccessQuickResult> DocumentStorageAccess::requestStorageAcc
         return StorageAccessQuickResult::Grant;
 
     auto& securityOrigin = m_document.securityOrigin();
-    if (!frame || securityOrigin.isUnique() || !isAllowedToRequestStorageAccess())
+    if (!frame || securityOrigin.isOpaque() || !isAllowedToRequestStorageAccess())
         return StorageAccessQuickResult::Reject;
 
     if (frame->isMainFrame())

--- a/Source/WebCore/dom/EmptyScriptExecutionContext.h
+++ b/Source/WebCore/dom/EmptyScriptExecutionContext.h
@@ -81,7 +81,7 @@ public:
 private:
     EmptyScriptExecutionContext(JSC::VM& vm)
         : m_vm(vm)
-        , m_origin(SecurityOrigin::createUnique())
+        , m_origin(SecurityOrigin::createOpaque())
         , m_eventLoop(EmptyEventLoop::create(vm))
         , m_eventLoopTaskGroup(makeUnique<EventLoopTaskGroup>(m_eventLoop))
     {

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -743,7 +743,7 @@ static bool isOriginEquivalentToLocal(const SecurityOrigin& origin)
 ScriptExecutionContext::HasResourceAccess ScriptExecutionContext::canAccessResource(ResourceType type) const
 {
     auto* origin = securityOrigin();
-    if (!origin || origin->isUnique())
+    if (!origin || origin->isOpaque())
         return HasResourceAccess::No;
 
     switch (type) {

--- a/Source/WebCore/dom/SecurityContext.cpp
+++ b/Source/WebCore/dom/SecurityContext.cpp
@@ -77,8 +77,8 @@ void SecurityContext::enforceSandboxFlags(SandboxFlags mask, SandboxFlagsSource 
     m_sandboxFlags |= mask;
 
     // The SandboxOrigin is stored redundantly in the security origin.
-    if (isSandboxed(SandboxOrigin) && securityOriginPolicy() && !securityOriginPolicy()->origin().isUnique())
-        setSecurityOriginPolicy(SecurityOriginPolicy::create(SecurityOrigin::createUnique()));
+    if (isSandboxed(SandboxOrigin) && securityOriginPolicy() && !securityOriginPolicy()->origin().isOpaque())
+        setSecurityOriginPolicy(SecurityOriginPolicy::create(SecurityOrigin::createOpaque()));
 }
 
 bool SecurityContext::isSupportedSandboxPolicy(StringView policy)

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -50,7 +50,7 @@ static String agentClusterKeyOrNullIfUnique(const SecurityOrigin& origin)
 {
     auto computeKey = [&] {
         // https://html.spec.whatwg.org/multipage/webappapis.html#obtain-agent-cluster-key
-        if (origin.isUnique())
+        if (origin.isOpaque())
             return origin.toString();
         RegistrableDomain registrableDomain { origin.data() };
         if (registrableDomain.isEmpty())

--- a/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
+++ b/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
@@ -210,8 +210,8 @@ RefPtr<SecurityOrigin> ThreadableBlobRegistry::getCachedOrigin(const URL& url)
     if (!url.protocolIsBlob() || !isBlobURLContainsNullOrigin(url))
         return nullptr;
 
-    // If we do not have a cached origin for null blob URLs, we use a unique origin.
-    return SecurityOrigin::createUnique();
+    // If we do not have a cached origin for null blob URLs, we use an opaque origin.
+    return SecurityOrigin::createOpaque();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -311,7 +311,7 @@ static inline bool shouldCrossOriginResourcePolicyCancelLoad(CrossOriginEmbedder
         return true;
 
     if (policy == CrossOriginResourcePolicy::SameSite) {
-        if (origin.isUnique())
+        if (origin.isOpaque())
             return true;
 #if ENABLE(PUBLIC_SUFFIX_LIST)
         if (!RegistrableDomain::uncheckedCreateFromHost(origin.host()).matches(response.url()))

--- a/Source/WebCore/loader/CrossOriginOpenerPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginOpenerPolicy.cpp
@@ -100,8 +100,8 @@ static std::tuple<Ref<SecurityOrigin>, CrossOriginOpenerPolicy> computeResponseO
     if (SecurityPolicy::shouldInheritSecurityOriginFromOwner(response.url()) && requester)
         return std::make_tuple(requester->securityOrigin, requester->securityOrigin->isSameOriginAs(requester->topOrigin) ? requester->crossOriginOpenerPolicy : CrossOriginOpenerPolicy { });
 
-    // If the HTTP response contains a CSP header, it may set sandbox flags, which would cause the origin to become unique.
-    auto responseOrigin = responseCSP && responseCSP->sandboxFlags() != SandboxNone ? SecurityOrigin::createUnique() : SecurityOrigin::create(response.url());
+    // If the HTTP response contains a CSP header, it may set sandbox flags, which would cause the origin to become opaque.
+    auto responseOrigin = responseCSP && responseCSP->sandboxFlags() != SandboxNone ? SecurityOrigin::createOpaque() : SecurityOrigin::create(response.url());
     return std::make_tuple(WTFMove(responseOrigin), obtainCrossOriginOpenerPolicy(response));
 }
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1213,7 +1213,7 @@ void DocumentLoader::stopLoadingForPolicyChange()
 // https://w3c.github.io/ServiceWorker/#control-and-use-window-client
 static inline bool shouldUseActiveServiceWorkerFromParent(const Document& document, const Document& parent)
 {
-    return !document.url().protocolIsInHTTPFamily() && !document.securityOrigin().isUnique() && parent.securityOrigin().isSameOriginDomain(document.securityOrigin());
+    return !document.url().protocolIsInHTTPFamily() && !document.securityOrigin().isOpaque() && parent.securityOrigin().isSameOriginDomain(document.securityOrigin());
 }
 #endif
 
@@ -1268,7 +1268,7 @@ void DocumentLoader::commitData(const SharedBuffer& data)
 #endif
 #if ENABLE(SERVICE_WORKER)
         if (m_canUseServiceWorkers) {
-            if (!document.securityOrigin().isUnique()) {
+            if (!document.securityOrigin().isOpaque()) {
                 if (m_serviceWorkerRegistrationData && m_serviceWorkerRegistrationData->activeWorker) {
                     document.setActiveServiceWorker(ServiceWorker::getOrCreate(document, WTFMove(m_serviceWorkerRegistrationData->activeWorker.value())));
                     m_serviceWorkerRegistrationData = { };
@@ -1277,8 +1277,8 @@ void DocumentLoader::commitData(const SharedBuffer& data)
                         document.setActiveServiceWorker(parent->activeServiceWorker());
                 }
             } else if (m_resultingClientId) {
-                // In case document has a unique origin, say due to sandboxing, we should have created a new context, let's create a new identifier instead.
-                if (document.securityOrigin().isUnique())
+                // In case document has an opaque origin, say due to sandboxing, we should have created a new context, let's create a new identifier instead.
+                if (document.securityOrigin().isOpaque())
                     document.createNewIdentifier();
             }
 

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -352,7 +352,7 @@ void DocumentThreadableLoader::redirectReceived(CachedResource& resource, Resour
     // https://fetch.spec.whatwg.org/#concept-http-redirect-fetch (Step 10).
     ASSERT(m_options.mode == FetchOptions::Mode::Cors);
     if (!securityOrigin().canRequest(redirectResponse.url()) && !protocolHostAndPortAreEqual(redirectResponse.url(), request.url()))
-        m_origin = SecurityOrigin::createUnique();
+        m_origin = SecurityOrigin::createOpaque();
 
     // Except in case where preflight is needed, loading should be able to continue on its own.
     // But we also handle credentials here if it is restricted to SameOrigin.

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3036,8 +3036,8 @@ void FrameLoader::addHTTPOriginIfNeeded(ResourceRequest& request, const String& 
 
     if (origin.isEmpty()) {
         // If we don't know what origin header to attach, we attach the value
-        // for an empty origin.
-        request.setHTTPOrigin(SecurityOrigin::createUnique()->toString());
+        // for an opaque origin.
+        request.setHTTPOrigin(SecurityOrigin::createOpaque()->toString());
         return;
     }
 

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -679,7 +679,7 @@ Expected<void, String> SubresourceLoader::checkRedirectionCrossOriginAccessContr
 
     // Implementing https://fetch.spec.whatwg.org/#concept-http-redirect-fetch step 10.
     if (crossOriginFlag && redirectingToNewOrigin)
-        m_origin = SecurityOrigin::createUnique();
+        m_origin = SecurityOrigin::createOpaque();
 
     newRequest.redirectAsGETIfNeeded(previousRequest, redirectResponse);
 

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -907,9 +907,9 @@ ExceptionOr<void> DOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobalObjec
         target = &sourceDocument->securityOrigin();
     } else if (options.targetOrigin != "*"_s) {
         target = SecurityOrigin::createFromString(options.targetOrigin);
-        // It doesn't make sense target a postMessage at a unique origin
-        // because there's no way to represent a unique origin in a string.
-        if (target->isUnique())
+        // It doesn't make sense target a postMessage at an opaque origin
+        // because there's no way to represent an opaque origin in a string.
+        if (target->isOpaque())
             return Exception { SyntaxError };
     }
 

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -210,7 +210,7 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
     const auto& documentSecurityOrigin = frame->document()->securityOrigin();
     // We allow sandboxed documents, 'data:'/'file:' URLs, etc. to use 'pushState'/'replaceState' to modify the URL query and fragments.
     // See https://bugs.webkit.org/show_bug.cgi?id=183028 for the compatibility concerns.
-    bool allowSandboxException = (documentSecurityOrigin.isLocal() || documentSecurityOrigin.isUnique())
+    bool allowSandboxException = (documentSecurityOrigin.isLocal() || documentSecurityOrigin.isOpaque())
         && documentURL.viewWithoutQueryOrFragmentIdentifier() == fullURL.viewWithoutQueryOrFragmentIdentifier();
 
     if (!allowSandboxException && !documentSecurityOrigin.canRequest(fullURL) && (fullURL.path() != documentURL.path() || fullURL.query() != documentURL.query()))

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -47,7 +47,7 @@ public:
     };
 
     WEBCORE_EXPORT static Ref<SecurityOrigin> create(const URL&);
-    WEBCORE_EXPORT static Ref<SecurityOrigin> createUnique();
+    WEBCORE_EXPORT static Ref<SecurityOrigin> createOpaque();
 
     WEBCORE_EXPORT static Ref<SecurityOrigin> createFromString(const String&);
     WEBCORE_EXPORT static Ref<SecurityOrigin> create(const String& protocol, const String& host, std::optional<uint16_t> port);
@@ -154,10 +154,10 @@ public:
     // The origin is a globally unique identifier assigned when the Document is
     // created. http://www.whatwg.org/specs/web-apps/current-work/#sandboxOrigin
     //
-    // There's a subtle difference between a unique origin and an origin that
+    // There's a subtle difference between an opaque origin and an origin that
     // has the SandboxOrigin flag set. The latter implies the former, and, in
     // addition, the SandboxOrigin flag is inherited by iframes.
-    bool isUnique() const { return !!m_uniqueOriginIdentifier; }
+    bool isOpaque() const { return !!m_opaqueOriginIdentifier; }
 
     // Marks a file:// origin as being in a domain defined by its path.
     // FIXME 81578: The naming of this is confusing. Files with restricted access to other local files
@@ -171,7 +171,7 @@ public:
     // the value of the SecurityOrigin's domain property.
     //
     // When using the string value, it's important to remember that it might be
-    // "null". This happens when this SecurityOrigin is unique. For example,
+    // "null". This happens when this SecurityOrigin is opaque. For example,
     // this SecurityOrigin might have come from a sandboxed iframe, the
     // SecurityOrigin might be empty, or we might have explicitly decided that
     // we shouldTreatURLSchemeAsNoAccess.
@@ -227,13 +227,13 @@ private:
     enum ShouldAllowFromThirdParty { AlwaysAllowFromThirdParty, MaybeAllowFromThirdParty };
     WEBCORE_EXPORT bool canAccessStorage(const SecurityOrigin*, ShouldAllowFromThirdParty = MaybeAllowFromThirdParty) const;
 
-    enum UniqueOriginIdentifierType { };
-    using UniqueOriginIdentifier = ProcessQualified<ObjectIdentifier<UniqueOriginIdentifierType>>;
+    enum OpaqueOriginIdentifierType { };
+    using OpaqueOriginIdentifier = ProcessQualified<ObjectIdentifier<OpaqueOriginIdentifierType>>;
 
     SecurityOriginData m_data;
     String m_domain;
     String m_filePath;
-    Markable<UniqueOriginIdentifier, UniqueOriginIdentifier::MarkableTraits> m_uniqueOriginIdentifier;
+    Markable<OpaqueOriginIdentifier, OpaqueOriginIdentifier::MarkableTraits> m_opaqueOriginIdentifier;
     bool m_universalAccess { false };
     bool m_domainWasSetInDOM { false };
     bool m_canLoadLocalResources { false };
@@ -254,7 +254,7 @@ template<class Encoder> inline void SecurityOrigin::encode(Encoder& encoder) con
     encoder << m_data;
     encoder << m_domain;
     encoder << m_filePath;
-    encoder << m_uniqueOriginIdentifier;
+    encoder << m_opaqueOriginIdentifier;
     encoder << m_universalAccess;
     encoder << m_domainWasSetInDOM;
     encoder << m_canLoadLocalResources;
@@ -278,7 +278,7 @@ template<class Decoder> inline RefPtr<SecurityOrigin> SecurityOrigin::decode(Dec
         return nullptr;
     if (!decoder.decode(origin->m_filePath))
         return nullptr;
-    if (!decoder.decode(origin->m_uniqueOriginIdentifier))
+    if (!decoder.decode(origin->m_opaqueOriginIdentifier))
         return nullptr;
     if (!decoder.decode(origin->m_universalAccess))
         return nullptr;

--- a/Source/WebCore/page/SecurityOriginData.h
+++ b/Source/WebCore/page/SecurityOriginData.h
@@ -80,7 +80,7 @@ struct SecurityOriginData {
     {
         return protocol.isNull() && host.isNull() && port == std::nullopt;
     }
-    bool isUnique() const
+    bool isOpaque() const
     {
         return protocol == emptyString() && host == emptyString() && !port;
     }

--- a/Source/WebCore/page/SecurityPolicy.cpp
+++ b/Source/WebCore/page/SecurityPolicy.cpp
@@ -229,8 +229,8 @@ bool SecurityPolicy::isAccessAllowed(const SecurityOrigin& activeOrigin, const U
 
 void SecurityPolicy::addOriginAccessAllowlistEntry(const SecurityOrigin& sourceOrigin, const String& destinationProtocol, const String& destinationDomain, bool allowDestinationSubdomains)
 {
-    ASSERT(!sourceOrigin.isUnique());
-    if (sourceOrigin.isUnique())
+    ASSERT(!sourceOrigin.isOpaque());
+    if (sourceOrigin.isOpaque())
         return;
 
     Locker locker { originAccessMapLock };
@@ -240,8 +240,8 @@ void SecurityPolicy::addOriginAccessAllowlistEntry(const SecurityOrigin& sourceO
 
 void SecurityPolicy::removeOriginAccessAllowlistEntry(const SecurityOrigin& sourceOrigin, const String& destinationProtocol, const String& destinationDomain, bool allowDestinationSubdomains)
 {
-    ASSERT(!sourceOrigin.isUnique());
-    if (sourceOrigin.isUnique())
+    ASSERT(!sourceOrigin.isOpaque());
+    if (sourceOrigin.isOpaque())
         return;
 
     Locker locker { originAccessMapLock };

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -90,7 +90,7 @@ static inline bool checkNonce(ContentSecurityPolicySourceListDirective* directiv
 }
 
 // Used to compute the comparison URL when checking frame-ancestors. We do this weird conversion so that child
-// frames of a page with a unique origin (e.g. about:blank) are not blocked due to their frame-ancestors policy
+// frames of a page with an opaque origin (e.g. about:blank) are not blocked due to their frame-ancestors policy
 // and do not need to add the parent's URL to their policy. The latter could allow the child page to be framed
 // by anyone. See <https://github.com/w3c/webappsec/issues/311> for more details.
 static inline URL urlFromOrigin(const SecurityOrigin& origin)

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -190,7 +190,7 @@ void Worker::notifyNetworkStateChange(bool isOnLine)
 void Worker::didReceiveResponse(ResourceLoaderIdentifier identifier, const ResourceResponse& response)
 {
     const URL& responseURL = response.url();
-    if (!responseURL.protocolIsBlob() && !responseURL.protocolIs("file"_s) && !SecurityOrigin::create(responseURL)->isUnique())
+    if (!responseURL.protocolIsBlob() && !responseURL.protocolIs("file"_s) && !SecurityOrigin::create(responseURL)->isOpaque())
         m_contentSecurityPolicyResponseHeaders = ContentSecurityPolicyResponseHeaders(response);
     InspectorInstrumentation::didReceiveScriptResponse(scriptExecutionContext(), identifier);
 }

--- a/Source/WebCore/worklets/WorkletGlobalScope.cpp
+++ b/Source/WebCore/worklets/WorkletGlobalScope.cpp
@@ -51,7 +51,7 @@ static std::atomic<unsigned> gNumberOfWorkletGlobalScopes { 0 };
 
 WorkletGlobalScope::WorkletGlobalScope(WorkerOrWorkletThread& thread, Ref<JSC::VM>&& vm, const WorkletParameters& parameters)
     : WorkerOrWorkletGlobalScope(WorkerThreadType::Worklet, parameters.sessionID, WTFMove(vm), &thread)
-    , m_topOrigin(SecurityOrigin::createUnique())
+    , m_topOrigin(SecurityOrigin::createOpaque())
     , m_url(parameters.windowURL)
     , m_jsRuntimeFlags(parameters.jsRuntimeFlags)
     , m_settingsValues(parameters.settingsValues)
@@ -66,7 +66,7 @@ WorkletGlobalScope::WorkletGlobalScope(WorkerOrWorkletThread& thread, Ref<JSC::V
 WorkletGlobalScope::WorkletGlobalScope(Document& document, Ref<JSC::VM>&& vm, ScriptSourceCode&& code)
     : WorkerOrWorkletGlobalScope(WorkerThreadType::Worklet, *document.sessionID(), WTFMove(vm), nullptr)
     , m_document(document)
-    , m_topOrigin(SecurityOrigin::createUnique())
+    , m_topOrigin(SecurityOrigin::createOpaque())
     , m_url(code.url())
     , m_jsRuntimeFlags(document.settings().javaScriptRuntimeFlags())
     , m_code(WTFMove(code))

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -249,7 +249,7 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
     , m_sampleBufferDisplayLayerManager(RemoteSampleBufferDisplayLayerManager::create(*this))
 #endif
 #if ENABLE(MEDIA_STREAM)
-    , m_captureOrigin(SecurityOrigin::createUnique())
+    , m_captureOrigin(SecurityOrigin::createOpaque())
 #endif
 #if ENABLE(VIDEO)
     , m_videoFrameObjectHeap(RemoteVideoFrameObjectHeap::create(m_connection.get()))

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -370,10 +370,10 @@ void NetworkLoadChecker::checkCORSRedirectedRequest(ResourceRequest&& request, V
     m_isSameOriginRequest = false;
 
     if (!m_origin->canRequest(m_previousURL) && !protocolHostAndPortAreEqual(m_previousURL, request.url())) {
-        // Use a unique origin for subsequent loads if needed.
+        // Use an opaque origin for subsequent loads if needed.
         // https://fetch.spec.whatwg.org/#concept-http-redirect-fetch (Step 10).
-        if (!m_origin || !m_origin->isUnique())
-            m_origin = SecurityOrigin::createUnique();
+        if (!m_origin || !m_origin->isOpaque())
+            m_origin = SecurityOrigin::createOpaque();
     }
 
     // FIXME: We should set the request referrer according the referrer policy.

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -724,7 +724,7 @@ std::optional<ResourceError> NetworkResourceLoader::doCrossOriginOpenerHandlingO
     }
 
     if (!m_currentCoopEnforcementResult) {
-        auto sourceOrigin = m_parameters.sourceOrigin ? Ref { *m_parameters.sourceOrigin } : SecurityOrigin::createUnique();
+        auto sourceOrigin = m_parameters.sourceOrigin ? Ref { *m_parameters.sourceOrigin } : SecurityOrigin::createOpaque();
         m_currentCoopEnforcementResult = CrossOriginOpenerPolicyEnforcementResult::from(m_parameters.documentURL, WTFMove(sourceOrigin), m_parameters.sourceCrossOriginOpenerPolicy, m_parameters.navigationRequester, m_parameters.openerURL);
     }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5070,7 +5070,7 @@ void WebPageProxy::callLoadCompletionHandlersIfNecessary(bool success)
 static OptionSet<CrossSiteNavigationDataTransfer::Flag> checkIfNavigationContainsDataTransfer(const SecurityOriginData requesterOrigin, const ResourceRequest& currentRequest)
 {
     OptionSet<CrossSiteNavigationDataTransfer::Flag> navigationDataTransfer;
-    if (requesterOrigin.securityOrigin()->isUnique())
+    if (requesterOrigin.securityOrigin()->isOpaque())
         return navigationDataTransfer;
 
     auto currentURL = currentRequest.url();
@@ -8920,7 +8920,7 @@ void WebPageProxy::queryPermission(const ClientOrigin& clientOrigin, const Permi
         completionHandler(*result);
     };
 
-    if (clientOrigin.topOrigin.isUnique()) {
+    if (clientOrigin.topOrigin.isOpaque()) {
         callback(PermissionState::Prompt);
         return;
     }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
@@ -40,13 +40,13 @@ static inline IPC::Connection& networkProcessConnection()
     return WebProcess::singleton().ensureNetworkProcessConnection().connection();
 }
 
-// Unique origins are only stored in process in m_channelsPerOrigin and never sent to the NetworkProcess as a ClientOrigin.
-// The identity of unique origins wouldn't be preserved when serializing them as a SecurityOriginData (via ClientOrigin).
-// Since BroadcastChannels from a unique origin can only communicate with other BroadcastChannels from the same unique origin,
+// Opaque origins are only stored in process in m_channelsPerOrigin and never sent to the NetworkProcess as a ClientOrigin.
+// The identity of opaque origins wouldn't be preserved when serializing them as a SecurityOriginData (via ClientOrigin).
+// Since BroadcastChannels from an opaque origin can only communicate with other BroadcastChannels from the same opaque origin,
 // the destination channels have to be within the same WebProcess anyway.
 static std::optional<WebCore::ClientOrigin> toClientOrigin(const WebCore::PartitionedSecurityOrigin& origin)
 {
-    if (origin.topOrigin->isUnique() || origin.clientOrigin->isUnique())
+    if (origin.topOrigin->isOpaque() || origin.clientOrigin->isOpaque())
         return std::nullopt;
     return WebCore::ClientOrigin { origin.topOrigin->data(), origin.clientOrigin->data() };
 }

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -735,10 +735,10 @@ static NSURL *origin(WebPage& page)
     URL mainFrameURL = mainFrame.url();
     Ref<SecurityOrigin> mainFrameOrigin = SecurityOrigin::create(mainFrameURL);
     String mainFrameOriginString;
-    if (!mainFrameOrigin->isUnique())
+    if (!mainFrameOrigin->isOpaque())
         mainFrameOriginString = mainFrameOrigin->toRawString();
     else
-        mainFrameOriginString = makeString(mainFrameURL.protocol(), ':'); // toRawString() is not supposed to work with unique origins, and would just return "://".
+        mainFrameOriginString = makeString(mainFrameURL.protocol(), ':'); // toRawString() is not supposed to work with opaque origins, and would just return "://".
 
     // +[NSURL URLWithString:] returns nil when its argument is malformed. It's unclear when we would have a malformed URL here,
     // but it happens in practice according to <rdar://problem/14173389>. Leaving an assertion in to catch a reproducible case.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TestSOAuthorization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TestSOAuthorization.mm
@@ -1644,7 +1644,7 @@ TEST(SOAuthorizationPopUp, NoInterceptionsSubFrame)
     [webView loadHTMLString:testHtml baseURL:baseURL.get()];
     Util::run(&navigationCompleted);
 
-    // The new window will not navigate to the testURL as the iframe has unique origin.
+    // The new window will not navigate to the testURL as the iframe has an opaque origin.
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
     Util::run(&newWindowCreated);
     EXPECT_FALSE(policyForAppSSOPerformed);


### PR DESCRIPTION
#### cb15a2032f30371ff6b9e23b34d51e25e8ff30a8
<pre>
Rename unique origin to opaque origin to match the naming in the specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=244934">https://bugs.webkit.org/show_bug.cgi?id=244934</a>

Reviewed by Alex Christensen and Brent Fulgham.

Rename unique origin to opaque origin to match the naming in the specification:
<a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque</a>

* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::clientOriginFromContext):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::initSecurityContext):
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::hasStorageAccessQuickCheck):
(WebCore::DocumentStorageAccess::requestStorageAccessQuickCheck):
* Source/WebCore/dom/EmptyScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::canAccessResource const):
* Source/WebCore/dom/SecurityContext.cpp:
(WebCore::SecurityContext::enforceSandboxFlags):
* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::agentClusterKeyOrNullIfUnique):
* Source/WebCore/fileapi/ThreadableBlobRegistry.cpp:
(WebCore::ThreadableBlobRegistry::getCachedOrigin):
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::shouldCrossOriginResourcePolicyCancelLoad):
* Source/WebCore/loader/CrossOriginOpenerPolicy.cpp:
(WebCore::computeResponseOriginAndCOOP):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::shouldUseActiveServiceWorkerFromParent):
(WebCore::DocumentLoader::commitData):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::redirectReceived):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::addHTTPOriginIfNeeded):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::checkRedirectionCrossOriginAccessControl):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::postMessage):
* Source/WebCore/page/History.cpp:
(WebCore::History::stateObjectAdded):
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::schemeRequiresHost):
(WebCore::shouldTreatAsOpaqueOrigin):
(WebCore::SecurityOrigin::create):
(WebCore::SecurityOrigin::createOpaque):
(WebCore::SecurityOrigin::isSameOriginDomain const):
(WebCore::SecurityOrigin::canRequest const):
(WebCore::SecurityOrigin::canShowNotifications const):
(WebCore::SecurityOrigin::isSameOriginAs const):
(WebCore::SecurityOrigin::toString const):
(WebCore::areOriginsMatching):
(WebCore::SecurityOrigin::equal const):
(WebCore::shouldTreatAsUniqueOrigin): Deleted.
(WebCore::SecurityOrigin::createUnique): Deleted.
* Source/WebCore/page/SecurityOrigin.h:
(WebCore::SecurityOrigin::isOpaque const):
(WebCore::SecurityOrigin::encode const):
(WebCore::SecurityOrigin::decode):
(WebCore::SecurityOrigin::isUnique const): Deleted.
* Source/WebCore/page/SecurityOriginData.h:
(WebCore::SecurityOriginData::isOpaque const):
(WebCore::SecurityOriginData::isUnique const): Deleted.
* Source/WebCore/page/SecurityPolicy.cpp:
(WebCore::SecurityPolicy::addOriginAccessAllowlistEntry):
(WebCore::SecurityPolicy::removeOriginAccessAllowlistEntry):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::didReceiveResponse):
* Source/WebCore/worklets/WorkletGlobalScope.cpp:
(WebCore::WorkletGlobalScope::WorkletGlobalScope):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::GPUConnectionToWebProcess):
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::checkCORSRedirectedRequest):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::doCrossOriginOpenerHandlingOfResponse):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::checkIfNavigationContainsDataTransfer):
(WebKit::WebPageProxy::queryPermission):
* Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp:
(WebKit::toClientOrigin):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::origin):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TestSOAuthorization.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/254284@main">https://commits.webkit.org/254284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0feeed005f2ede52b84d3a4681a0988a1b691ff1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97824 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31686 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80856 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/92460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94262 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/25140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/75590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/25078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/80024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/68042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29379 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29215 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/15102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3026 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32656 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31341 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/34212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->