### PR TITLE
Generate more serialization code

### DIFF
--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -2279,7 +2279,7 @@ RefPtr<WebGLActiveInfo> WebGL2RenderingContext::getTransformFeedbackVarying(WebG
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "getTransformFeedbackVarying", "program not linked");
         return nullptr;
     }
-    GraphicsContextGL::ActiveInfo info;
+    GraphicsContextGLActiveInfo info;
     m_context->getTransformFeedbackVarying(program.object(), index, info);
 
     if (!info.name || !info.type || !info.size)

--- a/Source/WebCore/html/canvas/WebGLProgram.cpp
+++ b/Source/WebCore/html/canvas/WebGLProgram.cpp
@@ -221,7 +221,7 @@ void WebGLProgram::cacheActiveAttribLocations(GraphicsContextGL* context3d)
     GCGLint numAttribs = context3d->getProgrami(object(), GraphicsContextGL::ACTIVE_ATTRIBUTES);
     m_activeAttribLocations.resize(static_cast<size_t>(numAttribs));
     for (int i = 0; i < numAttribs; ++i) {
-        GraphicsContextGL::ActiveInfo info;
+        GraphicsContextGLActiveInfo info;
 #if USE(ANGLE)
         context3d->getActiveAttrib(object(), i, info);
 #else

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3090,7 +3090,7 @@ RefPtr<WebGLActiveInfo> WebGLRenderingContextBase::getActiveAttrib(WebGLProgram&
 {
     if (!validateWebGLProgramOrShader("getActiveAttrib", &program))
         return nullptr;
-    GraphicsContextGL::ActiveInfo info;
+    GraphicsContextGLActiveInfo info;
     if (!m_context->getActiveAttrib(program.object(), index, info))
         return nullptr;
 
@@ -3103,7 +3103,7 @@ RefPtr<WebGLActiveInfo> WebGLRenderingContextBase::getActiveUniform(WebGLProgram
 {
     if (!validateWebGLProgramOrShader("getActiveUniform", &program))
         return nullptr;
-    GraphicsContextGL::ActiveInfo info;
+    GraphicsContextGLActiveInfo info;
     if (!m_context->getActiveUniform(program.object(), index, info))
         return nullptr;
     // FIXME: Do we still need this for the ANGLE backend?
@@ -3944,7 +3944,7 @@ RefPtr<WebGLUniformLocation> WebGLRenderingContextBase::getUniformLocation(WebGL
     static_cast<GraphicsContextGLOpenGL*>(m_context.get())->getNonBuiltInActiveSymbolCount(program.object(), GraphicsContextGL::ACTIVE_UNIFORMS, &activeUniforms);
 #endif
     for (GCGLint i = 0; i < activeUniforms; i++) {
-        GraphicsContextGL::ActiveInfo info;
+        GraphicsContextGLActiveInfo info;
         if (!m_context->getActiveUniform(program.object(), i, info))
             return nullptr;
         // Strip "[0]" from the name if it's an array.

--- a/Source/WebCore/loader/ResourceLoadObserver.h
+++ b/Source/WebCore/loader/ResourceLoadObserver.h
@@ -57,8 +57,8 @@ public:
     virtual void logFontLoad(const Document&, const String& /* familyName */, bool /* loadStatus */) { }
     virtual void logCanvasRead(const Document&) { }
     virtual void logCanvasWriteOrMeasure(const Document&, const String& /* textWritten */) { }
-    virtual void logNavigatorAPIAccessed(const Document&, const ResourceLoadStatistics::NavigatorAPI) { }
-    virtual void logScreenAPIAccessed(const Document&, const ResourceLoadStatistics::ScreenAPI) { }
+    virtual void logNavigatorAPIAccessed(const Document&, const NavigatorAPIsAccessed) { }
+    virtual void logScreenAPIAccessed(const Document&, const ScreenAPIsAccessed) { }
     virtual void logSubresourceLoadingForTesting(const RegistrableDomain& /* firstPartyDomain */, const RegistrableDomain& /* thirdPartyDomain */, bool /* shouldScheduleNotification */) { }
 
     virtual String statisticsForURL(const URL&) { return { }; }

--- a/Source/WebCore/loader/ResourceLoadStatistics.cpp
+++ b/Source/WebCore/loader/ResourceLoadStatistics.cpp
@@ -375,49 +375,49 @@ static void appendHashSet(StringBuilder& builder, const String& label, const Has
         builder.append("        ", entry, '\n');
 }
 
-static ASCIILiteral navigatorAPIEnumToString(ResourceLoadStatistics::NavigatorAPI navigatorEnum)
+static ASCIILiteral navigatorAPIEnumToString(NavigatorAPIsAccessed navigatorEnum)
 {
     switch (navigatorEnum) {
-    case ResourceLoadStatistics::NavigatorAPI::MimeTypes:
+    case NavigatorAPIsAccessed::MimeTypes:
         return "mimeTypes"_s;
-    case ResourceLoadStatistics::NavigatorAPI::CookieEnabled:
+    case NavigatorAPIsAccessed::CookieEnabled:
         return "cookieEnabled"_s;
-    case ResourceLoadStatistics::NavigatorAPI::Plugins:
+    case NavigatorAPIsAccessed::Plugins:
         return "plugins"_s;
-    case ResourceLoadStatistics::NavigatorAPI::UserAgent:
+    case NavigatorAPIsAccessed::UserAgent:
         return "userAgent"_s;
-    case ResourceLoadStatistics::NavigatorAPI::AppVersion:
+    case NavigatorAPIsAccessed::AppVersion:
         return "appVersion"_s;
     }
     ASSERT_NOT_REACHED();
     return "Invalid navigator API"_s;
 }
 
-static ASCIILiteral screenAPIEnumToString(ResourceLoadStatistics::ScreenAPI screenEnum)
+static ASCIILiteral screenAPIEnumToString(ScreenAPIsAccessed screenEnum)
 {
     switch (screenEnum) {
-    case ResourceLoadStatistics::ScreenAPI::Height:
+    case ScreenAPIsAccessed::Height:
         return "height"_s;
-    case ResourceLoadStatistics::ScreenAPI::Width:
+    case ScreenAPIsAccessed::Width:
         return "width"_s;
-    case ResourceLoadStatistics::ScreenAPI::ColorDepth:
+    case ScreenAPIsAccessed::ColorDepth:
         return "colorDepth"_s;
-    case ResourceLoadStatistics::ScreenAPI::PixelDepth:
+    case ScreenAPIsAccessed::PixelDepth:
         return "pixelDepth"_s;
-    case ResourceLoadStatistics::ScreenAPI::AvailLeft:
+    case ScreenAPIsAccessed::AvailLeft:
         return "availLeft"_s;
-    case ResourceLoadStatistics::ScreenAPI::AvailTop:
+    case ScreenAPIsAccessed::AvailTop:
         return "availTop"_s;
-    case ResourceLoadStatistics::ScreenAPI::AvailHeight:
+    case ScreenAPIsAccessed::AvailHeight:
         return "availHeight"_s;
-    case ResourceLoadStatistics::ScreenAPI::AvailWidth:
+    case ScreenAPIsAccessed::AvailWidth:
         return "availWidth"_s;
     }
     ASSERT_NOT_REACHED();
     return "Invalid screen API"_s;
 }
     
-static void appendNavigatorAPIOptionSet(StringBuilder& builder, const OptionSet<ResourceLoadStatistics::NavigatorAPI>& optionSet)
+static void appendNavigatorAPIOptionSet(StringBuilder& builder, const OptionSet<NavigatorAPIsAccessed>& optionSet)
 {
     if (optionSet.isEmpty())
         return;
@@ -426,7 +426,7 @@ static void appendNavigatorAPIOptionSet(StringBuilder& builder, const OptionSet<
         builder.append("        ", navigatorAPIEnumToString(navigatorAPI), '\n');
 }
     
-static void appendScreenAPIOptionSet(StringBuilder& builder, const OptionSet<ResourceLoadStatistics::ScreenAPI>& optionSet)
+static void appendScreenAPIOptionSet(StringBuilder& builder, const OptionSet<ScreenAPIsAccessed>& optionSet)
 {
     if (optionSet.isEmpty())
         return;

--- a/Source/WebCore/loader/ResourceLoadStatistics.h
+++ b/Source/WebCore/loader/ResourceLoadStatistics.h
@@ -27,6 +27,7 @@
 
 #include "CanvasActivityRecord.h"
 #include "RegistrableDomain.h"
+#include <wtf/ArgumentCoder.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
@@ -39,6 +40,25 @@ namespace WebCore {
 
 class KeyedDecoder;
 class KeyedEncoder;
+
+enum class NavigatorAPIsAccessed : uint64_t {
+    AppVersion = 1 << 0,
+    UserAgent = 1 << 1,
+    Plugins = 1 << 2,
+    MimeTypes = 1 << 3,
+    CookieEnabled = 1 << 4,
+};
+
+enum class ScreenAPIsAccessed : uint64_t {
+    Height = 1 << 0,
+    Width = 1 << 1,
+    ColorDepth = 1 << 2,
+    PixelDepth = 1 << 3,
+    AvailLeft = 1 << 4,
+    AvailTop = 1 << 5,
+    AvailHeight = 1 << 6,
+    AvailWidth = 1 << 7,
+};
 
 struct ResourceLoadStatistics {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
@@ -103,23 +123,6 @@ struct ResourceLoadStatistics {
 
     enum class IsEphemeral : bool { No, Yes };
 
-    enum class NavigatorAPI : uint64_t {
-        AppVersion = 1 << 0,
-        UserAgent = 1 << 1,
-        Plugins = 1 << 2,
-        MimeTypes = 1 << 3,
-        CookieEnabled = 1 << 4,
-    };
-    enum class ScreenAPI : uint64_t {
-        Height = 1 << 0,
-        Width = 1 << 1,
-        ColorDepth = 1 << 2,
-        PixelDepth = 1 << 3,
-        AvailLeft = 1 << 4,
-        AvailTop = 1 << 5,
-        AvailHeight = 1 << 6,
-        AvailWidth = 1 << 7,
-    };
 #if ENABLE(WEB_API_STATISTICS)
     // This set represents the registrable domain of the top frame where web API
     // were used in the top frame or one of its subframes.
@@ -127,38 +130,10 @@ struct ResourceLoadStatistics {
     HashSet<String> fontsFailedToLoad;
     HashSet<String> fontsSuccessfullyLoaded;
     CanvasActivityRecord canvasActivityRecord;
-    OptionSet<NavigatorAPI> navigatorFunctionsAccessed;
-    OptionSet<ScreenAPI> screenFunctionsAccessed;
+    OptionSet<NavigatorAPIsAccessed> navigatorFunctionsAccessed;
+    OptionSet<ScreenAPIsAccessed> screenFunctionsAccessed;
 #endif
+    friend struct IPC::ArgumentCoder<ResourceLoadStatistics, void>;
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ResourceLoadStatistics::NavigatorAPI> {
-    using values = EnumValues<
-        WebCore::ResourceLoadStatistics::NavigatorAPI,
-        WebCore::ResourceLoadStatistics::NavigatorAPI::AppVersion,
-        WebCore::ResourceLoadStatistics::NavigatorAPI::UserAgent,
-        WebCore::ResourceLoadStatistics::NavigatorAPI::Plugins,
-        WebCore::ResourceLoadStatistics::NavigatorAPI::MimeTypes,
-        WebCore::ResourceLoadStatistics::NavigatorAPI::CookieEnabled
-    >;
-};
-
-template<> struct EnumTraits<WebCore::ResourceLoadStatistics::ScreenAPI> {
-    using values = EnumValues<
-        WebCore::ResourceLoadStatistics::ScreenAPI,
-        WebCore::ResourceLoadStatistics::ScreenAPI::Height,
-        WebCore::ResourceLoadStatistics::ScreenAPI::Width,
-        WebCore::ResourceLoadStatistics::ScreenAPI::ColorDepth,
-        WebCore::ResourceLoadStatistics::ScreenAPI::PixelDepth,
-        WebCore::ResourceLoadStatistics::ScreenAPI::AvailLeft,
-        WebCore::ResourceLoadStatistics::ScreenAPI::AvailTop,
-        WebCore::ResourceLoadStatistics::ScreenAPI::AvailHeight,
-        WebCore::ResourceLoadStatistics::ScreenAPI::AvailWidth
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -73,7 +73,7 @@ String Navigator::appVersion() const
     if (!frame)
         return String();
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), ResourceLoadStatistics::NavigatorAPI::AppVersion);
+        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::AppVersion);
     return NavigatorBase::appVersion();
 }
 
@@ -83,7 +83,7 @@ const String& Navigator::userAgent() const
     if (!frame || !frame->page())
         return m_userAgent;
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), ResourceLoadStatistics::NavigatorAPI::UserAgent);
+        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::UserAgent);
     if (m_userAgent.isNull())
         m_userAgent = frame->loader().userAgent(frame->document()->url());
     return m_userAgent;
@@ -288,7 +288,7 @@ DOMPluginArray& Navigator::plugins()
 {
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled()) {
         if (auto* frame = this->frame())
-            ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), ResourceLoadStatistics::NavigatorAPI::Plugins);
+            ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::Plugins);
     }
     initializePluginAndMimeTypeArrays();
     return *m_plugins;
@@ -298,7 +298,7 @@ DOMMimeTypeArray& Navigator::mimeTypes()
 {
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled()) {
         if (auto* frame = this->frame())
-            ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), ResourceLoadStatistics::NavigatorAPI::MimeTypes);
+            ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::MimeTypes);
     }
     initializePluginAndMimeTypeArrays();
     return *m_mimeTypes;
@@ -311,7 +311,7 @@ bool Navigator::cookieEnabled() const
         return false;
 
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), ResourceLoadStatistics::NavigatorAPI::CookieEnabled);
+        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::CookieEnabled);
 
     auto* page = frame->page();
     if (!page)

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -56,7 +56,7 @@ unsigned Screen::height() const
     if (!frame)
         return 0;
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ResourceLoadStatistics::ScreenAPI::Height);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::Height);
     return static_cast<unsigned>(frame->screenSize().height());
 }
 
