### PR TITLE
Prevent calling an AT-SPI observer from invalidating map iterators

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -414,8 +414,7 @@ webkit.org/b/139352 accessibility/inline-block-assertion.html [ Failure ]
 webkit.org/b/153292 accessibility/text-marker [ Skip ]
 webkit.org/b/141072 accessibility/frame-disconnect-textmarker-cache-crash.html [ Skip ]
 
-# Crashing in Debug too, see webkit.org/b/245214
-webkit.org/b/163383 accessibility/meter-element.html [ Failure Crash ]
+webkit.org/b/163383 accessibility/meter-element.html [ Failure ]
 
 webkit.org/b/182107 accessibility/aria-combobox-control-owns-elements.html [ Timeout ]
 
@@ -469,12 +468,6 @@ webkit.org/b/232249 accessibility/video-element-url-attribute.html [ Failure ]
 webkit.org/b/232255 accessibility/math-has-non-presentational-children.html [ Failure ]
 
 webkit.org/b/232256 accessibility/auto-fill-crash.html [ Timeout ]
-
-webkit.org/b/245214 [ Debug ] accessibility/aria-checkbox-text.html [ Crash ]
-webkit.org/b/245214 [ Debug ] accessibility/aria-invalid.html [ Crash ]
-webkit.org/b/245214 [ Debug ] accessibility/aria-switch-text.html [ Crash ]
-webkit.org/b/245214 [ Debug ] accessibility/aria-visible-element-roles.html [ Crash ]
-webkit.org/b/245214 [ Debug ] accessibility/content-editable-as-textarea.html [ Crash ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Accessibility-related bugs

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -145,8 +145,6 @@ webkit.org/b/223862 accessibility/gtk/text-for-range-simple.html [ Failure ]
 webkit.org/b/223862 accessibility/gtk/text-for-range-table-cells.html [ Failure ]
 webkit.org/b/223862 accessibility/gtk/text-for-range-with-link.html [ Failure ]
 
-webkit.org/b/245214 [ Debug ] accessibility/gtk/input-slider.html [ Crash ]
-
 # Tests failing with ATSPI implementation.
 webkit.org/b/235941 accessibility/gtk/text-at-offset-embedded-objects.html [ Failure ]
 webkit.org/b/235941 accessibility/gtk/text-at-offset-special-chars.html [ Failure ]

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
@@ -835,11 +835,20 @@ void AccessibilityAtspi::removeNotificationObserver(void* context)
     m_notificationObservers.remove(context);
 }
 
