### PR TITLE
Align "UA" stylesheet for "hr", "fieldset", "marquee", "details" etc. with HTML Spec

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -56,6 +56,7 @@ address, article, aside, div, footer, header, hgroup, main, nav, section {
 
 marquee {
     display: inline-block;
+    text-align: initial;
 }
 
 blockquote {
@@ -104,6 +105,7 @@ hr {
     margin-inline-end: auto;
     border-style: inset;
     border-width: 1px;
+    overflow: hidden;
 }
 
 /* media elements */
@@ -373,7 +375,7 @@ fieldset {
     padding-inline-end: 0.75em;
     padding-block-end: 0.625em;
     border: 2px groove ThreeDFace;
-    min-width: min-content;
+    min-inline-size: min-content;
 }
 
 button {
@@ -1353,6 +1355,16 @@ details {
 
 summary {
     display: block;
+}
+
+details > summary:first-of-type {
+    display: list-item;
+    counter-increment: list-item 0;
+    list-style: disclosure-closed inside;
+}
+
+  details[open] > summary {
+    list-style-type: disclosure-open;
 }
 
 summary::-webkit-details-marker {


### PR DESCRIPTION
<pre>
Align "UA" stylesheet for "hr", "fieldset", "marquee", "details" etc. with HTML Spec

<a href="https://bugs.webkit.org/show_bug.cgi?id=245156">https://bugs.webkit.org/show_bug.cgi?id=245156</a>

Reviewed by NOBODY (OOPS!).

Align "UA" stylesheet with latest HTML Specifications:

1) marquee element is missing "text-align: initial".

<a href="https://html.spec.whatwg.org/#the-marquee-element-2">https://html.spec.whatwg.org/#the-marquee-element-2</a>

2) hr element is missing "overflow: hidden".

<a href="https://html.spec.whatwg.org/#the-hr-element-2">https://html.spec.whatwg.org/#the-hr-element-2</a>

3) fieldset element need change of "min-inline-size: min-content;" to "min-width: min-content;"

<a href="https://html.spec.whatwg.org/#the-fieldset-and-legend-elements">https://html.spec.whatwg.org/#the-fieldset-and-legend-elements</a>

4) details and summary elements to be aligned:

<a href="https://html.spec.whatwg.org/#the-details-and-summary-elements">https://html.spec.whatwg.org/#the-details-and-summary-elements</a>

Also bring change of Chrome / Blink and Firefox / Gecko as below:

details > summary:first-of-type {
    display: list-item;
    counter-increment: list-item 0;
    list-style: disclosure-closed inside;
}

*Source/WebCore/css/html.css - Update "UA" stylesheet with HTML Specifications
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67c05d3515efe6b1dff0ed60733af26c300628b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98434 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154742 "Found 6 new test failures: editing/execCommand/create-list-with-hr.html, editing/execCommand/insertHorizontalRule.html, editing/inserting/4278698.html, editing/inserting/insert-paragraph-03.html, editing/inserting/insert-paragraph-04.html, editing/undo/4063751.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32179 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27738 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81470 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92903 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94757 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25550 "Found 30 new test failures: compositing/reflections/mask-and-reflection.html, css1/basic/containment.html, css1/basic/contextual_selectors.html, css1/basic/grouping.html, css1/basic/id_as_selector.html, css1/basic/inheritance.html, css1/box_properties/border.html, css1/box_properties/border_bottom.html, css1/box_properties/border_bottom_inline.html, css1/box_properties/border_bottom_width.html ... (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76045 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25487 "Found 281 new test failures: css1/basic/containment.html, css1/basic/contextual_selectors.html, css1/basic/grouping.html, css1/basic/id_as_selector.html, css1/basic/inheritance.html, css1/box_properties/border.html, css1/box_properties/border_bottom.html, css1/box_properties/border_bottom_inline.html, css1/box_properties/border_bottom_width.html, css1/box_properties/border_bottom_width_inline.html ... (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68462 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29961 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14462 "Found 30 new test failures: css1/basic/containment.html, css1/basic/contextual_selectors.html, css1/basic/grouping.html, css1/box_properties/border.html, css1/box_properties/border_bottom.html, css1/box_properties/border_bottom_inline.html, css1/box_properties/border_bottom_width.html, css1/cascade/cascade_order.html, css1/cascade/important.html, css1/classification/display.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29689 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15433 "Found 30 new test failures: accessibility/mac/attributed-string/attributed-string-does-not-includes-misspelled-for-non-editable.html, compositing/shared-backing/overlap-after-end-sharing.html, css1/basic/containment.html, css1/basic/contextual_selectors.html, css1/basic/grouping.html, css1/basic/id_as_selector.html, css1/basic/inheritance.html, css1/box_properties/border.html, css1/box_properties/border_bottom.html, css1/box_properties/border_bottom_inline.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33133 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38384 "Found 30 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-focused-element-change.html, accessibility/accessibility-crash-setattribute.html, accessibility/accessibility-crash-with-dynamic-inline-content.html, accessibility/accessibility-node-reparent.html, accessibility/accessibility-object-detached.html, accessibility/accessibility-object-update-during-style-resolution-crash.html, accessibility/activation-of-input-field-inside-other-element.html, accessibility/custom-elements/role.html, accessibility/mac/abbr-acronym-tags.html ... (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31830 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34526 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->