### PR TITLE
REGRESSION (Safari 16 beta, STP): WebArchive can't be loaded

### DIFF
--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -429,7 +429,7 @@ struct MarkupAndArchive {
 
 static std::optional<MarkupAndArchive> extractMarkupAndArchive(SharedBuffer& buffer, const std::function<bool(const String)>& canShowMIMETypeAsHTML)
 {
-    auto archive = LegacyWebArchive::create(URL(), buffer);
+    auto archive = LegacyWebArchive::create(URL(), buffer, ArchiveResource::EnforceCrossOrigin::No);
     if (!archive)
         return std::nullopt;
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1230,14 +1230,9 @@ bool DocumentLoader::isLoadingRemoteArchive() const
 
 void DocumentLoader::commitData(const SharedBuffer& data)
 {
-#if ENABLE(WEB_ARCHIVE)
-    URL documentOrEmptyURL = isLoadingRemoteArchive() ? URL() : documentURL();
-#else
-    URL documentOrEmptyURL = documentURL();
-#endif
     if (!m_gotFirstByte) {
         m_gotFirstByte = true;
-        bool hasBegun = m_writer.begin(documentOrEmptyURL, false, nullptr, m_resultingClientId);
+        bool hasBegun = m_writer.begin(documentURL(), false, nullptr, m_resultingClientId);
         if (!hasBegun)
             return;
 
@@ -1261,7 +1256,6 @@ void DocumentLoader::commitData(const SharedBuffer& data)
 
 #if ENABLE(WEB_ARCHIVE)
         if (isLoadingRemoteArchive()) {
-            document.setBaseURLOverride(m_archive->mainResource()->url());
             if (LegacySchemeRegistry::shouldTreatURLSchemeAsLocal(documentURL().protocol().toStringWithoutCopying()))
                 document.securityOrigin().grantLoadLocalResources();
         }
@@ -1821,7 +1815,7 @@ bool DocumentLoader::scheduleArchiveLoad(ResourceLoader& loader, const ResourceR
         return false;
 
 #if ENABLE(WEB_ARCHIVE)
-    if (isLoadingRemoteArchive()) {
+    if (isLoadingRemoteArchive() && !(request.url().protocolIsData() || request.url().isLocalFile())) {
         DOCUMENTLOADER_RELEASE_LOG("scheduleArchiveLoad: Failed to unarchive subresource");
         loader.didFail(ResourceError(errorDomainWebKitInternal, 0, request.url(), "Failed to unarchive subresource"_s));
         return true;

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "ArchiveResource.h"
 #include "CachedRawResourceClient.h"
 #include "CachedResourceHandle.h"
 #include "ContentFilterClient.h"
@@ -72,7 +73,6 @@ namespace WebCore {
 class ApplicationCacheHost;
 class ApplicationManifestLoader;
 class Archive;
-class ArchiveResource;
 class ArchiveResourceCollection;
 class CachedRawResource;
 class CachedResourceLoader;

--- a/Source/WebCore/loader/archive/ArchiveResource.h
+++ b/Source/WebCore/loader/archive/ArchiveResource.h
@@ -32,8 +32,14 @@
 
 namespace WebCore {
 
+#if ENABLE(WEB_ARCHIVE) && USE(CF)
+static constexpr auto webArchivePrefix { "webarchive+"_s };
+#endif
+
 class ArchiveResource : public SubstituteResource {
 public:
+    enum class EnforceCrossOrigin : bool { No, Yes };
+
     static RefPtr<ArchiveResource> create(RefPtr<FragmentedSharedBuffer>&&, const URL&, const ResourceResponse&);
     WEBCORE_EXPORT static RefPtr<ArchiveResource> create(RefPtr<FragmentedSharedBuffer>&&, const URL&,
         const String& mimeType, const String& textEncoding, const String& frameName,

--- a/Source/WebCore/loader/archive/ArchiveResourceCollection.h
+++ b/Source/WebCore/loader/archive/ArchiveResourceCollection.h
@@ -48,7 +48,7 @@ public:
     void addResource(Ref<ArchiveResource>&&);
     void addAllResources(Archive&);
     
-    WEBCORE_EXPORT ArchiveResource* archiveResourceForURL(const URL&);
+    WEBCORE_EXPORT ArchiveResource* archiveResourceForURL(URL);
     RefPtr<Archive> popSubframeArchive(const String& frameName, const URL&);
     
 private:    

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
@@ -42,7 +42,7 @@ class LegacyWebArchive final : public Archive {
 public:
     WEBCORE_EXPORT static Ref<LegacyWebArchive> create();
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(FragmentedSharedBuffer&);
-    WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(const URL&, FragmentedSharedBuffer&);
+    WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(const URL&, FragmentedSharedBuffer&, ArchiveResource::EnforceCrossOrigin = ArchiveResource::EnforceCrossOrigin::Yes);
     WEBCORE_EXPORT static Ref<LegacyWebArchive> create(Ref<ArchiveResource>&& mainResource, Vector<Ref<ArchiveResource>>&& subresources, Vector<Ref<LegacyWebArchive>>&& subframeArchives);
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(Node&, Function<bool(Frame&)>&& frameFilter = { });
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(Frame&);
@@ -62,14 +62,14 @@ private:
     enum MainResourceStatus { Subresource, MainResource };
 
     static RefPtr<LegacyWebArchive> create(const String& markupString, Frame&, const Vector<Node*>& nodes, Function<bool(Frame&)>&& frameFilter);
-    static RefPtr<ArchiveResource> createResource(CFDictionaryRef);
+    static RefPtr<ArchiveResource> createResource(CFDictionaryRef, ArchiveResource::EnforceCrossOrigin = ArchiveResource::EnforceCrossOrigin::Yes);
     static ResourceResponse createResourceResponseFromMacArchivedData(CFDataRef);
     static ResourceResponse createResourceResponseFromPropertyListData(CFDataRef, CFStringRef responseDataType);
     static RetainPtr<CFDataRef> createPropertyListRepresentation(const ResourceResponse&);
     static RetainPtr<CFDictionaryRef> createPropertyListRepresentation(Archive&);
     static RetainPtr<CFDictionaryRef> createPropertyListRepresentation(ArchiveResource*, MainResourceStatus);
 
-    bool extract(CFDictionaryRef);
+    bool extract(CFDictionaryRef, ArchiveResource::EnforceCrossOrigin = ArchiveResource::EnforceCrossOrigin::Yes);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -119,6 +119,11 @@ static bool shouldTreatAsOpaqueOrigin(const URL& url)
         || url.protocolIs("x-apple-ql-id2"_s)
         || url.protocolIs("x-apple-ql-magic"_s)
 #endif
+#if ENABLE(WEB_ARCHIVE) && USE(CF)
+        || url.protocolIs("webarchive+http"_s)
+        || url.protocolIs("webarchive+https"_s)
+        || url.protocolIs("webarchive+ftp"_s)
+#endif
 #if PLATFORM(GTK) || PLATFORM(WPE)
         || url.protocolIs("resource"_s)
 #endif


### PR DESCRIPTION
#### a820369f98280ab3662d920b9b2c6e4f46faa0fe
<pre>
REGRESSION (Safari 16 beta, STP): WebArchive can&apos;t be loaded
<a href="https://bugs.webkit.org/show_bug.cgi?id=242687">https://bugs.webkit.org/show_bug.cgi?id=242687</a>
&lt;rdar://96970629&gt;

Reviewed by NOBODY (OOPS!).

Relative resource paths were not correctly resolved when loaded from
WebArchives. For example, the webarchive&apos;s document&apos;s baseURL resolution had a
problem when the document contained a base element with a relative path (e.g.,
&lt;base href=&quot;/&quot;&gt;). In addition, some DOM behavior could cause page
incompatibility. Now when every resource is loaded from a WebArchive, its URL
is prefixed with &quot;webarchive+&quot;. However, include exceptions for data: and file:
URLs, and document fragments coming from a Pasteboard.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::commitData):
* Source/WebCore/loader/archive/ArchiveResource.h:
* Source/WebCore/loader/archive/ArchiveResourceCollection.cpp:
(WebCore::ArchiveResourceCollection::addResource):
(WebCore::ArchiveResourceCollection::archiveResourceForURL):
* Source/WebCore/loader/archive/ArchiveResourceCollection.h:
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::createResource):
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::shouldTreatAsOpaqueOrigin):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a820369f98280ab3662d920b9b2c6e4f46faa0fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98664 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154970 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32392 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28123 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81693 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93089 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25729 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76271 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25673 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68649 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30166 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14613 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29893 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15562 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38519 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34653 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->