### PR TITLE
WebGL buffers maintain shadow copy

### DIFF
--- a/LayoutTests/fast/canvas/webgl/largeBuffer.html
+++ b/LayoutTests/fast/canvas/webgl/largeBuffer.html
@@ -9,10 +9,15 @@ const gl = canvas.getContext("webgl");
 
 const b = gl.createBuffer();
 gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, b);
+shouldBeEqualToNumber("gl.getError()", gl.NO_ERROR);
 gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, 0xf000000000, gl.STREAM_DRAW);
+shouldBeEqualToNumber("gl.getError()", gl.INVALID_VALUE);
 const size = gl.getBufferParameter(gl.ELEMENT_ARRAY_BUFFER, gl.BUFFER_SIZE);
 shouldBeEqualToNumber("size", 0);
 gl.bufferSubData(gl.ELEMENT_ARRAY_BUFFER, 0x4444444444, new ArrayBuffer(32));
+shouldBeEqualToNumber("gl.getError()", gl.INVALID_VALUE);
+shouldBeEqualToNumber("gl.getError()", gl.NO_ERROR);
+
 </script>
 </body>
 </html>

--- a/LayoutTests/platform/gtk/fast/canvas/webgl/largeBuffer-expected.txt
+++ b/LayoutTests/platform/gtk/fast/canvas/webgl/largeBuffer-expected.txt
@@ -1,4 +1,5 @@
 CONSOLE MESSAGE: WebGL: INVALID_VALUE: bufferData: size more than 32-bits
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: bufferSubData: offset out of range
 PASS gl.getError() is 0
 PASS gl.getError() is 1281
 PASS size is 0

--- a/LayoutTests/webgl/buffer-copysubdata-overlap-no-crash-expected.txt
+++ b/LayoutTests/webgl/buffer-copysubdata-overlap-no-crash-expected.txt
@@ -1,0 +1,11 @@
+Test that copyBufferSubData does not crash on overlapping data.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 2 PASS, 0 FAIL
+
+PASS Did not crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/buffer-copysubdata-overlap-no-crash.html
+++ b/LayoutTests/webgl/buffer-copysubdata-overlap-no-crash.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+</head>
+<body onload="test()">
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("Test that copyBufferSubData does not crash on overlapping data.");
+// Mostly crashes when running on ASAN.
+var wtu = WebGLTestUtils;
+var gl;
+function runTest(subcase)
+{
+    var c = document.createElement("canvas");
+	var gl = c.getContext("webgl2");
+    if (gl) {
+        var b = gl.createBuffer();
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, b);
+        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint8Array(100), gl.STREAM_DRAW);
+        gl.copyBufferSubData(gl.ELEMENT_ARRAY_BUFFER, gl.ELEMENT_ARRAY_BUFFER, 84, 80, 16);
+    }
+    testPassed(`Did not crash.`);
+}
+
+function test()
+{
+    runTest();
+    finishTest();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/webgl/webgl-allow-shared-expected.txt
+++ b/LayoutTests/webgl/webgl-allow-shared-expected.txt
@@ -1,9 +1,7 @@
-CONSOLE MESSAGE: WebGL: INVALID_VALUE: bufferSubData: offset out of range
 CONSOLE MESSAGE: WebGL: INVALID_ENUM: texImage2D: invalid texture type
 CONSOLE MESSAGE: WebGL: INVALID_ENUM: texSubImage2D: invalid texture type
 CONSOLE MESSAGE: WebGL: INVALID_ENUM: compressedTexImage2D: invalid format
 CONSOLE MESSAGE: WebGL: INVALID_ENUM: compressedTexSubImage2D: invalid format
-CONSOLE MESSAGE: WebGL: INVALID_VALUE: bufferSubData: offset out of range
 CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texImage3D: no texture bound to target
 CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texImage3D: no texture bound to target
 CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texSubImage3D: no texture bound to target

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -631,19 +631,7 @@ void WebGL2RenderingContext::copyBufferSubData(GCGLenum readTarget, GCGLenum wri
         return;
     }
 
-    if (!writeBuffer->associateCopyBufferSubData(*readBuffer, checkedReadOffset, checkedWriteOffset, checkedSize)) {
-        this->synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "copyBufferSubData", "offset out of range");
-        return;
-    }
-
-    m_context->moveErrorsToSyntheticErrorList();
-#if PLATFORM(COCOA)
     m_context->copyBufferSubData(readTarget, writeTarget, checkedReadOffset, checkedWriteOffset, checkedSize);
