### PR TITLE
Add the support for string reflections on ElementInternals

### DIFF
--- a/LayoutTests/accessibility/custom-elements/autocomplete-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/autocomplete-expected.txt
@@ -1,0 +1,13 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("custom-list").role is "AXRole: AXComboBox"
+PASS accessibilityController.accessibleElementById("custom-list").stringAttributeValue("AXAutocompleteValue") is "list"
+PASS accessibilityController.accessibleElementById("custom-textbox").role is "AXRole: AXTextField"
+PASS accessibilityController.accessibleElementById("custom-textbox").stringAttributeValue("AXAutocompleteValue") is "inline"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/custom-elements/autocomplete.html
+++ b/LayoutTests/accessibility/custom-elements/autocomplete.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<body id="body">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-list id="custom-list"></custom-checkbox>
+<custom-list id="custom-textbox" role="textbox" aria-autocomplete="inline"></custom-checkbox>
+<script>
+
+customElements.define('custom-list', class CustomElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'combobox';
+        internals.ariaAutoComplete = 'list';
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-list").role', 'AXRole: AXComboBox');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-list").stringAttributeValue("AXAutocompleteValue")', 'list');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-textbox").role', 'AXRole: AXTextField');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-textbox").stringAttributeValue("AXAutocompleteValue")', 'inline');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/current-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/current-expected.txt
@@ -1,0 +1,11 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("custom-location").currentStateValue is "location"
+PASS accessibilityController.accessibleElementById("custom-page").currentStateValue is "page"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/custom-elements/current.html
+++ b/LayoutTests/accessibility/custom-elements/current.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-element id="custom-location"></custom-element>
+<custom-element id="custom-page" aria-current="page"></custom-element>
+<script>
+
+customElements.define('custom-element', class CustomElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.ariaCurrent = 'location';
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-location").currentStateValue', 'location');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-page").currentStateValue', 'page');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/heading-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/heading-expected.txt
@@ -1,0 +1,11 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("heading-1").intValue is 1
+PASS accessibilityController.accessibleElementById("heading-1-1").intValue is 2
+PASS successfullyParsed is true
+
+TEST COMPLETE
+1. Some title 1.1. Subtitle

