### PR TITLE
AudioWorklet script doesn't inherit its owner document's referrer policy

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/worklets/audio-worklet-referrer.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/worklets/audio-worklet-referrer.https-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Origin https://localhost:9443 is not allowed by Access-Control-Allow-Origin. Status code: 500
 Blocked access to external URL https://www1.localhost:9443/worklets/resources/referrer-checker.py?referrer_policy=no-referrer&expected_referrer=
 Blocked access to external URL https://www1.localhost:9443/worklets/resources/referrer-checker.py?referrer_policy=origin&expected_referrer=https://localhost:9443/
 CONSOLE MESSAGE: Origin https://localhost:9443 is not allowed by Access-Control-Allow-Origin. Status code: 500
@@ -7,9 +6,9 @@ CONSOLE MESSAGE: Origin https://localhost:9443 is not allowed by Access-Control-
 
 PASS Importing a same-origin script from a page that has "no-referrer" referrer policy should not send referrer.
 PASS Importing a remote-origin script from a page that has "no-referrer" referrer policy should not send referrer.
-FAIL Importing a same-origin script from a page that has "origin" referrer policy should send only an origin as referrer. assert_equals: expected "RESOLVED" but got "Importing a module script failed."
-FAIL Importing a remote-origin script from a page that has "origin" referrer policy should send only an origin as referrer. assert_equals: expected "RESOLVED" but got "Cross-origin script load denied by Cross-Origin Resource Sharing policy."
-FAIL Importing a same-origin script from a page that has "same-origin" referrer policy should send referrer. assert_equals: expected "RESOLVED" but got "Importing a module script failed."
+PASS Importing a same-origin script from a page that has "origin" referrer policy should send only an origin as referrer.
+PASS Importing a remote-origin script from a page that has "origin" referrer policy should send only an origin as referrer.
+PASS Importing a same-origin script from a page that has "same-origin" referrer policy should send referrer.
 PASS Importing a remote-origin script from a page that has "same-origin" referrer policy should not send referrer.
 PASS Importing a same-origin script from a same-origin worklet script that has "no-referrer" referrer policy should not send referrer.
 FAIL Importing a remote-origin script from a same-origin worklet script that has "no-referrer" referrer policy should not send referrer. assert_equals: expected "RESOLVED" but got "Cross-origin script load denied by Cross-Origin Resource Sharing policy."

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/worklets/audio-worklet-referrer.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/worklets/audio-worklet-referrer.https-expected.txt
@@ -1,12 +1,11 @@
 CONSOLE MESSAGE: Origin https://web-platform.test:9443 is not allowed by Access-Control-Allow-Origin. Status code: 500
 CONSOLE MESSAGE: Origin https://web-platform.test:9443 is not allowed by Access-Control-Allow-Origin. Status code: 500
-CONSOLE MESSAGE: Origin https://web-platform.test:9443 is not allowed by Access-Control-Allow-Origin. Status code: 500
 
 PASS Importing a same-origin script from a page that has "no-referrer" referrer policy should not send referrer.
 PASS Importing a remote-origin script from a page that has "no-referrer" referrer policy should not send referrer.
-FAIL Importing a same-origin script from a page that has "origin" referrer policy should send only an origin as referrer. assert_equals: expected "RESOLVED" but got "Importing a module script failed."
-FAIL Importing a remote-origin script from a page that has "origin" referrer policy should send only an origin as referrer. assert_equals: expected "RESOLVED" but got "Cross-origin script load denied by Cross-Origin Resource Sharing policy."
-FAIL Importing a same-origin script from a page that has "same-origin" referrer policy should send referrer. assert_equals: expected "RESOLVED" but got "Importing a module script failed."
+PASS Importing a same-origin script from a page that has "origin" referrer policy should send only an origin as referrer.
+PASS Importing a remote-origin script from a page that has "origin" referrer policy should send only an origin as referrer.
+PASS Importing a same-origin script from a page that has "same-origin" referrer policy should send referrer.
 PASS Importing a remote-origin script from a page that has "same-origin" referrer policy should not send referrer.
 PASS Importing a same-origin script from a same-origin worklet script that has "no-referrer" referrer policy should not send referrer.
 PASS Importing a remote-origin script from a same-origin worklet script that has "no-referrer" referrer policy should not send referrer.

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
@@ -58,6 +58,7 @@ static WorkletParameters generateWorkletParameters(AudioWorklet& worklet)
         worklet.identifier(),
         *document->sessionID(),
         document->settingsValues(),
