### PR TITLE
Remove unused PlatformMouseEvent::modifierFlags() and m_modifierFlags

### DIFF
--- a/Source/WebCore/platform/PlatformMouseEvent.h
+++ b/Source/WebCore/platform/PlatformMouseEvent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,7 +68,6 @@ public:
     MouseButton button() const { return m_button; }
     unsigned short buttons() const { return m_buttons; }
     int clickCount() const { return m_clickCount; }
-    unsigned modifierFlags() const { return m_modifierFlags; }
     double force() const { return m_force; }
     SyntheticClickType syntheticClickType() const { return m_syntheticClickType; }
     PointerID pointerId() const { return m_pointerId; }
@@ -107,7 +106,6 @@ protected:
     PointerID m_pointerId { mousePointerID };
     String m_pointerType { mousePointerEventType() };
     int m_clickCount { 0 };
-    unsigned m_modifierFlags { 0 };
     unsigned short m_buttons { 0 };
     Vector<PlatformMouseEvent> m_coalescedEvents;
     Vector<PlatformMouseEvent> m_predictedEvents;

--- a/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
+++ b/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -757,7 +757,6 @@ public:
         m_force = pressure + stage;
 
         // Mac specific
-        m_modifierFlags = [event modifierFlags];
         m_eventNumber = [event eventNumber];
         m_menuTypeForEvent = typeForEvent(event);
     }

--- a/Source/WebCore/platform/win/PlatformMouseEventWin.cpp
+++ b/Source/WebCore/platform/win/PlatformMouseEventWin.cpp
@@ -84,7 +84,6 @@ PlatformMouseEvent::PlatformMouseEvent(HWND hWnd, UINT message, WPARAM wParam, L
     , m_position(positionForEvent(hWnd, lParam))
     , m_globalPosition(globalPositionForEvent(hWnd, lParam))
     , m_clickCount(0)
-    , m_modifierFlags(wParam)
     , m_buttons(buttonsForEvent(wParam))
     , m_didActivateWebView(didActivateWebView)
 {

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -305,15 +305,6 @@ public:
 #elif PLATFORM(WPE)
         m_syntheticClickType = static_cast<WebCore::SyntheticClickType>(webEvent.syntheticClickType());
 #endif
-        m_modifierFlags = 0;
-        if (webEvent.shiftKey())
-            m_modifierFlags |= static_cast<unsigned>(WebEventModifier::ShiftKey);
-        if (webEvent.controlKey())
-            m_modifierFlags |= static_cast<unsigned>(WebEventModifier::ControlKey);
-        if (webEvent.altKey())
-            m_modifierFlags |= static_cast<unsigned>(WebEventModifier::AltKey);
-        if (webEvent.metaKey())
-            m_modifierFlags |= static_cast<unsigned>(WebEventModifier::MetaKey);
 
         m_pointerId = webEvent.pointerId();
         m_pointerType = webEvent.pointerType();

--- a/Tools/TestWebKitAPI/Tests/mac/MenuTypesForMouseEvents.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/MenuTypesForMouseEvents.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,7 +62,7 @@ static void buildAndPerformTest(NSEventType buttonEvent, NSEventModifierFlags mo
         auto pme = WebCore::PlatformEventFactory::createPlatformMouseEvent(event, nil, webView.get());
 
         EXPECT_EQ(expectedButton, pme.button());
-        EXPECT_TRUE(!modifierFlags || pme.modifierFlags() & modifierFlags);
+        EXPECT_EQ(WebCore::modifiersForModifierFlags(modifierFlags), pme.modifiers());
         EXPECT_EQ(expectedMenu, pme.menuTypeForEvent());
         if (canCallMenuTypeForEvent())
             EXPECT_EQ(expectedMenu, [NSMenu menuTypeForEvent:event]);


### PR DESCRIPTION
#### c559ef21e24775338a1eb865f46d10d60f0bb953
<pre>
Remove unused PlatformMouseEvent::modifierFlags() and m_modifierFlags
<a href="https://bugs.webkit.org/show_bug.cgi?id=245108">https://bugs.webkit.org/show_bug.cgi?id=245108</a>
&lt;<a href="https://rdar.apple.com/99850228">rdar://99850228</a>&gt;

Reviewed by Darin Adler.

PlatformMouseEvent::modifierFlags() was last called from EventHandler to
pass raw modifier flags to Chrome::mouseDidMoveOverElement(), which was
removed in 264519@main for Bug 257175.  Since then, no code reads the
field.

Modifier information is already available through the base class via
PlatformEvent::modifiers() as an OptionSet&lt;PlatformEvent::Modifier&gt;.

* Source/WebCore/platform/PlatformMouseEvent.h:
(WebCore::PlatformMouseEvent::modifierFlags const): Delete.
(WebCore::PlatformMouseEvent::m_modifierFlags): Delete.
* Source/WebCore/platform/mac/PlatformEventFactoryMac.mm:
(WebCore::PlatformMouseEventBuilder::PlatformMouseEventBuilder):
* Source/WebCore/platform/win/PlatformMouseEventWin.cpp:
(WebCore::PlatformMouseEvent::PlatformMouseEvent):
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformMouseEvent::WebKit2PlatformMouseEvent):
- Remove unused modifierFlags() and m_modifierFlags.

* Tools/TestWebKitAPI/Tests/mac/MenuTypesForMouseEvents.mm:
(TestWebKitAPI::buildAndPerformTest):
- Replace the modifierFlags() assertion with a single EXPECT_EQ against
  pme.modifiers(), using modifiersForModifierFlags() to convert the
  NSEventModifierFlags parameter to an OptionSet&lt;PlatformEvent::Modifier&gt;.

Canonical link: <a href="https://commits.webkit.org/310567@main">https://commits.webkit.org/310567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4dd3baa0614fe2f80c9d0f9dc1ab4d9a2c368f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107665 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156070 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119255 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84303 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99951 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b357289-62a6-4c45-ae2b-45d76849a2bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20606 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18603 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10783 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130268 "Found 1 new API test failure: TestWebKitAPI.WKDownload.OriginatingFrameHostWhenDownloadComesFromClientInputNavigation (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165423 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8632 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127350 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127495 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138115 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83518 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23555 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22383 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14907 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26615 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90718 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26196 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26427 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26268 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->