### PR TITLE
Nodes with display::none should be considered search invisible.

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/word-display-none-expected.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/word-display-none-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - highlight simple start reference</title>
+<style>
+  span {
+    display: none;
+  }
+</style>
+
+<p>The test passes if the following word does not have a yellow background.</p>
+<div>This <span>word</span> should not be highlighted</div>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/word-display-none.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/word-display-none.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
+<meta charset="utf-8" />
+<title>Scroll to text fragment - highlight simple start text</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<style>
+  span {
+    display: none;
+  }
+</style>
+
+<p>The test passes if the following word does not have a yellow background.</p>
+<div>This <span>word</span> should not be highlighted</div>
+
+<script>
+  location.href = "#:~:text=This-,word,-should";
+</script>
+</html>

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -41,6 +41,7 @@
 #include "HTMLScriptElement.h"
 #include "HTMLStyleElement.h"
 #include "HTMLVideoElement.h"
+#include "NodeRenderStyle.h"
 #include "Position.h"
 #include "SimpleRange.h"
 #include "TextBoundaries.h"
@@ -55,7 +56,8 @@ enum class WordBounded : bool { No, Yes };
 // https://wicg.github.io/scroll-to-text-fragment/#search-invisible
 static bool isSearchInvisible(const Node& node)
 {
-    // FIXME: The computed value of its display property is none.
+    if (!node.renderStyle() || node.renderStyle()->display() == DisplayType::None)
+        return true;
     
     // FIXME: If the node serializes as void.
     


### PR DESCRIPTION
#### 66ee16990695ad226e81dc8571801e9741031fa7
<pre>
Nodes with display::none should be considered search invisible.
<a href="https://bugs.webkit.org/show_bug.cgi?id=245170">https://bugs.webkit.org/show_bug.cgi?id=245170</a>
&lt;rdar://99905766&gt;

Reviewed by Devin Rousso.

Address a FIXME from the spec implementation, nodes with display::none should be
considered search-invisible and not considered valid for a fragment.

* LayoutTests/http/tests/scroll-to-text-fragment/word-display-none-expected.html: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/word-display-none.html: Added.
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::isSearchInvisible):

Canonical link: <a href="https://commits.webkit.org/254498@main">https://commits.webkit.org/254498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b85dbc54eb5635693e45416b6b0560daa7f74ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98479 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154791 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32230 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27782 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92948 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25594 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76090 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25528 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68502 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30010 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14502 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29735 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15464 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3155 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38421 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34557 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->