### PR TITLE
[GTK] Stop using injected bundle messages for implementing snapshot API

### DIFF
--- a/Source/WebKit/Shared/ImageOptions.h
+++ b/Source/WebKit/Shared/ImageOptions.h
@@ -42,6 +42,9 @@ enum {
     SnapshotOptionsForceWhiteText = 1 << 7,
     SnapshotOptionsPrinting = 1 << 8,
     SnapshotOptionsUseScreenColorSpace = 1 << 9,
+    SnapshotOptionsVisibleContentRect = 1 << 10,
+    SnapshotOptionsFullContentRect = 1 << 11,
+    SnapshotOptionsTransparentBackground = 1 << 12
 };
 typedef uint32_t SnapshotOptions;
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitInjectedBundleClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitInjectedBundleClient.cpp
@@ -137,15 +137,6 @@ private:
                 webkitWebResourceFailed(resource.get(), resourceError.get());
 
             webkitWebViewRemoveLoadingWebResource(webView, resourceIdentifier->value());
-#if PLATFORM(GTK)
-        } else if (g_str_equal(messageName, "DidGetSnapshot")) {
-            API::UInt64* callbackID = static_cast<API::UInt64*>(message.get("CallbackID"_s));
-            if (!callbackID)
-                return;
-
-            WebImage* image = static_cast<WebImage*>(message.get("Snapshot"_s));
-            webKitWebViewDidReceiveSnapshot(webView, callbackID->value(), image);
-#endif
         }
     }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
@@ -198,13 +198,6 @@ private:
 #endif
     }
 
-    void didReceiveMessageToPage(InjectedBundle&, WebPage& page, const String& messageName, API::Object* messageBody) override
-    {
-        ASSERT(messageBody->type() == API::Object::Type::Dictionary);
-        if (auto* webPage = m_extension->priv->pages.get(&page))
-            webkitWebPageDidReceiveMessage(webPage, messageName, *static_cast<API::Dictionary*>(messageBody));
-    }
-
     WebKitWebExtension* m_extension;
 };
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPagePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPagePrivate.h
@@ -25,7 +25,6 @@
 #include "WebPage.h"
 
 WebKitWebPage* webkitWebPageCreate(WebKit::WebPage*);
-void webkitWebPageDidReceiveMessage(WebKitWebPage*, const String& messageName, API::Dictionary& message);
 void webkitWebPageDidReceiveUserMessage(WebKitWebPage*, WebKit::UserMessage&&, CompletionHandler<void(WebKit::UserMessage&&)>&&);
 WebKit::WebPage* webkitWebPageGetPage(WebKitWebPage*);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2005,7 +2005,7 @@ private:
 
     void setIsSuspended(bool);
 
-    RefPtr<WebImage> snapshotAtSize(const WebCore::IntRect&, const WebCore::IntSize& bitmapSize, SnapshotOptions);
+    RefPtr<WebImage> snapshotAtSize(const WebCore::IntRect&, const WebCore::IntSize& bitmapSize, SnapshotOptions, WebCore::Frame&, WebCore::FrameView&);
     RefPtr<WebImage> snapshotNode(WebCore::Node&, SnapshotOptions, unsigned maximumPixelCount = std::numeric_limits<unsigned>::max());
 #if PLATFORM(COCOA)
     RetainPtr<CFDataRef> pdfSnapshotAtSize(WebCore::IntRect, WebCore::IntSize bitmapSize, SnapshotOptions);


### PR DESCRIPTION
#### 910d348b46de94f5c1afbd1f853ebb7f0ebaaa22
<pre>
[GTK] Stop using injected bundle messages for implementing snapshot API
<a href="https://bugs.webkit.org/show_bug.cgi?id=245069">https://bugs.webkit.org/show_bug.cgi?id=245069</a>

Reviewed by Adrian Perez de Castro and Michael Catanzaro.

Add new options for the features required by gtk API and use WebPageProxy::takeSnapshot().

* Source/WebKit/Shared/ImageOptions.h:
* Source/WebKit/UIProcess/API/glib/WebKitInjectedBundleClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_get_snapshot):
(webKitWebViewDidReceiveSnapshot): Deleted.
(webKitSnapshotOptionsToSnapshotOptions): Deleted.
(toSnapshotRegion): Deleted.
(generateSnapshotCallbackID): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
(webkitWebPageDidReceiveMessage): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPagePrivate.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::takeSnapshot):
(WebKit::WebPage::scaledSnapshotWithOptions):
(WebKit::WebPage::paintSnapshotAtSize):
(WebKit::WebPage::snapshotAtSize):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/254723@main">https://commits.webkit.org/254723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba1decdf9dc356614c1ac736407922af0d7100fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98122 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/31987 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28013 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81160 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92738 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25391 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75898 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25341 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68307 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29781 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14324 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29512 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15315 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3320 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32951 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38259 "Found 1 new test failure: fast/events/blur-remove-parent-crash.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34420 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->