### PR TITLE
[Deprecation Reporting] Stub implementation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/pageload-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/pageload-image-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL The document for a standalone media file should have one child in the body. assert_equals: Media documents should be in standards mode expected "CSS1Compat" but got "BackCompat"
+PASS The document for a standalone media file should have one child in the body.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/pageload-video-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/pageload-video-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL The document for a standalone media file should have one child in the body. assert_equals: Media documents should be in standards mode expected "CSS1Compat" but got "BackCompat"
+PASS The document for a standalone media file should have one child in the body.
 

--- a/LayoutTests/media/modern-media-controls/media-documents/media-document-audio-ios-sizing-expected.txt
+++ b/LayoutTests/media/modern-media-controls/media-documents/media-document-audio-ios-sizing-expected.txt
@@ -3,7 +3,7 @@ Testing the size of the media element in an audio media document on iOS.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS getComputedStyle(media).width became "320px"
+PASS getComputedStyle(media).width became "390px"
 PASS getComputedStyle(media).height is "50px"
 
 PASS successfullyParsed is true

--- a/LayoutTests/media/modern-media-controls/media-documents/media-document-audio-ios-sizing.html
+++ b/LayoutTests/media/modern-media-controls/media-documents/media-document-audio-ios-sizing.html
@@ -20,7 +20,7 @@ let media;
         return;
     }
 
