### PR TITLE
Remove checks for A8 devices now that they are no longer supported

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/apple_platform_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/common/apple_platform_utils.mm
@@ -52,21 +52,11 @@ bool IsMetalRendererAvailable()
                         gpuFamilySufficient = true;
                 }
 #elif defined(ANGLE_PLATFORM_IOS) && !TARGET_OS_SIMULATOR
-                // A8 devices (iPad Mini 4, iPad Air 2) cannot use ANGLE's Metal backend.
-                // This check can be removed once they are no longer supported.
-                if (ANGLE_APPLE_AVAILABLE_XCI(10.15, 13.1, 13))
-                {
-                    if ([device supportsFamily:MTLGPUFamilyApple3])
-                        gpuFamilySufficient = true;
-                }
-                else
-                {
-                    // Hardcode constant to sidestep compiler errors. Call will
-                    // return false on older macOS versions.
-                    const NSUInteger iosFamily3v1 = 4;
-                    if ([device supportsFeatureSet:static_cast<MTLFeatureSet>(iosFamily3v1)])
-                        gpuFamilySufficient = true;
-                }
+                // Hardcode constant to sidestep compiler errors. Call will
+                // return false on older macOS versions.
+                const NSUInteger iosFamily3v1 = 4;
+                if ([device supportsFeatureSet:static_cast<MTLFeatureSet>(iosFamily3v1)])
+                    gpuFamilySufficient = true;
 #elif defined(ANGLE_PLATFORM_IOS) && TARGET_OS_SIMULATOR
                 // FIXME: Currently we do not have good simulator query, as it does not support
                 // the whole feature set needed for iOS.

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -105,16 +105,13 @@ static bool platformSupportsMetal()
     auto device = adoptNS(MTLCreateSystemDefaultDevice());
 
     if (device) {
-#if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR)
-        // A8 devices (iPad Mini 4, iPad Air 2) cannot use WebGL via Metal.
-        // This check can be removed once they are no longer supported.
-        return [device supportsFamily:MTLGPUFamilyApple3];
-#elif PLATFORM(MAC) || PLATFORM(MACCATALYST)
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
         // Old Macs, such as MacBookPro11,4 cannot use WebGL via Metal.
         // This check can be removed once they are no longer supported.
         return [device supportsFamily:MTLGPUFamilyMac2];
-#endif
+#else
         return true;
+#endif
     }
 
     return false;

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -194,12 +194,7 @@ bool Internals::platformSupportsMetal(bool isWebGL2)
     UNUSED_PARAM(isWebGL2);
 
     if (device) {
-#if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR)
-        // A8 devices (iPad Mini 4, iPad Air 2) cannot use WebGL2 via Metal.
-        // This check can be removed once they are no longer supported.
-        if (isWebGL2)
-            return [device supportsFamily:MTLGPUFamilyApple3];
-#elif PLATFORM(MAC) || PLATFORM(MACCATALYST)
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
         // Old Macs, such as MacBookPro11,4 cannot use WebGL via Metal.
         // This check can be removed once they are no longer supported.
         return [device supportsFamily:MTLGPUFamilyMac2];


### PR DESCRIPTION
As of iOS 16, A8 devices are no longer supported<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f05fdd19144eb40dfaafc422d35233b6c442bc18

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113348 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4146 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96368 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112412 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109910 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38658 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92865 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25692 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80314 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6596 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3575 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12741 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/46604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8514 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->