### PR TITLE
ViewUpdate*, Event*, WebInspectorInterruptDispatcher should be MessageReceivers

### DIFF
--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.cpp
@@ -26,17 +26,13 @@
 #include "config.h"
 #include "WebInspectorInterruptDispatcher.h"
 
+#include "Connection.h"
 #include "WebInspectorInterruptDispatcherMessages.h"
 #include <JavaScriptCore/VM.h>
 #include <WebCore/CommonVM.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebKit {
-
-Ref<WebInspectorInterruptDispatcher> WebInspectorInterruptDispatcher::create()
-{
-    return adoptRef(*new WebInspectorInterruptDispatcher);
-}
 
 WebInspectorInterruptDispatcher::WebInspectorInterruptDispatcher()
     : m_queue(WorkQueue::create("com.apple.WebKit.WebInspectorInterruptDispatcher"))
@@ -48,9 +44,9 @@ WebInspectorInterruptDispatcher::~WebInspectorInterruptDispatcher()
     ASSERT_NOT_REACHED();
 }
 
-void WebInspectorInterruptDispatcher::initializeConnection(IPC::Connection* connection)
+void WebInspectorInterruptDispatcher::initializeConnection(IPC::Connection& connection)
 {
-    connection->addWorkQueueMessageReceiver(Messages::WebInspectorInterruptDispatcher::messageReceiverName(), m_queue.get(), *this);
+    connection.addMessageReceiver(m_queue.get(), *this, Messages::WebInspectorInterruptDispatcher::messageReceiverName());
 }
 
 void WebInspectorInterruptDispatcher::notifyNeedDebuggerBreak()

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h
@@ -25,26 +25,29 @@
 
 #pragma once
 
