### PR TITLE
AudioWorklet script doesn't inherit its owner document's CSP

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https-expected.txt
@@ -1,5 +1,11 @@
 CONSOLE MESSAGE: Refused to load https://www1.web-platform.test:9443/worklets/resources/empty-worklet-script-with-cors-header.js because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load https://www1.web-platform.test:9443/worklets/resources/empty-worklet-script-with-cors-header.js because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Blocked by Content Security Policy.
 CONSOLE MESSAGE: Refused to load https://www1.web-platform.test:9443/worklets/resources/import-empty-worklet-script-with-cors-header.js because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load https://www1.web-platform.test:9443/worklets/resources/empty-worklet-script-with-cors-header.js because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Blocked by Content Security Policy.
+CONSOLE MESSAGE: Refused to load https://www1.web-platform.test:9443/worklets/resources/empty-worklet-script-with-cors-header.js because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Blocked by Content Security Policy.
 CONSOLE MESSAGE: [blocked] The page at https://web-platform.test:9443/worklets/resources/addmodule-window.html was not allowed to display insecure content from http://web-platform.test:8800/worklets/resources/empty-worklet-script-with-cors-header.js.
 
 CONSOLE MESSAGE: [blocked] The page at https://web-platform.test:9443/worklets/resources/addmodule-window.html was not allowed to display insecure content from http://web-platform.test:8800/worklets/resources/empty-worklet-script-with-cors-header.js.
@@ -10,10 +16,10 @@ CONSOLE MESSAGE: [blocked] The page at https://web-platform.test:9443/worklets/r
 
 
 PASS A remote-origin worklet should be blocked by the script-src 'self' directive.
-FAIL A same-origin worklet importing a remote-origin script should be blocked by the script-src 'self' directive. assert_equals: expected "REJECTED" but got "RESOLVED"
+PASS A same-origin worklet importing a remote-origin script should be blocked by the script-src 'self' directive.
 PASS A remote-origin worklet importing a remote-origin script should be blocked by the script-src 'self' directive.
-FAIL A remote-origin-redirected worklet should be blocked by the script-src 'self' directive. assert_equals: expected "REJECTED" but got "RESOLVED"
-FAIL A same-origin worklet importing a remote-origin-redirected script should be blocked by the script-src 'self' directive. assert_equals: expected "REJECTED" but got "RESOLVED"
+PASS A remote-origin-redirected worklet should be blocked by the script-src 'self' directive.
+PASS A same-origin worklet importing a remote-origin-redirected script should be blocked by the script-src 'self' directive.
 PASS A remote-origin worklet should not be blocked because the script-src directive specifying the origin allows it.
 PASS A same-origin worklet importing a remote-origin script should not be blocked because the script-src directive specifying the origin allows it.
 PASS A remote-origin worklet importing a remote-origin script should not be blocked because the script-src directive specifying the origin allows it.

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https-expected.txt
@@ -3,13 +3,9 @@ CONSOLE MESSAGE: Refused to load https://127.0.0.1:9443/worklets/resources/empty
 Blocked access to external URL https://www1.localhost:9443/worklets/resources/empty-worklet-script-with-cors-header.js
 CONSOLE MESSAGE: Refused to load https://127.0.0.1:9443/worklets/resources/import-empty-worklet-script-with-cors-header.js because it does not appear in the script-src directive of the Content Security Policy.
 CONSOLE MESSAGE: Refused to load https://127.0.0.1:9443/worklets/resources/import-empty-worklet-script-with-cors-header.js because it does not appear in the script-src directive of the Content Security Policy.
-CONSOLE MESSAGE: Refused to load https://127.0.0.1:9443/worklets/resources/empty-worklet-script-with-cors-header.js because it does not appear in the script-src directive of the Content Security Policy.
-CONSOLE MESSAGE: Blocked by Content Security Policy.
-CONSOLE MESSAGE: Refused to load https://www1.localhost:9443/worklets/resources/empty-worklet-script-with-cors-header.js because it does not appear in the script-src directive of the Content Security Policy.
-CONSOLE MESSAGE: Blocked by Content Security Policy.
 Blocked access to external URL https://www1.localhost:9443/worklets/resources/empty-worklet-script-with-cors-header.js
