### PR TITLE
workers/interfaces/WorkerUtils/importScripts/catch.sub.any.*.html WPT tests are failing in WebKit

### DIFF
--- a/LayoutTests/http/tests/workers/worker-importScriptsOnError-expected.txt
+++ b/LayoutTests/http/tests/workers/worker-importScriptsOnError-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Error: Script error.
+CONSOLE MESSAGE: NetworkError: Network response is CORS-cross-origin
 Test importScripts with error.
 
 
@@ -20,7 +20,7 @@ filename: http://127.0.0.1:8000/workers/resources/worker-importScripts-error.js,
 initEvent: function initEvent() { [native code] },
 isTrusted: true,
 lineno: 2,
-message: Error: Script error.,
+message: NetworkError: Network response is CORS-cross-origin,
 preventDefault: function preventDefault() { [native code] },
 returnValue: true,
 srcElement: [object Worker],

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/catch.sub.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/catch.sub.any.serviceworker-expected.txt
@@ -1,20 +1,8 @@
 
 PASS Same-origin syntax error
 PASS Same-origin throw
-FAIL Cross-origin syntax error assert_throws_dom: function "function () {
-    importScripts(crossOrigin +
-                  "/workers/modules/resources/syntax-error.js");
-  }" threw object "Error: Script error." that is not a DOMException NetworkError: property "code" is equal to undefined, expected 19
-FAIL Cross-origin throw assert_throws_dom: function "function () {
-    importScripts(crossOrigin +
-                  "/workers/modules/resources/throw.js");
-  }" threw object "Error: Script error." that is not a DOMException NetworkError: property "code" is equal to undefined, expected 19
-FAIL Redirect-to-cross-origin syntax error assert_throws_dom: function "function () {
-    importScripts(redirectToCrossOrigin +
-                  "/workers/modules/resources/syntax-error.js");
-  }" threw object "Error: Script error." that is not a DOMException NetworkError: property "code" is equal to undefined, expected 19
-FAIL Redirect-to-Cross-origin throw assert_throws_dom: function "function () {
-    importScripts(redirectToCrossOrigin +
-                  "/workers/modules/resources/throw.js");
-  }" threw object "Error: Script error." that is not a DOMException NetworkError: property "code" is equal to undefined, expected 19
+PASS Cross-origin syntax error
+PASS Cross-origin throw
+PASS Redirect-to-cross-origin syntax error
+PASS Redirect-to-Cross-origin throw
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/catch.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/catch.sub.any.sharedworker-expected.txt
@@ -1,20 +1,8 @@
 
 PASS Same-origin syntax error
 PASS Same-origin throw
-FAIL Cross-origin syntax error assert_throws_dom: function "function () {
-    importScripts(crossOrigin +
-                  "/workers/modules/resources/syntax-error.js");
-  }" threw object "Error: Script error." that is not a DOMException NetworkError: property "code" is equal to undefined, expected 19
-FAIL Cross-origin throw assert_throws_dom: function "function () {
-    importScripts(crossOrigin +
-                  "/workers/modules/resources/throw.js");
-  }" threw object "Error: Script error." that is not a DOMException NetworkError: property "code" is equal to undefined, expected 19
-FAIL Redirect-to-cross-origin syntax error assert_throws_dom: function "function () {
-    importScripts(redirectToCrossOrigin +
-                  "/workers/modules/resources/syntax-error.js");
-  }" threw object "Error: Script error." that is not a DOMException NetworkError: property "code" is equal to undefined, expected 19
-FAIL Redirect-to-Cross-origin throw assert_throws_dom: function "function () {
-    importScripts(redirectToCrossOrigin +
-                  "/workers/modules/resources/throw.js");
-  }" threw object "Error: Script error." that is not a DOMException NetworkError: property "code" is equal to undefined, expected 19
+PASS Cross-origin syntax error
+PASS Cross-origin throw
+PASS Redirect-to-cross-origin syntax error
+PASS Redirect-to-Cross-origin throw
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/catch.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/catch.sub.any.worker-expected.txt
@@ -1,20 +1,8 @@
 
 PASS Same-origin syntax error
 PASS Same-origin throw
