### PR TITLE
Implement nested Dedicated Workers

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -467,6 +467,7 @@ imported/w3c/web-platform-tests/web-locks/mode-mixed.tentative.https.any.html [ 
 imported/w3c/web-platform-tests/web-locks/steal.tentative.https.any.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-analysernode-interface/test-analyser-minimum.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audionode-interface/audionode-disconnect-audioparam.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/websockets/Create-on-worker-shutdown.any.worker.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/workers/same-origin-check.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/mixed-content [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/upgrade-insecure-requests [ DumpJSConsoleLogInStdErr ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -703,18 +703,18 @@ PASS WorkerGlobalScope interface: calling createImageBitmap(ImageBitmapSource, l
 PASS WorkerGlobalScope interface: self must inherit property "structuredClone(any, optional StructuredSerializeOptions)" with the proper type
 PASS WorkerGlobalScope interface: calling structuredClone(any, optional StructuredSerializeOptions) on self with too few arguments must throw TypeError
 PASS SharedWorkerGlobalScope interface: existence and properties of interface object
-FAIL Worker interface: existence and properties of interface object assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface object length assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface object name assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: existence and properties of interface prototype object assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: operation terminate() assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: operation postMessage(any, sequence<object>) assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: operation postMessage(any, optional StructuredSerializeOptions) assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: attribute onmessage assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: attribute onmessageerror assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: attribute onerror assert_own_property: self does not have own property "Worker" expected property "Worker" missing
+PASS Worker interface: existence and properties of interface object
+PASS Worker interface object length
+PASS Worker interface object name
+PASS Worker interface: existence and properties of interface prototype object
+PASS Worker interface: existence and properties of interface prototype object's "constructor" property
+PASS Worker interface: existence and properties of interface prototype object's @@unscopables property
+PASS Worker interface: operation terminate()
+PASS Worker interface: operation postMessage(any, sequence<object>)
+PASS Worker interface: operation postMessage(any, optional StructuredSerializeOptions)
+PASS Worker interface: attribute onmessage
+FAIL Worker interface: attribute onmessageerror assert_true: The prototype object must have a property "onmessageerror" expected true got false
+PASS Worker interface: attribute onerror
 PASS SharedWorker interface: existence and properties of interface object
 PASS WorkerNavigator interface: existence and properties of interface object
 PASS WorkerNavigator interface object length

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-classic.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-classic.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Mixed-Content: Expects allowed for worker-classic to same-https origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for worker-classic to same-https origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Mixed-Content: Expects allowed for worker-classic to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for worker-classic to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-classic to same-http origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-classic to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-module.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-module.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Mixed-Content: Expects allowed for worker-module to same-https origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for worker-module to same-https origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Mixed-Content: Expects allowed for worker-module to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for worker-module to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-module to same-http origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-module to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/unset/worker-classic.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/unset/worker-classic.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Mixed-Content: Expects allowed for worker-classic to same-https origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for worker-classic to same-https origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Mixed-Content: Expects allowed for worker-classic to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for worker-classic to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-classic to same-http origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-classic to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/unset/worker-module.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/unset/worker-module.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Mixed-Content: Expects allowed for worker-module to same-https origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for worker-module to same-https origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Mixed-Content: Expects allowed for worker-module to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for worker-module to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-module to same-http origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-module to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/opt-in/worker-classic.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/opt-in/worker-classic.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Mixed-Content: Expects allowed for worker-classic to same-https origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for worker-classic to same-https origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Mixed-Content: Expects allowed for worker-classic to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for worker-classic to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-classic to same-http origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-classic to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/opt-in/worker-module.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/opt-in/worker-module.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Mixed-Content: Expects allowed for worker-module to same-https origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for worker-module to same-https origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Mixed-Content: Expects allowed for worker-module to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for worker-module to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-module to same-http origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-module to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/unset/worker-classic.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/unset/worker-classic.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Mixed-Content: Expects allowed for worker-classic to same-https origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for worker-classic to same-https origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Mixed-Content: Expects allowed for worker-classic to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for worker-classic to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-classic to same-http origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-classic to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/unset/worker-module.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/unset/worker-module.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Mixed-Content: Expects allowed for worker-module to same-https origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for worker-module to same-https origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Mixed-Content: Expects allowed for worker-module to same-https origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for worker-module to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-module to same-http origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for worker-module to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
@@ -11,7 +11,7 @@ PASS Verify a no-cors cross-origin worker script served by a service worker fail
 PASS Register a service worker for worker subresource interception tests.
 PASS Requests on a dedicated worker controlled by a service worker.
 PASS Requests on a shared worker controlled by a service worker.
-FAIL Requests on a dedicated worker nested in a dedicated worker and controlled by a service worker assert_equals: expected "This load was successfully intercepted." but got "Unexpected error! Can't find variable: Worker"
+FAIL Requests on a dedicated worker nested in a dedicated worker and controlled by a service worker assert_equals: expected "This load was successfully intercepted." but got "{\"error\": {\"code\": 404, \"message\": \"404\"}}"
 FAIL Requests on a dedicated worker nested in a shared worker and controlled by a service worker assert_equals: expected "This load was successfully intercepted." but got "Unexpected error! Can't find variable: Worker"
 PASS Unregister a service worker for subresource interception tests.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-module.http-rp/upgrade/worker-classic.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-module.http-rp/upgrade/worker-classic.https-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL Upgrade-Insecure-Requests: Expects allowed for worker-classic to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for worker-classic to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for worker-classic to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for worker-classic to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-module.http-rp/upgrade/worker-module.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-module.http-rp/upgrade/worker-module.https-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL Upgrade-Insecure-Requests: Expects allowed for worker-module to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for worker-module to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for worker-module to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for worker-module to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/nested-worker-success.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/nested-worker-success.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL postMessaging to a dedicated sub-worker allows them to see each others' modifications Can't find variable: Worker
+PASS postMessaging to a dedicated sub-worker allows them to see each others' modifications
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/query.tentative.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/query.tentative.https.any.worker-expected.txt
@@ -6,6 +6,6 @@ PASS query() reports pending and held locks
 PASS query() reports held shared locks with appropriate count
 PASS query() reports pending shared locks with appropriate count
 PASS query() reports the same clientId for held locks from the same context
-FAIL query() reports different ids for held locks from different contexts promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL query() can observe a deadlock promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
+PASS query() reports different ids for held locks from different contexts
+PASS query() can observe a deadlock
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webmessaging/MessageEvent-trusted.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webmessaging/MessageEvent-trusted.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
 PASS With a MessageChannel and its MessagePorts
-FAIL With a BroadcastChannel Can't find variable: Worker
+PASS With a BroadcastChannel
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webmessaging/message-channels/worker-post-after-close.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webmessaging/message-channels/worker-post-after-close.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL MessageChannel/MessagePort should not work after a worker self.close() Can't find variable: Worker
+PASS MessageChannel/MessagePort should not work after a worker self.close()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webmessaging/message-channels/worker.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webmessaging/message-channels/worker.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL MessageChannel/MessagePort created and used after a worker self.close() Can't find variable: Worker
+PASS MessageChannel/MessagePort created and used after a worker self.close()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/Create-on-worker-shutdown.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/Create-on-worker-shutdown.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL WebSocket created after a worker self.close() Can't find variable: Worker
+PASS WebSocket created after a worker self.close()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/baseurl/alpha/worker-in-worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/baseurl/alpha/worker-in-worker-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: ReferenceError: Can't find variable: Worker
 
-FAIL Base URL in workers: new Worker() assert_unreached: Got error event Reached unreachable code
+PASS Base URL in workers: new Worker()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/expected-self-properties.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/expected-self-properties.worker-expected.txt
@@ -3,6 +3,6 @@ PASS existence of XMLHttpRequest
 PASS existence of WebSocket
 PASS existence of EventSource
 PASS existence of MessageChannel
-FAIL existence of Worker assert_true: expected true got false
+PASS existence of Worker
 FAIL existence of SharedWorker assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/dedicated-worker-in-data-url-context.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/dedicated-worker-in-data-url-context.window-expected.txt
@@ -1,7 +1,6 @@
-CONSOLE MESSAGE: ReferenceError: Can't find variable: Worker
 
 FAIL Create a dedicated worker in a data url frame assert_equals: expected "PASS" but got "Worker construction unexpectedly synchronously failed"
 FAIL Create a dedicated worker in a data url dedicated worker assert_equals: expected "PASS" but got "Worker construction unexpectedly synchronously failed"
 PASS Create a data url dedicated worker in a data url frame
-FAIL Create a data url dedicated worker in a data url dedicated worker promise_test: Unhandled rejection with value: "ReferenceError: Can't find variable: Worker"
+PASS Create a data url dedicated worker in a data url dedicated worker
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-blob-url.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-blob-url.any.worker-expected.txt
@@ -1,11 +1,14 @@
+Blocked access to external URL https://www1.localhost:9443/workers/modules/resources/export-on-load-script.py
 
-FAIL Static import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Static import (cross-origin). promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Static import (redirect). promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Nested static import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Static import and then dynamic import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Dynamic import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Nested dynamic import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Dynamic import and then static import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL eval(import()). promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
+Harness Error (FAIL), message = Error in remote: Importing a module script failed.
+
+PASS Static import.
+FAIL Static import (cross-origin). promise_test: Unhandled rejection with value: "Importing a module script failed."
+PASS Static import (redirect).
+PASS Nested static import.
+PASS Static import and then dynamic import.
+PASS Dynamic import.
+PASS Nested dynamic import.
+PASS Dynamic import and then static import.
+PASS eval(import()).
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-data-url.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-data-url.any.worker-expected.txt
@@ -1,11 +1,14 @@
+Blocked access to external URL https://www1.localhost:9443/workers/modules/resources/export-on-load-script.py
 
-FAIL Static import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Static import (cross-origin). promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Static import (redirect). promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Nested static import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Static import and then dynamic import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Dynamic import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Nested dynamic import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Dynamic import and then static import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL eval(import()). promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
+Harness Error (FAIL), message = Error in remote: Importing a module script failed.
+
+PASS Static import.
+TIMEOUT Static import (cross-origin). Test timed out
+NOTRUN Static import (redirect).
+NOTRUN Nested static import.
+NOTRUN Static import and then dynamic import.
+NOTRUN Dynamic import.
+NOTRUN Nested dynamic import.
+NOTRUN Dynamic import and then static import.
+NOTRUN eval(import()).
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import.any.worker-expected.txt
@@ -1,11 +1,14 @@
+Blocked access to external URL https://www1.localhost:9443/workers/modules/resources/export-on-load-script.py
 
-FAIL Static import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Static import (cross-origin). promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Static import (redirect). promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Nested static import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Static import and then dynamic import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Dynamic import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Nested dynamic import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL Dynamic import and then static import. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
-FAIL eval(import()). promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Worker"
+Harness Error (FAIL), message = Error in remote: Importing a module script failed.
+
+PASS Static import.
+FAIL Static import (cross-origin). promise_test: Unhandled rejection with value: "Importing a module script failed."
+PASS Static import (redirect).
+PASS Nested static import.
+PASS Static import and then dynamic import.
+PASS Dynamic import.
+PASS Nested dynamic import.
+PASS Dynamic import and then static import.
+PASS eval(import()).
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_close_from_parent_worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_close_from_parent_worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test terminating a nested workers by calling terminate() from its parent worker assert_equals: expected "Pass" but got "Fail: ReferenceError: Can't find variable: Worker"
+PASS Test terminating a nested workers by calling terminate() from its parent worker
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_close_self.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_close_self.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Nested work that closes itself Can't find variable: Worker
+PASS Nested work that closes itself
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_importScripts.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_importScripts.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Nested worker that calls importScripts() Can't find variable: Worker
+PASS Nested worker that calls importScripts()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_sync_xhr.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_sync_xhr.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Nested worker that issues a sync XHR Can't find variable: Worker
+PASS Nested worker that issues a sync XHR
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_terminate_from_document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_terminate_from_document-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test terminating a chain of nested workers by calling terminate() from the owning document assert_equals: expected "Pass" but got "Fail: ReferenceError: Can't find variable: Worker"
+PASS Test terminating a chain of nested workers by calling terminate() from the owning document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/interface-objects/001.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/interface-objects/001.worker-expected.txt
@@ -1,7 +1,7 @@
 
 PASS The WorkerGlobalScope interface object should be exposed.
 PASS The DedicatedWorkerGlobalScope interface object should be exposed.
-FAIL The Worker interface object should be exposed. assert_own_property: expected property "Worker" missing
+PASS The Worker interface object should be exposed.
 FAIL The SharedWorker interface object should be exposed. assert_own_property: expected property "SharedWorker" missing
 PASS The MessagePort interface object should be exposed.
 PASS The MessageEvent interface object should be exposed.

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/multiple-workers/exposure.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/multiple-workers/exposure.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Worker exposure assert_not_equals: got disallowed value undefined
+PASS Worker exposure
 PASS SharedWorker exposure
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -702,18 +702,18 @@ PASS WorkerGlobalScope interface: calling createImageBitmap(ImageBitmapSource, l
 PASS WorkerGlobalScope interface: self must inherit property "structuredClone(any, optional StructuredSerializeOptions)" with the proper type
 PASS WorkerGlobalScope interface: calling structuredClone(any, optional StructuredSerializeOptions) on self with too few arguments must throw TypeError
 PASS SharedWorkerGlobalScope interface: existence and properties of interface object
-FAIL Worker interface: existence and properties of interface object assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface object length assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface object name assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: existence and properties of interface prototype object assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: operation terminate() assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: operation postMessage(any, sequence<object>) assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: operation postMessage(any, optional StructuredSerializeOptions) assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: attribute onmessage assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: attribute onmessageerror assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: attribute onerror assert_own_property: self does not have own property "Worker" expected property "Worker" missing
+PASS Worker interface: existence and properties of interface object
+PASS Worker interface object length
+PASS Worker interface object name
+PASS Worker interface: existence and properties of interface prototype object
+PASS Worker interface: existence and properties of interface prototype object's "constructor" property
+PASS Worker interface: existence and properties of interface prototype object's @@unscopables property
+PASS Worker interface: operation terminate()
+PASS Worker interface: operation postMessage(any, sequence<object>)
+PASS Worker interface: operation postMessage(any, optional StructuredSerializeOptions)
+PASS Worker interface: attribute onmessage
+FAIL Worker interface: attribute onmessageerror assert_true: The prototype object must have a property "onmessageerror" expected true got false
+PASS Worker interface: attribute onerror
 PASS SharedWorker interface: existence and properties of interface object
 PASS WorkerNavigator interface: existence and properties of interface object
 PASS WorkerNavigator interface object length

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
@@ -27,7 +27,7 @@ PASS Verify a no-cors cross-origin worker script served by a service worker fail
 PASS Register a service worker for worker subresource interception tests.
 PASS Requests on a dedicated worker controlled by a service worker.
 PASS Requests on a shared worker controlled by a service worker.
-FAIL Requests on a dedicated worker nested in a dedicated worker and controlled by a service worker assert_equals: expected "This load was successfully intercepted." but got "Unexpected error! Can't find variable: Worker"
+FAIL Requests on a dedicated worker nested in a dedicated worker and controlled by a service worker assert_equals: expected "This load was successfully intercepted." but got "{\"error\": {\"code\": 404, \"message\": \"404\"}}"
 FAIL Requests on a dedicated worker nested in a shared worker and controlled by a service worker assert_equals: expected "This load was successfully intercepted." but got "Unexpected error! Can't find variable: Worker"
 PASS Unregister a service worker for subresource interception tests.
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-blob-url.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-blob-url.any.worker-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Static import.
+PASS Static import (cross-origin).
+PASS Static import (redirect).
+PASS Nested static import.
+PASS Static import and then dynamic import.
+PASS Dynamic import.
+PASS Nested dynamic import.
+PASS Dynamic import and then static import.
+PASS eval(import()).
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-data-url.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-data-url.any.worker-expected.txt
@@ -1,0 +1,14 @@
+CONSOLE MESSAGE: Cross-origin redirection to http://web-platform.test:8800/workers/modules/resources/export-on-load-script.js denied by Cross-Origin Resource Sharing policy: Origin null is not allowed by Access-Control-Allow-Origin. Status code: 302
+
+Harness Error (FAIL), message = Error in remote: Importing a module script failed.
+
+PASS Static import.
+PASS Static import (cross-origin).
+TIMEOUT Static import (redirect). Test timed out
+NOTRUN Nested static import.
+NOTRUN Static import and then dynamic import.
+NOTRUN Dynamic import.
+NOTRUN Nested dynamic import.
+NOTRUN Dynamic import and then static import.
+NOTRUN eval(import()).
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import.any.worker-expected.txt
@@ -1,0 +1,11 @@
+
+PASS Static import.
+PASS Static import (cross-origin).
+PASS Static import (redirect).
+PASS Nested static import.
+PASS Static import and then dynamic import.
+PASS Dynamic import.
+PASS Nested dynamic import.
+PASS Dynamic import and then static import.
+PASS eval(import()).
+

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -702,18 +702,18 @@ PASS WorkerGlobalScope interface: calling createImageBitmap(ImageBitmapSource, l
 PASS WorkerGlobalScope interface: self must inherit property "structuredClone(any, optional StructuredSerializeOptions)" with the proper type
 PASS WorkerGlobalScope interface: calling structuredClone(any, optional StructuredSerializeOptions) on self with too few arguments must throw TypeError
 PASS SharedWorkerGlobalScope interface: existence and properties of interface object
-FAIL Worker interface: existence and properties of interface object assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface object length assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface object name assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: existence and properties of interface prototype object assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: operation terminate() assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: operation postMessage(any, sequence<object>) assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: operation postMessage(any, optional StructuredSerializeOptions) assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: attribute onmessage assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: attribute onmessageerror assert_own_property: self does not have own property "Worker" expected property "Worker" missing
-FAIL Worker interface: attribute onerror assert_own_property: self does not have own property "Worker" expected property "Worker" missing
+PASS Worker interface: existence and properties of interface object
+PASS Worker interface object length
+PASS Worker interface object name
+PASS Worker interface: existence and properties of interface prototype object
+PASS Worker interface: existence and properties of interface prototype object's "constructor" property
+PASS Worker interface: existence and properties of interface prototype object's @@unscopables property
+PASS Worker interface: operation terminate()
+PASS Worker interface: operation postMessage(any, sequence<object>)
+PASS Worker interface: operation postMessage(any, optional StructuredSerializeOptions)
+PASS Worker interface: attribute onmessage
+FAIL Worker interface: attribute onmessageerror assert_true: The prototype object must have a property "onmessageerror" expected true got false
+PASS Worker interface: attribute onerror
 PASS SharedWorker interface: existence and properties of interface object
 PASS WorkerNavigator interface: existence and properties of interface object
 PASS WorkerNavigator interface object length

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic.http-rp/upgrade/worker-classic.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic.http-rp/upgrade/worker-classic.https-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL Upgrade-Insecure-Requests: Expects allowed for worker-classic to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for worker-classic to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-PASS Upgrade-Insecure-Requests: Expects allowed for worker-classic to same-https origin and downgrade redirection from https context.
+FAIL Upgrade-Insecure-Requests: Expects allowed for worker-classic to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic.http-rp/upgrade/worker-module.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic.http-rp/upgrade/worker-module.https-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL Upgrade-Insecure-Requests: Expects allowed for worker-module to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for worker-module to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-PASS Upgrade-Insecure-Requests: Expects allowed for worker-module to same-https origin and downgrade redirection from https context.
+FAIL Upgrade-Insecure-Requests: Expects allowed for worker-module to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module.http-rp/upgrade/worker-classic.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module.http-rp/upgrade/worker-classic.https-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL Upgrade-Insecure-Requests: Expects allowed for worker-classic to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for worker-classic to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-PASS Upgrade-Insecure-Requests: Expects allowed for worker-classic to same-https origin and downgrade redirection from https context.
+FAIL Upgrade-Insecure-Requests: Expects allowed for worker-classic to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module.http-rp/upgrade/worker-module.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module.http-rp/upgrade/worker-module.https-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL Upgrade-Insecure-Requests: Expects allowed for worker-module to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for worker-module to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-PASS Upgrade-Insecure-Requests: Expects allowed for worker-module to same-https origin and downgrade redirection from https context.
+FAIL Upgrade-Insecure-Requests: Expects allowed for worker-module to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -54,7 +54,9 @@ RefPtr<AudioWorkletGlobalScope> AudioWorkletGlobalScope::tryCreate(AudioWorkletT
     auto vm = JSC::VM::tryCreate();
     if (!vm)
         return nullptr;
-    return adoptRef(*new AudioWorkletGlobalScope(thread, vm.releaseNonNull(), parameters));
+    auto scope = adoptRef(*new AudioWorkletGlobalScope(thread, vm.releaseNonNull(), parameters));
+    scope->addToContextsMap();
+    return scope;
 }
 
 AudioWorkletGlobalScope::AudioWorkletGlobalScope(AudioWorkletThread& thread, Ref<JSC::VM>&& vm, const WorkletParameters& parameters)

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
@@ -98,6 +98,11 @@ RefPtr<RTCDataChannelRemoteHandlerConnection> AudioWorkletMessagingProxy::create
     return m_document->page()->webRTCProvider().createRTCDataChannelRemoteHandlerConnection();
 }
 
+ScriptExecutionContextIdentifier AudioWorkletMessagingProxy::loaderContextIdentifier() const
+{
+    return m_document->identifier();
+}
+
 void AudioWorkletMessagingProxy::postTaskToLoader(ScriptExecutionContext::Task&& task)
 {
     m_document->postTask(WTFMove(task));

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
@@ -53,6 +53,7 @@ public:
     AudioWorkletThread& workletThread() { return m_workletThread.get(); }
 
     void postTaskToAudioWorklet(Function<void(AudioWorklet&)>&&);
+    ScriptExecutionContextIdentifier loaderContextIdentifier() const final;
 
 private:
     explicit AudioWorkletMessagingProxy(AudioWorklet&);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -630,6 +630,7 @@ void Document::createNewIdentifier()
 Ref<Document> Document::create(Document& contextDocument)
 {
     auto document = adoptRef(*new Document(nullptr, contextDocument.m_settings, URL(), { }));
+    document->addToContextsMap();
     document->setContextDocument(contextDocument);
     document->setSecurityOriginPolicy(contextDocument.securityOriginPolicy());
     return document;
@@ -637,7 +638,9 @@ Ref<Document> Document::create(Document& contextDocument)
 
 Ref<Document> Document::createNonRenderedPlaceholder(Frame& frame, const URL& url)
 {
-    return adoptRef(*new Document(&frame, frame.settings(), url, { }, NonRenderedPlaceholder));
+    auto document = adoptRef(*new Document(&frame, frame.settings(), url, { }, NonRenderedPlaceholder));
+    document->addToContextsMap();
+    return document;
 }
 
 Document::~Document()

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -59,7 +59,9 @@ inline AXObjectCache* Document::existingAXObjectCache() const
 
 inline Ref<Document> Document::create(const Settings& settings, const URL& url)
 {
-    return adoptRef(*new Document(nullptr, settings, url));
+    auto document = adoptRef(*new Document(nullptr, settings, url));
+    document->addToContextsMap();
+    return document;
 }
 
 inline void Document::invalidateAccessKeyCache()

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -115,9 +115,6 @@ public:
 ScriptExecutionContext::ScriptExecutionContext(ScriptExecutionContextIdentifier contextIdentifier)
     : m_identifier(contextIdentifier ? contextIdentifier : ScriptExecutionContextIdentifier::generate())
 {
-    Locker locker { allScriptExecutionContextsMapLock };
-    ASSERT(!allScriptExecutionContextsMap().contains(m_identifier));
-    allScriptExecutionContextsMap().add(m_identifier, this);
 }
 
 void ScriptExecutionContext::regenerateIdentifier()
@@ -129,6 +126,13 @@ void ScriptExecutionContext::regenerateIdentifier()
 
     m_identifier = ScriptExecutionContextIdentifier::generate();
 
+    ASSERT(!allScriptExecutionContextsMap().contains(m_identifier));
+    allScriptExecutionContextsMap().add(m_identifier, this);
+}
+
+void ScriptExecutionContext::addToContextsMap()
+{
+    Locker locker { allScriptExecutionContextsMapLock };
     ASSERT(!allScriptExecutionContextsMap().contains(m_identifier));
     allScriptExecutionContextsMap().add(m_identifier, this);
 }

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -337,6 +337,7 @@ protected:
     ReasonForSuspension reasonForSuspendingActiveDOMObjects() const { return m_reasonForSuspendingActiveDOMObjects; }
 
     bool hasPendingActivity() const;
+    WEBCORE_EXPORT void addToContextsMap();
     void removeFromContextsMap();
     void removeRejectedPromiseTracker();
     void regenerateIdentifier();

--- a/Source/WebCore/dom/XMLDocument.h
+++ b/Source/WebCore/dom/XMLDocument.h
@@ -34,12 +34,16 @@ class XMLDocument : public Document {
 public:
     static Ref<XMLDocument> create(Frame* frame, const Settings& settings, const URL& url)
     {
-        return adoptRef(*new XMLDocument(frame, settings, url, { DocumentClass::XML }));
+        auto document = adoptRef(*new XMLDocument(frame, settings, url, { DocumentClass::XML }));
+        document->addToContextsMap();
+        return document;
     }
 
     static Ref<XMLDocument> createXHTML(Frame* frame, const Settings& settings, const URL& url)
     {
-        return adoptRef(*new XMLDocument(frame, settings, url, { DocumentClass::XML, DocumentClass::XHTML }));
+        auto document = adoptRef(*new XMLDocument(frame, settings, url, { DocumentClass::XML, DocumentClass::XHTML }));
+        document->addToContextsMap();
+        return document;
     }
 
 protected:

--- a/Source/WebCore/html/FTPDirectoryDocument.h
+++ b/Source/WebCore/html/FTPDirectoryDocument.h
@@ -33,7 +33,9 @@ class FTPDirectoryDocument final : public HTMLDocument {
 public:
     static Ref<FTPDirectoryDocument> create(Frame* frame, const Settings& settings, const URL& url)
     {
-        return adoptRef(*new FTPDirectoryDocument(frame, settings, url));
+        auto document = adoptRef(*new FTPDirectoryDocument(frame, settings, url));
+        document->addToContextsMap();
+        return document;
     }
 
 private:

--- a/Source/WebCore/html/HTMLDocument.cpp
+++ b/Source/WebCore/html/HTMLDocument.cpp
@@ -89,7 +89,9 @@ using namespace HTMLNames;
 
 Ref<HTMLDocument> HTMLDocument::createSynthesizedDocument(Frame& frame, const URL& url)
 {
-    return adoptRef(*new HTMLDocument(&frame, frame.settings(), url, { }, { DocumentClass::HTML }, Synthesized));
+    auto document = adoptRef(*new HTMLDocument(&frame, frame.settings(), url, { }, { DocumentClass::HTML }, Synthesized));
+    document->addToContextsMap();
+    return document;
 }
 
 HTMLDocument::HTMLDocument(Frame* frame, const Settings& settings, const URL& url, ScriptExecutionContextIdentifier documentIdentifier, DocumentClasses documentClasses, unsigned constructionFlags)

--- a/Source/WebCore/html/HTMLDocument.h
+++ b/Source/WebCore/html/HTMLDocument.h
@@ -67,7 +67,9 @@ private:
 
 inline Ref<HTMLDocument> HTMLDocument::create(Frame* frame, const Settings& settings, const URL& url, ScriptExecutionContextIdentifier identifier)
 {
-    return adoptRef(*new HTMLDocument(frame, settings, url, identifier, { DocumentClass::HTML }, 0));
+    auto document = adoptRef(*new HTMLDocument(frame, settings, url, identifier, { DocumentClass::HTML }, 0));
+    document->addToContextsMap();
+    return document;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/ImageDocument.h
+++ b/Source/WebCore/html/ImageDocument.h
@@ -36,7 +36,9 @@ class ImageDocument final : public HTMLDocument {
 public:
     static Ref<ImageDocument> create(Frame& frame, const URL& url)
     {
-        return adoptRef(*new ImageDocument(frame, url));
+        auto document = adoptRef(*new ImageDocument(frame, url));
+        document->addToContextsMap();
+        return document;
     }
 
     WEBCORE_EXPORT HTMLImageElement* imageElement() const;

--- a/Source/WebCore/html/MediaDocument.h
+++ b/Source/WebCore/html/MediaDocument.h
@@ -36,7 +36,9 @@ class MediaDocument final : public HTMLDocument {
 public:
     static Ref<MediaDocument> create(Frame* frame, const Settings& settings, const URL& url)
     {
-        return adoptRef(*new MediaDocument(frame, settings, url));
+        auto document = adoptRef(*new MediaDocument(frame, settings, url));
+        document->addToContextsMap();
+        return document;
     }
     virtual ~MediaDocument();
 

--- a/Source/WebCore/html/ModelDocument.h
+++ b/Source/WebCore/html/ModelDocument.h
@@ -36,7 +36,9 @@ class ModelDocument final : public HTMLDocument {
 public:
     static Ref<ModelDocument> create(Frame* frame, const Settings& settings, const URL& url)
     {
-        return adoptRef(*new ModelDocument(frame, settings, url));
+        auto document = adoptRef(*new ModelDocument(frame, settings, url));
+        document->addToContextsMap();
+        return document;
     }
 
     virtual ~ModelDocument() = default;

--- a/Source/WebCore/html/PDFDocument.h
+++ b/Source/WebCore/html/PDFDocument.h
@@ -38,7 +38,9 @@ class PDFDocument final : public HTMLDocument {
 public:
     static Ref<PDFDocument> create(Frame& frame, const URL& url)
     {
-        return adoptRef(*new PDFDocument(frame, url));
+        auto document = adoptRef(*new PDFDocument(frame, url));
+        document->addToContextsMap();
+        return document;
     }
 
     void updateDuringParsing();

--- a/Source/WebCore/html/PluginDocument.h
+++ b/Source/WebCore/html/PluginDocument.h
@@ -36,7 +36,9 @@ class PluginDocument final : public HTMLDocument {
 public:
     static Ref<PluginDocument> create(Frame& frame, const URL& url)
     {
-        return adoptRef(*new PluginDocument(frame, url));
+        auto document = adoptRef(*new PluginDocument(frame, url));
+        document->addToContextsMap();
+        return document;
     }
 
     WEBCORE_EXPORT PluginViewBase* pluginWidget();

--- a/Source/WebCore/html/TextDocument.h
+++ b/Source/WebCore/html/TextDocument.h
@@ -33,7 +33,9 @@ class TextDocument final : public HTMLDocument {
 public:
     static Ref<TextDocument> create(Frame* frame, const Settings& settings, const URL& url, ScriptExecutionContextIdentifier identifier)
     {
-        return adoptRef(*new TextDocument(frame, settings, url, identifier));
+        auto document = adoptRef(*new TextDocument(frame, settings, url, identifier));
+        document->addToContextsMap();
+        return document;
     }
 
 private:

--- a/Source/WebCore/loader/SinkDocument.h
+++ b/Source/WebCore/loader/SinkDocument.h
@@ -34,7 +34,9 @@ class SinkDocument final : public HTMLDocument {
 public:
     static Ref<SinkDocument> create(Frame& frame, const URL& url)
     {
-        return adoptRef(*new SinkDocument(frame, url));
+        auto document = adoptRef(*new SinkDocument(frame, url));
+        document->addToContextsMap();
+        return document;
     }
 
 private:

--- a/Source/WebCore/svg/SVGDocument.h
+++ b/Source/WebCore/svg/SVGDocument.h
@@ -46,7 +46,9 @@ private:
 
 inline Ref<SVGDocument> SVGDocument::create(Frame* frame, const Settings& settings, const URL& url)
 {
-    return adoptRef(*new SVGDocument(frame, settings, url));
+    auto document = adoptRef(*new SVGDocument(frame, settings, url));
+    document->addToContextsMap();
+    return document;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -83,14 +83,11 @@ public:
     void postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&&);
 
     static void forEachWorker(const Function<Function<void(ScriptExecutionContext&)>()>&);
-    static Worker* byIdentifier(ScriptExecutionContextIdentifier);
 
 private:
     Worker(ScriptExecutionContext&, JSC::RuntimeFlags, WorkerOptions&&);
 
     EventTargetInterface eventTargetInterface() const final { return WorkerEventTargetInterfaceType; }
-
-    void notifyNetworkStateChange(bool isOnline);
 
     void didReceiveResponse(ResourceLoaderIdentifier, const ResourceResponse&) final;
     void notifyFinished() final;
@@ -115,7 +112,7 @@ private:
     JSC::RuntimeFlags m_runtimeFlags;
     Deque<RefPtr<Event>> m_pendingEvents;
     bool m_wasTerminated { false };
-    ScriptExecutionContextIdentifier m_clientIdentifier;
+    const ScriptExecutionContextIdentifier m_clientIdentifier;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/Worker.idl
+++ b/Source/WebCore/workers/Worker.idl
@@ -26,7 +26,7 @@
 
 [
     ActiveDOMObject,
-    Exposed=Window
+    Exposed=(Window,DedicatedWorker)
 ] interface Worker : EventTarget {
     [CallWith=CurrentScriptExecutionContext&RuntimeFlags] constructor(USVString scriptUrl, optional WorkerOptions options);
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -131,8 +131,6 @@ WorkerGlobalScope::WorkerGlobalScope(WorkerThreadType type, const WorkerParamete
 WorkerGlobalScope::~WorkerGlobalScope()
 {
     ASSERT(thread().thread() == &Thread::current());
-    // We need to remove from the contexts map very early in the destructor so that calling postTask() on this WorkerGlobalScope from another thread is safe.
-    removeFromContextsMap();
 
     {
         Locker locker { allWorkerGlobalScopeIdentifiersLock };

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -121,6 +121,7 @@ public:
     WorkerNavigator& navigator();
 
     void setIsOnline(bool);
+    bool isOnline() const { return m_isOnline; }
 
     ExceptionOr<int> setTimeout(std::unique_ptr<ScheduledAction>, int timeout, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments);
     void clearTimeout(int timeoutId);

--- a/Source/WebCore/workers/WorkerLoaderProxy.h
+++ b/Source/WebCore/workers/WorkerLoaderProxy.h
@@ -55,6 +55,8 @@ public:
 
     virtual RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() = 0;
 
+    virtual ScriptExecutionContextIdentifier loaderContextIdentifier() const = 0;
+
     // Posts a task to the thread which runs the loading code (normally, the main thread).
     virtual void postTaskToLoader(ScriptExecutionContext::Task&&) = 0;
 };

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -77,6 +77,7 @@ private:
     // requests and to send callbacks back to WorkerGlobalScope.
     bool isWorkerMessagingProxy() const final { return true; }
     void postTaskToLoader(ScriptExecutionContext::Task&&) final;
+    ScriptExecutionContextIdentifier loaderContextIdentifier() const final;
     RefPtr<CacheStorageConnection> createCacheStorageConnection() final;
     StorageConnection* storageConnection() final;
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;
@@ -91,6 +92,7 @@ private:
     Worker* workerObject() const { return m_workerObject; }
 
     RefPtr<ScriptExecutionContext> m_scriptExecutionContext;
+    ScriptExecutionContextIdentifier m_loaderContextIdentifier;
     RefPtr<WorkerInspectorProxy> m_inspectorProxy;
     RefPtr<WorkerUserGestureForwarder> m_userGestureForwarder;
     Worker* m_workerObject;

--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -69,6 +69,9 @@ public:
     static Lock& workerOrWorkletThreadsLock() WTF_RETURNS_LOCK(s_workerOrWorkletThreadsLock);
     static void releaseFastMallocFreeMemoryInAllThreads();
 
+    void addChildThread(WorkerOrWorkletThread&);
+    void removeChildThread(WorkerOrWorkletThread&);
+
 protected:
     explicit WorkerOrWorkletThread(const String& inspectorIdentifier, WorkerThreadMode = WorkerThreadMode::CreateNewThread);
     void workerOrWorkletThread();
@@ -81,6 +84,7 @@ private:
     virtual RefPtr<WorkerOrWorkletGlobalScope> createGlobalScope() = 0;
     virtual void evaluateScriptIfNecessary(String&) { }
     virtual bool shouldWaitForWebInspectorOnStartup() const { return false; }
+    void destroyWorkerGlobalScope(Ref<WorkerOrWorkletThread>&& protectedThis);
 
     static Lock s_workerOrWorkletThreadsLock;
 
@@ -92,6 +96,8 @@ private:
     Function<void(const String&)> m_evaluateCallback;
     Function<void()> m_stoppedCallback;
     BinarySemaphore m_suspensionSemaphore;
+    HashSet<WorkerOrWorkletThread*> m_childThreads;
+    Function<void()> m_runWhenLastChildThreadIsGone;
     bool m_isSuspended { false };
     bool m_pausedForDebugger { false };
 };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -118,6 +118,11 @@ bool ServiceWorkerThreadProxy::postTaskForModeToWorkerOrWorkletGlobalScope(Scrip
     return true;
 }
 
+ScriptExecutionContextIdentifier ServiceWorkerThreadProxy::loaderContextIdentifier() const
+{
+    return m_document->identifier();
+}
+
 void ServiceWorkerThreadProxy::postTaskToLoader(ScriptExecutionContext::Task&& task)
 {
     callOnMainThread([task = WTFMove(task), this, protectedThis = Ref { *this }] () mutable {

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -103,6 +103,7 @@ private:
 
     // WorkerLoaderProxy
     void postTaskToLoader(ScriptExecutionContext::Task&&) final;
+    ScriptExecutionContextIdentifier loaderContextIdentifier() const final;
     RefPtr<CacheStorageConnection> createCacheStorageConnection() final;
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;
 

--- a/Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp
@@ -50,6 +50,12 @@ SharedWorkerGlobalScope::SharedWorkerGlobalScope(const String& name, const Worke
     applyContentSecurityPolicyResponseHeaders(params.contentSecurityPolicyResponseHeaders);
 }
 
+SharedWorkerGlobalScope::~SharedWorkerGlobalScope()
+{
+    // We need to remove from the contexts map very early in the destructor so that calling postTask() on this WorkerGlobalScope from another thread is safe.
+    removeFromContextsMap();
+}
+
 SharedWorkerThread& SharedWorkerGlobalScope::thread()
 {
     return static_cast<SharedWorkerThread&>(WorkerGlobalScope::thread());

--- a/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
@@ -37,7 +37,13 @@ struct WorkerParameters;
 class SharedWorkerGlobalScope final : public WorkerGlobalScope {
     WTF_MAKE_ISO_ALLOCATED(SharedWorkerGlobalScope);
 public:
-    template<typename... Args> static Ref<SharedWorkerGlobalScope> create(Args&&... args) { return adoptRef(*new SharedWorkerGlobalScope(std::forward<Args>(args)...)); }
+    template<typename... Args> static Ref<SharedWorkerGlobalScope> create(Args&&... args)
+    {
+        auto scope = adoptRef(*new SharedWorkerGlobalScope(std::forward<Args>(args)...));
+        scope->addToContextsMap();
+        return scope;
+    }
+    ~SharedWorkerGlobalScope();
 
     Type type() const final { return Type::SharedWorker; }
     const String& name() const { return m_name; }

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -161,6 +161,11 @@ RefPtr<RTCDataChannelRemoteHandlerConnection> SharedWorkerThreadProxy::createRTC
     return m_page->webRTCProvider().createRTCDataChannelRemoteHandlerConnection();
 }
 
+ScriptExecutionContextIdentifier SharedWorkerThreadProxy::loaderContextIdentifier() const
+{
+    return m_document->identifier();
+}
+
 void SharedWorkerThreadProxy::postTaskToLoader(ScriptExecutionContext::Task&& task)
 {
     callOnMainThread([task = WTFMove(task), protectedThis = Ref { *this }] () mutable {

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
@@ -74,6 +74,7 @@ private:
     RefPtr<CacheStorageConnection> createCacheStorageConnection() final;
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;
     void postTaskToLoader(ScriptExecutionContext::Task&&) final;
+    ScriptExecutionContextIdentifier loaderContextIdentifier() const final;
 
     // WorkerDebuggerProxy.
     void postMessageToDebugger(const String&) final;

--- a/Source/WebCore/worklets/PaintWorkletGlobalScope.cpp
+++ b/Source/WebCore/worklets/PaintWorkletGlobalScope.cpp
@@ -46,7 +46,9 @@ RefPtr<PaintWorkletGlobalScope> PaintWorkletGlobalScope::tryCreate(Document& doc
     RefPtr<VM> vm = VM::tryCreate();
     if (!vm)
         return nullptr;
-    return adoptRef(*new PaintWorkletGlobalScope(document, vm.releaseNonNull(), WTFMove(code)));
+    auto scope = adoptRef(*new PaintWorkletGlobalScope(document, vm.releaseNonNull(), WTFMove(code)));
+    scope->addToContextsMap();
+    return scope;
 }
 
 PaintWorkletGlobalScope::PaintWorkletGlobalScope(Document& document, Ref<VM>&& vm, ScriptSourceCode&& code)


### PR DESCRIPTION
#### 48880e342359f100878b1b87373e706db7dfe540
<pre>
Implement nested Dedicated Workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=22723">https://bugs.webkit.org/show_bug.cgi?id=22723</a>
&lt;rdar://6425810&gt;

Reviewed by Darin Adler.

Add support for nested dedicated workers. Blink and Gecko already support this.

Also fix an issue where ScriptExecutionContext were added too early to the ScriptExecutionContextMap.
This was marking calls to postTaskTo() unsafe since it would call the virtual postTask() function
on a ScriptExecutionContext that had potentially not finished construction. This was causing flaky
test crashes.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-classic.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/opt-in/worker-module.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/unset/worker-classic.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/unset/worker-module.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/opt-in/worker-classic.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/opt-in/worker-module.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/unset/worker-classic.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/unset/worker-module.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-classic.http-rp/upgrade/worker-classic.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-classic.http-rp/upgrade/worker-module.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-module.http-rp/upgrade/worker-classic.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-module.http-rp/upgrade/worker-module.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/nested-worker-success.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-locks/query.tentative.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webmessaging/MessageEvent-trusted.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webmessaging/message-channels/worker-post-after-close.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webmessaging/message-channels/worker.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/websockets/Create-on-worker-shutdown.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/baseurl/alpha/worker-in-worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/expected-self-properties.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/dedicated-worker-in-data-url-context.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-blob-url.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-data-url.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_close_from_parent_worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_close_self.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_importScripts.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_sync_xhr.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker_terminate_from_document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/interface-objects/001.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/multiple-workers/exposure.any.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-blob-url.any.worker-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-data-url.any.worker-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import.any.worker-expected.txt: Added.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp:
(WebCore::AudioWorkletMessagingProxy::loaderContextIdentifier const):
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
(WebCore::DedicatedWorkerGlobalScope::~DedicatedWorkerGlobalScope):
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::networkStateChanged):
(WebCore::Worker::Worker):
(WebCore::Worker::create):
(WebCore::Worker::~Worker):
(WebCore::Worker::forEachWorker):
(WebCore::Worker::notifyNetworkStateChange): Deleted.
(WebCore::Worker::byIdentifier): Deleted.
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/Worker.idl:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::~WorkerGlobalScope):
* Source/WebCore/workers/WorkerLoaderProxy.h:
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::WorkerMessagingProxy):
(WebCore::WorkerMessagingProxy::~WorkerMessagingProxy):
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
(WebCore::WorkerMessagingProxy::postMessageToWorkerObject):
(WebCore::WorkerMessagingProxy::postTaskToWorkerObject):
(WebCore::WorkerMessagingProxy::postMessageToWorkerGlobalScope):
(WebCore::WorkerMessagingProxy::loaderContextIdentifier const):
(WebCore::WorkerMessagingProxy::postTaskToLoader):
(WebCore::WorkerMessagingProxy::createCacheStorageConnection):
(WebCore::WorkerMessagingProxy::storageConnection):
(WebCore::WorkerMessagingProxy::createRTCDataChannelRemoteHandlerConnection):
(WebCore::WorkerMessagingProxy::postExceptionToWorkerObject):
(WebCore::WorkerMessagingProxy::workerObjectDestroyed):
(WebCore::WorkerMessagingProxy::workerGlobalScopeDestroyed):
(WebCore::WorkerMessagingProxy::workerGlobalScopeClosed):
(WebCore::WorkerMessagingProxy::workerGlobalScopeDestroyedInternal):
(WebCore::WorkerMessagingProxy::confirmMessageFromWorkerObject):
(WebCore::WorkerMessagingProxy::reportPendingActivity):
* Source/WebCore/workers/WorkerMessagingProxy.h:
* Source/WebCore/workers/WorkerOrWorkletThread.cpp:
(WebCore::WorkerOrWorkletThread::workerOrWorkletThread):
(WebCore::WorkerOrWorkletThread::destroyWorkerGlobalScope):
(WebCore::WorkerOrWorkletThread::stop):
(WebCore::WorkerOrWorkletThread::addChildThread):
(WebCore::WorkerOrWorkletThread::removeChildThread):
* Source/WebCore/workers/WorkerOrWorkletThread.h:
* Source/WebCore/workers/service/SWClientConnection.cpp:
(WebCore::SWClientConnection::postMessageToServiceWorkerClient):
(WebCore::SWClientConnection::notifyClientsOfControllerChange):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::~ServiceWorkerGlobalScope):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::loaderContextIdentifier const):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp:
(WebCore::SharedWorkerGlobalScope::~SharedWorkerGlobalScope):
* Source/WebCore/workers/shared/SharedWorkerGlobalScope.h:
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::loaderContextIdentifier const):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h:

Canonical link: <a href="https://commits.webkit.org/254597@main">https://commits.webkit.org/254597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/feb53520409303d08979fbb094f9c6cb7b00de38

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98883 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155473 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32636 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81947 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93293 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25924 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76450 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25871 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68862 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30393 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14754 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30141 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15687 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3232 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38643 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34778 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->