### PR TITLE
[WGSL] Port WGSLUnitTests to TestWebKitAPI

### DIFF
--- a/Tools/Scripts/run-api-tests
+++ b/Tools/Scripts/run-api-tests
@@ -117,6 +117,8 @@ def parse_args(args):
                              help='Only check and run TestWebCore.exe (Windows only)'),
         optparse.make_option('--webkit-legacy-only', action='store_const', const='TestWebKitLegacy', dest='api_binary',
                              help='Only check and run TestWebKitLegacy.exe (Windows only)'),
+        optparse.make_option('--wgsl-only', action='store_const', const='TestWGSL', dest='api_binary',
+                             help='Only check and run TestWGSL (Darwin ports only)'),
         optparse.make_option('-d', '--dump', action='store_true', default=False,
                              help='Dump all test names without running them'),
         optparse.make_option('--build', dest='build', action='store_true', default=True,

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -41,7 +41,7 @@ class DarwinPort(ApplePort):
     CURRENT_VERSION = None
     SDK = None
 
-    API_TEST_BINARY_NAMES = ['TestWTF', 'TestWebKitAPI', 'TestIPC']
+    API_TEST_BINARY_NAMES = ['TestWTF', 'TestWebKitAPI', 'TestIPC', 'TestWGSL']
 
     def __init__(self, host, port_name, **kwargs):
         ApplePort.__init__(self, host, port_name, **kwargs)

--- a/Tools/TestWebKitAPI/Configurations/TestWGSL.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWGSL.xcconfig
@@ -1,0 +1,44 @@
+// Copyright (C) 2022 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+PRODUCT_NAME = TestWGSL;
+
+PROJECT_HEADER_SEARCH_PATHS = $(SRCROOT)/../../Source/WebGPU/WGSL $(SRCROOT)/../../Source/WebGPU/WGSL/AST $(SRCROOT)/../../Source/WebGPU/WGSL/AST/Expressions $(SRCROOT)/../../Source/WebGPU/WGSL/AST/Statements $(inherited);
+
+GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) BUILDING_TEST_WGSL GTEST_API_=
+
+WK_UIKITMACHELPER_LDFLAGS = $(WK_UIKITMACHELPER_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_UIKITMACHELPER_LDFLAGS_maccatalyst = -framework UIKitMacHelper;
+
+OTHER_LDFLAGS = $(inherited) $(WK_UIKITMACHELPER_LDFLAGS) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH));
+OTHER_LDFLAGS_PLATFORM_ = -framework Cocoa -framework Carbon;
+OTHER_LDFLAGS_PLATFORM_cocoatouch = -framework CoreGraphics;
+
+STRIP_STYLE = debugging;
+
+ENTITLEMENTS_REQUIRED = $(ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_$(USE_INTERNAL_SDK))
+ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_ = NO;
+ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_NO = NO;
+ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_YES = $(ENTITLEMENTS_REQUIRED);

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 				537CF84822EFD72000C6EBB3 /* Check .xcfilelists */,
 			);
 			dependencies = (
+				3A5DDAFC28D3F2A7004DA950 /* PBXTargetDependency */,
 				7B9FC58828A26D83007570E7 /* PBXTargetDependency */,
 				7C83E0301D0A5E1B00FEBCF3 /* PBXTargetDependency */,
 				7C83E0321D0A5E1D00FEBCF3 /* PBXTargetDependency */,
@@ -209,6 +210,17 @@
 		37E1064C1697681800B78BD0 /* DOMHTMLTableCellElementCellAbove.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 37E1064B169767F700B78BD0 /* DOMHTMLTableCellElementCellAbove.html */; };
 		37E7DD671EA071F3009B396D /* AdditionalReadAccessAllowedURLsPlugin.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37E7DD661EA071F3009B396D /* AdditionalReadAccessAllowedURLsPlugin.mm */; };
 		37FB72971DB2E82F00E41BE4 /* ContextMenuDefaultItemsHaveTags.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37FB72951DB2E82F00E41BE4 /* ContextMenuDefaultItemsHaveTags.mm */; };
+		3A15784128D1505B00142DB1 /* mainIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E7765CC16C4D80A00BA2BB1 /* mainIOS.mm */; };
+		3A15784228D1505B00142DB1 /* mainMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E7765CE16C4D81100BA2BB1 /* mainMac.mm */; };
+		3A15784428D1505B00142DB1 /* TestsController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC131AA8117131FC00B69727 /* TestsController.cpp */; };
+		3A15784528D1505B00142DB1 /* UtilitiesCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C83E0391D0A602700FEBCF3 /* UtilitiesCocoa.mm */; };
+		3A5DDADA28D15169004DA950 /* LexerTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A5DDAD228D15169004DA950 /* LexerTests.cpp */; };
+		3A5DDAEE28D156FC004DA950 /* ParserTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A5DDAED28D156FC004DA950 /* ParserTests.cpp */; };
+		3A5DDAF028D15BF7004DA950 /* libgtest.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DDF3A83728930475005920CF /* libgtest.a */; };
+		3A5DDAF528D1638A004DA950 /* libicucore.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A5DDAF428D1638A004DA950 /* libicucore.tbd */; };
+		3A5DDB0C28D53325004DA950 /* WebKit.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = C081224813FC1B0300DC39AE /* WebKit.framework */; };
+		3A5DDB2C28D5525E004DA950 /* libWTF.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C83E0291D0A5CDF00FEBCF3 /* libWTF.a */; };
+		3A5DDB2D28D55265004DA950 /* libwgsl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A5DDB2028D54269004DA950 /* libwgsl.a */; };
 		3FBD1B4A1D3D66AB00E6D6FA /* FullscreenLayoutConstraints.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3FBD1B491D39D1DB00E6D6FA /* FullscreenLayoutConstraints.html */; };
 		3FCC4FE81EC4E8CA0076E37C /* PictureInPictureDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3FCC4FE61EC4E87E0076E37C /* PictureInPictureDelegate.html */; };
 		4102EE1727845ED500D6BE74 /* ServiceWorkerRoutines.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4102EE1627845ED500D6BE74 /* ServiceWorkerRoutines.cpp */; };
