### PR TITLE
RenderScrollbarPart::computePreferredLogicalWidths is dead code

### DIFF
--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -115,16 +115,6 @@ void RenderScrollbarPart::computeScrollbarHeight()
     m_marginBox.setBottom(minimumValueForLength(style().marginBottom(), { }));
 }
 
-void RenderScrollbarPart::computePreferredLogicalWidths()
-{
-    if (!preferredLogicalWidthsDirty())
-        return;
-    
-    m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = 0;
-
-    setPreferredLogicalWidthsDirty(false);
-}
-
 void RenderScrollbarPart::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     RenderBlock::styleDidChange(diff, oldStyle);

--- a/Source/WebCore/rendering/RenderScrollbarPart.h
+++ b/Source/WebCore/rendering/RenderScrollbarPart.h
@@ -60,7 +60,6 @@ private:
     void imageChanged(WrappedImagePtr, const IntRect* = nullptr) override;
 
     bool isRenderScrollbarPart() const override { return true; }
-    void computePreferredLogicalWidths() override;
 
     void layoutHorizontalPart();
     void layoutVerticalPart();


### PR DESCRIPTION
#### 28ebb9bd0c1e1d39a14d73c59823808e54357ba5
<pre>
RenderScrollbarPart::computePreferredLogicalWidths is dead code

RenderScrollbarPart::computePreferredLogicalWidths is dead code
<a href="https://bugs.webkit.org/show_bug.cgi?id=106684">https://bugs.webkit.org/show_bug.cgi?id=106684</a>

Reviewed by Alan Bujtas.

Patch Authored by Ojan Vafai

The layout methods never try to calculate the intrinsic or preferred widths. Also verified by adding an ASSERT_NOT_REACHED and running the layout tests as well as writing some extra tests to be sure it wasn&apos;t just a hole in the layout test coverage.

* Source/WebCore/rendering/RenderScrollbarPart.cpp:
(RenderScrollbarPart::computePreferredLogicalWidths()) - Removed
* Source/WebCore/rendering/RenderScrollbarPart.h - Removed &quot;computePreferredLogicalWidths&quot; function

Canonical link: <a href="https://commits.webkit.org/254417@main">https://commits.webkit.org/254417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17125050ec4d03e58eb64bda06b2b9091c74b3d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98035 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154531 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31904 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27510 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81077 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92656 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25317 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75816 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25270 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68232 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29701 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14250 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29430 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15247 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3092 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38175 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34353 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->