+        document->referrerPolicy(),
         worklet.audioContext() ? !worklet.audioContext()->isOfflineContext() : false
     };
 }

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -96,7 +96,7 @@ static WorkQueue& sharedFileSystemStorageQueue()
 WTF_MAKE_ISO_ALLOCATED_IMPL(WorkerGlobalScope);
 
 WorkerGlobalScope::WorkerGlobalScope(WorkerThreadType type, const WorkerParameters& params, Ref<SecurityOrigin>&& origin, WorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider)
-    : WorkerOrWorkletGlobalScope(type, params.sessionID, isMainThread() ? Ref { commonVM() } : JSC::VM::create(), &thread, params.clientIdentifier)
+    : WorkerOrWorkletGlobalScope(type, params.sessionID, isMainThread() ? Ref { commonVM() } : JSC::VM::create(), params.referrerPolicy, &thread, params.clientIdentifier)
     , m_url(params.scriptURL)
     , m_ownerURL(params.ownerURL)
     , m_inspectorIdentifier(params.inspectorIdentifier)
@@ -108,7 +108,6 @@ WorkerGlobalScope::WorkerGlobalScope(WorkerThreadType type, const WorkerParamete
     , m_socketProvider(socketProvider)
     , m_performance(Performance::create(this, params.timeOrigin))
     , m_reportingScope(ReportingScope::create(*this))
-    , m_referrerPolicy(params.referrerPolicy)
     , m_settingsValues(params.settingsValues)
     , m_workerType(params.workerType)
     , m_credentials(params.credentials)
@@ -569,11 +568,6 @@ void WorkerGlobalScope::beginLoadingFontSoon(FontLoadRequest& request)
 {
     ASSERT(is<WorkerFontLoadRequest>(request));
     downcast<WorkerFontLoadRequest>(request).load(*this);
-}
-
-ReferrerPolicy WorkerGlobalScope::referrerPolicy() const
-{
-    return m_referrerPolicy;
 }
 
 WorkerThread& WorkerGlobalScope::thread() const

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -154,8 +154,6 @@ public:
     std::unique_ptr<FontLoadRequest> fontLoadRequest(String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource) final;
     void beginLoadingFontSoon(FontLoadRequest&) final;
 
-    ReferrerPolicy referrerPolicy() const final;
-
     const Settings::Values& settingsValues() const final { return m_settingsValues; }
 
     FetchOptions::Credentials credentials() const { return m_credentials; }
@@ -241,7 +239,6 @@ private:
 #endif
     std::unique_ptr<CSSValuePool> m_cssValuePool;
     RefPtr<CSSFontSelector> m_cssFontSelector;
-    ReferrerPolicy m_referrerPolicy;
     Settings::Values m_settingsValues;
     WorkerType m_workerType;
     FetchOptions::Credentials m_credentials;

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
@@ -40,13 +40,14 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(WorkerOrWorkletGlobalScope);
 
-WorkerOrWorkletGlobalScope::WorkerOrWorkletGlobalScope(WorkerThreadType type, PAL::SessionID sessionID, Ref<JSC::VM>&& vm, WorkerOrWorkletThread* thread, ScriptExecutionContextIdentifier contextIdentifier)
+WorkerOrWorkletGlobalScope::WorkerOrWorkletGlobalScope(WorkerThreadType type, PAL::SessionID sessionID, Ref<JSC::VM>&& vm, ReferrerPolicy referrerPolicy, WorkerOrWorkletThread* thread, ScriptExecutionContextIdentifier contextIdentifier)
     : ScriptExecutionContext(contextIdentifier)
     , m_script(makeUnique<WorkerOrWorkletScriptController>(type, WTFMove(vm), this))
     , m_moduleLoader(makeUnique<ScriptModuleLoader>(*this, ScriptModuleLoader::OwnerType::WorkerOrWorklet))
     , m_thread(thread)
     , m_inspectorController(makeUnique<WorkerInspectorController>(*this))
     , m_sessionID(sessionID)
+    , m_referrerPolicy(referrerPolicy)
 {
 }
 

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
@@ -79,9 +79,10 @@ public:
     virtual void resume() { }
 
     virtual FetchOptions::Destination destination() const = 0;
+    ReferrerPolicy referrerPolicy() const final { return m_referrerPolicy; }
 
 protected:
-    WorkerOrWorkletGlobalScope(WorkerThreadType, PAL::SessionID, Ref<JSC::VM>&&, WorkerOrWorkletThread*, ScriptExecutionContextIdentifier = { });
+    WorkerOrWorkletGlobalScope(WorkerThreadType, PAL::SessionID, Ref<JSC::VM>&&, ReferrerPolicy, WorkerOrWorkletThread*, ScriptExecutionContextIdentifier = { });
 
     // ScriptExecutionContext.
     bool isJSExecutionForbidden() const final;
@@ -111,6 +112,7 @@ private:
     std::unique_ptr<EventLoopTaskGroup> m_defaultTaskGroup;
     std::unique_ptr<WorkerInspectorController> m_inspectorController;
     PAL::SessionID m_sessionID;
+    ReferrerPolicy m_referrerPolicy;
     bool m_isClosing { false };
 };
 

