### PR TITLE
[JSC] Implement support for class static initialization blocks

### DIFF
--- a/JSTests/ChakraCore/test/es6/globalCatchNewTargetSyntaxError.baseline-jsc
+++ b/JSTests/ChakraCore/test/es6/globalCatchNewTargetSyntaxError.baseline-jsc
@@ -1,2 +1,2 @@
-Exception: SyntaxError: new.target is only valid inside functions.
+Exception: SyntaxError: new.target is only valid inside functions or static blocks.
 at globalCatchNewTargetSyntaxError.js:6

--- a/JSTests/ChakraCore/test/es6/globalNewTargetSyntaxError.baseline-jsc
+++ b/JSTests/ChakraCore/test/es6/globalNewTargetSyntaxError.baseline-jsc
@@ -1,2 +1,2 @@
-Exception: SyntaxError: new.target is only valid inside functions.
+Exception: SyntaxError: new.target is only valid inside functions or static blocks.
 at globalNewTargetSyntaxError.js:6

--- a/JSTests/ChakraCore/test/es6/globalParamCatchNewTargetSyntaxError.baseline-jsc
+++ b/JSTests/ChakraCore/test/es6/globalParamCatchNewTargetSyntaxError.baseline-jsc
@@ -1,2 +1,2 @@
-Exception: SyntaxError: new.target is only valid inside functions.
+Exception: SyntaxError: new.target is only valid inside functions or static blocks.
 at globalParamCatchNewTargetSyntaxError.js:7