-#endif
-    if (m_context->moveErrorsToSyntheticErrorList()) {
-        // The bufferSubData function failed. Tell the buffer it doesn't have the data it thinks it does.
-        writeBuffer->disassociateBufferData();
-    }
 }
 
 void WebGL2RenderingContext::getBufferSubData(GCGLenum target, long long srcByteOffset, RefPtr<ArrayBufferView>&& dstData, GCGLuint dstOffset, GCGLuint length)
@@ -694,15 +682,6 @@ void WebGL2RenderingContext::getBufferSubData(GCGLenum target, long long srcByte
         return;
     }
 
-    Checked<GCGLintptr, RecordOverflow> checkedSrcByteOffset(srcByteOffset);
-    Checked<GCGLintptr, RecordOverflow> checkedCopyLengthPtr(copyLength);
-    Checked<GCGLintptr, RecordOverflow> checkedElementSize(elementSize);
-    auto checkedSourceEnd = checkedSrcByteOffset + checkedCopyLengthPtr * checkedElementSize;
-    if (checkedSourceEnd.hasOverflowed() || checkedSourceEnd > buffer->byteLength()) {
-        synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "getBufferSubData", "Parameters would read outside the bounds of the source buffer");
-        return;
-    }
-    
     if (!copyLength)
         return;
 
@@ -3209,58 +3188,6 @@ WebGLAny WebGL2RenderingContext::getParameter(GCGLenum pname)
     }
 }
 
