### PR TITLE
[iOS] Entering every other character in the find bar causes HTML notes to scroll to the top

### DIFF
--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -265,7 +265,11 @@ TemporarySelectionChange::~TemporarySelectionChange()
 
 void TemporarySelectionChange::setSelection(const VisibleSelection& selection, IsTemporarySelection isTemporarySelection)
 {
-    auto options = FrameSelection::defaultSetSelectionOptions(m_options.contains(TemporarySelectionOption::UserTriggered) ? UserTriggered : NotUserTriggered);
+    auto options = FrameSelection::defaultSetSelectionOptions();
+
+    if (m_options & TemporarySelectionOption::UserTriggered)
+        options.add(FrameSelection::IsUserTriggered);
+
     if (m_options & TemporarySelectionOption::DoNotSetFocus)
         options.add(FrameSelection::DoNotSetFocus);
 

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -2230,7 +2230,8 @@ bool FrameView::scrollToFragment(const URL& url)
             
             if (highlightRanges.size()) {
                 auto range = highlightRanges.first();
-                TemporarySelectionChange selectionChange(document, { range }, { TemporarySelectionOption::DelegateMainFrameScroll, TemporarySelectionOption::RevealSelectionBounds, TemporarySelectionOption::UserTriggered, TemporarySelectionOption::ForceCenterScroll });
+                // FIXME: <http://webkit.org/b/245262> (Scroll To Text Fragment should use DelegateMainFrameScroll)
+                TemporarySelectionChange selectionChange(document, { range }, { TemporarySelectionOption::RevealSelection, TemporarySelectionOption::RevealSelectionBounds, TemporarySelectionOption::UserTriggered, TemporarySelectionOption::ForceCenterScroll });
                 maintainScrollPositionAtScrollToTextFragmentRange(range);
                 if (frame().settings().scrollToTextFragmentIndicatorEnabled())
                     m_delayedTextFragmentIndicatorTimer.startOneShot(100_ms);
@@ -2477,8 +2478,9 @@ void FrameView::textFragmentIndicatorTimerFired()
         return;
     
     auto range = m_pendingTextFragmentIndicatorRange.value();
-    
-    TemporarySelectionChange selectionChange(document, { range }, { TemporarySelectionOption::DelegateMainFrameScroll, TemporarySelectionOption::RevealSelectionBounds, TemporarySelectionOption::UserTriggered, TemporarySelectionOption::ForceCenterScroll });
+
+    // FIXME: <http://webkit.org/b/245262> (Scroll To Text Fragment should use DelegateMainFrameScroll)
+    TemporarySelectionChange selectionChange(document, { range }, { TemporarySelectionOption::RevealSelection, TemporarySelectionOption::RevealSelectionBounds, TemporarySelectionOption::UserTriggered, TemporarySelectionOption::ForceCenterScroll });
     
     maintainScrollPositionAtScrollToTextFragmentRange(range);
     
@@ -3563,8 +3565,9 @@ void FrameView::scrollToTextFragmentRange()
     Ref document = *frame().document();
 
     SetForScope skipScrollResetOfScrollToTextFragmentRange(m_skipScrollResetOfScrollToTextFragmentRange, true);
-    
-    TemporarySelectionChange selectionChange(document, { range }, { TemporarySelectionOption::DelegateMainFrameScroll, TemporarySelectionOption::RevealSelectionBounds, TemporarySelectionOption::UserTriggered, TemporarySelectionOption::ForceCenterScroll });
+
+    // FIXME: <http://webkit.org/b/245262> (Scroll To Text Fragment should use DelegateMainFrameScroll)
+    TemporarySelectionChange selectionChange(document, { range }, { TemporarySelectionOption::RevealSelection, TemporarySelectionOption::RevealSelectionBounds, TemporarySelectionOption::UserTriggered, TemporarySelectionOption::ForceCenterScroll });
 }
 
 void FrameView::updateEmbeddedObject(RenderEmbeddedObject& embeddedObject)


### PR DESCRIPTION
#### b20f02feaf02b1c2c44ebfcdadda9dd4652e2cce
<pre>
[iOS] Entering every other character in the find bar causes HTML notes to scroll to the top
<a href="https://bugs.webkit.org/show_bug.cgi?id=245223">https://bugs.webkit.org/show_bug.cgi?id=245223</a>
rdar://99843009

Reviewed by Megan Gardner and Tim Horton.

250836@main updated the `TemporarySelectionChange` logic to incorporate the
user-triggered option for synchronous selection updates. 251398@main adopted
this option to ensure found text is scrolled into view.

However, the incorporation of the user-triggered option in 250836@main was
incorrect. The user-triggered option was passed directly into
`FrameSelection::defaultSetSelectionOptions`, for both the temporary change, and
the selection restoration. `defaultSetSelectionOptions` adds `RevealSelection`
and `FireSelectEvent` when the user-triggered option is specified.

Passing the option into `defaultSetSelectionOptions` in `TemporarySelectionChange`
is incorrect for multiple reasons:

1. `TemporarySelectionChange` has its own option to control selection revealing.
2. The default options are applied during selection restoration, breaking the use of `TemporarySelectionChange` to scroll to a range.
3. The select event should not be fired for a `TemporarySelectionChange`.

(2) is the cause of this bug, as the `RevealSelection` option is specified once the
original selection is revealed as the `TemporarySelectionChange` is destroyed.

* Source/WebCore/editing/Editor.cpp:
(WebCore::TemporarySelectionChange::setSelection):

To fix, do not pass in the user-triggered option to `FrameView::defaultSetSelectionOptions`.
Instead, only add the `FrameSelection::IsUserTriggered` option if the temporary
selection change is &quot;user-triggered&quot;. This ensures there is no unexpected
application of `RevealSelection` or `FireSelectEvent`.

* Source/WebCore/page/FrameView.cpp:

Continue using `RevealSelection` rather `DelegateMainFrameScroll` for the Scroll
To Text Fragment functionality, as existing tests depend on this behavior. Even
though `DelegateMainFrameScroll` was being specified here, it was being overwritten
by the `defaultSetSelectionOptions` with the user-triggered option. Since STTF
was introduced after 250836@main, preserve the current behavior. Adopting
`DelegateMainFrameScroll` should be considered in a subsequent patch.

(WebCore::FrameView::scrollToFragment):
(WebCore::FrameView::textFragmentIndicatorTimerFired):
(WebCore::FrameView::scrollToTextFragmentRange):

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(TEST):

Add an API test to exercise the failing scenario.

Canonical link: <a href="https://commits.webkit.org/254559@main">https://commits.webkit.org/254559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d1dc3e7ab2732e9560f589da7ec756c0109f0da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98747 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155053 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32486 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81780 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93159 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25799 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76333 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25727 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68714 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30245 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29983 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15596 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3200 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38559 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34687 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->