-CONSOLE MESSAGE: Refused to load https://www1.localhost:9443/worklets/resources/empty-worklet-script-with-cors-header.js because it does not appear in the script-src directive of the Content Security Policy.
-CONSOLE MESSAGE: Blocked by Content Security Policy.
+Blocked access to external URL https://www1.localhost:9443/worklets/resources/empty-worklet-script-with-cors-header.js
+Blocked access to external URL https://www1.localhost:9443/worklets/resources/empty-worklet-script-with-cors-header.js
 Blocked access to external URL https://www1.localhost:9443/worklets/resources/empty-worklet-script-with-cors-header.js
 Blocked access to external URL https://www1.localhost:9443/worklets/resources/empty-worklet-script-with-cors-header.js
 Blocked access to external URL https://www1.localhost:9443/worklets/resources/empty-worklet-script-with-cors-header.js
@@ -26,7 +22,7 @@ CONSOLE MESSAGE: [blocked] The page at https://localhost:9443/worklets/resources
 PASS A remote-origin worklet should be blocked by the script-src 'self' directive.
 PASS A same-origin worklet importing a remote-origin script should be blocked by the script-src 'self' directive.
 PASS A remote-origin worklet importing a remote-origin script should be blocked by the script-src 'self' directive.
-PASS A remote-origin-redirected worklet should be blocked by the script-src 'self' directive.
+FAIL A remote-origin-redirected worklet should be blocked by the script-src 'self' directive. assert_equals: expected "REJECTED" but got "RESOLVED"
 PASS A same-origin worklet importing a remote-origin-redirected script should be blocked by the script-src 'self' directive.
 PASS A remote-origin worklet should not be blocked because the script-src directive specifying the origin allows it.
 FAIL A same-origin worklet importing a remote-origin script should not be blocked because the script-src directive specifying the origin allows it. assert_equals: expected "RESOLVED" but got "REJECTED"

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -54,7 +54,9 @@ RefPtr<AudioWorkletGlobalScope> AudioWorkletGlobalScope::tryCreate(AudioWorkletT
     auto vm = JSC::VM::tryCreate();
     if (!vm)
         return nullptr;
-    return adoptRef(*new AudioWorkletGlobalScope(thread, vm.releaseNonNull(), parameters));
+    auto scope = adoptRef(*new AudioWorkletGlobalScope(thread, vm.releaseNonNull(), parameters));
+    scope->applyContentSecurityPolicyResponseHeaders(parameters.cspHeaders);
+    return scope;
 }
 
 AudioWorkletGlobalScope::AudioWorkletGlobalScope(AudioWorkletThread& thread, Ref<JSC::VM>&& vm, const WorkletParameters& parameters)

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
@@ -58,6 +58,7 @@ static WorkletParameters generateWorkletParameters(AudioWorklet& worklet)
         worklet.identifier(),
         *document->sessionID(),
         document->settingsValues(),
+        document->shouldBypassMainWorldContentSecurityPolicy() || !document->contentSecurityPolicy() ? ContentSecurityPolicyResponseHeaders { } : document->contentSecurityPolicy()->responseHeaders(),
         worklet.audioContext() ? !worklet.audioContext()->isOfflineContext() : false
     };
 }

--- a/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
@@ -39,6 +39,7 @@
 #include "ServiceWorkerGlobalScope.h"
 #include "WorkerScriptFetcher.h"
 #include "WorkerScriptLoader.h"