-bool WebGL2RenderingContext::validateIndexArrayConservative(GCGLenum type, unsigned& numElementsRequired)
-{
-    // Performs conservative validation by caching a maximum index of
-    // the given type per element array buffer. If all of the bound
-    // array buffers have enough elements to satisfy that maximum
-    // index, skips the expensive per-draw-call iteration in
-    // validateIndexArrayPrecise.
-
-    RefPtr<WebGLBuffer> elementArrayBuffer = m_boundVertexArrayObject->getElementArrayBuffer();
-
-    if (!elementArrayBuffer)
-        return false;
-
-    GCGLsizeiptr numElements = elementArrayBuffer->byteLength();
-    // The case count==0 is already dealt with in drawElements before validateIndexArrayConservative.
-    if (!numElements)
-        return false;
-    auto buffer = elementArrayBuffer->elementArrayBuffer();
-    ASSERT(buffer);
-
-    std::optional<unsigned> maxIndex = elementArrayBuffer->getCachedMaxIndex(type);
-    if (!maxIndex) {
-        // Compute the maximum index in the entire buffer for the given type of index.
-        switch (type) {
-        case GraphicsContextGL::UNSIGNED_BYTE:
-            maxIndex = getMaxIndex<GCGLubyte>(buffer, 0, numElements);
-            break;
-        case GraphicsContextGL::UNSIGNED_SHORT:
-            maxIndex = getMaxIndex<GCGLushort>(buffer, 0, numElements / sizeof(GCGLushort));
-            break;
-        case GraphicsContextGL::UNSIGNED_INT:
-            maxIndex = getMaxIndex<GCGLuint>(buffer, 0, numElements / sizeof(GCGLuint));
-            break;
-        default:
-            return false;
-        }
-        if (maxIndex)
-            elementArrayBuffer->setCachedMaxIndex(type, maxIndex.value());
-    }
-
-    if (!maxIndex)
-        return false;
-
-    // The number of required elements is one more than the maximum
-    // index that will be accessed.
-    auto checkedNumElementsRequired = checkedAddAndMultiply<unsigned>(maxIndex.value(), 1, 1);
-    if (!checkedNumElementsRequired)
-        return false;
-    numElementsRequired = checkedNumElementsRequired.value();
-
-    return true;
-}
 
 bool WebGL2RenderingContext::validateBlendEquation(const char* functionName, GCGLenum mode)
 {

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -293,7 +293,6 @@ private:
     bool validateAndCacheBufferBinding(const AbstractLocker&, const char* functionName, GCGLenum target, WebGLBuffer*) final;
     GCGLint getMaxDrawBuffers() final;
     GCGLint getMaxColorAttachments() final;
-    bool validateIndexArrayConservative(GCGLenum type, unsigned& numElementsRequired) final;
     bool validateBlendEquation(const char* functionName, GCGLenum mode) final;
     bool validateCapability(const char* functionName, GCGLenum cap) final;
     template<typename T, typename TypedArrayType>

--- a/Source/WebCore/html/canvas/WebGLBuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLBuffer.cpp
@@ -45,7 +45,6 @@ WebGLBuffer::WebGLBuffer(WebGLRenderingContextBase& ctx)
     : WebGLSharedObject(ctx)
 {
     setObject(ctx.graphicsContextGL()->createBuffer());
-    clearCachedMaxIndices();
 }
 
 WebGLBuffer::~WebGLBuffer()
@@ -61,6 +60,7 @@ void WebGLBuffer::deleteObjectImpl(const AbstractLocker&, GraphicsContextGL* con
     context3d->deleteBuffer(object);
 }
 
+#if !USE(ANGLE)
 bool WebGLBuffer::associateBufferDataImpl(const void* data, GCGLsizeiptr byteLength)
 {
     if (byteLength < 0)
@@ -91,18 +91,6 @@ bool WebGLBuffer::associateBufferDataImpl(const void* data, GCGLsizeiptr byteLen
         m_byteLength = byteLength;
         return true;
     default:
-#if ENABLE(WEBGL2)
-        switch (m_target) {
-        case GraphicsContextGL::COPY_READ_BUFFER:
-        case GraphicsContextGL::COPY_WRITE_BUFFER:
-        case GraphicsContextGL::PIXEL_PACK_BUFFER:
-        case GraphicsContextGL::PIXEL_UNPACK_BUFFER:
-        case GraphicsContextGL::TRANSFORM_FEEDBACK_BUFFER:
-        case GraphicsContextGL::UNIFORM_BUFFER:
-            m_byteLength = byteLength;
-            return true;
-        }
-#endif
         return false;
     }
 }
@@ -151,17 +139,6 @@ bool WebGLBuffer::associateBufferSubDataImpl(GCGLintptr offset, const void* data
     case GraphicsContextGL::ARRAY_BUFFER:
         return true;
     default:
-#if ENABLE(WEBGL2)
-        switch (m_target) {
-        case GraphicsContextGL::COPY_READ_BUFFER:
-        case GraphicsContextGL::COPY_WRITE_BUFFER:
-        case GraphicsContextGL::PIXEL_PACK_BUFFER:
-        case GraphicsContextGL::PIXEL_UNPACK_BUFFER:
-        case GraphicsContextGL::TRANSFORM_FEEDBACK_BUFFER:
-        case GraphicsContextGL::UNIFORM_BUFFER:
-            return true;
-        }
-#endif
         return false;
     }
 }
@@ -210,17 +187,6 @@ bool WebGLBuffer::associateCopyBufferSubData(const WebGLBuffer& readBuffer, GCGL
     case GraphicsContextGL::ARRAY_BUFFER:
         return true;
     default:
-#if ENABLE(WEBGL2)
-        switch (m_target) {
-        case GraphicsContextGL::COPY_READ_BUFFER:
-        case GraphicsContextGL::COPY_WRITE_BUFFER:
-        case GraphicsContextGL::PIXEL_PACK_BUFFER:
-        case GraphicsContextGL::PIXEL_UNPACK_BUFFER:
-        case GraphicsContextGL::TRANSFORM_FEEDBACK_BUFFER:
-        case GraphicsContextGL::UNIFORM_BUFFER:
-            return true;
-        }
-#endif
         return false;
     }
 }
