### PR TITLE
IPC::StreamServerConnection lacks send()

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -99,7 +99,7 @@ protected:
     virtual void platformWorkQueueInitialize(WebCore::GraphicsContextGLAttributes&&) { };
     void workQueueUninitialize();
     template<typename T>
-    bool send(T&& message) const { return m_streamConnection->connection().send(WTFMove(message), m_graphicsContextGLIdentifier); }
+    bool send(T&& message) const { return m_streamConnection->send(WTFMove(message), m_graphicsContextGLIdentifier); }
 
     // GraphicsContextGL::Client overrides.
     void didComposite() final;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -129,7 +129,7 @@ private:
     template<typename T>
     bool send(T&& message) const
     {
-        return m_streamConnection->connection().send(WTFMove(message), m_identifier);
+        return m_streamConnection->send(WTFMove(message), m_identifier);
     }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -83,6 +83,7 @@ public:
 
     void open();
     void invalidate();
+    template<typename T, typename U> bool send(T&& message, ObjectIdentifier<U> destinationID);
 
     template<typename T, typename... Arguments>
     void sendSyncReply(Connection::SyncRequestID, Arguments&&...);
@@ -141,6 +142,12 @@ private:
 
     friend class StreamConnectionWorkQueue;
 };
+
+template<typename T, typename U>
+bool StreamServerConnection::send(T&& message, ObjectIdentifier<U> destinationID)
+{
+    return m_connection->send(WTFMove(message), destinationID);
+}
 
 template<typename T, typename... Arguments>
 void StreamServerConnection::sendSyncReply(Connection::SyncRequestID syncRequestID, Arguments&&... arguments)

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -61,7 +61,7 @@ void IPCStreamTester::initialize()
     m_streamConnection->startReceivingMessages(*this, Messages::IPCStreamTester::messageReceiverName(), m_identifier.toUInt64());
     m_streamConnection->open();
     workQueue().dispatch([this] {
-        m_streamConnection->connection().send(Messages::IPCStreamTesterProxy::WasCreated(workQueue().wakeUpSemaphore(), m_streamConnection->clientWaitSemaphore()), m_identifier);
+        m_streamConnection->send(Messages::IPCStreamTesterProxy::WasCreated(workQueue().wakeUpSemaphore(), m_streamConnection->clientWaitSemaphore()), m_identifier);
     });
 }
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -556,6 +556,7 @@
 		7B9FC5D528A53137007570E7 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC90964D1255620C00083756 /* JavaScriptCore.framework */; };
 		7B9FC5D628A5326A007570E7 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F4FFAA01ED3D0DE00F7111F /* ImageIO.framework */; };
 		7BA3936C271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BA3936B271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm */; };
+		7BAA4A9028CA14AE004CE938 /* StreamConnectionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */; };
 		7C3965061CDD74F90094DBB8 /* ColorTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C3965051CDD74F90094DBB8 /* ColorTests.cpp */; };
 		7C486BA11AA12567003F6F9B /* bundle-file.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7C486BA01AA1254B003F6F9B /* bundle-file.html */; };
 		7C74C8FA22DFBA9600DA2DAB /* WTFStringUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CBD5A2222DE42A6004A9E32 /* WTFStringUtilities.cpp */; };
@@ -2643,6 +2644,7 @@
 		7B9FC5CC28A52DC0007570E7 /* libWebKitPlatform.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libWebKitPlatform.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		7BA3936B271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TestGraphicsContextGLCocoa.mm; sourceTree = "<group>"; };
 		7BA3936D271EEC530015911C /* WebCoreUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebCoreUtilities.h; sourceTree = "<group>"; };
+		7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamConnectionTests.cpp; sourceTree = "<group>"; };
 		7BB754AF274E39A100D00EC1 /* TestUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestUtilities.h; sourceTree = "<group>"; };
 		7BB754B0274E39A100D00EC1 /* TestUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestUtilities.cpp; sourceTree = "<group>"; };
 		7C1AF7931E8DCBAB002645B9 /* PrepareForMoveToWindow.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PrepareForMoveToWindow.mm; sourceTree = "<group>"; };
@@ -4251,6 +4253,7 @@
 			children = (
 				7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */,
 				7B9FC58328A26792007570E7 /* StreamConnectionBufferTests.cpp */,
