### PR TITLE
RTCDataChannelRemoteManager registers for work queue messages in wrong way

### DIFF
--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
@@ -26,7 +26,6 @@
 
 #if ENABLE(WEB_RTC)
 
-#include "Connection.h"
 #include "DataReference.h"
 #include "WorkQueueMessageReceiver.h"
 #include <WebCore/ProcessQualified.h>
@@ -38,18 +37,18 @@
 
 namespace WebKit {
 
-class RTCDataChannelRemoteManager final : public IPC::WorkQueueMessageReceiver {
+class RTCDataChannelRemoteManager final : private IPC::MessageReceiver {
 public:
     static RTCDataChannelRemoteManager& sharedManager();
 
     WebCore::RTCDataChannelRemoteHandlerConnection& remoteHandlerConnection();
-    void setConnection(IPC::Connection*);
     bool connectToRemoteSource(WebCore::RTCDataChannelIdentifier source, WebCore::RTCDataChannelIdentifier handler);
 
 private:
     RTCDataChannelRemoteManager();
+    void initialize();
 
-    // IPC::WorkQueueMessageReceiver 
+    // IPC::MessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
     // Messages


### PR DESCRIPTION
#### 18c0882056e44303ec3d1af63254bc67b02f5eeb
<pre>
RTCDataChannelRemoteManager registers for work queue messages in wrong way
<a href="https://bugs.webkit.org/show_bug.cgi?id=245064">https://bugs.webkit.org/show_bug.cgi?id=245064</a>
rdar://problem/99812041

Reviewed by Antti Koivisto.

RTCDataChannelRemoteManager:
 - is RefCounted but the initial ref is never adopted as expected
 - registers a work queue message handler before the vptr is correctly setup
   risking incorrect virtual function calls to the instance from another
   thread

Change the base class to IPC::MessageReceiver. This is not refcounted,
and is suitable for RTCDataChannelRemoteManager which is a singleton.

Register the message handler in a separate function after construction.

Register using addMessageReceiver(). This is work to simplify the IPC
thread related code, being able to remove Connection::addWorkQueueMessageReceiver().

* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp:
(WebKit::RTCDataChannelRemoteManager::sharedManager):
(WebKit::RTCDataChannelRemoteManager::RTCDataChannelRemoteManager):
(WebKit::RTCDataChannelRemoteManager::startListeningForIPC):
(WebKit::RTCDataChannelRemoteManager::setConnection): Deleted.
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h:

Canonical link: <a href="https://commits.webkit.org/254752@main">https://commits.webkit.org/254752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/475aeb0eca9812f7a8ff42bb2405fc6ddc62dd7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99430 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33151 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82454 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/94271 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26360 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76934 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26262 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69261 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/34317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15070 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16014 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3337 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/35902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38983 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/37804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35098 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->