### PR TITLE
REGRESSION (r293427): Images on web pages are not rendered

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp
@@ -172,6 +172,9 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
     if (linkedBefore(dyld_spring_2022_os_versions, DYLD_IOS_VERSION_15_4, DYLD_MACOSX_VERSION_12_3))
         disableBehavior(SDKAlignedBehavior::AuthorizationHeaderOnSameOriginRedirects);
 
+    if (linkedBefore(dyld_fall_2022_os_versions, DYLD_IOS_VERSION_16_0, DYLD_MACOSX_VERSION_13_0))
+        disableBehavior(SDKAlignedBehavior::SelfContainedWebArchive);
+
     disableAdditionalSDKAlignedBehaviors(behaviors);
 
     return behaviors;

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -80,6 +80,7 @@ enum class SDKAlignedBehavior {
     ProcessSwapOnCrossSiteNavigation,
     RequiresUserGestureToLoadVideo,
     RestrictsBaseURLSchemes,
+    SelfContainedWebArchive,
     ScrollViewContentInsetsAreNotObscuringInsets,
     SendsNativeMouseEvents,
     SessionCleanupByDefault,

--- a/Source/WTF/wtf/spi/darwin/dyldSPI.h
+++ b/Source/WTF/wtf/spi/darwin/dyldSPI.h
@@ -239,6 +239,10 @@ WTF_EXTERN_C_BEGIN
 #define dyld_spring_2022_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
 #endif
 
+#ifndef dyld_fall_2022_os_versions
+#define dyld_fall_2022_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
+#endif
+
 uint32_t dyld_get_program_sdk_version();
 bool dyld_program_sdk_at_least(dyld_build_version_t);
 extern const char* dyld_shared_cache_file_path(void);

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1230,14 +1230,9 @@ bool DocumentLoader::isLoadingRemoteArchive() const
 
 void DocumentLoader::commitData(const SharedBuffer& data)
 {
-#if ENABLE(WEB_ARCHIVE)
-    URL documentOrEmptyURL = isLoadingRemoteArchive() ? URL() : documentURL();
-#else
-    URL documentOrEmptyURL = documentURL();
-#endif
     if (!m_gotFirstByte) {
         m_gotFirstByte = true;
-        bool hasBegun = m_writer.begin(documentOrEmptyURL, false, nullptr, m_resultingClientId);
+        bool hasBegun = m_writer.begin(documentURL(), false, nullptr, m_resultingClientId);
         if (!hasBegun)
             return;
 
@@ -1261,7 +1256,6 @@ void DocumentLoader::commitData(const SharedBuffer& data)
 
 #if ENABLE(WEB_ARCHIVE)
         if (isLoadingRemoteArchive()) {
-            document.setBaseURLOverride(m_archive->mainResource()->url());
             if (LegacySchemeRegistry::shouldTreatURLSchemeAsLocal(documentURL().protocol().toStringWithoutCopying()))
                 document.securityOrigin().grantLoadLocalResources();
         }

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -132,6 +132,10 @@
 #define IS_MAIN_FRAME (m_frame ? m_frame->isMainFrame() : false)
 #define DOCUMENTLOADER_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] DocumentLoader::" fmt, this, PAGE_ID, FRAME_ID, IS_MAIN_FRAME, ##__VA_ARGS__)
 
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
+
 #if USE(APPLE_INTERNAL_SDK)
 #include <WebKitAdditions/DocumentLoaderAdditions.cpp>
 #endif
@@ -1815,7 +1819,7 @@ bool DocumentLoader::scheduleArchiveLoad(ResourceLoader& loader, const ResourceR
         return false;
 
 #if ENABLE(WEB_ARCHIVE)
-    if (isLoadingRemoteArchive()) {
+    if (isLoadingRemoteArchive() && linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::SelfContainedWebArchive)) {
         DOCUMENTLOADER_RELEASE_LOG("scheduleArchiveLoad: Failed to unarchive subresource");
         loader.didFail(ResourceError(errorDomainWebKitInternal, 0, request.url(), "Failed to unarchive subresource"_s));
         return true;

--- a/Source/WebCore/loader/archive/ArchiveResource.h
+++ b/Source/WebCore/loader/archive/ArchiveResource.h
@@ -32,6 +32,10 @@
 
 namespace WebCore {
 
+#if ENABLE(WEB_ARCHIVE) && USE(CF)
+static constexpr auto webArchivePrefix { "webarchive+"_s };
+#endif
+
 class ArchiveResource : public SubstituteResource {
 public:
     static RefPtr<ArchiveResource> create(RefPtr<FragmentedSharedBuffer>&&, const URL&, const ResourceResponse&);

--- a/Source/WebCore/loader/archive/ArchiveResourceCollection.h
+++ b/Source/WebCore/loader/archive/ArchiveResourceCollection.h
@@ -48,7 +48,7 @@ public:
     void addResource(Ref<ArchiveResource>&&);
     void addAllResources(Archive&);
     
-    WEBCORE_EXPORT ArchiveResource* archiveResourceForURL(const URL&);
+    WEBCORE_EXPORT ArchiveResource* archiveResourceForURL(URL);
     RefPtr<Archive> popSubframeArchive(const String& frameName, const URL&);
     
 private:    

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -56,6 +56,7 @@
 #include <wtf/ListHashSet.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/URLHash.h>
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/CString.h>
 
@@ -202,7 +203,8 @@ RefPtr<ArchiveResource> LegacyWebArchive::createResource(CFDictionaryRef diction
         return nullptr;
     }
 
-    URL url { webArchivePrefix + String { cfURL } };
+    auto schemePrefix = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::SelfContainedWebArchive) ? webArchivePrefix : ""_s;
+    URL url { schemePrefix + String { cfURL } };
 
     auto textEncoding = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceTextEncodingNameKey));
     if (textEncoding && CFGetTypeID(textEncoding) != CFStringGetTypeID()) {

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -196,11 +196,13 @@ RefPtr<ArchiveResource> LegacyWebArchive::createResource(CFDictionaryRef diction
         return nullptr;
     }
 
-    auto url = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceURLKey));
-    if (url && CFGetTypeID(url) != CFStringGetTypeID()) {
+    auto cfURL = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceURLKey));
+    if (cfURL && CFGetTypeID(cfURL) != CFStringGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - URL is not of type CFString, cannot create invalid resource");
         return nullptr;
     }
+
+    URL url { webArchivePrefix + String { cfURL } };
 
     auto textEncoding = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceTextEncodingNameKey));
     if (textEncoding && CFGetTypeID(textEncoding) != CFStringGetTypeID()) {
@@ -225,7 +227,7 @@ RefPtr<ArchiveResource> LegacyWebArchive::createResource(CFDictionaryRef diction
         response = createResourceResponseFromPropertyListData(resourceResponseData, resourceResponseVersion);
     }
 
-    return ArchiveResource::create(SharedBuffer::create(resourceData), URL { url }, mimeType, textEncoding, frameName, response);
+    return ArchiveResource::create(SharedBuffer::create(resourceData), url, mimeType, textEncoding, frameName, response);
 }
 
 Ref<LegacyWebArchive> LegacyWebArchive::create()

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -118,6 +118,11 @@ static bool shouldTreatAsOpaqueOrigin(const URL& url)
         || url.protocolIs("x-apple-ql-id"_s)
         || url.protocolIs("x-apple-ql-id2"_s)
         || url.protocolIs("x-apple-ql-magic"_s)
