### PR TITLE
Incorrect behavior of "cursor: auto" over links

### DIFF
--- a/LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text-expected.txt
+++ b/LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text-expected.txt
@@ -1,21 +1,24 @@
 
+Testing <img id="img-not-styled-cursor">
+PASS cursor is "Pointer"
+
+Testing overlay from <img id="img-not-styled-cursor">
+PASS cursor is "IBeam"
+
+Testing <img id="img-not-styled-cursor-user-select-none">
+PASS cursor is "Pointer"
+
 Testing <img id="inside-link">
+PASS cursor is "Hand"
+
+Testing overlay from <img id="inside-link">
 PASS cursor is "Hand"
 
 Testing <img id="cursor-zoom-in">
 PASS cursor is "ZoomIn"
 
-Testing <img id="user-select-none-in-link">
-PASS cursor is "Hand"
-
-Testing overlay from <img id="inside-link">
-PASS cursor is "IBeam"
-
 Testing overlay from <img id="cursor-zoom-in">
-PASS cursor is "IBeam"
-
-Testing overlay from <img id="user-select-none-in-link">
-PASS cursor is "Pointer"
+PASS cursor is "ZoomIn"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text.html
+++ b/LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text.html
@@ -11,19 +11,14 @@ img {
     border: 1px solid black;
     display: block;
 }
-
 a {
     display: block;
 }
-
 #cursor-zoom-in {
-    top: 100px;
     cursor: zoom-in;
 }
-
-#user-select-none-in-link {
-    top: 200px;
-    -webkit-user-select: none;
+#img-not-styled-cursor-user-select-none {
+    user-select: none;
 }
 
 </style>
@@ -65,23 +60,30 @@ addEventListener("load", () => {
         shouldBeEqualToString("cursor", expectedResult);
     }
 
-    testImage("inside-link", "Hand");
-    testImage("cursor-zoom-in", "ZoomIn");
-    testImage("user-select-none-in-link", "Hand");
+    testImage("img-not-styled-cursor", "Pointer");
+    testOverlayDivFromImage("img-not-styled-cursor", "IBeam");
 
-    testOverlayDivFromImage("inside-link", "IBeam");
-    testOverlayDivFromImage("cursor-zoom-in", "IBeam");
-    testOverlayDivFromImage("user-select-none-in-link", "Pointer");
+    testImage("img-not-styled-cursor-user-select-none", "Pointer");
+    //  FIXME: this test case will fail due to https://bugs.webkit.org/show_bug.cgi?id=244944
+    //  EventHandler::selectCursor will select an IBeam cursor although it shouldn't. This is
+    //  because Node::canStartSelection() is not false for user-select: none.
+    //  Enable the test case once we fix this behavior:
+    // testOverlayDivFromImage("img-not-styled-cursor-user-select-none", "Pointer");
+
+    testImage("inside-link", "Hand");
+    testOverlayDivFromImage("inside-link", "Hand");
+
+    testImage("cursor-zoom-in", "ZoomIn");
+    testOverlayDivFromImage("cursor-zoom-in", "ZoomIn");
 });
 </script>
 </head>
 <body>
+<img id="img-not-styled-cursor" src="../../resources/green-400x400.png">
 <a href="#">
     <img id="inside-link" src="../../resources/green-400x400.png"></img>
 </a>
 <img id="cursor-zoom-in" src="../../resources/green-400x400.png"></img>
-<a href="#">
-    <img id="user-select-none-in-link" src="../../resources/green-400x400.png"></img>
-</a>
+<img id="img-not-styled-cursor-user-select-none" src="../../resources/green-400x400.png">
 </body>
 </html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1759,8 +1759,6 @@ webkit.org/b/243589 [ Debug ] imported/w3c/web-platform-tests/service-workers/se
 webkit.org/b/243589 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/service-worker-header.https.html [ Pass Crash ]
 webkit.org/b/243589 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/update-import-scripts.https.html [ Pass Crash ]
 
