### PR TITLE
SecItemShimProxy should be a MessageReceiver

### DIFF
--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.cpp
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.cpp
@@ -41,7 +41,7 @@ SecItemShimProxy& SecItemShimProxy::singleton()
     static SecItemShimProxy* proxy;
     static dispatch_once_t once;
     dispatch_once(&once, ^{
-        proxy = adoptRef(new SecItemShimProxy).leakRef();
+        proxy = new SecItemShimProxy;
     });
     return *proxy;
 }
@@ -58,7 +58,7 @@ SecItemShimProxy::~SecItemShimProxy()
 
 void SecItemShimProxy::initializeConnection(IPC::Connection& connection)
 {
-    connection.addWorkQueueMessageReceiver(Messages::SecItemShimProxy::messageReceiverName(), m_queue.get(), *this);
+    connection.addMessageReceiver(m_queue.get(), *this, Messages::SecItemShimProxy::messageReceiverName());
 }
 
 void SecItemShimProxy::secItemRequest(const SecItemRequestData& request, CompletionHandler<void(std::optional<SecItemResponseData>&&)>&& response)

--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
@@ -35,7 +35,7 @@ namespace WebKit {
 class SecItemRequestData;
 class SecItemResponseData;
 
-class SecItemShimProxy : public IPC::WorkQueueMessageReceiver {
+class SecItemShimProxy final : private IPC::MessageReceiver {
 WTF_MAKE_NONCOPYABLE(SecItemShimProxy);
 public:
     static SecItemShimProxy& singleton();
@@ -46,7 +46,7 @@ private:
     SecItemShimProxy();
     ~SecItemShimProxy();
 
-    // IPC::WorkQueueMessageReceiver 
+    // IPC::Connection::MessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
 

--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.messages.in
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> SecItemShimProxy {
+messages -> SecItemShimProxy NotRefCounted {
 
 #if ENABLE(SEC_ITEM_SHIM)
     SecItemRequestSync(WebKit::SecItemRequestData request) -> (std::optional<WebKit::SecItemResponseData> response) Synchronous


### PR DESCRIPTION
#### 5b6e91526e2b738ccaa527f9ad58229b66ee143f
<pre>
SecItemShimProxy should be a MessageReceiver
<a href="https://bugs.webkit.org/show_bug.cgi?id=245067">https://bugs.webkit.org/show_bug.cgi?id=245067</a>
rdar://problem/99815679

Reviewed by Antti Koivisto.

SecItemShimProxy is a singleton, so it should not be a ref counted.
Use regular IPC::MessageReceiver when registering a message receiver
for messages dispatched in the sec item work queue.

This is work towards simplifying IPC::Connection by not having
IPC::Connection::addWorkQueueMessageReceiver.

* Source/WebKit/UIProcess/mac/SecItemShimProxy.cpp:
(WebKit::SecItemShimProxy::singleton):
(WebKit::SecItemShimProxy::initializeConnection):
* Source/WebKit/UIProcess/mac/SecItemShimProxy.h:
* Source/WebKit/UIProcess/mac/SecItemShimProxy.messages.in:

Canonical link: <a href="https://commits.webkit.org/254750@main">https://commits.webkit.org/254750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0cd6a93cc5bb9adc2cdbf82813546e3fc39384e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99431 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33152 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82444 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/94313 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26361 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76936 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26252 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69252 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/34318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/15069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16013 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3338 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/35903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38982 "Passed tests") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/37805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35097 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->