### PR TITLE
css-pseudo: ::placeholder should not support 'writing-mode', 'direction', and 'text-orientation'

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -762,7 +762,10 @@ textarea {
 ::placeholder {
     -webkit-text-security: none;
     color: darkGray;
+    direction: inherit !important;
     pointer-events: none !important;
+    text-orientation: inherit !important;
+    writing-mode: inherit !important;
 }
 
 input::placeholder {


### PR DESCRIPTION
#### b79ce718736d854df91a05173ba242e49d9cf2f2
<pre>
css-pseudo: ::placeholder should not support &apos;writing-mode&apos;, &apos;direction&apos;, and &apos;text-orientation&apos;

css-pseudo: ::placeholder should not support &apos;writing-mode&apos;, &apos;direction&apos;, and &apos;text-orientation&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=244982">https://bugs.webkit.org/show_bug.cgi?id=244982</a>

Reviewed by Alan Bujtas.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/68c32d4e9fe24e25e672095253e0f0b2e709ecf4%5E%21/">https://chromium.googlesource.com/chromium/src.git/+/68c32d4e9fe24e25e672095253e0f0b2e709ecf4%5E%21/</a>

It is to align Webkit behavior with Web-Spec:

<a href="https://drafts.csswg.org/css-pseudo-4/#placeholder-pseudo">https://drafts.csswg.org/css-pseudo-4/#placeholder-pseudo</a>

All properties that apply to the ::first-line pseudo-element also apply to the ::placeholder pseudo-element.

<a href="https://drafts.csswg.org/css-pseudo-4/#first-line-styling">https://drafts.csswg.org/css-pseudo-4/#first-line-styling</a>

User agents may apply other properties as well except for the following excluded properties:
- writing-mode
- direction
- text-orientation

* Source/WebCore/css/html.css - Updated ::placeholder to add &apos;direction&apos;, &apos;text-orientation&apos; and &apos;writing-mode&apos;

Canonical link: <a href="https://commits.webkit.org/254416@main">https://commits.webkit.org/254416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a3724c2e76d819659a9e962f52e0482697c3047

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98005 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154510 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31873 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27481 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81047 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92626 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25289 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75787 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25240 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68202 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29671 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14223 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29400 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15220 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3091 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38148 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34327 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->