@@ -1208,6 +1220,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		3A15785B28D1506E00142DB1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DDF3A82928930475005920CF /* gtest.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8D07F2BC0486CC7A007CD1D0;
+			remoteInfo = "gtest-framework";
+		};
+		3A5DDAFB28D3F2A7004DA950 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3A15783C28D1505B00142DB1;
+			remoteInfo = TestWGSL;
+		};
 		5C9D922122D7DC84008E9266 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
@@ -1337,6 +1363,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		3A15783D28D1505B00142DB1 /* Product Dependencies */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 16;
+			files = (
+				3A5DDB0C28D53325004DA950 /* WebKit.framework in Product Dependencies */,
+			);
+			name = "Product Dependencies";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7B6FF89528C22D3D00CA76B0 /* Product Dependencies */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2151,6 +2188,13 @@
 		37E7DD651EA0715B009B396D /* AdditionalReadAccessAllowedURLsProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AdditionalReadAccessAllowedURLsProtocol.h; sourceTree = "<group>"; };
 		37E7DD661EA071F3009B396D /* AdditionalReadAccessAllowedURLsPlugin.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AdditionalReadAccessAllowedURLsPlugin.mm; sourceTree = "<group>"; };
 		37FB72951DB2E82F00E41BE4 /* ContextMenuDefaultItemsHaveTags.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ContextMenuDefaultItemsHaveTags.mm; sourceTree = "<group>"; };
+		3A15785328D1505B00142DB1 /* TestWGSL */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = TestWGSL; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A5DDAD228D15169004DA950 /* LexerTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LexerTests.cpp; sourceTree = "<group>"; };
+		3A5DDADB28D15328004DA950 /* TestWGSL.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = TestWGSL.xcconfig; sourceTree = "<group>"; };
+		3A5DDAED28D156FC004DA950 /* ParserTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ParserTests.cpp; sourceTree = "<group>"; };
+		3A5DDAF228D1637A004DA950 /* libicu.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libicu.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A5DDAF428D1638A004DA950 /* libicucore.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libicucore.tbd; path = usr/lib/libicucore.tbd; sourceTree = SDKROOT; };
+		3A5DDB2028D54269004DA950 /* libwgsl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libwgsl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F1B52681D3D7129008D60C4 /* FullscreenLayoutConstraints.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenLayoutConstraints.mm; sourceTree = "<group>"; };
 		3FBD1B491D39D1DB00E6D6FA /* FullscreenLayoutConstraints.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = FullscreenLayoutConstraints.html; sourceTree = "<group>"; };
 		3FCC4FE41EC4E8520076E37C /* PictureInPictureDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PictureInPictureDelegate.mm; sourceTree = "<group>"; };
@@ -3412,6 +3456,17 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3A15784628D1505B00142DB1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3A5DDAF028D15BF7004DA950 /* libgtest.a in Frameworks */,
+				3A5DDAF528D1638A004DA950 /* libicucore.tbd in Frameworks */,
+				3A5DDB2D28D55265004DA950 /* libwgsl.a in Frameworks */,
+				3A5DDB2C28D5525E004DA950 /* libWTF.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7B9FC3A328A26137007570E7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -3648,6 +3703,7 @@
 			children = (
 				7B9FC57E28A26137007570E7 /* TestIPC */,
 				8DD76FA10486AA7600D96B5E /* TestWebKitAPI */,
+				3A15785328D1505B00142DB1 /* TestWGSL */,
 				7C83E0231D0A5AE400FEBCF3 /* TestWTF */,
 				BC575980126E74AF006F0F12 /* InjectedBundleTestWebKitAPI.bundle */,
 				7CCE7E8C1A41144E00447C4C /* libTestWebKitAPI.a */,
@@ -4009,6 +4065,15 @@
 			path = ios;
 			sourceTree = "<group>";
 		};
+		3A15785D28D150BB00142DB1 /* WGSL */ = {
+			isa = PBXGroup;
+			children = (
+				3A5DDAD228D15169004DA950 /* LexerTests.cpp */,
+				3A5DDAED28D156FC004DA950 /* ParserTests.cpp */,
+			);
+			path = WGSL;
+			sourceTree = "<group>";
+		};
 		440A1D3614A01000008A66F2 /* WebCore */ = {
 			isa = PBXGroup;
 			children = (
@@ -4272,11 +4337,14 @@
 				0F4FFAA01ED3D0DE00F7111F /* ImageIO.framework */,
 				CDA3159C1ED5643F009F60D3 /* IOKit.framework */,
 				5CFACF62226F73C60056C7D0 /* libboringssl.a */,
+				3A5DDAF228D1637A004DA950 /* libicu.a */,
 				7C83E0331D0A5F2700FEBCF3 /* libicucore.dylib */,
+				3A5DDAF428D1638A004DA950 /* libicucore.tbd */,
 				A1798B7E22431D2B000764BD /* libWebCoreTestSupport.dylib */,
 				4135FB862011FABF00332139 /* libWebCoreTestSupport.dylib */,
 				7B9FC5A928A38F2E007570E7 /* libWebKitIPC.a */,
 				7B9FC5CC28A52DC0007570E7 /* libWebKitPlatform.a */,
+				3A5DDB2028D54269004DA950 /* libwgsl.a */,
 				7C83E0291D0A5CDF00FEBCF3 /* libWTF.a */,
 				578CBD66204FB2C70083B9F2 /* LocalAuthentication.framework */,
 				516281282325C45400BB7E42 /* PDFKit.framework */,
@@ -4718,6 +4786,7 @@
 				7AB0173923FB2BF0002F8366 /* TestWebKitAPI-macOS.entitlements */,
 				BC90958012554CF900083756 /* TestWebKitAPI.xcconfig */,
 				7CCE7EA31A4115CB00447C4C /* TestWebKitAPILibrary.xcconfig */,
+				3A5DDADB28D15328004DA950 /* TestWGSL.xcconfig */,
 				7C83E0261D0A5B8D00FEBCF3 /* TestWTF.xcconfig */,
 				7C83E0271D0A5B8D00FEBCF3 /* TestWTFLibrary.xcconfig */,
 				A13EBB521B87346600097110 /* WebProcessPlugIn.xcconfig */,
@@ -5147,6 +5216,7 @@
 				1ABC3DEC1899BE55004F0626 /* WebKit Cocoa */,
 				BC3C4C6F14575B1D0025FB62 /* WebKit Objective-C */,
 				CDC8E4981BC728AE00594FEC /* WebKitLegacy */,
+				3A15785D28D150BB00142DB1 /* WGSL */,
 				BC9096461255618900083756 /* WTF */,
 			);
 			path = Tests;
@@ -5447,6 +5517,25 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		3A15783C28D1505B00142DB1 /* TestWGSL */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3A15785028D1505B00142DB1 /* Build configuration list for PBXNativeTarget "TestWGSL" */;
+			buildPhases = (
+				3A15783D28D1505B00142DB1 /* Product Dependencies */,
+				3A15783F28D1505B00142DB1 /* Sources */,
+				3A15784628D1505B00142DB1 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3A15785C28D1506E00142DB1 /* PBXTargetDependency */,
+			);
+			name = TestWGSL;
+			productInstallPath = "$(HOME)/bin";
+			productName = TestWebKitAPI;
+			productReference = 3A15785328D1505B00142DB1 /* TestWGSL */;
+			productType = "com.apple.product-type.tool";
+		};
 		7B9FC39428A26137007570E7 /* TestIPC */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7B9FC57B28A26137007570E7 /* Build configuration list for PBXNativeTarget "TestIPC" */;