--- a/Source/WebCore/worklets/WorkletGlobalScope.cpp
+++ b/Source/WebCore/worklets/WorkletGlobalScope.cpp
@@ -50,7 +50,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WorkletGlobalScope);
 static std::atomic<unsigned> gNumberOfWorkletGlobalScopes { 0 };
 
 WorkletGlobalScope::WorkletGlobalScope(WorkerOrWorkletThread& thread, Ref<JSC::VM>&& vm, const WorkletParameters& parameters)
-    : WorkerOrWorkletGlobalScope(WorkerThreadType::Worklet, parameters.sessionID, WTFMove(vm), &thread)
+    : WorkerOrWorkletGlobalScope(WorkerThreadType::Worklet, parameters.sessionID, WTFMove(vm), parameters.referrerPolicy, &thread)
     , m_topOrigin(SecurityOrigin::createOpaque())
     , m_url(parameters.windowURL)
     , m_jsRuntimeFlags(parameters.jsRuntimeFlags)
@@ -64,7 +64,7 @@ WorkletGlobalScope::WorkletGlobalScope(WorkerOrWorkletThread& thread, Ref<JSC::V
 }
 
 WorkletGlobalScope::WorkletGlobalScope(Document& document, Ref<JSC::VM>&& vm, ScriptSourceCode&& code)
-    : WorkerOrWorkletGlobalScope(WorkerThreadType::Worklet, *document.sessionID(), WTFMove(vm), nullptr)
+    : WorkerOrWorkletGlobalScope(WorkerThreadType::Worklet, *document.sessionID(), WTFMove(vm), document.referrerPolicy(), nullptr)
     , m_document(document)
     , m_topOrigin(SecurityOrigin::createOpaque())
     , m_url(code.url())