+#include "WorkletGlobalScope.h"
 
 namespace WebCore {
 
@@ -76,6 +77,7 @@ bool WorkerModuleScriptLoader::load(ScriptExecutionContext& context, URL&& sourc
 #endif
 
     ResourceRequest request { m_sourceURL };
+    request.setRequester(ResourceRequest::Requester::ImportModule);
 
     FetchOptions fetchOptions;
     fetchOptions.mode = FetchOptions::Mode::Cors;
@@ -84,7 +86,7 @@ bool WorkerModuleScriptLoader::load(ScriptExecutionContext& context, URL&& sourc
     fetchOptions.credentials = static_cast<WorkerScriptFetcher&>(scriptFetcher()).credentials();
     fetchOptions.destination = static_cast<WorkerScriptFetcher&>(scriptFetcher()).destination();
     fetchOptions.referrerPolicy = static_cast<WorkerScriptFetcher&>(scriptFetcher()).referrerPolicy();
-    auto contentSecurityPolicyEnforcement = context.shouldBypassMainWorldContentSecurityPolicy() ? ContentSecurityPolicyEnforcement::DoNotEnforce : ContentSecurityPolicyEnforcement::EnforceWorkerSrcDirective;
+    auto contentSecurityPolicyEnforcement = context.shouldBypassMainWorldContentSecurityPolicy() ? ContentSecurityPolicyEnforcement::DoNotEnforce : (is<WorkletGlobalScope>(context) ? ContentSecurityPolicyEnforcement::EnforceScriptSrcDirective : ContentSecurityPolicyEnforcement::EnforceWorkerSrcDirective);
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
     // If destination is "worker" or "sharedworker" and the top-level module fetch flag is set, then set request's mode to "same-origin".

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -167,7 +167,7 @@ public:
     bool hiddenFromInspector() const { return m_hiddenFromInspector; }
     void setHiddenFromInspector(bool hiddenFromInspector) { m_hiddenFromInspector = hiddenFromInspector; }
 
-    enum class Requester : uint8_t { Unspecified, Main, XHR, Fetch, Media, Model, ImportScripts, Ping, Beacon, EventSource };
+    enum class Requester : uint8_t { Unspecified, Main, XHR, Fetch, Media, Model, ImportScripts, ImportModule, Ping, Beacon, EventSource };
     Requester requester() const { return m_requester; }
     void setRequester(Requester requester) { m_requester = requester; }
 
@@ -431,6 +431,7 @@ template<> struct EnumTraits<WebCore::ResourceRequestBase::Requester> {
         WebCore::ResourceRequestBase::Requester::Fetch,
         WebCore::ResourceRequestBase::Requester::Media,
         WebCore::ResourceRequestBase::Requester::ImportScripts,
+        WebCore::ResourceRequestBase::Requester::ImportModule,
         WebCore::ResourceRequestBase::Requester::Ping,
         WebCore::ResourceRequestBase::Requester::Beacon,
         WebCore::ResourceRequestBase::Requester::EventSource

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -189,11 +189,6 @@ bool WorkerGlobalScope::isSecureContext() const
     return m_topOrigin->isPotentiallyTrustworthy();
 }
 
-void WorkerGlobalScope::applyContentSecurityPolicyResponseHeaders(const ContentSecurityPolicyResponseHeaders& contentSecurityPolicyResponseHeaders)
-{
-    contentSecurityPolicy()->didReceiveHeaders(contentSecurityPolicyResponseHeaders, String { });
-}
-
 URL WorkerGlobalScope::completeURL(const String& url, ForceUTF8) const
 {
     // Always return a null URL when passed a null string.

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -171,7 +171,6 @@ public:
 protected:
     WorkerGlobalScope(WorkerThreadType, const WorkerParameters&, Ref<SecurityOrigin>&&, WorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*);
 
-    void applyContentSecurityPolicyResponseHeaders(const ContentSecurityPolicyResponseHeaders&);
     void updateSourceProviderBuffers(const ScriptBuffer& mainScript, const HashMap<URL, ScriptBuffer>& importedScripts);
 
 private:

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
@@ -128,4 +128,9 @@ void WorkerOrWorkletGlobalScope::postTaskForMode(Task&& task, const String& mode
     workerOrWorkletThread()->runLoop().postTaskForMode(WTFMove(task), mode);
 }
 
+void WorkerOrWorkletGlobalScope::applyContentSecurityPolicyResponseHeaders(const ContentSecurityPolicyResponseHeaders& contentSecurityPolicyResponseHeaders)
+{
+    contentSecurityPolicy()->didReceiveHeaders(contentSecurityPolicyResponseHeaders, String { });
+}
+
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 
+class ContentSecurityPolicyResponseHeaders;
 class EventLoopTaskGroup;
 class ScriptModuleLoader;
 class WorkerEventLoop;
@@ -87,6 +88,7 @@ protected:
     bool isJSExecutionForbidden() const final;
 
     void markAsClosing() { m_isClosing = true; }
+    void applyContentSecurityPolicyResponseHeaders(const ContentSecurityPolicyResponseHeaders&);
 
 private:
     // ScriptExecutionContext.

--- a/Source/WebCore/worklets/WorkletParameters.h
+++ b/Source/WebCore/worklets/WorkletParameters.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ContentSecurityPolicyResponseHeaders.h"
 #include "Settings.h"
 #include <JavaScriptCore/RuntimeFlags.h>
 #include <wtf/URL.h>
@@ -38,10 +39,11 @@ struct WorkletParameters {
     String identifier;
     PAL::SessionID sessionID;
     Settings::Values settingsValues;
+    ContentSecurityPolicyResponseHeaders cspHeaders;
     bool isAudioContextRealTime;
 
-    WorkletParameters isolatedCopy() const & { return { windowURL.isolatedCopy(), jsRuntimeFlags, sampleRate, identifier.isolatedCopy(), sessionID, settingsValues.isolatedCopy(), isAudioContextRealTime }; }
-    WorkletParameters isolatedCopy() && { return { WTFMove(windowURL).isolatedCopy(), jsRuntimeFlags, sampleRate, WTFMove(identifier).isolatedCopy(), sessionID, WTFMove(settingsValues).isolatedCopy(), isAudioContextRealTime }; }
+    WorkletParameters isolatedCopy() const & { return { windowURL.isolatedCopy(), jsRuntimeFlags, sampleRate, identifier.isolatedCopy(), sessionID, settingsValues.isolatedCopy(), cspHeaders.isolatedCopy(), isAudioContextRealTime }; }
+    WorkletParameters isolatedCopy() && { return { WTFMove(windowURL).isolatedCopy(), jsRuntimeFlags, sampleRate, WTFMove(identifier).isolatedCopy(), sessionID, WTFMove(settingsValues).isolatedCopy(), WTFMove(cspHeaders).isolatedCopy(), isAudioContextRealTime }; }
 };
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -279,14 +279,14 @@ bool NetworkLoadChecker::isAllowedByContentSecurityPolicy(const ResourceRequest&
     auto preRedirectURL = m_networkResourceLoader ? m_networkResourceLoader.get()->originalRequest().url() : URL();
     auto redirectResponseReceived = isRedirected() ? ContentSecurityPolicy::RedirectResponseReceived::Yes : ContentSecurityPolicy::RedirectResponseReceived::No;
     switch (m_options.destination) {
-    case FetchOptions::Destination::Audioworklet:
-    case FetchOptions::Destination::Paintworklet:
     case FetchOptions::Destination::Worker:
     case FetchOptions::Destination::Serviceworker:
     case FetchOptions::Destination::Sharedworker:
         return contentSecurityPolicy->allowWorkerFromSource(request.url(), redirectResponseReceived, preRedirectURL);
+    case FetchOptions::Destination::Audioworklet:
+    case FetchOptions::Destination::Paintworklet:
     case FetchOptions::Destination::Script:
-        if (request.requester() == ResourceRequest::Requester::ImportScripts && !contentSecurityPolicy->allowScriptFromSource(request.url(), redirectResponseReceived, preRedirectURL))
+        if ((request.requester() == ResourceRequest::Requester::ImportScripts || request.requester() == ResourceRequest::Requester::ImportModule) && !contentSecurityPolicy->allowScriptFromSource(request.url(), redirectResponseReceived, preRedirectURL))
             return false;
         // FIXME: Check CSP for non-importScripts() initiated loads.
         return true;


### PR DESCRIPTION
#### 328ba40654819b90be9a7411fe6bd55ce0533b6d
<pre>
AudioWorklet script doesn&apos;t inherit its owner document&apos;s CSP
<a href="https://bugs.webkit.org/show_bug.cgi?id=244951">https://bugs.webkit.org/show_bug.cgi?id=244951</a>

Reviewed by NOBODY (OOPS!).

Make sure that AudioWorklet scripts inherit their CSP from their owner document.
Also, scripts imported by worklets should obey the script-src CSP rule, not the
worker-src rule.

* LayoutTests/imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https-expected.txt.
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp:
(WebCore::AudioWorkletGlobalScope::tryCreate):
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp:
(WebCore::generateWorkletParameters):
* Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp:
(WebCore::WorkerModuleScriptLoader::load):
* Source/WebCore/platform/network/ResourceRequestBase.h:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::applyContentSecurityPolicyResponseHeaders): Deleted.
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp:
(WebCore::WorkerOrWorkletGlobalScope::applyContentSecurityPolicyResponseHeaders):
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.h:
* Source/WebCore/worklets/WorkletParameters.h:
(WebCore::WorkletParameters::isolatedCopy const):
(WebCore::WorkletParameters::isolatedCopy):
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::isAllowedByContentSecurityPolicy):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/328ba40654819b90be9a7411fe6bd55ce0533b6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97853 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154411 "Failed to checkout and rebase branch from PR 4144") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31719 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27319 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80885 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92489 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94295 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25167 "Found 1 new test failure: imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75637 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25105 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68069 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29433 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14123 "Found 1 new test failure: imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29244 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15129 "Found 1 new test failure: imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32690 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38060 "Found 1 new test failure: imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34240 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->