### PR TITLE
Revert [253823@main] REGRESSION (253685@main): [ Monterey wk2 ] fast/images/text-recognition/mac/cursor-types-for-recognized-text.html is a consistent failure

### DIFF
--- a/LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text-expected.txt
+++ b/LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text-expected.txt
@@ -1,21 +1,12 @@
 
 Testing <img id="inside-link">
-PASS cursor is "Hand"
+PASS cursor is "IBeam"
 
 Testing <img id="cursor-zoom-in">
 PASS cursor is "ZoomIn"
 
 Testing <img id="user-select-none-in-link">
 PASS cursor is "Hand"
-
-Testing overlay from <img id="inside-link">
-PASS cursor is "IBeam"
-
-Testing overlay from <img id="cursor-zoom-in">
-PASS cursor is "IBeam"
-
-Testing overlay from <img id="user-select-none-in-link">
-PASS cursor is "Pointer"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text.html
+++ b/LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text.html
@@ -25,7 +25,6 @@ a {
     top: 200px;
     -webkit-user-select: none;
 }
-
 </style>
 <script>
 addEventListener("load", () => {
@@ -50,28 +49,15 @@ addEventListener("load", () => {
     function testImage(imageID, expectedResult) {
         let image = document.getElementById(imageID);
         let rect = image.getBoundingClientRect();
-        eventSender.mouseMoveTo(rect.left, rect.top);
+        eventSender.mouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
         cursor = internals.getCurrentCursorInfo().match(/type=(\w+)\s/).pop();
         debug(`\nTesting &lt;img id="${imageID}"&gt;`);
         shouldBeEqualToString("cursor", expectedResult);
     }
 
-    function testOverlayDivFromImage(hostID, expectedResult) {
-        let image = document.getElementById(hostID);
-        let rect = image.getBoundingClientRect();
-        eventSender.mouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
-        cursor = internals.getCurrentCursorInfo().match(/type=(\w+)\s/).pop();
-        debug(`\nTesting overlay from &lt;img id="${hostID}"&gt;`);
-        shouldBeEqualToString("cursor", expectedResult);
-    }
-
-    testImage("inside-link", "Hand");
+    testImage("inside-link", "IBeam");
     testImage("cursor-zoom-in", "ZoomIn");
     testImage("user-select-none-in-link", "Hand");
-
-    testOverlayDivFromImage("inside-link", "IBeam");
-    testOverlayDivFromImage("cursor-zoom-in", "IBeam");
-    testOverlayDivFromImage("user-select-none-in-link", "Pointer");
 });
 </script>
 </head>

--- a/Source/WebCore/html/shadow/imageOverlay.css
+++ b/Source/WebCore/html/shadow/imageOverlay.css
@@ -32,7 +32,6 @@ div#image-overlay {
     text-indent: 0;
     text-align: center;
     font-family: system-ui;
-    cursor: auto;
 }
 
 :host(:not(img)) div#image-overlay:-webkit-full-screen-document {


### PR DESCRIPTION
#### 29056c6d4d4beea9f843395a9bc14e253784c304
<pre>
Revert [253823@main] REGRESSION (253685@main): [ Monterey wk2 ] fast/images/text-recognition/mac/cursor-types-for-recognized-text.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244272">https://bugs.webkit.org/show_bug.cgi?id=244272</a>
&lt;rdar://99051044&gt;

Reviewed by Tim Nguyen.

* LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text-expected.txt:
* LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text.html:
* Source/WebCore/html/shadow/imageOverlay.css:
(div#image-overlay):

Canonical link: <a href="https://commits.webkit.org/254482@main">https://commits.webkit.org/254482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0926890e797840f666bf414710046059d58dac60

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98504 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154816 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32253 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27804 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81547 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92973 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25621 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76112 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25549 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80486 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68523 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30033 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29757 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15487 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3141 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33204 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31904 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34578 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->