### PR TITLE
Non-unified build fixes, mid September

### DIFF
--- a/Source/JavaScriptCore/bytecode/PolyProtoAccessChain.cpp
+++ b/Source/JavaScriptCore/bytecode/PolyProtoAccessChain.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "PolyProtoAccessChain.h"
 
+#include "CacheableIdentifierInlines.h"
 #include "JSCInlines.h"
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "TemporalPlainDatePrototype.h"
 
+#include "IntlObjectInlines.h"
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
 #include "TemporalDuration.h"

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -26,8 +26,10 @@
 #include "config.h"
 #include "TemporalPlainDateTimePrototype.h"
 
+#include "IntlObjectInlines.h"
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
+#include "TemporalDuration.h"
 #include "TemporalPlainDate.h"
 #include "TemporalPlainDateTime.h"
 #include "TemporalPlainTime.h"

--- a/Source/WebCore/dom/CustomElementDefaultARIA.h
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/HashMap.h>
+#include <wtf/IsoMalloc.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
 

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+using namespace HTMLNames;
+
 WTF_MAKE_ISO_ALLOCATED_IMPL(ElementInternals);
 
 ShadowRoot* ElementInternals::shadowRoot() const

--- a/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
+++ b/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
@@ -42,6 +42,7 @@
 #include <mutex>
 #include <wtf/CrossThreadQueue.h>
 #include <wtf/CrossThreadTask.h>
+#include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
 #include <wtf/MainThread.h>
 #include <wtf/RefPtr.h>

--- a/Source/WebCore/inspector/InspectorShaderProgram.cpp
+++ b/Source/WebCore/inspector/InspectorShaderProgram.cpp
@@ -32,6 +32,7 @@
 
 #if ENABLE(WEBGL)
 #include "JSExecState.h"
+#include "ScriptExecutionContext.h"
 #include "WebGLProgram.h"
 #include "WebGLRenderingContextBase.h"
 #include "WebGLSampler.h"

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -110,6 +110,7 @@
 #include "ScrollbarTheme.h"
 #include "ScrollingCoordinator.h"
 #include "Settings.h"
+#include "ShadowRoot.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
 #include "TextIndicator.h"

--- a/Source/WebCore/page/PointerLockController.h
+++ b/Source/WebCore/page/PointerLockController.h
@@ -38,6 +38,7 @@ class Page;
 class PlatformMouseEvent;
 class PlatformWheelEvent;
 class VoidCallback;
+class WeakPtrImplWithEventTargetData;
 
 class PointerLockController {
     WTF_MAKE_NONCOPYABLE(PointerLockController);

--- a/Source/WebKit/NetworkProcess/glib/WebKitOverridingResolver.cpp
+++ b/Source/WebKit/NetworkProcess/glib/WebKitOverridingResolver.cpp
@@ -26,10 +26,11 @@
 #include "config.h"
 #include "WebKitOverridingResolver.h"
 
+#include <wtf/HashSet.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
-
-using namespace WebKit;
+#include <wtf/text/StringHash.h>
+#include <wtf/text/WTFString.h>
 
 typedef struct {
     GRefPtr<GResolver> wrappedResolver;


### PR DESCRIPTION
#### 05b736c00c87831726db0d01e497e9875a34ffb2
<pre>
Non-unified build fixes, mid September

Unreviewed, patch co-authored by Adrian Perez de Castro &lt;aperez@igalia.com&gt;

* Source/JavaScriptCore/bytecode/PolyProtoAccessChain.cpp: Add missing include.
* Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp: Ditto.
* Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp: Ditto.
* Source/WebCore/dom/CustomElementDefaultARIA.h: Ditto.
* Source/WebCore/dom/ElementInternals.cpp: Use namespace HTMLNames.
* Source/WebCore/fileapi/ThreadableBlobRegistry.cpp: Add missing includes.
* Source/WebCore/inspector/InspectorShaderProgram.cpp: Ditto.
* Source/WebCore/page/FrameView.cpp: Ditto.
* Source/WebCore/page/PointerLockController.h: Forward declare WeakPtrImplWithEventTargetData.
* Source/WebKit/NetworkProcess/glib/WebKitOverridingResolver.cpp: Remove undeed using namespace and add missing headers.

Canonical link: <a href="https://commits.webkit.org/254425@main">https://commits.webkit.org/254425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40b1e95ef587325c9f876f9e750eaab92fcd774c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98310 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32088 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27666 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81385 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92827 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25478 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75977 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25414 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80343 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68383 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/80731 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29877 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74521 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29610 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15380 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26304 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3100 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38322 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/77382 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34474 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17139 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode (failure)") | 
<!--EWS-Status-Bubble-End-->