### PR TITLE
Revert (249987@main, 250226@main and 250267@main): Remove WebArchiveDebugMode

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -2482,17 +2482,6 @@ WebArchiveDebugModeEnabled:
     WebCore:
       default: false
 
-WebArchiveTestingModeEnabled:
-  type: bool
-  condition: ENABLE(WEB_ARCHIVE)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
-
 WebAudioEnabled:
   type: bool
   condition: ENABLE(WEB_AUDIO)

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1217,27 +1217,11 @@ static inline bool shouldUseActiveServiceWorkerFromParent(const Document& docume
 }
 #endif
 
-#if ENABLE(WEB_ARCHIVE)
-bool DocumentLoader::isLoadingRemoteArchive() const
-{
-    bool isQuickLookPreview = false;
-#if USE(QUICK_LOOK)
-    isQuickLookPreview = isQuickLookPreviewURL(m_response.url());
-#endif
-    return m_archive && !m_frame->settings().webArchiveTestingModeEnabled() && !isQuickLookPreview;
-}
-#endif
-
 void DocumentLoader::commitData(const SharedBuffer& data)
 {
-#if ENABLE(WEB_ARCHIVE)
-    URL documentOrEmptyURL = isLoadingRemoteArchive() ? URL() : documentURL();
-#else
-    URL documentOrEmptyURL = documentURL();
-#endif
     if (!m_gotFirstByte) {
         m_gotFirstByte = true;
-        bool hasBegun = m_writer.begin(documentOrEmptyURL, false, nullptr, m_resultingClientId);
+        bool hasBegun = m_writer.begin(documentURL(), false, nullptr, m_resultingClientId);
         if (!hasBegun)
             return;
 
@@ -1259,12 +1243,9 @@ void DocumentLoader::commitData(const SharedBuffer& data)
         if (frameLoader()->stateMachine().creatingInitialEmptyDocument())
             return;
 
-#if ENABLE(WEB_ARCHIVE)
-        if (isLoadingRemoteArchive()) {
+#if ENABLE(WEB_ARCHIVE) || ENABLE(MHTML)
+        if (m_archive && m_archive->shouldOverrideBaseURL())
             document.setBaseURLOverride(m_archive->mainResource()->url());
-            if (LegacySchemeRegistry::shouldTreatURLSchemeAsLocal(documentURL().protocol().toStringWithoutCopying()))
-                document.securityOrigin().grantLoadLocalResources();
-        }
 #endif
 #if ENABLE(SERVICE_WORKER)
         if (m_canUseServiceWorkers) {
@@ -1821,11 +1802,10 @@ bool DocumentLoader::scheduleArchiveLoad(ResourceLoader& loader, const ResourceR
         return false;
 
 #if ENABLE(WEB_ARCHIVE)
-    if (isLoadingRemoteArchive()) {
-        DOCUMENTLOADER_RELEASE_LOG("scheduleArchiveLoad: Failed to unarchive subresource");
-        loader.didFail(ResourceError(errorDomainWebKitInternal, 0, request.url(), "Failed to unarchive subresource"_s));
+    // The idea of WebArchiveDebugMode is that we should fail instead of trying to fetch from the network.
+    // Returning true ensures the caller will not try to fetch from the network.
+    if (m_frame->settings().webArchiveDebugModeEnabled() && responseMIMEType() == "application/x-webarchive"_s)
         return true;
-    }
 #endif
 
     // If we want to load from the archive only, then we should always return true so that the caller

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -507,10 +507,6 @@ private:
     void clearArchiveResources();
 #endif
 
-#if ENABLE(WEB_ARCHIVE)
-    bool isLoadingRemoteArchive() const;
-#endif
-
     void willSendRequest(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&);
     void finishedLoading();
     void mainReceivedError(const ResourceError&);

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -568,14 +568,14 @@ bool WKPreferencesGetDOMTimersThrottlingEnabled(WKPreferencesRef preferencesRef)
     return toImpl(preferencesRef)->domTimersThrottlingEnabled();
 }
 
-void WKPreferencesSetWebArchiveTestingModeEnabled(WKPreferencesRef preferencesRef, bool enabled)
+void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setWebArchiveTestingModeEnabled(enabled);
+    toImpl(preferencesRef)->setWebArchiveDebugModeEnabled(enabled);
 }
 
-bool WKPreferencesGetWebArchiveTestingModeEnabled(WKPreferencesRef preferencesRef)
+bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->webArchiveTestingModeEnabled();
+    return toImpl(preferencesRef)->webArchiveDebugModeEnabled();
 }
 
 void WKPreferencesSetLocalFileContentSniffingEnabled(WKPreferencesRef preferencesRef, bool enabled)
@@ -2152,15 +2152,6 @@ void WKPreferencesSetXSSAuditorEnabled(WKPreferencesRef, bool)
 }
 
 bool WKPreferencesGetXSSAuditorEnabled(WKPreferencesRef)
