### PR TITLE
[Nicosia] Async Scrolling: some elements are jumpy in gitlab

### DIFF
--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNode.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNode.cpp
@@ -73,6 +73,16 @@ void ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(const Scrol
     }
 }
 
+FloatSize ScrollingTreeOverflowScrollProxyNode::scrollDeltaSinceLastCommit() const
+{
+    if (auto* node = scrollingTree().nodeForID(m_overflowScrollingNodeID)) {
+        if (is<ScrollingTreeOverflowScrollingNode>(node))
+            return downcast<ScrollingTreeOverflowScrollingNode>(*node).scrollDeltaSinceLastCommit();
+    }
+
+    return { };
+}
+
 void ScrollingTreeOverflowScrollProxyNode::applyLayerPositions()
 {
     FloatPoint scrollOffset;

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNode.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNode.h
@@ -43,6 +43,8 @@ public:
     static Ref<ScrollingTreeOverflowScrollProxyNode> create(ScrollingTree&, ScrollingNodeID);
     virtual ~ScrollingTreeOverflowScrollProxyNode();
 
+    FloatSize scrollDeltaSinceLastCommit() const;
+
     ScrollingNodeID overflowScrollingNodeID() const { return m_overflowScrollingNodeID; }
 
 private:

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNode.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNode.cpp
@@ -71,7 +71,7 @@ void ScrollingTreePositionedNode::commitStateBeforeChildren(const ScrollingState
         scrollingTree().activePositionedNodes().add(*this);
 }
 
-void ScrollingTreePositionedNode::applyLayerPositions()
+FloatSize ScrollingTreePositionedNode::scrollDeltaSinceLastCommit() const
 {
     FloatSize delta;
     for (auto nodeID : m_relatedOverflowScrollingNodes) {
@@ -83,6 +83,13 @@ void ScrollingTreePositionedNode::applyLayerPositions()
         }
     }
 
+    // Positioned nodes compensate for scrolling, so negate the scroll delta.
+    return -delta;
+}
+
+void ScrollingTreePositionedNode::applyLayerPositions()
+{
+    FloatSize delta = scrollDeltaSinceLastCommit();
     FloatPoint layerPosition = m_constraints.layerPositionAtLastLayout() + delta;
 
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreePositionedNode " << scrollingNodeID() << " applyLayerPositions: overflow delta " << delta << " moving layer to " << layerPosition);

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNode.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNode.h
@@ -45,7 +45,11 @@ public:
     static Ref<ScrollingTreePositionedNode> create(ScrollingTree&, ScrollingNodeID);
     virtual ~ScrollingTreePositionedNode();
 
+    Nicosia::CompositionLayer* layer() const { return m_layer.get(); }
+
     const Vector<ScrollingNodeID>& relatedOverflowScrollingNodes() const { return m_relatedOverflowScrollingNodes; }
+
+    FloatSize scrollDeltaSinceLastCommit() const;
 
 private:
     ScrollingTreePositionedNode(ScrollingTree&, ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.h
@@ -45,6 +45,8 @@ public:
     static Ref<ScrollingTreeStickyNodeNicosia> create(ScrollingTree&, ScrollingNodeID);
     virtual ~ScrollingTreeStickyNodeNicosia() = default;
 
+    Nicosia::CompositionLayer* layer() const { return m_layer.get(); }
+
 private:
     ScrollingTreeStickyNodeNicosia(ScrollingTree&, ScrollingNodeID);
 


### PR DESCRIPTION
#### 414681c51c026880d048bccc323bc9cd32dc2a31
<pre>
[Nicosia] Async Scrolling: some elements are jumpy in gitlab
<a href="https://bugs.webkit.org/show_bug.cgi?id=245175">https://bugs.webkit.org/show_bug.cgi?id=245175</a>

Reviewed by Simon Fraser and Žan Doberšek.

Bring several fixes for fixed elements that landed in cocoa but not in nicosia specific code.

* Source/WebCore/page/scrolling/nicosia/ScrollingTreeFixedNode.cpp:
(WebCore::ScrollingTreeFixedNode::applyLayerPositions):
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNode.cpp:
(WebCore::ScrollingTreeOverflowScrollProxyNode::scrollDeltaSinceLastCommit const):
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNode.h:
* Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNode.cpp:
(WebCore::ScrollingTreePositionedNode::scrollDeltaSinceLastCommit const):
(WebCore::ScrollingTreePositionedNode::applyLayerPositions):
* Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNode.h:
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.h:

Canonical link: <a href="https://commits.webkit.org/254509@main">https://commits.webkit.org/254509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55a4e4005e29914f502c577366d6bd5e9c728d05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98490 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154802 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32240 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27792 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81534 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92959 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25607 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76100 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25537 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/92759 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68510 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/80881 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30020 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14511 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74673 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/88228 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29745 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15476 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26318 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3165 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38439 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/77538 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31891 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34567 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17154 "Passed tests") | 
<!--EWS-Status-Bubble-End-->