### PR TITLE
Implement Temporal.PlainDate[Time].{equals, add, subtract}

### DIFF
--- a/JSTests/stress/temporal-calendar.js
+++ b/JSTests/stress/temporal-calendar.js
@@ -97,6 +97,10 @@ shouldThrow(() => {
     shouldBe(JSON.parse(string, reviver).userCalendar instanceof Temporal.Calendar, true);
 }
 
+shouldBe(isoCalendar.toString(), isoCalendar.toJSON());
+shouldThrow(() => { Temporal.Calendar.prototype.toString.call({}); }, TypeError);
+shouldThrow(() => { Temporal.Calendar.prototype.toJSON.call({}); }, TypeError);
+
 shouldBe(Temporal.Calendar.prototype.dateFromFields.length, 1);
 shouldBe(isoCalendar.dateFromFields({ year: 2007, month: 1, day: 9 }).toString(), '2007-01-09');
 shouldBe(isoCalendar.dateFromFields({ year: 2007, monthCode: 'M01', day: 9 }).toString(), '2007-01-09');
@@ -113,3 +117,23 @@ shouldThrow(() => { isoCalendar.dateFromFields({ year: 2007, monthCode: 'M00', d
 shouldThrow(() => { isoCalendar.dateFromFields({ year: 2007, month: 1, day: 0 }); }, RangeError);
 shouldThrow(() => { isoCalendar.dateFromFields({ year: 2007, month: 1, monthCode: 'M02', day: 9 }); }, RangeError);
 shouldThrow(() => { isoCalendar.dateFromFields({ year: 2007, month: 20, day: 40 }, { overflow: 'reject' }); }, RangeError);
+
+shouldBe(Temporal.Calendar.prototype.dateAdd.length, 2);
+shouldBe(isoCalendar.dateAdd('2020-02-28', new Temporal.Duration()).toString(), '2020-02-28');
+shouldBe(isoCalendar.dateAdd('2020-02-28', { years: 1, months: 1 }).toString(), '2021-03-28');
+shouldBe(isoCalendar.dateAdd('2020-02-28', 'P1W1D').toString(), '2020-03-07');
+shouldBe(isoCalendar.dateAdd('2020-02-28', { hours: 24 }).toString(), '2020-02-29');
+shouldBe(isoCalendar.dateAdd('2020-02-28', { days: 36500000 }).toString(), '+101953-10-07');
+shouldBe(isoCalendar.dateAdd('2020-02-28', new Temporal.Duration(-1, -1, 0, -1)).toString(), '2019-01-27');
+shouldBe(isoCalendar.dateAdd('2020-01-30', { months: 1 }).toString(), '2020-02-29');
+shouldThrow(() => { isoCalendar.dateAdd('2020-01-30', { months: 1 }, { overflow: 'reject' }); }, RangeError);
+shouldThrow(() => { isoCalendar.dateAdd('2020-02-28', { years: 300000 }); }, RangeError);
+
+shouldBe(isoCalendar.dateAdd('2020-02-28', { years: -1, months: -1 }).toString(), '2019-01-28');
+shouldBe(isoCalendar.dateAdd('2020-02-28', '-P1W1D').toString(), '2020-02-20');
+shouldBe(isoCalendar.dateAdd('2020-02-28', { hours: -24 }).toString(), '2020-02-27');
+shouldBe(isoCalendar.dateAdd('2020-02-28', { days: -36500000 }).toString(), '-097914-07-21');
+shouldBe(isoCalendar.dateAdd('2020-02-28', new Temporal.Duration(1, 1, 0, 1)).toString(), '2021-03-29');
+shouldBe(isoCalendar.dateAdd('2020-03-30', { months: -1 }).toString(), '2020-02-29');
+shouldThrow(() => { isoCalendar.dateAdd('2020-03-30', { months: -1 }, { overflow: 'reject' }); }, RangeError);
+shouldThrow(() => { isoCalendar.dateAdd('2020-02-28', { years: -300000 }); }, RangeError);

--- a/JSTests/stress/temporal-plaindate.js
+++ b/JSTests/stress/temporal-plaindate.js
@@ -344,3 +344,36 @@ shouldThrow(() => { Temporal.PlainDate.from('2007-01-09').valueOf(); }, TypeErro
     let time = Temporal.PlainDate.from('2007-01-09');
     shouldBe(JSON.stringify(time.getISOFields()), `{"calendar":"iso8601","isoDay":9,"isoMonth":1,"isoYear":2007}`);
 }
+
+{
+    const ones = new Temporal.PlainDate(1,1,1);
+    shouldBe(ones.equals(new Temporal.PlainDate(1,1,1)), true);
+    shouldBe(ones.equals(new Temporal.PlainDate(2,1,1)), false);
+    shouldBe(ones.equals(new Temporal.PlainDate(1,2,1)), false);
+    shouldBe(ones.equals(new Temporal.PlainDate(1,1,2)), false);
+}
+
+shouldBe(Temporal.PlainDateTime.prototype.add.length, 1);
+shouldBe(Temporal.PlainDateTime.prototype.subtract.length, 1);
+{
+    const date = Temporal.PlainDate.from('2020-02-28');
+    shouldBe(date.add(new Temporal.Duration()).toString(), '2020-02-28');
+    shouldBe(date.add({ years: 1, months: 1 }).toString(), '2021-03-28');
+    shouldBe(date.add('P1W1D').toString(), '2020-03-07');
+    shouldBe(date.add({ hours: 24 }).toString(), '2020-02-29');
+    shouldBe(date.add({ days: 36500000 }).toString(), '+101953-10-07');
+    shouldBe(date.add(new Temporal.Duration(-1, -1, 0, -1)).toString(), '2019-01-27');
+    shouldBe(Temporal.PlainDate.from('2020-01-30').add({ months: 1 }).toString(), '2020-02-29');
+    shouldThrow(() => { Temporal.PlainDate.from('2020-01-30').add({ months: 1 }, { overflow: 'reject' }); }, RangeError);
+    shouldThrow(() => { date.add({ years: 300000 }); }, RangeError);
+
+    shouldBe(date.subtract(new Temporal.Duration()).toString(), '2020-02-28');
+    shouldBe(date.subtract({ years: 1, months: 1 }).toString(), '2019-01-28');
+    shouldBe(date.subtract('P1W1D').toString(), '2020-02-20');
+    shouldBe(date.subtract({ hours: 24 }).toString(), '2020-02-27');
+    shouldBe(date.subtract({ days: 36500000 }).toString(), '-097914-07-21');
+    shouldBe(date.subtract(new Temporal.Duration(-1, -1, 0, -1)).toString(), '2021-03-29');
+    shouldBe(Temporal.PlainDate.from('2020-03-30').subtract({ months: 1 }).toString(), '2020-02-29');
+    shouldThrow(() => { Temporal.PlainDate.from('2020-03-30').subtract({ months: 1 }, { overflow: 'reject' }); }, RangeError);
+    shouldThrow(() => { date.subtract({ years: 300000 }); }, RangeError);
+}

--- a/JSTests/stress/temporal-plaindatetime.js
+++ b/JSTests/stress/temporal-plaindatetime.js
@@ -239,3 +239,34 @@ shouldBe(pdt.toPlainTime().toString(), '04:05:06.007008009');
 
 shouldBe(Temporal.PlainDateTime.prototype.valueOf.length, 0);
 shouldThrow(() => pdt.valueOf(), TypeError);
+
+shouldBe(pdt.equals(new Temporal.PlainDateTime(1,2,3,4,5,6,7,8,9)), true);
+shouldBe(pdt.equals(new Temporal.PlainDateTime(2,2,3,4,5,6,7,8,9)), false);
+shouldBe(pdt.equals(new Temporal.PlainDateTime(1,3,3,4,5,6,7,8,9)), false);
+shouldBe(pdt.equals(new Temporal.PlainDateTime(1,2,4,4,5,6,7,8,9)), false);
+shouldBe(pdt.equals(new Temporal.PlainDateTime(1,2,3,5,5,6,7,8,9)), false);
+shouldBe(pdt.equals(new Temporal.PlainDateTime(1,2,3,4,6,6,7,8,9)), false);
+shouldBe(pdt.equals(new Temporal.PlainDateTime(1,2,3,4,5,7,7,8,9)), false);
+shouldBe(pdt.equals(new Temporal.PlainDateTime(1,2,3,4,5,6,8,8,9)), false);
+shouldBe(pdt.equals(new Temporal.PlainDateTime(1,2,3,4,5,6,7,9,9)), false);
+shouldBe(pdt.equals(new Temporal.PlainDateTime(1,2,3,4,5,6,7,8,1)), false);
+
+shouldBe(Temporal.PlainDateTime.prototype.add.length, 1);
+shouldBe(pdt.add(new Temporal.Duration()).toString(), '0001-02-03T04:05:06.007008009');
+shouldBe(pdt.add(new Temporal.Duration(1,1,1,1,1,1,1,1,1,1)).toString(), '0002-03-11T05:06:07.00800901');
+shouldBe(pdt.add('-P1Y1M1DT1H1M1.001001001S').toString(), '0000-01-02T03:04:05.006007008');
+shouldBe(pdt.add({ hours: 24 }).toString(), '0001-02-04T04:05:06.007008009');
+shouldBe(pdt.add(new Temporal.Duration(0,10,3,7,19,54,53,992,991,991)).toString(), '0002-01-01T00:00:00');
+shouldBe(Temporal.PlainDateTime.from('2020-01-30').add({ months: 1 }).toString(), '2020-02-29T00:00:00');
+shouldThrow(() => { Temporal.PlainDateTime.from('2020-01-30').add({ months: 1 }, { overflow: 'reject' }); }, RangeError);
+shouldThrow(() => { pdt.add({ years: 300000 }); }, RangeError);
+
+shouldBe(Temporal.PlainDateTime.prototype.subtract.length, 1);
+shouldBe(pdt.subtract(new Temporal.Duration()).toString(), '0001-02-03T04:05:06.007008009');
+shouldBe(pdt.subtract(new Temporal.Duration(1,1,0,1,1,1,1,1,1,1)).toString(), '0000-01-02T03:04:05.006007008');
+shouldBe(pdt.subtract('-P1Y1M1W1DT1H1M1.001001001S').toString(), '0002-03-11T05:06:07.00800901');
+shouldBe(pdt.subtract({ hours: 24 }).toString(), '0001-02-02T04:05:06.007008009');
+shouldBe(pdt.subtract(new Temporal.Duration(0,1,5,3,4,5,6,7,8,10)).toString(), '0000-11-25T23:59:59.999999999');
+shouldBe(Temporal.PlainDateTime.from('2020-03-30').subtract({ months: 1 }).toString(), '2020-02-29T00:00:00');
+shouldThrow(() => { Temporal.PlainDateTime.from('2020-03-30').subtract({ months: 1 }, { overflow: 'reject' }); }, RangeError);
+shouldThrow(() => { pdt.subtract({ years: 300000 }); }, RangeError);

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -36,21 +36,15 @@ skip:
     - test/built-ins/Temporal/Now/plainTimeISO
     - test/built-ins/Temporal/Now/zonedDateTime
     - test/built-ins/Temporal/Now/zonedDateTimeISO
-    - test/built-ins/Temporal/PlainDate/prototype/add
-    - test/built-ins/Temporal/PlainDate/prototype/equals
     - test/built-ins/Temporal/PlainDate/prototype/since
-    - test/built-ins/Temporal/PlainDate/prototype/subtract
     - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay
     - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth
     - test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime
     - test/built-ins/Temporal/PlainDate/prototype/until
     - test/built-ins/Temporal/PlainDate/prototype/with
     - test/built-ins/Temporal/PlainDate/prototype/withCalendar
-    - test/built-ins/Temporal/PlainDateTime/prototype/add
-    - test/built-ins/Temporal/PlainDateTime/prototype/equals
     - test/built-ins/Temporal/PlainDateTime/prototype/round
     - test/built-ins/Temporal/PlainDateTime/prototype/since
-    - test/built-ins/Temporal/PlainDateTime/prototype/subtract
     - test/built-ins/Temporal/PlainDateTime/prototype/toPlainMonthDay
     - test/built-ins/Temporal/PlainDateTime/prototype/toPlainYearMonth
     - test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime
@@ -368,6 +362,7 @@ skip:
     # Depends on Calendar support
     - test/built-ins/Temporal/PlainDate/basic.js
     - test/built-ins/Temporal/PlainDate/calendar-number.js
+    - test/built-ins/Temporal/PlainDate/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDate/calendar-wrong-type.js
     - test/built-ins/Temporal/PlainDate/compare/argument-calendar-datefromfields-called-with-null-prototype-fields.js
     - test/built-ins/Temporal/PlainDate/compare/argument-propertybag-calendar-leap-second.js
@@ -388,16 +383,34 @@ skip:
     - test/built-ins/Temporal/PlainDate/from/calendar-fields-custom.js
     - test/built-ins/Temporal/PlainDate/from/calendar-fields-iterable.js
     - test/built-ins/Temporal/PlainDate/from/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainDate/prototype/add/balance-smaller-units.js
+    - test/built-ins/Temporal/PlainDate/prototype/add/calendar-invalid-return.js
+    - test/built-ins/Temporal/PlainDate/prototype/add/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/day/calendar-returns-infinity.js
     - test/built-ins/Temporal/PlainDate/prototype/dayOfWeek/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/dayOfYear/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/daysInMonth/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/daysInWeek/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/daysInYear/custom.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-calendar-datefromfields-called-with-null-prototype-fields.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-object-valid.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-leap-second.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-number.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-invalid.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-string.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/calendar-call-different.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/calendar-call-same.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/calendar-datefromfields-called-with-options-undefined.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/calendar-fields-iterable.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDate/prototype/getISOFields/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/inLeapYear/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/month/calendar-returns-infinity.js
     - test/built-ins/Temporal/PlainDate/prototype/monthsInYear/custom.js
+    - test/built-ins/Temporal/PlainDate/prototype/subtract/balance-smaller-units.js
+    - test/built-ins/Temporal/PlainDate/prototype/subtract/calendar-invalid-return.js
+    - test/built-ins/Temporal/PlainDate/prototype/subtract/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-object.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/basic.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/calendar-temporal-object.js
@@ -414,13 +427,13 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/calendar-number.js
     - test/built-ins/Temporal/PlainDateTime/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDateTime/calendar-wrong-type.js
-    - test/built-ins/Temporal/PlainDateTime/constructor-full.js
     - test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDateTime/compare/argument-propertybag-calendar-wrong-type.js
     - test/built-ins/Temporal/PlainDateTime/compare/calendar-datefromfields-called-with-null-prototype-fields.js
     - test/built-ins/Temporal/PlainDateTime/compare/calendar-fields-iterable.js
     - test/built-ins/Temporal/PlainDateTime/compare/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainDateTime/constructor-full.js
     - test/built-ins/Temporal/PlainDateTime/from/argument-plaindate.js
     - test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-number.js
@@ -431,16 +444,25 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/from/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDateTime/from/overflow-invalid-string.js
     - test/built-ins/Temporal/PlainDateTime/from/overflow-wrong-type.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/add/calendar-dateadd.js
     - test/built-ins/Temporal/PlainDateTime/prototype/day/calendar-returns-infinity.js
     - test/built-ins/Temporal/PlainDateTime/prototype/dayOfWeek/custom.js
     - test/built-ins/Temporal/PlainDateTime/prototype/dayOfYear/custom.js
     - test/built-ins/Temporal/PlainDateTime/prototype/daysInMonth/custom.js
     - test/built-ins/Temporal/PlainDateTime/prototype/daysInWeek/custom.js
     - test/built-ins/Temporal/PlainDateTime/prototype/daysInYear/custom.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-leap-second.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-number.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/calendar-checked.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/calendar-datefromfields-called-with-null-prototype-fields.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/calendar-fields-iterable.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDateTime/prototype/getISOFields/custom.js
     - test/built-ins/Temporal/PlainDateTime/prototype/inLeapYear/custom.js
     - test/built-ins/Temporal/PlainDateTime/prototype/month/calendar-returns-infinity.js
     - test/built-ins/Temporal/PlainDateTime/prototype/monthsInYear/custom.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/subtract/calendar-dateadd.js
     - test/built-ins/Temporal/PlainDateTime/prototype/toString/calendarname-always.js
     - test/built-ins/Temporal/PlainDateTime/prototype/toString/calendarname-auto.js
     - test/built-ins/Temporal/PlainDateTime/prototype/toString/calendarname-invalid-string.js
@@ -472,7 +494,6 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/total/unit-plurals-accepted-string.js
     - test/built-ins/Temporal/Duration/prototype/total/unit-plurals-accepted.js
     - test/built-ins/Temporal/Instant/prototype/toString/smallestunit-plurals-accepted.js
-    - test/built-ins/Temporal/PlainDate/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDateTime/prototype/toString/smallestunit-plurals-accepted.js
     - test/built-ins/Temporal/PlainTime/prototype/round/smallestunit-plurals-accepted.js
     - test/built-ins/Temporal/PlainTime/prototype/toString/smallestunit-plurals-accepted.js
@@ -551,6 +572,12 @@ skip:
     - test/built-ins/Temporal/PlainDate/from/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-wrong-type.js
     - test/built-ins/Temporal/PlainDate/from/argument-zoneddatetime.js
     - test/built-ins/Temporal/PlainDate/from/overflow-invalid-string.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-zoneddatetime-convert.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-zoneddatetime-slots.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-non-integer.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-not-callable.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-wrong-type.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-balance-negative-time-units.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-negative-epochnanoseconds.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-non-integer.js
@@ -568,6 +595,12 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/from/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-not-callable.js
     - test/built-ins/Temporal/PlainDateTime/from/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
     - test/built-ins/Temporal/PlainDateTime/from/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-wrong-type.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-zoneddatetime-balance-negative-time-units.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-zoneddatetime-negative-epochnanoseconds.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-non-integer.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-not-callable.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-wrong-type.js
     - test/built-ins/Temporal/PlainTime/compare/argument-zoneddatetime-negative-epochnanoseconds.js
     - test/built-ins/Temporal/PlainTime/compare/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-non-integer.js
     - test/built-ins/Temporal/PlainTime/compare/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-not-callable.js

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -45,6 +45,9 @@ static constexpr int64_t nsPerSecond = 1000LL * 1000 * 1000;
 static constexpr int64_t nsPerMillisecond = 1000LL * 1000;
 static constexpr int64_t nsPerMicrosecond = 1000LL;
 
+static constexpr int32_t maxYear = 275760;
+static constexpr int32_t minYear = -271821;
+
 std::optional<TimeZoneID> parseTimeZoneName(StringView string)
 {
     const auto& timeZones = intlAvailableTimeZones();
@@ -1166,8 +1169,7 @@ uint8_t weekOfYear(PlainDate plainDate)
 
     if (week == 53) {
         // Check whether this is in next year's week 1.
-        int32_t daysInYear = isLeapYear(plainDate.year()) ? 366 : 365;
-        if ((daysInYear - dayOfYear) < (4 - dayOfWeek))
+        if ((daysInYear(plainDate.year()) - dayOfYear) < (4 - dayOfWeek))
             return 1;
     }
 
@@ -1458,6 +1460,12 @@ bool isDateTimeWithinLimits(int32_t year, uint8_t month, uint8_t day, unsigned h
     if (nanoseconds >= (ExactTime::maxValue + ExactTime::nsPerDay))
         return false;
     return true;
+}
+
+// More effective for our purposes than isInBounds<int32_t>.
+bool isYearWithinLimits(double year)
+{
+    return year >= minYear && year <= maxYear;
 }
 
 } // namespace ISO8601

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -230,6 +230,7 @@ public:
             && lhs.microsecond() == rhs.microsecond()
             && lhs.nanosecond() == rhs.nanosecond();
     }
+    friend bool operator!=(PlainTime lhs, PlainTime rhs) { return !(lhs == rhs); }
 
 private:
     uint8_t m_hour { 0 };
@@ -259,6 +260,14 @@ public:
         , m_day(day)
     {
     }
+
+    friend bool operator==(PlainDate lhs, PlainDate rhs)
+    {
+        return lhs.year() == rhs.year()
+            && lhs.month() == rhs.month()
+            && lhs.day() == rhs.day();
+    }
+    friend bool operator!=(PlainDate lhs, PlainDate rhs) { return !(lhs == rhs); }
 
     int32_t year() const { return m_year; }
     uint8_t month() const { return m_month; }
@@ -316,6 +325,7 @@ bool isValidDuration(const Duration&);
 std::optional<ExactTime> parseInstant(StringView);
 
 bool isDateTimeWithinLimits(int32_t year, uint8_t month, uint8_t day, unsigned hour, unsigned minute, unsigned second, unsigned millisecond, unsigned microsecond, unsigned nanosecond);
+bool isYearWithinLimits(double year);
 
 } // namespace ISO8601
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.h
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +50,7 @@ public:
     static JSObject* toTemporalCalendarWithISODefault(JSGlobalObject*, JSValue);
     static JSObject* getTemporalCalendarWithISODefault(JSGlobalObject*, JSValue);
     static ISO8601::PlainDate isoDateFromFields(JSGlobalObject*, JSObject*, TemporalOverflow);
+    static ISO8601::PlainDate isoDateAdd(JSGlobalObject*, const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
 
     CalendarID identifier() const { return m_identifier; }
     bool isISO8601() const { return m_identifier == iso8601CalendarID(); }
@@ -56,6 +58,8 @@ public:
     static std::optional<CalendarID> isBuiltinCalendar(StringView);
 
     static JSObject* from(JSGlobalObject*, JSValue);
+
+    bool equals(JSGlobalObject*, TemporalCalendar*);
 
 private:
     TemporalCalendar(VM&, Structure*, CalendarID);

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -158,6 +158,16 @@ static StringView singularUnit(StringView unit)
     return unit.endsWith('s') ? unit.left(unit.length() - 1) : unit;
 }
 
+double nonNegativeModulo(double x, double y)
+{
+    double result = std::fmod(x, y);
+    if (!result)
+        return 0;
+    if (result < 0)
+        result += y;
+    return result;
+}
+
 // For use in error messages where a string value is potentially unbounded
 WTF::String ellipsizeAt(unsigned maxLength, const WTF::String& string)
 {

--- a/Source/JavaScriptCore/runtime/TemporalObject.h
+++ b/Source/JavaScriptCore/runtime/TemporalObject.h
@@ -109,6 +109,7 @@ struct PrecisionData {
     unsigned increment;
 };
 
+double nonNegativeModulo(double x, double y);
 WTF::String ellipsizeAt(unsigned maxLength, const WTF::String&);
 PropertyName temporalUnitPluralPropertyName(VM&, TemporalUnit);
 PropertyName temporalUnitSingularPropertyName(VM&, TemporalUnit);

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -38,9 +38,6 @@ namespace TemporalPlainDateInternal {
 static constexpr bool verbose = false;
 }
 
-static constexpr int maxISOYear = 275760;
-static constexpr int minISOYear = -271821;
-
 const ClassInfo TemporalPlainDate::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TemporalPlainDate) };
 
 TemporalPlainDate* TemporalPlainDate::create(VM& vm, Structure* structure, ISO8601::PlainDate&& plainDate)
@@ -95,7 +92,7 @@ ISO8601::PlainDate TemporalPlainDate::toPlainDate(JSGlobalObject* globalObject, 
     double monthDouble = duration.months();
     double dayDouble = duration.days();
 
-    if (yearDouble > maxISOYear || yearDouble < minISOYear) {
+    if (!ISO8601::isYearWithinLimits(yearDouble)) {
         throwRangeError(globalObject, scope, "year is out of range"_s);
         return { };
     }

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -29,6 +29,7 @@
 
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
+#include "TemporalDuration.h"
 #include "TemporalPlainDate.h"
 #include "TemporalPlainDateTime.h"
 #include "TemporalPlainTime.h"
@@ -36,6 +37,9 @@
 namespace JSC {
 
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncGetISOFields);
+static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncAdd);
+static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncSubtract);
+static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncEquals);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainDateTime);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToString);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToJSON);
@@ -66,6 +70,9 @@ const ClassInfo TemporalPlainDatePrototype::s_info = { "Temporal.PlainDate"_s, &
 /* Source for TemporalPlainDatePrototype.lut.h
 @begin plainDatePrototypeTable
   getISOFields     temporalPlainDatePrototypeFuncGetISOFields       DontEnum|Function 0
+  add              temporalPlainDatePrototypeFuncAdd                DontEnum|Function 1
+  subtract         temporalPlainDatePrototypeFuncSubtract           DontEnum|Function 1
+  equals           temporalPlainDatePrototypeFuncEquals             DontEnum|Function 1
   toPlainDateTime  temporalPlainDatePrototypeFuncToPlainDateTime    DontEnum|Function 0
   toString         temporalPlainDatePrototypeFuncToString           DontEnum|Function 0
   toJSON           temporalPlainDatePrototypeFuncToJSON             DontEnum|Function 0
@@ -119,7 +126,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncGetISOFields, (JSGlobalOb
 
     auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
     if (!plainDate)
-        return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.equals called on value that's not a PlainDate"_s);
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.getISOFields called on value that's not a PlainDate"_s);
 
     JSObject* fields = constructEmptyObject(globalObject);
     fields->putDirect(vm, vm.propertyNames->calendar, plainDate->calendar());
@@ -127,6 +134,75 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncGetISOFields, (JSGlobalOb
     fields->putDirect(vm, vm.propertyNames->isoMonth, jsNumber(plainDate->month()));
     fields->putDirect(vm, vm.propertyNames->isoYear, jsNumber(plainDate->year()));
     return JSValue::encode(fields);
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.add
+JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncAdd, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    if (!plainDate)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.add called on value that's not a PlainDate"_s);
+
+    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSObject* options = intlGetOptionsObject(globalObject, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    TemporalOverflow overflow = toTemporalOverflow(globalObject, options);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    ISO8601::PlainDate result = TemporalCalendar::isoDateAdd(globalObject, plainDate->plainDate(), duration, overflow);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::create(vm, globalObject->plainDateStructure(), WTFMove(result))));
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.subtract
+JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncSubtract, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    if (!plainDate)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.subtract called on value that's not a PlainDate"_s);
+
+    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSObject* options = intlGetOptionsObject(globalObject, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    TemporalOverflow overflow = toTemporalOverflow(globalObject, options);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    ISO8601::PlainDate result = TemporalCalendar::isoDateAdd(globalObject, plainDate->plainDate(), -duration, overflow);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::create(vm, globalObject->plainDateStructure(), WTFMove(result))));
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.equals
+JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncEquals, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    if (!plainDate)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.equals called on value that's not a PlainDate"_s);
+
+    auto* other = TemporalPlainDate::from(globalObject, callFrame->argument(0), std::nullopt);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (plainDate->plainDate() != other->plainDate())
+        return JSValue::encode(jsBoolean(false));
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(plainDate->calendar()->equals(globalObject, other->calendar()))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplaindatetime

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -35,6 +35,9 @@
 namespace JSC {
 
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncGetISOFields);
+static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncAdd);
+static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncSubtract);
+static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncEquals);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncToPlainDate);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncToPlainTime);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncToString);
@@ -72,6 +75,9 @@ const ClassInfo TemporalPlainDateTimePrototype::s_info = { "Temporal.PlainDateTi
 /* Source for TemporalPlainDateTimePrototype.lut.h
 @begin plainDateTimePrototypeTable
   getISOFields     temporalPlainDateTimePrototypeFuncGetISOFields       DontEnum|Function 0
+  add              temporalPlainDateTimePrototypeFuncAdd                DontEnum|Function 1
+  subtract         temporalPlainDateTimePrototypeFuncSubtract           DontEnum|Function 1
+  equals           temporalPlainDateTimePrototypeFuncEquals             DontEnum|Function 1
   toPlainDate      temporalPlainDateTimePrototypeFuncToPlainDate        DontEnum|Function 0
   toPlainTime      temporalPlainDateTimePrototypeFuncToPlainTime        DontEnum|Function 0
   toString         temporalPlainDateTimePrototypeFuncToString           DontEnum|Function 0
@@ -132,7 +138,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncGetISOFields, (JSGlob
 
     auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
     if (!plainDateTime)
-        return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.equals called on value that's not a PlainDateTime"_s);
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.getISOFields called on value that's not a PlainDateTime"_s);
 
     JSObject* fields = constructEmptyObject(globalObject);
     fields->putDirect(vm, vm.propertyNames->calendar, plainDateTime->calendar());
@@ -146,6 +152,87 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncGetISOFields, (JSGlob
     fields->putDirect(vm, vm.propertyNames->isoSecond, jsNumber(plainDateTime->second()));
     fields->putDirect(vm, vm.propertyNames->isoYear, jsNumber(plainDateTime->year()));
     return JSValue::encode(fields);
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.add
+JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncAdd, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    if (!plainDateTime)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.add called on value that's not a PlainDateTime"_s);
+
+    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSObject* options = intlGetOptionsObject(globalObject, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    auto balancedTimeDuration = TemporalPlainTime::addTime(plainDateTime->plainTime(), duration);
+    auto plainTime = TemporalPlainTime::toPlainTime(globalObject, balancedTimeDuration);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    TemporalOverflow overflow = toTemporalOverflow(globalObject, options);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    ISO8601::Duration dateDuration { duration.years(), duration.months(), duration.weeks(), duration.days() + balancedTimeDuration.days(), 0, 0, 0, 0, 0, 0 };
+    ISO8601::PlainDate plainDate = TemporalCalendar::isoDateAdd(globalObject, plainDateTime->plainDate(), dateDuration, overflow);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTFMove(plainDate), WTFMove(plainTime))));
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.subtract
+JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncSubtract, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    if (!plainDateTime)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.subtract called on value that's not a PlainDateTime"_s);
+
+    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, { });
+    duration = -duration;
+
+    JSObject* options = intlGetOptionsObject(globalObject, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    auto balancedTimeDuration = TemporalPlainTime::addTime(plainDateTime->plainTime(), duration);
+    auto plainTime = TemporalPlainTime::toPlainTime(globalObject, balancedTimeDuration);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    TemporalOverflow overflow = toTemporalOverflow(globalObject, options);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    ISO8601::Duration dateDuration { duration.years(), duration.months(), duration.weeks(), duration.days() + balancedTimeDuration.days(), 0, 0, 0, 0, 0, 0 };
+    ISO8601::PlainDate plainDate = TemporalCalendar::isoDateAdd(globalObject, plainDateTime->plainDate(), dateDuration, overflow);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTFMove(plainDate), WTFMove(plainTime))));
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.equals
+JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncEquals, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    if (!plainDateTime)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.equals called on value that's not a PlainDateTime"_s);
+
+    auto* other = TemporalPlainDateTime::from(globalObject, callFrame->argument(0), std::nullopt);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (plainDateTime->plainDate() != other->plainDate() || plainDateTime->plainTime() != other->plainTime())
+        return JSValue::encode(jsBoolean(false));
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(plainDateTime->calendar()->equals(globalObject, other->calendar()))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaindate

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -143,16 +143,6 @@ TemporalPlainTime* TemporalPlainTime::tryCreateIfValid(JSGlobalObject* globalObj
     return TemporalPlainTime::create(vm, structure, WTFMove(plainTime));
 }
 
-static double nonNegativeModulo(double x, double y)
-{
-    double result = std::fmod(x, y);
-    if (!result)
-        return 0;
-    if (result < 0)
-        result += y;
-    return result;
-}
-
 // https://tc39.es/proposal-temporal/#sec-temporal-balancetime
 static ISO8601::Duration balanceTime(double hour, double minute, double second, double millisecond, double microsecond, double nanosecond)
 {
@@ -482,7 +472,8 @@ int32_t TemporalPlainTime::compare(const ISO8601::PlainTime& t1, const ISO8601::
     return 0;
 }
 
-static ISO8601::Duration addTime(const ISO8601::PlainTime& plainTime, const ISO8601::Duration& duration)
+// https://tc39.es/proposal-temporal/#sec-temporal-addtime
+ISO8601::Duration TemporalPlainTime::addTime(const ISO8601::PlainTime& plainTime, const ISO8601::Duration& duration)
 {
     return balanceTime(
         plainTime.hour() + duration.hours(),
@@ -491,28 +482,6 @@ static ISO8601::Duration addTime(const ISO8601::PlainTime& plainTime, const ISO8
         plainTime.millisecond() + duration.milliseconds(),
         plainTime.microsecond() + duration.microseconds(),
         plainTime.nanosecond() + duration.nanoseconds());
-}
-
-ISO8601::PlainTime TemporalPlainTime::add(JSGlobalObject* globalObject, JSValue temporalDurationLike) const
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, temporalDurationLike);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    RELEASE_AND_RETURN(scope, toPlainTime(globalObject, addTime(m_plainTime, duration)));
-}
-
-ISO8601::PlainTime TemporalPlainTime::subtract(JSGlobalObject* globalObject, JSValue temporalDurationLike) const
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, temporalDurationLike);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    RELEASE_AND_RETURN(scope, toPlainTime(globalObject, addTime(m_plainTime, -duration)));
 }
 
 ISO8601::PlainTime TemporalPlainTime::with(JSGlobalObject* globalObject, JSObject* temporalTimeLike, JSValue optionsValue) const

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.h
@@ -51,6 +51,7 @@ public:
     static ISO8601::Duration roundTime(ISO8601::PlainTime, double increment, TemporalUnit, RoundingMode, std::optional<double> dayLengthNs);
     static ISO8601::Duration toTemporalTimeRecord(JSGlobalObject*, JSObject*, bool skipRelevantPropertyCheck = false);
     static ISO8601::PlainTime regulateTime(JSGlobalObject*, ISO8601::Duration&&, TemporalOverflow);
+    static ISO8601::Duration addTime(const ISO8601::PlainTime&, const ISO8601::Duration&);
 
     static TemporalPlainTime* from(JSGlobalObject*, JSValue, std::optional<TemporalOverflow>);
     static int32_t compare(const ISO8601::PlainTime&, const ISO8601::PlainTime&);
@@ -64,8 +65,6 @@ public:
 #undef JSC_DEFINE_TEMPORAL_PLAIN_TIME_FIELD
 
     ISO8601::PlainTime with(JSGlobalObject*, JSObject* temporalTimeLike, JSValue options) const;
-    ISO8601::PlainTime add(JSGlobalObject*, JSValue) const;
-    ISO8601::PlainTime subtract(JSGlobalObject*, JSValue) const;
     ISO8601::PlainTime round(JSGlobalObject*, JSValue options) const;
     String toString(JSGlobalObject*, JSValue options) const;
     String toString(std::tuple<Precision, unsigned> precision = { Precision::Auto, 0 }) const

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
@@ -123,7 +123,10 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncAdd, (JSGlobalObject* glo
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.add called on value that's not a PlainTime"_s);
 
-    auto result = plainTime->add(globalObject, callFrame->argument(0));
+    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    auto result = TemporalPlainTime::toPlainTime(globalObject, TemporalPlainTime::addTime(plainTime->plainTime(), duration));
     RETURN_IF_EXCEPTION(scope, { });
 
     return JSValue::encode(TemporalPlainTime::create(vm, globalObject->plainTimeStructure(), WTFMove(result)));
@@ -139,7 +142,10 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncSubtract, (JSGlobalObject
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.subtract called on value that's not a PlainTime"_s);
 
-    auto result = plainTime->subtract(globalObject, callFrame->argument(0));
+    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    auto result = TemporalPlainTime::toPlainTime(globalObject, TemporalPlainTime::addTime(plainTime->plainTime(), -duration));
     RETURN_IF_EXCEPTION(scope, { });
 
     return JSValue::encode(TemporalPlainTime::create(vm, globalObject->plainTimeStructure(), WTFMove(result)));
@@ -247,7 +253,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncGetISOFields, (JSGlobalOb
 
     auto* plainTime = jsDynamicCast<TemporalPlainTime*>(callFrame->thisValue());
     if (!plainTime)
-        return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.equals called on value that's not a PlainTime"_s);
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.getISOFields called on value that's not a PlainTime"_s);
 
     JSObject* fields = constructEmptyObject(globalObject);
     fields->putDirect(vm, vm.propertyNames->calendar, plainTime->calendar());

--- a/Source/WTF/wtf/DateMath.h
+++ b/Source/WTF/wtf/DateMath.h
@@ -406,6 +406,8 @@ using WTF::calculateLocalTimeOffset;
 using WTF::dateToDaysFrom1970;
 using WTF::dayInMonthFromDayInYear;
 using WTF::dayInYear;
+using WTF::daysFrom1970ToYear;
+using WTF::daysInYear;
 using WTF::getTimeZoneOverride;
 using WTF::isLeapYear;
 using WTF::isTimeZoneValid;


### PR DESCRIPTION
#### d4d2f95f408151897208a3c8a48b09f387335984
<pre>
Implement Temporal.PlainDate[Time].{equals, add, subtract}
<a href="https://bugs.webkit.org/show_bug.cgi?id=245021">https://bugs.webkit.org/show_bug.cgi?id=245021</a>

Reviewed by Yusuke Suzuki.

This patch implements three more methods -- equals, add, and subtract -- for the PlainDate and PlainDateTime classes.

This is all fairly straightforward aside from `balanceISODate`: When adding / subtracting a significant number of days,
we need to recalculate year and month based on total days away from Unix epoch.
(We could, of course, add years in a loop, but that would penalize large additions / subtractions.)

This function is based on existing logic in DateMath with two key differences.
  1. We don&apos;t need to worry about units smaller than days (vs. msToYear).
  2. We can calculate month and day together in a single loop (vs. dayInMonthFromDayInYear and monthFromDayInYear,
     which are wastefully separated for some reason. This should probably be fixed for Date in a separate patch.)

* JSTests/stress/temporal-calendar.js: Add tests.
* JSTests/stress/temporal-plaindate.js: Add tests.
* JSTests/stress/temporal-plaindatetime.js: Add tests.
* JSTests/test262/config.yaml: Update known failures (due to calendar support).
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::weekOfYear): Use existing WTF helper.
(JSC::ISO8601::isYearWithinLimits): Added.
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/TemporalCalendar.cpp:
(JSC::balanceISODate): Added.
(JSC::TemporalCalendar::isoDateAdd): Added.
(JSC::TemporalCalendar::equals): Added.
* Source/JavaScriptCore/runtime/TemporalCalendar.h:
* Source/JavaScriptCore/runtime/TemporalCalendarPrototype.cpp:
* Source/JavaScriptCore/runtime/TemporalObject.cpp:
(JSC::nonNegativeModulo): Moved from TemporalPlainTime.
* Source/JavaScriptCore/runtime/TemporalObject.h:
* Source/JavaScriptCore/runtime/TemporalPlainDate.cpp:
(JSC::TemporalPlainDate::toPlainDate):
* Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp:
* Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp:
* Source/JavaScriptCore/runtime/TemporalPlainTime.cpp:
(JSC::TemporalPlainTime::addTime): Made public static.
(JSC::nonNegativeModulo): Moved to TemporalObject.
(JSC::TemporalPlainTime::add const): Refactored away.
(JSC::TemporalPlainTime::subtract const): Refactored away.
* Source/JavaScriptCore/runtime/TemporalPlainTime.h:
* Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp:
* Source/WTF/wtf/DateMath.h: Expose two functions that were missing from the list.

Canonical link: <a href="https://commits.webkit.org/254366@main">https://commits.webkit.org/254366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1043912d021319f1ee250d4032779d3bd9ef6c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98001 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31869 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27477 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92622 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25285 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75783 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25235 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68197 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/80519 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29667 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14218 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74300 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29396 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15216 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26273 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3063 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38142 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/77163 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34323 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17105 "Passed tests") | 
<!--EWS-Status-Bubble-End-->