### PR TITLE
[JSC] Use destroying delete for Wasm::Callee

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -48,14 +48,85 @@ Callee::Callee(Wasm::CompilationMode compilationMode, size_t index, std::pair<co
     CalleeRegistry::singleton().registerCallee(this);
 }
 
-Callee::~Callee()
+template<typename Func>
+inline void Callee::runWithDowncast(const Func& func)
 {
-    CalleeRegistry::singleton().unregisterCallee(this);
+    switch (m_compilationMode) {
+    case CompilationMode::LLIntMode:
+        func(static_cast<LLIntCallee*>(this));
+        break;
+#if ENABLE(WEBASSEMBLY_B3JIT)
+    case CompilationMode::BBQMode:
+        func(static_cast<BBQCallee*>(this));
+        break;
+    case CompilationMode::BBQForOSREntryMode:
+        func(static_cast<OSREntryCallee*>(this));
+        break;
+    case CompilationMode::OMGMode:
+        func(static_cast<OMGCallee*>(this));
+        break;
+    case CompilationMode::OMGForOSREntryMode:
+        func(static_cast<OSREntryCallee*>(this));
+        break;
+#else
+    case CompilationMode::BBQMode:
+    case CompilationMode::BBQForOSREntryMode:
+    case CompilationMode::OMGMode:
+    case CompilationMode::OMGForOSREntryMode:
+        break;
+#endif
+    case CompilationMode::EmbedderEntrypointMode:
+        func(static_cast<EmbedderEntrypointCallee*>(this));
+        break;
+    }
+}
+
+template<typename Func>
+inline void Callee::runWithDowncast(const Func& func) const
+{
+    const_cast<Callee*>(this)->runWithDowncast(func);
 }
 
 void Callee::dump(PrintStream& out) const
 {
     out.print(makeString(m_indexOrName));
+}
+
+CodePtr<WasmEntryPtrTag> Callee::entrypoint() const
+{
+    CodePtr<WasmEntryPtrTag> codePtr;
+    runWithDowncast([&](auto* derived) {
+        codePtr = derived->entrypointImpl();
+    });
+    return codePtr;
+}
+
+std::tuple<void*, void*> Callee::range() const
+{
+    std::tuple<void*, void*> result;
+    runWithDowncast([&](auto* derived) {
+        result = derived->rangeImpl();
+    });
+    return result;
+}
+
+RegisterAtOffsetList* Callee::calleeSaveRegisters()
+{
+    RegisterAtOffsetList* result = nullptr;
+    runWithDowncast([&](auto* derived) {
+        result = derived->calleeSaveRegistersImpl();
+    });
+    return result;
+}
+
+void Callee::operator delete(Callee* callee, std::destroying_delete_t)
+{
+    CalleeRegistry::singleton().unregisterCallee(callee);
+    callee->runWithDowncast([](auto* derived) {
+        using T = std::decay_t<decltype(*derived)>;
+        derived->~T();
+    });
+    Callee::freeAfterDestruction(callee);
 }
 
 const HandlerInfo* Callee::handlerForIndex(Instance& instance, unsigned index, const Tag* tag)
@@ -110,17 +181,7 @@ LLIntCallee::LLIntCallee(FunctionCodeBlockGenerator& generator, size_t index, st
     }
 }
 
-void LLIntCallee::setEntrypoint(CodePtr<WasmEntryPtrTag> entrypoint)
-{
-    m_entrypoint = entrypoint;
-}
-
-CodePtr<WasmEntryPtrTag> LLIntCallee::entrypoint() const
-{
-    return m_entrypoint;
-}
-
-RegisterAtOffsetList* LLIntCallee::calleeSaveRegisters()
+RegisterAtOffsetList* LLIntCallee::calleeSaveRegistersImpl()
 {
     static LazyNeverDestroyed<RegisterAtOffsetList> calleeSaveRegisters;
     static std::once_flag initializeFlag;
@@ -140,11 +201,6 @@ RegisterAtOffsetList* LLIntCallee::calleeSaveRegisters()
         calleeSaveRegisters.construct(WTFMove(registers));
     });
     return &calleeSaveRegisters.get();
-}
-
-std::tuple<void*, void*> LLIntCallee::range() const
-{
-    return { nullptr, nullptr };
 }
 
 WasmInstructionStream::Offset LLIntCallee::outOfLineJumpOffset(WasmInstructionStream::Offset bytecodeOffset)


### PR DESCRIPTION
#### a5afba21a12e7fce9d0a609c98f67277c1f2b8cd
<pre>
[JSC] Use destroying delete for Wasm::Callee
<a href="https://bugs.webkit.org/show_bug.cgi?id=245113">https://bugs.webkit.org/show_bug.cgi?id=245113</a>
&lt;rdar://99850863&gt;

Reviewed by Ross Kirsling.

This patch deploys destroying delete for Wasm::Callee to
make Wasm::Callee small size.

* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::runWithDowncast):
(JSC::Wasm::Callee::runWithDowncast const):
(JSC::Wasm::Callee::entrypoint const):
(JSC::Wasm:: const):
(JSC::Wasm::Callee::calleeSaveRegisters):
(JSC::Wasm::Callee::operator delete):
(JSC::Wasm::LLIntCallee::calleeSaveRegistersImpl):
(JSC::Wasm::Callee::~Callee): Deleted.
(JSC::Wasm::LLIntCallee::setEntrypoint): Deleted.
(JSC::Wasm::LLIntCallee::entrypoint const): Deleted.
(JSC::Wasm::LLIntCallee::calleeSaveRegisters): Deleted.
* Source/JavaScriptCore/wasm/WasmCallee.h:
(JSC::Wasm::JITCallee:: const):
(JSC::Wasm::JITCallee::entrypointImpl const):
(JSC::Wasm::JITCallee::calleeSaveRegistersImpl):

Canonical link: <a href="https://commits.webkit.org/254461@main">https://commits.webkit.org/254461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7b7b6c0664466c525c5774d8cc309a1b65dbe4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98301 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154656 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32078 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27660 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81376 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92820 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25469 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75970 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25401 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68370 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/80723 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29869 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14398 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74511 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29600 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15374 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26303 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3126 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38321 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/77372 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34469 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17138 "Passed tests") | 
<!--EWS-Status-Bubble-End-->