### PR TITLE
[git-webkit] Allow user to CC specific radar

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.8.0',
+    version='0.8.1',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 8, 0)
+version = Version(0, 8, 1)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -602,6 +602,6 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
 
         return 'Error Message: {}\n{}'.format(message, ''.join(error_messages))
 
-    def cc_radar(self, issue, block=False, timeout=None):
+    def cc_radar(self, issue, block=False, timeout=None, radar=None):
         sys.stderr.write('No radar CC implemented for GitHub Issues\n')
         return None

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -194,8 +194,8 @@ class Issue(object):
     def set_component(self, project=None, component=None, version=None):
         return self.tracker.set(self, project=project, component=component, version=version)
 
-    def cc_radar(self, block=False, timeout=None):
-        return self.tracker.cc_radar(self, block=block, timeout=timeout)
+    def cc_radar(self, block=False, timeout=None, radar=None):
+        return self.tracker.cc_radar(self, block=block, timeout=timeout, radar=radar)
 
     def __hash__(self):
         return hash(self.link)

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -155,11 +155,10 @@ class Bugzilla(Base, mocks.Requests):
                 if not candidate:
                     continue
                 issue['watchers'].append(candidate)
-                if 'Radar' not in candidate.name or 'Bug Importer' not in candidate.name:
+                if 'Radar' not in candidate.name or 'Bug Importer' not in candidate.name or 'InRadar' in data.get('keywords', {}).get('add', []):
                     continue
                 radar_id = issue['id']
                 if RadarMock.top:
-                    print('Ugh, this is the problem')
                     radar_id = RadarMock.top.add(dict(
                         title='{} ({})'.format(issue['description'], issue['id']),
                         timestamp=time.time(),

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -456,6 +456,6 @@ class Tracker(GenericTracker):
             result.assign(self.me())
         return result
 
-    def cc_radar(self, issue, block=False, timeout=None):
+    def cc_radar(self, issue, block=False, timeout=None, radar=None):
         # cc-ing radar is a no-op for radar
         return issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
@@ -142,5 +142,5 @@ class Tracker(object):
     def create(self, title, description, **kwargs):
         raise NotImplementedError()
 
-    def cc_radar(self, issue, block=False, timeout=None):
+    def cc_radar(self, issue, block=False, timeout=None, radar=None):
         raise NotImplementedError()

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.6.4',
+    version='5.6.5',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 6, 4)
+version = Version(5, 6, 5)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
@@ -138,11 +138,28 @@ class Branch(Command):
             else:
                 log.warning("'{}' has no spaces, assuming user intends it to be a branch name".format(args.issue))
 
-        if issue:
-            for tracker in Tracker._trackers:
-                if isinstance(tracker, radar.Tracker) and tracker.radarclient():
-                    issue.cc_radar(block=True)
-                    break
+        needs_radar = issue and not isinstance(issue.tracker, radar.Tracker)
+        needs_radar = needs_radar and any([
+            isinstance(tracker, radar.Tracker) and tracker.radarclient()
+            for tracker in Tracker._trackers
+        ])
+        needs_radar = needs_radar and not any([
+            isinstance(reference.tracker, radar.Tracker)
+            for reference in issue.references
+        ])
+
+        if needs_radar:
+            rdar = None
+            if not getattr(args, 'defaults', None):
+                sys.stdout.write('Existing radar to CC (leave empty to create new radar)')
+                sys.stdout.flush()
+                input = Terminal.input(': ')
+                if re.match(r'\d+', input):
+                    input = '<rdar://problem/{}>'.format(input)
+                rdar = Tracker.from_string(input)
+            issue.cc_radar(block=True, radar=rdar)
+
+        if issue and not isinstance(issue.tracker, radar.Tracker):
             args._title = issue.title
             args._bug_urls = Commit.bug_urls(issue)
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
@@ -24,7 +24,7 @@ import logging
 import os
 
 from mock import patch
-from webkitbugspy import bugzilla, mocks as bmocks, radar
+from webkitbugspy import bugzilla, mocks as bmocks, radar, Tracker
 from webkitcorepy import OutputCapture, testing, mocks as wkmocks
 from webkitcorepy.mocks import Time as MockTime, Terminal as MockTerminal, Environment
 from webkitscmpy import local, program, mocks, log
@@ -97,6 +97,108 @@ class TestBranch(testing.PathTestCase):
             self.assertEqual(local.Git(self.path).branch, 'eng/Example-feature-1')
         self.assertEqual(captured.root.log.getvalue(), "Creating the local development branch 'eng/Example-feature-1'...\n")
         self.assertEqual(captured.stdout.getvalue(), "Enter issue URL or title of new issue: \nCreated the local development branch 'eng/Example-feature-1'\n")
+
+    def test_automatic_radar_cc(self):
+        with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA), ''), OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            issues=bmocks.ISSUES,
+            projects=bmocks.PROJECTS,
+            users=bmocks.USERS,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), bmocks.Radar(issues=bmocks.ISSUES), patch('webkitbugspy.Tracker._trackers', [
+            bugzilla.Tracker(self.BUGZILLA, radar_importer=bmocks.USERS['Radar WebKit Bug Importer']),
+            radar.Tracker(),
+        ]), mocks.local.Svn(), MockTime:
+            self.assertEqual(0, program.main(args=('branch', '-v'), path=self.path))
+            self.assertEqual(local.Git(self.path).branch, 'eng/Example-feature-1')
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=2'.format(self.BUGZILLA))
+            self.assertEqual(len(issue.references), 2)
+            self.assertEqual(issue.references[0].link, '<rdar://4>')
+            self.assertEqual(issue.comments[-1].content, '<rdar://problem/4>')
+
+        self.assertEqual(
+            captured.root.log.getvalue(),
+            "CCing Radar WebKit Bug Importer\n"
+            "Creating the local development branch 'eng/Example-feature-1'...\n",
+        )
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Enter issue URL or title of new issue: \n"
+            "Existing radar to CC (leave empty to create new radar): \n"
+            "Created the local development branch 'eng/Example-feature-1'\n",
+        )
+
+    def test_manual_radar_cc(self):
+        with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '<rdar://4>'), OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            issues=bmocks.ISSUES,
+            projects=bmocks.PROJECTS,
+            users=bmocks.USERS,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), bmocks.Radar(issues=bmocks.ISSUES), patch('webkitbugspy.Tracker._trackers', [
+            bugzilla.Tracker(self.BUGZILLA, radar_importer=bmocks.USERS['Radar WebKit Bug Importer']),
+            radar.Tracker(),
+        ]), mocks.local.Svn(), MockTime:
+            self.assertEqual(0, program.main(args=('branch', '-v'), path=self.path))
+            self.assertEqual(local.Git(self.path).branch, 'eng/Example-feature-1')
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=2'.format(self.BUGZILLA))
+            self.assertEqual(len(issue.references), 2)
+            self.assertEqual(issue.references[0].link, '<rdar://2>')
+            self.assertEqual(issue.comments[-1].content, '<rdar://problem/2>')
+
+        self.assertEqual(
+            captured.root.log.getvalue(),
+            "CCing Radar WebKit Bug Importer\n"
+            "Creating the local development branch 'eng/Example-feature-1'...\n",
+        )
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Enter issue URL or title of new issue: \n"
+            "Existing radar to CC (leave empty to create new radar): \n"
+            "Created the local development branch 'eng/Example-feature-1'\n",
+        )
+
+    def test_manual_radar_cc_integer(self):
+        with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '4'), OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            issues=bmocks.ISSUES,
+            projects=bmocks.PROJECTS,
+            users=bmocks.USERS,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), bmocks.Radar(issues=bmocks.ISSUES), patch('webkitbugspy.Tracker._trackers', [
+            bugzilla.Tracker(self.BUGZILLA, radar_importer=bmocks.USERS['Radar WebKit Bug Importer']),
+            radar.Tracker(),
+        ]), mocks.local.Svn(), MockTime:
+            self.assertEqual(0, program.main(args=('branch', '-v'), path=self.path))
+            self.assertEqual(local.Git(self.path).branch, 'eng/Example-feature-1')
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=2'.format(self.BUGZILLA))
+            self.assertEqual(len(issue.references), 2)
+            self.assertEqual(issue.references[0].link, '<rdar://2>')
+            self.assertEqual(issue.comments[-1].content, '<rdar://problem/2>')
+
+        self.assertEqual(
+            captured.root.log.getvalue(),
+            "CCing Radar WebKit Bug Importer\n"
+            "Creating the local development branch 'eng/Example-feature-1'...\n",
+        )
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Enter issue URL or title of new issue: \n"
+            "Existing radar to CC (leave empty to create new radar): \n"
+            "Created the local development branch 'eng/Example-feature-1'\n",
+        )
 
     def test_redacted(self):
         class MockOptions(object):


### PR DESCRIPTION
#### d3db0af985b0d0b7c6d070b90934db4f901c1357
<pre>
[git-webkit] Allow user to CC specific radar
<a href="https://bugs.webkit.org/show_bug.cgi?id=245202">https://bugs.webkit.org/show_bug.cgi?id=245202</a>
&lt;rdar://problem/99942952&gt;

Unreviewed follow-up fix.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.cc_radar): Use radar number instead of bugzilla number.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py:
(TestBranch.test_manual_radar_cc): Correct test baseline.
(TestBranch.test_manual_radar_cc_integer): Ditto.
</pre>