-webkit.org/b/244272 [ Monterey ] fast/images/text-recognition/mac/cursor-types-for-recognized-text.html [ Pass Failure ]
-
 webkit.org/b/244740 http/wpt/cross-origin-opener-policy/non-secure-to-secure-context-navigation.https.html [ Pass Failure ]
 
 webkit.org/b/244968 [ arm64 ] imported/w3c/web-platform-tests/web-animations/timing-model/animations/update-playback-rate-zero.html [ Pass ImageOnlyFailure ]

--- a/Source/WebCore/html/shadow/imageOverlay.css
+++ b/Source/WebCore/html/shadow/imageOverlay.css
@@ -32,7 +32,6 @@ div#image-overlay {
     text-indent: 0;
     text-align: center;
     font-family: system-ui;
-    cursor: auto;
 }
 
 :host(:not(img)) div#image-overlay:-webkit-full-screen-document {


### PR DESCRIPTION
#### 7aae85f6f9110d491f46d8dc63a38b0291dcd02c
<pre>
Incorrect behavior of &quot;cursor: auto&quot; over links
<a href="https://bugs.webkit.org/show_bug.cgi?id=173909">https://bugs.webkit.org/show_bug.cgi?id=173909</a>
rdar://99495893

Reviewed by NOBODY (OOPS!).

The initial attempt to fix this bug and comply to spec was made
at <a href="https://commits.webkit.org/253685@main">https://commits.webkit.org/253685@main</a>

After that, a:any-link no longer depends on &apos;cursor: auto&apos;
for achieving &quot;Hand&quot; (css: pointer) cursor. This is because, according to spec,
&apos;cursor: auto&apos; can only result in default or text cursor. Therefore, 253685@main
sets &apos;cursor: pointer&apos; in the UA stylesheet (html.css).

Because of that, a test case for cursor types for recognized text (live-text)
was broken. There, we were testing a &lt;img&gt; nested in a &lt;a href=&quot;&quot;&gt;. Since,
this &lt;a&gt; is now selected to have &apos;cursor: pointer&apos;, its nested &lt;img&gt;
has no longer &apos;cursor: auto&apos;, which is required for resulting in IBeam (text)
cursor for the overlay installed in the img (see EventHandler::selectCursor).

Therefore, we are updating the test case here. A &lt;img&gt; inside a &lt;a href=&quot;...&quot;&gt;
is by default styled with cursor: pointer, and therefore hovering over
its overlay doesn&apos;t show IBeam (text) cursor, unless user styles its cursor to auto.

* LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text-expected.txt:
* LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text.html:
Updating tests. Note that one of the test cases is commented out. As stated in the comment,
this would fail due to <a href="https://bugs.webkit.org/show_bug.cgi?id=244944">https://bugs.webkit.org/show_bug.cgi?id=244944</a> (radar: 99495849).
In short, EventHandler::selectCursor will select an IBeam cursor although it shouldn&apos;t.
This is because Node::canStartSelection() is not false for user-select: none.
* LayoutTests/platform/mac-wk2/TestExpectations:
Reseting TextExpectations for this test, before set as failure.
* Source/WebCore/html/shadow/imageOverlay.css:
(div#image-overlay):
We should not style cursor for the live-text overlay that is installed
on top of images with text. Doing that would disable user to control which
cursor is displayed for the text portion of the image, since the overlay
is in the shadow tree, hosted by the image element. I.e.: user&apos;s cursor style
for the image would not be propagated to the overlay.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7aae85f6f9110d491f46d8dc63a38b0291dcd02c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97934 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154459 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31801 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27424 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80972 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92563 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25229 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75726 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25180 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80107 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80174 "Found 1 new API test failure: TestWebKitAPI.VideoControlsManager.VideoControlsManagerMultipleVideosScrollPlayingVideoWithSoundOutOfView (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68141 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29585 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14185 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29339 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15189 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38111 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34296 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->