### PR TITLE
CSP3: Deprecate `child-src`

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-about-blank-allowed-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-about-blank-allowed-expected.txt
@@ -1,3 +1,6 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: IFrame load event fired: the IFrame's location is 'about:blank'.
 'about:blank' should not be blocked by CSP.
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-allowed-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-allowed-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 ALERT: PASS
 CONSOLE MESSAGE: IFrame load event fired: the IFrame's location is 'http://127.0.0.1:8000/security/contentSecurityPolicy/resources/alert-pass.html'.
 Frames should be governed by 'child-src'.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-blocked-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/alert-fail.html because it does not appear in the frame-src directive of the Content Security Policy.
 This tests that an <iframe> load is blocked when using Content Security Policy child-src 'none'. This test PASSED if there is no JavaScript alert.
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-redirect-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-redirect-blocked-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Refused to load http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.html because it does not appear in the frame-src directive of the Content Security Policy.
 This tests that the Content Security Policy of the page blocks an <iframe> from loading a document of a different origin through a redirect. This test PASSED if there is no JavaScript alert.
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-src-takes-precedence-over-child-src-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-src-takes-precedence-over-child-src-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/alert-fail.html because it does not appear in the frame-src directive of the Content Security Policy.
 This tests that an <iframe> load is blocked when using Content Security Policy frame-src 'none'; child-src 'self' because the deprecated directive frame-src takes precedence over the directive child-src. This test PASSED if there is no JavaScript alert.
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-allowed-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-allowed-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 Workers should be governed by 'child-src'.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-blocked-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/alert-fail.js because it does not appear in the worker-src directive of the Content Security Policy.
 Workers should be governed by 'child-src'.
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-redirect-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-redirect-blocked-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Refused to load http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js because it does not appear in the worker-src directive of the Content Security Policy.
 CONSOLE MESSAGE: Blocked by Content Security Policy.
 CONSOLE MESSAGE: Cannot load http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js due to access control checks.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/securityviolationpolicy-block-frame-using-child-src-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/securityviolationpolicy-block-frame-using-child-src-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/alert-fail.html because it does not appear in the frame-src directive of the Content Security Policy.
 Check that a SecurityPolicyViolationEvent is fired upon blocking an frame by the child-src directive.
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/iframe-allowed-when-loaded-via-javascript-url-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/iframe-allowed-when-loaded-via-javascript-url-expected.txt
@@ -1,3 +1,6 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: PASS
 
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-child-src-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-child-src-expected.txt
@@ -1,2 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: PASS
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-child-src2-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-child-src2-expected.txt
@@ -1,2 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: PASS
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/iframe-redirect-blocked-by-child-src-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/iframe-redirect-blocked-by-child-src-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Refused to load http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.html because it does not appear in the frame-src directive of the Content Security Policy.
 Tests that an <iframe> that loads a cross-origin page via a redirect is blocked by the Content Security Policy child-src directive. This test PASSED if there is a console warning message.
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/object-src-allows-embed-blocked-by-child-src-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/object-src-allows-embed-blocked-by-child-src-expected.txt
@@ -1,2 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 ALERT: PASS
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/object-src-allows-object-blocked-by-child-src-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/object-src-allows-object-blocked-by-child-src-expected.txt
@@ -1,2 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 ALERT: PASS
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/object-src-blocks-embed-allowed-by-child-src-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/object-src-blocks-embed-allowed-by-child-src-expected.txt
@@ -1,2 +1,3 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/alert-fail.html because it does not appear in the object-src directive of the Content Security Policy.
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/object-src-blocks-object-allowed-by-child-src-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/object-src-blocks-object-allowed-by-child-src-expected.txt
@@ -1,2 +1,3 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/alert-fail.html because it does not appear in the object-src directive of the Content Security Policy.
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/redirect-does-not-match-paths-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/redirect-does-not-match-paths-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 
 
 PASS CSP ignores paths of redirected resources in matching algorithm for scripts.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/worker-redirect-allowed-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/worker-redirect-allowed-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 This tests that the Content Security Policy of the page allows loading a Web Worker's script redirected on the same origin.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/security/isolatedWorld/bypass-main-world-csp-worker-expected.txt
+++ b/LayoutTests/http/tests/security/isolatedWorld/bypass-main-world-csp-worker-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 This tests that in an isolated world the Content Security Policy of the parent origin (this page) is bypassed and a Web Worker is allowed to be instantiated with a script URL not listed in the CSP of the page.
 
 PASS worker instantiated.

--- a/LayoutTests/http/tests/security/isolatedWorld/bypass-main-world-csp-worker-redirect-expected.txt
+++ b/LayoutTests/http/tests/security/isolatedWorld/bypass-main-world-csp-worker-redirect-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
 
 CONSOLE MESSAGE: Cannot load http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js due to access control checks.

--- a/LayoutTests/platform/mac-wk1/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-redirect-blocked-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-redirect-blocked-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
 
 CONSOLE MESSAGE: Cannot load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/redir.py?url=http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js due to access control checks.

--- a/LayoutTests/platform/mac-wk1/http/tests/security/isolatedWorld/bypass-main-world-csp-worker-redirect-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/isolatedWorld/bypass-main-world-csp-worker-redirect-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
 
 CONSOLE MESSAGE: Cannot load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/redir.py?url=http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js due to access control checks.