-#include "Connection.h"
-#include "WorkQueueMessageReceiver.h"
+#include "MessageReceiver.h"
+#include <wtf/Ref.h>
+
+namespace WTF {
+class WorkQueue;
+}
 
 namespace WebKit {
 
-class WebInspectorInterruptDispatcher : public IPC::WorkQueueMessageReceiver {
+class WebInspectorInterruptDispatcher final : private IPC::MessageReceiver {
 public:
-    static Ref<WebInspectorInterruptDispatcher> create();
+    WebInspectorInterruptDispatcher();
     ~WebInspectorInterruptDispatcher();
     
-    void initializeConnection(IPC::Connection*);
+    void initializeConnection(IPC::Connection&);
     
 private:
-    WebInspectorInterruptDispatcher();
-    // IPC::WorkQueueMessageReceiver overrides.
+    // IPC::MessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
     
     void notifyNeedDebuggerBreak();
     
-    Ref<WorkQueue> m_queue;
+    Ref<WTF::WorkQueue> m_queue;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.messages.in
@@ -20,6 +20,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> WebInspectorInterruptDispatcher {
+messages -> WebInspectorInterruptDispatcher NotRefCounted {
     NotifyNeedDebuggerBreak()
 }

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -25,9 +25,8 @@
 
 #pragma once
 
-#include "Connection.h"
+#include "MessageReceiver.h"
 #include "WebEvent.h"
-#include "WorkQueueMessageReceiver.h"
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/PlatformWheelEvent.h>
 #include <WebCore/RectEdges.h>
@@ -38,6 +37,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/ThreadingPrimitives.h>
+#include <wtf/WorkQueue.h>
 
 #if ENABLE(MAC_GESTURE_EVENTS)
 #include "WebGestureEvent.h"
@@ -60,9 +60,9 @@ class WebWheelEvent;
 class WebTouchEvent;
 #endif
 
-class EventDispatcher : public IPC::WorkQueueMessageReceiver {
+class EventDispatcher final : private IPC::MessageReceiver {
 public:
-    static Ref<EventDispatcher> create();
+    EventDispatcher();
     ~EventDispatcher();
 
     WorkQueue& queue() { return m_queue.get(); }
@@ -77,7 +77,7 @@ public:
     void takeQueuedTouchEventsForPage(const WebPage&, TouchEventQueue&);
 #endif
 
-    void initializeConnection(IPC::Connection*);
+    void initializeConnection(IPC::Connection&);
 
     void notifyScrollingTreesDisplayWasRefreshed(WebCore::PlatformDisplayID);
 
@@ -85,9 +85,7 @@ public:
     void internalWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges, WheelEventOrigin);
 
 private:
-    EventDispatcher();
-
-    // IPC::WorkQueueMessageReceiver .
+    // IPC::MessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
     // Message handlers

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> EventDispatcher {
+messages -> EventDispatcher NotRefCounted {
     WheelEvent(WebCore::PageIdentifier pageID, WebKit::WebWheelEvent event, WebCore::RectEdges<bool> rubberBandableEdges)
 #if ENABLE(IOS_TOUCH_EVENTS)
     TouchEvent(WebCore::PageIdentifier pageID, WebKit::WebTouchEvent event) -> (bool handled) MainThreadCallback

--- a/Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.h
@@ -27,27 +27,28 @@
 
 #if ENABLE(UI_SIDE_COMPOSITING)
 
-#include "Connection.h"
-
+#include "MessageReceiver.h"
 #include "VisibleContentRectUpdateInfo.h"
-#include "WorkQueueMessageReceiver.h"
 #include <WebCore/PageIdentifier.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/Ref.h>
 
+namespace WTF {
+class WorkQueue;
+}
+
 namespace WebKit {
 
-class ViewUpdateDispatcher : public IPC::WorkQueueMessageReceiver {
+class ViewUpdateDispatcher final: private IPC::MessageReceiver {
 public:
-    static Ref<ViewUpdateDispatcher> create();
+    ViewUpdateDispatcher();
     ~ViewUpdateDispatcher();
 
-    void initializeConnection(IPC::Connection*);
+    void initializeConnection(IPC::Connection&);
 
 private:
-    ViewUpdateDispatcher();
-    // IPC::WorkQueueMessageReceiver .
+    // IPC::MessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
     void visibleContentRectUpdate(WebCore::PageIdentifier, const VisibleContentRectUpdateInfo&);
@@ -64,7 +65,7 @@ private:
         MonotonicTime oldestTimestamp;
     };
 
-    Ref<WorkQueue> m_queue;
+    Ref<WTF::WorkQueue> m_queue;
     Lock m_latestUpdateLock;
     HashMap<WebCore::PageIdentifier, UniqueRef<UpdateData>> m_latestUpdate WTF_GUARDED_BY_LOCK(m_latestUpdateLock);
 };

--- a/Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.messages.in
@@ -20,6 +20,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> ViewUpdateDispatcher {
+messages -> ViewUpdateDispatcher NotRefCounted {
     VisibleContentRectUpdate(WebCore::PageIdentifier pageID, WebKit::VisibleContentRectUpdateInfo visibleContentRectUpdateInfo)
 }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -285,12 +285,7 @@ WebProcess& WebProcess::singleton()
 }
 
 WebProcess::WebProcess()
-    : m_eventDispatcher(EventDispatcher::create())
-#if PLATFORM(IOS_FAMILY)
-    , m_viewUpdateDispatcher(ViewUpdateDispatcher::create())
-#endif
-    , m_webInspectorInterruptDispatcher(WebInspectorInterruptDispatcher::create())
-    , m_webLoaderStrategy(*new WebLoaderStrategy)
+    : m_webLoaderStrategy(*new WebLoaderStrategy)
     , m_cacheStorageProvider(WebCacheStorageProvider::create())
     , m_broadcastChannelRegistry(WebBroadcastChannelRegistry::create())
     , m_cookieJar(WebCookieJar::create())
@@ -388,12 +383,12 @@ void WebProcess::initializeConnection(IPC::Connection* connection)
     connection->setShouldExitOnSyncMessageSendFailure(true);
 #endif
 
-    m_eventDispatcher->initializeConnection(connection);
+    m_eventDispatcher.initializeConnection(*connection);
 #if PLATFORM(IOS_FAMILY)
-    m_viewUpdateDispatcher->initializeConnection(connection);
+    m_viewUpdateDispatcher.initializeConnection(*connection);
 #endif // PLATFORM(IOS_FAMILY)
 
-    m_webInspectorInterruptDispatcher->initializeConnection(connection);
+    m_webInspectorInterruptDispatcher.initializeConnection(*connection);
 
     for (auto& supplement : m_supplements.values())
         supplement->initializeConnection(connection);
@@ -1992,7 +1987,7 @@ bool WebProcess::areAllPagesThrottleable() const
 void WebProcess::displayWasRefreshed(uint32_t displayID, const DisplayUpdate& displayUpdate)
 {
     ASSERT(RunLoop::isMain());
-    m_eventDispatcher->notifyScrollingTreesDisplayWasRefreshed(displayID);
+    m_eventDispatcher.notifyScrollingTreesDisplayWasRefreshed(displayID);
     DisplayRefreshMonitorManager::sharedManager().displayWasUpdated(displayID, displayUpdate);
 }
 #endif

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -28,6 +28,7 @@
 #include "AccessibilityPreferences.h"
 #include "AuxiliaryProcess.h"
 #include "CacheModel.h"
+#include "EventDispatcher.h"
 #include "IdentifierTypes.h"
 #include "StorageAreaMapIdentifier.h"
 #include "TextCheckerState.h"
@@ -110,7 +111,6 @@ struct ServiceWorkerContextData;
 namespace WebKit {
 
 class AudioMediaStreamTrackRendererInternalUnitManager;
-class EventDispatcher;
 class GamepadData;
 class GPUProcessConnection;
 class InjectedBundle;
@@ -227,7 +227,7 @@ public:
     const TextCheckerState& textCheckerState() const { return m_textCheckerState; }
     void setTextCheckerState(const TextCheckerState&);
 
-    EventDispatcher& eventDispatcher() { return m_eventDispatcher.get(); }
+    EventDispatcher& eventDispatcher() { return m_eventDispatcher; }
 
     NetworkProcessConnection& ensureNetworkProcessConnection();
     void networkProcessConnectionClosed(NetworkProcessConnection*);
@@ -598,11 +598,11 @@ private:
     HashMap<PageGroupIdentifier, RefPtr<WebPageGroupProxy>> m_pageGroupMap;
     RefPtr<InjectedBundle> m_injectedBundle;
 
-    Ref<EventDispatcher> m_eventDispatcher;
+    EventDispatcher m_eventDispatcher;
 #if PLATFORM(IOS_FAMILY)
-    RefPtr<ViewUpdateDispatcher> m_viewUpdateDispatcher;
+    ViewUpdateDispatcher m_viewUpdateDispatcher;
 #endif
-    RefPtr<WebInspectorInterruptDispatcher> m_webInspectorInterruptDispatcher;
+    WebInspectorInterruptDispatcher m_webInspectorInterruptDispatcher;
 
     bool m_hasSetCacheModel { false };
     CacheModel m_cacheModel { CacheModel::DocumentViewer };


### PR DESCRIPTION
#### bb50e5a9e92cf937d06a193f9dd48c03395e506a
<pre>
ViewUpdate*, Event*, WebInspectorInterruptDispatcher should be MessageReceivers
<a href="https://bugs.webkit.org/show_bug.cgi?id=245068">https://bugs.webkit.org/show_bug.cgi?id=245068</a>
rdar://problem/99816958

Reviewed by Antti Koivisto.

These objects are never destroyed, and as such should not be refcounted.

Use addMessageReceiver when adding the work queue message receivers.

This is work towards simplifying IPC::Connection by working towards
removing addWorkQueueMessageReceiver().

* Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.cpp:
(WebKit::WebInspectorInterruptDispatcher::initializeConnection):
(WebKit::WebInspectorInterruptDispatcher::create): Deleted.
* Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.messages.in:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::initializeConnection):
(WebKit::EventDispatcher::internalWheelEvent):
(WebKit::EventDispatcher::gestureEvent):
(WebKit::EventDispatcher::touchEvent):
(WebKit::EventDispatcher::dispatchWheelEventViaMainThread):
(WebKit::EventDispatcher::create): Deleted.
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
(WebKit::EventDispatcher::queue): Deleted.
* Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in:
* Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.cpp:
(WebKit::ViewUpdateDispatcher::initializeConnection):
(WebKit::ViewUpdateDispatcher::visibleContentRectUpdate):
(WebKit::ViewUpdateDispatcher::create): Deleted.
* Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.h:
(WebKit::ViewUpdateDispatcher::UpdateData::UpdateData): Deleted.
* Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.messages.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::WebProcess):
(WebKit::WebProcess::initializeConnection):
(WebKit::WebProcess::displayWasRefreshed):
* Source/WebKit/WebProcess/WebProcess.h:
(WebKit::WebProcess::eventDispatcher):

Canonical link: <a href="https://commits.webkit.org/254753@main">https://commits.webkit.org/254753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5d60a5179e8936d1f2d044b0d183c3eb18245d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99433 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33154 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82446 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/94338 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26363 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76939 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26255 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69254 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/34320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/15071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16015 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3339 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/35905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38984 "Passed tests") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/37807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35099 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->