@@ -263,16 +229,12 @@ void WebGLBuffer::setCachedMaxIndex(GCGLenum type, unsigned value)
     m_nextAvailableCacheEntry = (m_nextAvailableCacheEntry + 1) % WTF_ARRAY_LENGTH(m_maxIndexCache);
 }
 
-void WebGLBuffer::setTarget(GCGLenum target)
-{
-    m_target = target;
-}
-
 void WebGLBuffer::clearCachedMaxIndices()
 {
     memset(m_maxIndexCache, 0, sizeof(m_maxIndexCache));
 }
 
+#endif
 }
 
 #endif // ENABLE(WEBGL)

--- a/Source/WebCore/html/canvas/WebGLBuffer.h
+++ b/Source/WebCore/html/canvas/WebGLBuffer.h
@@ -42,6 +42,7 @@ public:
     static Ref<WebGLBuffer> create(WebGLRenderingContextBase&);
     virtual ~WebGLBuffer();
 
+#if !USE(ANGLE)
     bool associateBufferData(GCGLsizeiptr size);
     bool associateBufferData(JSC::ArrayBuffer*);
     bool associateBufferData(JSC::ArrayBufferView*);
@@ -58,10 +59,10 @@ public:
     std::optional<unsigned> getCachedMaxIndex(GCGLenum type);
     // Sets the cached max index for the given type.
     void setCachedMaxIndex(GCGLenum type, unsigned value);
+#endif
 
     GCGLenum getTarget() const { return m_target; }
-    void setTarget(GCGLenum);
-
+    void setTarget(GCGLenum target) { m_target = target; }
     bool hasEverBeenBound() const { return object() && m_target; }
 
 private:
@@ -71,6 +72,7 @@ private:
 
     GCGLenum m_target { 0 };
 
+#if !USE(ANGLE)
     RefPtr<JSC::ArrayBuffer> m_elementArrayBuffer;
     GCGLsizeiptr m_byteLength { 0 };
 
@@ -87,7 +89,7 @@ private:
     };
     // OpenGL ES 2.0 only has two valid index types (UNSIGNED_BYTE
     // and UNSIGNED_SHORT) plus one extension (UNSIGNED_INT).
-    MaxIndexCacheEntry m_maxIndexCache[4];
+    MaxIndexCacheEntry m_maxIndexCache[4] { };
     unsigned m_nextAvailableCacheEntry { 0 };
 
     // Clears all of the cached max indices.
@@ -97,6 +99,7 @@ private:
     bool associateBufferDataImpl(const void* data, GCGLsizeiptr byteLength);
     // Helper function called by the two associateBufferSubData().
     bool associateBufferSubDataImpl(GCGLintptr offset, const void* data, GCGLsizeiptr byteLength);
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -324,6 +324,7 @@ GCGLint WebGLRenderingContext::getMaxColorAttachments()
     return m_maxColorAttachments;
 }
 
