### PR TITLE
Location.replace() is missing canNavigate() check

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/child-navigates-parent-cross-origin.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/child-navigates-parent-cross-origin.window-expected.txt
@@ -13,7 +13,7 @@ PASS Child document attempts to navigate cross-origin parent via location.href
 PASS Child document attempts to navigate cross-origin parent via location.pathname
 PASS Child document attempts to navigate cross-origin parent via location.protocol
 PASS Child document attempts to navigate cross-origin parent via location.reload()
-FAIL Child document attempts to navigate cross-origin parent via location.replace() assert_array_equals: expected property 0 to be "error: SecurityError" but got "success" (expected array ["error: SecurityError"] got ["success"])
+PASS Child document attempts to navigate cross-origin parent via location.replace()
 PASS Child document attempts to navigate cross-origin parent via location.search
 PASS Child document attempts to navigate cross-origin parent via non-standard location property
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/child-navigates-parent-cross-origin.window-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/child-navigates-parent-cross-origin.window-expected.txt
@@ -13,7 +13,7 @@ PASS Child document attempts to navigate cross-origin parent via location.href
 PASS Child document attempts to navigate cross-origin parent via location.pathname
 PASS Child document attempts to navigate cross-origin parent via location.protocol
 PASS Child document attempts to navigate cross-origin parent via location.reload()
-FAIL Child document attempts to navigate cross-origin parent via location.replace() assert_array_equals: expected property 0 to be "error: SecurityError" but got "success" (expected array ["error: SecurityError"] got ["success"])
+PASS Child document attempts to navigate cross-origin parent via location.replace()
 PASS Child document attempts to navigate cross-origin parent via location.search
 PASS Child document attempts to navigate cross-origin parent via non-standard location property
 

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -233,6 +233,9 @@ ExceptionOr<void> Location::replace(DOMWindow& activeWindow, DOMWindow& firstWin
     if (!completedURL.isValid())
         return Exception { SyntaxError };
 
+    if (!activeWindow.document()->canNavigate(frame, completedURL))
+        return Exception { SecurityError };
+
     // We call DOMWindow::setLocation directly here because replace() always operates on the current frame.
     frame->document()->domWindow()->setLocation(activeWindow, completedURL, LockHistoryAndBackForwardList);
     return { };


### PR DESCRIPTION
#### f1a9daf23ad9d05a9ff6cf7929389786ddcb5fb0
<pre>
Location.replace() is missing canNavigate() check
<a href="https://bugs.webkit.org/show_bug.cgi?id=245203">https://bugs.webkit.org/show_bug.cgi?id=245203</a>

Reviewed by Darin Adler.

Location.replace() is missing canNavigate() check, unlike other Location functions.

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/child-navigates-parent-cross-origin.window-expected.txt:
* Source/WebCore/page/Location.cpp:
(WebCore::Location::replace):

Canonical link: <a href="https://commits.webkit.org/254518@main">https://commits.webkit.org/254518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5178d175f25890b7a407cbdfdf3e86602d330e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33881 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/20104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98656 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/154965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32386 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81686 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93085 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94969 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/25726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/76267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/25671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/80602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/20104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68647 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30160 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/20104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29887 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/20104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3172 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33335 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/76267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32039 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/20104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->