### PR TITLE
[Gardening]: REGRESSION(253027@main): [ macOS ] 2X-TestWebKitAPI.VideoControlsManager.(VideoControlsManagerMultipleVideosScrollOnlyLargeVideoOutOfView,VideoControlsManagerMultipleVideosScrollPlayingVideoWithSoundOutOfView) are flaky timeouts

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm
@@ -177,7 +177,8 @@ TEST(VideoControlsManager, VideoControlsManagerMultipleVideosScrollPausedVideoOu
     [webView expectControlsManager:NO afterReceivingMessage:@"paused"];
 }
 
-TEST(VideoControlsManager, VideoControlsManagerMultipleVideosScrollPlayingVideoWithSoundOutOfView)
+ // FIXME: Re-enable after webkit.org/b/243675 is resolved
+ TEST(VideoControlsManager, DISABLED_VideoControlsManagerMultipleVideosScrollPlayingVideoWithSoundOutOfView)
 {
     RetainPtr<VideoControlsManagerTestWebView> webView = setUpWebViewForTestingVideoControlsManager(NSMakeRect(0, 0, 500, 500));
 


### PR DESCRIPTION
#### 916ab6d39d28545a6cfbc039c58043d49621b96b
<pre>
[Gardening]: REGRESSION(253027@main): [ macOS ] 2X-TestWebKitAPI.VideoControlsManager.(VideoControlsManagerMultipleVideosScrollOnlyLargeVideoOutOfView,VideoControlsManagerMultipleVideosScrollPlayingVideoWithSoundOutOfView) are flaky timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=243675">https://bugs.webkit.org/show_bug.cgi?id=243675</a>
rdar://problem/98327430

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm:
(TestWebKitAPI::TEST):

This commit include:

[Gardening]:  REGRESSION(253027@main): [ macOS ] 2X-TestWebKitAPI.VideoControlsManager.(VideoControlsManagerMultipleVideosScrollOnlyLargeVideoOutOfView,VideoControlsManagerMultipleVideosScrollPlayingVideoWithSoundOutOfView) are flaky timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=243675">https://bugs.webkit.org/show_bug.cgi?id=243675</a>
rdar://problem/98327430

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm:
(TestWebKitAPI::TEST):
(TestWebKitAPI::67b5243b2a1b): Deleted.

[Gardening]: REGRESSION(253027@main): [ macOS ] 2X TestWebKitAPI.VideoControlsManager.(VideoControlsManagerMultipleVideosScrollOnlyLargeVideoOutOfView,VideoControlsManagerMultipleVideosScrollPlayingVideoWithSoundOutOfView) are flaky timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=243675">https://bugs.webkit.org/show_bug.cgi?id=243675</a>
&lt;rdar://98327430&gt;

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92493839d5aa1018b949a77364539c431bb941dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89045 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98362 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32114 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81410 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92852 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94692 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/25501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/75999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/25439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/80363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/68411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29902 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29635 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/15400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33074 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/75999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1301 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31765 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/34493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->