### PR TITLE
WinCairo doesn't build without USE_GRAPHICS_LAYER_WC enabled

### DIFF
--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
@@ -29,6 +29,8 @@
 #include "config.h"
 #include "DrawingAreaProxyWC.h"
 
+#if USE(GRAPHICS_LAYER_WC)
+
 #include "DrawingAreaMessages.h"
 #include "UpdateInfo.h"
 #include "WebCoreArgumentCoders.h"
@@ -101,3 +103,5 @@ void DrawingAreaProxyWC::discardBackingStore()
 }
 
 } // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if USE(GRAPHICS_LAYER_WC)
+
 #include "BackingStore.h"
 #include "DrawingAreaProxy.h"
 
@@ -57,3 +59,5 @@ private:
 };
 
 } // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/UIProcess/win/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.cpp
@@ -28,13 +28,16 @@
 #include "PageClientImpl.h"
 
 #include "DrawingAreaProxyCoordinatedGraphics.h"
-#include "DrawingAreaProxyWC.h"
 #include "WebContextMenuProxyWin.h"
 #include "WebPageProxy.h"
 #include "WebPopupMenuProxyWin.h"
 #include "WebView.h"
 #include <WebCore/DOMPasteAccess.h>
 #include <WebCore/NotImplemented.h>
+
+#if USE(GRAPHICS_LAYER_WC)
+#include "DrawingAreaProxyWC.h"
+#endif
 
 namespace WebKit {
 using namespace WebCore;
@@ -47,8 +50,10 @@ PageClientImpl::PageClientImpl(WebView& view)
 // PageClient's pure virtual functions
 std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy(WebProcessProxy& process)
 {
+#if USE(GRAPHICS_LAYER_WC)
     if (m_view.page()->preferences().useGPUProcessForWebGLEnabled())
         return makeUnique<DrawingAreaProxyWC>(*m_view.page(), process);
+#endif
     return makeUnique<DrawingAreaProxyCoordinatedGraphics>(*m_view.page(), process);
 }
 
@@ -342,10 +347,12 @@ void PageClientImpl::didSameDocumentNavigationForMainFrame(SameDocumentNavigatio
     notImplemented();
 }
 
+#if USE(GRAPHICS_LAYER_WC)
 bool PageClientImpl::usesOffscreenRendering() const
 {
     return m_view.usesOffscreenRendering();
 }
+#endif
 
 void PageClientImpl::didChangeBackgroundColor()
 {

--- a/Source/WebKit/UIProcess/win/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.h
@@ -106,7 +106,10 @@ private:
     void didFinishNavigation(API::Navigation*) override;
     void didFailNavigation(API::Navigation*) override { }
     void didSameDocumentNavigationForMainFrame(SameDocumentNavigationType) override;
+
+#if USE(GRAPHICS_LAYER_WC)
     bool usesOffscreenRendering() const override;
+#endif
 
     // Auxiliary Client Creation
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/win/WebView.cpp
+++ b/Source/WebKit/UIProcess/win/WebView.cpp
@@ -29,7 +29,6 @@
 
 #include "APIPageConfiguration.h"
 #include "DrawingAreaProxyCoordinatedGraphics.h"
-#include "DrawingAreaProxyWC.h"
 #include "Logging.h"
 #include "NativeWebKeyboardEvent.h"
 #include "NativeWebMouseEvent.h"
@@ -66,7 +65,11 @@
 #if USE(CAIRO)
 #include <cairo-win32.h>
 #include <cairo.h>
-#endif 
+#endif
+
+#if USE(GRAPHICS_LAYER_WC)
+#include "DrawingAreaProxyWC.h"
+#endif
 
 namespace WebKit {
 using namespace WebCore;
@@ -498,9 +501,11 @@ void WebView::paint(HDC hdc, const IntRect& dirtyRect)
                 drawPageBackground(hdc, m_page.get(), rect);
         };
         switch (m_page->drawingArea()->type()) {
+#if USE(GRAPHICS_LAYER_WC)
         case DrawingAreaType::WC:
             painter(static_cast<DrawingAreaProxyWC*>(m_page->drawingArea()));
             break;
+#endif
         case DrawingAreaType::CoordinatedGraphics:
             painter(static_cast<DrawingAreaProxyCoordinatedGraphics*>(m_page->drawingArea()));
             break;

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/WCPlatformLayerGCGL.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/WCPlatformLayerGCGL.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if USE(GRAPHICS_LAYER_WC) && ENABLE(WEBGL)
+
 #include "GraphicsContextGLIdentifier.h"
 #include "WCContentBufferIdentifier.h"
 #include <WebCore/WCPlatformLayer.h>
@@ -50,3 +52,5 @@ private:
 };
 
 } // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC) && ENABLE(WEBGL)

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "DrawingAreaWC.h"
 
+#if USE(GRAPHICS_LAYER_WC)
+
 #include "DrawingAreaProxyMessages.h"
 #include "GraphicsLayerWC.h"
 #include "PlatformImageBufferShareableBackend.h"
@@ -382,3 +384,5 @@ void DrawingAreaWC::didUpdate()
 }
 
 } // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if USE(GRAPHICS_LAYER_WC)