@@ -66,7 +66,7 @@ unsigned Screen::width() const
     if (!frame)
         return 0;
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ResourceLoadStatistics::ScreenAPI::Width);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::Width);
     return static_cast<unsigned>(frame->screenSize().width());
 }
 
@@ -76,7 +76,7 @@ unsigned Screen::colorDepth() const
     if (!frame)
         return 0;
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ResourceLoadStatistics::ScreenAPI::ColorDepth);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::ColorDepth);
     return static_cast<unsigned>(screenDepth(frame->view()));
 }
 
@@ -86,7 +86,7 @@ unsigned Screen::pixelDepth() const
     if (!frame)
         return 0;
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ResourceLoadStatistics::ScreenAPI::PixelDepth);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::PixelDepth);
 
     auto* document = window()->document();
     if (!document || !document->quirks().needsHDRPixelDepthQuirk() || !screenSupportsHighDynamicRange(frame->view()))
@@ -101,7 +101,7 @@ int Screen::availLeft() const
     if (!frame)
         return 0;
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ResourceLoadStatistics::ScreenAPI::AvailLeft);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailLeft);
     return static_cast<int>(screenAvailableRect(frame->view()).x());
 }
 
@@ -111,7 +111,7 @@ int Screen::availTop() const
     if (!frame)
         return 0;
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ResourceLoadStatistics::ScreenAPI::AvailTop);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailTop);
     return static_cast<int>(screenAvailableRect(frame->view()).y());
 }
 
