### PR TITLE
Use std::optional for IDBResourceIdentifier in IDBRequestData and TransactionOperation

### DIFF
--- a/Source/WebCore/Modules/indexeddb/client/TransactionOperation.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/TransactionOperation.cpp
@@ -44,7 +44,7 @@ TransactionOperation::TransactionOperation(IDBTransaction& transaction, IDBReque
     if (m_indexIdentifier)
         m_indexRecordType = request.requestedIndexRecordType();
     if (auto* cursor = request.pendingCursor())
-        m_cursorIdentifier = makeUnique<IDBResourceIdentifier>(cursor->info().identifier());
+        m_cursorIdentifier = cursor->info().identifier();
 
     request.setTransactionOperationID(m_operationID);
     m_idbRequest = &request;

--- a/Source/WebCore/Modules/indexeddb/client/TransactionOperation.h
+++ b/Source/WebCore/Modules/indexeddb/client/TransactionOperation.h
@@ -127,7 +127,7 @@ protected:
     IDBResourceIdentifier m_identifier;
     uint64_t m_objectStoreIdentifier { 0 };
     uint64_t m_indexIdentifier { 0 };
-    std::unique_ptr<IDBResourceIdentifier> m_cursorIdentifier;
+    std::optional<IDBResourceIdentifier> m_cursorIdentifier;
     IndexedDB::IndexRecordType m_indexRecordType { IndexedDB::IndexRecordType::Key };
     Function<void()> m_performFunction;
     Function<void(const IDBResultData&)> m_completeFunction;
@@ -136,7 +136,7 @@ private:
     IDBResourceIdentifier transactionIdentifier() const { return m_transaction->info().identifier(); }
     uint64_t objectStoreIdentifier() const { return m_objectStoreIdentifier; }
     uint64_t indexIdentifier() const { return m_indexIdentifier; }
-    IDBResourceIdentifier* cursorIdentifier() const { return m_cursorIdentifier.get(); }
+    std::optional<IDBResourceIdentifier> cursorIdentifier() const { return m_cursorIdentifier; }
     IDBTransaction& transaction() { return m_transaction.get(); }
     IndexedDB::IndexRecordType indexRecordType() const { return m_indexRecordType; }
 

--- a/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
@@ -64,7 +64,7 @@ public:
     IndexedDB::IndexRecordType indexRecordType() const;
     IDBResourceIdentifier cursorIdentifier() const;
 
-    const IDBDatabaseIdentifier& databaseIdentifier() const;
+    WEBCORE_EXPORT IDBDatabaseIdentifier databaseIdentifier() const;
     uint64_t requestedVersion() const;
 
     bool isOpenRequest() const { return m_requestType == IndexedDB::RequestType::Open; }
@@ -74,40 +74,20 @@ public:
 
 private:
     friend struct IPC::ArgumentCoder<IDBRequestData, void>;
-    IDBRequestData(IDBConnectionIdentifier serverConnectionIdentifier, std::unique_ptr<IDBResourceIdentifier> requestIdentifier, std::unique_ptr<IDBResourceIdentifier> transactionIdentifier, std::unique_ptr<IDBResourceIdentifier> cursorIdentifier, uint64_t objectStoreIdentifier, uint64_t indexIdentifier, IndexedDB::IndexRecordType indexRecordType, std::optional<IDBDatabaseIdentifier> databaseIdentifier, uint64_t requestedVersion, IndexedDB::RequestType requestType)
-        : m_serverConnectionIdentifier(WTFMove(serverConnectionIdentifier))
-        , m_requestIdentifier(WTFMove(requestIdentifier))
-        , m_transactionIdentifier(WTFMove(transactionIdentifier))
-        , m_cursorIdentifier(WTFMove(cursorIdentifier))
-        , m_objectStoreIdentifier(WTFMove(objectStoreIdentifier))
-        , m_indexIdentifier(WTFMove(indexIdentifier))
-        , m_indexRecordType(WTFMove(indexRecordType))
-        , m_databaseIdentifier(WTFMove(databaseIdentifier))
-        , m_requestedVersion(WTFMove(requestedVersion))
-        , m_requestType(WTFMove(requestType)) { }
-
+    WEBCORE_EXPORT IDBRequestData(IDBConnectionIdentifier serverConnectionIdentifier, IDBResourceIdentifier requestIdentifier, std::optional<IDBResourceIdentifier>&& transactionIdentifier, std::optional<IDBResourceIdentifier>&& cursorIdentifier, uint64_t objectStoreIdentifier, uint64_t indexIdentifier, IndexedDB::IndexRecordType, std::optional<IDBDatabaseIdentifier>&&, uint64_t requestedVersion, IndexedDB::RequestType);
     static void isolatedCopy(const IDBRequestData& source, IDBRequestData& destination);
 
     IDBConnectionIdentifier m_serverConnectionIdentifier;
-    std::unique_ptr<IDBResourceIdentifier> m_requestIdentifier;
-    std::unique_ptr<IDBResourceIdentifier> m_transactionIdentifier;
-    std::unique_ptr<IDBResourceIdentifier> m_cursorIdentifier;
+    IDBResourceIdentifier m_requestIdentifier;
+    std::optional<IDBResourceIdentifier> m_transactionIdentifier;
+    std::optional<IDBResourceIdentifier> m_cursorIdentifier;
     uint64_t m_objectStoreIdentifier { 0 };
     uint64_t m_indexIdentifier { 0 };
     IndexedDB::IndexRecordType m_indexRecordType { IndexedDB::IndexRecordType::Key };
-
-    mutable std::optional<IDBDatabaseIdentifier> m_databaseIdentifier;
+    std::optional<IDBDatabaseIdentifier> m_databaseIdentifier;
     uint64_t m_requestedVersion { 0 };
 
     IndexedDB::RequestType m_requestType { IndexedDB::RequestType::Other };
 };