+
 #include "DrawingArea.h"
 #include "GraphicsLayerWC.h"
 #include "RemoteWCLayerTreeHostProxy.h"
@@ -94,3 +96,5 @@ private:
 };
 
 } // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -27,6 +27,8 @@
 #include "config.h"
 #include "GraphicsLayerWC.h"
 
+#if USE(GRAPHICS_LAYER_WC)
+
 #include "WCPlatformLayerGCGL.h"
 #include "WCTileGrid.h"
 #include <WebCore/TransformState.h>
@@ -718,3 +720,5 @@ void GraphicsLayerWC::recursiveCommitChanges(const TransformState& state)
 }
 
 } // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if USE(GRAPHICS_LAYER_WC)
+
 #include "WCUpateInfo.h"
 #include <WebCore/GraphicsLayerContentsDisplayDelegate.h>
 #include <wtf/DoublyLinkedList.h>
@@ -133,3 +135,5 @@ private:
 };
 
 } // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if USE(GRAPHICS_LAYER_WC)
+
 #include "ImageBufferBackendHandle.h"
 #include "ImageBufferBackendHandleSharing.h"
 #include <WebCore/ImageBuffer.h>
@@ -76,3 +78,5 @@ private:
 };
 
 } // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/WebProcess/WebPage/wc/WCLayerFactory.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCLayerFactory.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "WCLayerFactory.h"
 
+#if USE(GRAPHICS_LAYER_WC)
+
 #include "GraphicsLayerWC.h"
 
 namespace WebKit {
@@ -42,3 +44,5 @@ Ref<WebCore::GraphicsLayer> WCLayerFactory::createGraphicsLayer(WebCore::Graphic
 }
 
 } // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/WebProcess/WebPage/wc/WCLayerFactory.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCLayerFactory.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if USE(GRAPHICS_LAYER_WC)
+
 #include "GraphicsLayerWC.h"
 #include <WebCore/GraphicsLayerFactory.h>
 
@@ -42,3 +44,5 @@ private:
 };
 
 } // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "WCTileGrid.h"
 
+#if USE(GRAPHICS_LAYER_WC)
+
 namespace WebKit {
 
 WCTileGrid::Tile::Tile(WebCore::IntRect rect)
@@ -137,3 +139,5 @@ bool WCTileGrid::setCoverageRect(const WebCore::IntRect& coverage)
 }
 
 } // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if USE(GRAPHICS_LAYER_WC)
+
 #include <WebCore/IntRect.h>
 #include <WebCore/TextureMapperSparseBackingStore.h>
 
@@ -69,3 +71,5 @@ private:
 };
 
 } // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/WebProcess/WebPage/wc/WCUpateInfo.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCUpateInfo.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if USE(GRAPHICS_LAYER_WC)
+
 #include "WCBackingStore.h"
 #include "WCContentBufferIdentifier.h"
 #include "WebCoreArgumentCoders.h"
@@ -349,3 +351,5 @@ template<> struct EnumTraits<WebKit::WCLayerChange> {
 };
 
 } // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)


### PR DESCRIPTION
#### f26d171c4cc62f4c5fdb3a80be75d7c452eb80e6
<pre>
WinCairo doesn&apos;t build without USE_GRAPHICS_LAYER_WC enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=245196">https://bugs.webkit.org/show_bug.cgi?id=245196</a>

Reviewed by Fujii Hironori.

Fix the build when `USE_GRAPHICS_LAYER_WC` is disabled by adding checks
around WC code.

* Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp:
* Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h:
* Source/WebKit/UIProcess/win/PageClientImpl.cpp:
* Source/WebKit/UIProcess/win/PageClientImpl.h:
* Source/WebKit/UIProcess/win/WebView.cpp:
* Source/WebKit/WebProcess/GPU/graphics/wc/WCPlatformLayerGCGL.h:
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp:
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h:
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h:
* Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h:
* Source/WebKit/WebProcess/WebPage/wc/WCLayerFactory.cpp:
* Source/WebKit/WebProcess/WebPage/wc/WCLayerFactory.h:
* Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.cpp:
* Source/WebKit/WebProcess/WebPage/wc/WCTileGrid.h:
* Source/WebKit/WebProcess/WebPage/wc/WCUpateInfo.h:

Canonical link: <a href="https://commits.webkit.org/254503@main">https://commits.webkit.org/254503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf6d90071761322e36b36b74227b6fbc0d8459b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98550 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32303 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81595 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93014 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25657 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76148 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25592 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80523 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68570 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30080 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29805 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15512 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3160 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38473 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34603 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->