### PR TITLE
Revision field in the json data generated by run-webkit-tests is empty since migration to git

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py
@@ -397,12 +397,12 @@ def summarize_results(port_obj, expectations_by_type, initial_results, retry_res
         # FIXME: Do we really need to populate this both here and in the json_results_generator?
         if port_obj.get_option("builder_name"):
             port_obj.host.initialize_scm()
-            results['revision'] = str(port_obj.commits_for_upload()[0].get('revision', port_obj.commits_for_upload()[0].get('id')))
+            results['revision'] = str(port_obj.commits_for_upload()[0].get('identifier', port_obj.commits_for_upload()[0].get('hash')))
     except Exception as e:
-        _log.warn("Failed to determine svn revision for checkout (cwd: %s, webkit_base: %s), leaving 'revision' key blank in full_results.json.\n%s" % (port_obj._filesystem.getcwd(), port_obj.path_from_webkit_base(), e))
+        _log.warn("Failed to determine git revision for checkout (cwd: %s, webkit_base: %s), leaving 'revision' key blank in full_results.json.\n%s" % (port_obj._filesystem.getcwd(), port_obj.path_from_webkit_base(), e))
         # Handle cases where we're running outside of version control.
         import traceback
-        _log.debug('Failed to learn head svn revision:')
+        _log.debug('Failed to learn head git revision:')
         _log.debug(traceback.format_exc())
         results['revision'] = ""
 

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py
@@ -154,26 +154,20 @@ class SummarizedResultsTest(unittest.TestCase):
         host = MockHost(initialize_scm_by_default=False, create_stub_repository_files=True)
         self.port = host.port_factory.get(port_name='test', options=MockOptions(http=True, pixel_tests=False, world_leaks=False))
 
-    def test_no_svn_revision(self):
+    def test_no_git_revision(self):
         summary = summarized_results(self.port, expected=False, passing=False, flaky=False)
         self.assertNotIn('revision', summary)
 
-    def test_svn_revision_exists(self):
+    def test_git_revision_exists(self):
         self.port._options.builder_name = 'dummy builder'
         summary = summarized_results(self.port, expected=False, passing=False, flaky=False)
         self.assertNotEqual(summary['revision'], '')
 
-    def test_svn_revision(self):
-        with mocks.local.Svn(path='/'), mocks.local.Git():
+    def test_git_revision_identifier(self):
+        with mocks.local.Git(path='/'), OutputCapture():
             self.port._options.builder_name = 'dummy builder'
             summary = summarized_results(self.port, expected=False, passing=False, flaky=False)
-            self.assertEqual(summary['revision'], '6')
-
-    def test_svn_revision_git(self):
-        with mocks.local.Svn(), mocks.local.Git(path='/', git_svn=True), OutputCapture():
-            self.port._options.builder_name = 'dummy builder'
-            summary = summarized_results(self.port, expected=False, passing=False, flaky=False)
-            self.assertEqual(summary['revision'], '9')
+            self.assertEqual(summary['revision'], '5@main')
 
     def test_summarized_results_wontfix(self):
         self.port._options.builder_name = 'dummy builder'


### PR DESCRIPTION
#### ee1be476e83b744d0d91887b48953cb2552fcfc0
<pre>
Revision field in the json data generated by run-webkit-tests is empty since migration to git
<a href="https://bugs.webkit.org/show_bug.cgi?id=244960">https://bugs.webkit.org/show_bug.cgi?id=244960</a>

Reviewed by Jonathan Bedard.

The script run-webkit-tests generates a json file with the information of
the test run (usually named full_results.json).

This json included a &quot;revision&quot; field with the SVN revision of the checkout.
But since the migration to git this &quot;revision&quot; field is null.

Fix it by setting as revision number the canonical identifier &quot;number@main&quot;
if available, otherwise default to the git commit hash.

* Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py:
(summarize_results):
* Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py:
(SummarizedResultsTest.test_no_git_revision):
(SummarizedResultsTest.test_git_revision_exists):
(SummarizedResultsTest.test_git_revision_identifier):
(SummarizedResultsTest.test_no_svn_revision): Deleted.
(SummarizedResultsTest.test_svn_revision_exists): Deleted.
(SummarizedResultsTest.test_svn_revision): Deleted.
(SummarizedResultsTest.test_svn_revision_git): Deleted.

Canonical link: <a href="https://commits.webkit.org/254376@main">https://commits.webkit.org/254376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d312ea9deaeff90baa9b6dc7322597d0a532d675

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97861 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31727 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27333 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80893 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92497 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25174 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75652 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25110 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/92263 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68076 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29453 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14129 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29252 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15134 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3070 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38087 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34245 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->