### PR TITLE
[Filters] Limit the memory cost of FilterResults to 100MB

### DIFF
--- a/LayoutTests/svg/filters/repeated-drop-shadow-effects-expected.svg
+++ b/LayoutTests/svg/filters/repeated-drop-shadow-effects-expected.svg
@@ -1,0 +1,25 @@
+<svg width="404" height="404" xmlns="http://www.w3.org/2000/svg">
+    <path d="M 2 202 L 202 2 L 402 202 L 202 402" fill="green"/>
+    <g id="zigzag-border"/>
+    <script><![CDATA[
+        let nameSpace = "http://www.w3.org/2000/svg";
+        let groupElement = document.getElementById("zigzag-border");
+
+        function createBorderRects(count, x, y, dx, dy) {
+            for (let i = 0; i < count; i++) {
+                var rectElement = document.createElementNS(nameSpace, "rect");
+                rectElement.setAttribute("x", (x + i * dx).toString());
+                rectElement.setAttribute("y", (y + i * dy).toString());
+                rectElement.setAttribute("width", "4");
+                rectElement.setAttribute("height", "4");
+                rectElement.setAttribute("fill", "green");
+                groupElement.appendChild(rectElement);
+            }
+        }
+
+        createBorderRects(101,   0, 200,  2, -2);
+        createBorderRects(101, 200,   0,  2,  2);
+        createBorderRects(101, 400, 200, -2,  2);
+        createBorderRects(101, 200, 400, -2, -2);
+     ]]></script>
+</svg>

--- a/LayoutTests/svg/filters/repeated-drop-shadow-effects.svg
+++ b/LayoutTests/svg/filters/repeated-drop-shadow-effects.svg
@@ -1,0 +1,26 @@
+<svg width="404" height="404" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <filter id="repeated-drop-shadow" filterUnits="userSpaceOnUse"/>
+    </defs>
+    <rect x="200" y="200" width="4" height="4" style="fill:green; filter:url(#repeated-drop-shadow);"/>
+    <script><![CDATA[
+        let nameSpace = "http://www.w3.org/2000/svg";
+        let filterElement = document.getElementById("repeated-drop-shadow");
+
+        function createDropShadowEffects(count, dx, dy) {
+            for (let i = 0; i < count; i++) {
+                var dropShadowElement = document.createElementNS(nameSpace, "feDropShadow");
+                dropShadowElement.setAttribute("dx", dx.toString());
+                dropShadowElement.setAttribute("dy", dy.toString());
+                dropShadowElement.setAttribute("stdDeviation", "0");
+                dropShadowElement.setAttribute("flood-color", "green");
+                filterElement.appendChild(dropShadowElement);
+            }
+        }
+
+        createDropShadowEffects(50, -2,  2);
+        createDropShadowEffects(50,  2, -2);
+        createDropShadowEffects(50,  2,  2);
+        createDropShadowEffects(50, -2, -2);
+    ]]></script>
+</svg>

--- a/Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm
@@ -48,6 +48,12 @@ void FilterImage::setCIImage(RetainPtr<CIImage>&& ciImage)
     m_ciImage = WTFMove(ciImage);
 }
 
+size_t FilterImage::memoryCostOfCIImage() const
+{
+    ASSERT(m_ciImage);
+    return FloatSize([m_ciImage.get() extent].size).area() * 4;
+}
+
 ImageBuffer* FilterImage::imageBufferFromCIImage()
 {
     ASSERT(m_ciImage);

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -87,6 +87,27 @@ FloatPoint FilterImage::mappedAbsolutePoint(const FloatPoint& point) const
     return FloatPoint(point - m_absoluteImageRect.location());
 }
 
