### PR TITLE
Web Inspector: REGRESSION(252489@main): RTL: Network: initiated indicator is not aligned correctly

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
@@ -108,7 +108,7 @@
 
 .network-table.highlight-initiated > .table li.initiated .cell.name::after {
     display: inline-block;
-    float: right;
+    float: inline-end;
     width: 4px;
     height: 4px;
     margin-top: 8px;


### PR DESCRIPTION
#### e1ec431ac3d644df1846ab4b9d1fd0bafd0f0912
<pre>
Web Inspector: REGRESSION(252489@main): RTL: Network: initiated indicator is not aligned correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=245084">https://bugs.webkit.org/show_bug.cgi?id=245084</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css:
(.network-table.highlight-initiated &gt; .table li.initiated .cell.name::after):

Canonical link: <a href="https://commits.webkit.org/254398@main">https://commits.webkit.org/254398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/281b5f1762e996738feb23ef4674f2132d8f5e64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33510 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/19823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/98225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32016 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81207 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92764 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25424 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/75923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/25364 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80292 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/19823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/68331 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29807 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/19823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29538 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/19823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/32977 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/75923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1292 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31666 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/19823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->