+#if ENABLE(WEB_ARCHIVE) && USE(CF)
+        || url.protocolIs("webarchive+http"_s)
+        || url.protocolIs("webarchive+https"_s)
+        || url.protocolIs("webarchive+ftp"_s)
+#endif
 #endif
 #if PLATFORM(GTK) || PLATFORM(WPE)
         || url.protocolIs("resource"_s)


### PR DESCRIPTION
#### c819fbe23828dfd8e5adc2352304c52cd208d17a
<pre>
REGRESSION (r293427): Scrivener 3: Images on web pages are not rendered
<a href="https://bugs.webkit.org/show_bug.cgi?id=245141">https://bugs.webkit.org/show_bug.cgi?id=245141</a>
rdar://97580190

Reviewed by NOBODY (OOPS!).

Add LinkedOnOrAfter condition for deciding if WebArchives should be considered
as self-contained, or if they should be allowed to fetch resources from the
Internet.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp:
(WTF::computeSDKAlignedBehaviors):
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::scheduleArchiveLoad):
* Source/WebCore/loader/archive/ArchiveResourceCollection.cpp:
(WebCore::ArchiveResourceCollection::addResource):
(WebCore::ArchiveResourceCollection::archiveResourceForURL):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::createResource):
</pre>
----------------------------------------------------------------------
#### 0408a105ae5dfe4434b019ba436f6100ac7c6e47
<pre>
REGRESSION (Safari 16 beta, STP): WebArchive can&apos;t be loaded
<a href="https://bugs.webkit.org/show_bug.cgi?id=242687">https://bugs.webkit.org/show_bug.cgi?id=242687</a>
&lt;rdar://96970629&gt;

