### PR TITLE
Mail sometimes crashes under -beginDraggingSessionWithItems: when dragging attachments in compose

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -534,7 +534,7 @@ public:
     void rotateWithEvent(NSEvent *);
     void smartMagnifyWithEvent(NSEvent *);
 
-    void setLastMouseDownEvent(NSEvent *);
+    RetainPtr<NSEvent> setLastMouseDownEvent(NSEvent *);
 
     void gestureEventWasNotHandledByWebCore(NSEvent *);
     void gestureEventWasNotHandledByWebCoreFromViewOnly(NSEvent *);

--- a/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
+++ b/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
@@ -133,6 +133,7 @@ typedef NSDictionary<NSNumber *, NSValue *> *ProgressToCGPointValueMap;
 @property (nonatomic, strong) NSPasteboard *externalDragPasteboard;
 @property (nonatomic, strong) NSImage *externalDragImage;
 @property (nonatomic, readonly) NSArray<NSURL *> *externalPromisedFiles;
+@property (nonatomic, copy) dispatch_block_t willBeginDraggingHandler;
 @property (nonatomic, copy) dispatch_block_t willEndDraggingHandler;
 
 - (void)writePromisedFiles:(NSArray<NSURL *> *)fileURLs;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -143,6 +143,7 @@
 - (void)sendClicksAtPoint:(NSPoint)pointInWindow numberOfClicks:(NSUInteger)numberOfClicks;
 - (void)sendClickAtPoint:(NSPoint)pointInWindow;
 - (void)wheelEventAtPoint:(CGPoint)pointInWindow wheelDelta:(CGSize)delta;
+- (BOOL)acceptsFirstMouseAtPoint:(NSPoint)pointInWindow;
 - (NSWindow *)hostWindow;
 - (void)typeCharacter:(char)character modifiers:(NSEventModifierFlags)modifiers;
 - (void)typeCharacter:(char)character;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -863,6 +863,11 @@ static WKContentView *recursiveFindWKContentView(UIView *view)
     [self sendClicksAtPoint:pointInWindow numberOfClicks:1];
 }
 
+- (BOOL)acceptsFirstMouseAtPoint:(NSPoint)pointInWindow
+{
+    return [self acceptsFirstMouse:[self _mouseEventWithType:NSEventTypeLeftMouseDown atLocation:pointInWindow]];
+}
+
 - (void)mouseEnterAtPoint:(NSPoint)pointInWindow
 {
     [self mouseEntered:[self _mouseEventWithType:NSEventTypeMouseEntered atLocation:pointInWindow]];


### PR DESCRIPTION
#### 78fca16e3ae8ef10f630dc7c2b44afe887f86c5c
<pre>
Mail sometimes crashes under -beginDraggingSessionWithItems: when dragging attachments in compose
<a href="https://bugs.webkit.org/show_bug.cgi?id=245142">https://bugs.webkit.org/show_bug.cgi?id=245142</a>
rdar://99662145

Reviewed by Tim Horton.

This is a speculative fix for occasional crashes in Mail when dragging attachment elements, due to
the `NSEvent` passed into `-[WKWebView beginDraggingSessionWithItems:event:source:]` being nil,
when AppKit attempts to add this `NSEvent` as a value in a dictionary. While I wasn&apos;t able to
reproduce the crash locally, there are two reasons why the crash might be happening, from code
inspection:

1.  `-acceptsFirstMouse:` or `-shouldDelayWindowOrderingForEvent:` is called after `-mouseDown:`,
    but before the drag has actually begun. This causes us to clear out `m_lastMouseDownEvent`
    before initiating the drag session.

2. `-mouseUp:` is called right after the drag hysteresis has been exceeded in the web process (and
    we&apos;re initiating the drag in `DragController`), but before the drag session has actually begun
    in the UI process.

This patch mitigates both potential causes by adjusting the implementations of `acceptsFirstMouse`
and `shouldDelayWindowOrderingForEvent` to set `m_lastMouseDownEvent` back to its previous value,
rather than nil; additionally, if `m_lastMouseDownEvent` is already nil when attempting to start the
attachment drag session, cancel the drag session and bail instead of attempting to proceed with a
nil event.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::acceptsFirstMouse):
(WebKit::WebViewImpl::shouldDelayWindowOrderingForEvent):
(WebKit::WebViewImpl::startDrag):
(WebKit::WebViewImpl::setLastMouseDownEvent):

Make this return the previous `m_lastMouseDownEvent`, so that we can restore it when the event is
only being set temporarily (i.e. in `acceptsFirstMouse` and `shouldDelayWindowOrderingForEvent`).

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView acceptsFirstMouseAtPoint:]):

Add a helper method that wraps calls to `-acceptsFirstMouse:`.

* Tools/TestWebKitAPI/mac/DragAndDropSimulatorMac.mm:
(-[DragAndDropTestWKWebView beginDraggingSessionWithItems:event:source:]):
(-[DragAndDropSimulator runFrom:to:]):
(-[DragAndDropSimulator willBeginDraggingHandler]):
(-[DragAndDropSimulator setWillBeginDraggingHandler:]):

Add a mechanism to run some testing logic right before synthesizing mouse drag events, when
simulating drag and drop.

Canonical link: <a href="https://commits.webkit.org/254450@main">https://commits.webkit.org/254450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2ab0cb3b577024497d25e76e9b4e5feb71dfc3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19915 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98381 "Failed to checkout and rebase branch from PR 4313") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154704 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32133 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27709 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81429 "Failed to checkout and rebase branch from PR 4313") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92870 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25515 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76016 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/81429 "Failed to checkout and rebase branch from PR 4313") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80379 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/81429 "Failed to checkout and rebase branch from PR 4313") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29920 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29654 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15412 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3119 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38356 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34505 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->