+#if !USE(ANGLE)
 bool WebGLRenderingContext::validateIndexArrayConservative(GCGLenum type, unsigned& numElementsRequired)
 {
     // Performs conservative validation by caching a maximum index of
@@ -388,6 +389,7 @@ bool WebGLRenderingContext::validateIndexArrayConservative(GCGLenum type, unsign
 
     return true;
 }
+#endif
 
 bool WebGLRenderingContext::validateBlendEquation(const char* functionName, GCGLenum mode)
 {

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.h
@@ -48,7 +48,9 @@ public:
     GCGLint getMaxDrawBuffers() final;
     GCGLint getMaxColorAttachments() final;
     void initializeVertexArrayObjects() final;
+#if !USE(ANGLE)
     bool validateIndexArrayConservative(GCGLenum type, unsigned& numElementsRequired) final;
+#endif
     bool validateBlendEquation(const char* functionName, GCGLenum mode) final;
 
 private:

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1843,17 +1843,26 @@ void WebGLRenderingContextBase::bufferData(GCGLenum target, long long size, GCGL
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "bufferData", "size < 0");
         return;
     }
+    if (size > static_cast<long long>(std::numeric_limits<unsigned>::max())) {
+        // Trying to allocate too large buffers cause unexpected context loss. Better to disallow
+        // it in validation.
+        synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "bufferData", "size more than 32-bits");
+        return;
+    }
+#if !USE(ANGLE)
     if (!buffer->associateBufferData(static_cast<GCGLsizeiptr>(size))) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "bufferData", "invalid buffer");
         return;
     }
-
     m_context->moveErrorsToSyntheticErrorList();
+#endif
     m_context->bufferData(target, static_cast<GCGLsizeiptr>(size), usage);
+#if !USE(ANGLE)
     if (m_context->moveErrorsToSyntheticErrorList()) {
         // The bufferData function failed. Tell the buffer it doesn't have the data it thinks it does.
         buffer->disassociateBufferData();
     }
+#endif
 }
 
 void WebGLRenderingContextBase::bufferData(GCGLenum target, std::optional<BufferDataSource>&& data, GCGLenum usage)
@@ -1869,17 +1878,21 @@ void WebGLRenderingContextBase::bufferData(GCGLenum target, std::optional<Buffer
         return;
 
     std::visit([&](auto& data) {
+#if !USE(ANGLE)
         if (!buffer->associateBufferData(data.get())) {
             this->synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "bufferData", "invalid buffer");
             return;
         }
 
         m_context->moveErrorsToSyntheticErrorList();
+#endif
         m_context->bufferData(target, GCGLSpan<const GCGLvoid>(data->data(), data->byteLength()), usage);
+#if !USE(ANGLE)
         if (m_context->moveErrorsToSyntheticErrorList()) {
             // The bufferData function failed. Tell the buffer it doesn't have the data it thinks it does.
             buffer->disassociateBufferData();
         }
+#endif
     }, data.value());
 }
 
@@ -1896,17 +1909,20 @@ void WebGLRenderingContextBase::bufferSubData(GCGLenum target, long long offset,
     }
 
     std::visit([&](auto& data) {
+#if !USE(ANGLE)
         if (!buffer->associateBufferSubData(static_cast<GCGLintptr>(offset), data.get())) {
             this->synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "bufferSubData", "offset out of range");
             return;
         }
-
         m_context->moveErrorsToSyntheticErrorList();
+#endif
         m_context->bufferSubData(target, static_cast<GCGLintptr>(offset), GCGLSpan<const GCGLvoid>(data->data(), data->byteLength()));
+#if !USE(ANGLE)
         if (m_context->moveErrorsToSyntheticErrorList()) {
             // The bufferSubData function failed. Tell the buffer it doesn't have the data it thinks it does.
             buffer->disassociateBufferData();
         }
+#endif
     }, data);
 }
 
@@ -2493,6 +2509,7 @@ bool WebGLRenderingContextBase::validateVertexArrayObject(const char* functionNa
     return true;
 }
 
+#if !USE(ANGLE)
 bool WebGLRenderingContextBase::validateElementArraySize(GCGLsizei count, GCGLenum type, GCGLintptr offset)
 {
     RefPtr<WebGLBuffer> elementArrayBuffer = m_boundVertexArrayObject->getElementArrayBuffer();
@@ -2532,7 +2549,9 @@ bool WebGLRenderingContextBase::validateElementArraySize(GCGLsizei count, GCGLen
     }
     return true;
 }
+#endif
 
