### PR TITLE
angle_version.h and angle_version_info.h should not use the same header guard macro

### DIFF
--- a/Source/ThirdParty/ANGLE/changes.diff
+++ b/Source/ThirdParty/ANGLE/changes.diff
@@ -1,3 +1,24 @@
+diff --git a/src/common/angle_version_info.h b/src/common/angle_version_info.h
+index 27de24182bdb30b736c17ac025df19d2aea56712..1d5392068c277d4999a0710eb56ab87ff6857129 100644
+--- a/src/common/angle_version_info.h
++++ b/src/common/angle_version_info.h
+@@ -5,8 +5,8 @@
+ //
+ // angle_version_info.h: ANGLE version queries.
+ 
+-#ifndef COMMON_VERSION_H_
+-#define COMMON_VERSION_H_
++#ifndef COMMON_VERSION_INFO_H_
++#define COMMON_VERSION_INFO_H_
+ 
+ namespace angle
+ {
+@@ -17,4 +17,4 @@ int GetANGLECommitHashSize();
+ bool GetANGLEHasBinaryLoading();
+ }  // namespace angle
+ 
+-#endif  // COMMON_VERSION_H_
++#endif  // COMMON_VERSION_INFO_H_
 diff --git a/src/common/apple_platform_utils.mm b/src/common/apple_platform_utils.mm
 index a9757cbb72b7c75f155a1cfedd84a2e98120b564..eebe70cdcc3e1db0d7922f083ae9287b3c0cb16d 100644
 --- a/src/common/apple_platform_utils.mm

--- a/Source/ThirdParty/ANGLE/src/common/angle_version_info.h
+++ b/Source/ThirdParty/ANGLE/src/common/angle_version_info.h
@@ -5,8 +5,8 @@
 //
 // angle_version_info.h: ANGLE version queries.
 
-#ifndef COMMON_VERSION_H_
-#define COMMON_VERSION_H_
+#ifndef COMMON_VERSION_INFO_H_
+#define COMMON_VERSION_INFO_H_
 
 namespace angle
 {
@@ -17,4 +17,4 @@ int GetANGLECommitHashSize();
 bool GetANGLEHasBinaryLoading();
 }  // namespace angle
 
-#endif  // COMMON_VERSION_H_
+#endif  // COMMON_VERSION_INFO_H_


### PR DESCRIPTION
#### 1a61b3dac3ce7fe41c4f5eb58211ee6e4de04f8c
<pre>
angle_version.h and angle_version_info.h should not use the same header guard macro
<a href="https://bugs.webkit.org/show_bug.cgi?id=245018">https://bugs.webkit.org/show_bug.cgi?id=245018</a>
&lt;rdar://99770768&gt;

Reviewed by Kimmo Kinnunen.

* Source/ThirdParty/ANGLE/changes.diff: Update.
* Source/ThirdParty/ANGLE/src/common/angle_version_info.h:
- Change header guard to COMMON_VERSION_INFO_H_ so that it
  differs from COMMON_VERSION_H_ in angle_version.h.

Canonical link: <a href="https://commits.webkit.org/254370@main">https://commits.webkit.org/254370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10c412f81d14e67450c84d765feba42e5e300389

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98008 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31877 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27484 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81050 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92629 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25293 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75790 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25243 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80209 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68205 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29674 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14230 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29403 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15225 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3066 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38152 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34332 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->