-{
-    return false;
-}
-
-void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef, bool enabled)
-{
-}
-
-bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef)
 {
     return false;
 }

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
@@ -126,8 +126,8 @@ WK_EXPORT void WKPreferencesSetDOMTimersThrottlingEnabled(WKPreferencesRef prefe
 WK_EXPORT bool WKPreferencesGetDOMTimersThrottlingEnabled(WKPreferencesRef preferences);
 
 // Defaults to false.
-WK_EXPORT void WKPreferencesSetWebArchiveTestingModeEnabled(WKPreferencesRef preferences, bool enabled);
-WK_EXPORT bool WKPreferencesGetWebArchiveTestingModeEnabled(WKPreferencesRef preferences);
+WK_EXPORT void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferences, bool enabled);
+WK_EXPORT bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferences);
 
 // Defaults to false.
 WK_EXPORT void WKPreferencesSetLocalFileContentSniffingEnabled(WKPreferencesRef preferences, bool enabled);
@@ -565,8 +565,6 @@ WK_EXPORT void WKPreferencesSetResourceTimingEnabled(WKPreferencesRef, bool) WK_
 WK_EXPORT bool WKPreferencesGetResourceTimingEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
 WK_EXPORT void WKPreferencesSetSubpixelCSSOMElementMetricsEnabled(WKPreferencesRef, bool) WK_C_API_DEPRECATED;
 WK_EXPORT bool WKPreferencesGetSubpixelCSSOMElementMetricsEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
-WK_EXPORT void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferences, bool enabled) WK_C_API_DEPRECATED;
-WK_EXPORT bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferences) WK_C_API_DEPRECATED;
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -992,14 +992,14 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
     return _preferences->domTimersThrottlingEnabled();
 }
 
-- (void)_setWebArchiveTestingModeEnabled:(BOOL)enabled
+- (void)_setWebArchiveDebugModeEnabled:(BOOL)enabled
 {
-    _preferences->setWebArchiveTestingModeEnabled(enabled);
+    _preferences->setWebArchiveDebugModeEnabled(enabled);
 }
 
-- (BOOL)_webArchiveTestingModeEnabled
+- (BOOL)_webArchiveDebugModeEnabled
 {
-    return _preferences->webArchiveTestingModeEnabled();
+    return _preferences->webArchiveDebugModeEnabled();
 }
 
 - (void)_setLocalFileContentSniffingEnabled:(BOOL)enabled
@@ -1626,15 +1626,6 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 }
 
 - (BOOL)_subpixelCSSOMElementMetricsEnabled
-{
-    return NO;
-}
-
-- (void)_setWebArchiveDebugModeEnabled:(BOOL)enabled
-{
-}
-
-- (BOOL)_webArchiveDebugModeEnabled
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -186,7 +186,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setDefaultTextEncodingName:) NSString *_defaultTextEncodingName WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setAuthorAndUserStylesEnabled:) BOOL _authorAndUserStylesEnabled WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setDOMTimersThrottlingEnabled:) BOOL _domTimersThrottlingEnabled WK_API_AVAILABLE(macos(10.13.4));
-@property (nonatomic, setter=_setWebArchiveTestingModeEnabled:) BOOL _webArchiveTestingModeEnabled WK_API_AVAILABLE(macos(13.0));
+@property (nonatomic, setter=_setWebArchiveDebugModeEnabled:) BOOL _webArchiveDebugModeEnabled WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setLocalFileContentSniffingEnabled:) BOOL _localFileContentSniffingEnabled WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setUsesPageCache:) BOOL _usesPageCache WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setPageCacheSupportsPlugins:) BOOL _pageCacheSupportsPlugins WK_API_AVAILABLE(macos(10.13.4));
@@ -231,6 +231,6 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setRequestAnimationFrameEnabled:) BOOL _requestAnimationFrameEnabled WK_API_DEPRECATED("requestAnimationFrame is always enabled", macos(10.15.4, 13.0), ios(13.4, 16.0));
 #if !TARGET_OS_IPHONE
 @property (nonatomic, setter=_setSubpixelCSSOMElementMetricsEnabled:) BOOL _subpixelCSSOMElementMetricsEnabled WK_API_DEPRECATED("Subpixel CSSOM element metrics are no longer supported", macos(10.13.4, 10.15));
