### PR TITLE
Simplify FrameLoaderStateMachine and FrameLoader::transitionToCommitted()

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -411,6 +411,7 @@ void DocumentLoader::commitIfReady()
     if (!m_committed) {
         m_committed = true;
         frameLoader()->commitProvisionalLoad();
+        m_writer.setMIMEType(m_response.mimeType());
     }
 }
 
@@ -1258,6 +1259,8 @@ void DocumentLoader::commitData(const SharedBuffer& data)
 
         if (frameLoader()->stateMachine().creatingInitialEmptyDocument())
             return;
+        if (frameLoader()->stateMachine().isDisplayingInitialEmptyDocument())
+            frameLoader()->stateMachine().advanceTo(FrameLoaderStateMachine::CommittedFirstRealLoad);
 
 #if ENABLE(WEB_ARCHIVE)
         if (isLoadingRemoteArchive()) {

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -472,8 +472,6 @@ private:
     PageDismissalType m_pageDismissalEventBeingDispatched { PageDismissalType::None };
     bool m_isComplete;
 
-    RefPtr<SerializedScriptValue> m_pendingStateObject;
-
     bool m_needsClear;
 
     URL m_submittedFormURL;

--- a/Source/WebCore/loader/FrameLoaderStateMachine.cpp
+++ b/Source/WebCore/loader/FrameLoaderStateMachine.cpp
@@ -46,7 +46,7 @@ bool FrameLoaderStateMachine::committingFirstRealLoad() const
 
 bool FrameLoaderStateMachine::committedFirstRealDocumentLoad() const 
 {
-    return m_state >= DisplayingInitialEmptyDocumentPostCommit;
+    return m_state >= CommittedFirstRealLoad;
 }
 
 bool FrameLoaderStateMachine::creatingInitialEmptyDocument() const 
@@ -56,17 +56,12 @@ bool FrameLoaderStateMachine::creatingInitialEmptyDocument() const
 
 bool FrameLoaderStateMachine::isDisplayingInitialEmptyDocument() const 
 {
-    return m_state == DisplayingInitialEmptyDocument || m_state == DisplayingInitialEmptyDocumentPostCommit;
-}
-
-bool FrameLoaderStateMachine::firstLayoutDone() const
-{
-    return m_state == FirstLayoutDone;
+    return m_state == DisplayingInitialEmptyDocument;
 }
 
 void FrameLoaderStateMachine::advanceTo(State state)
 {
-    ASSERT(State(m_state + 1) == state || (firstLayoutDone() && state == CommittedFirstRealLoad));
+    ASSERT(State(m_state + 1) == state);
     m_state = state;
 }
 

--- a/Source/WebCore/loader/FrameLoaderStateMachine.h
+++ b/Source/WebCore/loader/FrameLoaderStateMachine.h
@@ -45,16 +45,13 @@ public:
     enum State {
         CreatingInitialEmptyDocument,
         DisplayingInitialEmptyDocument,
-        DisplayingInitialEmptyDocumentPostCommit,
-        CommittedFirstRealLoad,
-        FirstLayoutDone
+        CommittedFirstRealLoad
     };
 
     WEBCORE_EXPORT bool committingFirstRealLoad() const;
-    bool committedFirstRealDocumentLoad() const;
+    WEBCORE_EXPORT bool committedFirstRealDocumentLoad() const;
     WEBCORE_EXPORT bool creatingInitialEmptyDocument() const;
     WEBCORE_EXPORT bool isDisplayingInitialEmptyDocument() const;
-    WEBCORE_EXPORT bool firstLayoutDone() const;
     void advanceTo(State);
 
     State stateForDebugging() const { return m_state; }

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -62,10 +62,6 @@ public:
 
     void invalidateCurrentItemCachedPage();
 
-    void updateForBackForwardNavigation();
-    void updateForReload();
-    void updateForStandardLoad(HistoryUpdateType updateType = UpdateAll);
-    void updateForRedirectWithLockedBackForwardList();
     void updateForClientRedirect();
     void updateForCommit();
     void updateForSameDocumentNavigation();
@@ -96,6 +92,11 @@ private:
     void initializeItem(HistoryItem&);
     Ref<HistoryItem> createItem();
     Ref<HistoryItem> createItemTree(Frame& targetFrame, bool clipAtTarget);
+
+    void updateForBackForwardNavigation();
+    void updateForReload();
+    void updateForStandardLoad();
+    void updateForRedirectWithLockedBackForwardList();
 
     void recursiveSetProvisionalItem(HistoryItem&, HistoryItem*);
     void recursiveGoToItem(HistoryItem&, HistoryItem*, FrameLoadType, ShouldTreatAsContinuingLoad);

--- a/Source/WebCore/loader/ProgressTracker.cpp
+++ b/Source/WebCore/loader/ProgressTracker.cpp
@@ -29,8 +29,8 @@
 #include "DocumentLoader.h"
 #include "Frame.h"
 #include "FrameLoader.h"
-#include "FrameLoaderStateMachine.h"
 #include "FrameLoaderClient.h"
+#include "FrameView.h"
 #include "InspectorInstrumentation.h"
 #include "Logging.h"
 #include "ProgressTrackerClient.h"
@@ -245,7 +245,7 @@ void ProgressTracker::incrementProgress(ResourceLoaderIdentifier identifier, uns
     // For documents that use WebCore's layout system, treat first layout as the half-way point.
     // FIXME: The hasHTMLView function is a sort of roundabout way of asking "do you use WebCore's layout system".
     bool useClampedMaxProgress = frame->loader().client().hasHTMLView()
-        && !frame->loader().stateMachine().firstLayoutDone();
+        && !frame->view()->didFirstLayout();
     double maxProgressValue = useClampedMaxProgress ? 0.5 : finalProgressValue;
     increment = (maxProgressValue - m_progressValue) * percentOfRemainingBytes;
     m_progressValue += increment;

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -454,6 +454,7 @@ EncodedDataStatus SVGImage::dataChanged(bool allDataReceived)
         FrameLoader& loader = frame.loader();
         loader.forceSandboxFlags(SandboxAll);
 
+        frame.view()->setScrollbarsSuppressed(true);
         frame.view()->setCanHaveScrollbars(false); // SVG Images will always synthesize a viewBox, if it's not available, and thus never see scrollbars.
         frame.view()->setTransparent(true); // SVG Images are transparent.
 


### PR DESCRIPTION
<pre>
Simplify FrameLoaderStateMachine and FrameLoader::transitionToCommitted().

<a href="https://bugs.webkit.org/show_bug.cgi?id=115689">https://bugs.webkit.org/show_bug.cgi?id=115689</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/88f7b61ee65840ec235b0ceae317b23b18a9a627">https://chromium.googlesource.com/chromium/blink/+/88f7b61ee65840ec235b0ceae317b23b18a9a627</a>

This removes two cases from FrameLoaderStateMachine. FirstLayoutDone is closely approximated by FrameView, and DisplayingInitialEmptyDocumentPostCommit appears to be a workaround for declaring the first real load committed a bit too early.

* Source/WebCore/loader/DocumentLoader.cpp: 
(DocumentLoader::commitIfReady): Add MIMEType condition 
(DocumentLoader::commitData): Add if conditions about isDisplayingInitialEmptyDocument and CommittedFirstRealLoad
* Source/WebCore/loader/FrameLoader.cpp: 
(FrameLoader::didExplicitOpen()): Changed DisplayingInitialEmptyDocumentPostCommit with CommittedFirstRealLoad (FrameLoader::clear): Remove stateMachine conditions 
(FrameLoader::didBeginDocument): Replaced "PendingStateObject" by linking with history 
(FrameLoader::setOpener): Remove stateMachine for CommittedFirstRealLoad condition (FrameLoader::transistionToCommitted): remove history update and remove handling case for back and forward list (FrameLoader::checkLoadCompleteForThisFrame): Removed stateMachine condition for creatingInitialEmptyDocument and committedFirstRealDocumentLoad 
(FrameLoader::frameLoadCompleted): Removed statemMachine condition for provisional load and reset while displaying page
* Source/WebCore/loader/FrameLoader.h: Removed RefPtr pointer for m_pendingStateObject
* Source/WebCore/loader/FrameLoaderStateMachine.cpp: 
(FrameLoaderStateMachine::committingFirstReload): changed m_state from DisplayingInitialEmptyDocumentPostCommit to CommittedFirstRealLoad 
(FrameLoaderStateMachine::creatingInitialEmptyDocument): Removed old logic for isDisplayingInitialEmptyDocument to return DisplayingInitialEmptyDocument and also updated Assert condition for FrameLoaderStateMachine::advanceTo
* Source/WebCore/loader/FrameLoaderStateMachine.h: Removed unused state and added "committingFirstRealLoad" and also remove firstLayoutDone as well from WEBCORE_EXPORT
* Source/WebCore/loader/HistoryController.cpp:
(FrameLoader::HistoryController::updateForReload): Removed HistoryUpdateType updateType from array (FrameLoader::HistoryController::updateForStandardLoad): Removed extra condition from historyURL not being empty (FrameLoader::HistoryController::updateForCommit): change provisionalDocumentLoader to documentLoader and also add type case to detail different cases and their return as needed
* Source/WebCore/loader/HistoryController.h: moved functions from public to private ad also removed values from updateForStandardLoad
* Source/WebCore/loader/ProgressTracker.cpp: Removed "FrameLoaderStateMachine.h" header and added "FrameView.h" and (ProgressTracker::incrementProgress): updated stateMachine condition in useClampedMaxProgress to didFirstLayout
* Source/WebCore/svg/graphics/SVGImage.cpp:
(SVGImage::dataChanged): Added setScrollbarsSuppressed

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d4ae830b098079c0ebe962ac5a18785eee53ebd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90346 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34933 "Hash 9d4ae830 for PR 4364 does not build (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/20950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99681 "Hash 9d4ae830 for PR 4364 does not build (failure)") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/157147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94355 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33431 "Hash 9d4ae830 for PR 4364 does not build (failure)") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82706 "Hash 9d4ae830 for PR 4364 does not build (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/96128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96001 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/64/builds/33431 "Hash 9d4ae830 for PR 4364 does not build (failure)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/82706 "Hash 9d4ae830 for PR 4364 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/64/builds/33431 "Hash 9d4ae830 for PR 4364 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/20950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/82706 "Hash 9d4ae830 for PR 4364 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34527 "Hash 9d4ae830 for PR 4364 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/20950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/20950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36114 "Hash 9d4ae830 for PR 4364 does not build (failure)") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38028 "Hash 9d4ae830 for PR 4364 does not build (failure)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/20950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->