+#if !USE(ANGLE)
 bool WebGLRenderingContextBase::validateIndexArrayPrecise(GCGLsizei count, GCGLenum type, GCGLintptr offset, unsigned& numElementsRequired)
 {
     ASSERT(count >= 0 && offset >= 0);
@@ -2571,13 +2590,11 @@ bool WebGLRenderingContextBase::validateIndexArrayPrecise(GCGLsizei count, GCGLe
     numElementsRequired = checkedNumElementsRequired.value();
     return true;
 }
+#endif
 
+#if !USE(ANGLE)
 bool WebGLRenderingContextBase::validateVertexAttributes(unsigned elementCount, unsigned primitiveCount)
 {
-#if USE(ANGLE)
-    UNUSED_PARAM(elementCount);
-    UNUSED_PARAM(primitiveCount);
-#else
     if (!m_currentProgram)
         return false;
 
@@ -2645,10 +2662,9 @@ bool WebGLRenderingContextBase::validateVertexAttributes(unsigned elementCount, 
             return false;
         }
     }
-#endif
-
     return true;
 }
+#endif
 
 bool WebGLRenderingContextBase::validateWebGLObject(const char* functionName, WebGLObject* object)
 {
@@ -2728,12 +2744,11 @@ bool WebGLRenderingContextBase::validateDrawArrays(const char* functionName, GCG
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "attempt to access out of bounds arrays");
         return false;
     }
-#if !USE(ANGLE)
+
     if (!validateSimulatedVertexAttrib0(checkedSum.value() - 1)) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "attempt to access outside the bounds of the simulated vertexAttrib0 array");
         return false;
     }
-#endif
 
     const char* reason = "framebuffer incomplete";
     if (m_framebufferBinding && !m_framebufferBinding->onAccess(graphicsContextGL(), &reason)) {
@@ -2743,7 +2758,9 @@ bool WebGLRenderingContextBase::validateDrawArrays(const char* functionName, GCG
 
     return true;
 }
+#endif
 
+#if !USE(ANGLE)
 bool WebGLRenderingContextBase::validateDrawElements(const char* functionName, GCGLenum mode, GCGLsizei count, GCGLenum type, long long offset, unsigned& numElements, GCGLsizei primitiveCount)
 {
     if (isContextLostOrPending() || !validateDrawMode(functionName, mode))
@@ -2808,12 +2825,10 @@ bool WebGLRenderingContextBase::validateDrawElements(const char* functionName, G
         }
     }
 
-#if !USE(ANGLE)
     if (!validateSimulatedVertexAttrib0(numElements)) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "attempt to access outside the bounds of the simulated vertexAttrib0 array");
         return false;
     }
-#endif
     
     const char* reason = "framebuffer incomplete";
     if (m_framebufferBinding && !m_framebufferBinding->onAccess(graphicsContextGL(), &reason)) {

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -542,6 +542,7 @@ protected:
     // like GL_FLOAT, GL_INT, etc.
     unsigned sizeInBytes(GCGLenum type);
 
+#if !USE(ANGLE)
     // Basic validation of count and offset against number of elements in element array buffer
     bool validateElementArraySize(GCGLsizei count, GCGLenum type, GCGLintptr offset);
 
@@ -551,6 +552,7 @@ protected:
     // Precise but slow index validation -- only done if conservative checks fail
     bool validateIndexArrayPrecise(GCGLsizei count, GCGLenum type, GCGLintptr offset, unsigned& numElementsRequired);
     bool validateVertexAttributes(unsigned elementCount, unsigned primitiveCount = 0);
+#endif
 
     // Validates the incoming WebGL object, which is assumed to be non-null.
     // Checks that the object belongs to this context and that it's not marked for
@@ -1186,8 +1188,10 @@ protected:
     OffscreenCanvas* offscreenCanvas();
 #endif
 
+#if !USE(ANGLE)
     template <typename T> inline std::optional<T> checkedAddAndMultiply(T value, T add, T multiply);
     template <typename T> unsigned getMaxIndex(const RefPtr<JSC::ArrayBuffer> elementArrayBuffer, GCGLintptr uoffset, GCGLsizei n);
+#endif
 
     bool validateArrayBufferType(const char* functionName, GCGLenum type, std::optional<JSC::TypedArrayType>);
 
@@ -1212,6 +1216,7 @@ private:
     uint64_t m_activeOrdinal { 0 };
 };
 
