### PR TITLE
String.prototype.includes incorrectly returns false when string is empty and position is past end of string

### DIFF
--- a/LayoutTests/js/script-tests/string-includes.js
+++ b/LayoutTests/js/script-tests/string-includes.js
@@ -38,6 +38,9 @@ shouldBeTrue("'abc'.includes('ab', -Infinity)");
 shouldBeFalse("'abc'.includes('cd', -Infinity)");
 shouldBeTrue("'abc'.includes('ab', 0)");
 shouldBeFalse("'abc'.includes('cd', 0)");
+shouldBeTrue("'abc'.includes('', 3)")
+shouldBeTrue("'abc'.includes('', 4)")
+shouldBeTrue("'abc'.includes('', Infinity)")
 
 // Test startsWith
 shouldBe("String.prototype.startsWith.name", "'startsWith'");
@@ -75,6 +78,9 @@ shouldBeTrue("'abc'.startsWith('b', 1)");
 shouldBeFalse("'abc'.startsWith('b', 2)");
 shouldBeTrue("'abc'.startsWith('c', 2)");
 shouldBeFalse("'abc'.startsWith('a', Math.pow(2, 33))");
+shouldBeTrue("'abc'.startsWith('', 3)")
+shouldBeTrue("'abc'.startsWith('', 4)")
+shouldBeTrue("'abc'.startsWith('', Infinity)")
 
 // Test endsWith
 shouldBe("String.prototype.endsWith.name", "'endsWith'");
@@ -117,6 +123,9 @@ shouldBeFalse("'abc'.endsWith('b', 1)");
 shouldBeTrue("'abc'.endsWith('b', 2)");
 shouldBeFalse("'abc'.endsWith('bc', 2)");
 shouldBeTrue("'abc'.endsWith('bc', 3)");
+shouldBeTrue("'abc'.endsWith('', 3)")
+shouldBeTrue("'abc'.endsWith('', 4)")
+shouldBeTrue("'abc'.endsWith('', Infinity)")
 
 // Call functions with an environment record as 'this'.
 shouldThrow("(function() { var f = String.prototype.startsWith; (function() { f('a'); })(); })()");

--- a/LayoutTests/js/string-includes-expected.txt
+++ b/LayoutTests/js/string-includes-expected.txt
@@ -40,6 +40,9 @@ PASS 'abc'.includes('ab', -Infinity) is true
 PASS 'abc'.includes('cd', -Infinity) is false
 PASS 'abc'.includes('ab', 0) is true
 PASS 'abc'.includes('cd', 0) is false
+PASS 'abc'.includes('', 3) is true
+PASS 'abc'.includes('', 4) is true
+PASS 'abc'.includes('', Infinity) is true
 PASS String.prototype.startsWith.name is 'startsWith'
 PASS String.prototype.startsWith.length is 1
 PASS 'foo bar'.startsWith('foo') is true
@@ -75,6 +78,9 @@ PASS 'abc'.startsWith('b', 1) is true
 PASS 'abc'.startsWith('b', 2) is false
 PASS 'abc'.startsWith('c', 2) is true
 PASS 'abc'.startsWith('a', Math.pow(2, 33)) is false
+PASS 'abc'.startsWith('', 3) is true
+PASS 'abc'.startsWith('', 4) is true
+PASS 'abc'.startsWith('', Infinity) is true
 PASS String.prototype.endsWith.name is 'endsWith'
 PASS String.prototype.endsWith.length is 1
 PASS 'foo bar'.endsWith('bar') is true
@@ -115,6 +121,9 @@ PASS 'abc'.endsWith('b', 1) is false
 PASS 'abc'.endsWith('b', 2) is true
 PASS 'abc'.endsWith('bc', 2) is false
 PASS 'abc'.endsWith('bc', 3) is true
