### PR TITLE
Represent feComponentTransfer CSS filters as feColorMatrix

### DIFF
--- a/LayoutTests/css3/filters/effect-brightness.html
+++ b/LayoutTests/css3/filters/effect-brightness.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-12300">
+    <meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-22300">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
     <script>

--- a/LayoutTests/css3/filters/effect-combined.html
+++ b/LayoutTests/css3/filters/effect-combined.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-600" />
+    <meta name="fuzzy" content="maxDifference=0-4; totalPixels=0-16400">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
     <script>

--- a/LayoutTests/css3/filters/effect-contrast-hw.html
+++ b/LayoutTests/css3/filters/effect-contrast-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-230; totalPixels=0-36000">
+    <meta name="fuzzy" content="maxDifference=0-230; totalPixels=0-44000">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-grayscale-hw.html
+++ b/LayoutTests/css3/filters/effect-grayscale-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-33000">
+    <meta name="fuzzy" content="maxDifference=0-45; totalPixels=0-57000">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-invert.html
+++ b/LayoutTests/css3/filters/effect-invert.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-10000" />
+    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-40000">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
     <script>

--- a/LayoutTests/css3/filters/effect-opacity.html
+++ b/LayoutTests/css3/filters/effect-opacity.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-2500">
+    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-30000">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
     <script>

--- a/LayoutTests/css3/filters/effect-sepia-hw.html
+++ b/LayoutTests/css3/filters/effect-sepia-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-36800">
+    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-58000">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filters-grayscale-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filters-grayscale-001.html
@@ -5,6 +5,7 @@
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#supported-filter-functions">
 <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=831485">
 <link rel="match" href="reference/backdrop-filters-grayscale-001-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-7500">
 <meta name="assert" content="Check that backdrop-filter works with grayscale(50%)."/>
 <style>
 .square {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-grayscale.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-grayscale.html
@@ -9,6 +9,7 @@
     <link rel="help" href="https://www.w3.org/TR/filter-effects-1/#funcdef-filter-grayscale">
     <link rel="help" href="http://www.w3.org/TR/css3-animations/#animations">
     <link rel="match" href="css-filters-animation-grayscale-ref.html">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-10000">
     <meta name="assert" content="The blue square should be half-grayscaled">
     <style type="text/css">
         @keyframes animate {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filters-grayscale-001-test.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filters-grayscale-001-test.html
@@ -7,6 +7,7 @@
     <link rel="help" href="http://www.w3.org/TR/filter-effects-1/#FilterProperty">
     <link rel="help" href="https://www.w3.org/TR/filter-effects-1/#funcdef-filter-grayscale">
     <link rel="match" href="filters-grayscale-001-ref.html">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-40000">
     <meta name="assert" content="If the test runs, you should see a black olive colored rectangle.">
     <style type="text/css">
 

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
@@ -27,6 +27,8 @@
 
 namespace WebCore {
 
+// FEColorMatrix is used in the implementation of SVGColorMatixElement, so this enum only contains types specified in https://www.w3.org/TR/filter-effects-1/#feColorMatrixElement.
+// Ideally this platform class wouldn't reflect SVG behavior and would also have values for brightness, contrast, grayscale, invert, opacity and sepia.
 enum ColorMatrixType {
     FECOLORMATRIX_TYPE_UNKNOWN          = 0,
     FECOLORMATRIX_TYPE_MATRIX           = 1,


### PR DESCRIPTION
#### d3496a0787a4db8f177e6c4642771fbe7d99c268
<pre>
Represent feComponentTransfer CSS filters as feColorMatrix
<a href="https://bugs.webkit.org/show_bug.cgi?id=245111">https://bugs.webkit.org/show_bug.cgi?id=245111</a>
&lt;rdar://99850797&gt;

Reviewed by NOBODY (OOPS!).

The &quot;feComponentTransfer&quot; type CSS filters (invert, opacity, brightness, contrast) can
be represented as feColorMatrix, which will enable future optimizations.

We were already converting these to color matrix to hand to Core Animation; this change
factors the matrix construction into ColorMatrix.h, and calls that code from CSSFilter
and PlatformCAFiltersCocoa.

Using FEColorMatrix was slower than FEComponentTransfer (e.g. 48ms per invocation vs. 17ms)
but we can make it faster by using vImage when the matrix has values in the last column; we
can represent these as post-bias in the vImage call. This speeds it up (6ms in my test).

* LayoutTests/css3/filters/effect-brightness.html:
* LayoutTests/css3/filters/effect-combined.html:
* LayoutTests/css3/filters/effect-contrast.html:
* LayoutTests/css3/filters/effect-invert.html:
* Source/WebCore/platform/graphics/filters/FEColorMatrix.h:
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::createBrightnessEffect):
(WebCore::createContrastEffect):
(WebCore::createInvertEffect):
(WebCore::createOpacityEffect):
(WebCore::CSSFilter::apply):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3496a0787a4db8f177e6c4642771fbe7d99c268

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24282 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20712 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22911 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21720 "Exiting early after 10 failures. 95 tests run. 1 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25137 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20281 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26535 "Found 1 new test failure: css3/filters/effect-contrast.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20373 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20520 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-backgrounds/border-radius-clipping-with-transform-001.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24389 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/21049 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17850 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-backgrounds/border-radius-clipping-with-transform-001.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20502 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20090 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5336 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-backgrounds/border-radius-clipping-with-transform-001.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/21040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->