@@ -121,7 +121,7 @@ unsigned Screen::availHeight() const
     if (!frame)
         return 0;
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ResourceLoadStatistics::ScreenAPI::AvailHeight);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailHeight);
     return static_cast<unsigned>(screenAvailableRect(frame->view()).height());
 }
 
@@ -131,7 +131,7 @@ unsigned Screen::availWidth() const
     if (!frame)
         return 0;
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ResourceLoadStatistics::ScreenAPI::AvailWidth);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailWidth);
     return static_cast<unsigned>(screenAvailableRect(frame->view()).width());
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -58,6 +58,12 @@ class MediaPlayer;
 class VideoFrame;
 #endif
 
+struct GraphicsContextGLActiveInfo {
+    String name;
+    GCGLenum type;
+    GCGLint size;
+};
+
 // Base class for graphics context for implementing WebGL rendering model.
 class GraphicsContextGL : public RefCounted<GraphicsContextGL> {
 public:
@@ -1068,12 +1074,6 @@ public:
         virtual void dispatchContextChangedNotification() = 0;
     };
 
-    struct ActiveInfo {
-        String name;
-        GCGLenum type;
-        GCGLint size;
-    };
-
     WEBCORE_EXPORT GraphicsContextGL(GraphicsContextGLAttributes);
     WEBCORE_EXPORT virtual ~GraphicsContextGL();
 
@@ -1139,8 +1139,8 @@ public:
 
     virtual void generateMipmap(GCGLenum target) = 0;
 
-    virtual bool getActiveAttrib(PlatformGLObject program, GCGLuint index, ActiveInfo&) = 0;
-    virtual bool getActiveUniform(PlatformGLObject program, GCGLuint index, ActiveInfo&) = 0;
+    virtual bool getActiveAttrib(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&) = 0;
+    virtual bool getActiveUniform(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&) = 0;
 
     virtual GCGLint getAttribLocation(PlatformGLObject, const String& name) = 0;
 
@@ -1371,7 +1371,7 @@ public:
     virtual void beginTransformFeedback(GCGLenum primitiveMode) = 0;
     virtual void endTransformFeedback() = 0;
     virtual void transformFeedbackVaryings(PlatformGLObject program, const Vector<String>& varyings, GCGLenum bufferMode) = 0;
-    virtual void getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, ActiveInfo&) = 0;
+    virtual void getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&) = 0;
     virtual void pauseTransformFeedback() = 0;
     virtual void resumeTransformFeedback() = 0;
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -1185,7 +1185,7 @@ void GraphicsContextGLANGLE::generateMipmap(GCGLenum target)
     GL_GenerateMipmap(target);
 }
 