+				7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */,
 			);
 			path = IPC;
 			sourceTree = "<group>";
@@ -5767,6 +5770,7 @@
 				7B9FC39F28A26137007570E7 /* mainIOS.mm in Sources */,
 				7B9FC3A028A26137007570E7 /* mainMac.mm in Sources */,
 				7B9FC58428A26792007570E7 /* StreamConnectionBufferTests.cpp in Sources */,
+				7BAA4A9028CA14AE004CE938 /* StreamConnectionTests.cpp in Sources */,
 				7B9FC58C28A2717D007570E7 /* TestsController.cpp in Sources */,
 				7B397C0828BE394B00239202 /* UtilitiesCocoa.mm in Sources */,
 			);

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Test.h"  // NOLINT
+
+#include "ArgumentCoders.h"
+#include "StreamClientConnection.h"
+#include "StreamConnectionWorkQueue.h"
+#include "StreamServerConnection.h"
+#include "Utilities.h"
+#include <optional>
+#include <wtf/Lock.h>
+
+namespace TestWebKitAPI {
+
+namespace {
+static constexpr Seconds defaultSendTimeout = 1_s;
+
+enum TestObjectIdentifierTag { };
+using TestObjectIdentifier = ObjectIdentifier<TestObjectIdentifierTag>;
+
+template <typename T>
+std::optional<T> refViaEncoder(const T& o)
+{
+    IPC::Encoder encoder(static_cast<IPC::MessageName>(78), 0);
+    encoder << o;
+    auto decoder = IPC::Decoder::create(encoder.buffer(), encoder.bufferSize(), encoder.releaseAttachments());
+    return decoder->decode<T>();
+}
+
+struct MessageInfo {
+    IPC::MessageName messageName;
+    uint64_t destinationID;
+};
+
+struct MockTestMessage1 {
+    static constexpr bool isSync = false;
+    static constexpr bool isStreamEncodable = true;
+    static constexpr bool isStreamBatched = false;
+    static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(123); }
+    std::tuple<> arguments() { return { }; }
+};
+
+class WaitForMessageMixin {
+public:
+    ~WaitForMessageMixin()
+    {
+        ASSERT(m_messages.isEmpty()); // Received unexpected messages.
+    }
+    MessageInfo waitForMessage()
+    {
+        Locker locker { m_lock };
+        if (m_messages.isEmpty()) {
+            m_continueWaitForMessage = false;
+            DropLockForScope unlocker { locker };
+            while (!m_continueWaitForMessage)
+                Util::spinRunLoop(1);
+        }
+        ASSERT(m_messages.size() >= 1);
+        return m_messages.takeLast();
+    }
+
+    void addMessage(IPC::Decoder& decoder)
+    {
+        Locker locker { m_lock };
+        m_messages.insert(0, { decoder.messageName(), decoder.destinationID() });
+        m_continueWaitForMessage = true;
+    }
+
+protected:
+    Lock m_lock;
+    Vector<MessageInfo> m_messages WTF_GUARDED_BY_LOCK(m_lock);
+    std::atomic<bool> m_continueWaitForMessage { false };
+};
+
+class MockMessageReceiver : public IPC::MessageReceiver, public WaitForMessageMixin {
+public:
+    // IPC::Connection::MessageReceiver overrides.
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder& decoder) override
+    {
+        addMessage(decoder);
+    }
+
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override
+    {
+        return false;
+    }
+};
+
+class MockStreamMessageReceiver : public IPC::StreamMessageReceiver, public WaitForMessageMixin {
+public:
+    // IPC::StreamMessageReceiver overrides.
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder& decoder) override
+    {
+        addMessage(decoder);
+    }
+};
+
+}
+
+class StreamConnectionTest : public ::testing::Test {
+public:
+    StreamConnectionTest()
+        : m_workQueue(IPC::StreamConnectionWorkQueue::create("StreamConnectionTest work queue"))
+    {
+    }
+
+    void SetUp() override
+    {
+        WTF::initializeMainThread();
+        auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::createWithDedicatedConnection(m_mockClientReceiver, 1000);
+        auto serverConnection = IPC::StreamServerConnection::createWithDedicatedConnection(WTFMove(serverConnectionHandle), *refViaEncoder(clientConnection->streamBuffer()), *m_workQueue);
+        m_clientConnection = WTFMove(clientConnection);
+        m_serverConnection = WTFMove(serverConnection);
+    }
+    void TearDown() override
+    {
+        m_workQueue->stopAndWaitForCompletion();
+        m_clientConnection->invalidate();
+        m_serverConnection->invalidate();
+    }
+protected:
+    MockMessageReceiver m_mockClientReceiver;
+    RefPtr<IPC::StreamConnectionWorkQueue> m_workQueue;
+    std::unique_ptr<IPC::StreamClientConnection> m_clientConnection;
+    RefPtr<IPC::StreamServerConnection> m_serverConnection;
+};
+
+TEST_F(StreamConnectionTest, OpenConnections)
+{
+    m_clientConnection->open();
+    m_serverConnection->open();
+    m_clientConnection->invalidate();
+    m_serverConnection->invalidate();
+}
+
+TEST_F(StreamConnectionTest, SendLocalMessage)
+{
+    m_clientConnection->open();
+    m_serverConnection->open();
+    RefPtr<MockStreamMessageReceiver> mockServerReceiver = adoptRef(new MockStreamMessageReceiver);
+    m_serverConnection->startReceivingMessages(*mockServerReceiver, IPC::receiverName(MockTestMessage1::name()), 77);
+    for (uint64_t i = 0u; i < 55u; ++i)
+        m_clientConnection->send(MockTestMessage1 { }, makeObjectIdentifier<TestObjectIdentifier>(77), defaultSendTimeout);
+    m_workQueue->dispatch([this] {
+        for (uint64_t i = 100u; i < 160u; ++i)
+            m_serverConnection->send(MockTestMessage1 { }, makeObjectIdentifier<TestObjectIdentifier>(i));
+    });
+    for (uint64_t i = 100u; i < 160u; ++i) {
+        auto message = m_mockClientReceiver.waitForMessage();
+        EXPECT_EQ(message.messageName, MockTestMessage1::name());
+        EXPECT_EQ(message.destinationID, i);
+    }
+    for (uint64_t i = 0u; i < 55u; ++i) {
+        auto message = mockServerReceiver->waitForMessage();
+        EXPECT_EQ(message.messageName, MockTestMessage1::name());
+        EXPECT_EQ(message.destinationID, 77u);
+    }
+    m_serverConnection->stopReceivingMessages(IPC::receiverName(MockTestMessage1::name()), 77);
+}
+
+}


