### PR TITLE
[MSE] Round SourceBuffer removal range

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -282,7 +282,9 @@ ExceptionOr<void> SourceBuffer::abort()
 
 ExceptionOr<void> SourceBuffer::remove(double start, double end)
 {
-    return remove(MediaTime::createWithDouble(start), MediaTime::createWithDouble(end));
+    // Limit timescale to 1/1000 of microsecond so samples won't accidentally overlap with removal range by precision lost (e.g. by 0.000000000000X [sec]).
+    static const uint32_t timescale = 1000000000;
+    return remove(MediaTime::createWithDouble(start, timescale), MediaTime::createWithDouble(end, timescale));
 }
 
 ExceptionOr<void> SourceBuffer::remove(const MediaTime& start, const MediaTime& end)


### PR DESCRIPTION
#### 2fc32818fdd29c1ec7d7570727a5d68d057c446f
<pre>
[MSE] Round SourceBuffer removal range
<a href="https://bugs.webkit.org/show_bug.cgi?id=245081">https://bugs.webkit.org/show_bug.cgi?id=245081</a>

Reviewed by Xabier Rodriguez-Calvar.

Representation of removal times as double in SourceBuffer::remove() can cause
problems in HBOMax due to precision/rounding problems.

In some problematic cases an unintended frame would be marked for removal because
of the very small overlap that could come from precision lost. For instance,
HBOMax uses the PTS of the next sample as removal &apos;end&apos; and unexpectedly removes
the next segment (as it&apos;s a sync frame) sometimes.

Rounding the double removal range delimiters to nanoseconds would help to avoid
those problematic cases.

Original author: Andrzej Surdej &lt;Andrzej_Surdej@comcast.com&gt;
See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/921">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/921</a>

* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::remove): Round the removal range start/end values to millisecond precision.

Canonical link: <a href="https://commits.webkit.org/254472@main">https://commits.webkit.org/254472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b09324293e7ecbb9897917b7480c10cc95ad107d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98219 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154613 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32015 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27612 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81224 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92763 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25422 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75922 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25367 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68334 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29806 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14352 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29537 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15338 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3135 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38279 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34440 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->