### PR TITLE
Ship new `perspective: 0` behavior from CSS3DTransformInteroperabilityEnabled

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1840,7 +1840,7 @@ TransformationMatrix RenderLayer::perspectiveTransform() const
 
     TransformationMatrix transform;
     style.unapplyTransformOrigin(transform, transformOrigin);
-    style.applyPerspective(transform, renderer(), perspectiveOrigin);
+    style.applyPerspective(transform, perspectiveOrigin);
     style.applyTransformOrigin(transform, transformOrigin);
     return transform;
 }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1461,7 +1461,7 @@ void RenderObject::getTransformFromContainer(const RenderObject* containerObject
         FloatPoint perspectiveOrigin = downcast<RenderLayerModelObject>(*containerObject).layer()->perspectiveOrigin();
 
         TransformationMatrix perspectiveMatrix;
-        perspectiveMatrix.applyPerspective(containerObject->style().usedPerspective(*this));
+        perspectiveMatrix.applyPerspective(containerObject->style().usedPerspective());
         
         transform.translateRight3d(-perspectiveOrigin.x(), -perspectiveOrigin.y(), 0);
         transform = perspectiveMatrix * transform;

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1493,7 +1493,7 @@ FloatPoint RenderStyle::computePerspectiveOrigin(const FloatRect& boundingBox) c
     return boundingBox.location() + floatPointForLengthPoint(perspectiveOrigin(), boundingBox.size());
 }
 
-void RenderStyle::applyPerspective(TransformationMatrix& transform, const RenderObject& renderer, const FloatPoint& originTranslate) const
+void RenderStyle::applyPerspective(TransformationMatrix& transform, const FloatPoint& originTranslate) const
 {
     // https://www.w3.org/TR/css-transforms-2/#perspective
     // The perspective matrix is computed as follows:
@@ -1503,7 +1503,7 @@ void RenderStyle::applyPerspective(TransformationMatrix& transform, const Render
     transform.translate(originTranslate.x(), originTranslate.y());
 
     // 3. Multiply by the matrix that would be obtained from the perspective() transform function, where the length is provided by the value of the perspective property
-    transform.applyPerspective(usedPerspective(renderer));
+    transform.applyPerspective(usedPerspective());
 
     // 4. Translate by the negated computed X and Y values of perspective-origin
     transform.translate(-originTranslate.x(), -originTranslate.y());
@@ -1912,11 +1912,6 @@ AnimationList& RenderStyle::ensureTransitions()
     if (!m_rareNonInheritedData.access().transitions)
         m_rareNonInheritedData.access().transitions = AnimationList::create();
     return *m_rareNonInheritedData->transitions;
-}
-
-float RenderStyle::usedPerspective(const RenderObject& object) const
-{
-    return object.document().settings().css3DTransformInteroperabilityEnabled() ? std::max(1.0f, perspective()) : perspective();
 }
 
 const FontCascade& RenderStyle::fontCascade() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -719,7 +719,7 @@ public:
     bool affectedByTransformOrigin() const;
 
     FloatPoint computePerspectiveOrigin(const FloatRect& boundingBox) const;
-    void applyPerspective(TransformationMatrix&, const RenderObject&, const FloatPoint& originTranslate) const;
+    void applyPerspective(TransformationMatrix&, const FloatPoint& originTranslate) const;
 
     FloatPoint3D computeTransformOrigin(const FloatRect& boundingBox) const;
     void applyTransformOrigin(TransformationMatrix&, const FloatPoint3D& originTranslate) const;
@@ -767,7 +767,7 @@ public:
 
     BackfaceVisibility backfaceVisibility() const { return static_cast<BackfaceVisibility>(m_rareNonInheritedData->backfaceVisibility); }
     float perspective() const { return m_rareNonInheritedData->perspective; }
-    float usedPerspective(const RenderObject&) const;
+    float usedPerspective() const { return std::max(1.0f, perspective()); }
     bool hasPerspective() const { return m_rareNonInheritedData->perspective != initialPerspective(); }
     const Length& perspectiveOriginX() const { return m_rareNonInheritedData->perspectiveOriginX; }
     const Length& perspectiveOriginY() const { return m_rareNonInheritedData->perspectiveOriginY; }


### PR DESCRIPTION
#### 5730d5c8fb455166bc00aaaef3689b3d07dcdc34
<pre>
Ship new `perspective: 0` behavior from CSS3DTransformInteroperabilityEnabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=245110">https://bugs.webkit.org/show_bug.cgi?id=245110</a>
&lt;rdar://99850527&gt;

Reviewed by Simon Fraser.

This behavior is already to shipped by Chrome &amp; Firefox, so it is web-compatible.
Also move it out from CSS3DTransformInteroperabilityEnabled, since it is not directly related to 3D transforms.

Tests:
- imported/w3c/web-platform-tests/css/css-transforms/perspective-zero-2.html
- imported/w3c/web-platform-tests/css/css-transforms/transform3d-perspective-005.html

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::perspectiveTransform const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::getTransformFromContainer const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::applyPerspective const):
(WebCore::RenderStyle::usedPerspective const): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::usedPerspective const):

Canonical link: <a href="https://commits.webkit.org/254420@main">https://commits.webkit.org/254420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77a8254198fe0394c09b74347b50d06f5cb88c9b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33574 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/19870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98302 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32079 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81377 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92821 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94657 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/25470 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/75971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/25403 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80335 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/19870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68372 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29870 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/19870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29601 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/19870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3094 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33040 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/75971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31730 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/19870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->