### PR TITLE
Add ImageBitmapRenderingContext support to OffscreenCanvas

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.nocrash-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.nocrash-expected.txt
@@ -1,5 +1,5 @@
 Tests that an ImageBitmap in Offscreen without content does not crash.
 
 
-FAIL offscreencanvas Argument 1 ('contextType') to OffscreenCanvas.getContext must be one of: "2d", "webgl", "webgl2"
+PASS offscreencanvas
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1060,14 +1060,6 @@ webkit.org/b/209144 imported/w3c/web-platform-tests/html/canvas/offscreen/shadow
 webkit.org/b/209144 imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1.html [ DumpJSConsoleLogInStdErr ]
 webkit.org/b/209144 imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.2.html [ DumpJSConsoleLogInStdErr ]
 
-# Tests requiring bitmaprenderer context support in OffscreenCanvas.
-# Might need glib-specific baselines when actually fixed as the root expectations fail with missing OffscreenCanvas support.
-webkit.org/b/197421 imported/w3c/web-platform-tests/imagebitmap-renderingcontext/context-creation-offscreen-with-alpha.html [ Failure ]
-webkit.org/b/197421 imported/w3c/web-platform-tests/imagebitmap-renderingcontext/context-creation-offscreen.html [ Failure ]
-webkit.org/b/197421 imported/w3c/web-platform-tests/imagebitmap-renderingcontext/tranferFromImageBitmap-ToBlob-offscreen.html [ Failure ]
-webkit.org/b/197421 imported/w3c/web-platform-tests/imagebitmap-renderingcontext/tranferFromImageBitmap-TransferToImageBitmap-offscreen.html [ Failure ]
-webkit.org/b/197421 imported/w3c/web-platform-tests/imagebitmap-renderingcontext/tranferFromImageBitmap-null-offscreen.html [ Failure ]
-
 webkit.org/b/221311 [ Debug ] imported/w3c/web-platform-tests/html/canvas/offscreen/filter/offscreencanvas.filter.w.html [ Slow ]
 webkit.org/b/221311 [ Debug ] imported/w3c/web-platform-tests/html/canvas/offscreen/manual/filter/offscreencanvas.filter.w.html [ Slow ]
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/context-creation-offscreen-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/context-creation-offscreen-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that canvas.getContext('bitmaprenderer') returns an instance of ImageBitmapRenderingContext and ctx.canvas on a ImageBitmapRenderingContext returns the original OffscreenCanvas
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/context-creation-offscreen-with-alpha-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/context-creation-offscreen-with-alpha-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Test that an ImageBitmapRenderingContext with alpha disabled makes the canvas opaque
+PASS Test that an ImageBitmapRenderingContext with alpha enabled preserves the alpha
+PASS Test that the 'alpha' context creation attribute is true by default
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/toBlob-origin-clean-offscreen.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/toBlob-origin-clean-offscreen.sub-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test that call convertToBlob on a tainted OffscreenCanvas throws exception Argument 1 ('contextType') to OffscreenCanvas.getContext must be one of: "2d", "webgl", "webgl2"
+PASS Test that call convertToBlob on a tainted OffscreenCanvas throws exception
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/tranferFromImageBitmap-ToBlob-offscreen-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/tranferFromImageBitmap-ToBlob-offscreen-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that convertToBlob works and produce the expected image
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/tranferFromImageBitmap-TransferToImageBitmap-offscreen-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/tranferFromImageBitmap-TransferToImageBitmap-offscreen-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that transferToImageBitmap works and that resets the imagebitmap to black
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/tranferFromImageBitmap-null-offscreen-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/tranferFromImageBitmap-null-offscreen-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that transferFromImageBitmap(null) discards the previously transferred image
+

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -80,6 +80,8 @@ public:
 
     ImageBuffer* buffer() const;
 
+    virtual void setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&&) { }
+
     virtual AffineTransform baseTransform() const;
 
     void makeRenderingResultsAvailable();

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -121,7 +121,7 @@ public:
 
     // FIXME: Only some canvas rendering contexts need an ImageBuffer.
     // It would be better to have the contexts own the buffers.
-    void setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&&);
+    void setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&&) final;
 
     WEBCORE_EXPORT static void setMaxPixelMemoryForTesting(std::optional<size_t>);
     WEBCORE_EXPORT static void setMaxCanvasAreaForTesting(std::optional<size_t>);

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -34,6 +34,7 @@
 #include "Document.h"
 #include "HTMLCanvasElement.h"
 #include "ImageBitmap.h"
+#include "ImageBitmapRenderingContext.h"
 #include "ImageData.h"
 #include "JSBlob.h"
 #include "JSDOMPromiseDeferred.h"
@@ -234,6 +235,22 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
             return { { std::nullopt } };
 
         return { { RefPtr<OffscreenCanvasRenderingContext2D> { &downcast<OffscreenCanvasRenderingContext2D>(*m_context) } } };