Reviewed by NOBODY (OOPS!).

Relative resource paths were not correctly resolved when loaded from
WebArchives. For example. the webarchive&apos;s document&apos;s baseURL resolution had a
problem when the document contained a base element with a relative path (e.g.,
&lt;base href=&quot;/&quot;&gt;). In addition, some DOM behavior could cause page
incompatibility. Now when every resource is loaded from a WebArchive, its URL
is prefixed with &quot;webarchive+&quot;.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::commitData):
* Source/WebCore/loader/archive/ArchiveResource.h:
* Source/WebCore/loader/archive/ArchiveResourceCollection.cpp:
(WebCore::ArchiveResourceCollection::addResource):
(WebCore::ArchiveResourceCollection::archiveResourceForURL):
* Source/WebCore/loader/archive/ArchiveResourceCollection.h:
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::createResource):
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::shouldTreatAsOpaqueOrigin):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c819fbe23828dfd8e5adc2352304c52cd208d17a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98452 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154764 "Hash c819fbe2 for PR 4316 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32203 "Built successfully") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28082 "Failed to checkout and rebase branch from PR 4316") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81494 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92924 "Hash c819fbe2 for PR 4316 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94781 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25571 "Found 8 new test failures: editing/pasteboard/4641033.html, editing/pasteboard/4989774.html, editing/pasteboard/block-wrappers-necessary.html, editing/pasteboard/img-srcset-copy-paste-canonicalization.html, editing/pasteboard/reveal-selection-after-pasting-images.html, editing/pasteboard/styled-element-markup.html, http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html, webarchive/loading/test-loading-archive-subresource-null-mimetype.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76067 "Built successfully") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80432 "Found 4 new API test failures: TestWebKitAPI.WKAttachmentTests.CopyAndPasteImageBetweenWebViews, TestWebKitAPI.WKAttachmentTests.CopyAndPasteBetweenWebViews, TestWebKitAPI.WKAttachmentTests.PasteWebArchiveContainingImages, TestWebKitAPI.WKAttachmentTests.InsertDataURLImagesAsAttachments (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80412 "Found 5 new API test failures: TestWebKitAPI.WKAttachmentTests.CopyAndPasteBetweenWebViews, TestWebKitAPI.WebKitLegacy.AccessingImageInPastedWebArchive, TestWebKitAPI.WKAttachmentTests.PasteWebArchiveContainingImages, TestWebKitAPI.WKAttachmentTests.CopyAndPasteImageBetweenWebViews, TestWebKitAPI.WKAttachmentTests.InsertDataURLImagesAsAttachments (failure)") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/80846 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29985 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14478 "Found 19 new test failures: editing/pasteboard/4641033.html, editing/pasteboard/4947130.html, editing/pasteboard/4989774.html, editing/pasteboard/block-wrappers-necessary.html, editing/pasteboard/copy-resolves-urls.html, editing/pasteboard/copy-text-with-wrapped-tag.html, editing/pasteboard/drag-and-drop-objectimage-contenteditable.html, editing/pasteboard/drag-image-to-contenteditable-in-iframe.html, editing/pasteboard/drag-selected-image-to-contenteditable.html, editing/pasteboard/img-srcset-copy-paste-canonicalization.html ... (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74636 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29711 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15447 "Found 12 new test failures: editing/pasteboard/4641033.html, editing/pasteboard/4989774.html, editing/pasteboard/block-wrappers-necessary.html, editing/pasteboard/copy-resolves-urls.html, editing/pasteboard/copy-text-with-wrapped-tag.html, editing/pasteboard/img-srcset-copy-paste-canonicalization.html, editing/pasteboard/paste-noscript.html, editing/pasteboard/reveal-selection-after-pasting-images.html, editing/pasteboard/styled-element-markup.html, http/tests/misc/copy-resolves-urls.html ... (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26312 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33157 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38400 "Found 12 new test failures: editing/pasteboard/4641033.html, editing/pasteboard/4989774.html, editing/pasteboard/block-wrappers-necessary.html, editing/pasteboard/copy-resolves-urls.html, editing/pasteboard/copy-text-with-wrapped-tag.html, editing/pasteboard/img-srcset-copy-paste-canonicalization.html, editing/pasteboard/paste-noscript.html, editing/pasteboard/reveal-selection-after-pasting-images.html, editing/pasteboard/styled-element-markup.html, http/tests/misc/copy-resolves-urls.html ... (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/77498 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34540 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17148 "Passed tests") | 
<!--EWS-Status-Bubble-End-->