### PR TITLE
Properly construct C++ std strings

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/apple_platform_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/common/apple_platform_utils.mm
@@ -16,7 +16,7 @@ bool IsMetalRendererAvailable()
     static bool queriedSystemDevice = false;
     static bool gpuFamilySufficient = false;
 
-    // We only support macos 10.13+ and 11 for now. Since they are requirements for Metal 2.0.
+    // We only support macOS 10.13+ and 11 for now. Since they are requirements for Metal 2.0.
 #if TARGET_OS_SIMULATOR
     if (ANGLE_APPLE_AVAILABLE_XCI(10.13, 13.0, 13))
 #else

--- a/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_macos.mm
+++ b/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_macos.mm
@@ -47,7 +47,7 @@ std::string GetMachineModel()
 
     if (platformExpert == IO_OBJECT_NULL)
     {
-        return "";
+        return {};
     }
 
     CFDataRef modelData = static_cast<CFDataRef>(
@@ -55,10 +55,10 @@ std::string GetMachineModel()
     if (modelData == nullptr)
     {
         IOObjectRelease(platformExpert);
-        return "";
+        return {};
     }
 
-    std::string result = reinterpret_cast<const char *>(CFDataGetBytePtr(modelData));
+    std::string result(reinterpret_cast<const char *>(CFDataGetBytePtr(modelData)));
 
     IOObjectRelease(platformExpert);
     CFRelease(modelData);

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_common.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_common.mm
@@ -96,7 +96,7 @@ std::string FormatMetalErrorMessage(NSError *error)
 {
     if (!error)
     {
-        return "";
+        return {};
     }
 
     std::stringstream errorStream;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm
@@ -52,7 +52,7 @@ ANGLE_APPLE_UNUSED
 std::string GetMetalCaptureFile()
 {
 #if !ANGLE_METAL_FRAME_CAPTURE_ENABLED
-    return "";
+    return {};
 #else
     auto var                   = std::getenv("ANGLE_METAL_FRAME_CAPTURE_FILE");
     const std::string filePath = var ? var : "";


### PR DESCRIPTION
"" is an empty C string in Objective-C++, and we need to use the constructor to turn a C string into std::string.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd811255e96b135f69e1083731d14442ef1ab854

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97903 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31772 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27400 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80938 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92539 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25209 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75703 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25152 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68121 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29543 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14161 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29309 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15170 "Found 2 new test failures: webanimations/accelerated-animation-with-delay.html, webanimations/animation-of-accelerated-property-after-non-accelerated-property.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38100 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34276 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->