-@property (nonatomic, setter=_setWebArchiveDebugModeEnabled:) BOOL _webArchiveDebugModeEnabled WK_API_DEPRECATED("WebArchive Debug Mode is no longer supported", macos(10.13.4, 13.0));
 #endif
+
 @end

--- a/Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm
@@ -32,7 +32,6 @@
 #import "TestWKWebView.h"
 #import <WebKit/WKDragDestinationAction.h>
 #import <WebKit/WKNavigationPrivate.h>
-#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
@@ -206,9 +205,9 @@ TEST(LoadWebArchive, DragNavigationReload)
     EXPECT_WK_STREQ(finalURL, "");
 }
 
-static NSData* constructArchive(const char *script)
+static NSData* constructArchive()
 {
-    auto *js = [NSString stringWithUTF8String:script];
+    NSString *js = @"alert('loaded http subresource successfully')";
     auto response = adoptNS([[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://download/script.js"] MIMEType:@"application/javascript" expectedContentLength:js.length textEncodingName:@"utf-8"]);
     auto responseArchiver = adoptNS([[NSKeyedArchiver alloc] initRequiringSecureCoding:YES]);
     [responseArchiver encodeObject:response.get() forKey:@"WebResourceResponse"];
@@ -233,7 +232,7 @@ static NSData* constructArchive(const char *script)
 
 TEST(LoadWebArchive, HTTPSUpgrade)
 {
-    NSData *data = constructArchive("alert('loaded http subresource successfully')");
+    NSData *data = constructArchive();
 
     auto webView = adoptNS([WKWebView new]);
     [webView loadData:data MIMEType:@"application/x-webarchive" characterEncodingName:@"utf-8" baseURL:[NSURL URLWithString:@"http://download/"]];
@@ -242,7 +241,7 @@ TEST(LoadWebArchive, HTTPSUpgrade)
 
 TEST(LoadWebArchive, DisallowedNetworkHosts)
 {
-    NSData *data = constructArchive("alert('loaded http subresource successfully')");
+    NSData *data = constructArchive();
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get()._allowedNetworkHosts = [NSSet set];
@@ -253,7 +252,3 @@ TEST(LoadWebArchive, DisallowedNetworkHosts)
 }
 
 } // namespace TestWebKitAPI
-
-#if USE(APPLE_INTERNAL_SDK)
-#import <WebKitAdditions/LoadWebArchiveAdditions.mm>
-#endif


### PR DESCRIPTION
#### 4949001341c54e7b4541088e7537f987460383e5
<pre>
Revert (249987@main, 250226@main and 250267@main): Remove WebArchiveDebugMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=245228">https://bugs.webkit.org/show_bug.cgi?id=245228</a>
&lt;rdar://97580190&gt;

Reviewed by Said Abou-Hallawa.

Changes resulted in too much breakage. Reverting 249987@main, 250226@main and
250267@main.

* Source/WTF/Scripts/Preferences/WebPreferences.yaml:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::commitData):
(WebCore::DocumentLoader::scheduleArchiveLoad):
(WebCore::DocumentLoader::isLoadingRemoteArchive const): Deleted.
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebKit/UIProcess/API/C/WKPreferences.cpp:
(WKPreferencesSetWebArchiveDebugModeEnabled):
(WKPreferencesGetWebArchiveDebugModeEnabled):
(WKPreferencesSetWebArchiveTestingModeEnabled): Deleted.
(WKPreferencesGetWebArchiveTestingModeEnabled): Deleted.
* Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _setWebArchiveDebugModeEnabled:]):
(-[WKPreferences _webArchiveDebugModeEnabled]):
(-[WKPreferences _setWebArchiveTestingModeEnabled:]): Deleted.
(-[WKPreferences _webArchiveTestingModeEnabled]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm:
(TestWebKitAPI::constructArchive):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/254575@main">https://commits.webkit.org/254575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f70e1d9503d0dd2c42294f66e35e8e00a337f234

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98773 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155079 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32512 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93185 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25824 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76354 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25759 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68747 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81141 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30271 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14676 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74951 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30009 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15615 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26380 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3208 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38573 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/77819 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1348 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34706 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17219 "Passed tests") | 
<!--EWS-Status-Bubble-End-->