-FAIL Cross-origin syntax error assert_throws_dom: function "function () {
-    importScripts(crossOrigin +
-                  "/workers/modules/resources/syntax-error.js");
-  }" threw object "Error: Script error." that is not a DOMException NetworkError: property "code" is equal to undefined, expected 19
-FAIL Cross-origin throw assert_throws_dom: function "function () {
-    importScripts(crossOrigin +
-                  "/workers/modules/resources/throw.js");
-  }" threw object "Error: Script error." that is not a DOMException NetworkError: property "code" is equal to undefined, expected 19
-FAIL Redirect-to-cross-origin syntax error assert_throws_dom: function "function () {
-    importScripts(redirectToCrossOrigin +
-                  "/workers/modules/resources/syntax-error.js");
-  }" threw object "Error: Script error." that is not a DOMException NetworkError: property "code" is equal to undefined, expected 19
-FAIL Redirect-to-Cross-origin throw assert_throws_dom: function "function () {
-    importScripts(redirectToCrossOrigin +
-                  "/workers/modules/resources/throw.js");
-  }" threw object "Error: Script error." that is not a DOMException NetworkError: property "code" is equal to undefined, expected 19
+PASS Cross-origin syntax error
+PASS Cross-origin throw
+PASS Redirect-to-cross-origin syntax error
+PASS Redirect-to-Cross-origin throw
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-cross-origin.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-cross-origin.sub.any.sharedworker-expected.txt
@@ -1,9 +1,5 @@
 
-FAIL WorkerGlobalScope error event: error assert_equals: e.error should be a DOMException expected function "function DOMException() {
-    [native code]
-}" but got function "function Error() {
-    [native code]
-}"
+PASS WorkerGlobalScope error event: error
 PASS WorkerGlobalScope error event: message
 PASS WorkerGlobalScope error event: filename
 PASS WorkerGlobalScope error event: lineno

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-cross-origin.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-cross-origin.sub.any.worker-expected.txt
@@ -1,9 +1,5 @@
 
-FAIL WorkerGlobalScope error event: error assert_equals: e.error should be a DOMException expected function "function DOMException() {
-    [native code]
-}" but got function "function Error() {
-    [native code]
-}"
+PASS WorkerGlobalScope error event: error
 PASS WorkerGlobalScope error event: message
 PASS WorkerGlobalScope error event: filename
 PASS WorkerGlobalScope error event: lineno

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-redirect-to-cross-origin.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-redirect-to-cross-origin.sub.any.sharedworker-expected.txt
@@ -1,9 +1,5 @@
 
-FAIL WorkerGlobalScope error event: error assert_equals: e.error should be a DOMException expected function "function DOMException() {
-    [native code]
-}" but got function "function Error() {
-    [native code]
-}"
+PASS WorkerGlobalScope error event: error
 PASS WorkerGlobalScope error event: message
 PASS WorkerGlobalScope error event: filename
 PASS WorkerGlobalScope error event: lineno

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-redirect-to-cross-origin.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-redirect-to-cross-origin.sub.any.worker-expected.txt
@@ -1,9 +1,5 @@
 
-FAIL WorkerGlobalScope error event: error assert_equals: e.error should be a DOMException expected function "function DOMException() {
-    [native code]
-}" but got function "function Error() {
-    [native code]
-}"
+PASS WorkerGlobalScope error event: error
 PASS WorkerGlobalScope error event: message
 PASS WorkerGlobalScope error event: filename
 PASS WorkerGlobalScope error event: lineno

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-cross-origin.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-cross-origin.sub.any.sharedworker-expected.txt
@@ -1,9 +1,5 @@
 
-FAIL WorkerGlobalScope error event: error assert_equals: e.error should be a DOMException expected function "function DOMException() {
-    [native code]
-}" but got function "function Error() {
-    [native code]
-}"
+PASS WorkerGlobalScope error event: error
 PASS WorkerGlobalScope error event: message
 PASS WorkerGlobalScope error event: filename
 PASS WorkerGlobalScope error event: lineno

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-cross-origin.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-cross-origin.sub.any.worker-expected.txt
@@ -1,9 +1,5 @@
 
-FAIL WorkerGlobalScope error event: error assert_equals: e.error should be a DOMException expected function "function DOMException() {
-    [native code]
-}" but got function "function Error() {
-    [native code]
-}"
+PASS WorkerGlobalScope error event: error
 PASS WorkerGlobalScope error event: message
 PASS WorkerGlobalScope error event: filename
 PASS WorkerGlobalScope error event: lineno

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-redirect-to-cross-origin.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-redirect-to-cross-origin.sub.any.sharedworker-expected.txt
@@ -1,9 +1,5 @@
 
-FAIL WorkerGlobalScope error event: error assert_equals: e.error should be a DOMException expected function "function DOMException() {
-    [native code]
-}" but got function "function Error() {
-    [native code]
-}"
+PASS WorkerGlobalScope error event: error
 PASS WorkerGlobalScope error event: message
 PASS WorkerGlobalScope error event: filename
 PASS WorkerGlobalScope error event: lineno

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-redirect-to-cross-origin.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-redirect-to-cross-origin.sub.any.worker-expected.txt
@@ -1,9 +1,5 @@
 