### PR DESCRIPTION
#### c4c9eb9732f57b4283201a304f5bb8fb1bffd4e9
<pre>
IPC::StreamServerConnection lacks send()
<a href="https://bugs.webkit.org/show_bug.cgi?id=244971">https://bugs.webkit.org/show_bug.cgi?id=244971</a>

Reviewed by Antti Koivisto.

Clients of IPC::StreamServerConnection should use the class itself,
not its implementation detail (connection()).
Add IPC::StreamServerConnection::send() that is supposed to send
messages through the connection. This way if the implementation changes,
the client sending code is already correct and unsuprising.

Uses this as an excuse to implement some tests for the Stream*Connection.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
(WebKit::RemoteGraphicsContextGL::send const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
(IPC::StreamServerConnection::send):
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::initialize):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::StreamConnectionTest::StreamConnectionTest):
(TestWebKitAPI::TEST_F):
(TestWebKitAPI::refViaEncoder): Deleted.

Canonical link: <a href="https://commits.webkit.org/254484@main">https://commits.webkit.org/254484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d96efb1c68bee7daa512655fd4af8326c4a7c96b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98101 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154596 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31970 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27572 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81143 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92721 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25376 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75882 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25326 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80282 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68291 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29764 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14307 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29495 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15302 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3143 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38244 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34407 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->