-void AccessibilityAtspi::notifyStateChanged(AccessibilityObjectAtspi& atspiObject, const char* name, bool value) const
+void AccessibilityAtspi::notify(AccessibilityObjectAtspi& atspiObject, const char* name, NotificationObserverParameter parameter) const
 {
     if (m_notificationObservers.isEmpty())
         return;
 
+    for (auto* context : copyToVector(m_notificationObservers.keys())) {
+        auto it = m_notificationObservers.find(context);
+        ASSERT(it != m_notificationObservers.end());
+        it->value(atspiObject, name, parameter);
+    }
+}
+
+void AccessibilityAtspi::notifyStateChanged(AccessibilityObjectAtspi& atspiObject, const char* name, bool value) const
+{
     auto notificationName = [&](const char* name) -> const char* {
         if (!g_strcmp0(name, "checked"))
             return "CheckedStateChanged";
@@ -870,39 +879,33 @@ void AccessibilityAtspi::notifyStateChanged(AccessibilityObjectAtspi& atspiObjec
     const char* notification = notificationName(name);
     if (!notification)
         return;
-
-    for (const auto& observer : m_notificationObservers.values())
-        observer(atspiObject, notification, value);
+    
+    notify(atspiObject, notification, value);
 }
 
 void AccessibilityAtspi::notifySelectionChanged(AccessibilityObjectAtspi& atspiObject) const
-{
-    for (const auto& observer : m_notificationObservers.values())
-        observer(atspiObject, "AXSelectedChildrenChanged", nullptr);
+{   
+    notify(atspiObject, "AXSelectedChildrenChanged", nullptr);
 }
 
 void AccessibilityAtspi::notifyMenuSelectionChanged(AccessibilityObjectAtspi& atspiObject) const
 {
-    for (const auto& observer : m_notificationObservers.values())
-        observer(atspiObject, "AXMenuItemSelected", nullptr);
+    notify(atspiObject, "AXMenuItemSelected", nullptr);
 }
 
 void AccessibilityAtspi::notifyTextChanged(AccessibilityObjectAtspi& atspiObject) const
 {
-    for (const auto& observer : m_notificationObservers.values())
-        observer(atspiObject, "AXTextChanged", nullptr);
+    notify(atspiObject, "AXTextChanged", nullptr);
 }
 
 void AccessibilityAtspi::notifyTextCaretMoved(AccessibilityObjectAtspi& atspiObject, unsigned caretOffset) const
 {
-    for (const auto& observer : m_notificationObservers.values())
-        observer(atspiObject, "AXTextCaretMoved", caretOffset);
+    notify(atspiObject, "AXTextCaretMoved", caretOffset);
 }
 
 void AccessibilityAtspi::notifyValueChanged(AccessibilityObjectAtspi& atspiObject) const
 {
-    for (const auto& observer : m_notificationObservers.values())
-        observer(atspiObject, "AXValueChanged", nullptr);
+    notify(atspiObject, "AXValueChanged", nullptr);
 }
 
 void AccessibilityAtspi::notifyLoadEvent(AccessibilityObjectAtspi& atspiObject, const CString& event) const
@@ -910,8 +913,7 @@ void AccessibilityAtspi::notifyLoadEvent(AccessibilityObjectAtspi& atspiObject, 
     if (event != "LoadComplete")
         return;
 
-    for (const auto& observer : m_notificationObservers.values())
-        observer(atspiObject, "AXLoadComplete", nullptr);
+    notify(atspiObject, "AXLoadComplete", nullptr);
 }
 
 #endif

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
@@ -111,6 +111,7 @@ private:
     bool shouldEmitSignal(const char* interface, const char* name, const char* detail = "");
 
 #if ENABLE(DEVELOPER_MODE)
+    void notify(AccessibilityObjectAtspi&, const char*, NotificationObserverParameter) const;
     void notifyStateChanged(AccessibilityObjectAtspi&, const char*, bool) const;
     void notifySelectionChanged(AccessibilityObjectAtspi&) const;
     void notifyMenuSelectionChanged(AccessibilityObjectAtspi&) const;


### PR DESCRIPTION
#### f170deb7670205b57a795284f19361010e8a4207
<pre>
Prevent calling an AT-SPI observer from invalidating map iterators
<a href="https://bugs.webkit.org/show_bug.cgi?id=245214">https://bugs.webkit.org/show_bug.cgi?id=245214</a>

Reviewed by Carlos Garcia Campos.

* Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp:
(WebCore::AccessibilityAtspi::notify const):
(WebCore::AccessibilityAtspi::notifyStateChanged const):
(WebCore::AccessibilityAtspi::notifySelectionChanged const):
(WebCore::AccessibilityAtspi::notifyMenuSelectionChanged const):
(WebCore::AccessibilityAtspi::notifyTextChanged const):
(WebCore::AccessibilityAtspi::notifyTextCaretMoved const):
(WebCore::AccessibilityAtspi::notifyValueChanged const):
(WebCore::AccessibilityAtspi::notifyLoadEvent const):
* Source/WebCore/accessibility/atspi/AccessibilityAtspi.h:

Canonical link: <a href="https://commits.webkit.org/254722@main">https://commits.webkit.org/254722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b40d970f985b4fac0057108a702abcff164e3787

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99151 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155992 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32873 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28313 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82178 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93501 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26120 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76654 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26047 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69048 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30623 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14922 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30364 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15863 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38817 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1414 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34947 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->