@@ -150,11 +150,6 @@ void WorkletGlobalScope::addMessage(MessageSource source, MessageLevel level, co
     if (!m_document || isJSExecutionForbidden())
         return;
     m_document->addMessage(source, level, messageText, sourceURL, lineNumber, columnNumber, WTFMove(callStack), nullptr, requestIdentifier);
-}
-
-ReferrerPolicy WorkletGlobalScope::referrerPolicy() const
-{
-    return ReferrerPolicy::NoReferrer;
 }
 
 void WorkletGlobalScope::fetchAndInvokeScript(const URL& moduleURL, FetchRequestCredentials credentials, CompletionHandler<void(std::optional<Exception>&&)>&& completionHandler)

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -72,8 +72,6 @@ public:
 
     void evaluate();
 
-    ReferrerPolicy referrerPolicy() const final;
-
     void addConsoleMessage(std::unique_ptr<Inspector::ConsoleMessage>&&) final;
 
     SecurityOrigin& topOrigin() const final { return m_topOrigin.get(); }

--- a/Source/WebCore/worklets/WorkletParameters.h
+++ b/Source/WebCore/worklets/WorkletParameters.h
@@ -38,10 +38,11 @@ struct WorkletParameters {
     String identifier;
     PAL::SessionID sessionID;
     Settings::Values settingsValues;
+    ReferrerPolicy referrerPolicy;
     bool isAudioContextRealTime;
 
-    WorkletParameters isolatedCopy() const & { return { windowURL.isolatedCopy(), jsRuntimeFlags, sampleRate, identifier.isolatedCopy(), sessionID, settingsValues.isolatedCopy(), isAudioContextRealTime }; }
-    WorkletParameters isolatedCopy() && { return { WTFMove(windowURL).isolatedCopy(), jsRuntimeFlags, sampleRate, WTFMove(identifier).isolatedCopy(), sessionID, WTFMove(settingsValues).isolatedCopy(), isAudioContextRealTime }; }
+    WorkletParameters isolatedCopy() const & { return { windowURL.isolatedCopy(), jsRuntimeFlags, sampleRate, identifier.isolatedCopy(), sessionID, settingsValues.isolatedCopy(), referrerPolicy, isAudioContextRealTime }; }
+    WorkletParameters isolatedCopy() && { return { WTFMove(windowURL).isolatedCopy(), jsRuntimeFlags, sampleRate, WTFMove(identifier).isolatedCopy(), sessionID, WTFMove(settingsValues).isolatedCopy(), referrerPolicy, isAudioContextRealTime }; }
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 499fe5155e3e556619dd33e61d09868d35da531f
<pre>
AudioWorklet script doesn&apos;t inherit its owner document&apos;s referrer policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=244938">https://bugs.webkit.org/show_bug.cgi?id=244938</a>

Reviewed by Geoffrey Garen and Darin Adler.

* LayoutTests/imported/w3c/web-platform-tests/worklets/audio-worklet-referrer.https-expected.txt:
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp:
(WebCore::generateWorkletParameters):
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::WorkerGlobalScope):
(WebCore::WorkerGlobalScope::beginLoadingFontSoon):
(WebCore::WorkerGlobalScope::referrerPolicy const): Deleted.
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp:
(WebCore::WorkerOrWorkletGlobalScope::WorkerOrWorkletGlobalScope):
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.h:
(WebCore::WorkerOrWorkletGlobalScope::WorkerOrWorkletGlobalScope):
* Source/WebCore/worklets/WorkletGlobalScope.cpp:
(WebCore::WorkletGlobalScope::WorkletGlobalScope):
(WebCore::WorkletGlobalScope::referrerPolicy const): Deleted.
* Source/WebCore/worklets/WorkletGlobalScope.h:
* Source/WebCore/worklets/WorkletParameters.h:
(WebCore::WorkletParameters::isolatedCopy const):
(WebCore::WorkletParameters::isolatedCopy):

Canonical link: <a href="https://commits.webkit.org/254306@main">https://commits.webkit.org/254306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/913b1724e43477127b7d0a1e3513490ed380db41

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97852 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31718 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27318 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92488 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25168 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75635 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25103 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80051 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68067 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29432 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29243 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15126 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3041 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38059 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34237 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->