--- a/LayoutTests/platform/win/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-redirect-blocked-expected.txt
+++ b/LayoutTests/platform/win/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-redirect-blocked-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
 
 CONSOLE MESSAGE: Cannot load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/redir.py?url=http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js due to access control checks.

--- a/LayoutTests/platform/win/http/tests/security/isolatedWorld/bypass-main-world-csp-worker-redirect-expected.txt
+++ b/LayoutTests/platform/win/http/tests/security/isolatedWorld/bypass-main-world-csp-worker-redirect-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'child-src' has been deprecated. Instead, you should use 'worker-src'.
 CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
 
 CONSOLE MESSAGE: Cannot load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/redir.py?url=http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js due to access control checks.

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -900,6 +900,11 @@ void ContentSecurityPolicy::reportUnsupportedDirective(const String& name) const
     logToConsole(message);
 }
 
+void ContentSecurityPolicy::reportDeprecatedDirective(const String& deprecated, const String& preferred)
+{
+    logToConsole("The Content Security Policy directive '" + deprecated + "' has been deprecated. Instead, you should use '" + preferred + "'.");
+}
+
 void ContentSecurityPolicy::reportDirectiveAsSourceExpression(const String& directiveName, StringView sourceExpression) const
 {
     logToConsole("The Content Security Policy directive '" + directiveName + "' contains '" + sourceExpression + "' as a source expression. Did you mean '" + directiveName + " ...; " + sourceExpression + "...' (note the semicolon)?");

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -161,6 +161,7 @@ public:
     bool allowContentSecurityPolicySourceStarToMatchAnyProtocol() const;
 
     // Used by ContentSecurityPolicyDirectiveList
+    void reportDeprecatedDirective(const String& deprecated, const String& preferred);
     void reportDuplicateDirective(const String&) const;
     void reportInvalidDirectiveValueCharacter(const String& directiveName, const String& value) const;
     void reportInvalidSandboxFlags(const String&) const;

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -643,8 +643,6 @@ void ContentSecurityPolicyDirectiveList::addDirective(ParsedDirective&& directiv
     else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::workerSrc))
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTFMove(directive), m_workerSrc);
     else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::frameSrc)) {
-        // FIXME: Log to console "The frame-src directive is deprecated. Use the child-src directive instead."
-        // See <https://bugs.webkit.org/show_bug.cgi?id=155773>.
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTFMove(directive), m_frameSrc);
     } else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::imgSrc))
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTFMove(directive), m_imgSrc);
@@ -658,8 +656,10 @@ void ContentSecurityPolicyDirectiveList::addDirective(ParsedDirective&& directiv
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTFMove(directive), m_mediaSrc);
     else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::connectSrc))
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTFMove(directive), m_connectSrc);
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::childSrc))
+    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::childSrc)) {
+        m_policy.reportDeprecatedDirective(ContentSecurityPolicyDirectiveNames::childSrc, ContentSecurityPolicyDirectiveNames::workerSrc);
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTFMove(directive), m_childSrc);
+    }
     else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::formAction))
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTFMove(directive), m_formAction);
     else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::baseURI))


### PR DESCRIPTION
#### e7c16821d2711722f3738332a230cf9b34c822d9
<pre>
CSP3: Deprecate `child-src`
<a href="https://bugs.webkit.org/show_bug.cgi?id=165136">https://bugs.webkit.org/show_bug.cgi?id=165136</a>
&lt;rdar://problem/83733875&gt;

Reviewed by NOBODY (OOPS!).

The CSP Level 3 specification deprecated `child-src` in favor of `worker-src`. We should continue to honor the
directive, but provide console logging to warn developers that they are using deprecated rules.

No behavior change, but rebaselined to include the expected new console logging about the deprecation.

* LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-about-blank-allowed-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-allowed-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-blocked-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-redirect-blocked-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/frame-src-takes-precedence-over-child-src-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-allowed-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-blocked-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-redirect-blocked-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/1.1/securityviolationpolicy-block-frame-using-child-src-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/iframe-allowed-when-loaded-via-javascript-url-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-child-src-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-child-src2-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/iframe-redirect-blocked-by-child-src-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/object-src-allows-embed-blocked-by-child-src-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/object-src-allows-object-blocked-by-child-src-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/object-src-blocks-embed-allowed-by-child-src-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/object-src-blocks-object-allowed-by-child-src-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/redirect-does-not-match-paths-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/worker-redirect-allowed-expected.txt:
* LayoutTests/http/tests/security/isolatedWorld/bypass-main-world-csp-worker-expected.txt:
* LayoutTests/http/tests/security/isolatedWorld/bypass-main-world-csp-worker-redirect-expected.txt:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::reportDeprecatedDirective): New convenience method.
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::addDirective): Use deprecation warning message if relevant.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7c16821d2711722f3738332a230cf9b34c822d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33913 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/20123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98689 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154993 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32418 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/81736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93108 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25753 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/76286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25693 "layout-tests (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/80632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/20123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/68679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30185 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/20123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29915 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/20123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33363 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/76286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32071 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/20123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->