### PR TITLE
Revert [253685@main] Incorrect behavior of "cursor: auto" over links

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/mouse-cursor-imagemap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/mouse-cursor-imagemap-expected.txt
@@ -2,5 +2,5 @@
 An unclickable (non-link) area should not show the link cursor when hovered.
 
 
-PASS Only clickable areas should show the link cursor.
+FAIL Only clickable areas should show the link cursor. assert_equals: expected "pointer" but got "auto"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/no-help-cursor-on-links.historical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/no-help-cursor-on-links.historical-expected.txt
@@ -1,4 +1,4 @@
 
-PASS Unvisited help links must have pointer cursor, not help cursor
-PASS Visited help links must have pointer cursor, not help cursor
+FAIL Unvisited help links must have pointer cursor, not help cursor assert_equals: expected "pointer" but got "auto"
+FAIL Visited help links must have pointer cursor, not help cursor assert_equals: expected "pointer" but got "auto"
 unvisited will be visited

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1293,19 +1293,11 @@ input[type="file"]:focus::file-selector-button {
 a:any-link {
     color: -webkit-link;
     text-decoration: underline;
-    cursor: pointer;
+    cursor: auto;
 }
 
 a:any-link:active {
     color: -webkit-activelink;
-}
-
-a:any-link:read-write {
-    cursor: text;
-}
-
-area:any-link {
-    cursor: pointer;
 }
 
 /* HTML5 ruby elements */

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -343,7 +343,7 @@ public:
     WEBCORE_EXPORT void cancelSelectionAutoscroll();
 #endif
 
-    WEBCORE_EXPORT std::optional<Cursor> selectCursor(const HitTestResult&);
+    WEBCORE_EXPORT std::optional<Cursor> selectCursor(const HitTestResult&, bool shiftKey);
 
 #if ENABLE(KINETIC_SCROLLING)
     std::optional<WheelScrollGestureState> wheelScrollGestureState() const { return m_wheelScrollGestureState; }
@@ -405,7 +405,7 @@ private:
 
     bool internalKeyEvent(const PlatformKeyboardEvent&);
 
-    void updateCursor(FrameView&, const HitTestResult&);
+    void updateCursor(FrameView&, const HitTestResult&, bool shiftKey);
 
     void hoverTimerFired();
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3245,7 +3245,7 @@ InteractionInformationAtPosition WebPage::positionInformation(const InteractionI
 
     auto hitTestResult = eventHandler.hitTestResultAtPoint(request.point, hitTestRequestTypes);
     if (auto* hitFrame = hitTestResult.innerNodeFrame()) {
-        info.cursor = hitFrame->eventHandler().selectCursor(hitTestResult);
+        info.cursor = hitFrame->eventHandler().selectCursor(hitTestResult, false);
         if (request.includeCaretContext)
             populateCaretContext(hitTestResult, request, info);
     }


### PR DESCRIPTION
#### 2ef8bf040a9db8c0af836f5a92916e087e9b9e16
<pre>
Revert [253685@main] Incorrect behavior of &quot;cursor: auto&quot; over links
<a href="https://bugs.webkit.org/show_bug.cgi?id=173909">https://bugs.webkit.org/show_bug.cgi?id=173909</a>
rdar://33054544

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/mouse-cursor-imagemap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/no-help-cursor-on-links.historical-expected.txt:
* Source/WebCore/css/html.css:
(a:any-link):
(a:any-link:read-write): Deleted.
(area:any-link): Deleted.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::updateCursor):
(WebCore::EventHandler::selectCursor):
(WebCore::EventHandler::handleMouseMoveEvent):
* Source/WebCore/page/EventHandler.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::positionInformation):

Canonical link: <a href="https://commits.webkit.org/254480@main">https://commits.webkit.org/254480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe30bf2725f76ef828a1e721b34a2a21f0935a28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98505 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154817 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32254 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81548 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92974 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25619 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/76113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25551 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80483 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68525 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30034 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29758 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15486 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3142 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33205 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/76113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34577 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->