### PR TITLE
Consider Container Percentage Sizes When Determining Definite Cross Size

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-definite-cross-size-constrained-percentage-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-definite-cross-size-constrained-percentage-expected.html
@@ -1,0 +1,17 @@
+<html>
+    <meta charset="utf-8">
+    <link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#min-size-auto">
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#definite">
+    <link rel="help" href="https://www.w3.org/TR/css-sizing-3/#definite">
+    <title>Flex item cross size set by definite flex container size with percentage height</title>
+    <style>
+        img {
+            width: 25px;
+            height: 25px;
+        }
+    </style>
+    <body>
+        <img src="support/60x60-green.png">
+    </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-definite-cross-size-constrained-percentage-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-definite-cross-size-constrained-percentage-ref.html
@@ -1,0 +1,17 @@
+<html>
+    <meta charset="utf-8">
+    <link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#min-size-auto">
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#definite">
+    <link rel="help" href="https://www.w3.org/TR/css-sizing-3/#definite">
+    <title>Flex item cross size set by definite flex container size with percentage height</title>
+    <style>
+        img {
+            width: 25px;
+            height: 25px;
+        }
+    </style>
+    <body>
+        <img src="support/60x60-green.png">
+    </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-definite-cross-size-constrained-percentage.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-definite-cross-size-constrained-percentage.html
@@ -1,0 +1,26 @@
+<html>
+    <meta charset="utf-8">
+    <link rel="match" href="flexbox-definite-cross-size-constrained-percentage-ref.html">
+    <link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#min-size-auto">
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#definite">
+    <link rel="help" href="https://www.w3.org/TR/css-sizing-3/#definite">
+    <title>Flex item cross size set by definite flex container size with percentage height</title>
+    <style>
+        .constraining-container {
+            height: 50px;
+        }
+
+        .flex-container {
+            height: 50%;
+            display: flex;
+        }
+    </style>
+    <body>
+        <div class="constraining-container">
+            <div class="flex-container">
+                <img src="support/60x60-green.png">
+            </div>
+        </div>
+    </body>
+</html>

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1020,9 +1020,8 @@ bool RenderFlexibleBox::childCrossSizeShouldUseContainerCrossSize(const RenderBo
         if (crossAxisIsPhysicalWidth())
             return true;
         // This must be kept in sync with computeMainSizeFromAspectRatioUsing().
-        // FIXME: so far we're only considered fixed sizes but we should extend it to other definite sizes.
         auto& crossSize = isHorizontalFlow() ? style().height() : style().width();
-        return crossSize.isFixed();
+        return crossSize.isFixed() || (crossSize.isPercent() && availableLogicalHeightForPercentageComputation());  
     }
     return false;
 }
@@ -1794,8 +1793,10 @@ LayoutUnit RenderFlexibleBox::computeCrossSizeForChildUsingContainerCrossSize(co
         // Let's compute the definite size value for the flex item (value that we can resolve without running layout).
         auto isHorizontal = isHorizontalFlow();
         auto size = isHorizontal ? style().height() : style().width();
-        ASSERT(size.isFixed());
+        ASSERT(size.isFixed() || (size.isPercent() && availableLogicalHeightForPercentageComputation()));
         auto definiteValue = LayoutUnit { size.value() };
+        if (size.isPercent())
+            definiteValue = availableLogicalHeightForPercentageComputation().value_or(0_lu);
 
         auto maximumSize = isHorizontal ? style().maxHeight() : style().maxWidth();
         if (maximumSize.isFixed())


### PR DESCRIPTION
#### 39cc41965e9ea32db1eecab5bea00b539397d22a
<pre>
Consider Container Percentage Sizes When Determining Definite Cross Size
<a href="https://bugs.webkit.org/show_bug.cgi?id=245194">https://bugs.webkit.org/show_bug.cgi?id=245194</a>
rdar://99469852

Reviewed by Alan Bujtas.

When computing the transferred size suggestion for the minimum size of
flex items, we need to use the intrinsic aspect ratio and the definite
cross size. Both the Flexbox specification and CSS-Sizing specification
provide information on when a size can be considered definite. This
patch implements the following portion of the Flexbox spec to determine
the definite cross size:

If a single-line flex container has a definite cross size, the outer
cross size of any stretched flex items is the flex container’s inner
cross size (clamped to the flex item’s min and max cross size) and is
considered definite.

The new test case provides an instance of a scenario where this addition
is important. The image is being used as a flex item, but the flex
container is being constrained by another containing block that has a
specified height that is smaller than the image. When computing the
automatic minimum size (specifically the transferred size suggestion),
we can determine that the flex container has a definite cross size using
its percentage specified height along with the height available to it.
Then, we can use this cross size along with the image&apos;s aspect ratio
to determine the appropriate main size.

Spec: <a href="https://www.w3.org/TR/css-flexbox-1/#min-size-auto">https://www.w3.org/TR/css-flexbox-1/#min-size-auto</a>
<a href="https://www.w3.org/TR/css-flexbox-1/#definite">https://www.w3.org/TR/css-flexbox-1/#definite</a>

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::childCrossSizeShouldUseContainerCrossSize const):
(WebCore::RenderFlexibleBox::computeCrossSizeForChildUsingContainerCrossSize const):

Canonical link: <a href="https://commits.webkit.org/254758@main">https://commits.webkit.org/254758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6e15d782280682b3858cfc466d640718de3c4be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99377 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156882 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33082 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28457 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82380 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93673 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26292 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76854 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26205 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69206 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/34282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15034 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15975 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3341 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/35867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38935 "Passed tests") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/37768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35059 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->