### PR TITLE
Align "UA" stylesheet for "fieldset" with HTML Spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/min-inline-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/min-inline-size-expected.txt
@@ -3,8 +3,8 @@
 
 
 PASS horizontal-tb
-FAIL vertical-lr  assert_equals: height expected "100px" but got "0px"
-FAIL vertical-rl  assert_equals: height expected "100px" but got "0px"
+PASS vertical-lr
+PASS vertical-rl
 PASS horizontal-tb override
 PASS vertical-lr override
 PASS vertical-rl override

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -373,7 +373,7 @@ fieldset {
     padding-inline-end: 0.75em;
     padding-block-end: 0.625em;
     border: 2px groove ThreeDFace;
-    min-width: min-content;
+    min-inline-size: min-content;
 }
 
 button {


### PR DESCRIPTION
#### 3e77428f1d57c556a0d131005e91c27975e7e51c
<pre>
Align &quot;UA&quot; stylesheet for &quot;fieldset&quot; with HTML Spec

Align &quot;UA&quot; stylesheet for &quot;fieldset&quot; with HTML Spec

<a href="https://bugs.webkit.org/show_bug.cgi?id=245159">https://bugs.webkit.org/show_bug.cgi?id=245159</a>

Reviewed by Tim Nguyen.

Align &quot;UA&quot; stylesheet with latest HTML Specifications:

- fieldset element need change from min-width: min-content; to min-inline-size: min-content;

<a href="https://html.spec.whatwg.org/#the-fieldset-and-legend-elements">https://html.spec.whatwg.org/#the-fieldset-and-legend-elements</a>

* Source/WebCore/css/html.css - Update &quot;UA&quot; stylesheet with HTML Specifications
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/min-inline-size-expected.txt - Updated Test Expectations

Canonical link: <a href="https://commits.webkit.org/254485@main">https://commits.webkit.org/254485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/811e02d92bd397b87bc8ba77b26e605e7a1ebeb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98510 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154823 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32260 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27808 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81553 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92979 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25630 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/76116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25555 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/80495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68529 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30039 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29763 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15490 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3145 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33210 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/76116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34581 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->