--- a/LayoutTests/accessibility/custom-elements/heading.html
+++ b/LayoutTests/accessibility/custom-elements/heading.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-heading id="heading-1">1. Some title</custom-heading>
+<custom-heading id="heading-1-1" aria-level="2">1.1. Subtitle</custom-heading>
+<script>
+
+customElements.define('custom-heading', class CustomElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'heading';
+        internals.ariaLevel = '1';
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBe('accessibilityController.accessibleElementById("heading-1").intValue', '1');
+    shouldBe('accessibilityController.accessibleElementById("heading-1-1").intValue', '2');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/hidden-button-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/hidden-button-expected.txt
@@ -1,0 +1,16 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("item-1") is null
+PASS accessibilityController.accessibleElementById("item-2").role is "AXRole: AXButton"
+PASS accessibilityController.accessibleElementById("item-2").stringAttributeValue("AXInvalid") is "grammar"
+PASS accessibilityController.accessibleElementById("item-2").stringAttributeValue("AXKeyShortcutsValue") is "Shift + E"
+PASS accessibilityController.accessibleElementById("item-3").role is "AXRole: AXButton"
+PASS accessibilityController.accessibleElementById("item-3").stringAttributeValue("AXInvalid") is "spelling"
+PASS accessibilityController.accessibleElementById("item-3").stringAttributeValue("AXKeyShortcutsValue") is "Command + T"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/custom-elements/hidden-button.html
+++ b/LayoutTests/accessibility/custom-elements/hidden-button.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-button id="item-1"></custom-button>
+<custom-button id="item-2" aria-hidden="false"></custom-button>
+<custom-button id="item-3" aria-hidden="false" aria-invalid="spelling" aria-keyshortcuts="Command + T"></custom-button>
+<script>
+
+customElements.define('custom-button', class CustomElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'button';
+        internals.ariaHidden = 'true';
+        internals.ariaInvalid = 'grammar';
+        internals.ariaKeyShortcuts = "Shift + E";
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBe('accessibilityController.accessibleElementById("item-1")', 'null');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("item-2").role', 'AXRole: AXButton');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("item-2").stringAttributeValue("AXInvalid")', 'grammar');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("item-2").stringAttributeValue("AXKeyShortcutsValue")', 'Shift + E');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("item-3").role', 'AXRole: AXButton');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("item-3").stringAttributeValue("AXInvalid")', 'spelling');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("item-3").stringAttributeValue("AXKeyShortcutsValue")', 'Command + T');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/liveregions-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/liveregions-expected.txt
@@ -1,0 +1,18 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("custom-element") is null
+PASS accessibilityController.accessibleElementById("custom-liveregion").boolAttributeValue("AXARIAAtomic") is true
+PASS accessibilityController.accessibleElementById("custom-liveregion").boolAttributeValue("AXElementBusy") is true
+PASS accessibilityController.accessibleElementById("custom-liveregion").stringAttributeValue("AXARIALive") is "polite"
+PASS accessibilityController.accessibleElementById("custom-liveregion").stringAttributeValue("AXARIARelevant") is "additions"
+PASS accessibilityController.accessibleElementById("text-liveregion").boolAttributeValue("AXARIAAtomic") is false
+PASS accessibilityController.accessibleElementById("text-liveregion").boolAttributeValue("AXElementBusy") is false
+PASS accessibilityController.accessibleElementById("text-liveregion").stringAttributeValue("AXARIALive") is "assertive"
+PASS accessibilityController.accessibleElementById("text-liveregion").stringAttributeValue("AXARIARelevant") is "text"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/custom-elements/liveregions.html
+++ b/LayoutTests/accessibility/custom-elements/liveregions.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<body id="body">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-element id="custom-element"></custom-element>
+<custom-liveregion id="custom-liveregion"></custom-checkbox>
+<custom-liveregion id="text-liveregion" aria-atomic="false" aria-busy="false" aria-live="assertive" aria-relevant="text"></custom-checkbox>
+<script>
+
+customElements.define('custom-element', class CustomElement extends HTMLElement {});
+customElements.define('custom-liveregion', class CustomElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.ariaAtomic = 'true';
+        internals.ariaBusy = 'true';
+        internals.ariaLive = 'polite';
+        internals.ariaRelevant = 'additions';
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBe('accessibilityController.accessibleElementById("custom-element")', 'null');
+
+    shouldBe('accessibilityController.accessibleElementById("custom-liveregion").boolAttributeValue("AXARIAAtomic")', 'true');
+    shouldBe('accessibilityController.accessibleElementById("custom-liveregion").boolAttributeValue("AXElementBusy")', 'true');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-liveregion").stringAttributeValue("AXARIALive")', 'polite');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-liveregion").stringAttributeValue("AXARIARelevant")', 'additions');
+
+    shouldBe('accessibilityController.accessibleElementById("text-liveregion").boolAttributeValue("AXARIAAtomic")', 'false');
+    shouldBe('accessibilityController.accessibleElementById("text-liveregion").boolAttributeValue("AXElementBusy")', 'false');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("text-liveregion").stringAttributeValue("AXARIALive")', 'assertive');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("text-liveregion").stringAttributeValue("AXARIARelevant")', 'text');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/menuitem-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/menuitem-expected.txt
@@ -1,0 +1,15 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("item-1").isEnabled is false
+PASS accessibilityController.accessibleElementById("item-1").isExpanded is true
+PASS accessibilityController.accessibleElementById("item-1").hasPopup is true
+PASS accessibilityController.accessibleElementById("item-2").isEnabled is true
+PASS accessibilityController.accessibleElementById("item-2").isExpanded is false
+PASS accessibilityController.accessibleElementById("item-2").hasPopup is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/custom-elements/menuitem.html
+++ b/LayoutTests/accessibility/custom-elements/menuitem.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-menuitem id="item-1"></custom-menuitem>
+<custom-menuitem id="item-2" aria-disabled="false" aria-expanded="false" aria-haspopup="false"></custom-menuitem>
+<script>
+
+customElements.define('custom-menuitem', class CustomElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'menuitem';
+        internals.ariaDisabled = 'true';
+        internals.ariaExpanded = 'true';
+        internals.ariaHasPopup = 'true';
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBe('accessibilityController.accessibleElementById("item-1").isEnabled', 'false');
+    shouldBe('accessibilityController.accessibleElementById("item-1").isExpanded', 'true');
+    shouldBe('accessibilityController.accessibleElementById("item-1").hasPopup', 'true');
+    shouldBe('accessibilityController.accessibleElementById("item-2").isEnabled', 'true');
+    shouldBe('accessibilityController.accessibleElementById("item-2").isExpanded', 'false');
+    shouldBe('accessibilityController.accessibleElementById("item-2").hasPopup', 'false');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/modal-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/modal-expected.txt
@@ -1,0 +1,13 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS !accessibilityController.accessibleElementById("background-content") || accessibilityController.accessibleElementById("background-content").isIgnored === true
+PASS accessibilityController.accessibleElementById("background-content").isIgnored === false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+background
+
+modal content

--- a/LayoutTests/accessibility/custom-elements/modal.html
+++ b/LayoutTests/accessibility/custom-elements/modal.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<p role="group" id="background-content">background</p>
+<custom-dialog id="custom-dialog">modal content</custom-dialog>
+<script>
+
+customElements.define('custom-dialog', class CustomDialog extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'dialog';
+        internals.ariaModal = 'true';
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    jsTestIsAsync = true;
+    (async () => {
+        await expectAsyncExpression('!accessibilityController.accessibleElementById("background-content") || accessibilityController.accessibleElementById("background-content").isIgnored', 'true');
+        document.getElementById('custom-dialog').setAttribute('aria-modal', 'false');
+        await new Promise(requestAnimationFrame);
+        await expectAsyncExpression('accessibilityController.accessibleElementById("background-content").isIgnored', 'false');
+        finishJSTest();
+    })();
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/multiselectable-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/multiselectable-expected.txt
@@ -1,0 +1,11 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("grid-1").isMultiSelectable is true
+PASS accessibilityController.accessibleElementById("grid-2").isMultiSelectable is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/custom-elements/multiselectable.html
+++ b/LayoutTests/accessibility/custom-elements/multiselectable.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-grid id="grid-1"></custom-grid>
+<custom-grid id="grid-2" aria-multiselectable="false"></custom-grid>
+<script>
+
+customElements.define('custom-grid', class CustomGrid extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'grid';
+        internals.ariaMultiSelectable = 'true';
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBe('accessibilityController.accessibleElementById("grid-1").isMultiSelectable', 'true');
+    shouldBe('accessibilityController.accessibleElementById("grid-2").isMultiSelectable', 'false');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/orientation-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/orientation-expected.txt
@@ -1,0 +1,11 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("group-1").orientation is "AXOrientation: AXVerticalOrientation"
+PASS accessibilityController.accessibleElementById("group-2").orientation is "AXOrientation: AXHorizontalOrientation"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/custom-elements/orientation.html
+++ b/LayoutTests/accessibility/custom-elements/orientation.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-radio-group id="group-1"></custom-radio-group>
+<custom-radio-group id="group-2" aria-orientation="horizontal"></custom-radio-group>
+<script>
+
+customElements.define('custom-radio-group', class CustomGrid extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'radiogroup';
+        internals.ariaOrientation = 'vertical';
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBeEqualToString('accessibilityController.accessibleElementById("group-1").orientation', 'AXOrientation: AXVerticalOrientation');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("group-2").orientation', 'AXOrientation: AXHorizontalOrientation');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/posinset-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/posinset-expected.txt
@@ -1,0 +1,13 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("item-1").numberAttributeValue("AXARIASetSize") is 100
+PASS accessibilityController.accessibleElementById("item-1").numberAttributeValue("AXARIAPosInSet") is 5
+PASS accessibilityController.accessibleElementById("item-2").numberAttributeValue("AXARIASetSize") is 50
+PASS accessibilityController.accessibleElementById("item-2").numberAttributeValue("AXARIAPosInSet") is 3
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/custom-elements/posinset.html
+++ b/LayoutTests/accessibility/custom-elements/posinset.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<div id="tree" role="tree">
+    <custom-item id="item-1" role="treeitem"></custom-item>
+    <custom-item id="item-2" aria-setsize="50" aria-posinset="3"></custom-item>
+</div>
+<script>
+
+customElements.define('custom-item', class CustomItem extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'treeitem';
+        internals.ariaSetSize = '100';
+        internals.ariaPosInSet = '5';
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBe('accessibilityController.accessibleElementById("item-1").numberAttributeValue("AXARIASetSize")', '100');
+    shouldBe('accessibilityController.accessibleElementById("item-1").numberAttributeValue("AXARIAPosInSet")', '5');
+    shouldBe('accessibilityController.accessibleElementById("item-2").numberAttributeValue("AXARIASetSize")', '50');
+    shouldBe('accessibilityController.accessibleElementById("item-2").numberAttributeValue("AXARIAPosInSet")', '3');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/pressed-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/pressed-expected.txt
@@ -1,0 +1,17 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("button-1").role is "AXRole: AXCheckBox"
+PASS accessibilityController.accessibleElementById("button-1").stringValue is "AXValue: 1"
+PASS accessibilityController.accessibleElementById("button-1").isRequired is true
+PASS accessibilityController.accessibleElementById("button-1").isSelected is true
+PASS accessibilityController.accessibleElementById("button-2").role is "AXRole: AXCheckBox"
+PASS accessibilityController.accessibleElementById("button-2").stringValue is "AXValue: 0"
+PASS accessibilityController.accessibleElementById("button-2").isRequired is false
+PASS accessibilityController.accessibleElementById("button-2").isSelected is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/custom-elements/pressed.html
+++ b/LayoutTests/accessibility/custom-elements/pressed.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-button id="button-1"></custom-button>
+<custom-button id="button-2" aria-pressed="false" aria-required="false" aria-selected="false"></custom-button>
+<script>
+
+customElements.define('custom-button', class CustomButton extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'button';
+        internals.ariaPressed = 'true';
+        internals.ariaRequired = 'true';
+        internals.ariaSelected = 'true';
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBeEqualToString('accessibilityController.accessibleElementById("button-1").role', 'AXRole: AXCheckBox');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("button-1").stringValue', 'AXValue: 1');
+    shouldBeTrue('accessibilityController.accessibleElementById("button-1").isRequired');
+    shouldBeTrue('accessibilityController.accessibleElementById("button-1").isSelected');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("button-2").role', 'AXRole: AXCheckBox');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("button-2").stringValue', 'AXValue: 0');
+    shouldBeFalse('accessibilityController.accessibleElementById("button-2").isRequired');
+    shouldBeFalse('accessibilityController.accessibleElementById("button-2").isSelected');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/role-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/role-expected.txt
@@ -7,9 +7,11 @@ PASS accessibilityController.accessibleElementById("custom-element") is null
 PASS accessibilityController.accessibleElementById("custom-checkbox").role is "AXRole: AXCheckBox"
 PASS accessibilityController.accessibleElementById("custom-checkbox").roleDescription is "AXRoleDescription: some description"
 PASS platformValueForW3CName(accessibilityController.accessibleElementById("custom-checkbox")) is "some label"
+PASS accessibilityController.accessibleElementById("custom-checkbox").isChecked is true
 PASS accessibilityController.accessibleElementById("button-checkbox").role is "AXRole: AXButton"
 PASS accessibilityController.accessibleElementById("button-checkbox").roleDescription is "AXRoleDescription: other description"
 PASS platformValueForW3CName(accessibilityController.accessibleElementById("button-checkbox")) is "other label"
+PASS accessibilityController.accessibleElementById("button-checkbox").isChecked is false
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/custom-elements/role.html
+++ b/LayoutTests/accessibility/custom-elements/role.html
@@ -5,9 +5,7 @@
 <script src="../../resources/accessibility-helper.js"></script>
 <custom-element id="custom-element"></custom-element>
 <custom-checkbox id="custom-checkbox"></custom-checkbox>
-<custom-checkbox id="button-checkbox" role="button" aria-roledescription="other description" aria-label="other label"></custom-checkbox>
-<p id="description"></p>
-<div id="console"></div>
+<custom-checkbox id="button-checkbox" role="button" aria-roledescription="other description" aria-label="other label" aria-checked="false"></custom-checkbox>
 <script>
 
 customElements.define('custom-element', class CustomElement extends HTMLElement {});
@@ -19,6 +17,7 @@ customElements.define('custom-checkbox', class CustomElement extends HTMLElement
         internals.role = 'checkbox';
         internals.ariaRoleDescription = 'some description';
         internals.ariaLabel = 'some label';
+        internals.ariaChecked = 'true';
     }
 });
 
@@ -30,13 +29,13 @@ else {
     shouldBeEqualToString('accessibilityController.accessibleElementById("custom-checkbox").role', 'AXRole: AXCheckBox');
     shouldBeEqualToString('accessibilityController.accessibleElementById("custom-checkbox").roleDescription', 'AXRoleDescription: some description');
     shouldBeEqualToString('platformValueForW3CName(accessibilityController.accessibleElementById("custom-checkbox"))', 'some label');
+    shouldBe('accessibilityController.accessibleElementById("custom-checkbox").isChecked', 'true');
     shouldBeEqualToString('accessibilityController.accessibleElementById("button-checkbox").role', 'AXRole: AXButton');
     shouldBeEqualToString('accessibilityController.accessibleElementById("button-checkbox").roleDescription', 'AXRoleDescription: other description');
     shouldBeEqualToString('platformValueForW3CName(accessibilityController.accessibleElementById("button-checkbox"))', 'other label');
+    shouldBe('accessibilityController.accessibleElementById("button-checkbox").isChecked', 'false');
 }
 
 </script>
-
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/custom-elements/slider-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/slider-expected.txt
@@ -1,0 +1,19 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("slider-1").role is "AXRole: AXSlider"
+PASS accessibilityController.accessibleElementById("slider-1").intValue is 5
+PASS accessibilityController.accessibleElementById("slider-1").maxValue is 10
+PASS accessibilityController.accessibleElementById("slider-1").minValue is 1
+PASS accessibilityController.accessibleElementById("slider-1").valueDescription is "AXValueDescription: 5/10"
+PASS accessibilityController.accessibleElementById("slider-2").role is "AXRole: AXSlider"
+PASS accessibilityController.accessibleElementById("slider-2").intValue is 7
+PASS accessibilityController.accessibleElementById("slider-2").maxValue is 15
+PASS accessibilityController.accessibleElementById("slider-2").minValue is 3
+PASS accessibilityController.accessibleElementById("slider-2").valueDescription is "AXValueDescription: 7 out of 15"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/custom-elements/slider.html
+++ b/LayoutTests/accessibility/custom-elements/slider.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-slider id="slider-1"></custom-slider>
+<custom-slider id="slider-2" aria-valuemax="15" aria-valuemin="3" aria-valuenow="7" aria-valuetext="7 out of 15"></custom-slider>
+<script>
+
+customElements.define('custom-slider', class CustomSlider extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'slider';
+        internals.ariaValueMax = 10;
+        internals.ariaValueMin = 1;
+        internals.ariaValueNow = 5;
+        internals.ariaValueText = '5/10';
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBeEqualToString('accessibilityController.accessibleElementById("slider-1").role', 'AXRole: AXSlider');
+    shouldBe('accessibilityController.accessibleElementById("slider-1").intValue', '5');
+    shouldBe('accessibilityController.accessibleElementById("slider-1").maxValue', '10');
+    shouldBe('accessibilityController.accessibleElementById("slider-1").minValue', '1');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("slider-1").valueDescription', 'AXValueDescription: 5/10');
+
+    shouldBeEqualToString('accessibilityController.accessibleElementById("slider-2").role', 'AXRole: AXSlider');
+    shouldBe('accessibilityController.accessibleElementById("slider-2").intValue', '7');
+    shouldBe('accessibilityController.accessibleElementById("slider-2").maxValue', '15');
+    shouldBe('accessibilityController.accessibleElementById("slider-2").minValue', '3');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("slider-2").valueDescription', 'AXValueDescription: 7 out of 15');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/table-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/table-expected.txt
@@ -1,0 +1,44 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("table-1").role is "AXRole: AXTable"
+PASS accessibilityController.accessibleElementById("table-1").rowCount is 4
+PASS accessibilityController.accessibleElementById("table-1").columnCount is 4
+PASS accessibilityController.accessibleElementById("table-1").numberAttributeValue("AXARIAColumnCount") is 4
+PASS accessibilityController.accessibleElementById("table-1").numberAttributeValue("AXARIARowCount") is 8
+PASS accessibilityController.accessibleElementById("row-header").role is "AXRole: AXRow"
+PASS accessibilityController.accessibleElementById("header-1").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("header-1").sortDirection is "AXAscendingSortDirection"
+PASS accessibilityController.accessibleElementById("row-1").role is "AXRole: AXRow"
+PASS accessibilityController.accessibleElementById("cell1").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell1").numberAttributeValue("AXARIARowIndex") is 7
+PASS accessibilityController.accessibleElementById("cell1").numberAttributeValue("AXARIAColumnIndex") is 2
+PASS accessibilityController.accessibleElementById("cell2").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell2").numberAttributeValue("AXARIARowIndex") is 7
+PASS accessibilityController.accessibleElementById("cell2").numberAttributeValue("AXARIAColumnIndex") is 3
+PASS accessibilityController.accessibleElementById("cell3").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell3").numberAttributeValue("AXARIARowIndex") is 7
+PASS accessibilityController.accessibleElementById("cell3").numberAttributeValue("AXARIAColumnIndex") is 4
+PASS accessibilityController.accessibleElementById("cell3").rowIndexRange() is "{1, 2}"
+PASS accessibilityController.accessibleElementById("cell4").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell4").numberAttributeValue("AXARIARowIndex") is 7
+PASS accessibilityController.accessibleElementById("cell4").numberAttributeValue("AXARIAColumnIndex") is 5
+PASS accessibilityController.accessibleElementById("cell4").rowIndexRange() is "{1, 3}"
+PASS accessibilityController.accessibleElementById("row-2").role is "AXRole: AXRow"
+PASS accessibilityController.accessibleElementById("cell5").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell5").numberAttributeValue("AXARIARowIndex") is 8
+PASS accessibilityController.accessibleElementById("cell5").numberAttributeValue("AXARIAColumnIndex") is 2
+PASS accessibilityController.accessibleElementById("cell5").rowIndexRange() is "{2, 1}"
+PASS accessibilityController.accessibleElementById("cell5").columnIndexRange() is "{0, 2}"
+PASS accessibilityController.accessibleElementById("row-3").role is "AXRole: AXRow"
+PASS accessibilityController.accessibleElementById("cell6").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell6").numberAttributeValue("AXARIARowIndex") is 9
+PASS accessibilityController.accessibleElementById("cell6").numberAttributeValue("AXARIAColumnIndex") is 2
+PASS accessibilityController.accessibleElementById("cell6").rowIndexRange() is "{3, 1}"
+PASS accessibilityController.accessibleElementById("cell6").columnIndexRange() is "{0, 3}"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/custom-elements/table.html
+++ b/LayoutTests/accessibility/custom-elements/table.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-table id="table-1">
+    <custom-row id="row-header" aria-rowindex="1">
+        <custom-cell id="header-1" role="columnheader" aria-sort="ascending"></custom-cell>
+    </custom-row>
+    <custom-row id="row-1">
+        <custom-cell id="cell1"></custom-cell>
+        <custom-cell id="cell2" aria-colindex="3"></custom-cell>
+        <custom-rowspan-cell id="cell3"></custom-rowspan-cell>
+        <custom-rowspan-cell id="cell4" aria-colindex="5" aria-rowspan="3"></custom-rowspan-cell>
+    </custom-row>
+    <custom-row id="row-2" role="row" aria-rowindex="8">
+        <custom-colspan-cell id="cell5"></custom-colspan-cell>
+    </custom-row>
+    <custom-row id="row-3" role="row" aria-rowindex="9">
+        <custom-colspan-cell id="cell6" aria-colspan="3"></custom-colspan-cell>
+    </custom-row>
+</custom-table>
+<script>
+
+customElements.define('custom-table', class CustomTable extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'grid';
+        internals.ariaColCount = '4';
+        internals.ariaRowCount = '8';
+    }
+});
+
+customElements.define('custom-row', class CustomRow extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'row';
+        internals.ariaRowIndex = 7;
+    }
+});
+
+customElements.define('custom-cell', class CustomCell extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'gridcell';
+        internals.ariaColIndex = 2;
+    }
+});
+
+customElements.define('custom-rowspan-cell', class CustomRowspanCell extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'gridcell';
+        internals.ariaColIndex = 4;
+        internals.ariaRowSpan = 2;
+    }
+});
+
+customElements.define('custom-colspan-cell', class CustomColspanCell extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'gridcell';
+        internals.ariaColIndex = 2;
+        internals.ariaColSpan = 2;
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBeEqualToString('accessibilityController.accessibleElementById("table-1").role', 'AXRole: AXTable');
+    shouldBe('accessibilityController.accessibleElementById("table-1").rowCount', '4');
+    shouldBe('accessibilityController.accessibleElementById("table-1").columnCount', '4');
+    shouldBe('accessibilityController.accessibleElementById("table-1").numberAttributeValue("AXARIAColumnCount")', '4');
+    shouldBe('accessibilityController.accessibleElementById("table-1").numberAttributeValue("AXARIARowCount")', '8');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("row-header").role', 'AXRole: AXRow');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("header-1").role', 'AXRole: AXCell');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("header-1").sortDirection', 'AXAscendingSortDirection');
+
+    shouldBeEqualToString('accessibilityController.accessibleElementById("row-1").role', 'AXRole: AXRow');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("cell1").role', 'AXRole: AXCell');
+    shouldBe('accessibilityController.accessibleElementById("cell1").numberAttributeValue("AXARIARowIndex")', '7');
+    shouldBe('accessibilityController.accessibleElementById("cell1").numberAttributeValue("AXARIAColumnIndex")', '2');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("cell2").role', 'AXRole: AXCell');
+    shouldBe('accessibilityController.accessibleElementById("cell2").numberAttributeValue("AXARIARowIndex")', '7');
+    shouldBe('accessibilityController.accessibleElementById("cell2").numberAttributeValue("AXARIAColumnIndex")', '3');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("cell3").role', 'AXRole: AXCell');
+    shouldBe('accessibilityController.accessibleElementById("cell3").numberAttributeValue("AXARIARowIndex")', '7');
+    shouldBe('accessibilityController.accessibleElementById("cell3").numberAttributeValue("AXARIAColumnIndex")', '4');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("cell3").rowIndexRange()', '{1, 2}');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("cell4").role', 'AXRole: AXCell');
+    shouldBe('accessibilityController.accessibleElementById("cell4").numberAttributeValue("AXARIARowIndex")', '7');
+    shouldBe('accessibilityController.accessibleElementById("cell4").numberAttributeValue("AXARIAColumnIndex")', '5');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("cell4").rowIndexRange()', '{1, 3}');
+
+    shouldBeEqualToString('accessibilityController.accessibleElementById("row-2").role', 'AXRole: AXRow');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("cell5").role', 'AXRole: AXCell');
+    shouldBe('accessibilityController.accessibleElementById("cell5").numberAttributeValue("AXARIARowIndex")', '8');
+    shouldBe('accessibilityController.accessibleElementById("cell5").numberAttributeValue("AXARIAColumnIndex")', '2');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("cell5").rowIndexRange()', '{2, 1}');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("cell5").columnIndexRange()', '{0, 2}');
+
+    shouldBeEqualToString('accessibilityController.accessibleElementById("row-3").role', 'AXRole: AXRow');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("cell6").role', 'AXRole: AXCell');
+    shouldBe('accessibilityController.accessibleElementById("cell6").numberAttributeValue("AXARIARowIndex")', '9');
+    shouldBe('accessibilityController.accessibleElementById("cell6").numberAttributeValue("AXARIAColumnIndex")', '2');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("cell6").rowIndexRange()', '{3, 1}');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("cell6").columnIndexRange()', '{0, 3}');
+
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/textbox-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/textbox-expected.txt
@@ -1,0 +1,15 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("multiline-textbox").role is "AXRole: AXTextArea"
+PASS accessibilityController.accessibleElementById("multiline-textbox").stringAttributeValue("AXPlaceholderValue") is "some text"
+PASS accessibilityController.accessibleElementById("multiline-textbox").isAttributeSettable("AXValue") is false
+PASS accessibilityController.accessibleElementById("singleline-textbox").role is "AXRole: AXTextField"
+PASS accessibilityController.accessibleElementById("singleline-textbox").stringAttributeValue("AXPlaceholderValue") is "another text"
+PASS accessibilityController.accessibleElementById("singleline-textbox").isAttributeSettable("AXValue") is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/custom-elements/textbox.html
+++ b/LayoutTests/accessibility/custom-elements/textbox.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-textbox id="multiline-textbox"></custom-textbox>
+<custom-textbox id="singleline-textbox" aria-multiline="false" aria-placeholder="another text" aria-readonly="false"></custom-textbox>
+<script>
+
+customElements.define('custom-textbox', class CustomTextbox extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'textbox';
+        internals.ariaMultiLine = 'true';
+        internals.ariaPlaceholder = 'some text';
+        internals.ariaReadOnly = 'true';
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBeEqualToString('accessibilityController.accessibleElementById("multiline-textbox").role', 'AXRole: AXTextArea');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("multiline-textbox").stringAttributeValue("AXPlaceholderValue")', 'some text');
+    shouldBeFalse('accessibilityController.accessibleElementById("multiline-textbox").isAttributeSettable("AXValue")');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("singleline-textbox").role', 'AXRole: AXTextField');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("singleline-textbox").stringAttributeValue("AXPlaceholderValue")', 'another text');
+    shouldBeTrue('accessibilityController.accessibleElementById("singleline-textbox").isAttributeSettable("AXValue")');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-accessibility-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-accessibility-expected.txt
@@ -1,48 +1,48 @@
 
 PASS role is defined in ElementInternals
 FAIL ariaActiveDescendantElement is defined in ElementInternals assert_inherits: property "ariaActiveDescendantElement" not found in prototype chain