-bool GraphicsContextGLANGLE::getActiveAttribImpl(PlatformGLObject program, GCGLuint index, ActiveInfo& info)
+bool GraphicsContextGLANGLE::getActiveAttribImpl(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo& info)
 {
     if (!program) {
         synthesizeGLError(INVALID_VALUE);
@@ -1210,12 +1210,12 @@ bool GraphicsContextGLANGLE::getActiveAttribImpl(PlatformGLObject program, GCGLu
     return true;
 }
 
-bool GraphicsContextGLANGLE::getActiveAttrib(PlatformGLObject program, GCGLuint index, ActiveInfo& info)
+bool GraphicsContextGLANGLE::getActiveAttrib(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo& info)
 {
     return getActiveAttribImpl(program, index, info);
 }
 
-bool GraphicsContextGLANGLE::getActiveUniformImpl(PlatformGLObject program, GCGLuint index, ActiveInfo& info)
+bool GraphicsContextGLANGLE::getActiveUniformImpl(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo& info)
 {
     if (!program) {
         synthesizeGLError(INVALID_VALUE);
@@ -1241,7 +1241,7 @@ bool GraphicsContextGLANGLE::getActiveUniformImpl(PlatformGLObject program, GCGL
     return true;
 }
 
-bool GraphicsContextGLANGLE::getActiveUniform(PlatformGLObject program, GCGLuint index, ActiveInfo& info)
+bool GraphicsContextGLANGLE::getActiveUniform(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo& info)
 {
     return getActiveUniformImpl(program, index, info);
 }
@@ -2359,7 +2359,7 @@ void GraphicsContextGLANGLE::transformFeedbackVaryings(PlatformGLObject program,
     GL_TransformFeedbackVaryings(program, pointersToVaryings.size(), pointersToVaryings.data(), bufferMode);
 }
 
-void GraphicsContextGLANGLE::getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, ActiveInfo& info)
+void GraphicsContextGLANGLE::getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo& info)
 {
     if (!makeContextCurrent())
         return;

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -114,10 +114,10 @@ public:
     void framebufferTexture2D(GCGLenum target, GCGLenum attachment, GCGLenum textarget, PlatformGLObject, GCGLint level) final;
     void frontFace(GCGLenum mode) final;
     void generateMipmap(GCGLenum target) final;
-    bool getActiveAttrib(PlatformGLObject program, GCGLuint index, ActiveInfo&) final;
-    bool getActiveAttribImpl(PlatformGLObject program, GCGLuint index, ActiveInfo&);
-    bool getActiveUniform(PlatformGLObject program, GCGLuint index, ActiveInfo&) final;
-    bool getActiveUniformImpl(PlatformGLObject program, GCGLuint index, ActiveInfo&);
+    bool getActiveAttrib(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&) final;
+    bool getActiveAttribImpl(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&);
+    bool getActiveUniform(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&) final;
+    bool getActiveUniformImpl(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&);
     void getAttachedShaders(PlatformGLObject program, GCGLsizei maxCount, GCGLsizei* count, PlatformGLObject* shaders);
     GCGLint getAttribLocation(PlatformGLObject, const String& name) final;
     void getBooleanv(GCGLenum pname, GCGLSpan<GCGLboolean> value) final;
@@ -292,7 +292,7 @@ public:
     void beginTransformFeedback(GCGLenum primitiveMode) final;
     void endTransformFeedback() final;
     void transformFeedbackVaryings(PlatformGLObject program, const Vector<String>& varyings, GCGLenum bufferMode) final;
-    void getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, ActiveInfo&) final;
+    void getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&) final;
     void pauseTransformFeedback() final;
     void resumeTransformFeedback() final;
     void bindBufferBase(GCGLenum target, GCGLuint index, PlatformGLObject buffer) final;

--- a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGL.cpp
+++ b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGL.cpp
@@ -1040,7 +1040,7 @@ void GraphicsContextGLOpenGL::generateMipmap(GCGLenum target)
     ::glGenerateMipmap(target);
 }
 
