### PR TITLE
KVO exception under WebAVPictureInPictureController stopPictureInPicture

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoFullscreenInterfacePiP.mm
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenInterfacePiP.mm
@@ -253,9 +253,11 @@ static const NSTimeInterval startPictureInPictureTimeInterval = 5.0;
 
 - (void)stopPictureInPicture
 {
-    [_startPictureInPictureTimer invalidate];
-    _startPictureInPictureTimer = nil;
-    [self removeObserver];
+    if (_startPictureInPictureTimer) {
+        [_startPictureInPictureTimer invalidate];
+        _startPictureInPictureTimer = nil;
+        [self removeObserver];
+    }
     [_pip stopPictureInPicture];
 }
 


### PR DESCRIPTION
#### 32c0971e6d80908d0a4d8ac06165c619ba6afe63
<pre>
KVO exception under WebAVPictureInPictureController stopPictureInPicture
<a href="https://bugs.webkit.org/show_bug.cgi?id=244949">https://bugs.webkit.org/show_bug.cgi?id=244949</a>
&lt;rdar://problem/99618553&gt;

Reviewed by Jean-Yves Avenard.

* Source/WebCore/platform/cocoa/VideoFullscreenInterfacePiP.mm:
(-[WebAVPictureInPictureController stopPictureInPicture]):
-removeObserver must be strictly paired, and throws an exception if you
try to remove a nonexistent observer. Only try to remove an observer if
we have one installed (indirectly determined by whether the timer is still
outstanding, exactly as done in -dealloc, and in VideoFullscreenInterfaceAVKit).

Canonical link: <a href="https://commits.webkit.org/254288@main">https://commits.webkit.org/254288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61a6aaa41fe2b7e56c94c27ab6c25ef68d4b9893

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97837 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31702 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27296 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80869 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92473 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25150 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75609 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25087 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80034 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68051 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29401 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29228 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15110 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3033 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32674 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34221 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->