### PR TITLE
[JSC] Microtask should not care about exceptions

### DIFF
--- a/Source/JavaScriptCore/runtime/CatchScope.h
+++ b/Source/JavaScriptCore/runtime/CatchScope.h
@@ -45,6 +45,13 @@ public:
     JS_EXPORT_PRIVATE ~CatchScope();
 
     void clearException() { m_vm.clearException(); }
+    bool clearExceptionExceptTermination()
+    {
+        if (UNLIKELY(m_vm.hasPendingTerminationException()))
+            return false;
+        m_vm.clearException();
+        return true;
+    }
 };
 
 #define DECLARE_CATCH_SCOPE(vm__) \
@@ -61,6 +68,13 @@ public:
     CatchScope(CatchScope&&) = default;
 
     ALWAYS_INLINE void clearException() { m_vm.clearException(); }
+    ALWAYS_INLINE bool clearExceptionExceptTermination()
+    {
+        if (UNLIKELY(m_vm.hasPendingTerminationException()))
+            return false;
+        m_vm.clearException();
+        return true;
+    }
 };
 
 #define DECLARE_CATCH_SCOPE(vm__) \

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -28,6 +28,7 @@
 
 #include "CatchScope.h"
 #include "Debugger.h"
+#include "DeferTermination.h"
 #include "JSGlobalObject.h"
 #include "JSObjectInlines.h"
 #include "Microtask.h"