-FAIL WorkerGlobalScope error event: error assert_equals: e.error should be a DOMException expected function "function DOMException() {
-    [native code]
-}" but got function "function Error() {
-    [native code]
-}"
+PASS WorkerGlobalScope error event: error
 PASS WorkerGlobalScope error event: message
 PASS WorkerGlobalScope error event: filename
 PASS WorkerGlobalScope error event: lineno

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -477,7 +477,7 @@ void CachedResource::setResponse(const ResourceResponse& response)
     }
 #endif
     m_response.setRedirected(m_redirectChainCacheStatus.status != RedirectChainCacheStatus::Status::NoRedirection);
-    if (m_response.tainting() == ResourceResponse::Tainting::Basic || m_response.tainting() == ResourceResponse::Tainting::Cors)
+    if ((m_response.tainting() == ResourceResponse::Tainting::Basic || m_response.tainting() == ResourceResponse::Tainting::Cors) && !m_response.url().protocolIsData())
         m_response.setTainting(m_responseTainting);
 }
 

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -248,6 +248,7 @@ void WorkerScriptLoader::didReceiveResponse(ResourceLoaderIdentifier identifier,
     m_certificateInfo = response.certificateInfo() ? *response.certificateInfo() : CertificateInfo();
     m_responseMIMEType = response.mimeType();
     m_responseSource = response.source();
+    m_responseTainting = response.tainting();
     m_isRedirected = response.isRedirected();
     m_contentSecurityPolicy = ContentSecurityPolicyResponseHeaders { response };
     if (m_isCOEPEnabled)

--- a/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/Source/WebCore/workers/WorkerScriptLoader.h
@@ -81,6 +81,7 @@ public:
     bool isRedirected() const { return m_isRedirected; }
     const CertificateInfo& certificateInfo() const { return m_certificateInfo; }
     const String& responseMIMEType() const { return m_responseMIMEType; }
+    ResourceResponse::Tainting responseTainting() const { return m_responseTainting; }
     bool failed() const { return m_failed; }
     ResourceLoaderIdentifier identifier() const { return m_identifier; }
     const ResourceError& error() const { return m_error; }
@@ -137,6 +138,7 @@ private:
     bool m_isRedirected { false };
     bool m_isCOEPEnabled { false };
     ResourceResponse::Source m_responseSource { ResourceResponse::Source::Unknown };
+    ResourceResponse::Tainting m_responseTainting { ResourceResponse::Tainting::Basic };
     ResourceError m_error;
     ScriptExecutionContextIdentifier m_clientIdentifier;
 #if ENABLE(SERVICE_WORKER)


### PR DESCRIPTION
#### d9c375a06164c8ed5126013714208853be9d6833
<pre>
workers/interfaces/WorkerUtils/importScripts/catch.sub.any.*.html WPT tests are failing in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=245098">https://bugs.webkit.org/show_bug.cgi?id=245098</a>

Reviewed by Darin Adler.

Implement the &quot;muted error&quot; logic from:
- <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-imported-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-imported-script</a> (step 8)

* LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/catch.sub.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/catch.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/catch.sub.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-cross-origin.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-cross-origin.sub.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-redirect-to-cross-origin.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-redirect-to-cross-origin.sub.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-cross-origin.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-cross-origin.sub.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-redirect-to-cross-origin.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-redirect-to-cross-origin.sub.any.worker-expected.txt:
Rebaseline tests that are now passing.

* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::setResponse):
Response tainting should be &quot;basic&quot; for data URLs:
- <a href="https://fetch.spec.whatwg.org/#concept-main-fetch">https://fetch.spec.whatwg.org/#concept-main-fetch</a> (Step 11)

* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::importScripts):
Implemented the &quot;muted errors&quot; logic from:
- <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-imported-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-imported-script</a> (step 8)

* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::didReceiveResponse):
* Source/WebCore/workers/WorkerScriptLoader.h:
(WebCore::WorkerScriptLoader::responseTainting const):
Keep track for the response&apos;s tainting so that we can use it in importScripts.

Canonical link: <a href="https://commits.webkit.org/254447@main">https://commits.webkit.org/254447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6df07227f2ebbe22370ce3bf19ddad87fc00ccb9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98295 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154652 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32072 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27656 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81370 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92814 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25463 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75966 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25405 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68374 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29863 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14394 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29594 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15371 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38315 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1309 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34466 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->