@@ -5632,6 +5721,7 @@
 				7C83DE951D0A590C00FEBCF3 /* TestWTFLibrary */,
 				7B9FC39428A26137007570E7 /* TestIPC */,
 				8DD76F960486AA7600D96B5E /* TestWebKitAPI */,
+				3A15783C28D1505B00142DB1 /* TestWGSL */,
 				7C83DF951D0A5AE400FEBCF3 /* TestWTF */,
 				BC57597F126E74AF006F0F12 /* InjectedBundleTestWebKitAPI */,
 				A13EBB481B87339E00097110 /* WebProcessPlugIn */,
@@ -5765,6 +5855,19 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3A15783F28D1505B00142DB1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3A5DDADA28D15169004DA950 /* LexerTests.cpp in Sources */,
+				3A15784128D1505B00142DB1 /* mainIOS.mm in Sources */,
+				3A15784228D1505B00142DB1 /* mainMac.mm in Sources */,
+				3A5DDAEE28D156FC004DA950 /* ParserTests.cpp in Sources */,
+				3A15784428D1505B00142DB1 /* TestsController.cpp in Sources */,
+				3A15784528D1505B00142DB1 /* UtilitiesCocoa.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7B9FC39B28A26137007570E7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -6485,6 +6588,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		3A15785C28D1506E00142DB1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "gtest-framework";
+			targetProxy = 3A15785B28D1506E00142DB1 /* PBXContainerItemProxy */;
+		};
+		3A5DDAFC28D3F2A7004DA950 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3A15783C28D1505B00142DB1 /* TestWGSL */;
+			targetProxy = 3A5DDAFB28D3F2A7004DA950 /* PBXContainerItemProxy */;
+		};
 		5C9D922222D7DC84008E9266 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 5C9D921422D7DA02008E9266 /* Generate Unified Sources */;
@@ -6567,6 +6680,20 @@
 		1DEB927A08733DD40010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC90957F12554CF900083756 /* DebugRelease.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		3A15785128D1505B00142DB1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3A5DDADB28D15328004DA950 /* TestWGSL.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		3A15785228D1505B00142DB1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3A5DDADB28D15328004DA950 /* TestWGSL.xcconfig */;
 			buildSettings = {
 			};
 			name = Release;
