### PR TITLE
getKeyframes() returns equal "from" and "to" values for a "width" transition

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/KeyframeEffect-getKeyframes-width-and-height-transition.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/KeyframeEffect-getKeyframes-width-and-height-transition.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+PASS getKeyframes() output for a width transition
+PASS getKeyframes() output for a height transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/KeyframeEffect-getKeyframes-width-and-height-transition.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/KeyframeEffect-getKeyframes-width-and-height-transition.tentative.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>AnimationEffect.getKeyframes() for CSS transitions of the width and height properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/#csstransition">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/helper.js"></script>
+<style>
+
+.animated-div {
+  width: 100px;
+  height: 100px;
+}
+
+</style>
+<div id="log"></div>
+<script>
+
+'use strict';
+
+test(t => {
+  const div = addDiv(t, { class: 'animated-div' });
+  div.style.transition = 'width 10s';
+  getComputedStyle(div).width;
+  div.style.width = '200px';
+
+  const keyframes = div.getAnimations()[0].effect.getKeyframes();
+  assert_equals(keyframes[0].width, "100px", 'from keyframe value');
+  assert_equals(keyframes[1].width, "200px", 'to keyframe value');
+}, 'getKeyframes() output for a width transition');
+
+test(t => {
+  const div = addDiv(t, { class: 'animated-div' });
+  div.style.transition = 'height 10s';
+  getComputedStyle(div).height;
+  div.style.height = '200px';
+
+  const keyframes = div.getAnimations()[0].effect.getKeyframes();
+  assert_equals(keyframes[0].height, "100px", 'from keyframe value');
+  assert_equals(keyframes[1].height, "200px", 'to keyframe value');
+}, 'getKeyframes() output for a height transition');
+
+</script>


### PR DESCRIPTION
#### 1ed5a302e8a063553b8fcf90d58e9bed53716c5c
<pre>
getKeyframes() returns equal &quot;from&quot; and &quot;to&quot; values for a &quot;width&quot; transition
<a href="https://bugs.webkit.org/show_bug.cgi?id=245179">https://bugs.webkit.org/show_bug.cgi?id=245179</a>
&lt;rdar://100223910&gt;

Reviewed by Antti Koivisto.

Adding a new test that checks that the value returned by getKeyframes() for
&quot;width&quot; and &quot;height&quot; transitions between mixed length types is correct. A test
alone is sufficient since the changes that landed for bug 23924 already fixed
the problem.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/KeyframeEffect-getKeyframes-width-and-height-transition.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/KeyframeEffect-getKeyframes-width-and-height-transition.tentative.html: Added.

Canonical link: <a href="https://commits.webkit.org/254793@main">https://commits.webkit.org/254793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/330161acce82f0cd413deb65f51691b88d996f85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99567 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157059 "Reverted pull request changes (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33294 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82589 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96032 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26482 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77083 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26374 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81095 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69376 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editable/editable (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34418 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/15158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32251 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16111 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39065 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1438 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35198 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->