-bool GraphicsContextGLOpenGL::getActiveAttribImpl(PlatformGLObject program, GCGLuint index, ActiveInfo& info)
+bool GraphicsContextGLOpenGL::getActiveAttribImpl(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo& info)
 {
     if (!program) {
         synthesizeGLError(INVALID_VALUE);
@@ -1072,7 +1072,7 @@ bool GraphicsContextGLOpenGL::getActiveAttribImpl(PlatformGLObject program, GCGL
     return true;
 }
 
-bool GraphicsContextGLOpenGL::getActiveAttrib(PlatformGLObject program, GCGLuint index, ActiveInfo& info)
+bool GraphicsContextGLOpenGL::getActiveAttrib(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo& info)
 {
     GCGLint symbolCount;
     auto result = m_shaderProgramSymbolCountMap.find(program);
@@ -1087,7 +1087,7 @@ bool GraphicsContextGLOpenGL::getActiveAttrib(PlatformGLObject program, GCGLuint
     return getActiveAttribImpl(program, rawIndex, info);
 }
 
-bool GraphicsContextGLOpenGL::getActiveUniformImpl(PlatformGLObject program, GCGLuint index, ActiveInfo& info)
+bool GraphicsContextGLOpenGL::getActiveUniformImpl(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo& info)
 {
     if (!program) {
         synthesizeGLError(INVALID_VALUE);
@@ -1121,7 +1121,7 @@ bool GraphicsContextGLOpenGL::getActiveUniformImpl(PlatformGLObject program, GCG
     return true;
 }
 
-bool GraphicsContextGLOpenGL::getActiveUniform(PlatformGLObject program, GCGLuint index, ActiveInfo& info)
+bool GraphicsContextGLOpenGL::getActiveUniform(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo& info)
 {
     GCGLint symbolCount;
     auto result = m_shaderProgramSymbolCountMap.find(program);
@@ -1956,7 +1956,7 @@ void GraphicsContextGLOpenGL::getNonBuiltInActiveSymbolCount(PlatformGLObject pr
     GCGLint attributeCount = 0;
     ::glGetProgramiv(program, ACTIVE_ATTRIBUTES, &attributeCount);
     for (GCGLint i = 0; i < attributeCount; ++i) {
-        ActiveInfo info;
+        GraphicsContextGLActiveInfo info;
         getActiveAttribImpl(program, i, info);
         if (info.name.startsWith("gl_"_s))
             continue;
@@ -1968,7 +1968,7 @@ void GraphicsContextGLOpenGL::getNonBuiltInActiveSymbolCount(PlatformGLObject pr
     GCGLint uniformCount = 0;
     ::glGetProgramiv(program, ACTIVE_UNIFORMS, &uniformCount);
     for (GCGLint i = 0; i < uniformCount; ++i) {
-        ActiveInfo info;
+        GraphicsContextGLActiveInfo info;
         getActiveUniformImpl(program, i, info);
         if (info.name.startsWith("gl_"_s))
             continue;
@@ -2910,7 +2910,7 @@ void GraphicsContextGLOpenGL::transformFeedbackVaryings(PlatformGLObject program
     UNUSED_PARAM(bufferMode);
 }
 
-void GraphicsContextGLOpenGL::getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, ActiveInfo&)
+void GraphicsContextGLOpenGL::getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&)
 {
     UNUSED_PARAM(program);
     UNUSED_PARAM(index);

--- a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGL.h
+++ b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGL.h
@@ -130,10 +130,10 @@ public:
     void frontFace(GCGLenum mode) final;
     void generateMipmap(GCGLenum target) final;
 
-    bool getActiveAttrib(PlatformGLObject program, GCGLuint index, ActiveInfo&) final;
-    bool getActiveAttribImpl(PlatformGLObject program, GCGLuint index, ActiveInfo&);
-    bool getActiveUniform(PlatformGLObject program, GCGLuint index, ActiveInfo&) final;
-    bool getActiveUniformImpl(PlatformGLObject program, GCGLuint index, ActiveInfo&);
+    bool getActiveAttrib(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&) final;
+    bool getActiveAttribImpl(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&);
+    bool getActiveUniform(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&) final;
+    bool getActiveUniformImpl(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&);
     void getAttachedShaders(PlatformGLObject program, GCGLsizei maxCount, GCGLsizei* count, PlatformGLObject* shaders);
     GCGLint getAttribLocation(PlatformGLObject, const String& name) final;
     void getBooleanv(GCGLenum pname, GCGLSpan<GCGLboolean> value) final;
@@ -347,7 +347,7 @@ public:
     void beginTransformFeedback(GCGLenum primitiveMode) final;
     void endTransformFeedback() final;
     void transformFeedbackVaryings(PlatformGLObject program, const Vector<String>& varyings, GCGLenum bufferMode) final;
-    void getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, ActiveInfo&) final;
+    void getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo&) final;
     void pauseTransformFeedback() final;
     void resumeTransformFeedback() final;
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -111,8 +111,8 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void FramebufferTexture2D(uint32_t target, uint32_t attachment, uint32_t textarget, uint32_t arg3, int32_t level)
     void FrontFace(uint32_t mode)
     void GenerateMipmap(uint32_t target)
-    void GetActiveAttrib(uint32_t program, uint32_t index) -> (bool returnValue, WebCore::GraphicsContextGL::ActiveInfo arg2) Synchronous
-    void GetActiveUniform(uint32_t program, uint32_t index) -> (bool returnValue, WebCore::GraphicsContextGL::ActiveInfo arg2) Synchronous
+    void GetActiveAttrib(uint32_t program, uint32_t index) -> (bool returnValue, struct WebCore::GraphicsContextGLActiveInfo arg2) Synchronous
+    void GetActiveUniform(uint32_t program, uint32_t index) -> (bool returnValue, struct WebCore::GraphicsContextGLActiveInfo arg2) Synchronous
     void GetAttribLocation(uint32_t arg0, String name) -> (int32_t returnValue) Synchronous
     void GetBufferParameteri(uint32_t target, uint32_t pname) -> (int32_t returnValue) Synchronous
     void GetString(uint32_t name) -> (String returnValue) Synchronous
@@ -283,7 +283,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void BeginTransformFeedback(uint32_t primitiveMode)
     void EndTransformFeedback()
     void TransformFeedbackVaryings(uint32_t program, Vector<String> varyings, uint32_t bufferMode)
-    void GetTransformFeedbackVarying(uint32_t program, uint32_t index) -> (WebCore::GraphicsContextGL::ActiveInfo arg2) Synchronous
+    void GetTransformFeedbackVarying(uint32_t program, uint32_t index) -> (struct WebCore::GraphicsContextGLActiveInfo arg2) Synchronous
     void PauseTransformFeedback()
     void ResumeTransformFeedback()
     void BindBufferBase(uint32_t target, uint32_t index, uint32_t buffer)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -296,18 +296,18 @@
         assertIsCurrent(workQueue());
         m_context->generateMipmap(target);
     }
-    void getActiveAttrib(uint32_t program, uint32_t index, CompletionHandler<void(bool, WebCore::GraphicsContextGL::ActiveInfo&&)>&& completionHandler)
+    void getActiveAttrib(uint32_t program, uint32_t index, CompletionHandler<void(bool, struct WebCore::GraphicsContextGLActiveInfo&&)>&& completionHandler)
     {
         bool returnValue = { };
-        WebCore::GraphicsContextGL::ActiveInfo arg2 { };
+        struct WebCore::GraphicsContextGLActiveInfo arg2 { };
         assertIsCurrent(workQueue());
         returnValue = m_context->getActiveAttrib(program, index, arg2);
         completionHandler(returnValue, WTFMove(arg2));
     }
-    void getActiveUniform(uint32_t program, uint32_t index, CompletionHandler<void(bool, WebCore::GraphicsContextGL::ActiveInfo&&)>&& completionHandler)
+    void getActiveUniform(uint32_t program, uint32_t index, CompletionHandler<void(bool, struct WebCore::GraphicsContextGLActiveInfo&&)>&& completionHandler)
     {
         bool returnValue = { };
-        WebCore::GraphicsContextGL::ActiveInfo arg2 { };
+        struct WebCore::GraphicsContextGLActiveInfo arg2 { };
         assertIsCurrent(workQueue());
         returnValue = m_context->getActiveUniform(program, index, arg2);
         completionHandler(returnValue, WTFMove(arg2));
@@ -1261,9 +1261,9 @@
         assertIsCurrent(workQueue());
         m_context->transformFeedbackVaryings(program, varyings, bufferMode);
     }
-    void getTransformFeedbackVarying(uint32_t program, uint32_t index, CompletionHandler<void(WebCore::GraphicsContextGL::ActiveInfo&&)>&& completionHandler)
+    void getTransformFeedbackVarying(uint32_t program, uint32_t index, CompletionHandler<void(struct WebCore::GraphicsContextGLActiveInfo&&)>&& completionHandler)
     {
-        WebCore::GraphicsContextGL::ActiveInfo arg2 { };
+        struct WebCore::GraphicsContextGLActiveInfo arg2 { };
         assertIsCurrent(workQueue());
         m_context->getTransformFeedbackVarying(program, index, arg2);
         completionHandler(WTFMove(arg2));

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -271,7 +271,11 @@ def generate_cpp(serialized_types, serialized_enums, headers):
         if type.populate_from_empty_constructor:
             result.append('    ' + type.namespace_and_name() + ' result;')
             for member in type.members:
+                if member.condition is not None:
+                    result.append('#if ' + member.condition)
                 result.append('    result.' + member.name + ' = WTFMove(*' + member.name + ');')
+                if member.condition is not None:
+                    result.append('#endif')
             result.append('    return { WTFMove(result) };')
         else:
             if type.return_ref:

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -337,6 +337,7 @@ def serialized_identifiers():
 def types_that_cannot_be_forward_declared():
     return frozenset([
         'CVPixelBufferRef',
+        'GCGLint',
         'IPC::DataReference',
         'IPC::FilterReference',
         'IPC::FontReference',
@@ -708,6 +709,7 @@ def headers_for_type(type):
 
     special_cases = {
         'CVPixelBufferRef': ['<WebCore/CVUtilities.h>'],
+        'GCGLint': ['<WebCore/GraphicsTypesGL.h>'],
         'IPC::Semaphore': ['"IPCSemaphore.h"'],
         'Inspector::ExtensionError': ['"InspectorExtensionTypes.h"'],
         'Inspector::FrontendChannel::ConnectionType': ['<JavaScriptCore/InspectorFrontendChannel.h>'],
@@ -805,6 +807,7 @@ def headers_for_type(type):
         'WebCore::FrameLoadType': ['<WebCore/FrameLoaderTypes.h>'],
         'WebCore::GenericCueData': ['<WebCore/InbandGenericCue.h>'],
         'WebCore::GrammarDetail': ['<WebCore/TextCheckerClient.h>'],
+        'WebCore::GraphicsContextGLActiveInfo': ['<WebCore/GraphicsContextGL.h>'],
         'WebCore::HasInsecureContent': ['<WebCore/FrameLoaderTypes.h>'],
         'WebCore::HighlightRequestOriginatedInApp': ['<WebCore/AppHighlight.h>'],
         'WebCore::HighlightVisibility': ['<WebCore/HighlightVisibility.h>'],

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -209,8 +209,12 @@ void ArgumentCoder<Namespace::EmptyConstructorNullable>::encode(Encoder& encoder
     encoder << instance.m_isNull;
     if (instance.m_isNull)
         return;
+#if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     encoder << instance.m_type;
+#endif
+#if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     encoder << instance.m_value;
+#endif
 }
 
 std::optional<Namespace::EmptyConstructorNullable> ArgumentCoder<Namespace::EmptyConstructorNullable>::decode(Decoder& decoder)
@@ -222,20 +226,28 @@ std::optional<Namespace::EmptyConstructorNullable> ArgumentCoder<Namespace::Empt
     if (*m_isNull)
         return { Namespace::EmptyConstructorNullable { } };
 
+#if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     std::optional<MemberType> m_type;
     decoder >> m_type;
     if (!m_type)
         return std::nullopt;
+#endif
 
+#if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     std::optional<OtherMemberType> m_value;
     decoder >> m_value;
     if (!m_value)
         return std::nullopt;
+#endif
 
     Namespace::EmptyConstructorNullable result;
     result.m_isNull = WTFMove(*m_isNull);
+#if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     result.m_type = WTFMove(*m_type);
+#endif
+#if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     result.m_value = WTFMove(*m_value);
+#endif
     return { WTFMove(result) };
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -32,8 +32,10 @@ class Namespace::OtherClass {
 
 [LegacyPopulateFrom=EmptyConstructor] class Namespace::EmptyConstructorNullable {
     [ReturnEarlyIfTrue] bool m_isNull;
+#if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     MemberType m_type;
     OtherMemberType m_value;
+#endif
 }
 
 class WithoutNamespace {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -169,10 +169,8 @@ struct Length;
 struct GrammarDetail;
 struct MimeClassInfo;
 struct PasteboardImage;
-struct PluginInfo;
 struct PromisedAttachmentInfo;
 struct RecentSearch;
-struct ResourceLoadStatistics;
 struct ScrollableAreaParameters;
 struct TextCheckingResult;
 struct TextIndicatorData;
@@ -306,11 +304,6 @@ template<> struct ArgumentCoder<WebCore::VelocityData> {
 template<> struct ArgumentCoder<WebCore::MimeClassInfo> {
     static void encode(Encoder&, const WebCore::MimeClassInfo&);
     static std::optional<WebCore::MimeClassInfo> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<WebCore::PluginInfo> {
-    static void encode(Encoder&, const WebCore::PluginInfo&);
-    static std::optional<WebCore::PluginInfo> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<WebCore::AuthenticationChallenge> {
@@ -568,11 +561,6 @@ template<> struct ArgumentCoder<WebCore::ExceptionDetails> {
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ExceptionDetails&);
 };
 
-template<> struct ArgumentCoder<WebCore::ResourceLoadStatistics> {
-    static void encode(Encoder&, const WebCore::ResourceLoadStatistics&);
-    static std::optional<WebCore::ResourceLoadStatistics> decode(Decoder&);
-};
-
 #if ENABLE(APPLE_PAY)
 
 template<> struct ArgumentCoder<WebCore::Payment> {
@@ -726,15 +714,6 @@ template<> struct ArgumentCoder<WebCore::CDMInstanceSession::Message> {
 template<> struct ArgumentCoder<WebCore::PaymentInstallmentConfiguration> {
     static void encode(Encoder&, const WebCore::PaymentInstallmentConfiguration&);
     static std::optional<WebCore::PaymentInstallmentConfiguration> decode(Decoder&);
-};
-#endif
-
-#if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
-
-template<> struct ArgumentCoder<WebCore::GraphicsContextGL::ActiveInfo> {
-    template<typename Encoder>
-    static void encode(Encoder&, const WebCore::GraphicsContextGL::ActiveInfo&);
-    static std::optional<WebCore::GraphicsContextGL::ActiveInfo> decode(Decoder&);
 };
 #endif
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -331,3 +331,63 @@ header: <WebCore/TimingFunction.h>
     double damping()
     double initialVelocity()
 };
+
+header: <WebCore/ResourceLoadStatistics.h>
+[LegacyPopulateFrom=EmptyConstructor] struct WebCore::ResourceLoadStatistics {
+    WebCore::RegistrableDomain registrableDomain;
+    WallTime lastSeen;
+    bool hadUserInteraction;
+    WallTime mostRecentUserInteractionTime;
+    bool grandfathered;
+    HashSet<WebCore::RegistrableDomain> storageAccessUnderTopFrameDomains;
+    HashSet<WebCore::RegistrableDomain> topFrameUniqueRedirectsTo;
+    HashSet<WebCore::RegistrableDomain> topFrameUniqueRedirectsToSinceSameSiteStrictEnforcement;
+    HashSet<WebCore::RegistrableDomain> topFrameUniqueRedirectsFrom;
+    HashSet<WebCore::RegistrableDomain> topFrameLinkDecorationsFrom;
+    bool gotLinkDecorationFromPrevalentResource;
+    HashSet<WebCore::RegistrableDomain> topFrameLoadedThirdPartyScripts;
+    HashSet<WebCore::RegistrableDomain> subframeUnderTopFrameDomains;
+    HashSet<WebCore::RegistrableDomain> subresourceUnderTopFrameDomains;
+    HashSet<WebCore::RegistrableDomain> subresourceUniqueRedirectsTo;
+    HashSet<WebCore::RegistrableDomain> subresourceUniqueRedirectsFrom;
+    bool isPrevalentResource;
+    bool isVeryPrevalentResource;
+    unsigned dataRecordsRemoved;
+    unsigned timesAccessedAsFirstPartyDueToUserInteraction;
+    unsigned timesAccessedAsFirstPartyDueToStorageAccessAPI;
+#if ENABLE(WEB_API_STATISTICS)
+    HashSet<WebCore::RegistrableDomain> topFrameRegistrableDomainsWhichAccessedWebAPIs;
+    HashSet<String> fontsFailedToLoad;
+    HashSet<String> fontsSuccessfullyLoaded;
+    WebCore::CanvasActivityRecord canvasActivityRecord;
+    OptionSet<WebCore::NavigatorAPIsAccessed> navigatorFunctionsAccessed;
+    OptionSet<WebCore::ScreenAPIsAccessed> screenFunctionsAccessed;
+#endif
+};
+
+[OptionSet] enum class WebCore::NavigatorAPIsAccessed : uint64_t {
+    AppVersion,
+    UserAgent,
+    Plugins,
+    MimeTypes,
+    CookieEnabled
+};
+
+[OptionSet] enum class WebCore::ScreenAPIsAccessed : uint64_t {
+    Height,
+    Width,
+    ColorDepth,
+    PixelDepth,
+    AvailLeft,
+    AvailTop,
+    AvailHeight,
+    AvailWidth
+};
+
+#if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
+[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::GraphicsContextGLActiveInfo {
+    String name;
+    GCGLenum type;
+    GCGLint size;
+};
+#endif

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -138,8 +138,8 @@ public:
     void framebufferTexture2D(GCGLenum target, GCGLenum attachment, GCGLenum textarget, PlatformGLObject arg3, GCGLint level) final;
     void frontFace(GCGLenum mode) final;
     void generateMipmap(GCGLenum target) final;
-    bool getActiveAttrib(PlatformGLObject program, GCGLuint index, ActiveInfo& arg2) final;
-    bool getActiveUniform(PlatformGLObject program, GCGLuint index, ActiveInfo& arg2) final;
+    bool getActiveAttrib(PlatformGLObject program, GCGLuint index, struct WebCore::GraphicsContextGLActiveInfo& arg2) final;
+    bool getActiveUniform(PlatformGLObject program, GCGLuint index, struct WebCore::GraphicsContextGLActiveInfo& arg2) final;
     GCGLint getAttribLocation(PlatformGLObject arg0, const String& name) final;
     GCGLint getBufferParameteri(GCGLenum target, GCGLenum pname) final;
     String getString(GCGLenum name) final;
@@ -310,7 +310,7 @@ public:
     void beginTransformFeedback(GCGLenum primitiveMode) final;
     void endTransformFeedback() final;
     void transformFeedbackVaryings(PlatformGLObject program, const Vector<String>& varyings, GCGLenum bufferMode) final;
-    void getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, ActiveInfo& arg2) final;
+    void getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, struct WebCore::GraphicsContextGLActiveInfo& arg2) final;
     void pauseTransformFeedback() final;
     void resumeTransformFeedback() final;
     void bindBufferBase(GCGLenum target, GCGLuint index, PlatformGLObject buffer) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -505,7 +505,7 @@ void RemoteGraphicsContextGLProxy::generateMipmap(GCGLenum target)
     }
 }
 
-bool RemoteGraphicsContextGLProxy::getActiveAttrib(PlatformGLObject program, GCGLuint index, ActiveInfo& arg2)
+bool RemoteGraphicsContextGLProxy::getActiveAttrib(PlatformGLObject program, GCGLuint index, struct WebCore::GraphicsContextGLActiveInfo& arg2)
 {
     bool returnValue = { };
     if (!isContextLost()) {
@@ -516,7 +516,7 @@ bool RemoteGraphicsContextGLProxy::getActiveAttrib(PlatformGLObject program, GCG
     return returnValue;
 }
 
-bool RemoteGraphicsContextGLProxy::getActiveUniform(PlatformGLObject program, GCGLuint index, ActiveInfo& arg2)
+bool RemoteGraphicsContextGLProxy::getActiveUniform(PlatformGLObject program, GCGLuint index, struct WebCore::GraphicsContextGLActiveInfo& arg2)
 {
     bool returnValue = { };
     if (!isContextLost()) {
@@ -2170,7 +2170,7 @@ void RemoteGraphicsContextGLProxy::transformFeedbackVaryings(PlatformGLObject pr
     }
 }
 
-void RemoteGraphicsContextGLProxy::getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, ActiveInfo& arg2)
+void RemoteGraphicsContextGLProxy::getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, struct WebCore::GraphicsContextGLActiveInfo& arg2)
 {
     if (!isContextLost()) {
         auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTransformFeedbackVarying(program, index), Messages::RemoteGraphicsContextGL::GetTransformFeedbackVarying::Reply(arg2));

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
@@ -212,7 +212,7 @@ void WebResourceLoadObserver::logCanvasWriteOrMeasure(const Document& document, 
 #endif
 }
     
-void WebResourceLoadObserver::logNavigatorAPIAccessed(const Document& document, const ResourceLoadStatistics::NavigatorAPI functionName)
+void WebResourceLoadObserver::logNavigatorAPIAccessed(const Document& document, const NavigatorAPIsAccessed functionName)
 {
     if (isEphemeral())
         return;
@@ -236,7 +236,7 @@ void WebResourceLoadObserver::logNavigatorAPIAccessed(const Document& document, 
 #endif
 }
     
-void WebResourceLoadObserver::logScreenAPIAccessed(const Document& document, const ResourceLoadStatistics::ScreenAPI functionName)
+void WebResourceLoadObserver::logScreenAPIAccessed(const Document& document, const ScreenAPIsAccessed functionName)
 {
     if (isEphemeral())
         return;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.h
@@ -51,8 +51,8 @@ public:
     void logFontLoad(const WebCore::Document&, const String& familyName, bool loadStatus) final;
     void logCanvasRead(const WebCore::Document&) final;
     void logCanvasWriteOrMeasure(const WebCore::Document&, const String& textWritten) final;
-    void logNavigatorAPIAccessed(const WebCore::Document&, const WebCore::ResourceLoadStatistics::NavigatorAPI) final;
-    void logScreenAPIAccessed(const WebCore::Document&, const WebCore::ResourceLoadStatistics::ScreenAPI) final;
+    void logNavigatorAPIAccessed(const WebCore::Document&, const WebCore::NavigatorAPIsAccessed) final;
+    void logScreenAPIAccessed(const WebCore::Document&, const WebCore::ScreenAPIsAccessed) final;
     void logSubresourceLoadingForTesting(const WebCore::RegistrableDomain& firstPartyDomain, const WebCore::RegistrableDomain& thirdPartyDomain, bool shouldScheduleNotification);
 
 #if !RELEASE_LOG_DISABLED


### PR DESCRIPTION
#### 11f7471c70b0d9aff5c0bfd95d5b4175e5bf2f2d
<pre>
Generate more serialization code
<a href="https://bugs.webkit.org/show_bug.cgi?id=245106">https://bugs.webkit.org/show_bug.cgi?id=245106</a>

Reviewed by Chris Dumez.

* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::getTransformFeedbackVarying):
* Source/WebCore/html/canvas/WebGLProgram.cpp:
(WebCore::WebGLProgram::cacheActiveAttribLocations):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::getActiveAttrib):
(WebCore::WebGLRenderingContextBase::getActiveUniform):
(WebCore::WebGLRenderingContextBase::getUniformLocation):
* Source/WebCore/loader/ResourceLoadObserver.h:
(WebCore::ResourceLoadObserver::logNavigatorAPIAccessed):
(WebCore::ResourceLoadObserver::logScreenAPIAccessed):
* Source/WebCore/loader/ResourceLoadStatistics.cpp:
(WebCore::navigatorAPIEnumToString):
(WebCore::screenAPIEnumToString):
(WebCore::appendNavigatorAPIOptionSet):
(WebCore::appendScreenAPIOptionSet):
* Source/WebCore/loader/ResourceLoadStatistics.h:
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::appVersion const):
(WebCore::Navigator::userAgent const):
(WebCore::Navigator::plugins):
(WebCore::Navigator::mimeTypes):
(WebCore::Navigator::cookieEnabled const):
* Source/WebCore/page/Screen.cpp:
(WebCore::Screen::height const):
(WebCore::Screen::width const):
(WebCore::Screen::colorDepth const):
(WebCore::Screen::pixelDepth const):
(WebCore::Screen::availLeft const):
(WebCore::Screen::availTop const):
(WebCore::Screen::availHeight const):
(WebCore::Screen::availWidth const):
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::getActiveAttribImpl):
(WebCore::GraphicsContextGLANGLE::getActiveAttrib):
(WebCore::GraphicsContextGLANGLE::getActiveUniformImpl):
(WebCore::GraphicsContextGLANGLE::getActiveUniform):
(WebCore::GraphicsContextGLANGLE::getTransformFeedbackVarying):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGL.cpp:
(WebCore::GraphicsContextGLOpenGL::getActiveAttribImpl):
(WebCore::GraphicsContextGLOpenGL::getActiveAttrib):
(WebCore::GraphicsContextGLOpenGL::getActiveUniformImpl):
(WebCore::GraphicsContextGLOpenGL::getActiveUniform):
(WebCore::GraphicsContextGLOpenGL::getNonBuiltInActiveSymbolCount):
(WebCore::GraphicsContextGLOpenGL::getTransformFeedbackVarying):
* Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(getActiveAttrib):
(getActiveUniform):
(getTransformFeedbackVarying):
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;PluginInfo&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;PluginInfo&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;ResourceLoadStatistics&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;ResourceLoadStatistics&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::GraphicsContextGL::ActiveInfo&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::GraphicsContextGL::ActiveInfo&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::getActiveAttrib):
(WebKit::RemoteGraphicsContextGLProxy::getActiveUniform):
(WebKit::RemoteGraphicsContextGLProxy::getTransformFeedbackVarying):
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp:
(WebKit::WebResourceLoadObserver::logNavigatorAPIAccessed):
(WebKit::WebResourceLoadObserver::logScreenAPIAccessed):
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.h:

Canonical link: <a href="https://commits.webkit.org/254446@main">https://commits.webkit.org/254446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ce20777b4bfb015005e0f6e564dd17854935153

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98380 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154703 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32132 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27708 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81428 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92869 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25517 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76015 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25451 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/92650 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68423 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29919 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29653 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15410 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3114 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38355 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34503 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->