@@ -66,9 +67,16 @@ Ref<Microtask> createJSMicrotask(VM& vm, JSValue job, JSValue argument0, JSValue
 void runJSMicrotask(JSGlobalObject* globalObject, MicrotaskIdentifier identifier, JSValue job, JSValue argument0, JSValue argument1, JSValue argument2, JSValue argument3)
 {
     VM& vm = globalObject->vm();
+
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
+    // If termination is issued, do not run microtasks. Otherwise, microtask should not care about exceptions.
+    if (UNLIKELY(!scope.clearExceptionExceptTermination()))
+        return;
+
     auto handlerCallData = JSC::getCallData(job);
+    if (UNLIKELY(!scope.clearExceptionExceptTermination()))
+        return;
     ASSERT(handlerCallData.type != CallData::Type::None);
 
     MarkedArgumentBuffer handlerArguments;
@@ -79,14 +87,22 @@ void runJSMicrotask(JSGlobalObject* globalObject, MicrotaskIdentifier identifier
     if (UNLIKELY(handlerArguments.hasOverflowed()))
         return;
 
-    if (UNLIKELY(globalObject->hasDebugger()))
+    if (UNLIKELY(globalObject->hasDebugger())) {
+        DeferTerminationForAWhile deferTerminationForAWhile(vm);
         globalObject->debugger()->willRunMicrotask(globalObject, identifier);
+        scope.clearException();
+    }
 
-    profiledCall(globalObject, ProfilingReason::Microtask, job, handlerCallData, jsUndefined(), handlerArguments);
-    scope.clearException();
+    if (LIKELY(!vm.hasPendingTerminationException())) {
+        profiledCall(globalObject, ProfilingReason::Microtask, job, handlerCallData, jsUndefined(), handlerArguments);
+        scope.clearExceptionExceptTermination();
+    }
 
-    if (UNLIKELY(globalObject->hasDebugger()))
+    if (UNLIKELY(globalObject->hasDebugger())) {
+        DeferTerminationForAWhile deferTerminationForAWhile(vm);
         globalObject->debugger()->didRunMicrotask(globalObject, identifier);
+        scope.clearException();
+    }
 }
 
 void JSMicrotask::run(JSGlobalObject* globalObject)

--- a/Source/WebCore/bindings/js/JSDOMMicrotask.cpp
+++ b/Source/WebCore/bindings/js/JSDOMMicrotask.cpp
@@ -57,26 +57,44 @@ Ref<Microtask> createJSDOMMicrotask(VM& vm, JSObject* job)
 
 void JSDOMMicrotask::run(JSGlobalObject* globalObject)
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+
     JSObject* job = m_job.get();
+
 
     auto* lexicalGlobalObject = job->globalObject();
     auto* context = jsCast<JSDOMGlobalObject*>(lexicalGlobalObject)->scriptExecutionContext();
     if (!context || context->activeDOMObjectsAreSuspended() || context->activeDOMObjectsAreStopped())
         return;
 
+    if (UNLIKELY(!scope.clearExceptionExceptTermination()))
+        return;
+
     auto callData = JSC::getCallData(job);
+    if (UNLIKELY(!scope.clearExceptionExceptTermination()))
+        return;
     ASSERT(callData.type != CallData::Type::None);
 
-    if (UNLIKELY(globalObject->hasDebugger()))
+    if (UNLIKELY(globalObject->hasDebugger())) {
+        JSC::DeferTerminationForAWhile deferTerminationForAWhile(vm);
         globalObject->debugger()->willRunMicrotask(globalObject, identifier());
+        scope.clearException();
+    }
 
     NakedPtr<JSC::Exception> returnedException = nullptr;
-    JSExecState::profiledCall(lexicalGlobalObject, JSC::ProfilingReason::Microtask, job, callData, jsUndefined(), ArgList(), returnedException);
-    if (returnedException)
-        reportException(lexicalGlobalObject, returnedException);
+    if (LIKELY(!vm.hasPendingTerminationException())) {
+        JSExecState::profiledCall(lexicalGlobalObject, JSC::ProfilingReason::Microtask, job, callData, jsUndefined(), ArgList(), returnedException);
+        if (returnedException)
+            reportException(lexicalGlobalObject, returnedException);
+        scope.clearExceptionExceptTermination();
+    }
 
-    if (UNLIKELY(globalObject->hasDebugger()))
+    if (UNLIKELY(globalObject->hasDebugger())) {
+        JSC::DeferTerminationForAWhile deferTerminationForAWhile(vm);
         globalObject->debugger()->didRunMicrotask(globalObject, identifier());
+        scope.clearException();
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/ScheduledAction.cpp
+++ b/Source/WebCore/bindings/js/ScheduledAction.cpp
@@ -111,7 +111,8 @@ void ScheduledAction::executeFunctionInContext(JSGlobalObject* globalObject, JSV
             throwOutOfMemoryError(lexicalGlobalObject, throwScope);
         }
         NakedPtr<JSC::Exception> exception = catchScope.exception();
-        catchScope.clearException();
+        if (UNLIKELY(!catchScope.clearExceptionExceptTermination()))
+            return;
         reportException(lexicalGlobalObject, exception);
         return;
     }
@@ -120,7 +121,7 @@ void ScheduledAction::executeFunctionInContext(JSGlobalObject* globalObject, JSV
 
     NakedPtr<JSC::Exception> exception;
     JSExecState::profiledCall(lexicalGlobalObject, JSC::ProfilingReason::Other, m_function.get(), callData, thisValue, arguments, exception);
-    EXCEPTION_ASSERT(!catchScope.exception());
+    catchScope.assertNoExceptionExceptTermination();
     
     InspectorInstrumentation::didCallFunction(&context);
 


### PR DESCRIPTION
#### 634d22fbdc856a59f02b6527d68a415bf1d7841a
<pre>
[JSC] Microtask should not care about exceptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=245199">https://bugs.webkit.org/show_bug.cgi?id=245199</a>
rdar://99237677

Reviewed by Mark Lam.

Microtask execution should be done without exception, and any exceptions thrown can be cleared when running microtasks.
We clear exceptions extensively for all cases, plus, we early return if termination exception is already thrown.

* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::runJSMicrotask):

Canonical link: <a href="https://commits.webkit.org/254546@main">https://commits.webkit.org/254546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/863596e817f2980e2602dedb1f6a41fcf076018b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98706 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155012 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32440 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27942 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93122 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25765 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76298 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25705 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68690 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81073 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30204 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74877 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29937 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15578 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26365 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3192 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38537 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/77744 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34669 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17204 "Passed tests") | 
<!--EWS-Status-Bubble-End-->