### PR TITLE
[Filters] FilterImage should hold one form of the result image

### DIFF
--- a/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,31 +29,17 @@
 #if USE(CORE_IMAGE)
 
 #import "FilterImage.h"
-#import "PlatformImageBuffer.h"
-#import <CoreImage/CIContext.h>
-#import <CoreImage/CIFilter.h>
-#import <CoreImage/CoreImage.h>
 
 namespace WebCore {
 
 bool SourceGraphicCoreImageApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
 {
     auto& input = inputs[0].get();
-
-    auto sourceImage = input.imageBuffer();
-    if (!sourceImage)
+    auto ciImage = input.ciImage();
+    if (!ciImage)
         return false;
 
-    RetainPtr<CIImage> image;
-    if (is<IOSurfaceImageBuffer>(*sourceImage))
-        image = [CIImage imageWithIOSurface:downcast<IOSurfaceImageBuffer>(*sourceImage).surface().surface()];
-    else
-        image = [CIImage imageWithCGImage:sourceImage->copyNativeImage()->platformImage().get()];
-
-    if (!image)
-        return false;
-
-    result.setCIImage(WTFMove(image));
+    result.setCIImage(WTFMove(ciImage));
     return true;
 }
 


### PR DESCRIPTION
#### 70479af6eba9f1eb8b121d5fee287160e49b188c
<pre>
[Filters] FilterImage should hold one form of the result image
<a href="https://bugs.webkit.org/show_bug.cgi?id=244940">https://bugs.webkit.org/show_bug.cgi?id=244940</a>

Reviewed by NOBODY (OOPS!).

Usually the software image form of FilterImage is be converted to another form;
e.g. ImageBuffer -&gt; PixelBuffer. But we rarely need both forms of image. There
are instances of filters where we fail to render the filtered image just because
we cache more than form of the image of FilterImage.

We should keep only one form of the image. And we can get the original form of
the image from the new one if we want. This will reduce the memory needed to
generate the software filtered image.

* Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm:
(WebCore::FilterImage::ciImage const):
(WebCore::FilterImage::ciImageSlot const):
(WebCore::FilterImage::setCIImage):
(WebCore::FilterImage::createImageBuffer const):
(WebCore::FilterImage::imageBufferFromCIImage): Deleted.
* Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm:
(WebCore::SourceGraphicCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::FilterImage::FilterImage):
(WebCore::FilterImage::createImageBuffer const):
(WebCore::FilterImage::imageBuffer const):
(WebCore::FilterImage::imageBufferSlot const):
(WebCore::FilterImage::createPixelBuffer const):
(WebCore::FilterImage::pixelBuffer const):
(WebCore::FilterImage::pixelBufferSlot const):
(WebCore::FilterImage::copyPixelBuffer):
(WebCore::FilterImage::correctPremultipliedPixelBuffer):
(WebCore::FilterImage::transformToColorSpace):
(WebCore::FilterImage::imageBuffer): Deleted.
(WebCore::FilterImage::imageBufferFromPixelBuffer): Deleted.
(WebCore::FilterImage::pixelBufferSlot): Deleted.
(WebCore::FilterImage::pixelBuffer): Deleted.
* Source/WebCore/platform/graphics/filters/FilterImage.h:
(WebCore::FilterImage::ciImage const): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70479af6eba9f1eb8b121d5fee287160e49b188c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97818 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154385 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31679 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27270 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80850 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92454 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25135 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75580 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25070 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68034 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29370 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14084 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29209 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15098 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38026 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34207 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->