### PR TITLE
[CMake] Share utilities build after 254382@main

### DIFF
--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -20,6 +20,7 @@ endmacro()
 set(TestWTF_SOURCES
     Counters.cpp
     TestsController.cpp
+    Utilities.cpp
     WTFStringUtilities.cpp
 
     Tests/WTF/AtomString.cpp
@@ -172,6 +173,7 @@ endif ()
 if (ENABLE_WEBCORE)
     set(TestWebCore_SOURCES
         TestsController.cpp
+        Utilities.cpp
         WTFStringUtilities.cpp
 
         Tests/WebCore/AffineTransform.cpp
@@ -258,6 +260,8 @@ endif ()
 # TestWebKit definitions
 if (ENABLE_WEBKIT)
     set(TestWebKit_SOURCES
+        Utilities.cpp
+
         Tests/WebKit/AboutBlankLoad.cpp
         Tests/WebKit/CanHandleRequest.cpp
         Tests/WebKit/DOMWindowExtensionBasic.cpp
@@ -353,6 +357,8 @@ if (ENABLE_WEBKIT)
         InjectedBundleController.cpp
         InjectedBundleMain.cpp
         PlatformUtilities.cpp
+        Utilities.cpp
+
         Tests/WebKit/CanHandleRequest_Bundle.cpp
         Tests/WebKit/DidAssociateFormControls_Bundle.cpp
         Tests/WebKit/DOMWindowExtensionBasic_Bundle.cpp

--- a/Tools/TestWebKitAPI/PlatformGTK.cmake
+++ b/Tools/TestWebKitAPI/PlatformGTK.cmake
@@ -14,8 +14,6 @@ set(test_main_SOURCES gtk/main.cpp)
 list(APPEND TestWTF_SOURCES
     ${test_main_SOURCES}
 
-    Utilities.cpp
-
     Tests/WTF/glib/GRefPtr.cpp
     Tests/WTF/glib/GUniquePtr.cpp
     Tests/WTF/glib/WorkQueueGLib.cpp
@@ -32,8 +30,6 @@ list(APPEND TestWTF_LIBRARIES
 # TestWebCore
 list(APPEND TestWebCore_SOURCES
     ${test_main_SOURCES}
-
-    Utilities.cpp
 
     Tests/WebCore/UserAgentQuirks.cpp
     Tests/WebCore/gstreamer/GStreamerTest.cpp
@@ -56,8 +52,6 @@ list(APPEND TestWebCore_LIBRARIES
 # TestWebKit
 list(APPEND TestWebKit_SOURCES
     ${test_main_SOURCES}
-
-    Utilities.cpp
 
     gtk/PlatformUtilitiesGtk.cpp
     gtk/PlatformWebViewGtk.cpp
@@ -82,8 +76,6 @@ target_include_directories(TestWebKitAPIBase PRIVATE "${CMAKE_SOURCE_DIR}/Source
 # TestWebKitAPIInjectedBundle
 target_sources(TestWebKitAPIInjectedBundle PRIVATE
     gtk/PlatformUtilitiesGtk.cpp
-
-    Utilities.cpp
 )
 target_include_directories(TestWebKitAPIInjectedBundle PRIVATE
     "${CMAKE_SOURCE_DIR}/Source"

--- a/Tools/TestWebKitAPI/PlatformJSCOnly.cmake
+++ b/Tools/TestWebKitAPI/PlatformJSCOnly.cmake
@@ -5,7 +5,5 @@ list(APPEND TestWTF_SOURCES generic/main.cpp)
 if (LOWERCASE_EVENT_LOOP_TYPE STREQUAL "glib")
     list(APPEND TestWTF_PRIVATE_INCLUDE_DIRECTORIES
         ${GLIB_INCLUDE_DIRS}
-
-        Utilities.cpp
     )
 endif ()

--- a/Tools/TestWebKitAPI/PlatformPlayStation.cmake
+++ b/Tools/TestWebKitAPI/PlatformPlayStation.cmake
@@ -34,8 +34,6 @@ if (ENABLE_WEBKIT)
     list(APPEND TestWebKit_SOURCES
         ${test_main_SOURCES}
 
-        Utilities.cpp
-
         Tests/WebKit/curl/Certificates.cpp
 
         playstation/PlatformUtilitiesPlayStation.cpp

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -14,8 +14,6 @@ set(test_main_SOURCES generic/main.cpp)
 list(APPEND TestWTF_SOURCES
     ${test_main_SOURCES}
 
-    Utilities.cpp
-
     Tests/WTF/glib/GRefPtr.cpp
     Tests/WTF/glib/GUniquePtr.cpp
     Tests/WTF/glib/WorkQueueGLib.cpp
@@ -34,8 +32,6 @@ list(APPEND TestJavaScriptCore_SYSTEM_INCLUDE_DIRECTORIES
 list(APPEND TestWebCore_SOURCES
     ${test_main_SOURCES}
 
-    Utilities.cpp
-
     Tests/WebCore/UserAgentQuirks.cpp
     Tests/WebCore/gstreamer/GStreamerTest.cpp
     Tests/WebCore/gstreamer/GstMappedBuffer.cpp
@@ -53,8 +49,6 @@ list(APPEND TestWebCore_SYSTEM_INCLUDE_DIRECTORIES
 # TestWebKit
 list(APPEND TestWebKit_SOURCES
     ${test_main_SOURCES}
-
-    Utilities.cpp
 
     wpe/PlatformUtilitiesWPE.cpp
     wpe/PlatformWebViewWPE.cpp
@@ -84,8 +78,6 @@ target_include_directories(TestWebKitAPIBase PRIVATE
 
 # TestWebKitAPIInjectedBundle
 target_sources(TestWebKitAPIInjectedBundle PRIVATE
-    Utilities.cpp
-
     wpe/PlatformUtilitiesWPE.cpp
 )
 target_include_directories(TestWebKitAPIInjectedBundle PRIVATE

--- a/Tools/TestWebKitAPI/PlatformWin.cmake
+++ b/Tools/TestWebKitAPI/PlatformWin.cmake
@@ -13,7 +13,6 @@ set(test_main_SOURCES
 # TestWTF
 list(APPEND TestWTF_SOURCES
     ${test_main_SOURCES}
-    Utilities.cpp
 )
 
 WEBKIT_WRAP_EXECUTABLE(TestWTF
@@ -118,15 +117,11 @@ endif ()
 # TestWebKit
 if (ENABLE_WEBKIT)
     target_sources(TestWebKitAPIInjectedBundle PRIVATE
-        Utilities.cpp
-
         win/PlatformUtilitiesWin.cpp
     )
 
     list(APPEND TestWebKit_SOURCES
         ${test_main_SOURCES}
-
-        Utilities.cpp
 
         Tests/WebKit/CookieStorageFile.cpp
 


### PR DESCRIPTION
#### 440d3b257da6fce84947ddd42b7db47d1200edd3
<pre>
[CMake] Share utilities build after 254382@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=245089">https://bugs.webkit.org/show_bug.cgi?id=245089</a>

Reviewed by Michael Catanzaro.

In 254382@main all of the `TestWebKitAPI::Util` code in `Utilities.h`
was consolidated for all non-Cocoa ports. When updating the build the
ports specific implementation was just replaced with `Utilities.cpp`.
Instead of specifying it per port the `Utilities.cpp` is added to the
sources. For Cocoa ports the implementation in there is guarded with
`!PLATFORM(COCOA)` so it is safe to add it.

* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/PlatformGTK.cmake:
* Tools/TestWebKitAPI/PlatformJSCOnly.cmake:
* Tools/TestWebKitAPI/PlatformPlayStation.cmake:
* Tools/TestWebKitAPI/PlatformWPE.cmake:
* Tools/TestWebKitAPI/PlatformWin.cmake:

Canonical link: <a href="https://commits.webkit.org/254412@main">https://commits.webkit.org/254412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8904d9f5dfcbd05ed9df376bbe65d8fff2bdf503

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33535 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/19844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98253 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/92967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32040 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81336 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92786 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25446 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/75944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25379 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80313 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/19844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68346 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/80685 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29831 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/19844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74473 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29562 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/19844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26299 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3089 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33001 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/75944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/77334 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31691 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/19844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17132 "Passed tests") | 
<!--EWS-Status-Bubble-End-->