### PR TITLE
Update JetStream2.1 run-benchmark plan file.

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream2.1.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream2.1.plan
@@ -1,12 +1,12 @@
 {
     "timeout": 1200,
     "count": 5,
-    "local_git_archive": "PerformanceTests/JetStream2@5186d5c427b58d37a83770006221c541e5415690",
-    "github_source": "https://github.com/WebKit/WebKit/tree/5186d5c427b58d37a83770006221c541e5415690/PerformanceTests/JetStream2",
+    "local_git_archive": "PerformanceTests/JetStream2@05ce373a859fbb562ab903f1c706e0843a248169",
+    "github_source": "https://github.com/WebKit/WebKit/tree/05ce373a859fbb562ab903f1c706e0843a248169/PerformanceTests/JetStream2",
     "entry_point": "index.html?report=true",
     "output_file": "jetstream2.result",
     "github_subtree": {
-        "url": "https://api.github.com/repos/WebKit/WebKit/git/trees/daa4085ae24f00a4bbefaa2f1abf02ab31b57afd",
+        "url": "https://api.github.com/repos/WebKit/WebKit/git/trees/51fcdc288eaccb1ff2f73e86d441a72c5970fd56",
         "truncated": false,
         "tree": [
             {"path": "ARES-6", "mode": "040000", "type": "tree"},


### PR DESCRIPTION
#### 533f50c9c8a93606c6e2d1e313e1d7f4e520b3b3
<pre>
Update JetStream2.1 run-benchmark plan file.
<a href="https://bugs.webkit.org/show_bug.cgi?id=245004">https://bugs.webkit.org/show_bug.cgi?id=245004</a>
rdar://99759230

Reviewed by Stephanie Lewis.

Update JetStream2.1 plan file to 254292@main.
Add a custom JSON encoder for plan file so that each dictionary under
&apos;github_subtree -&gt; tree&apos; are in one line.

* Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream2.1.plan:
* Tools/Scripts/webkitpy/benchmark_runner/plan_file_optimizer.py:
(PlanPrettyPrintEncoder):
(PlanPrettyPrintEncoder.iterencode):
(optimize_plan_file):

Canonical link: <a href="https://commits.webkit.org/254341@main">https://commits.webkit.org/254341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e111356ee878f9d5bb85b1e9b4fb922ddac5986

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33327 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/19650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97967 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31832 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81006 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/92589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94391 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/25253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/75750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/25210 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/92350 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/80130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/19650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/68172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29631 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/19650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/29362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/19650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3052 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32798 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/75750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31485 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/19650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->