+    } else if (contextType == RenderingContextType::Bitmaprenderer) {
+        if (m_context) {
+            if (!is<ImageBitmapRenderingContext>(*m_context))
+                return { { std::nullopt } };
+            return { { RefPtr<ImageBitmapRenderingContext> { &downcast<ImageBitmapRenderingContext>(*m_context) } } };
+        }
+
+        auto scope = DECLARE_THROW_SCOPE(state.vm());
+        auto settings = convert<IDLDictionary<ImageBitmapRenderingContextSettings>>(state, arguments.isEmpty() ? JSC::jsUndefined() : (arguments[0].isObject() ? arguments[0].get() : JSC::jsNull()));
+        RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
+
+        m_context = ImageBitmapRenderingContext::create(*this, WTFMove(settings));
+        if (!m_context)
+            return { { std::nullopt } };
+
+        return { { RefPtr<ImageBitmapRenderingContext> { &downcast<ImageBitmapRenderingContext>(*m_context) } } };
     }
 #if ENABLE(WEBGL)
     else {
@@ -271,7 +288,7 @@ ExceptionOr<RefPtr<ImageBitmap>> OffscreenCanvas::transferToImageBitmap()
     if (m_detached || !m_context)
         return Exception { InvalidStateError };
 
-    if (is<OffscreenCanvasRenderingContext2D>(*m_context)) {
+    if (is<OffscreenCanvasRenderingContext2D>(*m_context) || is<ImageBitmapRenderingContext>(*m_context)) {
         if (!width() || !height())
             return { RefPtr<ImageBitmap> { nullptr } };
 
@@ -280,14 +297,23 @@ ExceptionOr<RefPtr<ImageBitmap>> OffscreenCanvas::transferToImageBitmap()
             return { ImageBitmap::create(ImageBitmapBacking(WTFMove(buffer))) };
         }
 
-        // As the canvas context state is stored in GraphicsContext, which is owned
-        // by buffer(), to avoid resetting the context state, we have to make a copy and
-        // clear the original buffer rather than returning the original buffer.
-        auto bufferCopy = buffer()->clone();
-        downcast<OffscreenCanvasRenderingContext2D>(*m_context).clearCanvas();
+        RefPtr<ImageBuffer> bitmap;
+        if (is<OffscreenCanvasRenderingContext2D>(*m_context)) {
+            // As the canvas context state is stored in GraphicsContext, which is owned
+            // by buffer(), to avoid resetting the context state, we have to make a copy and
+            // clear the original buffer rather than returning the original buffer.
+            bitmap = buffer()->clone();
+            downcast<OffscreenCanvasRenderingContext2D>(*m_context).clearCanvas();
+        } else {
+            // ImageBitmapRenderingContext doesn't use the context state, so we can just take its
+            // buffer, and then call transferFromImageBitmap(nullptr) which will trigger it to allocate
+            // a new blank bitmap.
+            bitmap = buffer();
+            downcast<ImageBitmapRenderingContext>(*m_context).transferFromImageBitmap(nullptr);
+        }
         clearCopiedImage();
 
-        return { ImageBitmap::create(ImageBitmapBacking(WTFMove(bufferCopy), originClean() ? SerializationState::OriginClean : SerializationState())) };
+        return { ImageBitmap::create(ImageBitmapBacking(WTFMove(bitmap), originClean() ? SerializationState::OriginClean : SerializationState())) };
     }
 
 #if ENABLE(WEBGL)
@@ -495,6 +521,14 @@ void OffscreenCanvas::createImageBuffer() const
 
     auto colorSpace = m_context ? m_context->colorSpace() : DestinationColorSpace::SRGB();
     setImageBuffer(ImageBitmap::createImageBuffer(*canvasBaseScriptExecutionContext(), size(), RenderingMode::Unaccelerated, colorSpace));
+}
+
+void OffscreenCanvas::setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&& buffer)
+{
+    m_hasCreatedImageBuffer = true;
+    setImageBuffer(WTFMove(buffer));
+
+    didDraw(FloatRect(FloatPoint(), size()));
 }
 
 RefPtr<ImageBuffer> OffscreenCanvas::takeImageBuffer() const

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -55,6 +55,7 @@ class CSSValuePool;
 class DeferredPromise;
 class HTMLCanvasElement;
 class ImageBitmap;
+class ImageBitmapRenderingContext;
 class ImageData;
 class OffscreenCanvasRenderingContext2D;
 class WebGL2RenderingContext;
@@ -68,6 +69,7 @@ using OffscreenRenderingContext = std::variant<
 #if ENABLE(WEBGL2)
     RefPtr<WebGL2RenderingContext>,
 #endif
+    RefPtr<ImageBitmapRenderingContext>,
     RefPtr<OffscreenCanvasRenderingContext2D>
 >;
 