-FAIL ariaAtomic is defined in ElementInternals assert_inherits: property "ariaAtomic" not found in prototype chain
-FAIL ariaAutoComplete is defined in ElementInternals assert_inherits: property "ariaAutoComplete" not found in prototype chain
-FAIL ariaBusy is defined in ElementInternals assert_inherits: property "ariaBusy" not found in prototype chain
-FAIL ariaChecked is defined in ElementInternals assert_inherits: property "ariaChecked" not found in prototype chain
-FAIL ariaColCount is defined in ElementInternals assert_inherits: property "ariaColCount" not found in prototype chain
-FAIL ariaColIndex is defined in ElementInternals assert_inherits: property "ariaColIndex" not found in prototype chain
-FAIL ariaColSpan is defined in ElementInternals assert_inherits: property "ariaColSpan" not found in prototype chain
+PASS ariaAtomic is defined in ElementInternals
+PASS ariaAutoComplete is defined in ElementInternals
+PASS ariaBusy is defined in ElementInternals
+PASS ariaChecked is defined in ElementInternals
+PASS ariaColCount is defined in ElementInternals
+PASS ariaColIndex is defined in ElementInternals
+PASS ariaColSpan is defined in ElementInternals
 FAIL ariaControlsElements is defined in ElementInternals assert_inherits: property "ariaControlsElements" not found in prototype chain
