### PR TITLE
[LBSE] Not all 'outermost' <svg> elements enforce a stacking context

### DIFF
--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/css/text-shadow-multiple-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/css/text-shadow-multiple-expected.txt
@@ -13,10 +13,6 @@ layer at (0,0) size 800x408
           text run at (0,0) width 567: "The next two texts have subtle differences, as the stroke/fill is painted seperated in SVG."
       RenderBlock (anonymous) at (0,238) size 800x154
         RenderText {#text} at (0,0) size 0x0
-layer at (0,100) size 800x100
-  RenderSVGRoot {svg} at (0,50) size 800x100
-layer at (0,304) size 800x100
-  RenderSVGRoot {svg} at (0,50) size 800x100
 layer at (20,50) size 717x58
   RenderBlock (positioned) {div} at (20,50) size 717x58
     RenderInline {span} at (0,0) size 95x56 [textStrokeWidth=1.00]
@@ -35,6 +31,8 @@ layer at (20,50) size 717x58
     RenderText {#text} at (505,1) size 212x56
       text run at (505,1) width 15: " "
       text run at (519,1) width 198: "shadows"
+layer at (0,100) size 800x100
+  RenderSVGRoot {svg} at (0,50) size 800x100
 layer at (0,100) size 800x100
   RenderSVGViewportContainer at (0,0) size 800x100
 layer at (20,121) size 717x56
@@ -73,6 +71,8 @@ layer at (20,254) size 717x58
     RenderText {#text} at (505,1) size 212x56
       text run at (505,1) width 15: " "
       text run at (519,1) width 198: "shadows"
+layer at (0,304) size 800x100
+  RenderSVGRoot {svg} at (0,50) size 800x100
 layer at (0,304) size 800x100
   RenderSVGViewportContainer at (0,0) size 800x100
 layer at (20,325) size 717x56

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/image-parent-translation-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/image-parent-translation-expected.txt
@@ -22,14 +22,14 @@ layer at (0,0) size 800x219
         RenderText {#text} at (0,0) size 0x0
 layer at (8,132) size 75x75
   RenderSVGRoot {svg} at (0,0) size 75x75
-layer at (87,132) size 75x75
-  RenderSVGRoot {svg} at (79,0) size 75x75
 layer at (8,132) size 75x75
   RenderSVGViewportContainer at (0,0) size 75x75
 layer at (8,132) size 75x75
   RenderSVGImage {image} at (0,0) size 75x75
 layer at (8,132) size 75x75
   RenderSVGRect {rect} at (0,0) size 75x75 [stroke={[type=SOLID] [color=#FF0000] [stroke width=6.00]}] [x=0.00] [y=0.00] [width=75.00] [height=75.00]
+layer at (87,132) size 75x75
+  RenderSVGRoot {svg} at (79,0) size 75x75
 layer at (87,132) size 75x75
   RenderSVGViewportContainer at (0,0) size 75x75
 layer at (87,132) size 75x75

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/second-inline-text-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/second-inline-text-expected.txt
@@ -12,8 +12,6 @@ layer at (0,0) size 800x162
         RenderText {#text} at (0,0) size 0x0
 layer at (8,50) size 100x100
   RenderSVGRoot {svg} at (0,0) size 100x100
-layer at (112,50) size 100x100
-  RenderSVGRoot {svg} at (104,0) size 100x100
 layer at (8,50) size 100x100
   RenderSVGViewportContainer at (0,0) size 100x100
 layer at (36,69) size 45x63
@@ -22,6 +20,8 @@ layer at (18,86) size 38x18
   RenderSVGText {text} at (10,36) size 39x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 39x18
       chunk 1 text run 1 at (10.00,50.00) startOffset 0 endOffset 4 width 38.25: "PASS"
+layer at (112,50) size 100x100
+  RenderSVGRoot {svg} at (104,0) size 100x100
 layer at (112,50) size 100x100
   RenderSVGViewportContainer at (0,0) size 100x100
 layer at (140,69) size 45x63

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -709,7 +709,8 @@ void Adjuster::adjustSVGElementStyle(RenderStyle& style, const SVGElement& svgEl
         ASSERT(!style.clipPath());
         ASSERT(!style.hasFilter());
 
-        if (svgElement.hasTagName(SVGNames::foreignObjectTag)
+        if (svgElement.isOutermostSVGSVGElement()
+            || svgElement.hasTagName(SVGNames::foreignObjectTag)
             || svgElement.hasTagName(SVGNames::imageTag)
             || svgElement.hasTagName(SVGNames::markerTag)
             || svgElement.hasTagName(SVGNames::maskTag)


### PR DESCRIPTION
#### a57723e637107f43ea2bd1c5284dffe714da13da
<pre>
[LBSE] Not all &apos;outermost&apos; &lt;svg&gt; elements enforce a stacking context
<a href="https://bugs.webkit.org/show_bug.cgi?id=244965">https://bugs.webkit.org/show_bug.cgi?id=244965</a>

Reviewed by Rob Buis.

Add missing condition in Style::Adjuster::adjustSVGElementStyle() to enforce
a stacking context if the element that receives the style is an outermost
&lt;svg&gt; element (or acts as such). It is mentioned in the SVG2 spec note just
a few lines above, but not implemented yet.

* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/css/text-shadow-multiple-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/image-parent-translation-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/second-inline-text-expected.txt:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustSVGElementStyle):

Canonical link: <a href="https://commits.webkit.org/254314@main">https://commits.webkit.org/254314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abb2f354f07b3b2efee54b1284ce078d3ba4a382

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97880 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31746 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27364 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80913 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92516 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25195 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75683 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25126 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68091 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29509 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29271 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15154 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3044 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32717 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38088 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31400 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34263 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->