### PR TITLE
Follow-up: Modernize PlatformCAAnimationWin.cpp similar to PlatformCAAnimationCocoa.mm

### DIFF
--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
@@ -324,18 +324,18 @@ void PlatformCAAnimationCocoa::setFillMode(FillModeType value)
     [m_animation setFillMode:toCAFillModeType(value)];
 }
 
-void PlatformCAAnimationCocoa::setTimingFunction(const TimingFunction* value, bool reverse)
+void PlatformCAAnimationCocoa::setTimingFunction(const TimingFunction* timingFunction, bool reverse)
 {
-    ASSERT(value);
+    ASSERT(timingFunction);
     switch (animationType()) {
     case Basic:
     case Keyframe:
-        [m_animation setTimingFunction:toCAMediaTimingFunction(*value, reverse)];
+        [m_animation setTimingFunction:toCAMediaTimingFunction(*timingFunction, reverse)];
         break;
     case Spring:
-        if (value->isSpringTimingFunction()) {
+        if (timingFunction->isSpringTimingFunction()) {
             // FIXME: Handle reverse.
-            auto& function = *static_cast<const SpringTimingFunction*>(value);
+            auto& function = *static_cast<const SpringTimingFunction*>(timingFunction);
             CASpringAnimation *springAnimation = (CASpringAnimation *)m_animation.get();
             springAnimation.mass = function.mass();
             springAnimation.stiffness = function.stiffness();
@@ -561,9 +561,9 @@ void PlatformCAAnimationCocoa::copyKeyTimesFrom(const PlatformCAAnimation& value
     [static_cast<CAKeyframeAnimation *>(m_animation.get()) setKeyTimes:[other keyTimes]];
 }
 
-void PlatformCAAnimationCocoa::setTimingFunctions(const Vector<Ref<const TimingFunction>>& value, bool reverse)
+void PlatformCAAnimationCocoa::setTimingFunctions(const Vector<Ref<const TimingFunction>>& timingFunctions, bool reverse)
 {
-    [static_cast<CAKeyframeAnimation *>(m_animation.get()) setTimingFunctions:createNSArray(value, [&] (auto& function) {
+    [static_cast<CAKeyframeAnimation *>(m_animation.get()) setTimingFunctions:createNSArray(timingFunctions, [&] (auto& function) {
         return toCAMediaTimingFunction(function.get(), reverse);
     }).get()];
 }

--- a/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp
+++ b/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp
@@ -293,10 +293,10 @@ void PlatformCAAnimationWin::setFillMode(FillModeType value)
     CACFAnimationSetFillMode(m_animation.get(), toCACFFillModeType(value));
 }
 
-void PlatformCAAnimationWin::setTimingFunction(const TimingFunction* value, bool reverse)
+void PlatformCAAnimationWin::setTimingFunction(const TimingFunction* timingFunction, bool reverse)
 {
-    ASSERT(value);
-    CACFAnimationSetTimingFunction(m_animation.get(), toCACFTimingFunction(*value, reverse).get());
+    ASSERT(timingFunction);
+    CACFAnimationSetTimingFunction(m_animation.get(), toCACFTimingFunction(*timingFunction, reverse).get());
 }
 
 void PlatformCAAnimationWin::copyTimingFunctionFrom(const PlatformCAAnimation& value)
@@ -537,13 +537,13 @@ void PlatformCAAnimationWin::copyKeyTimesFrom(const PlatformCAAnimation& value)
     CACFAnimationSetKeyTimes(m_animation.get(), CACFAnimationGetKeyTimes(downcast<PlatformCAAnimationWin>(value).platformAnimation()));
 }
 
-void PlatformCAAnimationWin::setTimingFunctions(const Vector<Ref<const TimingFunction>>& value, bool reverse)
+void PlatformCAAnimationWin::setTimingFunctions(const Vector<Ref<const TimingFunction>>& timingFunctions, bool reverse)
 {
     if (animationType() != Keyframe)
         return;
 
-    RetainPtr<CFMutableArrayRef> array = adoptCF(CFArrayCreateMutable(0, value.size(), &kCFTypeArrayCallBacks));
-    for (auto& timingFunction : value)
+    RetainPtr<CFMutableArrayRef> array = adoptCF(CFArrayCreateMutable(0, timingFunctions.size(), &kCFTypeArrayCallBacks));
+    for (auto& timingFunction : timingFunctions)
         CFArrayAppendValue(array.get(), toCACFTimingFunction(timingFunction.get(), reverse).get());
 
     CACFAnimationSetTimingFunctions(m_animation.get(), array.get());


### PR DESCRIPTION
#### c020d23d66d15443ad6a21789bf92c63f66bc5c3
<pre>
Follow-up: Modernize PlatformCAAnimationWin.cpp similar to PlatformCAAnimationCocoa.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=245088">https://bugs.webkit.org/show_bug.cgi?id=245088</a>
&lt;rdar://99830432&gt;

Reviewed by Sam Weinig and Brent Fulgham.

* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm:
(WebCore::PlatformCAAnimationCocoa::setTimingFunction):
(WebCore::PlatformCAAnimationCocoa::setTimingFunctions):
* Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp:
(PlatformCAAnimationWin::setTimingFunction):
(PlatformCAAnimationWin::setTimingFunctions):
- Rename &apos;value&apos; parameters to be more descriptive.

Canonical link: <a href="https://commits.webkit.org/254460@main">https://commits.webkit.org/254460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49f85be2b438b8d8e1cb91ddb444f2cfe72e4ff5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33676 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/19945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98433 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154747 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32184 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27743 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81475 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92908 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94762 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/25557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76050 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25490 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/80418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/19945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68465 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29966 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/19945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29694 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/19945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3123 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33138 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31835 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/19945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->