### PR TITLE
REGRESSION (254304@main): [ macOS wk1 ] Four compositing test are a consistent failure

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1056,6 +1056,11 @@ webkit.org/b/165541 compositing/rtl/rtl-fixed-overflow.html [ Failure ]
 
 webkit.org/b/154612 compositing/repaint/fixed-background-scroll.html [ Pass Failure ]
 
+webkit.org/b/245030 compositing/contents-opaque/body-background-skipped.html [ Pass Failure ]
+webkit.org/b/245030 compositing/rtl/rtl-fixed.html [ Pass Failure ]
+webkit.org/b/245030 compositing/contents-opaque/body-background-painted.html [ Pass Failure ]
+webkit.org/b/245030 compositing/fixed-image-loading.html [ Pass Failure ]
+
 webkit.org/b/165589 pointer-lock/lock-lost-on-esc-in-fullscreen.html [ Skip ]
 webkit.org/b/244304 pointer-lock/pointermove-movement-delta.html [ Pass Timeout ]
 


### PR DESCRIPTION
#### 18122106d7b37bc6613d473cf7df5b40f35ae184
<pre>
REGRESSION (254304@main): [ macOS wk1 ] Four compositing test are a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=245030">https://bugs.webkit.org/show_bug.cgi?id=245030</a>
&lt;rdar://99781740&gt;

Unreviewed test rebaseline.

* LayoutTests/compositing/contents-opaque/body-background-painted-expected.txt:
* LayoutTests/compositing/contents-opaque/body-background-skipped-expected.txt:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac/compositing/fixed-image-loading-expected.txt:
* LayoutTests/platform/mac/compositing/rtl/rtl-fixed-expected.txt:
</pre>