-FAIL ariaCurrent is defined in ElementInternals assert_inherits: property "ariaCurrent" not found in prototype chain
+PASS ariaCurrent is defined in ElementInternals
 FAIL ariaDescribedByElements is defined in ElementInternals assert_inherits: property "ariaDescribedByElements" not found in prototype chain
 FAIL ariaDetailsElements is defined in ElementInternals assert_inherits: property "ariaDetailsElements" not found in prototype chain
-FAIL ariaDisabled is defined in ElementInternals assert_inherits: property "ariaDisabled" not found in prototype chain
+PASS ariaDisabled is defined in ElementInternals
 FAIL ariaErrorMessageElement is defined in ElementInternals assert_inherits: property "ariaErrorMessageElement" not found in prototype chain
-FAIL ariaExpanded is defined in ElementInternals assert_inherits: property "ariaExpanded" not found in prototype chain
+PASS ariaExpanded is defined in ElementInternals
 FAIL ariaFlowToElements is defined in ElementInternals assert_inherits: property "ariaFlowToElements" not found in prototype chain
-FAIL ariaHasPopup is defined in ElementInternals assert_inherits: property "ariaHasPopup" not found in prototype chain
-FAIL ariaHidden is defined in ElementInternals assert_inherits: property "ariaHidden" not found in prototype chain
-FAIL ariaInvalid is defined in ElementInternals assert_inherits: property "ariaInvalid" not found in prototype chain
-FAIL ariaKeyShortcuts is defined in ElementInternals assert_inherits: property "ariaKeyShortcuts" not found in prototype chain
+PASS ariaHasPopup is defined in ElementInternals
+PASS ariaHidden is defined in ElementInternals
+PASS ariaInvalid is defined in ElementInternals
+PASS ariaKeyShortcuts is defined in ElementInternals
 PASS ariaLabel is defined in ElementInternals
 FAIL ariaLabelledByElements is defined in ElementInternals assert_inherits: property "ariaLabelledByElements" not found in prototype chain