--- a/JSTests/stress/class-static-block.js
+++ b/JSTests/stress/class-static-block.js
@@ -1,0 +1,649 @@
+function assert(b) {
+    if (!b) {
+        throw "bad assert!"
+    }
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`
+            bad error:      ${String(error)}
+            expected error: ${errorMessage}
+        `);
+}
+
+// ---------- single static block ---------- 
+{
+    var y = 'Outer y';
+
+    class A {
+        static field = 'Inner y';
+        static {
+            var y = this.field;
+        }
+    }
+
+    assert(y === 'Outer y');
+}
+
+//  ---------- multiple static blocks ---------- 
+{
+    class C {
+        static {
+            assert(this.x === undefined);
+        }
+        static x = 10;
+        static {
+            assert(this.x === 10);
+            assert(this.y === undefined);
+        }
+        static y = 20;
+        static {
+            assert(this.y === 20);
+        }
+    }
+}
+
+//  ---------- use this ---------- 
+{
+    class A {
+        static field = 'A static field';
+        static {
+            assert(this.field === 'A static field');
+        }
+    }
+}
+
+//  ---------- use super ---------- 
+{
+    class A {
+        static fieldA = 'A.fieldA';
+    }
+    class B extends A {
+        static {
+            assert(super.fieldA === 'A.fieldA');
+        }
+    }
+}
+
+//  ---------- access to private fields ---------- 
+{
+    let getDPrivateField;
+
+    class D {
+        #privateField;
+        constructor(v) {
+            this.#privateField = v;
+        }
+        static {
+            getDPrivateField = (d) => d.#privateField;
+        }
+    }
+
+    assert(getDPrivateField(new D('private')) === 'private');
+}
+
+// ---------- "friend" access ----------
+{
+    let A, B;
+
+    let friendA;
+
+    A = class A {
+        #x;
+        constructor(x) {
+            this.#x = x;
+        }
+        static {
+            friendA = {
+                getX(obj) { return obj.#x },
+                setX(obj, value) { obj.#x = value }
+            };
+        }
+        getX() {
+            return this.#x;
+        }
+    };
+
+    B = class B {
+        constructor(a) {
+            const x = friendA.getX(a);
+            friendA.setX(a, x + 32);
+        }
+    };
+
+    let a = new A(10);
+    new B(a);
+
+    assert(a.getX() === 42);
+}
+
+// ---------- break ----------
+{
+    class C {
+        static {
+            while (false)
+                break;           // isStaticBlock = true, isValid = false, isCurrentScopeValid = true
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            while (false) {
+                break;           // isStaticBlock = true, isValid = true, isCurrentScopeValid = false
+            }
+        }
+    }
+}
+
+shouldThrow(() => {
+    eval(`
+        while (false) {
+            class C {
+                static {
+                    break;       // isStaticBlock = true, isValid = false, isCurrentScopeValid = false
+                }
+            }
+        }
+    `);
+}, `SyntaxError: 'break' cannot cross static block boundary.`);
+
+shouldThrow(() => {
+    eval(`
+        class C {
+            static {
+                break;           // isStaticBlock = true, isValid = false, isCurrentScopeValid = false
+            }
+        }
+    `);
+}, `SyntaxError: 'break' cannot cross static block boundary.`);
+
+shouldThrow(() => {
+    eval(`
+        while (false) {
+            class C {
+                static {
+                    {
+                        break;   // isStaticBlock = true, isValid = false, isCurrentScopeValid = false
+                    }
+                }
+            }
+        }
+    `);
+}, `SyntaxError: 'break' cannot cross static block boundary.`);
+
+shouldThrow(() => {
+    eval(`
+        class C {
+            static {
+                {
+                    break;        // isStaticBlock = true, isValid = false, isCurrentScopeValid = false
+                }
+            }
+        }
+    `);
+}, `SyntaxError: 'break' cannot cross static block boundary.`);
+
+// ---------- continue ----------
+{
+    class C {
+        static {
+            while (false)
+                continue;           // isStaticBlock = true, isValid = false, isCurrentScopeValid = true
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            while (false) {
+                continue;           // isStaticBlock = true, isValid = true, isCurrentScopeValid = false
+            }
+        }
+    }
+}
+
+shouldThrow(() => {
+    eval(`
+        while (false) {
+            class C {
+                static {
+                    continue;       // isStaticBlock = true, isValid = false, isCurrentScopeValid = false
+                }
+            }
+        }
+    `);
+}, `SyntaxError: 'continue' cannot cross static block boundary.`);
+
+shouldThrow(() => {
+    eval(`
+        class C {
+            static {
+                continue;           // isStaticBlock = true, isValid = false, isCurrentScopeValid = false
+            }
+        }
+    `);
+}, `SyntaxError: 'continue' cannot cross static block boundary.`);
+
+shouldThrow(() => {
+    eval(`
+        while (false) {
+            class C {
+                static {
+                    {
+                        continue;   // isStaticBlock = true, isValid = false, isCurrentScopeValid = false
+                    }
+                }
+            }
+        }
+    `);
+}, `SyntaxError: 'continue' cannot cross static block boundary.`);
+
+shouldThrow(() => {
+    eval(`
+        class C {
+            static {
+                {
+                    continue;       // isStaticBlock = true, isValid = false, isCurrentScopeValid = false
+                }
+            }
+        }
+    `);
+}, `SyntaxError: 'continue' cannot cross static block boundary.`);
+
+// ---------- arguments ----------
+{
+    class C {
+        static {
+            function inner() {
+                [arguments]();
+            }
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            class B {
+                inner() {
+                    [arguments]();
+                }
+            }
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            function inner() {
+                arguments[0];
+            }
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            class B {
+                inner() {
+                    arguments[0];
+                }
+            }
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            (a, b) => {
+                this.arguments[0];
+            };
+        }
+    }
+}
+
+shouldThrow(() => {
+    eval(`
+        class C {
+            static {
+                arguments;
+            }
+        }
+    `);
+}, `SyntaxError: Cannot use 'arguments' as an identifier in static block.`);
+
+// ---------- yield ----------
+
+{
+    class A {
+        static {
+            function* gen() {
+                yield 42;
+            }
+        }
+    }
+}
+
+{
+    class A {
+        static {
+            class B {
+                *gen() {
+                    yield 42;
+                }
+            }
+        }
+
+    }
+}
+
+shouldThrow(() => {
+    eval(`
+        class C {
+            static {
+                function inner() {
+                    yield 0;
+                }
+            }
+        }
+    `);
+}, `SyntaxError: Unexpected keyword 'yield'. Cannot use yield expression out of generator.`);
+
+shouldThrow(() => {
+    eval(`
+        class C {
+            static {
+                yield 0;
+            }
+        }
+    `);
+}, `SyntaxError: Unexpected keyword 'yield'. Cannot use 'yield' within static block.`);
+
+// ---------- await ----------
+{
+    class C {
+        static {
+            function inner() {
+                try { } catch (await) { }
+            }
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            class B {
+                inner() {
+                    try { } catch (await) { }
+                }
+            }
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            async function inner() {
+                await 0;
+            }
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            class B {
+                async inner() {
+                    await 0;
+                }
+            }
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            function inner() {
+                let await = 10;
+            }
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            class B {
+                inner() {
+                    let await = 10;
+                }
+            }
+        }
+    }
+}
+
+{
+    async function outer() {
+        class C {
+            static {
+                async function inner() {
+                    await 0;
+                }
+            }
+        }
+    }
+}
+
+{
+    async function outer() {
+        class C {
+            static {
+                class B {
+                    async inner() {
+                        await 0;
+                    }
+                }
+            }
+        }
+    }
+}
+
+{
+    async function outer() {
+        class C {
+            static {
+                function inner() {
+                    let await = 10;
+                }
+            }
+        }
+    }
+}
+
+{
+    async function outer() {
+        class C {
+            static {
+                class B {
+                    inner() {
+                        let await = 10;
+                    }
+                }
+            }
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            function inner() {
+                [await]();
+            }
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            class B {
+                inner() {
+                    [await]();
+                }
+            }
+        }
+    }
+}
+
+// ---------- others ----------
+{
+    function doSomethingWith(x) {
+        return {
+            y: x + 1,
+            z: x + 2
+        };
+    }
+
+    class C {
+        static x = 10;
+        static y;
+        static z;
+        static {
+            try {
+                const obj = doSomethingWith(this.x);
+                C.y = obj.y;
+                C["z"] = obj.z;
+            } catch {
+            }
+        }
+    }
+
+    assert(C.y === 11);
+    assert(C.z === 12);
+}
+
+{
+    class C {
+        static y;
+        static z;
+        static {
+            try {
+                throw "err";
+            } catch {
+                C.y = 13;
+                C['z'] = 14;
+            }
+        }
+    }
+
+    assert(C.y === 13);
+    assert(C.z === 14);
+}
+
+{
+    var value = null;
+    class C {
+        static {
+            function inner() {
+                value = new.target;
+            }
+            inner();
+        }
+    }
+    assert(value === undefined);
+}
+
+{
+    class C {
+        static {
+            value = new.target;
+        }
+    }
+    assert(value === undefined);
+}
+
+{
+    class C {
+        static {
+            function inner() {
+                {
+                    return 10;
+                }
+            }
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            function inner() {
+                Promise.resolve().then(makeMasquerader(), makeMasquerader());
+            }
+            {
+                Promise.resolve().then(makeMasquerader(), makeMasquerader());
+            }
+        }
+    }
+}
+
+{
+    class C {
+        static {
+            {
+                function foo(arg) {
+                    let o;
+                    if (arg) {
+                        o = {};
+                    } else {
+                        o = function() { }
+                    }
+                    return typeof o;
+                }
+                noInline(foo);
+                
+                for (let i = 0; i < 10000; i++) {
+                    let bool = !!(i % 2);
+                    let result = foo(bool);
+                    if (bool)
+                        assert(result === "object");
+                    else
+                        assert(result === "function");
+                }
+            }
+        }
+    }
+}
+
+{
+    function foo() {
+        assert(foo.caller === null);
+    }
+    class C {
+        static {
+            foo();
+        }
+    }
+}

--- a/JSTests/stress/code-cache-incorrect-caching.js
+++ b/JSTests/stress/code-cache-incorrect-caching.js
@@ -35,7 +35,7 @@ var global = this;
             eval('new.target');
         } catch (e) {
             thrown = true;
-            shouldBe(String(e), "SyntaxError: new.target is only valid inside functions.");
+            shouldBe(String(e), "SyntaxError: new.target is only valid inside functions or static blocks.");
         }
         shouldBe(thrown, true);
     `);
@@ -45,7 +45,7 @@ var global = this;
         globalEval('new.target');
     } catch (e) {
         thrown = true;
-        shouldBe(String(e), "SyntaxError: new.target is only valid inside functions.");
+        shouldBe(String(e), "SyntaxError: new.target is only valid inside functions or static blocks.");
     }
     shouldBe(thrown, true);
 }

--- a/JSTests/stress/modules-syntax-error.js
+++ b/JSTests/stress/modules-syntax-error.js
@@ -356,7 +356,7 @@ export * as "\ud800" from "./ok.js"
 
 checkModuleSyntaxError(String.raw`
 new.target;
-`, `SyntaxError: new.target is only valid inside functions.:2`);
+`, `SyntaxError: new.target is only valid inside functions or static blocks.:2`);
 
 checkModuleSyntaxError(String.raw`
 super();

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -20,7 +20,6 @@ skip:
     - regexp-lookbehind
     - regexp-v-flag
     - resizable-arraybuffer
-    - class-static-block
     - callable-boundary-realms
     - FinalizationRegistry.prototype.cleanupSome
     - decorators

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -129,6 +129,7 @@ public:
     static constexpr OptionSet<LexerFlags> DontBuildStrings = { };
 
     ExpressionNode* makeBinaryNode(const JSTokenLocation&, int token, std::pair<ExpressionNode*, BinaryOpInfo>, std::pair<ExpressionNode*, BinaryOpInfo>);
+    ExpressionNode* makeStaticBlockFunctionCallNode(const JSTokenLocation&, ExpressionNode* func, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
     ExpressionNode* makeFunctionCallNode(const JSTokenLocation&, ExpressionNode* func, bool previousBaseWasSuper, ArgumentsNode* args, const JSTextPosition& divotStart, const JSTextPosition& divot, const JSTextPosition& divotEnd, size_t callOrApplyChildDepth, bool isOptionalCall);
 
     JSC::SourceElements* createSourceElements() { return new (m_parserArena) JSC::SourceElements(); }
@@ -519,6 +520,10 @@ public:
         return new (m_parserArena) PropertyNode(ident, methodDef, type, SuperBinding::Needed, tag);
     }
 
+    PropertyNode* createProperty(const Identifier* propertyName, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag)
+    {
+        return new (m_parserArena) PropertyNode(*propertyName, type, superBinding, tag);
+    }
     PropertyNode* createProperty(const Identifier* propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, InferName inferName, ClassElementTag tag)
     {
         if (inferName == InferName::Allowed) {
@@ -1411,6 +1416,11 @@ ExpressionNode* ASTBuilder::makeCoalesceNode(const JSTokenLocation& location, Ex
     }
     constexpr bool hasAbsorbedOptionalChain = false;
     return new (m_parserArena) CoalesceNode(location, expr1, expr2, hasAbsorbedOptionalChain);
+}
+
+ExpressionNode* ASTBuilder::makeStaticBlockFunctionCallNode(const JSTokenLocation& location, ExpressionNode* func, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
+{
+    return new (m_parserArena) StaticBlockFunctionCallNode(location, func, divot, divotStart, divotEnd);
 }
 
 ExpressionNode* ASTBuilder::makeFunctionCallNode(const JSTokenLocation& location, ExpressionNode* func, bool previousBaseWasSuper, ArgumentsNode* args, const JSTextPosition& divotStart, const JSTextPosition& divot, const JSTextPosition& divotEnd, size_t callOrApplyChildDepth, bool isOptionalCall)

--- a/Source/JavaScriptCore/parser/NodeConstructors.h
+++ b/Source/JavaScriptCore/parser/NodeConstructors.h
@@ -246,6 +246,14 @@ namespace JSC {
     {
     }
 
+    inline PropertyNode::PropertyNode(const Identifier& name, Type type, SuperBinding superBinding, ClassElementTag tag)
+        : m_name(&name)
+        , m_type(type)
+        , m_needsSuperBinding(superBinding == SuperBinding::Needed)
+        , m_classElementTag(static_cast<unsigned>(tag))
+    {
+    }
+
     inline PropertyNode::PropertyNode(const Identifier& name, ExpressionNode* assign, Type type, SuperBinding superBinding, ClassElementTag tag)
         : m_name(&name)
         , m_assign(assign)
@@ -386,6 +394,14 @@ namespace JSC {
         , ThrowableExpressionData(divot, divotStart, divotEnd)
         , m_expr(expr)
         , m_args(args)
+    {
+        ASSERT(divot.offset >= divotStart.offset);
+    }
+
+    inline StaticBlockFunctionCallNode::StaticBlockFunctionCallNode(const JSTokenLocation& location, ExpressionNode* expr, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
+        : ExpressionNode(location)
+        , ThrowableExpressionData(divot, divotStart, divotEnd)
+        , m_expr(expr)
     {
         ASSERT(divot.offset >= divotStart.offset);
     }

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -380,7 +380,7 @@ template <class TreeBuilder> bool Parser<LexerType>::isArrowFunctionParameters(T
     }
 
     if (matchSpecIdentifier()) {
-        semanticFailIfTrue(isDisallowedIdentifierAwait(m_token), "Cannot use 'await' as a parameter name in an async function");
+        semanticFailIfTrue(isDisallowedIdentifierAwait(m_token), "Cannot use 'await' as a parameter name ", disallowedIdentifierAwaitReason());
         SavePoint saveArrowFunctionPoint = createSavePoint(context);
         next();
         bool isArrowFunction = match(ARROWFUNCTION);
@@ -772,6 +772,10 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatementList
         FALLTHROUGH;
     case AWAIT:
     case YIELD: {
+        if (UNLIKELY(currentScope()->isStaticBlock())) {
+            failIfTrue(match(YIELD), "Cannot use 'yield' within static block");
+            failIfTrue(match(AWAIT), "Cannot use 'await' within static block");
+        }
         // This is a convenient place to notice labeled statements
         // (even though we also parse them as normal statements)
         // because we allow the following type of code in sloppy mode:
@@ -891,6 +895,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseVariableDecl
 
         failIfTrue(match(PRIVATENAME), "Cannot use a private name to declare a variable");
         if (matchSpecIdentifier()) {
+            semanticFailIfTrue(currentScope()->isStaticBlock() && isArgumentsIdentifier(), "Cannot use 'arguments' as an identifier in static block");
             failIfTrue(isPossiblyEscapedLet(m_token) && (declarationType == DeclarationType::LetDeclaration || declarationType == DeclarationType::ConstDeclaration), 
                 "Cannot use 'let' as an identifier name for a LexicalDeclaration");
             semanticFailIfTrue(isDisallowedIdentifierAwait(m_token), "Cannot use 'await' as a ", declarationTypeToVariableKind(declarationType), " ", disallowedIdentifierAwaitReason());
@@ -1617,9 +1622,15 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseBreakStatemen
     JSTextPosition start = tokenStartPosition();
     JSTextPosition end = tokenEndPosition();
     next();
-    
+
+    std::optional<bool> isBreakValid;
+    if (UNLIKELY(currentScope()->isStaticBlock())) {
+        isBreakValid = breakIsValid();
+        semanticFailIfTrue(!currentScope()->breakIsValid() && !isBreakValid.value(), "'break' cannot cross static block boundary");
+    }
+
     if (autoSemiColon()) {
-        semanticFailIfFalse(breakIsValid(), "'break' is only valid inside a switch or loop statement");
+        semanticFailIfFalse(isBreakValid.value_or(breakIsValid()), "'break' is only valid inside a switch or loop statement");
         return context.createBreakStatement(location, &m_vm.propertyNames->nullIdentifier, start, end);
     }
     failIfFalse(matchSpecIdentifier(), "Expected an identifier as the target for a break statement");
@@ -1639,9 +1650,15 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseContinueState
     JSTextPosition start = tokenStartPosition();
     JSTextPosition end = tokenEndPosition();
     next();
-    
+
+    std::optional<bool> isContinueValid;
+    if (UNLIKELY(currentScope()->isStaticBlock())) {
+        isContinueValid = continueIsValid();
+        semanticFailIfTrue(!currentScope()->continueIsValid() && !isContinueValid.value(), "'continue' cannot cross static block boundary");
+    }
+
     if (autoSemiColon()) {
-        semanticFailIfFalse(continueIsValid(), "'continue' is only valid inside a loop statement");
+        semanticFailIfFalse(isContinueValid.value_or(continueIsValid()), "'continue' is only valid inside a loop statement");
         return context.createContinueStatement(location, &m_vm.propertyNames->nullIdentifier, start, end);
     }
     failIfFalse(matchSpecIdentifier(), "Expected an identifier as the target for a continue statement");
@@ -1660,7 +1677,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseReturnStateme
 {
     ASSERT(match(RETURN));
     JSTokenLocation location(tokenLocation());
-    semanticFailIfFalse(currentScope()->isFunction(), "Return statements are only valid inside functions");
+    semanticFailIfFalse(currentScope()->isFunction() && !currentScope()->isStaticBlock(), "Return statements are only valid inside functions");
     JSTextPosition start = tokenStartPosition();
     JSTextPosition end = tokenEndPosition();
     next();
@@ -1833,6 +1850,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseTryStatement(
         } else {
             handleProductionOrFail(OPENPAREN, "(", "start", "'catch' target");
             DepthManager statementDepth(&m_statementDepth);
+            semanticFailIfTrue(currentScope()->isStaticBlock() && match(AWAIT), "Cannot use 'await' as identifier within static block");
             m_statementDepth++;
             AutoPopScopeRef catchScope(this, pushScope());
             catchScope->setIsLexicalScope();
@@ -1850,8 +1868,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseTryStatement(
             }
             handleProductionOrFail(CLOSEPAREN, ")", "end", "'catch' target");
             matchOrFail(OPENBRACE, "Expected exception handler to be a block statement");
-            constexpr bool isCatchBlock = true;
-            catchBlock = parseBlockStatement(context, isCatchBlock);
+            catchBlock = parseBlockStatement(context, BlockType::CatchBlock);
             failIfFalse(catchBlock, "Unable to parse 'catch' block");
             std::tie(catchEnvironment, functionStack) = popScope(catchScope, TreeBuilder::NeedsFreeVariableInfo);
             ASSERT(functionStack.isEmpty());
@@ -1884,7 +1901,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseDebuggerState
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeStatement Parser<LexerType>::parseBlockStatement(TreeBuilder& context, bool isCatchBlock)
+template <class TreeBuilder> TreeStatement Parser<LexerType>::parseBlockStatement(TreeBuilder& context, BlockType type)
 {
     ASSERT(match(OPENBRACE));
 
@@ -1896,8 +1913,19 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseBlockStatemen
         ScopeRef newScope = pushScope();
         newScope->setIsLexicalScope();
         newScope->preventVarDeclarations();
-        if (isCatchBlock)
+        switch (type) {
+        case BlockType::CatchBlock:
             newScope->setIsCatchBlockScope();
+            break;
+        case BlockType::StaticBlock:
+            newScope->setIsStaticBlock();
+            break;
+        case BlockType::Normal:
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
         lexicalScope.setIsValid(newScope, this);
     }
     JSTokenLocation location(tokenLocation());
@@ -2217,6 +2245,7 @@ static const char* stringArticleForFunctionMode(SourceParseMode mode)
     case SourceParseMode::ModuleAnalyzeMode:
     case SourceParseMode::ModuleEvaluateMode:
     case SourceParseMode::ClassFieldInitializerMode:
+    case SourceParseMode::ClassStaticBlockMode:
         RELEASE_ASSERT_NOT_REACHED();
         return "";
     }
@@ -2259,6 +2288,7 @@ static const char* stringForFunctionMode(SourceParseMode mode)
     case SourceParseMode::ModuleAnalyzeMode:
     case SourceParseMode::ModuleEvaluateMode:
     case SourceParseMode::ClassFieldInitializerMode:
+    case SourceParseMode::ClassStaticBlockMode:
         RELEASE_ASSERT_NOT_REACHED();
         return "";
     }
@@ -2271,6 +2301,8 @@ template <typename LexerType> template <class TreeBuilder, class FunctionInfoTyp
     auto mode = sourceParseMode();
     RELEASE_ASSERT(!(SourceParseModeSet(SourceParseMode::ProgramMode, SourceParseMode::ModuleAnalyzeMode, SourceParseMode::ModuleEvaluateMode).contains(mode)));
     TreeFormalParameterList parameterList = context.createFormalParameterList();
+    if (mode == SourceParseMode::ClassStaticBlockMode)
+        return parameterList;
     SetForScope functionParsePhasePoisoner(m_parserState.functionParsePhase, FunctionParsePhase::Parameters);
     
     if (UNLIKELY((SourceParseModeSet(SourceParseMode::ArrowFunctionMode, SourceParseMode::AsyncArrowFunctionMode).contains(mode)))) {
@@ -2655,7 +2687,7 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
     context.setEndOffset(functionInfo.body, m_lexer->currentOffset());
     if (functionScope->strictMode() && requirements != FunctionNameRequirements::Unnamed) {
         ASSERT(functionInfo.name);
-        RELEASE_ASSERT(SourceParseModeSet(SourceParseMode::NormalFunctionMode, SourceParseMode::MethodMode, SourceParseMode::ArrowFunctionMode, SourceParseMode::GeneratorBodyMode, SourceParseMode::GeneratorWrapperFunctionMode).contains(mode) || isAsyncFunctionOrAsyncGeneratorWrapperParseMode(mode));
+        RELEASE_ASSERT(SourceParseModeSet(SourceParseMode::NormalFunctionMode, SourceParseMode::MethodMode, SourceParseMode::ArrowFunctionMode, SourceParseMode::GeneratorBodyMode, SourceParseMode::GeneratorWrapperFunctionMode, SourceParseMode::ClassStaticBlockMode).contains(mode) || isAsyncFunctionOrAsyncGeneratorWrapperParseMode(mode));
         semanticFailIfTrue(m_vm.propertyNames->arguments == *functionInfo.name, "'", functionInfo.name->impl(), "' is not a valid function name in strict mode");
         semanticFailIfTrue(m_vm.propertyNames->eval == *functionInfo.name, "'", functionInfo.name->impl(), "' is not a valid function name in strict mode");
     }
@@ -2923,6 +2955,7 @@ template <class TreeBuilder> TreeClassExpression Parser<LexerType>::parseClass(T
     classHeadScope->preventVarDeclarations();
     classHeadScope->setStrictMode();
     next();
+    semanticFailIfTrue(currentScope()->isStaticBlock() && match(AWAIT), "Cannot use 'await' as a class name within static block");
 
     ASSERT_WITH_MESSAGE(requirements != FunctionNameRequirements::Unnamed, "Currently, there is no caller that uses FunctionNameRequirements::Unnamed for class syntax.");
     ASSERT_WITH_MESSAGE(!(requirements == FunctionNameRequirements::None && !info.className), "When specifying FunctionNameRequirements::None, we need to initialize info.className with the default value in the caller side.");
@@ -2977,6 +3010,7 @@ template <class TreeBuilder> TreeClassExpression Parser<LexerType>::parseClass(T
 
         // For backwards compatibility, "static" is a non-reserved keyword in non-strict mode.
         ClassElementTag tag = ClassElementTag::Instance;
+        SourceParseMode parseMode = SourceParseMode::MethodMode;
         auto type = PropertyNode::Constant;
         if (match(RESERVED_IF_STRICT) && *m_token.m_data.ident == m_vm.propertyNames->staticKeyword) {
             SavePoint savePoint = createSavePoint(context);
@@ -2984,8 +3018,11 @@ template <class TreeBuilder> TreeClassExpression Parser<LexerType>::parseClass(T
             if (match(OPENPAREN) || match(SEMICOLON) || match(EQUAL)) {
                 // Reparse "static()" as a method or "static" as a class field.
                 restoreSavePoint(context, savePoint);
-            } else
+            } else {
                 tag = ClassElementTag::Static;
+                if (match(OPENBRACE))
+                    parseMode = SourceParseMode::ClassStaticBlockMode;
+            }
         }
 
         // FIXME: Figure out a way to share more code with parseProperty.
@@ -2994,7 +3031,6 @@ template <class TreeBuilder> TreeClassExpression Parser<LexerType>::parseClass(T
         TreeExpression computedPropertyName = 0;
         bool isGetter = false;
         bool isSetter = false;
-        SourceParseMode parseMode = SourceParseMode::MethodMode;
         if (consume(TIMES))
             parseMode = SourceParseMode::GeneratorWrapperMethodMode;
 
@@ -3047,6 +3083,7 @@ parseMethod:
             break;
         case OPENBRACKET:
             next();
+            semanticFailIfTrue(currentScope()->isStaticBlock() && match(IDENT) && isArgumentsIdentifier(), "Cannot use 'arguments' as an identifier in static block");
             computedPropertyName = parseAssignmentExpression(context);
             type = static_cast<PropertyNode::Type>(type | PropertyNode::Computed);
             failIfFalse(computedPropertyName, "Cannot parse computed property name");
@@ -3075,6 +3112,10 @@ parseMethod:
             type = static_cast<PropertyNode::Type>(type | PropertyNode::PrivateField);
             break;
         }
+        case OPENBRACE:
+            failIfFalse(parseMode == SourceParseMode::ClassStaticBlockMode, "Cannot parse static block without 'static'");
+            type = static_cast<PropertyNode::Type>(type | PropertyNode::Block);
+            break;
         default:
             if (m_token.m_type & KeywordTokenFlag)
                 goto namedKeyword;
@@ -3143,6 +3184,16 @@ parseMethod:
                 property = context.createProperty(ident, computedPropertyName, initializer, type, SuperBinding::NotNeeded, tag);
             else
                 property = context.createProperty(ident, initializer, type, SuperBinding::NotNeeded, inferName, tag);
+        } else if (parseMode == SourceParseMode::ClassStaticBlockMode) {
+            matchOrFail(OPENBRACE, "Expected block statement for class static block");
+            size_t usedVariablesSize = currentScope()->currentUsedVariablesSize();
+            currentScope()->pushUsedVariableSet();
+            SetForScope parsingWithClassStaticBlockMode(m_parseMode, parseMode);
+            DepthManager statementDepth(&m_statementDepth);
+            m_statementDepth = 1;
+            failIfFalse(parseBlockStatement(context, BlockType::StaticBlock), "Cannot parse class static block");
+            property = context.createProperty(ident, type, SuperBinding::Needed, tag);
+            classScope->markLastUsedVariablesSetAsCaptured(usedVariablesSize);
         } else {
             ParserFunctionInfo<TreeBuilder> methodInfo;
             bool isConstructor = tag == ClassElementTag::Instance && *ident == propertyNames.constructor;
@@ -3275,6 +3326,9 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFie
                 type = DefineFieldNode::Type::ComputedName;
                 break;
             }
+            case OPENBRACE:
+                RELEASE_ASSERT(isStaticField);
+                break;
             default:
                 if (m_token.m_type & KeywordTokenFlag)
                     goto namedKeyword;
@@ -3283,17 +3337,35 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFie
         }
 
         // Only valid class fields are handled in this function.
-        ASSERT(match(EQUAL) || match(SEMICOLON) || match(CLOSEBRACE) || m_lexer->hasLineTerminatorBeforeToken());
+        ASSERT(match(EQUAL) || match(SEMICOLON) || match(CLOSEBRACE) || match(OPENBRACE) || m_lexer->hasLineTerminatorBeforeToken());
 
-        TreeExpression initializer = 0;
-        if (consume(EQUAL))
-            initializer = parseAssignmentExpression(context);
+        TreeStatement statement;
+        if (match(OPENBRACE) && isStaticField) {
+            JSTextPosition startPosition = tokenStartPosition();
+            JSTokenLocation startLocation(tokenLocation());
+            unsigned expressionStart = tokenStart();
 
-        if (type == DefineFieldNode::Type::PrivateName)
-            currentScope()->useVariable(ident, false);
+            ParserFunctionInfo<TreeBuilder> functionInfo;
+            functionInfo.name = &m_vm.propertyNames->nullIdentifier;
+            SetForScope setInnerParseMode(m_parseMode, SourceParseMode::ClassStaticBlockMode);
+            failIfFalse((parseFunctionInfo(context, FunctionNameRequirements::None, false, ConstructorKind::None, SuperBinding::Needed, expressionStart, functionInfo, FunctionDefinitionType::Expression)), "Cannot parse static block function");
+            TreeExpression expression = context.createFunctionExpr(startLocation, functionInfo);
 
-        TreeStatement defineField = context.createDefineField(fieldLocation, ident, initializer, type);
-        context.appendStatement(sourceElements, defineField);
+            JSTextPosition endPosition = lastTokenEndPosition();
+            expression = context.makeStaticBlockFunctionCallNode(startLocation, expression, endPosition, startPosition, lastTokenEndPosition());
+
+            statement = context.createExprStatement(startLocation, expression, startPosition, m_lastTokenEndPosition.line);
+        } else {
+            TreeExpression initializer = 0;
+            if (consume(EQUAL))
+                initializer = parseAssignmentExpression(context);
+
+            if (type == DefineFieldNode::Type::PrivateName)
+                currentScope()->useVariable(ident, false);
+
+            statement = context.createDefineField(fieldLocation, ident, initializer, type);
+        }
+        context.appendStatement(sourceElements, statement);
     }
 
     ASSERT(!hasError());
@@ -4108,6 +4180,22 @@ template <typename TreeBuilder> TreeExpression Parser<LexerType>::parseAssignmen
     }
 
     TreeExpression lhs = parseConditionalExpression(context);
+
+    // Current implementation of parseAssignmentExpression causes a weird parsing loop 
+    // for this example:
+    //
+    //      class C {
+    //          static {
+    //              ((x = await) => 0);
+    //          }
+    //      }
+    //
+    // which makes the 'await' error caught in parseConditionalExpression escaping from
+    // parseAssignmentExpression. Therefore, we need to capture the error directly after
+    // parseConditionalExpression. Besides, the usage of `await` is strictly limited in 
+    // class static block.
+    if (UNLIKELY(!lhs && currentScope()->isStaticBlock() && match(AWAIT)))
+        propagateError();
 
     if (maybeValidArrowFunctionStart && !match(EOFTOK)) {
         bool isArrowFunctionToken = match(ARROWFUNCTION);
@@ -4934,6 +5022,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePrimaryExpre
         return context.createThisExpr(location);
     }
     case AWAIT:
+        semanticFailIfTrue(currentScope()->isStaticBlock(), "The 'await' keyword is disallowed in the IdentifierReference position within static block");
         if (m_parserState.functionParsePhase == FunctionParsePhase::Parameters)
             semanticFailIfFalse(m_parserState.allowAwait, "Cannot use 'await' within a parameter default expression");
         else if (currentFunctionScope()->isAsyncFunctionBoundary() || isModuleParseMode(sourceParseMode()))
@@ -4941,6 +5030,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePrimaryExpre
 
         goto identifierExpression;
     case IDENT: {
+        semanticFailIfTrue(currentScope()->isStaticBlock() && isArgumentsIdentifier(), "Cannot use 'arguments' as an identifier in static block");
         if (UNLIKELY(*m_token.m_data.ident == m_vm.propertyNames->async && !m_token.m_data.escaped)) {
             JSTextPosition start = tokenStartPosition();
             const Identifier* ident = m_token.m_data.ident;
@@ -4957,7 +5047,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePrimaryExpre
             return createResolveAndUseVariable(context, ident, isEval, start, location);
         }
         if (UNLIKELY(m_parserState.isParsingClassFieldInitializer))
-            failIfTrue(*m_token.m_data.ident == m_vm.propertyNames->arguments, "Cannot reference 'arguments' in class field initializer");
+            failIfTrue(isArgumentsIdentifier(), "Cannot reference 'arguments' in class field initializer");
     identifierExpression:
         JSTextPosition start = tokenStartPosition();
         const Identifier* ident = m_token.m_data.ident;
@@ -5163,7 +5253,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
             ScopeRef closestOrdinaryFunctionScope = closestParentOrdinaryFunctionNonLexicalScope();
             bool isClassFieldInitializer = m_parserState.isParsingClassFieldInitializer;
             bool isFunctionEvalContextType = m_isInsideOrdinaryFunction && (closestOrdinaryFunctionScope->evalContextType() == EvalContextType::FunctionEvalContext || closestOrdinaryFunctionScope->evalContextType() == EvalContextType::InstanceFieldEvalContext);
-            semanticFailIfFalse(currentScope()->isFunction() || isFunctionEvalContextType || isClassFieldInitializer, "new.target is only valid inside functions");
+            semanticFailIfFalse(currentScope()->isFunction() || currentScope()->isStaticBlock() || isFunctionEvalContextType || isClassFieldInitializer, "new.target is only valid inside functions or static blocks");
             baseIsNewTarget = true;
             if (currentScope()->isArrowFunction()) {
                 semanticFailIfFalse(!closestOrdinaryFunctionScope->isGlobalCodeScope() || isFunctionEvalContextType || isClassFieldInitializer, "new.target is not valid inside arrow functions in global code");
@@ -5451,8 +5541,10 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseUnaryExpress
     bool hasPrefixUpdateOp = false;
     unsigned lastOperator = 0;
 
-    if (UNLIKELY(match(AWAIT) && (currentFunctionScope()->isAsyncFunctionBoundary() || isModuleParseMode(sourceParseMode()))))
+    if (UNLIKELY(match(AWAIT) && (currentFunctionScope()->isAsyncFunctionBoundary() || isModuleParseMode(sourceParseMode())))) {
+        semanticFailIfTrue(currentScope()->isStaticBlock(), "Cannot use 'await' within static block");
         return parseAwaitExpression(context);
+    }
 
     JSTokenLocation location(tokenLocation());
 

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -148,7 +148,7 @@ struct Scope {
     WTF_MAKE_NONCOPYABLE(Scope);
 
 public:
-    Scope(const VM& vm, ImplementationVisibility implementationVisibility, LexicalScopeFeatures lexicalScopeFeatures, bool isFunction, bool isGenerator, bool isArrowFunction, bool isAsyncFunction)
+    Scope(const VM& vm, ImplementationVisibility implementationVisibility, LexicalScopeFeatures lexicalScopeFeatures, bool isFunction, bool isGenerator, bool isArrowFunction, bool isAsyncFunction, bool isStaticBlock)
         : m_vm(vm)
         , m_implementationVisibility(implementationVisibility)
         , m_lexicalScopeFeatures(lexicalScopeFeatures)
@@ -156,6 +156,7 @@ public:
         , m_isGenerator(isGenerator)
         , m_isArrowFunction(isArrowFunction)
         , m_isAsyncFunction(isAsyncFunction)
+        , m_isStaticBlock(isStaticBlock)
     {
         m_usedVariables.append(UniquedStringImplPtrSet());
     }
@@ -237,6 +238,11 @@ public:
             setIsFunction();
             break;
 
+        case SourceParseMode::ClassStaticBlockMode:
+            setIsFunction();
+            setIsStaticBlock();
+            break;
+
         case SourceParseMode::ArrowFunctionMode:
             setIsArrowFunction();
             break;
@@ -276,6 +282,14 @@ public:
 
     void setIsCatchBlockScope() { m_isCatchBlockScope = true; }
     bool isCatchBlockScope() { return m_isCatchBlockScope; }
+
+    void setIsStaticBlock()
+    {
+        m_isStaticBlock = true;
+        m_isStaticBlockBoundary = true;
+    }
+    bool isStaticBlock() { return m_isStaticBlock; }
+    bool isStaticBlockBoundary() { return m_isStaticBlockBoundary; }
 
     void setIsLexicalScope() 
     { 
@@ -805,6 +819,8 @@ private:
         m_isArrowFunction = false;
         m_isAsyncFunction = false;
         m_isAsyncFunctionBoundary = false;
+        m_isStaticBlock = false;
+        m_isStaticBlockBoundary = false;
     }
 
     void setIsGeneratorFunction()
@@ -895,6 +911,8 @@ private:
     bool m_isGlobalCodeScope : 1 { false };
     bool m_isSimpleCatchParameterScope : 1 { false };
     bool m_isCatchBlockScope : 1 { false };
+    bool m_isStaticBlock : 1 { false };
+    bool m_isStaticBlockBoundary : 1 { false };
     bool m_isFunctionBoundary : 1 { false };
     bool m_isValidStrictMode : 1 { true };
     bool m_hasArguments : 1 { false };
@@ -1281,6 +1299,7 @@ private:
         bool isGenerator = false;
         bool isArrowFunction = false;
         bool isAsyncFunction = false;
+        bool isStaticBlock = false;
         if (!m_scopeStack.isEmpty()) {
             implementationVisibility = m_scopeStack.last().implementationVisibility();
             lexicalScopeFeatures = m_scopeStack.last().lexicalScopeFeatures();
@@ -1288,8 +1307,9 @@ private:
             isGenerator = m_scopeStack.last().isGenerator();
             isArrowFunction = m_scopeStack.last().isArrowFunction();
             isAsyncFunction = m_scopeStack.last().isAsyncFunction();
+            isStaticBlock = m_scopeStack.last().isStaticBlock();
         }
-        m_scopeStack.constructAndAppend(m_vm, implementationVisibility, lexicalScopeFeatures, isFunction, isGenerator, isArrowFunction, isAsyncFunction);
+        m_scopeStack.constructAndAppend(m_vm, implementationVisibility, lexicalScopeFeatures, isFunction, isGenerator, isArrowFunction, isAsyncFunction, isStaticBlock);
         return currentScope();
     }
 
@@ -1674,7 +1694,7 @@ private:
     {
         ScopeRef current = currentScope();
         while (!current->breakIsValid()) {
-            if (!current.hasContainingScope())
+            if (!current.hasContainingScope() || current->isStaticBlockBoundary())
                 return false;
             current = current.containingScope();
         }
@@ -1684,7 +1704,7 @@ private:
     {
         ScopeRef current = currentScope();
         while (!current->continueIsValid()) {
-            if (!current.hasContainingScope())
+            if (!current.hasContainingScope() || current->isStaticBlockBoundary())
                 return false;
             current = current.containingScope();
         }
@@ -1751,7 +1771,8 @@ private:
     template <class TreeBuilder> TreeStatement parseExpressionStatement(TreeBuilder&);
     template <class TreeBuilder> TreeStatement parseExpressionOrLabelStatement(TreeBuilder&, bool allowFunctionDeclarationAsStatement);
     template <class TreeBuilder> TreeStatement parseIfStatement(TreeBuilder&);
-    template <class TreeBuilder> TreeStatement parseBlockStatement(TreeBuilder&, bool isCatchBlock = false);
+    enum class BlockType : uint8_t { Normal, CatchBlock, StaticBlock };
+    template <class TreeBuilder> TreeStatement parseBlockStatement(TreeBuilder&, BlockType = BlockType::Normal);
 
     enum class IsOnlyChildOfStatement { Yes, No };
     template <class TreeBuilder> TreeExpression parseExpression(TreeBuilder&, IsOnlyChildOfStatement = IsOnlyChildOfStatement::No);
@@ -1874,7 +1895,7 @@ private:
 
     ALWAYS_INLINE bool canUseIdentifierAwait()
     {
-        return m_parserState.allowAwait && !currentScope()->isAsyncFunction() && m_scriptMode != JSParserScriptMode::Module;
+        return m_parserState.allowAwait && !currentScope()->isAsyncFunction() && !currentScope()->isStaticBlock() && m_scriptMode != JSParserScriptMode::Module;
     }
 
     bool isDisallowedIdentifierYield(const JSToken& token)
@@ -1932,6 +1953,8 @@ private:
     {
         if (!m_parserState.allowAwait || currentScope()->isAsyncFunction())
             return "in an async function";
+        if (currentScope()->isStaticBlock())
+            return "in a static block";
         if (m_scriptMode == JSParserScriptMode::Module)
             return "in a module";
         RELEASE_ASSERT_NOT_REACHED();
@@ -1946,6 +1969,11 @@ private:
             return "in a generator function";
         RELEASE_ASSERT_NOT_REACHED();
         return nullptr;
+    }
+
+    ALWAYS_INLINE bool isArgumentsIdentifier()
+    {
+        return *m_token.m_data.ident == m_vm.propertyNames->arguments;
     }
 
     enum class FunctionParsePhase { Parameters, Body };

--- a/Source/JavaScriptCore/parser/ParserModes.h
+++ b/Source/JavaScriptCore/parser/ParserModes.h
@@ -69,6 +69,7 @@ enum class SourceParseMode : uint8_t {
     AsyncGeneratorWrapperMethodMode   = 17,
     GeneratorWrapperMethodMode        = 18,
     ClassFieldInitializerMode         = 19,
+    ClassStaticBlockMode              = 20,
 };
 
 class SourceParseModeSet { 
@@ -118,7 +119,8 @@ ALWAYS_INLINE bool isFunctionParseMode(SourceParseMode parseMode)
         SourceParseMode::AsyncGeneratorBodyMode,
         SourceParseMode::AsyncGeneratorWrapperFunctionMode,
         SourceParseMode::AsyncGeneratorWrapperMethodMode,
-        SourceParseMode::ClassFieldInitializerMode).contains(parseMode);
+        SourceParseMode::ClassFieldInitializerMode,
+        SourceParseMode::ClassStaticBlockMode).contains(parseMode);
 } 
 
 ALWAYS_INLINE bool isAsyncFunctionParseMode(SourceParseMode parseMode) 
@@ -206,7 +208,8 @@ ALWAYS_INLINE bool isMethodParseMode(SourceParseMode parseMode)
         SourceParseMode::SetterMode,
         SourceParseMode::MethodMode,
         SourceParseMode::AsyncMethodMode,
-        SourceParseMode::AsyncGeneratorWrapperMethodMode).contains(parseMode);
+        SourceParseMode::AsyncGeneratorWrapperMethodMode,
+        SourceParseMode::ClassStaticBlockMode).contains(parseMode);
 }
 
 ALWAYS_INLINE bool isGeneratorOrAsyncFunctionBodyParseMode(SourceParseMode parseMode)

--- a/Source/JavaScriptCore/parser/SyntaxChecker.h
+++ b/Source/JavaScriptCore/parser/SyntaxChecker.h
@@ -148,6 +148,7 @@ public:
     static constexpr OptionSet<LexerFlags> DontBuildStrings = LexerFlags::DontBuildStrings;
 
     int createSourceElements() { return SourceElementsResult; }
+    ExpressionType makeStaticBlockFunctionCallNode(const JSTokenLocation&, ExpressionType, int, int, int) { return CallExpr; }
     ExpressionType makeFunctionCallNode(const JSTokenLocation&, ExpressionType, bool, int, int, int, int, size_t, bool) { return CallExpr; }
     ExpressionType createCommaExpr(const JSTokenLocation&, ExpressionType) { return CommaExpr; }
     ExpressionType appendToCommaExpr(const JSTokenLocation&, ExpressionType, ExpressionType, ExpressionType) { return CommaExpr; }
@@ -236,6 +237,10 @@ public:
         return Property(type);
     }
     Property createProperty(const Identifier*, int, int, PropertyNode::Type type, SuperBinding, ClassElementTag)
+    {
+        return Property(type);
+    }
+    Property createProperty(const Identifier*, PropertyNode::Type type, SuperBinding, ClassElementTag)
     {
         return Property(type);
     }

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
@@ -206,6 +206,7 @@ JSString* FunctionExecutable::toStringSlow(JSGlobalObject* globalObject)
 
     case SourceParseMode::ArrowFunctionMode:
     case SourceParseMode::ClassFieldInitializerMode:
+    case SourceParseMode::ClassStaticBlockMode:
         break;
 
     case SourceParseMode::AsyncFunctionMode:


### PR DESCRIPTION
#### c33391001b54c44edeaac63efff2b07c0e57e7be
<pre>
[JSC] Implement support for class static initialization blocks
<a href="https://bugs.webkit.org/show_bug.cgi?id=235085">https://bugs.webkit.org/show_bug.cgi?id=235085</a>
rdar://99056882

Reviewed by Yusuke Suzuki.

Class static initialization block is a new feature of a class to perform
additional static initialization during class definition evaluation.

```
class C {
    static { /* … */ }
}
```

TC39 Spec: <a href="https://tc39.es/proposal-class-static-block/">https://tc39.es/proposal-class-static-block/</a>
TC39 Proposal: <a href="https://github.com/tc39/proposal-class-static-block">https://github.com/tc39/proposal-class-static-block</a>
MDN Web Doc: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_static_initialization_blocks">https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_static_initialization_blocks</a>

In this patch, static blocks are implemented as functions which are
evaluated along with the initialization of static class fields during
class definition evaluation. This can be further optimized by inlining
static block functions to the field initialization.

* JSTests/stress/class-static-block.js: Added.
(assert):
(A):
(assert.C):
(assert.B):
(assert.D):
(assert.A):
(assert.A.friendA.prototype.getX):
(assert.A.friendA.prototype.setX):
(assert.A.prototype.getX):
(assert.inner):
(catch.C.prototype.async inner):
(catch.C):
(catch):
(async inner.C.prototype.async inner):
(async inner.C):
(async inner):
(C.inner):
(C):
(await.C.inner):
(await.C):
(await):
(arguments.C.inner):
(arguments.C):
(arguments):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::PropertyListNode::emitBytecode):
(JSC::FunctionCallValueNode::emitBytecode):
(JSC::FuncExprNode::emitBytecode):
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::createFunctionExpr):
(JSC::ASTBuilder::createProperty):
(JSC::ASTBuilder::makeFunctionCallNode):
* Source/JavaScriptCore/parser/NodeConstructors.h:
(JSC::PropertyNode::PropertyNode):
(JSC::FunctionCallValueNode::FunctionCallValueNode):
(JSC::FuncExprNode::FuncExprNode):
* Source/JavaScriptCore/parser/Nodes.h:
(JSC::FuncExprNode::isStaticBlockFunction const):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::isArrowFunctionParameters):
(JSC::Parser&lt;LexerType&gt;::parseStatementListItem):
(JSC::Parser&lt;LexerType&gt;::parseVariableDeclarationList):
(JSC::Parser&lt;LexerType&gt;::parseBreakStatement):
(JSC::Parser&lt;LexerType&gt;::parseContinueStatement):
(JSC::Parser&lt;LexerType&gt;::parseReturnStatement):
(JSC::Parser&lt;LexerType&gt;::parseTryStatement):
(JSC::Parser&lt;LexerType&gt;::parseBlockStatement):
(JSC::stringArticleForFunctionMode):
(JSC::stringForFunctionMode):
(JSC::Parser&lt;LexerType&gt;::parseFunctionParameters):
(JSC::Parser&lt;LexerType&gt;::parseFunctionInfo):
(JSC::Parser&lt;LexerType&gt;::parseClass):
(JSC::Parser&lt;LexerType&gt;::parseClassFieldInitializerSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseAssignmentExpression):
(JSC::Parser&lt;LexerType&gt;::parsePrimaryExpression):
(JSC::Parser&lt;LexerType&gt;::parseMemberExpression):
(JSC::Parser&lt;LexerType&gt;::parseUnaryExpression):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope::setSourceParseMode):
(JSC::Scope::setIsStaticBlockScope):
(JSC::Scope::isStaticBlockScope):
(JSC::Parser::canUseIdentifierAwait):
(JSC::Parser::disallowedIdentifierAwaitReason):
(JSC::Parser::findClosetFunctionScope):
(JSC::Parser::findClosetAsyncFunctionScope):
(JSC::Parser::findScopeUntilStaticBlock):
* Source/JavaScriptCore/parser/ParserModes.h:
(JSC::isFunctionParseMode):
(JSC::isMethodParseMode):
* Source/JavaScriptCore/parser/SyntaxChecker.h:
(JSC::SyntaxChecker::makeFunctionCallNode):
(JSC::SyntaxChecker::createFunctionExpr):
(JSC::SyntaxChecker::createProperty):
* Source/JavaScriptCore/runtime/FunctionExecutable.cpp:
(JSC::FunctionExecutable::toStringSlow):

Canonical link: <a href="https://commits.webkit.org/255173@main">https://commits.webkit.org/255173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7555f15ffeb15c6be7f33f859e9cedf4a94c7592

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101268 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161348 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/719 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97619 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/449 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27401 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82373 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70440 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82993 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35681 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16055 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78037 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33452 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17149 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26951 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3589 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37274 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80642 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36266 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17670 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.no-llint (failure)") | 
<!--EWS-Status-Bubble-End-->