### PR TITLE
[Gardening]: REGRESSION (252741@main?): [ BigSur wk2 Release ]  webgl/2.0.0/deqp/functional/gles3/uniformbuffers/single_basic_type.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1775,4 +1775,4 @@ webkit.org/b/244983 [ BigSur Release ] webgl/2.0.0/deqp/functional/gles3/uniform
 webkit.org/b/244983 [ BigSur Release ] webgl/2.0.0/deqp/functional/gles3/uniformapi/value_initial.html [ Pass Failure ]
 webkit.org/b/244983 [ BigSur Release ] webgl/2.0.0/deqp/functional/gles3/uniformapi/random.html [ Pass Failure ]
 
-webkit.org/b/244980 webgl/2.0.0/deqp/functional/gles3/uniformbuffers/single_basic_type.html [ Pass Failure ]
+webkit.org/b/244980 [ BigSur Release ] webgl/2.0.0/deqp/functional/gles3/uniformbuffers/single_basic_type.html [ Pass Failure ]


### PR DESCRIPTION
#### 952ebeb016eb381fa2e832615e958f53560ea35f
<pre>
[Gardening]: REGRESSION (252741@main?): [ BigSur wk2 Release ]  webgl/2.0.0/deqp/functional/gles3/uniformbuffers/single_basic_type.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244980">https://bugs.webkit.org/show_bug.cgi?id=244980</a>
&lt;rdar://99745054&gt;

Unreviewed test gardening.

* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/254313@main">https://commits.webkit.org/254313@main</a>
</pre>