@@ -110,7 +112,8 @@ public:
     enum class RenderingContextType {
         _2d,
         Webgl,
-        Webgl2
+        Webgl2,
+        Bitmaprenderer
     };
 
     static bool enabledForContext(ScriptExecutionContext&);
@@ -124,6 +127,8 @@ public:
     unsigned height() const final;
     void setWidth(unsigned);
     void setHeight(unsigned);
+
+    void setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&&) final;
 
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
 

--- a/Source/WebCore/html/OffscreenCanvas.idl
+++ b/Source/WebCore/html/OffscreenCanvas.idl
@@ -30,6 +30,7 @@ typedef (
 #if defined(ENABLE_WEBGL2) && ENABLE_WEBGL2
     WebGL2RenderingContext or
 #endif
+    ImageBitmapRenderingContext or
     OffscreenCanvasRenderingContext2D) OffscreenRenderingContext;
 
 dictionary ImageEncodeOptions
@@ -42,7 +43,8 @@ enum OffscreenRenderingContextType
 {
    "2d",
    "webgl",
-   "webgl2"
+   "webgl2",
+   "bitmaprenderer"
 };
 
 [

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
@@ -37,6 +37,12 @@ namespace WebCore {
 class ImageBitmap;
 class ImageBuffer;
 
+#if ENABLE(OFFSCREEN_CANVAS)
+using ImageBitmapCanvas = std::variant<RefPtr<HTMLCanvasElement>, RefPtr<OffscreenCanvas>>;
+#else
+using ImageBitmapCanvas = std::variant<RefPtr<HTMLCanvasElement>>;
+#endif
+
 class ImageBitmapRenderingContext final : public CanvasRenderingContext {
     WTF_MAKE_ISO_ALLOCATED(ImageBitmapRenderingContext);
 public:
@@ -49,7 +55,7 @@ public:
 
     ~ImageBitmapRenderingContext();
 
-    HTMLCanvasElement* canvas() const;
+    ImageBitmapCanvas canvas();
 
     ExceptionOr<void> transferFromImageBitmap(RefPtr<ImageBitmap>);
 

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.idl
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.idl
@@ -23,12 +23,18 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if defined(ENABLE_OFFSCREEN_CANVAS)
+typedef (HTMLCanvasElement or OffscreenCanvas) ImageBitmapCanvas;
+#else
+typedef (HTMLCanvasElement) ImageBitmapCanvas;
+#endif
+
 [
     EnabledByDeprecatedGlobalSetting=ImageBitmapEnabled,
     Exposed=(Window,Worker),
     CallTracer=InspectorCanvasCallTracer,
 ] interface ImageBitmapRenderingContext {
-    readonly attribute HTMLCanvasElement canvas;
+    readonly attribute ImageBitmapCanvas canvas;
 
     undefined transferFromImageBitmap(ImageBitmap? bitmap);
 };


### PR DESCRIPTION
#### b861c55669ed7191403b900d55ab30147ba41735
<pre>
Add ImageBitmapRenderingContext support to OffscreenCanvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=197421">https://bugs.webkit.org/show_bug.cgi?id=197421</a>

Reviewed by Chris Lord.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.nocrash-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/context-creation-offscreen-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/context-creation-offscreen-with-alpha-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/toBlob-origin-clean-offscreen.sub-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/tranferFromImageBitmap-ToBlob-offscreen-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/tranferFromImageBitmap-TransferToImageBitmap-offscreen-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/imagebitmap-renderingcontext/tranferFromImageBitmap-null-offscreen-expected.txt: Added.
* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::setImageBufferAndMarkDirty):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::getContext):
(WebCore::OffscreenCanvas::transferToImageBitmap):
(WebCore::OffscreenCanvas::setImageBufferAndMarkDirty):
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/OffscreenCanvas.idl:
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp:
(WebCore::ImageBitmapRenderingContext::canvas):
(WebCore::ImageBitmapRenderingContext::setOutputBitmap):
(WebCore::ImageBitmapRenderingContext::canvas const): Deleted.
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.h:
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.idl:

Canonical link: <a href="https://commits.webkit.org/254697@main">https://commits.webkit.org/254697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2104769be93193464e53699f0397becdb3788042

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98952 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155637 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32705 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28178 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82022 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93360 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25988 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76516 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25937 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80744 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68931 "Found 7 new API test failures: /WebKit2Gtk/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/children-changed, /WebKit2Gtk/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /TestWTF:WTF_WordLock.ManyContendedLongSections, /WebKit2Gtk/TestWebKitSettings:/webkit/WebKitSettings/webkit-settings, /WebKit2Gtk/TestWebKitVersion:/webkit/WebKitVersion/version, /WebKit2Gtk/TestLoaderClient:/webkit/WebKitWebPage/redirect-to-data-uri, /WebKit2Gtk/TestUIClient:/webkit/WebKitWebView/allow-modal-dialogs (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30460 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14826 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30210 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15758 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3299 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38703 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34850 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->