-FAIL ariaLevel is defined in ElementInternals assert_inherits: property "ariaLevel" not found in prototype chain
-FAIL ariaLive is defined in ElementInternals assert_inherits: property "ariaLive" not found in prototype chain
-FAIL ariaModal is defined in ElementInternals assert_inherits: property "ariaModal" not found in prototype chain
-FAIL ariaMultiLine is defined in ElementInternals assert_inherits: property "ariaMultiLine" not found in prototype chain
-FAIL ariaMultiSelectable is defined in ElementInternals assert_inherits: property "ariaMultiSelectable" not found in prototype chain
-FAIL ariaOrientation is defined in ElementInternals assert_inherits: property "ariaOrientation" not found in prototype chain
+PASS ariaLevel is defined in ElementInternals
+PASS ariaLive is defined in ElementInternals
+PASS ariaModal is defined in ElementInternals
+PASS ariaMultiLine is defined in ElementInternals
+PASS ariaMultiSelectable is defined in ElementInternals
+PASS ariaOrientation is defined in ElementInternals
 FAIL ariaOwnsElements is defined in ElementInternals assert_inherits: property "ariaOwnsElements" not found in prototype chain
-FAIL ariaPlaceholder is defined in ElementInternals assert_inherits: property "ariaPlaceholder" not found in prototype chain
-FAIL ariaPosInSet is defined in ElementInternals assert_inherits: property "ariaPosInSet" not found in prototype chain
-FAIL ariaPressed is defined in ElementInternals assert_inherits: property "ariaPressed" not found in prototype chain
-FAIL ariaReadOnly is defined in ElementInternals assert_inherits: property "ariaReadOnly" not found in prototype chain
-FAIL ariaRelevant is defined in ElementInternals assert_inherits: property "ariaRelevant" not found in prototype chain
-FAIL ariaRequired is defined in ElementInternals assert_inherits: property "ariaRequired" not found in prototype chain
+PASS ariaPlaceholder is defined in ElementInternals
+PASS ariaPosInSet is defined in ElementInternals
+PASS ariaPressed is defined in ElementInternals
+PASS ariaReadOnly is defined in ElementInternals
+PASS ariaRelevant is defined in ElementInternals
+PASS ariaRequired is defined in ElementInternals
 PASS ariaRoleDescription is defined in ElementInternals
-FAIL ariaRowCount is defined in ElementInternals assert_inherits: property "ariaRowCount" not found in prototype chain
-FAIL ariaRowIndex is defined in ElementInternals assert_inherits: property "ariaRowIndex" not found in prototype chain
-FAIL ariaRowSpan is defined in ElementInternals assert_inherits: property "ariaRowSpan" not found in prototype chain
-FAIL ariaSelected is defined in ElementInternals assert_inherits: property "ariaSelected" not found in prototype chain
-FAIL ariaSort is defined in ElementInternals assert_inherits: property "ariaSort" not found in prototype chain
-FAIL ariaValueMax is defined in ElementInternals assert_inherits: property "ariaValueMax" not found in prototype chain
-FAIL ariaValueMin is defined in ElementInternals assert_inherits: property "ariaValueMin" not found in prototype chain
-FAIL ariaValueNow is defined in ElementInternals assert_inherits: property "ariaValueNow" not found in prototype chain
-FAIL ariaValueText is defined in ElementInternals assert_inherits: property "ariaValueText" not found in prototype chain
+PASS ariaRowCount is defined in ElementInternals
+PASS ariaRowIndex is defined in ElementInternals
+PASS ariaRowSpan is defined in ElementInternals
+PASS ariaSelected is defined in ElementInternals
+PASS ariaSort is defined in ElementInternals
+PASS ariaValueMax is defined in ElementInternals
+PASS ariaValueMin is defined in ElementInternals
+PASS ariaValueNow is defined in ElementInternals
+PASS ariaValueText is defined in ElementInternals
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -211,6 +211,9 @@ webrtc/vp8-then-h264-gpu-process-crash.html [ Skip ]
 # ARIA description needs to be supported on GTK.
 accessibility/aria-description.html [ Skip ]
 
+# default ARIA for custom elements tests that timeout in GTK:
+accessibility/custom-elements/modal.html [ Skip ]
+
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End of Triaged Expectations
 # Legacy Expectations sections below

