### PR TITLE
[WebAuthn] Give back user gesture freebie after successful assertion/registration

### DIFF
--- a/LayoutTests/http/wpt/webauthn/ctap-hid-success.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/ctap-hid-success.https-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 
 PASS CTAP HID with keep alive message in a mock hid authenticator.
 PASS CTAP HID with fast data arrival in a mock hid authenticator.

--- a/LayoutTests/http/wpt/webauthn/idl.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/idl.https-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 Description
 
 This test verifies that the implementations of the WebAuthN API match with its WebIDL definition.

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid.https-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 
 PASS PublicKeyCredential's [[create]] with minimum options in a mock ccid authenticator.
 PASS PublicKeyCredential's [[create]] with minimum options in a mock ccid authenticator with contactless.

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
@@ -1,21 +1,4 @@
 CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 
 PASS PublicKeyCredential's [[create]] with minimum options in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with user handle of length=1 in a mock hid authenticator.

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https-expected.txt
@@ -1,12 +1,3 @@
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 
 PASS PublicKeyCredential's [[create]] with minimum options in a mock local authenticator.
 PASS PublicKeyCredential's [[create]] with minimum options in a mock local authenticator checking getPublicKey()

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https-expected.txt
@@ -1,9 +1,3 @@
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 
 PASS PublicKeyCredential's [[create]] with minimum options in a mock nfc authenticator.
 PASS PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform' } in a mock nfc authenticator.

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-u2f.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-u2f.https-expected.txt
@@ -1,9 +1,3 @@
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 
 PASS PublicKeyCredential's [[create]] with minimum options in a mock u2f authenticator.
 PASS PublicKeyCredential's [[create]] with excludeCredentials in a mock u2f authenticator.

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt
@@ -1,11 +1,4 @@
 CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 
 PASS PublicKeyCredential's [[get]] with minimum options in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with matched allow credentials in a mock hid authenticator.

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-local.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-local.https-expected.txt
@@ -1,5 +1,4 @@
 CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 
 PASS PublicKeyCredential's [[get]] with minimum options in a mock local authenticator.
 PASS PublicKeyCredential's [[get]] with matched allow credentials in a mock local authenticator.

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-nfc.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-nfc.https-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 
 PASS PublicKeyCredential's [[get]] with minimum options in a mock nfc authenticator.
 PASS PublicKeyCredential's [[get]] with U2F in a mock nfc authenticator.

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https-expected.txt
@@ -1,13 +1,3 @@
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 
 PASS PublicKeyCredential's [[get]] with minimum options in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with more allow credentials in a mock hid authenticator.

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.h
@@ -30,6 +30,7 @@
 #include "IDLTypes.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebAuthn {
 enum class Scope;
@@ -52,7 +53,7 @@ template<typename IDLType> class DOMPromiseDeferred;
 using CredentialPromise = DOMPromiseDeferred<IDLNullable<IDLInterface<BasicCredential>>>;
 using ScopeAndCrossOriginParent = std::pair<WebAuthn::Scope, std::optional<SecurityOriginData>>;
 
-class AuthenticatorCoordinator final {
+class AuthenticatorCoordinator final : public CanMakeWeakPtr<AuthenticatorCoordinator> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(AuthenticatorCoordinator);
 public:
@@ -60,8 +61,8 @@ public:
     WEBCORE_EXPORT void setClient(std::unique_ptr<AuthenticatorCoordinatorClient>&&);
 
     // The following methods implement static methods of PublicKeyCredential.
-    void create(const Document&, const PublicKeyCredentialCreationOptions&, WebAuthn::Scope, RefPtr<AbortSignal>&&, CredentialPromise&&) const;
-    void discoverFromExternalSource(const Document&, CredentialRequestOptions&&, const ScopeAndCrossOriginParent&, CredentialPromise&&) const;
+    void create(const Document&, const PublicKeyCredentialCreationOptions&, WebAuthn::Scope, RefPtr<AbortSignal>&&, CredentialPromise&&);
+    void discoverFromExternalSource(const Document&, CredentialRequestOptions&&, const ScopeAndCrossOriginParent&, CredentialPromise&&);
     void isUserVerifyingPlatformAuthenticatorAvailable(const Document&, DOMPromiseDeferred<IDLBoolean>&&) const;
     void isConditionalMediationAvailable(DOMPromiseDeferred<IDLBoolean>&&) const;
 


### PR DESCRIPTION
#### a6664c87fe8f76c799e342e496d18e852134d751
<pre>
[WebAuthn] Give back user gesture freebie after successful assertion/registration
<a href="https://bugs.webkit.org/show_bug.cgi?id=244990">https://bugs.webkit.org/show_bug.cgi?id=244990</a>
&lt;rdar://99535178&gt;

Reviewed by Brent Fulgham.

Some SPA-based application&apos;s user gestures don&apos;t register, causing headaches with WebAuthn
flows. Here we partially mitigate that issue by restoring the user gesture freebie upon a
successful registration/assertion. This does not make it possible for an RP to spam
WebAuthn calls as the freebie is only restored after the user provided consent for the previous
operation.

* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::create):
(WebCore::AuthenticatorCoordinator::discoverFromExternalSource):
(WebCore::AuthenticatorCoordinator::create const): Deleted.
(WebCore::AuthenticatorCoordinator::discoverFromExternalSource const): Deleted.
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/web-authentication-make-credential-la-no-mock.html:

Canonical link: <a href="https://commits.webkit.org/257940@main">https://commits.webkit.org/257940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecf52c230edf67902f97f7150489324c9eb759f9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109599 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169826 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104268 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/10535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92693 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107486 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106051 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34504 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89758 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; 10 api tests failed or timed out; 10 api tests failed or timed out; Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change (exception)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77454 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3196 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24015 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3177 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43505 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5441 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5005 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->