### PR TITLE
PopState event should be fired synchronously, even before the load event

### DIFF
--- a/LayoutTests/fast/loader/stateobjects/document-destroyed-navigate-back-expected.txt
+++ b/LayoutTests/fast/loader/stateobjects/document-destroyed-navigate-back-expected.txt
@@ -4,13 +4,13 @@ ALERT: State popped - SecondEntry (type string)
 ALERT: Navigating back...
 main frame - has 1 onunload handler(s)
 ALERT: Last path component of location is document-destroyed-navigate-back.html?SecondEntryWillLaterBeReactivated
-ALERT: State popped - SecondEntryWillLaterBeReactivated (type string)
+ALERT: Page shown - SecondEntryWillLaterBeReactivated (type string)
 ALERT: State popped - FirstEntryWillLaterBeReactivated (type string)
 ALERT: Test complete
 This test:
 -Builds up a list of state object entries with fragment URLs.
 -Navigates through them to verify that the popstate event is fired.
 -Navigates away to a new document, with the old document being destroyed.
--Navigates back to the state object entries and verifies the popstate event is fired even on the new documents.
+-Navigates back to the state object entries and verifies the pageshow or popstate events are fired on the new documents.
 
 

--- a/LayoutTests/fast/loader/stateobjects/document-destroyed-navigate-back-with-fragment-scroll-expected.txt
+++ b/LayoutTests/fast/loader/stateobjects/document-destroyed-navigate-back-with-fragment-scroll-expected.txt
@@ -8,7 +8,6 @@ ALERT: Navigating back...
 main frame - has 1 onunload handler(s)
 ALERT: LOADED
 ALERT: Last path component of location is document-destroyed-navigate-back-with-fragment-scroll.html#SecondEntryWillLaterBeReactivated
-ALERT: State popped - SecondEntryWillLaterBeReactivated (type string)
 ALERT: State popped - FirstEntryWillLaterBeReactivated (type string)
 ALERT: hashChanged - Last path component of location is document-destroyed-navigate-back-with-fragment-scroll.html#FirstEntryWillLaterBeReactivated
 ALERT: Test complete

--- a/LayoutTests/fast/loader/stateobjects/document-destroyed-navigate-back.html
+++ b/LayoutTests/fast/loader/stateobjects/document-destroyed-navigate-back.html
@@ -21,39 +21,26 @@ function runFirstStageOfTest()
     history.back();
 }
 
-function runSecondStageOfTest()
-{
-    alert("Last path component of location is " + lastPathComponent());
-}
-
-function runThirdStageOfTest()
-{
-    alert("Final stage of test loaded");
-}
-
 function runTest()
 {
     if (!sessionStorage.stage) {
         // Location changes need to happen outside the onload handler to generate history entries.
         setTimeout(runFirstStageOfTest, 0);
     } else if (sessionStorage.stage == 2)
-        runSecondStageOfTest();
-    else if (sessionStorage.stage == 3)
-        runThirdStageOfTest();
+        alert("Last path component of location is " + lastPathComponent());
 }
 
