### PR TITLE
Add fetch retries to improve networking robustness for JetStream2.1.

### DIFF
--- a/PerformanceTests/JetStream2/index.html
+++ b/PerformanceTests/JetStream2/index.html
@@ -36,7 +36,15 @@
     const isInBrowser = true;
     const isD8 = false;
     var allIsGood = true;
-    window.onerror = function() { allIsGood = false; }
+    window.onerror = function(e) {
+        if (e == "Script error.") {
+            // This is a workaround for Firefox on iOS which has an uncaught exception from
+            // its injected script. We should not stop the benchmark from running due to that
+            // if it can otherwise run.
+            return;
+        }
+        allIsGood = false;
+    }
 
     async function initialize() {
         if (allIsGood) {


### PR DESCRIPTION
#### eaf0a297d03f1bca1d20fdae0517b820664fc6d6
<pre>
Add fetch retries to improve networking robustness for JetStream2.1.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244937">https://bugs.webkit.org/show_bug.cgi?id=244937</a>
&lt;rdar://problem/99701290&gt;

Reviewed by Alexey Shvaika.

If burst mode fetches fail, we&apos;ll switch to fetching the resources one at a time sequentially.
In burst mode and in the sequential refetch, fetch of each resource may be tried up to 3 times
before giving up.  This improves robustness and help reduce the chance that JetStream 2.1 fails
to run due to poor network conditions.

Also remove the browser only code in fetchResources().  This is now handled by
prefetchResourcesForBrowser(), which handles retries more robustly.

* PerformanceTests/JetStream2/JetStreamDriver.js:
(prototype.async _loadInternal):
(Driver):
(Driver.prototype.async start):
(Driver.prototype.async initialize):
(Driver.prototype.async prefetchResourcesForBrowser):
(prototype.async run):
(prototype.async doLoadBlob):
(prototype.async loadBlob):
(prototype.updateCounter):
(prototype.prefetchResourcesForBrowser):
(prototype.async retryPrefetchResource):
(prototype.async retryPrefetchResourcesForBrowser):
(prototype.fetchResources):
(Driver.prototype.async preloadFilesForBrowser): Deleted.
(prototype.preloadFilesForBrowser): Deleted.
* PerformanceTests/JetStream2/index.html:

Canonical link: <a href="https://commits.webkit.org/254289@main">https://commits.webkit.org/254289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71c632136942c32be93170868a5bb2441316a20f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97841 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31706 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27302 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80873 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92477 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25153 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75615 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25090 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80037 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68054 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29408 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29232 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15118 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38048 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1233 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34229 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->