+#if !USE(ANGLE)
 template <typename T>
 inline std::optional<T> WebGLRenderingContextBase::checkedAddAndMultiply(T value, T add, T multiply)
 {
@@ -1224,17 +1229,12 @@ inline std::optional<T> WebGLRenderingContextBase::checkedAddAndMultiply(T value
     return checkedResult.value();
 }
 
+
 template<typename T>
 inline unsigned WebGLRenderingContextBase::getMaxIndex(const RefPtr<JSC::ArrayBuffer> elementArrayBuffer, GCGLintptr uoffset, GCGLsizei n)
 {
     unsigned maxIndex = 0;
     T restartIndex = 0;
-
-#if ENABLE(WEBGL2)
-    // WebGL 2 spec enforces that GL_PRIMITIVE_RESTART_FIXED_INDEX is always enabled, so ignore the restart index.
-    if (isWebGL2())
-        restartIndex = std::numeric_limits<T>::max();
-#endif
 
     // Make uoffset an element offset.
     uoffset /= sizeof(T);
@@ -1247,6 +1247,7 @@ inline unsigned WebGLRenderingContextBase::getMaxIndex(const RefPtr<JSC::ArrayBu
 
     return maxIndex;
 }
+#endif
 
 WebCoreOpaqueRoot root(WebGLRenderingContextBase*);
 


### PR DESCRIPTION
#### be0a403feb9da4434c92bdde78e7722997268dcf
<pre>
WebGL buffers maintain shadow copy
<a href="https://bugs.webkit.org/show_bug.cgi?id=245137">https://bugs.webkit.org/show_bug.cgi?id=245137</a>
rdar://97453557

Reviewed by Kenneth Russell.

Remove the code caching the WebGL buffer data and size.
The data was used to assert that indices drawn with DrawElements are
in range for other buffers.
Remove the data, it is verified by ANGLE.

The size was used to assert that updates to the buffer are in range.
Since we do not check the success of the updates, we cannot cache the
size. The size is checked by ANGLE.

* LayoutTests/webgl/buffer-copysubdata-overlap-no-crash.html: Added.
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::copyBufferSubData):
(WebCore::WebGL2RenderingContext::getBufferSubData):
(WebCore::WebGL2RenderingContext::validateIndexArrayConservative): Deleted.
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLBuffer.cpp:
(WebCore::WebGLBuffer::WebGLBuffer):
(WebCore::WebGLBuffer::associateBufferDataImpl):
(WebCore::WebGLBuffer::associateBufferSubDataImpl):
(WebCore::WebGLBuffer::associateCopyBufferSubData):
* Source/WebCore/html/canvas/WebGLBuffer.h:
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
* Source/WebCore/html/canvas/WebGLRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::bufferData):
(WebCore::WebGLRenderingContextBase::bufferSubData):
(WebCore::WebGLRenderingContextBase::validateVertexAttributes):
(WebCore::WebGLRenderingContextBase::validateDrawArrays):
(WebCore::WebGLRenderingContextBase::validateDrawElements):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::getMaxIndex):

Canonical link: <a href="https://commits.webkit.org/254544@main">https://commits.webkit.org/254544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cc27b274377b147f6fdaf6a4f0642d913df78dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98594 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154917 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32350 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27888 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93050 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25691 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76237 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25633 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68609 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/80988 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30124 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14580 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74786 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29851 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15534 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26342 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3191 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38493 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/77652 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34625 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17178 "Found 1 new JSC stress test failure: stress/verify-can-gc-node-index.js.default (failure)") | 
<!--EWS-Status-Bubble-End-->