### PR TITLE
[Rebaseline]:(254246@main): [ Monterey wk2 ]  Two http/tests/security/xss-DENIED-xsl-external-entity tests are a consistent failure

### DIFF
--- a/LayoutTests/platform/mac-monterey/https/tests/security/xss-DENIED-xsl-external-entity-expected.txt
+++ b/LayoutTests/platform/mac-monterey/https/tests/security/xss-DENIED-xsl-external-entity-expected.txt
@@ -1,6 +1,0 @@
-CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/security/resources/target.xml from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
-
-CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/security/resources/target.xml from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
-
-This test includes a cross-origin external entity. It passes if the load fails and thus there is no text below this line.
-

--- a/LayoutTests/platform/mac-monterey/https/tests/security/xss-DENIED-xsl-external-entity-redirect-expected.txt
+++ b/LayoutTests/platform/mac-monterey/https/tests/security/xss-DENIED-xsl-external-entity-redirect-expected.txt
@@ -1,4 +1,0 @@
-CONSOLE MESSAGE: Did not parse external entity resource at 'http://127.0.0.1:8000/resources/redirect.py?url=http://localhost:8000/security/resources/target.xml' because cross-origin loads are not allowed.
-CONSOLE MESSAGE: Did not parse external entity resource at 'http://127.0.0.1:8000/resources/redirect.py?url=http://localhost:8000/security/resources/target.xml' because cross-origin loads are not allowed.
-This test includes a cross-origin external entity. It passes if the load fails and thus there is no text below this line.
-


### PR DESCRIPTION
#### 60345005f7d1796c8026cc2e16dc6ef4d2957608
<pre>
[Rebaseline]:(254246@main): [ Monterey wk2 ]  Two http/tests/security/xss-DENIED-xsl-external-entity tests are a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244992">https://bugs.webkit.org/show_bug.cgi?id=244992</a>
rdar://problem/99751762

Unreviewed test gardening.

* LayoutTests/platform/mac-monterey/https/tests/security/xss-DENIED-xsl-external-entity-expected.txt: Added.
* LayoutTests/platform/mac-monterey/https/tests/security/xss-DENIED-xsl-external-entity-redirect-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ef49d60d0606afca5ee505eec9b4ed6c762f6eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/88730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/69/builds/33296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/19624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/97932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/64/builds/31799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/80970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/92561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/94360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/64/builds/31799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/75724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/80970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/64/builds/31799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/19624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/80970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/29583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/19624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/29337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/19624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/32763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/75724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/31449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/19624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->