--- a/LayoutTests/platform/gtk/accessibility/custom-elements/autocomplete-expected.txt
+++ b/LayoutTests/platform/gtk/accessibility/custom-elements/autocomplete-expected.txt
@@ -1,0 +1,14 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("custom-list").role is "AXRole: AXComboBox"
+FAIL accessibilityController.accessibleElementById("custom-list").stringAttributeValue("AXAutocompleteValue") should be list. Was .
+PASS accessibilityController.accessibleElementById("custom-textbox").role is "AXRole: AXTextField"
+FAIL accessibilityController.accessibleElementById("custom-textbox").stringAttributeValue("AXAutocompleteValue") should be inline. Was .
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/gtk/accessibility/custom-elements/hidden-button-expected.txt
+++ b/LayoutTests/platform/gtk/accessibility/custom-elements/hidden-button-expected.txt
@@ -1,0 +1,17 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("item-1") is null
+PASS accessibilityController.accessibleElementById("item-2").role is "AXRole: AXButton"
+PASS accessibilityController.accessibleElementById("item-2").stringAttributeValue("AXInvalid") is "grammar"
+FAIL accessibilityController.accessibleElementById("item-2").stringAttributeValue("AXKeyShortcutsValue") should be Shift + E. Was .
+PASS accessibilityController.accessibleElementById("item-3").role is "AXRole: AXButton"
+PASS accessibilityController.accessibleElementById("item-3").stringAttributeValue("AXInvalid") is "spelling"
+FAIL accessibilityController.accessibleElementById("item-3").stringAttributeValue("AXKeyShortcutsValue") should be Command + T. Was .
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/gtk/accessibility/custom-elements/modal-expected.txt
+++ b/LayoutTests/platform/gtk/accessibility/custom-elements/modal-expected.txt
@@ -1,0 +1,15 @@
+background
+
+modal content
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL !accessibilityController.accessibleElementById("background-content") || accessibilityController.accessibleElementById("background-content").isIgnored should be true. Was false.
+PASS accessibilityController.accessibleElementById("background-content").isIgnored is false
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/gtk/accessibility/custom-elements/pressed-expected.txt
+++ b/LayoutTests/platform/gtk/accessibility/custom-elements/pressed-expected.txt
@@ -1,0 +1,18 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL accessibilityController.accessibleElementById("button-1").role should be AXRole: AXCheckBox. Was AXRole: AXToggleButton.
+FAIL accessibilityController.accessibleElementById("button-1").stringValue should be AXValue: 1. Was AXValue: .
+PASS accessibilityController.accessibleElementById("button-1").isRequired is true
+PASS accessibilityController.accessibleElementById("button-1").isSelected is true
+FAIL accessibilityController.accessibleElementById("button-2").role should be AXRole: AXCheckBox. Was AXRole: AXToggleButton.
+FAIL accessibilityController.accessibleElementById("button-2").stringValue should be AXValue: 0. Was AXValue: .
+PASS accessibilityController.accessibleElementById("button-2").isRequired is false
+PASS accessibilityController.accessibleElementById("button-2").isSelected is false
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/gtk/accessibility/custom-elements/table-expected.txt
+++ b/LayoutTests/platform/gtk/accessibility/custom-elements/table-expected.txt
@@ -1,0 +1,45 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("table-1").role is "AXRole: AXTable"
+PASS accessibilityController.accessibleElementById("table-1").rowCount is 4
+PASS accessibilityController.accessibleElementById("table-1").columnCount is 4
+PASS accessibilityController.accessibleElementById("table-1").numberAttributeValue("AXARIAColumnCount") is 4
+PASS accessibilityController.accessibleElementById("table-1").numberAttributeValue("AXARIARowCount") is 8
+PASS accessibilityController.accessibleElementById("row-header").role is "AXRole: AXRow"
+FAIL accessibilityController.accessibleElementById("header-1").role should be AXRole: AXCell. Was AXRole: AXColumnHeader.
+FAIL accessibilityController.accessibleElementById("header-1").sortDirection should be AXAscendingSortDirection (of type string). Was null (of type object).
+PASS accessibilityController.accessibleElementById("row-1").role is "AXRole: AXRow"
+PASS accessibilityController.accessibleElementById("cell1").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell1").numberAttributeValue("AXARIARowIndex") is 7
+PASS accessibilityController.accessibleElementById("cell1").numberAttributeValue("AXARIAColumnIndex") is 2
+PASS accessibilityController.accessibleElementById("cell2").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell2").numberAttributeValue("AXARIARowIndex") is 7
+PASS accessibilityController.accessibleElementById("cell2").numberAttributeValue("AXARIAColumnIndex") is 3
+PASS accessibilityController.accessibleElementById("cell3").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell3").numberAttributeValue("AXARIARowIndex") is 7
+PASS accessibilityController.accessibleElementById("cell3").numberAttributeValue("AXARIAColumnIndex") is 4
+PASS accessibilityController.accessibleElementById("cell3").rowIndexRange() is "{1, 2}"
+PASS accessibilityController.accessibleElementById("cell4").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell4").numberAttributeValue("AXARIARowIndex") is 7
+PASS accessibilityController.accessibleElementById("cell4").numberAttributeValue("AXARIAColumnIndex") is 5
+PASS accessibilityController.accessibleElementById("cell4").rowIndexRange() is "{1, 3}"
+PASS accessibilityController.accessibleElementById("row-2").role is "AXRole: AXRow"
+PASS accessibilityController.accessibleElementById("cell5").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell5").numberAttributeValue("AXARIARowIndex") is 8
+PASS accessibilityController.accessibleElementById("cell5").numberAttributeValue("AXARIAColumnIndex") is 2
+PASS accessibilityController.accessibleElementById("cell5").rowIndexRange() is "{2, 1}"
+PASS accessibilityController.accessibleElementById("cell5").columnIndexRange() is "{0, 2}"
+PASS accessibilityController.accessibleElementById("row-3").role is "AXRole: AXRow"
+PASS accessibilityController.accessibleElementById("cell6").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell6").numberAttributeValue("AXARIARowIndex") is 9
+PASS accessibilityController.accessibleElementById("cell6").numberAttributeValue("AXARIAColumnIndex") is 2
+PASS accessibilityController.accessibleElementById("cell6").rowIndexRange() is "{3, 1}"
+PASS accessibilityController.accessibleElementById("cell6").columnIndexRange() is "{0, 3}"
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/gtk/accessibility/custom-elements/textbox-expected.txt
+++ b/LayoutTests/platform/gtk/accessibility/custom-elements/textbox-expected.txt
@@ -1,0 +1,16 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL accessibilityController.accessibleElementById("multiline-textbox").role should be AXRole: AXTextArea. Was AXRole: AXTextField.
+PASS accessibilityController.accessibleElementById("multiline-textbox").stringAttributeValue("AXPlaceholderValue") is "some text"
+PASS accessibilityController.accessibleElementById("multiline-textbox").isAttributeSettable("AXValue") is false
+PASS accessibilityController.accessibleElementById("singleline-textbox").role is "AXRole: AXTextField"
+PASS accessibilityController.accessibleElementById("singleline-textbox").stringAttributeValue("AXPlaceholderValue") is "another text"
+PASS accessibilityController.accessibleElementById("singleline-textbox").isAttributeSettable("AXValue") is true
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk1/accessibility/custom-elements/current-expected.txt
+++ b/LayoutTests/platform/mac-wk1/accessibility/custom-elements/current-expected.txt
@@ -1,0 +1,12 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL accessibilityController.accessibleElementById("custom-location").currentStateValue should be location (of type string). Was undefined (of type undefined).
+FAIL accessibilityController.accessibleElementById("custom-page").currentStateValue should be page (of type string). Was undefined (of type undefined).
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk1/accessibility/custom-elements/hidden-button-expected.txt
+++ b/LayoutTests/platform/mac-wk1/accessibility/custom-elements/hidden-button-expected.txt
@@ -1,0 +1,17 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL accessibilityController.accessibleElementById("item-1") should be null (of type object). Was undefined (of type undefined).
+PASS accessibilityController.accessibleElementById("item-2").role is "AXRole: AXButton"
+PASS accessibilityController.accessibleElementById("item-2").stringAttributeValue("AXInvalid") is "grammar"
+PASS accessibilityController.accessibleElementById("item-2").stringAttributeValue("AXKeyShortcutsValue") is "Shift + E"
+PASS accessibilityController.accessibleElementById("item-3").role is "AXRole: AXButton"
+PASS accessibilityController.accessibleElementById("item-3").stringAttributeValue("AXInvalid") is "spelling"
+PASS accessibilityController.accessibleElementById("item-3").stringAttributeValue("AXKeyShortcutsValue") is "Command + T"
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk1/accessibility/custom-elements/liveregions-expected.txt
+++ b/LayoutTests/platform/mac-wk1/accessibility/custom-elements/liveregions-expected.txt
@@ -1,0 +1,19 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL accessibilityController.accessibleElementById("custom-element") should be null (of type object). Was undefined (of type undefined).
+PASS accessibilityController.accessibleElementById("custom-liveregion").boolAttributeValue("AXARIAAtomic") is true
+PASS accessibilityController.accessibleElementById("custom-liveregion").boolAttributeValue("AXElementBusy") is true
+PASS accessibilityController.accessibleElementById("custom-liveregion").stringAttributeValue("AXARIALive") is "polite"
+PASS accessibilityController.accessibleElementById("custom-liveregion").stringAttributeValue("AXARIARelevant") is "additions"
+PASS accessibilityController.accessibleElementById("text-liveregion").boolAttributeValue("AXARIAAtomic") is false
+PASS accessibilityController.accessibleElementById("text-liveregion").boolAttributeValue("AXElementBusy") is false
+PASS accessibilityController.accessibleElementById("text-liveregion").stringAttributeValue("AXARIALive") is "assertive"
+PASS accessibilityController.accessibleElementById("text-liveregion").stringAttributeValue("AXARIARelevant") is "text"
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk1/accessibility/custom-elements/table-expected.txt
+++ b/LayoutTests/platform/mac-wk1/accessibility/custom-elements/table-expected.txt
@@ -1,0 +1,45 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("table-1").role is "AXRole: AXTable"
+PASS accessibilityController.accessibleElementById("table-1").rowCount is 4
+PASS accessibilityController.accessibleElementById("table-1").columnCount is 4
+PASS accessibilityController.accessibleElementById("table-1").numberAttributeValue("AXARIAColumnCount") is 4
+PASS accessibilityController.accessibleElementById("table-1").numberAttributeValue("AXARIARowCount") is 8
+PASS accessibilityController.accessibleElementById("row-header").role is "AXRole: AXRow"
+PASS accessibilityController.accessibleElementById("header-1").role is "AXRole: AXCell"
+FAIL accessibilityController.accessibleElementById("header-1").sortDirection should be AXAscendingSortDirection (of type string). Was undefined (of type undefined).
+PASS accessibilityController.accessibleElementById("row-1").role is "AXRole: AXRow"
+PASS accessibilityController.accessibleElementById("cell1").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell1").numberAttributeValue("AXARIARowIndex") is 7
+PASS accessibilityController.accessibleElementById("cell1").numberAttributeValue("AXARIAColumnIndex") is 2
+PASS accessibilityController.accessibleElementById("cell2").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell2").numberAttributeValue("AXARIARowIndex") is 7
+PASS accessibilityController.accessibleElementById("cell2").numberAttributeValue("AXARIAColumnIndex") is 3
+PASS accessibilityController.accessibleElementById("cell3").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell3").numberAttributeValue("AXARIARowIndex") is 7
+PASS accessibilityController.accessibleElementById("cell3").numberAttributeValue("AXARIAColumnIndex") is 4
+PASS accessibilityController.accessibleElementById("cell3").rowIndexRange() is "{1, 2}"
+PASS accessibilityController.accessibleElementById("cell4").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell4").numberAttributeValue("AXARIARowIndex") is 7
+PASS accessibilityController.accessibleElementById("cell4").numberAttributeValue("AXARIAColumnIndex") is 5
+PASS accessibilityController.accessibleElementById("cell4").rowIndexRange() is "{1, 3}"
+PASS accessibilityController.accessibleElementById("row-2").role is "AXRole: AXRow"
+PASS accessibilityController.accessibleElementById("cell5").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell5").numberAttributeValue("AXARIARowIndex") is 8
+PASS accessibilityController.accessibleElementById("cell5").numberAttributeValue("AXARIAColumnIndex") is 2
+PASS accessibilityController.accessibleElementById("cell5").rowIndexRange() is "{2, 1}"
+PASS accessibilityController.accessibleElementById("cell5").columnIndexRange() is "{0, 2}"
+PASS accessibilityController.accessibleElementById("row-3").role is "AXRole: AXRow"
+PASS accessibilityController.accessibleElementById("cell6").role is "AXRole: AXCell"
+PASS accessibilityController.accessibleElementById("cell6").numberAttributeValue("AXARIARowIndex") is 9
+PASS accessibilityController.accessibleElementById("cell6").numberAttributeValue("AXARIAColumnIndex") is 2
+PASS accessibilityController.accessibleElementById("cell6").rowIndexRange() is "{3, 1}"
+PASS accessibilityController.accessibleElementById("cell6").columnIndexRange() is "{0, 3}"
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -547,7 +547,7 @@ accessibility/live-region-attributes-update-after-dynamic-change.html [ Skip ]
 accessibility/ignored-textfield-still-accessible.html [ Skip ]
 
 # Default ARIA for custom elements are not yet enabled