@@ -6716,6 +6843,15 @@
 			buildConfigurations = (
 				1DEB927908733DD40010E9CD /* Debug */,
 				1DEB927A08733DD40010E9CD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3A15785028D1505B00142DB1 /* Build configuration list for PBXNativeTarget "TestWGSL" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3A15785128D1505B00142DB1 /* Debug */,
+				3A15785228D1505B00142DB1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWGSL.xcscheme
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWGSL.xcscheme
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3A15783C28D1505B00142DB1"
+               BuildableName = "TestWGSL"
+               BlueprintName = "TestWGSL"
+               ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3A15783C28D1505B00142DB1"
+            BuildableName = "TestWGSL"
+            BlueprintName = "TestWGSL"
+            ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3A15783C28D1505B00142DB1"
+            BuildableName = "TestWGSL"
+            BlueprintName = "TestWGSL"
+            ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -1,0 +1,444 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Lexer.h"
+
+namespace TestWebKitAPI {
+
+static WGSL::Token checkSingleToken(const String& string, WGSL::TokenType type)
+{
+    WGSL::Lexer<LChar> lexer(string);
+    WGSL::Token result = lexer.lex();
+    EXPECT_EQ(result.m_type, type);
+    return result;
+}
+
+static void checkSingleLiteral(const String& string, WGSL::TokenType type, double literalValue)
+{
+    WGSL::Token result = checkSingleToken(string, type);
+    EXPECT_EQ(result.m_literalValue, literalValue);
+}
+
+template<typename T>
+static WGSL::Token checkNextTokenIs(WGSL::Lexer<T>& lexer, WGSL::TokenType type, unsigned lineNumber)
+{
+    WGSL::Token result = lexer.lex();
+    EXPECT_EQ(result.m_type, type);
+    EXPECT_EQ(result.m_span.m_line, lineNumber);
+    return result;
+}
+
+template<typename T>
+static void checkNextTokenIsIdentifier(WGSL::Lexer<T>& lexer, const String& ident, unsigned lineNumber)
+{
+    WGSL::Token result = checkNextTokenIs(lexer, WGSL::TokenType::Identifier, lineNumber);
+    EXPECT_EQ(result.m_ident, ident);
+}
+
+template<typename T>
+static void checkNextTokenIsLiteral(WGSL::Lexer<T>& lexer, WGSL::TokenType type, double literalValue, unsigned lineNumber)
+{
+    WGSL::Token result = checkNextTokenIs(lexer, type, lineNumber);
+    EXPECT_EQ(result.m_literalValue, literalValue);
+}
+
+template<typename T>
+static void checkNextTokensAreBuiltinAttr(WGSL::Lexer<T>& lexer, const String& attr, unsigned lineNumber)
+{
+    checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "builtin"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIsIdentifier(lexer, attr, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+};
+
+TEST(WGSLLexerTests, SingleTokens)
+{
+    checkSingleToken(""_s, WGSL::TokenType::EndOfFile);
+    checkSingleLiteral("1"_s, WGSL::TokenType::IntegerLiteral, 1);
+    checkSingleLiteral("0"_s, WGSL::TokenType::IntegerLiteral, 0);
+    checkSingleLiteral("142"_s, WGSL::TokenType::IntegerLiteral, 142);
+    checkSingleLiteral("1.1"_s, WGSL::TokenType::DecimalFloatLiteral, 1.1);
+    checkSingleLiteral("0.4"_s, WGSL::TokenType::DecimalFloatLiteral, 0.4);
+    checkSingleLiteral("0123.456"_s, WGSL::TokenType::DecimalFloatLiteral, 0123.456);
+    checkSingleToken("0123"_s, WGSL::TokenType::Invalid);
+    checkSingleLiteral("0123."_s, WGSL::TokenType::DecimalFloatLiteral, 123);
+    checkSingleLiteral(".456"_s, WGSL::TokenType::DecimalFloatLiteral, 0.456);
+    checkSingleToken("."_s, WGSL::TokenType::Period);
+    checkSingleLiteral("42f"_s, WGSL::TokenType::DecimalFloatLiteral, 42);
+    checkSingleLiteral("42e0f"_s, WGSL::TokenType::DecimalFloatLiteral, 42);
+    checkSingleLiteral("042e0f"_s, WGSL::TokenType::DecimalFloatLiteral, 42);
+    checkSingleToken("042f"_s, WGSL::TokenType::Invalid);
+    checkSingleLiteral("42e-3"_s, WGSL::TokenType::DecimalFloatLiteral, 42e-3);
+    checkSingleLiteral("42e-a"_s, WGSL::TokenType::IntegerLiteral, 42);
+}
+
+TEST(WGSLLexerTests, SpecialTokens)
+{
+    checkSingleToken("->"_s, WGSL::TokenType::Arrow);
+    checkSingleToken("@"_s, WGSL::TokenType::Attribute);
+    checkSingleToken("{"_s, WGSL::TokenType::BraceLeft);
+    checkSingleToken("}"_s, WGSL::TokenType::BraceRight);
+    checkSingleToken("["_s, WGSL::TokenType::BracketLeft);
+    checkSingleToken("]"_s, WGSL::TokenType::BracketRight);
+    checkSingleToken(":"_s, WGSL::TokenType::Colon);
+    checkSingleToken(","_s, WGSL::TokenType::Comma);
+    checkSingleToken("="_s, WGSL::TokenType::Equal);
+    checkSingleToken(">"_s, WGSL::TokenType::GT);
+    checkSingleToken("<"_s, WGSL::TokenType::LT);
+    checkSingleToken("-"_s, WGSL::TokenType::Minus);
+    checkSingleToken("--"_s, WGSL::TokenType::MinusMinus);
+    checkSingleToken("."_s, WGSL::TokenType::Period);
+    checkSingleToken("("_s, WGSL::TokenType::ParenLeft);
+    checkSingleToken(")"_s, WGSL::TokenType::ParenRight);
+    checkSingleToken(";"_s, WGSL::TokenType::Semicolon);
+}
+
+TEST(WGSLLexerTests, ComputeShader)
+{
+    WGSL::Lexer<LChar> lexer(
+        "@block struct B {\n"
+        "    a: i32;\n"
+        "}\n"
+        "\n"
+        "@group(0) @binding(0)\n"
+        "var<storage, read_write> x: B;\n"
+        "\n"
+        "@compute\n"
+        "fn main() {\n"
+        "    x.a = 42;\n"
+        "}"_s);
+
+    unsigned lineNumber = 0;
+    // @block struct B {
+    checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "block"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordStruct, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "B"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::BraceLeft, lineNumber);
+
+    // a: i32;
+    ++lineNumber;
+    checkNextTokenIsIdentifier(lexer, "a"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Colon, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordI32, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Semicolon, lineNumber);
+
+    // }
+    ++lineNumber;
+    checkNextTokenIs(lexer, WGSL::TokenType::BraceRight, lineNumber);
+
+    // @group(0) @binding(0)
+    lineNumber += 2;
+    checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "group"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::IntegerLiteral, 0, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "binding"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::IntegerLiteral, 0, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+
+    // var<storage, read_write> x: B;
+    ++lineNumber;
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordVar, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordStorage, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordReadWrite, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::GT, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "x"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Colon, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "B"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Semicolon, lineNumber);
+
+    // @compute
+    lineNumber += 2;
+    checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "compute"_s, lineNumber);
+
+    // fn main() {
+    ++lineNumber;
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordFn, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "main"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::BraceLeft, lineNumber);
+
+    // x.a = 42;
+    ++lineNumber;
+    checkNextTokenIsIdentifier(lexer, "x"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Period, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "a"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Equal, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::IntegerLiteral, 42, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Semicolon, lineNumber);
+
+    // }
+    ++lineNumber;
+    checkNextTokenIs(lexer, WGSL::TokenType::BraceRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::EndOfFile, lineNumber);
+}
+
+TEST(WGSLLexerTests, GraphicsShader)
+{
+    WGSL::Lexer<LChar> lexer(
+        "@vertex\n"
+        "fn vertexShader(@location(0) x: vec4<f32>) -> @builtin(position) vec4<f32> {\n"
+        "    return x;\n"
+        "}\n"
+        "\n"
+        "@fragment\n"
+        "fn fragmentShader() -> @location(0) vec4<f32> {\n"
+        "    return vec4<f32>(0.4, 0.4, 0.8, 1.0);\n"
+        "}"_s);
+
+    unsigned lineNumber = 0;
+
+    // @vertex
+    checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "vertex"_s, lineNumber);
+
+    ++lineNumber;
+    // fn vertexShader(@location(0) x: vec4<f32>) -> @builtin(position) vec4<f32> {
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordFn, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "vertexShader"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "location"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::IntegerLiteral, 0, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "x"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Colon, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "vec4"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::GT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Arrow, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "builtin"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "position"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "vec4"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::GT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::BraceLeft, lineNumber);
+
+    // return x;
+    ++lineNumber;
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordReturn, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "x"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Semicolon, lineNumber);
+
+    // }
+    ++lineNumber;
+    checkNextTokenIs(lexer, WGSL::TokenType::BraceRight, lineNumber);
+
+    // @fragment
+    lineNumber += 2;
+    checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "fragment"_s, lineNumber);
+
+    // fn fragmentShader() -> @location(0) vec4<f32> {
+    ++lineNumber;
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordFn, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "fragmentShader"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Arrow, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "location"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::IntegerLiteral, 0, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "vec4"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::GT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::BraceLeft, lineNumber);
+
+    // return vec4<f32>(0.4, 0.4, 0.8, 1.0);
+    ++lineNumber;
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordReturn, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "vec4"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::GT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.4, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.4, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.8, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 1.0, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Semicolon, lineNumber);
+
+    // }
+    ++lineNumber;
+    checkNextTokenIs(lexer, WGSL::TokenType::BraceRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::EndOfFile, lineNumber);
+}
+
+TEST(WGSLLexerTests, TriangleVert)
+{
+    WGSL::Lexer<LChar> lexer(
+        "@vertex\n"
+        "fn main(\n"
+        "    @builtin(vertex_index) VertexIndex : u32\n"
+        ") -> @builtin(position) vec4<f32> {\n"
+        "    var pos = array<vec2<f32>, 3>(\n"
+        "        vec2<f32>(0.0, 0.5),\n"
+        "        vec2<f32>(-0.5, -0.5),\n"
+        "        vec2<f32>(0.5, -0.5)\n"
+        "    );\n\n"
+        "    return vec4<f32>(pos[VertexIndex], 0.0, 1.0);\n"
+        "}\n"_s);
+
+    unsigned lineNumber = 0;
+
+    // @vertex
+    checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "vertex"_s, lineNumber);
+
+    ++lineNumber;
+    // fn main(
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordFn, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "main"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+
+    ++lineNumber;
+    //    @builtin(vertex_index) VertexIndex : u32
+    checkNextTokensAreBuiltinAttr(lexer, "vertex_index"_s, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "VertexIndex"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Colon, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordU32, lineNumber);
+
+    ++lineNumber;
+    // ) -> @builtin(position) vec4<f32> {
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Arrow, lineNumber);
+    checkNextTokensAreBuiltinAttr(lexer, "position"_s, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "vec4"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::GT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::BraceLeft, lineNumber);
+
+    ++lineNumber;
+    //    var pos = array<vec2<f32>, 3>(
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordVar, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "pos"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Equal, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordArray, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "vec2"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::GT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::IntegerLiteral, 3, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::GT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+
+    ++lineNumber;
+    //        vec2<f32>(0.0, 0.5),
+    checkNextTokenIsIdentifier(lexer, "vec2"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::GT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.0, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
+
+    ++lineNumber;
+    //        vec2<f32>(-0.5, -0.5),
+    checkNextTokenIsIdentifier(lexer, "vec2"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::GT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Minus, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Minus, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
+
+    ++lineNumber;
+    //        vec2<f32>(0.5, -0.5)
+    checkNextTokenIsIdentifier(lexer, "vec2"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::GT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Minus, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+
+    ++lineNumber;
+    //    );
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Semicolon, lineNumber);
+
+    lineNumber += 2;
+    //    return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordReturn, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "vec4"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::GT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "pos"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::BracketLeft, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "VertexIndex"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::BracketRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.0, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 1.0, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Semicolon, lineNumber);
+
+    ++lineNumber;
+    // }
+    checkNextTokenIs(lexer, WGSL::TokenType::BraceRight, lineNumber);
+}
+
+}

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "Parser.h"
+
+#import "ArrayAccess.h"
+#import "AssignmentStatement.h"
+#import "CallableExpression.h"
+#import "IdentifierExpression.h"
+#import "Lexer.h"
+#import "LiteralExpressions.h"
+#import "ReturnStatement.h"
+#import "StructureAccess.h"
+#import "UnaryExpression.h"
+#import "VariableStatement.h"
+#import "WGSL.h"
+#import <wtf/DataLog.h>
+
+namespace TestWebKitAPI {
+
+TEST(WGSLParserTests, Struct)
+{
+    auto shader = WGSL::parseLChar(
+        "struct B {\n"
+        "    a: i32;\n"
+        "}"_s);
+
+    if (!shader.has_value())
+        dataLogLn(shader.error());
+    EXPECT_TRUE(shader.has_value());
+    EXPECT_TRUE(shader->directives().isEmpty());
+    EXPECT_EQ(shader->structs().size(), 1u);
+    EXPECT_TRUE(shader->globalVars().isEmpty());
+    EXPECT_TRUE(shader->functions().isEmpty());
+    WGSL::AST::StructDecl& str = shader->structs()[0];
+    EXPECT_EQ(str.name(), "B"_s);
+    EXPECT_TRUE(str.attributes().isEmpty());
+    EXPECT_EQ(str.members().size(), 1u);
+    EXPECT_TRUE(str.members()[0]->attributes().isEmpty());
+    EXPECT_EQ(str.members()[0]->name(), "a"_s);
+    EXPECT_TRUE(str.members()[0]->type().isNamed());
+    WGSL::AST::NamedType& memberType = downcast<WGSL::AST::NamedType>(str.members()[0]->type());
+    EXPECT_EQ(memberType.name(), "i32"_s);
+}
+
+TEST(WGSLParserTests, GlobalVariable)
+{
+    auto shader = WGSL::parseLChar(
+        "@group(0) @binding(0)\n"
+        "var<storage, read_write> x: B;\n"_s);
+
+    if (!shader.has_value())
+        dataLogLn(shader.error());
+    EXPECT_TRUE(shader.has_value());
+    EXPECT_FALSE(shader->directives().size());
+    EXPECT_TRUE(shader->structs().isEmpty());
+    EXPECT_EQ(shader->globalVars().size(), 1u);
+    EXPECT_TRUE(shader->functions().isEmpty());
+    WGSL::AST::VariableDecl& var = shader->globalVars()[0];
+    EXPECT_EQ(var.attributes().size(), 2u);
+    EXPECT_TRUE(var.attributes()[0]->isGroup());
+    EXPECT_FALSE(downcast<WGSL::AST::GroupAttribute>(var.attributes()[0].get()).group());
+    EXPECT_TRUE(var.attributes()[1]->isBinding());
+    EXPECT_FALSE(downcast<WGSL::AST::BindingAttribute>(var.attributes()[1].get()).binding());
+    EXPECT_EQ(var.name(), "x"_s);
+    EXPECT_TRUE(var.maybeQualifier());
+    EXPECT_EQ(var.maybeQualifier()->storageClass(), WGSL::AST::StorageClass::Storage);
+    EXPECT_EQ(var.maybeQualifier()->accessMode(), WGSL::AST::AccessMode::ReadWrite);
+    EXPECT_TRUE(var.maybeTypeDecl());
+    EXPECT_TRUE(var.maybeTypeDecl()->isNamed());
+    WGSL::AST::NamedType& namedType = downcast<WGSL::AST::NamedType>(*var.maybeTypeDecl());
+    EXPECT_EQ(namedType.name(), "B"_s);
+    EXPECT_FALSE(var.maybeInitializer());
+}
+
+TEST(WGSLParserTests, FunctionDecl)
+{
+    auto shader = WGSL::parseLChar(
+        "@compute\n"
+        "fn main() {\n"
+        "    x.a = 42i;\n"
+        "}"_s);
+
+    if (!shader.has_value())
+        dataLogLn(shader.error());
+    EXPECT_TRUE(shader.has_value());
+    EXPECT_FALSE(shader->directives().size());
+    EXPECT_TRUE(shader->structs().isEmpty());
+    EXPECT_TRUE(shader->globalVars().isEmpty());
+    EXPECT_EQ(shader->functions().size(), 1u);
+    WGSL::AST::FunctionDecl& func = shader->functions()[0];
+    EXPECT_EQ(func.attributes().size(), 1u);
+    EXPECT_TRUE(func.attributes()[0]->isStage());
+    EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0].get()).stage(), WGSL::AST::StageAttribute::Stage::Compute);
+    EXPECT_EQ(func.name(), "main"_s);
+    EXPECT_TRUE(func.parameters().isEmpty());
+    EXPECT_TRUE(func.returnAttributes().isEmpty());
+    EXPECT_FALSE(func.maybeReturnType());
+    EXPECT_EQ(func.body().statements().size(), 1u);
+    EXPECT_TRUE(func.body().statements()[0]->isAssignment());
+    WGSL::AST::AssignmentStatement& stmt = downcast<WGSL::AST::AssignmentStatement>(func.body().statements()[0].get());
+    EXPECT_TRUE(stmt.maybeLhs());
+    EXPECT_TRUE(stmt.maybeLhs()->isStructureAccess());
+    WGSL::AST::StructureAccess& structAccess = downcast<WGSL::AST::StructureAccess>(*stmt.maybeLhs());
+    EXPECT_TRUE(structAccess.base()->isIdentifier());
+    WGSL::AST::IdentifierExpression base = downcast<WGSL::AST::IdentifierExpression>(structAccess.base().get());
+    EXPECT_EQ(base.identifier(), "x"_s);
+    EXPECT_EQ(structAccess.fieldName(), "a"_s);
+    EXPECT_TRUE(stmt.rhs().isInt32Literal());
+    WGSL::AST::Int32Literal& rhs = downcast<WGSL::AST::Int32Literal>(stmt.rhs());
+    EXPECT_EQ(rhs.value(), 42);
+}
+
+TEST(WGSLParserTests, TrivialGraphicsShader)
+{
+    auto shader = WGSL::parseLChar(
+        "@vertex\n"
+        "fn vertexShader(@location(0) x: vec4<f32>) -> @builtin(position) vec4<f32> {\n"
+        "    return x;\n"
+        "}\n\n"
+        "@fragment\n"
+        "fn fragmentShader() -> @location(0) vec4<f32> {\n"
+        "    return vec4<f32>(0.4, 0.4, 0.8, 1.0);\n"
+        "}"_s);
+
+    if (!shader.has_value())
+        dataLogLn(shader.error());
+    EXPECT_TRUE(shader.has_value());
+    EXPECT_FALSE(shader->directives().size());
+    EXPECT_TRUE(shader->structs().isEmpty());
+    EXPECT_TRUE(shader->globalVars().isEmpty());
+    EXPECT_EQ(shader->functions().size(), 2u);
+
+    {
+        WGSL::AST::FunctionDecl& func = shader->functions()[0];
+        EXPECT_EQ(func.attributes().size(), 1u);
+        EXPECT_TRUE(func.attributes()[0]->isStage());
+        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0].get()).stage(), WGSL::AST::StageAttribute::Stage::Vertex);
+        EXPECT_EQ(func.name(), "vertexShader"_s);
+        EXPECT_EQ(func.parameters().size(), 1u);
+        EXPECT_EQ(func.parameters()[0]->name(), "x"_s);
+        EXPECT_EQ(func.parameters()[0]->attributes().size(), 1u);
+        EXPECT_TRUE(func.parameters()[0]->attributes()[0]->isLocation());
+        EXPECT_FALSE(downcast<WGSL::AST::LocationAttribute>(func.parameters()[0]->attributes()[0].get()).location());
+        EXPECT_TRUE(func.parameters()[0]->type().isParameterized());
+        WGSL::AST::ParameterizedType& paramType = downcast<WGSL::AST::ParameterizedType>(func.parameters()[0]->type());
+        EXPECT_EQ(paramType.base(), WGSL::AST::ParameterizedType::Base::Vec4);
+        EXPECT_TRUE(paramType.elementType().isNamed());
+        EXPECT_EQ(downcast<WGSL::AST::NamedType>(paramType.elementType()).name(), "f32"_s);
+        EXPECT_EQ(func.returnAttributes().size(), 1u);
+        EXPECT_TRUE(func.returnAttributes()[0]->isBuiltin());
+        EXPECT_EQ(downcast<WGSL::AST::BuiltinAttribute>(func.returnAttributes()[0].get()).name(), "position"_s);
+        EXPECT_TRUE(func.maybeReturnType());
+        EXPECT_TRUE(func.maybeReturnType()->isParameterized());
+        EXPECT_EQ(func.body().statements().size(), 1u);
+        EXPECT_TRUE(func.body().statements()[0]->isReturn());
+        WGSL::AST::ReturnStatement& stmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0].get());
+        EXPECT_TRUE(stmt.maybeExpression());
+        EXPECT_TRUE(stmt.maybeExpression()->isIdentifier());
+    }
+
+    {
+        WGSL::AST::FunctionDecl& func = shader->functions()[1];
+        EXPECT_EQ(func.attributes().size(), 1u);
+        EXPECT_TRUE(func.attributes()[0]->isStage());
+        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0].get()).stage(), WGSL::AST::StageAttribute::Stage::Fragment);
+        EXPECT_EQ(func.name(), "fragmentShader"_s);
+        EXPECT_TRUE(func.parameters().isEmpty());
+        EXPECT_EQ(func.returnAttributes().size(), 1u);
+        EXPECT_TRUE(func.returnAttributes()[0]->isLocation());
+        EXPECT_FALSE(downcast<WGSL::AST::LocationAttribute>(func.returnAttributes()[0].get()).location());
+        EXPECT_TRUE(func.maybeReturnType());
+        EXPECT_TRUE(func.maybeReturnType()->isParameterized());
+        EXPECT_EQ(func.body().statements().size(), 1u);
+        EXPECT_TRUE(func.body().statements()[0]->isReturn());
+        WGSL::AST::ReturnStatement& stmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0].get());
+        EXPECT_TRUE(stmt.maybeExpression());
+        EXPECT_TRUE(stmt.maybeExpression()->isCallableExpression());
+        WGSL::AST::CallableExpression& expr = downcast<WGSL::AST::CallableExpression>(*stmt.maybeExpression());
+        EXPECT_TRUE(expr.target().isParameterized());
+        EXPECT_EQ(expr.arguments().size(), 4u);
+        EXPECT_TRUE(expr.arguments()[0].get().isAbstractFloatLiteral());
+        EXPECT_TRUE(expr.arguments()[1].get().isAbstractFloatLiteral());
+        EXPECT_TRUE(expr.arguments()[2].get().isAbstractFloatLiteral());
+        EXPECT_TRUE(expr.arguments()[3].get().isAbstractFloatLiteral());
+    }
+}
+
+#pragma mark -
+#pragma mark Declarations
+
+TEST(WGSLParserTests, LocalVariable)
+{
+    auto shader = WGSL::parseLChar(
+        "@vertex\n"
+        "fn main() -> vec4<f32> {\n"
+        "    var x = vec4<f32>(0.4, 0.4, 0.8, 1.0);\n"
+        "    return x;\n"
+        "}"_s);
+
+    if (!shader.has_value())
+        dataLogLn(shader.error());
+    EXPECT_TRUE(shader.has_value());
+    EXPECT_TRUE(shader->directives().isEmpty());
+    EXPECT_TRUE(shader->structs().isEmpty());
+    EXPECT_TRUE(shader->globalVars().isEmpty());
+    EXPECT_EQ(shader->functions().size(), 1u);
+
+    {
+        WGSL::AST::FunctionDecl& func = shader->functions()[0];
+        // @vertex
+        EXPECT_EQ(func.attributes().size(), 1u);
+        EXPECT_TRUE(func.attributes()[0]->isStage());
+        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0].get()).stage(), WGSL::AST::StageAttribute::Stage::Vertex);
+
+        // fn main() -> vec4<f32> {
+        EXPECT_EQ(func.name(), "main"_s);
+        EXPECT_EQ(func.parameters().size(), 0u);
+        EXPECT_EQ(func.returnAttributes().size(), 0u);
+        EXPECT_TRUE(func.maybeReturnType());
+        EXPECT_TRUE(func.maybeReturnType()->isParameterized());
+        EXPECT_EQ(func.body().statements().size(), 2u);
+
+        // var x = vec4<f32>(0.4, 0.4, 0.8, 1.0);
+        EXPECT_TRUE(func.body().statements()[0]->isVariable());
+        WGSL::AST::VariableStatement& varStmt = downcast<WGSL::AST::VariableStatement>(func.body().statements()[0].get());
+        WGSL::AST::VariableDecl& varDecl = downcast<WGSL::AST::VariableDecl>(varStmt.declaration());
+        EXPECT_EQ(varDecl.name(), "x"_s);
+        EXPECT_EQ(varDecl.attributes().size(), 0u);
+        EXPECT_EQ(varDecl.maybeQualifier(), nullptr);
+        EXPECT_EQ(varDecl.maybeTypeDecl(), nullptr);
+        EXPECT_TRUE(varDecl.maybeInitializer());
+        WGSL::AST::CallableExpression& varInitExpr = downcast<WGSL::AST::CallableExpression>(*varDecl.maybeInitializer());
+        EXPECT_TRUE(varInitExpr.target().isParameterized());
+        EXPECT_EQ(varInitExpr.arguments().size(), 4u);
+        EXPECT_TRUE(varInitExpr.arguments()[0].get().isAbstractFloatLiteral());
+        EXPECT_TRUE(varInitExpr.arguments()[1].get().isAbstractFloatLiteral());
+        EXPECT_TRUE(varInitExpr.arguments()[2].get().isAbstractFloatLiteral());
+        EXPECT_TRUE(varInitExpr.arguments()[3].get().isAbstractFloatLiteral());
+
+        // return x;
+        EXPECT_TRUE(func.body().statements()[1]->isReturn());
+        WGSL::AST::ReturnStatement& retStmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[1].get());
+        EXPECT_TRUE(retStmt.maybeExpression());
+        EXPECT_TRUE(retStmt.maybeExpression()->isIdentifier());
+        WGSL::AST::IdentifierExpression retExpr = downcast<WGSL::AST::IdentifierExpression>(*retStmt.maybeExpression());
+        EXPECT_EQ(retExpr.identifier(), "x"_s);
+    }
+}
+
+#pragma mark -
+#pragma mark Expressions
+
+TEST(WGSLParserTests, ArrayAccess)
+{
+    auto shader = WGSL::parseLChar("fn test() { return x[42i]; }"_s);
+
+    if (!shader.has_value())
+        dataLogLn(shader.error());
+    EXPECT_TRUE(shader.has_value());
+    EXPECT_TRUE(shader->directives().isEmpty());
+    EXPECT_TRUE(shader->structs().isEmpty());
+    EXPECT_TRUE(shader->globalVars().isEmpty());
+    EXPECT_EQ(shader->functions().size(), 1u);
+
+    {
+        WGSL::AST::FunctionDecl& func = shader->functions()[0];
+
+        // fn test() { ... }
+        EXPECT_EQ(func.name(), "test"_s);
+        EXPECT_TRUE(func.parameters().isEmpty());
+        EXPECT_TRUE(func.returnAttributes().isEmpty());
+        EXPECT_FALSE(func.maybeReturnType());
+
+        EXPECT_EQ(func.body().statements().size(), 1u);
+        // return x[42];
+        EXPECT_TRUE(func.body().statements()[0]->isReturn());
+        WGSL::AST::ReturnStatement& retStmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0].get());
+        EXPECT_TRUE(retStmt.maybeExpression());
+        EXPECT_TRUE(retStmt.maybeExpression()->isArrayAccess());
+        WGSL::AST::ArrayAccess& arrayAccess = downcast<WGSL::AST::ArrayAccess>(*retStmt.maybeExpression());
+        EXPECT_TRUE(arrayAccess.base()->isIdentifier());
+        WGSL::AST::IdentifierExpression& base = downcast<WGSL::AST::IdentifierExpression>(arrayAccess.base().get());
+        EXPECT_EQ(base.identifier(), "x"_s);
+        EXPECT_TRUE(arrayAccess.index()->isInt32Literal());
+        WGSL::AST::Int32Literal& index = downcast<WGSL::AST::Int32Literal>(arrayAccess.index().get());
+        EXPECT_EQ(index.value(), 42);
+    }
+}
+
+TEST(WGSLParserTests, UnaryExpression)
+{
+    auto shader = WGSL::parseLChar(
+        "fn negate(x: f32) -> f32 {\n"
+        "    return -x;\n"
+        "}"_s);
+
+    if (!shader.has_value())
+        dataLogLn(shader.error());
+    EXPECT_TRUE(shader.has_value());
+    EXPECT_EQ(shader->directives().size(), 0ull);
+    EXPECT_EQ(shader->structs().size(), 0ull);
+    EXPECT_EQ(shader->globalVars().size(), 0ull);
+    EXPECT_EQ(shader->functions().size(), 1ull);
+
+    {
+        WGSL::AST::FunctionDecl& func = shader->functions()[0];
+        // @vertex
+        EXPECT_TRUE(func.attributes().isEmpty());
+
+        // fn negate(x: f32) -> f32 {
+        EXPECT_EQ(func.name(), "negate"_s);
+        EXPECT_EQ(func.parameters().size(), 1u);
+        EXPECT_TRUE(func.returnAttributes().isEmpty());
+        EXPECT_TRUE(func.maybeReturnType());
+        EXPECT_TRUE(func.maybeReturnType()->isNamed());
+
+        EXPECT_EQ(func.body().statements().size(), 1u);
+        // return x;
+        EXPECT_TRUE(func.body().statements()[0]->isReturn());
+        WGSL::AST::ReturnStatement& retStmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0].get());
+        EXPECT_TRUE(retStmt.maybeExpression());
+        EXPECT_TRUE(retStmt.maybeExpression()->isUnaryExpression());
+        WGSL::AST::UnaryExpression& retExpr = downcast<WGSL::AST::UnaryExpression>(*retStmt.maybeExpression());
+        EXPECT_EQ(retExpr.operation(), WGSL::AST::UnaryOperation::Negate);
+        EXPECT_TRUE(retExpr.expression().isIdentifier());
+        WGSL::AST::IdentifierExpression& negateExpr = downcast<WGSL::AST::IdentifierExpression>(retExpr.expression());
+        EXPECT_EQ(negateExpr.identifier(), "x"_s);
+    }
+}
+
+}

