### PR TITLE
Handling of text documents does not comply with modern HTML spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_putall.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_putall.tentative.any-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (8,8) size 784x579
+layer at (0,0) size 800x41
+  RenderBlock {HTML} at (0,0) size 800x41
+    RenderBody {BODY} at (8,13) size 784x15
       RenderBlock {PRE} at (0,0) size 784x15
         RenderText {#text} at (0,0) size 328x15
           text run at (0,0) width 328: "{\"error\": {\"code\": 404, \"message\": \"404\"}}"

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_putall.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_putall.tentative.any.worker-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (8,8) size 784x579
+layer at (0,0) size 800x41
+  RenderBlock {HTML} at (0,0) size 800x41
+    RenderBody {BODY} at (8,13) size 784x15
       RenderBlock {PRE} at (0,0) size 784x15
         RenderText {#text} at (0,0) size 328x15
           text run at (0,0) width 328: "{\"error\": {\"code\": 404, \"message\": \"404\"}}"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-text/load-text-plain-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-text/load-text-plain-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Checking document metadata for text file assert_equals: expected "CSS1Compat" but got "BackCompat"
+PASS Checking document metadata for text file
 PASS Checking DOM for text file
 PASS Checking contents for text file
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-set.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-set.any-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (8,8) size 784x579
+layer at (0,0) size 800x41
+  RenderBlock {HTML} at (0,0) size 800x41
+    RenderBody {BODY} at (8,13) size 784x15
       RenderBlock {PRE} at (0,0) size 784x15
         RenderText {#text} at (0,0) size 328x15
           text run at (0,0) width 328: "{\"error\": {\"code\": 404, \"message\": \"404\"}}"

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-set.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-set.any.worker-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (8,8) size 784x579
+layer at (0,0) size 800x41
+  RenderBlock {HTML} at (0,0) size 800x41
+    RenderBody {BODY} at (8,13) size 784x15
       RenderBlock {PRE} at (0,0) size 784x15
         RenderText {#text} at (0,0) size 328x15
           text run at (0,0) width 328: "{\"error\": {\"code\": 404, \"message\": \"404\"}}"

--- a/LayoutTests/platform/glib/fast/loader/text-document-wrapping-expected.txt
+++ b/LayoutTests/platform/glib/fast/loader/text-document-wrapping-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderFrame {FRAME} at (0,0) size 800x600
         layer at (0,0) size 800x600
           RenderView at (0,0) size 800x600
-        layer at (0,0) size 800x600
-          RenderBlock {HTML} at (0,0) size 800x600
-            RenderBody {BODY} at (8,8) size 784x579
+        layer at (0,0) size 800x101
+          RenderBlock {HTML} at (0,0) size 800x101
+            RenderBody {BODY} at (8,13) size 784x75
               RenderBlock {PRE} at (0,0) size 784x75
                 RenderText {#text} at (0,0) size 784x75
                   text run at (0,0) width 416: "This line should wrap with no horizontal scroll bar:"

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/rsa_importKey.https.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/rsa_importKey.https.worker-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (8,8) size 784x579
+layer at (0,0) size 800x41
+  RenderBlock {HTML} at (0,0) size 800x41
+    RenderBody {BODY} at (8,13) size 784x15
       RenderBlock {PRE} at (0,0) size 784x15
         RenderText {#text} at (0,0) size 336x15
           text run at (0,0) width 336: "{\"error\": {\"code\": 404, \"message\": \"404\"}}"

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/wasm/jsapi/global/value-set.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/wasm/jsapi/global/value-set.any-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (8,8) size 784x579
+layer at (0,0) size 800x41
+  RenderBlock {HTML} at (0,0) size 800x41
+    RenderBody {BODY} at (8,13) size 784x15
       RenderBlock {PRE} at (0,0) size 784x15
         RenderText {#text} at (0,0) size 336x15
           text run at (0,0) width 336: "{\"error\": {\"code\": 404, \"message\": \"404\"}}"

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/wasm/jsapi/global/value-set.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/wasm/jsapi/global/value-set.any.worker-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (8,8) size 784x579
+layer at (0,0) size 800x41
+  RenderBlock {HTML} at (0,0) size 800x41
+    RenderBody {BODY} at (8,13) size 784x15
       RenderBlock {PRE} at (0,0) size 784x15
         RenderText {#text} at (0,0) size 336x15
           text run at (0,0) width 336: "{\"error\": {\"code\": 404, \"message\": \"404\"}}"

--- a/LayoutTests/platform/gtk/fast/forms/targeted-frame-submission-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/targeted-frame-submission-expected.txt
@@ -18,9 +18,9 @@ layer at (0,0) size 800x600
         RenderIFrame {IFRAME} at (0,0) size 304x154 [border: (2px inset #000000)]
           layer at (0,0) size 300x150
             RenderView at (0,0) size 300x150
-          layer at (0,0) size 300x150
-            RenderBlock {HTML} at (0,0) size 300x150
-              RenderBody {BODY} at (8,8) size 284x129
+          layer at (0,0) size 300x41
+            RenderBlock {HTML} at (0,0) size 300x41
+              RenderBody {BODY} at (8,13) size 284x15
                 RenderBlock {PRE} at (0,0) size 284x15
                   RenderText {#text} at (0,0) size 56x15
                     text run at (0,0) width 56: "SUCCESS"

--- a/LayoutTests/platform/ios-wk2/fast/forms/targeted-frame-submission-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/forms/targeted-frame-submission-expected.txt
@@ -18,9 +18,9 @@ layer at (0,0) size 800x600
         RenderIFrame {IFRAME} at (0,0) size 304x154 [border: (2px inset #000000)]
           layer at (0,0) size 300x150
             RenderView at (0,0) size 300x150
-          layer at (0,0) size 300x150
-            RenderBlock {HTML} at (0,0) size 300x150
-              RenderBody {BODY} at (8,8) size 284x129
+          layer at (0,0) size 300x40
+            RenderBlock {HTML} at (0,0) size 300x40
+              RenderBody {BODY} at (8,13) size 284x14
                 RenderBlock {PRE} at (0,0) size 284x14
                   RenderText {#text} at (0,0) size 55x14
                     text run at (0,0) width 55: "SUCCESS"

--- a/LayoutTests/platform/ios-wk2/fast/loader/text-document-wrapping-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/loader/text-document-wrapping-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderFrame {FRAME} at (0,0) size 800x600
         layer at (0,0) size 800x600
           RenderView at (0,0) size 800x600
-        layer at (0,0) size 800x600
-          RenderBlock {HTML} at (0,0) size 800x600
-            RenderBody {BODY} at (8,8) size 784x579
+        layer at (0,0) size 800x96
+          RenderBlock {HTML} at (0,0) size 800x96
+            RenderBody {BODY} at (8,13) size 784x70
               RenderBlock {PRE} at (0,0) size 784x70
                 RenderText {#text} at (0,0) size 781x70
                   text run at (0,0) width 406: "This line should wrap with no horizontal scroll bar:"

--- a/LayoutTests/platform/ios/fast/forms/targeted-frame-submission-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/targeted-frame-submission-expected.txt
@@ -18,9 +18,9 @@ layer at (0,0) size 800x600
         RenderIFrame {IFRAME} at (0,0) size 304x154 [border: (2px inset #000000)]
           layer at (0,0) size 300x150
             RenderView at (0,0) size 300x150
-          layer at (0,0) size 300x150
-            RenderBlock {HTML} at (0,0) size 300x150
-              RenderBody {BODY} at (8,8) size 284x129
+          layer at (0,0) size 300x40
+            RenderBlock {HTML} at (0,0) size 300x40
+              RenderBody {BODY} at (8,13) size 284x14
                 RenderBlock {PRE} at (0,0) size 284x14
                   RenderText {#text} at (0,0) size 55x14
                     text run at (0,0) width 55: "SUCCESS"

--- a/LayoutTests/platform/ios/fast/loader/text-document-wrapping-expected.txt
+++ b/LayoutTests/platform/ios/fast/loader/text-document-wrapping-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderFrame {FRAME} at (0,0) size 800x600
         layer at (0,0) size 800x600
           RenderView at (0,0) size 800x600
-        layer at (0,0) size 800x600
-          RenderBlock {HTML} at (0,0) size 800x600
-            RenderBody {BODY} at (8,8) size 784x579
+        layer at (0,0) size 800x101
+          RenderBlock {HTML} at (0,0) size 800x101
+            RenderBody {BODY} at (8,13) size 784x70
               RenderBlock {PRE} at (0,0) size 784x70
                 RenderText {#text} at (0,0) size 781x70
                   text run at (0,0) width 406: "This line should wrap with no horizontal scroll bar:"

--- a/LayoutTests/platform/mac/fast/forms/targeted-frame-submission-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/targeted-frame-submission-expected.txt
@@ -18,9 +18,9 @@ layer at (0,0) size 800x600
         RenderIFrame {IFRAME} at (0,0) size 304x154 [border: (2px inset #000000)]
           layer at (0,0) size 300x150
             RenderView at (0,0) size 300x150
-          layer at (0,0) size 300x150
-            RenderBlock {HTML} at (0,0) size 300x150
-              RenderBody {BODY} at (8,8) size 284x129
+          layer at (0,0) size 300x41
+            RenderBlock {HTML} at (0,0) size 300x41
+              RenderBody {BODY} at (8,13) size 284x15
                 RenderBlock {PRE} at (0,0) size 284x15
                   RenderText {#text} at (0,0) size 55x15
                     text run at (0,0) width 55: "SUCCESS"

--- a/LayoutTests/platform/mac/fast/loader/text-document-wrapping-expected.txt
+++ b/LayoutTests/platform/mac/fast/loader/text-document-wrapping-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderFrame {FRAME} at (0,0) size 800x600
         layer at (0,0) size 800x600
           RenderView at (0,0) size 800x600
-        layer at (0,0) size 800x600
-          RenderBlock {HTML} at (0,0) size 800x600
-            RenderBody {BODY} at (8,8) size 784x579
+        layer at (0,0) size 800x101
+          RenderBlock {HTML} at (0,0) size 800x101
+            RenderBody {BODY} at (8,13) size 784x75
               RenderBlock {PRE} at (0,0) size 784x75
                 RenderText {#text} at (0,0) size 781x75
                   text run at (0,0) width 406: "This line should wrap with no horizontal scroll bar:"

--- a/LayoutTests/platform/mac/http/tests/misc/acid3-expected.txt
+++ b/LayoutTests/platform/mac/http/tests/misc/acid3-expected.txt
@@ -38,11 +38,11 @@ layer at (20,20) size 644x433
                 RenderBody {BODY} at (0,0) size 0x1
                   RenderImage {IMG} at (0,0) size 1x1
           RenderIFrame {IFRAME} at (0,0) size 0x0
-            layer at (0,0) size 16x2166
+            layer at (0,0) size 16x2171
               RenderView at (0,0) size 0x0
-            layer at (0,0) size 0x2166
-              RenderBlock {HTML} at (0,0) size 0x2166
-                RenderBody {BODY} at (8,8) size 0x2145
+            layer at (0,0) size 0x2171
+              RenderBlock {HTML} at (0,0) size 0x2171
+                RenderBody {BODY} at (8,13) size 0x2145
                   RenderBlock {PRE} at (0,0) size 0x2145
                     RenderText {#text} at (0,0) size 8x2145
                       text run at (0,0) width 8: "<"

--- a/LayoutTests/platform/win/fast/loader/text-document-wrapping-expected.txt
+++ b/LayoutTests/platform/win/fast/loader/text-document-wrapping-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderFrame {FRAME} at (0,0) size 800x600
         layer at (0,0) size 800x600
           RenderView at (0,0) size 800x600
-        layer at (0,0) size 800x600
-          RenderBlock {HTML} at (0,0) size 800x600
-            RenderBody {BODY} at (8,8) size 784x579
+        layer at (0,0) size 800x101
+          RenderBlock {HTML} at (0,0) size 800x101
+            RenderBody {BODY} at (8,13) size 784x75
               RenderBlock {PRE} at (0,0) size 784x75
                 RenderText {#text} at (0,0) size 784x75
                   text run at (0,0) width 416: "This line should wrap with no horizontal scroll bar:"

--- a/LayoutTests/platform/wincairo/fast/loader/text-document-wrapping-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/loader/text-document-wrapping-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderFrame {FRAME} at (0,0) size 800x600
         layer at (0,0) size 800x600
           RenderView at (0,0) size 800x600
-        layer at (0,0) size 800x600
-          RenderBlock {HTML} at (0,0) size 800x600
-            RenderBody {BODY} at (8,8) size 784x579
+        layer at (0,0) size 800x101
+          RenderBlock {HTML} at (0,0) size 800x101
+            RenderBody {BODY} at (8,13) size 784x80
               RenderBlock {PRE} at (0,0) size 784x80
                 RenderText {#text} at (0,0) size 784x80
                   text run at (0,0) width 416: "This line should wrap with no horizontal scroll bar:"

--- a/Source/WebCore/html/TextDocument.cpp
+++ b/Source/WebCore/html/TextDocument.cpp
@@ -35,7 +35,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(TextDocument);
 TextDocument::TextDocument(Frame* frame, const Settings& settings, const URL& url, ScriptExecutionContextIdentifier identifier)
     : HTMLDocument(frame, settings, url, identifier, { DocumentClass::Text })
 {
-    setCompatibilityMode(DocumentCompatibilityMode::QuirksMode);
+    setCompatibilityMode(DocumentCompatibilityMode::NoQuirksMode);
     lockCompatibilityMode();
 }
 


### PR DESCRIPTION
#### e30caa272fe6d8f18f34521fe30ef5c9d97125a8
<pre>
Handling of text documents does not comply with modern HTML spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=244950">https://bugs.webkit.org/show_bug.cgi?id=244950</a>
&lt;rdar://problem/99719728&gt;

Reviewed by Chris Dumez.

The spec language in <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#read-text">https://html.spec.whatwg.org/multipage/browsing-the-web.html#read-text</a>, indicates that Text documents
must be in no-quirks mode: (7.11.4.3 Set document&apos;s mode to &quot;no-quirks&quot;.)

This is in conflict with the source code in the TextDocument constructor:

  setCompatibilityMode(DocumentCompatibilityMode::QuirksMode);

This causes the following WPT failure:

wpt /html/browsers/browsing-the-web/read-text/load-text-plain.html

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-text/load-text-plain-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_putall.tentative.any-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_putall.tentative.any.worker-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-set.any-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/global/value-set.any.worker-expected.txt
* LayoutTests/platform/glib/fast/loader/text-document-wrapping-expected.txt
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/rsa_importKey.https.worker-expected.txt
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/wasm/jsapi/global/value-set.any-expected.txt
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/wasm/jsapi/global/value-set.any.worker-expected.txt
* LayoutTests/platform/gtk/fast/forms/targeted-frame-submission-expected.txt
* LayoutTests/platform/ios-wk2/fast/forms/targeted-frame-submission-expected.txt
* LayoutTests/platform/ios-wk2/fast/loader/text-document-wrapping-expected.txt
* LayoutTests/platform/ios/fast/forms/targeted-frame-submission-expected.txt
* LayoutTests/platform/ios/fast/loader/text-document-wrapping-expected.txt
* LayoutTests/platform/mac/fast/forms/targeted-frame-submission-expected.txt
* LayoutTests/platform/mac/fast/loader/text-document-wrapping-expected.txt
* LayoutTests/platform/mac/http/tests/misc/acid3-expected.txt
* LayoutTests/platform/win/fast/loader/text-document-wrapping-expected.txt
* LayoutTests/platform/wincairo/fast/loader/text-document-wrapping-expected.txt
* Source/WebCore/html/TextDocument.cpp:

Canonical link: <a href="https://commits.webkit.org/254389@main">https://commits.webkit.org/254389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68cde4cee70e0b321ef37954aa91a625dd1d1814

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97966 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31831 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27446 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81005 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92588 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25250 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75749 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25209 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68171 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29630 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14200 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29361 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15200 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3078 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38124 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34307 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->