-    shouldBecomeEqualToString("getComputedStyle(media).width", "320px", () => {
+    shouldBecomeEqualToString("getComputedStyle(media).width", "390px", () => {
         shouldBeEqualToString("getComputedStyle(media).height", "50px");
 
         debug("");

--- a/LayoutTests/platform/ipad/media/modern-media-controls/media-documents/media-document-audio-ios-sizing-expected.txt
+++ b/LayoutTests/platform/ipad/media/modern-media-controls/media-documents/media-document-audio-ios-sizing-expected.txt
@@ -3,7 +3,7 @@ Testing the size of the media element in an audio media document on iOS.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS getComputedStyle(media).width became "650px"
+PASS getComputedStyle(media).width became "800px"
 PASS getComputedStyle(media).height is "50px"
 
 PASS successfullyParsed is true

--- a/LayoutTests/platform/ipad/media/modern-media-controls/media-documents/media-document-audio-ios-sizing.html
+++ b/LayoutTests/platform/ipad/media/modern-media-controls/media-documents/media-document-audio-ios-sizing.html
@@ -20,7 +20,7 @@ let media;
         return;
     }
 
-    shouldBecomeEqualToString("getComputedStyle(media).width", "650px", () => {
+    shouldBecomeEqualToString("getComputedStyle(media).width", "800px", () => {
         shouldBeEqualToString("getComputedStyle(media).height", "50px");
 
         debug("");

--- a/LayoutTests/platform/mac-wk1/fast/events/standalone-image-drag-to-editable-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/events/standalone-image-drag-to-editable-expected.txt
@@ -1,0 +1,27 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderFrameSet {FRAMESET} at (0,0) size 800x600
+      RenderFrame {FRAME} at (0,0) size 800x100
+        layer at (0,0) size 785x102
+          RenderView at (0,0) size 785x100
+        layer at (0,0) size 785x102
+          RenderBlock {HTML} at (0,0) size 785x102
+            RenderBody {BODY} at (0,0) size 785x102
+              RenderBlock {DIV} at (0,0) size 785x102 [border: (1px solid #000000)]
+                RenderBlock (anonymous) at (1,1) size 783x36
+                  RenderText {#text} at (0,0) size 702x18
+                    text run at (0,0) width 702: "This layout test is checks that we don't crash when a stand alone image is dragged into a content editable div. "
+                  RenderBR {BR} at (701,0) size 1x18
+                  RenderInline {A} at (0,0) size 153x18 [color=#0000EE]
+                    RenderText {#text} at (0,18) size 153x18
+                      text run at (0,18) width 153: "rdar://problem/5021127"
+                RenderImage {IMG} at (1,37) size 25x25
+      RenderFrame {FRAME} at (0,106) size 800x100
+        layer at (0,0) size 800x100
+          RenderView at (0,0) size 800x100
+        layer at (0,0) size 800x100
+          RenderBlock {HTML} at (0,0) size 800x100
+            RenderBody {BODY} at (0,0) size 800x100
+              RenderImage {IMG} at (0,0) size 25x25

--- a/LayoutTests/platform/mac/editing/pasteboard/copy-standalone-image-expected.html
+++ b/LayoutTests/platform/mac/editing/pasteboard/copy-standalone-image-expected.html
@@ -1,0 +1,15 @@
+<html>
+<body>
+<p>This is an automatic test of copying an image document.</p>
+<p>To perform this test manually, click once in the image frame, choose Edit -> Copy
+then click in the red box and paste the image. If the image pastes successfully the
+test is passed.</p>
+
+<iframe name="imageframe" src="../../../../editing/resources/abe.png"></iframe>
+
+<div id="dest" contenteditable="true"><br><img src="../../../../editing/resources/abe.png" style="-webkit-user-select:none;"></div>
+<script>
+frames['imageframe'].focus();
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac/http/tests/misc/acid3-expected.txt
+++ b/LayoutTests/platform/mac/http/tests/misc/acid3-expected.txt
@@ -33,9 +33,9 @@ layer at (20,20) size 644x433
           RenderIFrame {IFRAME} at (0,0) size 0x0
             layer at (0,0) size 1x1
               RenderView at (0,0) size 0x0
-            layer at (0,0) size 0x1
-              RenderBlock {HTML} at (0,0) size 0x1
-                RenderBody {BODY} at (0,0) size 0x1
+            layer at (0,0) size 0x0
+              RenderBlock {HTML} at (0,0) size 0x0
+                RenderBody {BODY} at (0,0) size 0x0
                   RenderImage {IMG} at (0,0) size 1x1
           RenderIFrame {IFRAME} at (0,0) size 0x0
             layer at (0,0) size 16x2171

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -209,7 +209,7 @@ ImageDocument::ImageDocument(Frame& frame, const URL& url)
 #endif
     , m_shouldShrinkImage(frame.settings().shrinksStandaloneImagesToFit() && frame.isMainFrame())
 {
-    setCompatibilityMode(DocumentCompatibilityMode::QuirksMode);
+    setCompatibilityMode(DocumentCompatibilityMode::NoQuirksMode);
     lockCompatibilityMode();
 }
     
@@ -223,6 +223,7 @@ void ImageDocument::createDocumentStructure()
     auto rootElement = HTMLHtmlElement::create(*this);
     appendChild(rootElement);
     rootElement->insertedByParser();
+    rootElement->setInlineStyleProperty(CSSPropertyHeight, 100, CSSUnitType::CSS_PERCENTAGE);
 
     frame()->injectUserScripts(UserScriptInjectionTime::DocumentStart);
 
@@ -231,7 +232,7 @@ void ImageDocument::createDocumentStructure()
     rootElement->appendChild(head);
 
     auto body = HTMLBodyElement::create(*this);
-    body->setAttribute(styleAttr, "margin: 0px"_s);
+    body->setAttribute(styleAttr, "margin: 0px; height: 100%"_s);
     if (MIMETypeRegistry::isPDFMIMEType(document().loader()->responseMIMEType()))
         body->setInlineStyleProperty(CSSPropertyBackgroundColor, "white"_s);
     rootElement->appendChild(body);
@@ -240,7 +241,7 @@ void ImageDocument::createDocumentStructure()
     if (m_shouldShrinkImage)
         imageElement->setAttribute(styleAttr, "-webkit-user-select:none; display:block; margin:auto; padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);"_s);
     else
-        imageElement->setAttribute(styleAttr, "-webkit-user-select:none; padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);"_s);
+        imageElement->setAttribute(styleAttr, "-webkit-user-select:none; display:block; padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);"_s);
     imageElement->setLoadManually(true);
     imageElement->setSrc(AtomString { url().string() });
     imageElement->cachedImage()->setResponse(loader()->response());

--- a/Source/WebCore/html/MediaDocument.cpp
+++ b/Source/WebCore/html/MediaDocument.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2022 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -141,7 +141,7 @@ void MediaDocumentParser::appendBytes(DocumentWriter&, const uint8_t*, size_t)
 MediaDocument::MediaDocument(Frame* frame, const Settings& settings, const URL& url)
     : HTMLDocument(frame, settings, url, { }, { DocumentClass::Media })
 {
-    setCompatibilityMode(DocumentCompatibilityMode::QuirksMode);
+    setCompatibilityMode(DocumentCompatibilityMode::NoQuirksMode);
     lockCompatibilityMode();
     if (frame)
         m_outgoingReferrer = frame->loader().outgoingReferrer();

--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,6 +72,8 @@ void PluginDocumentParser::createDocumentStructure()
     auto rootElement = HTMLHtmlElement::create(document);
     document.appendChild(rootElement);
     rootElement->insertedByParser();
+    rootElement->setInlineStyleProperty(CSSPropertyHeight, 100, CSSUnitType::CSS_PERCENTAGE);
+    rootElement->setInlineStyleProperty(CSSPropertyWidth, 100, CSSUnitType::CSS_PERCENTAGE);
 
     if (document.frame())
         document.frame()->injectUserScripts(UserScriptInjectionTime::DocumentStart);
@@ -85,9 +87,9 @@ void PluginDocumentParser::createDocumentStructure()
     body->setAttributeWithoutSynchronization(marginwidthAttr, "0"_s);
     body->setAttributeWithoutSynchronization(marginheightAttr, "0"_s);
 #if PLATFORM(IOS_FAMILY)
-    body->setAttribute(styleAttr, "background-color: rgb(217,224,233)"_s);
+    body->setAttribute(styleAttr, "background-color: rgb(217,224,233); height: 100%; width: 100%; overflow:hidden; margin: 0"_s);
 #else
-    body->setAttribute(styleAttr, "background-color: rgb(38,38,38)"_s);
+    body->setAttribute(styleAttr, "background-color: rgb(38,38,38); height: 100%; width: 100%; overflow:hidden; margin: 0"_s);
 #endif
 
     rootElement->appendChild(body);
@@ -147,7 +149,7 @@ void PluginDocumentParser::appendBytes(DocumentWriter&, const uint8_t*, size_t)
 PluginDocument::PluginDocument(Frame& frame, const URL& url)
     : HTMLDocument(&frame, frame.settings(), url, { }, { DocumentClass::Plugin })
 {
-    setCompatibilityMode(DocumentCompatibilityMode::QuirksMode);
+    setCompatibilityMode(DocumentCompatibilityMode::NoQuirksMode);
     lockCompatibilityMode();
 }
 

--- a/Source/WebCore/loader/SinkDocument.cpp
+++ b/Source/WebCore/loader/SinkDocument.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,7 +56,7 @@ private:
 SinkDocument::SinkDocument(Frame& frame, const URL& url)
     : HTMLDocument(&frame, frame.settings(), url, { })
 {
-    setCompatibilityMode(DocumentCompatibilityMode::QuirksMode);
+    setCompatibilityMode(DocumentCompatibilityMode::NoQuirksMode);
     lockCompatibilityMode();
 }
 


### PR DESCRIPTION
#### c9b4dccdaf956edcacbf76cd8b927420ae0129f7
<pre>
[Deprecation Reporting] Stub implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=245245">https://bugs.webkit.org/show_bug.cgi?id=245245</a>
&lt;rdar://problem/99988574&gt;

Reviewed by NOBODY (OOPS!).

Import the Web Platform Tests for the Deprecation Reporting API, create a new Experimental Feature flag to represent the
feature, and provide a stub implementation of the Deprecation Report Body.

Further work will be done to issue reports once the specification is clarify under what circumstances reports should
be generated.

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/META.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/w3c-import.log: Added.
* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/reporting/DeprecationReportBody.cpp: Added.
(WebCore::DeprecationReportBody::testReportType):
(WebCore::DeprecationReportBody::DeprecationReportBody):
(WebCore::DeprecationReportBody::create):
(WebCore::DeprecationReportBody::type const):
(WebCore::DeprecationReportBody::id const):
(WebCore::DeprecationReportBody::anticipatedRemoval const):
(WebCore::DeprecationReportBody::message const):
(WebCore::DeprecationReportBody::sourceFile const):
(WebCore::DeprecationReportBody::lineNumber const):
(WebCore::DeprecationReportBody::columnNumber const):
(WebCore::DeprecationReportBody::createReportFormDataForViolation):
* Source/WebCore/Modules/reporting/DeprecationReportBody.h: Copied from Source/WebCore/Modules/reporting/TestReportBody.h.
(WebCore::DeprecationReportBody::encode const):
(WebCore::DeprecationReportBody::decode):
(isType):
* Source/WebCore/Modules/reporting/DeprecationReportBody.idl: Copied from Source/WebCore/Modules/reporting/ViolationReportType.h.
* Source/WebCore/Modules/reporting/TestReportBody.h:
* Source/WebCore/Modules/reporting/ViolationReportType.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSReportBodyCustom.cpp:
(WebCore::toJSNewlyCreated): Add support for the new DeprecationReportBody.
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::sendViolationReport): Add support for the new DeprecationReportBody.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ReportBody&gt;&gt;::encode): Add support for the new DeprecationReportBody.
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ReportBody&gt;&gt;::decode): Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb948b45920726b60586ab893a85df28faafeb6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33911 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/20121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/98687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32416 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81713 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/93106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95000 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/25754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/76284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/25692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/80633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/20121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/68674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30183 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/20121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29913 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/20121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3177 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33361 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/76284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32069 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/20121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->