--- a/Tools/TestWebKitAPI/ios/mainIOS.mm
+++ b/Tools/TestWebKitAPI/ios/mainIOS.mm
@@ -28,7 +28,7 @@
 #import "UIKitMacHelperSPI.h"
 #import <wtf/RetainPtr.h>
 
-#if !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_IPC)
+#if !defined(BUILDING_TEST_IPC) && !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_WGSL)
 #import <WebKit/WKProcessPoolPrivate.h>
 #endif
 
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
 
         [[NSUserDefaults standardUserDefaults] setVolatileDomain:argumentDomain.get() forName:NSArgumentDomain];
 
-#if !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_IPC)
+#if !defined(BUILDING_TEST_IPC) && !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_WGSL)
         [WKProcessPool _setLinkedOnOrAfterEverythingForTesting];
 #endif
 

--- a/Tools/TestWebKitAPI/mac/mainMac.mm
+++ b/Tools/TestWebKitAPI/mac/mainMac.mm
@@ -27,7 +27,7 @@
 #import "TestsController.h"
 #import <wtf/RetainPtr.h>
 
-#if !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_IPC)
+#if !defined(BUILDING_TEST_IPC) && !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_WGSL)
 #import <WebKit/WKProcessPoolPrivate.h>
 #endif
 
@@ -57,7 +57,7 @@ int main(int argc, char** argv)
         [argumentDomain addEntriesFromDictionary:dict];
         [[NSUserDefaults standardUserDefaults] setVolatileDomain:argumentDomain.get() forName:NSArgumentDomain];
 
