### PR TITLE
IPC::Connection declaration has unrelated platform implementation declarations

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
@@ -29,6 +29,7 @@
 #include "Connection.h"
 #include "RemoteVideoFrameProxy.h"
 #include "ThreadSafeObjectHeap.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/DestinationColorSpace.h>
 #include <WebCore/VideoFrame.h>
 
@@ -43,7 +44,7 @@ class PixelBufferConformerCV;
 namespace WebKit {
 
 // Holds references to all VideoFrame instances that are mapped from GPU process to Web process.
-class RemoteVideoFrameObjectHeap final : public IPC::Connection::WorkQueueMessageReceiver {
+class RemoteVideoFrameObjectHeap final : public IPC::WorkQueueMessageReceiver {
 public:
     static Ref<RemoteVideoFrameObjectHeap> create(Ref<IPC::Connection>&&);
     ~RemoteVideoFrameObjectHeap();

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -34,6 +34,7 @@
 #include "RemoteVideoFrameIdentifier.h"
 #include "SharedMemory.h"
 #include "SharedVideoFrame.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/ProcessIdentity.h>
 #include <atomic>
 #include <wtf/ThreadAssertions.h>
@@ -60,7 +61,7 @@ class RemoteVideoFrameObjectHeap;
 struct SharedVideoFrame;
 class SharedVideoFrameReader;
 
-class LibWebRTCCodecsProxy final : public IPC::Connection::WorkQueueMessageReceiver {
+class LibWebRTCCodecsProxy final : public IPC::WorkQueueMessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<LibWebRTCCodecsProxy> create(GPUConnectionToWebProcess&);
@@ -74,7 +75,7 @@ private:
     auto createDecoderCallback(RTCDecoderIdentifier, bool useRemoteFrames);
     WorkQueue& workQueue() const { return m_queue; }
 
-    // IPC::Connection::WorkQueueMessageReceiver overrides.
+    // IPC::WorkQueueMessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
     void createH264Decoder(RTCDecoderIdentifier, bool useRemoteFrames);

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h
@@ -30,6 +30,7 @@
 #include "Connection.h"
 #include "RemoteSampleBufferDisplayLayerManagerMessagesReplies.h"
 #include "SampleBufferDisplayLayerIdentifier.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/IntSize.h>
 #include <wtf/HashMap.h>
 
@@ -46,7 +47,7 @@ namespace WebKit {
 class GPUConnectionToWebProcess;
 class RemoteSampleBufferDisplayLayer;
 
-class RemoteSampleBufferDisplayLayerManager final : public IPC::Connection::WorkQueueMessageReceiver {
+class RemoteSampleBufferDisplayLayerManager final : public IPC::WorkQueueMessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<RemoteSampleBufferDisplayLayerManager> create(GPUConnectionToWebProcess& connection)
@@ -65,7 +66,7 @@ private:
     explicit RemoteSampleBufferDisplayLayerManager(GPUConnectionToWebProcess&);
     void startListeningForIPC();
 
-    // IPC::Connection::WorkQueueMessageReceiver overrides.
+    // IPC::WorkQueueMessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -34,6 +34,7 @@
 #include "StorageNamespaceIdentifier.h"
 #include "WebPageProxyIdentifier.h"
 #include "WebsiteData.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/ClientOrigin.h>
 #include <WebCore/FileSystemHandleIdentifier.h>
 #include <WebCore/FileSystemSyncAccessHandleIdentifier.h>
@@ -70,7 +71,7 @@ class IDBStorageRegistry;
 class StorageAreaBase;
 class StorageAreaRegistry;
 
-class NetworkStorageManager final : public IPC::Connection::WorkQueueMessageReceiver {
+class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver {
 public:
     static void forEach(const Function<void(NetworkStorageManager&)>&);
     static Ref<NetworkStorageManager> create(PAL::SessionID, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, bool shouldUseCustomPaths);

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
@@ -28,6 +28,7 @@
 
 #include "Connection.h"
 #include "DataReference.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/RTCDataChannelRemoteHandlerConnection.h>
 #include <WebCore/RTCDataChannelRemoteSourceConnection.h>
 #include <wtf/WorkQueue.h>
@@ -36,7 +37,7 @@ namespace WebKit {
 
 class NetworkConnectionToWebProcess;
 
-class RTCDataChannelRemoteManagerProxy final : public IPC::Connection::WorkQueueMessageReceiver {
+class RTCDataChannelRemoteManagerProxy final : public IPC::WorkQueueMessageReceiver {
 public:
     static Ref<RTCDataChannelRemoteManagerProxy> create() { return adoptRef(*new RTCDataChannelRemoteManagerProxy); }
 
@@ -46,7 +47,7 @@ public:
 private:
     RTCDataChannelRemoteManagerProxy();
 
-    // IPC::Connection::WorkQueueMessageReceiver
+    // IPC::WorkQueueMessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
     // To source

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -29,6 +29,7 @@
 #include "Logging.h"
 #include "MessageFlags.h"
 #include "MessageReceiveQueues.h"
+#include "WorkQueueMessageReceiver.h"
 #include <memory>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/HashSet.h>

--- a/Source/WebKit/Platform/IPC/MessageObserver.h
+++ b/Source/WebKit/Platform/IPC/MessageObserver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,40 +25,25 @@
 
 #pragma once
 
-#define ASSERT_IS_TESTING_IPC() ASSERT(IPC::isTestingIPC(), "Untrusted connection sent invalid data. Should only happen when testing IPC.")
+#if ENABLE(IPC_TESTING_API)
+
+#include <wtf/OptionSet.h>
+#include <wtf/WeakPtr.h>
 
 namespace IPC {
 
-// Function to check when asserting IPC-related failures, so that IPC testing skips the assertions
-// and exposes bugs underneath.
-bool isTestingIPC();
+class Decoder;
+class Encoder;
 
-#if ENABLE(IPC_TESTING_API)
-void startTestingIPC();
-void stopTestingIPC();
-#else
-inline bool isTestingIPC()
-{
-    return false;
-}
-#endif
+enum class SendOption : uint8_t;
 
-#if USE(UNIX_DOMAIN_SOCKETS)
-struct SocketPair {
-    int client;
-    int server;
+class MessageObserver : public CanMakeWeakPtr<MessageObserver> {
+public:
+    virtual ~MessageObserver() = default;
+    virtual void willSendMessage(const Encoder&, OptionSet<SendOption>) = 0;
+    virtual void didReceiveMessage(const Decoder&) = 0;
 };
 
-enum PlatformConnectionOptions {
-    SetCloexecOnClient = 1 << 0,
-    SetCloexecOnServer = 1 << 1,
-};
-
-SocketPair createPlatformConnection(unsigned options = SetCloexecOnClient | SetCloexecOnServer);
-#endif
-
-#if OS(WINDOWS)
-bool createServerAndClientIdentifiers(HANDLE& serverIdentifier, HANDLE& clientIdentifier);
-#endif
-
 }
+
+#endif

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
@@ -27,6 +27,7 @@
 
 #include "Connection.h"
 #include "MessageReceiveQueue.h"
+#include "WorkQueueMessageReceiver.h"
 
 namespace IPC {
 
@@ -54,7 +55,7 @@ private:
 class WorkQueueMessageReceiverQueue final : public MessageReceiveQueue {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WorkQueueMessageReceiverQueue(WorkQueue& queue, Connection::WorkQueueMessageReceiver& receiver)
+    WorkQueueMessageReceiverQueue(WorkQueue& queue, WorkQueueMessageReceiver& receiver)
         : m_queue(queue)
         , m_receiver(receiver)
     {
@@ -69,7 +70,7 @@ public:
     }
 private:
     Ref<WorkQueue> m_queue;
-    Ref<Connection::WorkQueueMessageReceiver> m_receiver;
+    Ref<WorkQueueMessageReceiver> m_receiver;
 };
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/WorkQueueMessageReceiver.h
+++ b/Source/WebKit/Platform/IPC/WorkQueueMessageReceiver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,40 +25,13 @@
 
 #pragma once
 
-#define ASSERT_IS_TESTING_IPC() ASSERT(IPC::isTestingIPC(), "Untrusted connection sent invalid data. Should only happen when testing IPC.")
+#include "MessageReceiver.h"
+#include <wtf/ThreadSafeRefCounted.h>
 
 namespace IPC {
 
-// Function to check when asserting IPC-related failures, so that IPC testing skips the assertions
-// and exposes bugs underneath.
-bool isTestingIPC();
+class WorkQueueMessageReceiver : public MessageReceiver, public ThreadSafeRefCounted<WorkQueueMessageReceiver> {
 
-#if ENABLE(IPC_TESTING_API)
-void startTestingIPC();
-void stopTestingIPC();
-#else
-inline bool isTestingIPC()
-{
-    return false;
-}
-#endif
-
-#if USE(UNIX_DOMAIN_SOCKETS)
-struct SocketPair {
-    int client;
-    int server;
 };
-
-enum PlatformConnectionOptions {
-    SetCloexecOnClient = 1 << 0,
-    SetCloexecOnServer = 1 << 1,
-};
-
-SocketPair createPlatformConnection(unsigned options = SetCloexecOnClient | SetCloexecOnServer);
-#endif
-
-#if OS(WINDOWS)
-bool createServerAndClientIdentifiers(HANDLE& serverIdentifier, HANDLE& clientIdentifier);
-#endif
 
 }

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -29,6 +29,7 @@
 #include "Connection.h"
 
 #include "DataReference.h"
+#include "IPCUtilities.h"
 #include "SharedMemory.h"
 #include "UnixMessage.h"
 #include <sys/socket.h>
@@ -588,7 +589,7 @@ bool Connection::sendOutputMessage(UnixMessage& outputMessage)
     return true;
 }
 
-Connection::SocketPair Connection::createPlatformConnection(unsigned options)
+SocketPair createPlatformConnection(unsigned options)
 {
     int sockets[2];
     RELEASE_ASSERT(socketpair(AF_UNIX, SOCKET_TYPE, 0, sockets) != -1);
@@ -619,7 +620,7 @@ void Connection::didReceiveSyncReply(OptionSet<SendSyncOption>)
 
 std::optional<Connection::ConnectionIdentifierPair> Connection::createConnectionIdentifierPair()
 {
-    Connection::SocketPair socketPair = Connection::createPlatformConnection();
+    SocketPair socketPair = createPlatformConnection();
     return ConnectionIdentifierPair { Identifier { UnixFileDescriptor { socketPair.server,  UnixFileDescriptor::Adopt } }, UnixFileDescriptor { socketPair.client, UnixFileDescriptor::Adopt } };
 }
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
@@ -29,6 +29,7 @@
 #include "DataReference.h"
 #include "Decoder.h"
 #include "Encoder.h"
+#include "IPCUtilities.h"
 #include <wtf/ArgumentCoder.h>
 #include <wtf/HexNumber.h>
 #include <wtf/RandomNumber.h>
@@ -38,7 +39,7 @@ namespace IPC {
 // FIXME: Rename this or use a different constant on windows.
 static const size_t inlineMessageMaxSize = 4096;
 
-bool Connection::createServerAndClientIdentifiers(HANDLE& serverIdentifier, HANDLE& clientIdentifier)
+bool createServerAndClientIdentifiers(HANDLE& serverIdentifier, HANDLE& clientIdentifier)
 {
     String pipeName;
 
@@ -370,7 +371,7 @@ std::optional<Connection::ConnectionIdentifierPair> Connection::createConnection
 {
     HANDLE serverIdentifier;
     HANDLE clientIdentifier;
-    if (!Connection::createServerAndClientIdentifiers(serverIdentifier, clientIdentifier)) {
+    if (!createServerAndClientIdentifiers(serverIdentifier, clientIdentifier)) {
         LOG_ERROR("Failed to create server and client identifiers");
         return std::nullopt;
     }

--- a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
@@ -30,6 +30,7 @@
 #include "BubblewrapLauncher.h"
 #include "Connection.h"
 #include "FlatpakLauncher.h"
+#include "IPCUtilities.h"
 #include "ProcessExecutablePath.h"
 #include <errno.h>
 #include <fcntl.h>
@@ -70,7 +71,7 @@ static bool isFlatpakSpawnUsable()
 
 void ProcessLauncher::launchProcess()
 {
-    IPC::Connection::SocketPair socketPair = IPC::Connection::createPlatformConnection(IPC::Connection::ConnectionOptions::SetCloexecOnServer);
+    IPC::SocketPair socketPair = IPC::createPlatformConnection(IPC::PlatformConnectionOptions::SetCloexecOnServer);
 
     String executablePath;
     CString realExecutablePath;

--- a/Source/WebKit/UIProcess/Launcher/playstation/ProcessLauncherPlayStation.cpp
+++ b/Source/WebKit/UIProcess/Launcher/playstation/ProcessLauncherPlayStation.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "ProcessLauncher.h"
 
+#include "IPCUtilities.h"
 #include <process-launcher.h>
 #include <stdint.h>
 #include <sys/socket.h>
@@ -53,7 +54,7 @@ static const char* defaultProcessPath(ProcessLauncher::ProcessType processType)
 
 void ProcessLauncher::launchProcess()
 {
-    IPC::Connection::SocketPair socketPair = IPC::Connection::createPlatformConnection(IPC::Connection::ConnectionOptions::SetCloexecOnServer);
+    IPC::SocketPair socketPair = IPC::createPlatformConnection(IPC::PlatformConnectionOptions::SetCloexecOnServer);
 
     int sendBufSize = 32 * 1024;
     setsockopt(socketPair.server, SOL_SOCKET, SO_SNDBUF, &sendBufSize, 4);

--- a/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
+++ b/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
@@ -28,6 +28,7 @@
 #include "ProcessLauncher.h"
 
 #include "Connection.h"
+#include "IPCUtilities.h"
 #include <WTF/RunLoop.h>
 #include <shlwapi.h>
 #include <wtf/text/StringBuilder.h>
@@ -53,7 +54,7 @@ void ProcessLauncher::launchProcess()
 {
     // First, create the server and client identifiers.
     HANDLE serverIdentifier, clientIdentifier;
-    if (!IPC::Connection::createServerAndClientIdentifiers(serverIdentifier, clientIdentifier)) {
+    if (!IPC::createServerAndClientIdentifiers(serverIdentifier, clientIdentifier)) {
         // FIXME: What should we do here?
         ASSERT_NOT_REACHED();
     }

--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
@@ -28,13 +28,14 @@
 #if ENABLE(SEC_ITEM_SHIM)
 
 #include "Connection.h"
+#include "WorkQueueMessageReceiver.h"
 
 namespace WebKit {
 
 class SecItemRequestData;
 class SecItemResponseData;
 
-class SecItemShimProxy : public IPC::Connection::WorkQueueMessageReceiver {
+class SecItemShimProxy : public IPC::WorkQueueMessageReceiver {
 WTF_MAKE_NONCOPYABLE(SecItemShimProxy);
 public:
     static SecItemShimProxy& singleton();
@@ -45,7 +46,7 @@ private:
     SecItemShimProxy();
     ~SecItemShimProxy();
 
-    // IPC::Connection::WorkQueueMessageReceiver
+    // IPC::WorkQueueMessageReceiver 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1346,6 +1346,8 @@
 		7BBA63DF280E93D200B04823 /* IPCConnectionTesterIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BBA63DC280E93B500B04823 /* IPCConnectionTesterIdentifier.h */; };
 		7BBA63E0280E93D600B04823 /* IPCConnectionTester.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BBA63DE280E93B600B04823 /* IPCConnectionTester.h */; };
 		7BCF70DE2615D06E00E4FB70 /* ScopedRenderingResourcesRequestCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BCF70CB2614935E00E4FB70 /* ScopedRenderingResourcesRequestCocoa.mm */; };
+		7BDD9DDC28D205C6004CDF48 /* MessageObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BDD9DDA28D205C6004CDF48 /* MessageObserver.h */; };
+		7BDD9DDD28D205C6004CDF48 /* WorkQueueMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BDD9DDB28D205C6004CDF48 /* WorkQueueMessageReceiver.h */; };
 		7BE37F9327C7CA51007A6CD3 /* IPCStreamTesterIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE37F9227C7C518007A6CD3 /* IPCStreamTesterIdentifier.h */; };
 		7BE9326327F5C75A00D5FEFB /* ReceiverMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE9326227F5C75A00D5FEFB /* ReceiverMatcher.h */; };
 		7BEDA69E28B396BB00B41C7C /* WebCore.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 1AA1C79A100E7FC50078DEBC /* WebCore.framework */; };
@@ -5573,6 +5575,8 @@
 		7BCF70CC2614935F00E4FB70 /* ScopedWebGLRenderingResourcesRequest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ScopedWebGLRenderingResourcesRequest.cpp; sourceTree = "<group>"; };
 		7BCF70CD2614935F00E4FB70 /* ScopedRenderingResourcesRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScopedRenderingResourcesRequest.h; sourceTree = "<group>"; };
 		7BCF70CE2614935F00E4FB70 /* ScopedWebGLRenderingResourcesRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScopedWebGLRenderingResourcesRequest.h; sourceTree = "<group>"; };
+		7BDD9DDA28D205C6004CDF48 /* MessageObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageObserver.h; sourceTree = "<group>"; };
+		7BDD9DDB28D205C6004CDF48 /* WorkQueueMessageReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WorkQueueMessageReceiver.h; sourceTree = "<group>"; };
 		7BDDA33F275652EA0038659E /* AuxiliaryProcessCreationParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AuxiliaryProcessCreationParameters.h; sourceTree = "<group>"; };
 		7BDDA340275652EA0038659E /* AuxiliaryProcessCreationParameters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AuxiliaryProcessCreationParameters.cpp; sourceTree = "<group>"; };
 		7BE37F6F27B1475F007A6CD3 /* ThreadSafeObjectHeap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadSafeObjectHeap.h; sourceTree = "<group>"; };
@@ -8408,6 +8412,7 @@
 				9B47908E253151CC00EC11AB /* JSIPCBinding.h */,
 				9B47908C25314D8300EC11AB /* MessageArgumentDescriptions.h */,
 				1AC4C82816B876A90069DCCD /* MessageFlags.h */,
+				7BDD9DDA28D205C6004CDF48 /* MessageObserver.h */,
 				7B483F1C25CDDA9B00120486 /* MessageReceiveQueue.h */,
 				7B483F1D25CDDA9B00120486 /* MessageReceiveQueueMap.cpp */,
 				7B483F1B25CDDA9B00120486 /* MessageReceiveQueueMap.h */,
@@ -8434,6 +8439,7 @@
 				7B73123725CC8524003B2796 /* StreamServerConnection.cpp */,
 				7B73123825CC8524003B2796 /* StreamServerConnection.h */,
 				F48570A22644BEC400C05F71 /* Timeout.h */,
+				7BDD9DDB28D205C6004CDF48 /* WorkQueueMessageReceiver.h */,
 			);
 			path = IPC;
 			sourceTree = "<group>";
@@ -14417,6 +14423,7 @@
 				51933DEF1965EB31008AC3EA /* MenuUtilities.h in Headers */,
 				9B47908D25314D8300EC11AB /* MessageArgumentDescriptions.h in Headers */,
 				1AC4C82916B876A90069DCCD /* MessageFlags.h in Headers */,
+				7BDD9DDC28D205C6004CDF48 /* MessageObserver.h in Headers */,
 				7B483F2025CDDA9C00120486 /* MessageReceiveQueue.h in Headers */,
 				7B483F1F25CDDA9C00120486 /* MessageReceiveQueueMap.h in Headers */,
 				7B483F2225CDDA9C00120486 /* MessageReceiveQueues.h in Headers */,
@@ -15566,6 +15573,7 @@
 				1AD60F6018E20F740020C034 /* WKWindowFeaturesInternal.h in Headers */,
 				6A5080BF1F0EDAAA00E617C5 /* WKWindowFeaturesPrivate.h in Headers */,
 				1A7C0DF71B7D1F1000A9B848 /* WKWindowFeaturesRef.h in Headers */,
+				7BDD9DDD28D205C6004CDF48 /* WorkQueueMessageReceiver.h in Headers */,
 				C15E6CB324B7BE6F00E501A2 /* XPCEndpoint.h in Headers */,
 				C15E6CB424B7BE7600E501A2 /* XPCEndpointClient.h in Headers */,
 				BCBECDE816B6416800047A1A /* XPCServiceEntryPoint.h in Headers */,

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
@@ -30,6 +30,7 @@
 #include "Connection.h"
 #include "SharedMemory.h"
 #include "WebProcess.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/CARingBuffer.h>
 #include <WebCore/MediaPlayerIdentifier.h>
@@ -39,7 +40,7 @@ namespace WebKit {
 
 class RemoteAudioSourceProvider;
 
-class RemoteAudioSourceProviderManager : public IPC::Connection::WorkQueueMessageReceiver {
+class RemoteAudioSourceProviderManager : public IPC::WorkQueueMessageReceiver {
 public:
     static Ref<RemoteAudioSourceProviderManager> create() { return adoptRef(*new RemoteAudioSourceProviderManager()); }
     ~RemoteAudioSourceProviderManager();

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -37,6 +37,7 @@
 #include "RemoteVideoFrameIdentifier.h"
 #include "RemoteVideoFrameProxy.h"
 #include "SharedVideoFrame.h"
+#include "WorkQueueMessageReceiver.h"
 #include <map>
 #include <webrtc/api/video/video_codec_type.h>
 #include <wtf/HashMap.h>
@@ -59,7 +60,7 @@ namespace WebKit {
 
 class RemoteVideoFrameObjectHeapProxy;
 
-class LibWebRTCCodecs : public IPC::Connection::WorkQueueMessageReceiver, public GPUProcessConnection::Client {
+class LibWebRTCCodecs : public IPC::WorkQueueMessageReceiver, public GPUProcessConnection::Client {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<LibWebRTCCodecs> create();

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
@@ -32,7 +32,7 @@
 #include "MessageReceiver.h"
 #include "RemoteVideoFrameIdentifier.h"
 #include "SharedVideoFrame.h"
-
+#include "WorkQueueMessageReceiver.h"
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
@@ -55,7 +55,7 @@ namespace WebKit {
 
 class RemoteVideoFrameProxy;
 
-class RemoteVideoFrameObjectHeapProxyProcessor : public IPC::Connection::WorkQueueMessageReceiver, public GPUProcessConnection::Client {
+class RemoteVideoFrameObjectHeapProxyProcessor : public IPC::WorkQueueMessageReceiver, public GPUProcessConnection::Client {
 public:
     static Ref<RemoteVideoFrameObjectHeapProxyProcessor> create(GPUProcessConnection&);
     ~RemoteVideoFrameObjectHeapProxyProcessor();

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h
@@ -26,10 +26,11 @@
 #pragma once
 
 #include "Connection.h"
+#include "WorkQueueMessageReceiver.h"
 
 namespace WebKit {
 
-class WebInspectorInterruptDispatcher : public IPC::Connection::WorkQueueMessageReceiver {
+class WebInspectorInterruptDispatcher : public IPC::WorkQueueMessageReceiver {
 public:
     static Ref<WebInspectorInterruptDispatcher> create();
     ~WebInspectorInterruptDispatcher();
@@ -38,7 +39,7 @@ public:
     
 private:
     WebInspectorInterruptDispatcher();
-    // IPC::Connection::WorkQueueMessageReceiver.
+    // IPC::WorkQueueMessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
     
     void notifyNeedDebuggerBreak();

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
@@ -28,6 +28,7 @@
 
 #include "Connection.h"
 #include "DataReference.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/ProcessQualified.h>
 #include <WebCore/RTCDataChannelRemoteHandler.h>
 #include <WebCore/RTCDataChannelRemoteHandlerConnection.h>
@@ -37,7 +38,7 @@
 
 namespace WebKit {
 
-class RTCDataChannelRemoteManager final : public IPC::Connection::WorkQueueMessageReceiver {
+class RTCDataChannelRemoteManager final : public IPC::WorkQueueMessageReceiver {
 public:
     static RTCDataChannelRemoteManager& sharedManager();
 
@@ -48,7 +49,7 @@ public:
 private:
     RTCDataChannelRemoteManager();
 
-    // IPC::Connection::WorkQueueMessageReceiver
+    // IPC::WorkQueueMessageReceiver 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
     // Messages

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
@@ -37,6 +37,7 @@
 #include "WebPageProxyIdentifier.h"
 #include "WebPreferencesStore.h"
 #include "WebSWContextManagerConnectionMessagesReplies.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/SWContextManager.h>
 #include <WebCore/ServiceWorkerClientData.h>
 #include <WebCore/ServiceWorkerTypes.h>
@@ -59,7 +60,7 @@ class RemoteWorkerFrameLoaderClient;
 class WebUserContentController;
 struct RemoteWorkerInitializationData;
 
-class WebSWContextManagerConnection final : public WebCore::SWContextManager::Connection, public IPC::Connection::WorkQueueMessageReceiver {
+class WebSWContextManagerConnection final : public WebCore::SWContextManager::Connection, public IPC::WorkQueueMessageReceiver {
 public:
     static Ref<WebSWContextManagerConnection> create(Ref<IPC::Connection>&& connection, WebCore::RegistrableDomain&& registrableDomain, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, PageGroupIdentifier pageGroupID, WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier pageID, const WebPreferencesStore& store, RemoteWorkerInitializationData&& initializationData) { return adoptRef(*new WebSWContextManagerConnection(WTFMove(connection), WTFMove(registrableDomain), serviceWorkerPageIdentifier, pageGroupID, webPageProxyID, pageID, store, WTFMove(initializationData))); }
     ~WebSWContextManagerConnection();
@@ -68,8 +69,8 @@ public:
 
     WebCore::PageIdentifier pageIdentifier() const final { return m_pageID; }
 
-    void ref() const final { IPC::Connection::WorkQueueMessageReceiver::ref(); }
-    void deref() const final { IPC::Connection::WorkQueueMessageReceiver::deref(); }
+    void ref() const final { IPC::WorkQueueMessageReceiver::ref(); }
+    void deref() const final { IPC::WorkQueueMessageReceiver ::deref(); }
 
 private:
     WebSWContextManagerConnection(Ref<IPC::Connection>&&, WebCore::RegistrableDomain&&, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, PageGroupIdentifier, WebPageProxyIdentifier, WebCore::PageIdentifier, const WebPreferencesStore&, RemoteWorkerInitializationData&&);

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -27,6 +27,7 @@
 
 #include "Connection.h"
 #include "WebEvent.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/PlatformWheelEvent.h>
 #include <WebCore/RectEdges.h>
@@ -59,7 +60,7 @@ class WebWheelEvent;
 class WebTouchEvent;
 #endif
 
-class EventDispatcher : public IPC::Connection::WorkQueueMessageReceiver {
+class EventDispatcher : public IPC::WorkQueueMessageReceiver {
 public:
     static Ref<EventDispatcher> create();
     ~EventDispatcher();
@@ -86,7 +87,7 @@ public:
 private:
     EventDispatcher();
 
-    // IPC::Connection::WorkQueueMessageReceiver.
+    // IPC::WorkQueueMessageReceiver .
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
     // Message handlers

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -35,6 +35,7 @@
 #include "IPCStreamTesterMessages.h"
 #include "JSIPCBinding.h"
 #include "MessageArgumentDescriptions.h"
+#include "MessageObserver.h"
 #include "NetworkProcessConnection.h"
 #include "RemoteRenderingBackendCreationParameters.h"
 #include "SerializedTypeInfo.h"
@@ -291,7 +292,7 @@ private:
     Ref<SharedMemory> m_sharedMemory;
 };
 
-class JSMessageListener final : public IPC::Connection::MessageObserver {
+class JSMessageListener final : public IPC::MessageObserver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Type { Incoming, Outgoing };

--- a/Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.h
@@ -30,6 +30,7 @@
 #include "Connection.h"
 
 #include "VisibleContentRectUpdateInfo.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/PageIdentifier.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
@@ -37,7 +38,7 @@
 
 namespace WebKit {
 
-class ViewUpdateDispatcher : public IPC::Connection::WorkQueueMessageReceiver {
+class ViewUpdateDispatcher : public IPC::WorkQueueMessageReceiver {
 public:
     static Ref<ViewUpdateDispatcher> create();
     ~ViewUpdateDispatcher();
@@ -46,7 +47,7 @@ public:
 
 private:
     ViewUpdateDispatcher();
-    // IPC::Connection::WorkQueueMessageReceiver.
+    // IPC::WorkQueueMessageReceiver .
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
     void visibleContentRectUpdate(WebCore::PageIdentifier, const VisibleContentRectUpdateInfo&);

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
@@ -35,6 +35,7 @@
 #include "RemoteVideoFrameIdentifier.h"
 #include "RemoteVideoFrameProxy.h"
 #include "SharedMemory.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/CARingBuffer.h>
 #include <WebCore/WebAudioBufferList.h>
@@ -49,7 +50,7 @@ class ImageTransferSessionVT;
 namespace WebKit {
 class RemoteVideoFrameObjectHeapProxy;
 
-class RemoteCaptureSampleManager : public IPC::Connection::WorkQueueMessageReceiver {
+class RemoteCaptureSampleManager : public IPC::WorkQueueMessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     RemoteCaptureSampleManager();
@@ -63,7 +64,7 @@ public:
     void didUpdateSourceConnection(IPC::Connection&);
     void setVideoFrameObjectHeapProxy(RemoteVideoFrameObjectHeapProxy*);
 
-    // IPC::Connection::WorkQueueMessageReceiver overrides.
+    // IPC::WorkQueueMessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
 private:


### PR DESCRIPTION
#### 3f576a1763a5651d3609d6d364fa109fd915a2f3
<pre>
IPC::Connection declaration has unrelated platform implementation declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=245178">https://bugs.webkit.org/show_bug.cgi?id=245178</a>
rdar://problem/99916528

Reviewed by Antti Koivisto.

Move inner-classes to standalone classes in their own headers:
 - MessageObserver
 - WorkQueueMessageReceiver

Move platform-specific pipe and socket creation functions to
IPCtilities.h.

This way IPC::Connection declaration is easier to understand.

* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/IPCUtilities.h:
* Source/WebKit/Platform/IPC/MessageObserver.h: Copied from Source/WebKit/Platform/IPC/IPCUtilities.h.
* Source/WebKit/Platform/IPC/MessageReceiveQueues.h:
* Source/WebKit/Platform/IPC/WorkQueueMessageReceiver.h: Copied from Source/WebKit/Platform/IPC/IPCUtilities.h.
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::createPlatformConnection):
(IPC::Connection::createConnectionIdentifierPair):
(IPC::Connection::createPlatformConnection): Deleted.
* Source/WebKit/Platform/IPC/win/ConnectionWin.cpp:
(IPC::createServerAndClientIdentifiers):
(IPC::Connection::createConnectionIdentifierPair):
(IPC::Connection::createServerAndClientIdentifiers): Deleted.
* Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKit/UIProcess/Launcher/playstation/ProcessLauncherPlayStation.cpp:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKit/UIProcess/mac/SecItemShimProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h:
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
* Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.h:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h:

Canonical link: <a href="https://commits.webkit.org/254728@main">https://commits.webkit.org/254728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/977e2071d0cc69ace80972639cd0311f446b2cc9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99309 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33019 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82315 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93620 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26232 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76783 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26150 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80911 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69152 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/34259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14994 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15935 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3322 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/35844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38894 "Passed tests") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/37744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35019 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->