### PR TITLE
[macOS] Memory leaks because of reference cycle created by -[WebRevealHighlight setClearTextIndicator:]

### DIFF
--- a/Source/WebCore/editing/cocoa/DictionaryLookup.mm
+++ b/Source/WebCore/editing/cocoa/DictionaryLookup.mm
@@ -137,8 +137,7 @@ SOFT_LINK(UIKitMacHelper, UINSSharedRevealController, id<UINSRevealController>, 
 {
     UNUSED_PARAM(context);
     UNUSED_PARAM(item);
-    auto block = WTFMove(_clearTextIndicator);
-    if (block)
+    if (auto block = std::exchange(_clearTextIndicator, nullptr))
         block();
 }
 
@@ -466,10 +465,11 @@ static WKRevealController showPopupOrCreateAnimationController(bool createAnimat
     auto context = adoptNS([PAL::allocRVPresentingContextInstance() initWithPointerLocationInView:pointerLocation inView:view highlightDelegate:webHighlight.get()]);
     auto item = adoptNS([PAL::allocRVItemInstance() initWithText:dictionaryPopupInfo.attributedString.get().string selectedRange:NSMakeRange(0, dictionaryPopupInfo.attributedString.get().string.length)]);
 
-    [webHighlight setClearTextIndicator:[webHighlight = WTFMove(webHighlight), clearTextIndicator = WTFMove(clearTextIndicator)] {
-        if (clearTextIndicator)
+    if (clearTextIndicator) {
+        [webHighlight setClearTextIndicator:[clearTextIndicator = WTFMove(clearTextIndicator)] {
             clearTextIndicator();
-    }];
+        }];
+    }
 
     if (createAnimationController)
         return [presenter animationControllerForItem:item.get() documentContext:nil presentingContext:context.get() options:nil];


### PR DESCRIPTION
#### d4bba747437a2aaf524494e364a184992b966cf9
<pre>
[macOS] Memory leaks because of reference cycle created by -[WebRevealHighlight setClearTextIndicator:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=245003">https://bugs.webkit.org/show_bug.cgi?id=245003</a>
rdar://99411435

Reviewed by Tim Horton.

* Source/WebCore/editing/cocoa/DictionaryLookup.mm:
(-[WebRevealHighlight revealContext:stopHighlightingItem:]): Use std::exchange instead
of just WTFMove to get and clear the &quot;clear text indicator&quot; function. Not needed to fix
the bug, but a more correct idiom, since WTFMove is not guaranteed to clear out the object
being moved from.

(WebCore::showPopupOrCreateAnimationController): Moved the null check of clearTextIndicator
outside the block. This is not needed to fix the bug, but the function can&apos;t become null
later, so it can be checked first, and when there is no function it is correct and safe to
not call setClearTextIndicator: on the newly created WebRevealHighlight object. Removed the
unnecessary capture of webHighlight. This is the bug fix. Capturing this created a reference
cycle that wouldn&apos;t be broken until the -[WebRevealHighlight revealContext:stopHighlightingItem:]
method is called, and was unnecessary.

Canonical link: <a href="https://commits.webkit.org/254359@main">https://commits.webkit.org/254359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48d04f3e48ea57010b53b2e085c84410ffabe70d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97965 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31830 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27445 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92587 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25251 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75748 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25206 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68167 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29628 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14198 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29360 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15199 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3059 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38122 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34306 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->