-
-inline const IDBDatabaseIdentifier& IDBRequestData::databaseIdentifier() const
-{
-    ASSERT(m_databaseIdentifier);
-    if (!m_databaseIdentifier)
-        m_databaseIdentifier = IDBDatabaseIdentifier { };
-    return *m_databaseIdentifier;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h
@@ -44,7 +44,6 @@ class IDBConnectionToClient;
 using IDBConnectionIdentifier = ProcessIdentifier;
 
 class IDBResourceIdentifier {
-    WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit IDBResourceIdentifier(const IDBClient::IDBConnectionProxy&);
     IDBResourceIdentifier(const IDBClient::IDBConnectionProxy&, const IDBRequest&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -216,9 +216,9 @@ class WebCore::IDBValue {
 header: <WebCore/IDBRequestData.h>
 class WebCore::IDBRequestData {
     WebCore::IDBConnectionIdentifier m_serverConnectionIdentifier;
-    std::unique_ptr<WebCore::IDBResourceIdentifier> m_requestIdentifier;
-    std::unique_ptr<WebCore::IDBResourceIdentifier> m_transactionIdentifier;
-    std::unique_ptr<WebCore::IDBResourceIdentifier> m_cursorIdentifier;
+    WebCore::IDBResourceIdentifier m_requestIdentifier;
+    std::optional<WebCore::IDBResourceIdentifier> m_transactionIdentifier;
+    std::optional<WebCore::IDBResourceIdentifier> m_cursorIdentifier;
     uint64_t m_objectStoreIdentifier;
     uint64_t m_indexIdentifier;
     WebCore::IndexedDB::IndexRecordType m_indexRecordType;


### PR DESCRIPTION
#### 2f9d01af63cb2f223c20b9bb2a87c99539da2997
<pre>
Use std::optional for IDBResourceIdentifier in IDBRequestData and TransactionOperation
<a href="https://bugs.webkit.org/show_bug.cgi?id=244996">https://bugs.webkit.org/show_bug.cgi?id=244996</a>

Reviewed by Chris Dumez.

IDBResourceIdentifier is small enough and members in IDBRequestData and TransactionOperation are not changed after
initialization.

* Source/WebCore/Modules/indexeddb/client/TransactionOperation.cpp:
(WebCore::IDBClient::TransactionOperation::TransactionOperation):
* Source/WebCore/Modules/indexeddb/client/TransactionOperation.h:
(WebCore::IDBClient::TransactionOperation::cursorIdentifier const):
* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp:
(WebCore::IDBRequestData::IDBRequestData):
(WebCore::IDBRequestData::isolatedCopy):
(WebCore::IDBRequestData::requestIdentifier const):
(WebCore::IDBRequestData::databaseIdentifier const):
* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h:
(WebCore::IDBRequestData::IDBRequestData): Deleted.
(WebCore::IDBRequestData::databaseIdentifier const): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/254402@main">https://commits.webkit.org/254402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c12c23d04223da70cab4a1c161819c494d18589

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98226 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32017 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27614 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81233 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92765 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25426 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75924 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25365 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80294 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68332 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29808 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29539 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/15339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3084 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32978 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31667 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/34441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->