### PR TITLE
Fix WPT flex item transferred sizes tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing-expected.html
@@ -6,7 +6,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#min-width" />
     <link rel="help" href="https://drafts.csswg.org/css-sizing/#box-sizing" />
     <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=243887" />
-    <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+    <link rel="match" href="../reference/ref-filled-green-100px-square-only.html" />
   </head>
     <style>
       div {
@@ -16,6 +16,7 @@
       }
     </style>
   <body>
+    <p>Test passes if there is a filled green square.</p>
     <div></div>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing.html
@@ -6,7 +6,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#min-width" />
     <link rel="help" href="https://drafts.csswg.org/css-sizing/#box-sizing" />
     <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=243887" />
-    <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+    <link rel="match" href="../reference/ref-filled-green-100px-square-only.html" />
   </head>
   <!-- The box should be a 100px x 100px green square. The initial width should
        be 90px due to the  transferred min-width constraint from the specified
@@ -29,6 +29,7 @@
     }
   </style>
   <body>
+    <p>Test passes if there is a filled green square.</p>
     <div class="flexContainer">
       <div class="item" style="min-height:100px; aspect-ratio: 1/1;"></div>
     </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing-expected.html
@@ -6,7 +6,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#min-width" />
     <link rel="help" href="https://drafts.csswg.org/css-sizing/#box-sizing" />
     <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=243887" />
-    <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+    <link rel="match" href="../reference/ref-filled-green-100px-square-only.html" />
   </head>
     <style>
       div {
@@ -16,6 +16,7 @@
       }
     </style>
   <body>
+    <p>Test passes if there is a filled green square.</p>
     <div></div>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing.html
@@ -6,7 +6,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-sizing-3/#min-width" />
     <link rel="help" href="https://drafts.csswg.org/css-sizing/#box-sizing" />
     <link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=243887" />
-    <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+    <link rel="match" href="../reference/ref-filled-green-100px-square-only.html" />
   </head>
   <!-- Item div should be a 100px x 100px square. Content width will be 90px,
        which comes from the min-height constraint being transferred to the
@@ -24,6 +24,7 @@
     }
   </style>
   <body>
+    <p>Test passes if there is a filled green square.</p>
     <div class="flexContainer">
       <div class="item" style="min-height:90px; aspect-ratio: 1/1;"></div>
     </div>


### PR DESCRIPTION
#### d3957df2df789f88812bb43b87dbe13f5a5a604d
<pre>
Fix WPT flex item transferred sizes tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=245114">https://bugs.webkit.org/show_bug.cgi?id=245114</a>
rdar://99850970

Reviewed by Tim Nguyen.

The original version of these tests were referencing an expectation
that had some extra text that were not in the test files. This was
causing the tests to fail on all engines on WPT. However, since our
expectation did not have the test, we were passing it outside of
WPT. The change now links to a test with just the green square and
without the text.

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-border-sizing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-transferred-sizes-padding-content-sizing.html:

Canonical link: <a href="https://commits.webkit.org/254421@main">https://commits.webkit.org/254421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b45518714d39865244bcd34e0e7880c90ed1131

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33586 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/19877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98312 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32091 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81387 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92829 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94669 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-15-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/75979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/25413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/19877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/68382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29880 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/19877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29612 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/19877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3096 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33051 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/75979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31742 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/19877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->