+size_t FilterImage::memoryCost() const
+{
+    CheckedSize memoryCost;
+
+    if (m_imageBuffer)
+        memoryCost += m_imageBuffer->memoryCost();
+
+    if (m_unpremultipliedPixelBuffer)
+        memoryCost += m_unpremultipliedPixelBuffer->sizeInBytes();
+
+    if (m_premultipliedPixelBuffer)
+        memoryCost += m_premultipliedPixelBuffer->sizeInBytes();
+
+#if USE(CORE_IMAGE)
+    if (m_ciImage)
+        memoryCost += memoryCostOfCIImage();
+#endif
+
+    return memoryCost;
+}
+
 ImageBuffer* FilterImage::imageBuffer()
 {
 #if USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/filters/FilterImage.h
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.h
@@ -63,6 +63,8 @@ public:
     RenderingMode renderingMode() const { return m_renderingMode; }
     const DestinationColorSpace& colorSpace() const { return m_colorSpace; }
 
+    size_t memoryCost() const;
+
     WEBCORE_EXPORT ImageBuffer* imageBuffer();
     PixelBuffer* pixelBuffer(AlphaPremultiplication);
 
@@ -75,6 +77,7 @@ public:
 #if USE(CORE_IMAGE)
     RetainPtr<CIImage> ciImage() const { return m_ciImage; }
     void setCIImage(RetainPtr<CIImage>&&);
+    size_t memoryCostOfCIImage() const;
 #endif
 
 private:

--- a/Source/WebCore/platform/graphics/filters/FilterResults.h
+++ b/Source/WebCore/platform/graphics/filters/FilterResults.h
@@ -49,6 +49,9 @@ public:
     void clearEffectResult(FilterEffect&);
 
 private:
+    size_t memoryCost() const;
+    bool canCacheResult(const FilterImage&) const;
+
     HashMap<Ref<FilterEffect>, Ref<FilterImage>> m_results;
 
     // The value is a list of FilterEffects, whose FilterImages depend on the key FilterImage.

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -33,7 +33,6 @@
 
 namespace WebCore {
 
-static constexpr unsigned maxTotalNumberFilterEffects = 100;
 static constexpr unsigned maxCountChildNodes = 200;
 
 RefPtr<SVGFilter> SVGFilter::create(SVGFilterElement& filterElement, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
@@ -137,10 +136,10 @@ std::optional<std::tuple<SVGFilterExpression, FilterEffectVector>> SVGFilter::bu
         ASSERT(index != notFound);
         expression.append({ static_cast<unsigned>(index), level, effectGeometry(effect) });
     });
-    
-    if (!success || expression.size() > maxTotalNumberFilterEffects)
+
+    if (!success)
         return std::nullopt;
-    
+
     expression.reverse();
     expression.shrinkToFit();
     return { { WTFMove(expression), WTFMove(effects) } };


### PR DESCRIPTION
#### 93ee37d3063287725be2d54acbaf38fade9dd4d5
<pre>
[Filters] Limit the memory cost of FilterResults to 100MB
<a href="https://bugs.webkit.org/show_bug.cgi?id=245230">https://bugs.webkit.org/show_bug.cgi?id=245230</a>

Reviewed by Cameron McCormack.

The SVGFilter is completely discarded if the number of unique effects is more
than 100 or the number of children of any effect is more than 200. This is a
naive way to limit the memory used for caching the results because it does not
consider the size of the FilterImage. Moreover this limitation prevents displaying
the sourceImage itself. So we end up with a blank rectangle.

A better approach is to allow caching the FilterImages up to 100MB per filter.
All FilterImages which are generated after that limit will be discarded after
they are used. Any subsequent filter applying will regenerate these FilterImages.

* LayoutTests/svg/filters/repeated-drop-shadow-effects-expected.svg: Added.
* LayoutTests/svg/filters/repeated-drop-shadow-effects.svg: Added.
* Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm:
(WebCore::FilterImage::memoryCostOfCIImage const):
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::FilterImage::memoryCost const):
* Source/WebCore/platform/graphics/filters/FilterImage.h:
* Source/WebCore/platform/graphics/filters/FilterResults.cpp:
(WebCore::FilterResults::memoryCost const):
(WebCore::FilterResults::canCacheResult const):
(WebCore::FilterResults::setEffectResult):
* Source/WebCore/platform/graphics/filters/FilterResults.h:
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::buildExpression):

Canonical link: <a href="https://commits.webkit.org/264807@main">https://commits.webkit.org/264807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9566658832da91c38dd7578b9b4e49f035467218

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10309 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8665 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11533 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9823 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10466 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7122 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7916 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15442 "1 flakes 150 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8064 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11406 "8 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6973 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7815 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2108 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12027 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->