### PR TITLE
Fix parsing of negative age values in CORS prefetch responses

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache-expected.txt
@@ -5,6 +5,6 @@ PASS Test preflight
 PASS preflight for x-print should be cached
 PASS age = blank, should be cached
 PASS age = 0, should not be cached
-FAIL age = -1, should not be cached assert_equals: did preflight expected "1" but got "0"
+PASS age = -1, should not be cached
 PASS preflight first request, second from cache, wait, third should preflight again
 

--- a/Source/WebCore/loader/CrossOriginPreflightResultCache.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightResultCache.cpp
@@ -48,7 +48,7 @@ CrossOriginPreflightResultCache::CrossOriginPreflightResultCache()
 static bool parseAccessControlMaxAge(const String& string, Seconds& expiryDelta)
 {
     // FIXME: This should probably reject strings that have a leading "+".
-    auto parsedInteger = parseInteger<uint64_t>(string);
+    auto parsedInteger = parseInteger<int64_t>(string);
     expiryDelta = Seconds(static_cast<double>(parsedInteger.value_or(0)));
     return parsedInteger.has_value();
 }


### PR DESCRIPTION
#### 46bb54071fc38dbc58e9d96598c04fdd898f9484
<pre>
Fix parsing of negative age values in CORS prefetch responses
<a href="https://bugs.webkit.org/show_bug.cgi?id=244959">https://bugs.webkit.org/show_bug.cgi?id=244959</a>

Reviewed by Darin Adler.

This aligns our behavior with Blink and Gecko.

* LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache-expected.txt:
* Source/WebCore/loader/CrossOriginPreflightResultCache.cpp:
(WebCore::parseAccessControlMaxAge):

Canonical link: <a href="https://commits.webkit.org/254410@main">https://commits.webkit.org/254410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1124b8ec07646855717eaaad95fdbcedefff0aaa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97858 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154415 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31724 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27327 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80890 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92494 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25171 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75647 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25108 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68072 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29447 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14128 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29249 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15133 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3087 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38066 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34244 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->