-function statePopped()
+function continueTest(state)
 {
-    alert("State popped - " + event.state + " (type " + typeof event.state + ")");
-    if (event.state == "FirstEntry") {
+    if (state == "FirstEntry") {
         history.replaceState("FirstEntryWillLaterBeReactivated", null, "?FirstEntryWillLaterBeReactivated");
         history.forward();
-    } else if (event.state == "SecondEntry") {
+    } else if (state == "SecondEntry") {
         history.replaceState("SecondEntryWillLaterBeReactivated", null, "?SecondEntryWillLaterBeReactivated");
         window.location = "resources/navigate-back.html";
-    } else if (event.state == "SecondEntryWillLaterBeReactivated")
+    } else if (state == "SecondEntryWillLaterBeReactivated")
         history.back();
-    else if (event.state == "FirstEntryWillLaterBeReactivated") {
+    else if (state == "FirstEntryWillLaterBeReactivated") {
         alert("Test complete");
         sessionStorage.clear();
         if (window.testRunner)
@@ -61,14 +48,30 @@ function statePopped()
     }
 }
 
+window.onpopstate = function statePopped()
+{
+    var state = event.state;
+    alert("State popped - " + state + " (type " + typeof state + ")");
+    continueTest(state);
+}
+
+window.onpageshow = function pageShown()
+{
+    if (sessionStorage.stage == 2) {
+        var state = history.state;
+        alert("Page shown - " + state + " (type " + typeof state + ")");
+        continueTest(state);
+    }
+}
+
 </script>
-<body onload="runTest();" onpopstate="statePopped();" onunload="/* disable page cache */">
+<body onload="runTest();" onunload="/* disable page cache */">
 <pre>
 This test:
 -Builds up a list of state object entries with fragment URLs.
 -Navigates through them to verify that the popstate event is fired.
 -Navigates away to a new document, with the old document being destroyed.
--Navigates back to the state object entries and verifies the popstate event is fired even on the new documents.
+-Navigates back to the state object entries and verifies the pageshow or popstate events are fired on the new documents.
 </pre><br>
 <pre id="logger"></pre>
 </body>

--- a/LayoutTests/fast/loader/stateobjects/replacestate-in-iframe-expected.txt
+++ b/LayoutTests/fast/loader/stateobjects/replacestate-in-iframe-expected.txt
@@ -1,7 +1,8 @@
 main frame - has 1 onunload handler(s)
 frame "<!--frame1-->" - has 1 onunload handler(s)
+ALERT: onpageshow
 ALERT: Navigating back...
 main frame - has 1 onunload handler(s)
 frame "<!--frame1-->" - has 1 onunload handler(s)
-ALERT: onpopstate
+ALERT: onpageshow
 PASS

--- a/LayoutTests/fast/loader/stateobjects/resources/replacestate-in-iframe-window-child.html
+++ b/LayoutTests/fast/loader/stateobjects/resources/replacestate-in-iframe-window-child.html
@@ -10,8 +10,11 @@ window.onunload = function() {
   // No page cache
 }
 
-window.onpopstate = function(e) {
-  alert("onpopstate");
-  top.opener.notifyDone(window == parent ? "FAIL" : "PASS");
+window.onpageshow = function(e) {
+  alert("onpageshow");
+  if (sessionStorage.alreadyShown)
+    top.opener.notifyDone(window == parent ? "FAIL" : "PASS");
+  else
+    sessionStorage.alreadyShown = true;
 }
 </script>

--- a/LayoutTests/http/tests/dom/document-fragment-expected.txt
+++ b/LayoutTests/http/tests/dom/document-fragment-expected.txt
@@ -1,2 +1,2 @@
-ALERT: continuing with correct fragment, promise, popstate, hashchange, timeout
+ALERT: popstate, continuing with correct fragment, promise, hashchange, timeout
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/event-order/before-load-hash-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/event-order/before-load-hash-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL when changing hash, before load assert_array_equals: lengths differ, expected array ["popstate"] length 1, got [] length 0
+FAIL when changing hash, before load assert_array_equals: lengths differ, expected array ["popstate", "hashchange", "load"] length 3, got ["popstate", "load"] length 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/event-order/before-load-hash-twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/event-order/before-load-hash-twice-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL when changing hash twice, before load assert_array_equals: lengths differ, expected array ["popstate"] length 1, got [] length 0
+FAIL when changing hash twice, before load assert_array_equals: lengths differ, expected array ["popstate", "popstate", "hashchange", "hashchange", "load"] length 5, got ["popstate", "popstate", "load"] length 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/event-order/pushState-inside-popstate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/event-order/pushState-inside-popstate-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL pushState inside popstate assert_true: expected true got false
+PASS pushState inside popstate
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/007-expected.txt
@@ -3,9 +3,9 @@ It looks like the browser stopped loading the page when encountering a .go(-1) c
 PASS history.state should initially be null
 PASS history.pushState support is needed for this testcase
 PASS history.state should reflect pushed state
-FAIL popstate event should fire before onload fires assert_true: expected true got false
-FAIL the correct state should be restored when navigating during initial load assert_equals: expected (string) "state1" but got (boolean) false
+PASS popstate event should fire before onload fires
+PASS the correct state should be restored when navigating during initial load
 PASS history.state should reflect the navigated state onload
-FAIL popstate event should not fire after onload fires assert_false: expected false got true
+PASS popstate event should not fire after onload fires
 PASS history.state should reflect the navigated state after onload
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/history_forward_cross_realm_method-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/history_forward_cross_realm_method-expected.txt
@@ -1,4 +1,6 @@
 
 
+Harness Error (TIMEOUT), message = null
+
 PASS history.forward() uses this's associated document's browsing context to determine if navigation is allowed
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3265,8 +3265,6 @@ void Document::implicitClose()
 
     dispatchWindowLoadEvent();
     dispatchPageshowEvent(PageshowEventNotPersisted);
-    if (m_pendingStateObject)
-        dispatchPopstateEvent(WTFMove(m_pendingStateObject));
 
     if (f)
         f->loader().dispatchOnloadEvents();
@@ -6578,12 +6576,7 @@ void Document::statePopped(Ref<SerializedScriptValue>&& stateObject)
     if (!frame())
         return;
     
-    // Per step 11 of section 6.5.9 (history traversal) of the HTML5 spec, we 
-    // defer firing of popstate until we're in the complete state.
-    if (m_readyState == Complete)
-        dispatchPopstateEvent(WTFMove(stateObject));
-    else
-        m_pendingStateObject = WTFMove(stateObject);
+    dispatchPopstateEvent(WTFMove(stateObject));
 }
 
 void Document::attachRange(Range& range)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1922,7 +1922,6 @@ private:
 
     std::unique_ptr<LazyLoadImageObserver> m_lazyLoadImageObserver;
 
-    RefPtr<SerializedScriptValue> m_pendingStateObject;
 #if !LOG_DISABLED
     MonotonicTime m_documentCreationTime;
 #endif


### PR DESCRIPTION
#### 9497f1badb3df074553143a369942473cf13c10d
<pre>
PopState event should be fired synchronously, even before the load event
<a href="https://bugs.webkit.org/show_bug.cgi?id=245153">https://bugs.webkit.org/show_bug.cgi?id=245153</a>

Reviewed by Brent Fulgham.

PopState event should be fired synchronously, even before the load event:
- <a href="https://github.com/whatwg/html/issues/1792">https://github.com/whatwg/html/issues/1792</a>

We used to delay PopState events until the load event has fired but this
doesn&apos;t match other Blink or Gecko.

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/event-order/before-load-hash-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/event-order/before-load-hash-twice-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/event-order/pushState-inside-popstate-expected.txt:
Rebaseline WPT tests that are now passing or failing a little further. The ones that are still failing and due to the fact that
we fire the load event synchronously instead of queuing a task. As a result, it may fire before hashchange events that were
scheduled before the load has completed. I plan to look into this in a follow-up.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::implicitClose):
(WebCore::Document::statePopped):
* Source/WebCore/dom/Document.h:

Canonical link: <a href="https://commits.webkit.org/254519@main">https://commits.webkit.org/254519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41cce0ab1079ba24c952798a4221d51f8a6ce63a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98520 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154833 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32271 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27817 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81563 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92989 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25632 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76125 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25562 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68536 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30049 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14533 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29773 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15496 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3174 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38455 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31923 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34587 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->