+PASS 'abc'.endsWith('', 3) is true
+PASS 'abc'.endsWith('', 4) is true
+PASS 'abc'.endsWith('', Infinity) is true
 PASS (function() { var f = String.prototype.startsWith; (function() { f('a'); })(); })() threw exception TypeError: Type error.
 PASS (function() { var f = String.prototype.endsWith; (function() { f('a'); })(); })() threw exception TypeError: Type error.
 PASS (function() { var f = String.prototype.includes; (function() { f('a'); })(); })() threw exception TypeError: Type error.

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1727,11 +1727,11 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncStartsWith, (JSGlobalObject* globalObjec
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     JSValue positionArg = callFrame->argument(1);
-    unsigned start = 0;
+    unsigned length = stringToSearchIn.length();
+    unsigned start;
     if (positionArg.isInt32())
-        start = std::max(0, positionArg.asInt32());
+        start = std::min(clampTo<unsigned>(positionArg.asInt32()), length);
     else {
-        unsigned length = stringToSearchIn.length();
         start = clampAndTruncateToUnsigned(positionArg.toIntegerOrInfinity(globalObject), 0, length);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
@@ -1760,28 +1760,29 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncEndsWith, (JSGlobalObject* globalObject,
     String searchString = a0.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-    unsigned length = stringToSearchIn.length();
-
     JSValue endPositionArg = callFrame->argument(1);
-    unsigned end = length;
-    if (endPositionArg.isInt32())
-        end = std::max(0, endPositionArg.asInt32());
-    else if (!endPositionArg.isUndefined()) {
+    unsigned length = stringToSearchIn.length();
+    unsigned end;
+    if (endPositionArg.isUndefined())
+        end = length;
+    else if (endPositionArg.isInt32())
+        end = std::min(clampTo<unsigned>(endPositionArg.asInt32()), length);
+    else {
         end = clampAndTruncateToUnsigned(endPositionArg.toIntegerOrInfinity(globalObject), 0, length);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
 
-    return JSValue::encode(jsBoolean(stringToSearchIn.hasInfixEndingAt(searchString, std::min(end, length))));
+    return JSValue::encode(jsBoolean(stringToSearchIn.hasInfixEndingAt(searchString, end)));
 }
 
 static EncodedJSValue stringIncludesImpl(JSGlobalObject* globalObject, VM& vm, String stringToSearchIn, String searchString, JSValue positionArg)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    unsigned start = 0;
+    auto length = stringToSearchIn.length();
+    unsigned start;
     if (positionArg.isInt32())
-        start = std::max(0, positionArg.asInt32());
+        start = std::min(clampTo<unsigned>(positionArg.asInt32()), length);
     else {
-        unsigned length = stringToSearchIn.length();
         start = clampAndTruncateToUnsigned(positionArg.toIntegerOrInfinity(globalObject), 0, length);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }


### PR DESCRIPTION
#### ebf196ed572433cb92280dac2a1d62a57ce773b5
<pre>
String.prototype.includes incorrectly returns false when string is empty and position is past end of string
<a href="https://bugs.webkit.org/show_bug.cgi?id=244196">https://bugs.webkit.org/show_bug.cgi?id=244196</a>

Reviewed by Alexey Shvayka.

Added length clamping to the Int32 special case of the startsWith
and includes functions. These functions could be optimized for all sorts
of cases including not fetching string lengths multiple times, and even
optimizing rope cases to not require resolving the whole rope, but for now
didn&apos;t worry about any of that, just added that bit of extra checking.

* LayoutTests/js/script-tests/string-includes.js: Added test cases.
* LayoutTests/js/string-includes-expected.txt: Added expected result.

* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::stringProtoFuncStartsWith): Added clamping to the Int32 special case.
(JSC::stringProtoFuncEndsWith): Refactored clamping to match startsWith
and includes, which removes one redudant clamp.
(JSC::stringIncludesImpl): Added clamping to the Int32 special case.

Canonical link: <a href="https://commits.webkit.org/254319@main">https://commits.webkit.org/254319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc215b56dd8040c9fdea1364c26481e4ece82738

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/88734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/69/builds/33300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/19628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97937 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/64/builds/31803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/80975 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/92565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/94364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/64/builds/31803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/75728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/25191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/64/builds/31803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/19628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/68152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/80457 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/29588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/19628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74236 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/29341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/19628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26259 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3045 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32768 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/75728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/77095 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31454 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/19628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17087 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode (failure)") | 
<!--EWS-Status-Bubble-End-->