-accessibility/custom-elements/role.html [ Skip ]
+accessibility/custom-elements/ [ Skip ]
 
 # TODO Conic gradients
 http/wpt/css/css-images-4/conic-gradient-parsing.html [ Skip ]

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2259,11 +2259,17 @@ bool AccessibilityObject::hasTagName(const QualifiedName& tagName) const
     
 bool AccessibilityObject::hasAttribute(const QualifiedName& attribute) const
 {
-    Node* node = this->node();
-    if (!is<Element>(node))
+    RefPtr element = this->element();
+    if (!element)
         return false;
-    
-    return downcast<Element>(*node).hasAttributeWithoutSynchronization(attribute);
+
+    if (element->hasAttributeWithoutSynchronization(attribute))
+        return true;
+
+    if (auto* defaultARIA = element->customElementDefaultARIAIfExists())
+        return defaultARIA->hasAttribute(attribute);
+
+    return false;
 }
     
 const AtomString& AccessibilityObject::getAttribute(const QualifiedName& attribute) const
@@ -2273,7 +2279,7 @@ const AtomString& AccessibilityObject::getAttribute(const QualifiedName& attribu
         if (!value.isNull())
             return value;
         if (auto* defaultARIA = element->customElementDefaultARIAIfExists())
-            return defaultARIA->valueForAttribute(attribute.localName());
+            return defaultARIA->valueForAttribute(attribute);
     }
     return nullAtom();
 }

--- a/Source/WebCore/dom/CustomElementDefaultARIA.cpp
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.cpp
@@ -35,17 +35,22 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(CustomElementDefaultARIA);
 CustomElementDefaultARIA::CustomElementDefaultARIA() = default;
 CustomElementDefaultARIA::~CustomElementDefaultARIA() = default;
 
-void CustomElementDefaultARIA::setValueForAttribute(const AtomString& key, const AtomString& value)
+void CustomElementDefaultARIA::setValueForAttribute(const QualifiedName& name, const AtomString& value)
 {
-    m_map.set(key, value);
+    m_map.set(name, value);
 }
 
-const AtomString& CustomElementDefaultARIA::valueForAttribute(const AtomString& key) const
+const AtomString& CustomElementDefaultARIA::valueForAttribute(const QualifiedName& name) const
 {
-    auto it = m_map.find(key);
+    auto it = m_map.find(name);
     if (it == m_map.end())
         return nullAtom();
     return it->value;
+}
+
+bool CustomElementDefaultARIA::hasAttribute(const QualifiedName& name) const
+{
+    return m_map.find(name) != m_map.end();
 }
 
 }; // namespace WebCore

--- a/Source/WebCore/dom/CustomElementDefaultARIA.h
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
+#include "QualifiedName.h"
 #include <wtf/HashMap.h>
 #include <wtf/IsoMalloc.h>
 #include <wtf/text/AtomString.h>
-#include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {
 
@@ -38,11 +38,12 @@ public:
     CustomElementDefaultARIA();
     ~CustomElementDefaultARIA();
 
-    void setValueForAttribute(const AtomString& key, const AtomString& value);
-    const AtomString& valueForAttribute(const AtomString& key) const;
+    bool hasAttribute(const QualifiedName&) const;
+    const AtomString& valueForAttribute(const QualifiedName&) const;
+    void setValueForAttribute(const QualifiedName&, const AtomString&);
 
 private:
-    HashMap<AtomString, AtomString> m_map;
+    HashMap<QualifiedName, AtomString> m_map;
 };
 
 }; // namespace WebCore

--- a/Source/WebCore/dom/ElementInternals.h
+++ b/Source/WebCore/dom/ElementInternals.h
@@ -43,23 +43,15 @@ public:
     Element* element() const { return m_element.get(); }
     ShadowRoot* shadowRoot() const;
 
-    void setRole(const AtomString&);
-    const AtomString& role();
-
-    void setAriaLabel(const AtomString&);
-    const AtomString& ariaLabel();
-
-    void setAriaRoleDescription(const AtomString&);
-    const AtomString& ariaRoleDescription();
+    // For ARIAMixin
+    const AtomString& attributeWithoutSynchronization(const QualifiedName&) const;
+    void setAttributeWithoutSynchronization(const QualifiedName&, const AtomString& value);
 
 private:
     ElementInternals(HTMLElement& element)
         : m_element(element)
     {
     }
-
-    void setAriaValueForAttribute(const AtomString& key, const AtomString& value);
-    const AtomString& ariaValueForAttribute(const AtomString&);
 
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_element;
 };