-#if !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_IPC)
+#if !defined(BUILDING_TEST_IPC) && !defined(BUILDING_TEST_WTF) && !defined(BUILDING_TEST_WGSL)
         [WKProcessPool _setLinkedOnOrAfterEverythingForTesting];
 #endif
 


### PR DESCRIPTION
#### 5bda1cab2367440c3b9bb734234b75d876d3e6c1
<pre>
[WGSL] Port WGSLUnitTests to TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=245061">https://bugs.webkit.org/show_bug.cgi?id=245061</a>
rdar://problem/99808942

Reviewed by Elliott Williams.

So we can run the tests on EWS, port the XCTest-based WGSLUnitTests to
gtest-based standalone executable TestWGSL. This was a straight-forward change
of ObjC interfaces to C++ classes and renaming of testing macros.

* Tools/Scripts/run-api-tests:
* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort):
* Tools/TestWebKitAPI/Configurations/TestWGSL.xcconfig: Added.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWGSL.xcscheme: Added.
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp: Added.
(TestWebKitAPI::checkSingleToken):
(TestWebKitAPI::checkSingleLiteral):
(TestWebKitAPI::checkNextTokenIs):
(TestWebKitAPI::checkNextTokenIsIdentifier):
(TestWebKitAPI::checkNextTokenIsLiteral):
(TestWebKitAPI::checkNextTokensAreBuiltinAttr):
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp: Added.
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/mac/mainMac.mm:
(main):

Canonical link: <a href="https://commits.webkit.org/254654@main">https://commits.webkit.org/254654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3d5e4c28b74eaf8a6217117fdeefd8cd073b402

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98947 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155634 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32700 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28174 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82017 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93355 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25982 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76512 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25931 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/93241 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68925 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30455 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14822 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30205 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15754 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3268 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33653 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38700 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-inherit-to-blank-document-unsandboxed.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34845 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->