--- a/Source/WebCore/dom/ElementInternals.idl
+++ b/Source/WebCore/dom/ElementInternals.idl
@@ -30,7 +30,49 @@
 ] interface ElementInternals {
     readonly attribute ShadowRoot? shadowRoot;
 
-    [CEReactions, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute [AtomString] DOMString? role;
-    [CEReactions, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute [AtomString] DOMString? ariaLabel;
-    [CEReactions, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute [AtomString] DOMString? ariaRoleDescription;
+    [CEReactions, Reflect, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? role;
+    [CEReactions, Reflect=aria_atomic, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaAtomic;
+    [CEReactions, Reflect=aria_autocomplete, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaAutoComplete;
+    [CEReactions, Reflect=aria_busy, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaBusy;
+    [CEReactions, Reflect=aria_checked, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaChecked;
+    [CEReactions, Reflect=aria_colcount, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaColCount;
+    [CEReactions, Reflect=aria_colindex, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaColIndex;
+    [CEReactions, Reflect=aria_colspan, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaColSpan;
+
+    [CEReactions, Reflect=aria_current, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaCurrent;
+
+    [CEReactions, Reflect=aria_disabled, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaDisabled;
+
+    [CEReactions, Reflect=aria_expanded, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaExpanded;
+
+    [CEReactions, Reflect=aria_haspopup, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaHasPopup;
+    [CEReactions, Reflect=aria_hidden, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaHidden;
+    [CEReactions, Reflect=aria_invalid, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaInvalid;
+    [CEReactions, Reflect=aria_keyshortcuts, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaKeyShortcuts;
+    [CEReactions, Reflect=aria_label, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaLabel;
+
+    [CEReactions, Reflect=aria_level, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaLevel;
+    [CEReactions, Reflect=aria_live, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaLive;
+    [CEReactions, Reflect=aria_modal, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaModal;
+    [CEReactions, Reflect=aria_multiline, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaMultiLine;
+    [CEReactions, Reflect=aria_multiselectable, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaMultiSelectable;
+    [CEReactions, Reflect=aria_orientation, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaOrientation;
+
+    [CEReactions, Reflect=aria_placeholder, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaPlaceholder;
+    [CEReactions, Reflect=aria_posinset, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaPosInSet;
+    [CEReactions, Reflect=aria_pressed, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaPressed;
+    [CEReactions, Reflect=aria_readonly, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaReadOnly;
+    [CEReactions, Reflect=aria_relevant, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaRelevant;
+    [CEReactions, Reflect=aria_required, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaRequired;
+    [CEReactions, Reflect=aria_roledescription, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaRoleDescription;
+    [CEReactions, Reflect=aria_rowcount, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaRowCount;
+    [CEReactions, Reflect=aria_rowindex, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaRowIndex;
+    [CEReactions, Reflect=aria_rowspan, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaRowSpan;
+    [CEReactions, Reflect=aria_selected, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaSelected;
+    [CEReactions, Reflect=aria_setsize, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaSetSize;
+    [CEReactions, Reflect=aria_sort, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaSort;
+    [CEReactions, Reflect=aria_valuemax, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaValueMax;
+    [CEReactions, Reflect=aria_valuemin, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaValueMin;
+    [CEReactions, Reflect=aria_valuenow, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaValueNow;
+    [CEReactions, Reflect=aria_valuetext, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaValueText;
 };

--- a/Source/WebCore/dom/QualifiedName.h
+++ b/Source/WebCore/dom/QualifiedName.h
@@ -24,6 +24,7 @@
 #include <wtf/Hasher.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/AtomString.h>
+#include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {
 


### PR DESCRIPTION
#### 341101190ec82f392260c91d397d571b97661621
<pre>
Add the support for string reflections on ElementInternals
<a href="https://bugs.webkit.org/show_bug.cgi?id=245028">https://bugs.webkit.org/show_bug.cgi?id=245028</a>

Reviewed by Chris Fleizach.

Added the rest of string reflections on ElementInternals.
Also use Reflect IDL attribute on ElementInternals to share more code between attributes.

* LayoutTests/accessibility/custom-elements/autocomplete-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/autocomplete.html: Added.
* LayoutTests/accessibility/custom-elements/current-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/current.html: Added.
* LayoutTests/accessibility/custom-elements/heading-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/heading.html: Added.
* LayoutTests/accessibility/custom-elements/hidden-button-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/hidden-button.html: Added.
* LayoutTests/accessibility/custom-elements/liveregions-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/liveregions.html: Added.
* LayoutTests/accessibility/custom-elements/menuitem-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/menuitem.html: Added.
* LayoutTests/accessibility/custom-elements/modal-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/modal.html: Added.
* LayoutTests/accessibility/custom-elements/multiselectable-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/multiselectable.html: Added.
* LayoutTests/accessibility/custom-elements/orientation-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/orientation.html: Added.
* LayoutTests/accessibility/custom-elements/posinset-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/posinset.html: Added.
* LayoutTests/accessibility/custom-elements/pressed-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/pressed.html: Added.
* LayoutTests/accessibility/custom-elements/role-expected.txt:
* LayoutTests/accessibility/custom-elements/role.html:
* LayoutTests/accessibility/custom-elements/slider-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/slider.html: Added.
* LayoutTests/accessibility/custom-elements/table-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/table.html: Added.
* LayoutTests/accessibility/custom-elements/textbox-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/textbox.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-accessibility-expected.txt: Rebaselined.
* LayoutTests/platform/gtk/accessibility/custom-elements/autocomplete-expected.txt: Added.
* LayoutTests/platform/gtk/accessibility/custom-elements/hidden-button-expected.txt: Added.
* LayoutTests/platform/gtk/accessibility/custom-elements/modal-expected.txt: Added.
* LayoutTests/platform/gtk/accessibility/custom-elements/pressed-expected.txt: Added.
* LayoutTests/platform/gtk/accessibility/custom-elements/table-expected.txt: Added.
* LayoutTests/platform/gtk/accessibility/custom-elements/textbox-expected.txt: Added.
* LayoutTests/platform/mac-wk1/accessibility/custom-elements/current-expected.txt: Added.
* LayoutTests/platform/mac-wk1/accessibility/custom-elements/hidden-button-expected.txt: Added.
* LayoutTests/platform/mac-wk1/accessibility/custom-elements/liveregions-expected.txt: Added.
* LayoutTests/platform/mac-wk1/accessibility/custom-elements/table-expected.txt: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/win/TestExpectations:

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::isModalElement const): Added a fallback for default ARIA
(WebCore::nodeHasRole): Ditto.

* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::hasAttribute const): Ditto.
(WebCore::AccessibilityObject::getAttribute const):

* Source/WebCore/dom/CustomElementDefaultARIA.cpp:
(WebCore::CustomElementDefaultARIA::setValueForAttribute): Use QualifiedName instead of
AtomString for the mapping attributes.
(WebCore::CustomElementDefaultARIA::valueForAttribute const): Ditto.
(WebCore::CustomElementDefaultARIA::hasAttribute const): Added.

* Source/WebCore/dom/CustomElementDefaultARIA.h:
(WebCore::CustomElementDefaultARIA):

* Source/WebCore/dom/ElementInternals.cpp:
(WebCore::ElementInternals::setRole): Deleted.
(WebCore::ElementInternals::role): Deleted.
(WebCore::ElementInternals::setAriaRoleDescription): Deleted.
(WebCore::ElementInternals::ariaRoleDescription): Deleted.
(WebCore::ElementInternals::setAriaLabel): Deleted.
(WebCore::ElementInternals::ariaLabel): Deleted.
(WebCore::ElementInternals::setAriaValueForAttribute): Deleted.
(WebCore::ElementInternals::ariaValueForAttribute): Deleted.
(WebCore::ElementInternals::setAttributeWithoutSynchronization): Notify AX object cache.
(WebCore::ElementInternals::attributeWithoutSynchronization const):

* Source/WebCore/dom/ElementInternals.h:
* Source/WebCore/dom/ElementInternals.idl:

* Source/WebCore/dom/QualifiedName.h: Added the missing include for AtomStringHash.h.

Canonical link: <a href="https://commits.webkit.org/254549@main">https://commits.webkit.org/254549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3caedcd046d10330b05996ec36b47143f3b65aa1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98677 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154980 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32401 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27921 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81725 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93097 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25738 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76277 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25704 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80555 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68688 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30174 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29902 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15566 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33350 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38523 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1335 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34657 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->