### PR TITLE
Add debug logging for process and page state

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include <wtf/MemoryPressureHandler.h>
 
+#include <atomic>
 #include <wtf/Logging.h>
 #include <wtf/MemoryFootprint.h>
 #include <wtf/NeverDestroyed.h>
@@ -45,14 +46,22 @@ static const double s_strictThresholdFraction = 0.5;
 static const std::optional<double> s_killThresholdFraction;
 static const Seconds s_pollInterval = 30_s;
 
+static std::atomic<bool> s_hasCreatedMemoryPressureHandler;
+
 MemoryPressureHandler& MemoryPressureHandler::singleton()
 {
     static LazyNeverDestroyed<MemoryPressureHandler> memoryPressureHandler;
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
         memoryPressureHandler.construct();
+        s_hasCreatedMemoryPressureHandler.store(true);
     });
     return memoryPressureHandler;
+}
+
+static MemoryPressureHandler* memoryPressureHandlerIfExists()
+{
+    return s_hasCreatedMemoryPressureHandler.load() ? &MemoryPressureHandler::singleton() : nullptr;
 }
 
 MemoryPressureHandler::MemoryPressureHandler()
@@ -246,6 +255,19 @@ void MemoryPressureHandler::setProcessState(WebsamProcessState state)
     if (m_processState == state)
         return;
     m_processState = state;
+}
+
+ASCIILiteral MemoryPressureHandler::processStateDescription()
+{
+    if (auto handler = memoryPressureHandlerIfExists()) {
+        switch (handler->processState()) {
+        case WebsamProcessState::Active:
+            return "active"_s;
+        case WebsamProcessState::Inactive:
+            return "inactive"_s;
+        }
+    }
+    return "unknown"_s;
 }
 
 void MemoryPressureHandler::beginSimulatedMemoryPressure()

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -223,6 +223,8 @@ public:
     WTF_EXPORT_PRIVATE void setProcessState(WebsamProcessState);
     WebsamProcessState processState() const { return m_processState; }
 
+    WTF_EXPORT_PRIVATE static ASCIILiteral processStateDescription();
+
     WTF_EXPORT_PRIVATE static void setPageCount(unsigned);
 
     void setShouldLogMemoryMemoryPressureEvents(bool shouldLog) { m_shouldLogMemoryMemoryPressureEvents = shouldLog; }

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -197,6 +197,7 @@ void logMemoryStatistics(LogMemoryStatisticsReason reason)
     const char* description = logMemoryStatisticsReasonDescription(reason);
 
     RELEASE_LOG(MemoryPressure, "WebKit memory usage statistics at time of %" PUBLIC_LOG_STRING ":", description);
+    RELEASE_LOG(MemoryPressure, "Websam state: %" PUBLIC_LOG_STRING, MemoryPressureHandler::processStateDescription().characters());
     auto stats = PerformanceLogging::memoryUsageStatistics(ShouldIncludeExpensiveComputations::Yes);
     for (auto& [key, val] : stats)
         RELEASE_LOG(MemoryPressure, "%" PUBLIC_LOG_STRING ": %zu", key, val);

--- a/Source/WebCore/platform/CountedUserActivity.h
+++ b/Source/WebCore/platform/CountedUserActivity.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 class CountedUserActivity {
 public:
-    explicit CountedUserActivity(const char* description)
+    explicit CountedUserActivity(ASCIILiteral description)
         : m_activity(description)
     {
     }

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -38,6 +38,7 @@ namespace WebCore {
 
 #define WEBCORE_LOG_CHANNELS(M) \
     M(Accessibility) \
+    M(ActivityState) \
     M(Animations) \
     M(AppHighlights) \
     M(ApplePay) \

--- a/Source/WebCore/platform/UserActivity.cpp
+++ b/Source/WebCore/platform/UserActivity.cpp
@@ -30,7 +30,7 @@ namespace WebCore {
 
 #if !HAVE(NS_ACTIVITY)
 
-UserActivity::Impl::Impl(const char*)
+UserActivity::Impl::Impl(ASCIILiteral)
 {
 }
 
@@ -44,7 +44,7 @@ void UserActivity::Impl::endActivity()
 
 #endif
 
-UserActivity::UserActivity(const char* description)
+UserActivity::UserActivity(ASCIILiteral description)
     : PAL::HysteresisActivity([this](PAL::HysteresisState state) { hysteresisUpdated(state); })
     , m_impl(description)
 {

--- a/Source/WebCore/platform/UserActivity.h
+++ b/Source/WebCore/platform/UserActivity.h
@@ -44,7 +44,7 @@ class UserActivity : public PAL::HysteresisActivity {
 public:
     class Impl {
     public:
-        explicit Impl(const char* description);
+        explicit Impl(ASCIILiteral description);
 
         void beginActivity();
         void endActivity();
@@ -56,7 +56,7 @@ public:
 #endif
     };
 
-    WEBCORE_EXPORT explicit UserActivity(const char* description);
+    WEBCORE_EXPORT explicit UserActivity(ASCIILiteral);
 
 private:
     void hysteresisUpdated(PAL::HysteresisState);

--- a/Source/WebCore/platform/mac/UserActivityMac.mm
+++ b/Source/WebCore/platform/mac/UserActivityMac.mm
@@ -26,18 +26,21 @@
 #import "config.h"
 #import "UserActivity.h"
 
+#import "Logging.h"
+
 namespace WebCore {
 
 #if HAVE(NS_ACTIVITY)
 
-UserActivity::Impl::Impl(const char* description)
-    : m_description([NSString stringWithUTF8String:description])
+UserActivity::Impl::Impl(ASCIILiteral descriptionLiteral)
+    : m_description(descriptionLiteral.createNSString())
 {
 }
 
 void UserActivity::Impl::beginActivity()
 {
     if (!m_activity) {
+        RELEASE_LOG(ActivityState, "%p - UserActivity::Impl::beginActivity: description=%" PUBLIC_LOG_STRING, this, [m_description UTF8String]);
         NSActivityOptions options = (NSActivityUserInitiatedAllowingIdleSystemSleep | NSActivityLatencyCritical) & ~(NSActivitySuddenTerminationDisabled | NSActivityAutomaticTerminationDisabled);
         m_activity = [[NSProcessInfo processInfo] beginActivityWithOptions:options reason:m_description.get()];
     }
@@ -45,6 +48,7 @@ void UserActivity::Impl::beginActivity()
 
 void UserActivity::Impl::endActivity()
 {
+    RELEASE_LOG(ActivityState, "%p - UserActivity::Impl::endActivity: description=%" PUBLIC_LOG_STRING, this, [m_description UTF8String]);
     [[NSProcessInfo processInfo] endActivity:m_activity.get()];
     m_activity.clear();
 }

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -109,7 +109,7 @@ DisplayCaptureSourceCocoa::DisplayCaptureSourceCocoa(UniqueRef<Capturer>&& captu
     : RealtimeMediaSource(RealtimeMediaSource::Type::Video, WTFMove(name), WTFMove(deviceID), WTFMove(hashSalt), pageIdentifier)
     , m_capturer(WTFMove(capturer))
     , m_timer(RunLoop::current(), this, &DisplayCaptureSourceCocoa::emitFrame)
-    , m_userActivity("App nap disabled for screen capture")
+    , m_userActivity("App nap disabled for screen capture"_s)
 {
     m_capturer->setObserver(this);
 }

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -50,7 +50,7 @@ using namespace WebCore;
 
 AuxiliaryProcess::AuxiliaryProcess()
     : m_terminationCounter(0)
-    , m_processSuppressionDisabled("Process Suppression Disabled by UIProcess")
+    , m_processSuppressionDisabled("Process Suppression Disabled by UIProcess"_s)
 {
 }
 

--- a/Source/WebKit/UIProcess/ProcessAssertion.cpp
+++ b/Source/WebKit/UIProcess/ProcessAssertion.cpp
@@ -26,12 +26,31 @@
 #include "config.h"
 #include "ProcessAssertion.h"
 
-#if !PLATFORM(COCOA) || !USE(RUNNINGBOARD)
-
 #include "WKBase.h"
 #include <wtf/RunLoop.h>
 
 namespace WebKit {
+
+ASCIILiteral processAssertionTypeDescription(ProcessAssertionType type)
+{
+    switch (type) {
+    case ProcessAssertionType::Suspended:
+        return "suspended"_s;
+    case ProcessAssertionType::Background:
+        return "background"_s;
+    case ProcessAssertionType::UnboundedNetworking:
+        return "unbounded-networking"_s;
+    case ProcessAssertionType::Foreground:
+        return "foreground"_s;
+    case ProcessAssertionType::MediaPlayback:
+        return "media-playback"_s;
+    case ProcessAssertionType::FinishTaskInterruptable:
+        return "finish-task-interruptible"_s;
+    }
+    return "unknown"_s;
+}
+
+#if !PLATFORM(COCOA) || !USE(RUNNINGBOARD)
 
 ProcessAssertion::ProcessAssertion(ProcessID pid, const String& reason, ProcessAssertionType assertionType)
     : m_assertionType(assertionType)
@@ -69,6 +88,7 @@ ProcessAndUIAssertion::ProcessAndUIAssertion(ProcessID pid, const String& reason
 
 ProcessAndUIAssertion::~ProcessAndUIAssertion() = default;
 
+#endif // !USE(RUNNINGBOARD)
+
 } // namespace WebKit
 
-#endif // !USE(RUNNINGBOARD)

--- a/Source/WebKit/UIProcess/ProcessAssertion.h
+++ b/Source/WebKit/UIProcess/ProcessAssertion.h
@@ -54,6 +54,8 @@ enum class ProcessAssertionType {
     FinishTaskInterruptable,
 };
 
+ASCIILiteral processAssertionTypeDescription(ProcessAssertionType);
+
 class ProcessAssertion : public ThreadSafeRefCounted<ProcessAssertion>, public CanMakeWeakPtr<ProcessAssertion, WeakPtrFactoryInitialization::Eager> {
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -39,6 +39,10 @@
 #define PROCESSTHROTTLER_RELEASE_LOG_WITH_PID(msg, ...) RELEASE_LOG(ProcessSuspension, "%p - [PID=%d] ProcessThrottler::" msg, this, ##__VA_ARGS__)
 #define PROCESSTHROTTLER_ACTIVITY_RELEASE_LOG(msg, ...) RELEASE_LOG(ProcessSuspension, "%p - [PID=%d, throttler=%p] ProcessThrottler::Activity::" msg, this, m_throttler->m_processIdentifier, m_throttler, ##__VA_ARGS__)
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebKit {
     
 enum UserObservablePageCounterType { };
@@ -134,6 +138,8 @@ public:
     void setAllowsActivities(bool);
 
 private:
+    friend WTF::TextStream& operator<<(WTF::TextStream&, const ProcessThrottler&);
+
     ProcessAssertionType expectedAssertionType();
     void updateAssertionIfNeeded();
     void updateAssertionTypeNow();
@@ -174,6 +180,8 @@ inline auto ProcessThrottler::backgroundActivity(ASCIILiteral name) -> UniqueRef
 {
     return makeUniqueRef<BackgroundActivity>(*this, name);
 }
+
+WTF::TextStream& operator<<(WTF::TextStream&, const ProcessThrottler&);
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -84,6 +84,7 @@
 #include <wtf/URL.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/TextStream.h>
 #include <wtf/text/WTFString.h>
 
 #if PLATFORM(COCOA)
@@ -2122,6 +2123,32 @@ void WebProcessProxy::permissionChanged(WebCore::PermissionName permissionName, 
 void WebProcessProxy::sendPermissionChanged(WebCore::PermissionName permissionName, const WebCore::SecurityOriginData& topOrigin)
 {
     send(Messages::WebPermissionController::permissionChanged(permissionName, topOrigin), 0);
+}
+
+TextStream& operator<<(TextStream& ts, const WebProcessProxy& process)
+{
+    auto appendCount = [&ts](unsigned value, ASCIILiteral description) {
+        if (value)
+            ts << ", " << description << ": " << value;
+    };
+    auto appendIf = [&ts](bool value, ASCIILiteral description) {
+        if (value)
+            ts << ", " << description;
+    };
+
+    ts << "pid: " << process.processIdentifier();
+    appendCount(process.pageCount(), "pages"_s);
+    appendCount(process.visiblePageCount(), "visible-pages"_s);
+    appendCount(process.provisionalPageCount(), "provisional-pages"_s);
+    appendCount(process.suspendedPageCount(), "suspended-pages"_s);
+    appendIf(process.isPrewarmed(), "prewarmed"_s);
+    appendIf(process.isInProcessCache(), "in-process-cache"_s);
+    appendIf(process.isRunningServiceWorkers(), "has-service-worker"_s);
+    appendIf(process.isRunningSharedWorkers(), "has-shared-worker"_s);
+    appendIf(process.isUnderMemoryPressure(), "under-memory-pressure"_s);
+    ts << ", " << process.throttler();
+
+    return ts;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -84,6 +84,10 @@ using FramesPerSecond = unsigned;
 using PlatformDisplayID = uint32_t;
 }
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebKit {
 
 class AudioSessionRoutingArbitratorProxy;
@@ -277,6 +281,7 @@ public:
     void setIsHoldingLockedFiles(bool);
 
     ProcessThrottler& throttler() final { return m_throttler; }
+    const ProcessThrottler& throttler() const { return m_throttler; }
 
     void isResponsive(CompletionHandler<void(bool isWebProcessResponsive)>&&);
     void isResponsiveWithLazyStop();
@@ -692,5 +697,7 @@ private:
     std::unique_ptr<WebPermissionControllerProxy> m_webPermissionController;
     bool m_isConnectedToHardwareConsole { true };
 };
+
+WTF::TextStream& operator<<(WTF::TextStream&, const WebProcessProxy&);
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -567,7 +567,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 #endif
     , m_layerVolatilityTimer(*this, &WebPage::layerVolatilityTimerFired)
     , m_activityState(parameters.activityState)
-    , m_userActivity("App nap disabled for page due to user activity")
+    , m_userActivity("App nap disabled for page due to user activity"_s)
     , m_userInterfaceLayoutDirection(parameters.userInterfaceLayoutDirection)
     , m_overrideContentSecurityPolicy { parameters.overrideContentSecurityPolicy }
     , m_cpuLimit(parameters.cpuLimit)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -663,6 +663,9 @@ public:
     bool isVisible() const { return m_activityState.contains(WebCore::ActivityState::IsVisible); }
     bool isVisibleOrOccluded() const { return m_activityState.contains(WebCore::ActivityState::IsVisibleOrOccluded); }
 
+    OptionSet<WebCore::ActivityState::Flag> activityState() const { return m_activityState; }
+    bool isThrottleable() const;
+
     LayerHostingMode layerHostingMode() const { return m_layerHostingMode; }
     void setLayerHostingMode(LayerHostingMode);
 
@@ -1416,7 +1419,6 @@ public:
     void updateIntrinsicContentSizeIfNeeded(const WebCore::IntSize&);
 
     void scheduleFullEditorStateUpdate();
-    bool isThrottleable() const;
 
     bool userIsInteracting() const { return m_userIsInteracting; }
     void setUserIsInteracting(bool userIsInteracting) { m_userIsInteracting = userIsInteracting; }

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -106,6 +106,7 @@
 #import <wtf/FileSystem.h>
 #import <wtf/Language.h>
 #import <wtf/LogInitialization.h>
+#import <wtf/MemoryPressureHandler.h>
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/cocoa/NSURLExtras.h>
@@ -624,6 +625,8 @@ RetainPtr<NSDictionary> WebProcess::additionalStateForDiagnosticReport() const
 
         return [NSDate dateWithTimeIntervalSince1970:page->loadCommitTime().secondsSinceEpoch().seconds()];
     });
+    auto websamStateDescription = MemoryPressureHandler::processStateDescription().createNSString();
+    [stateDictionary setObject:websamStateDescription.get() forKey:@"Websam State"];
 
     // Adding an empty array to the process state may provide an
     // indication of the existance of private sessions, which we'd like


### PR DESCRIPTION
#### 501a16433dc7ebb67f2de223f3dd4fbd2af4fe03
<pre>
Add debug logging for process and page state
<a href="https://bugs.webkit.org/show_bug.cgi?id=245244">https://bugs.webkit.org/show_bug.cgi?id=245244</a>
rdar://problem/99986063

Reviewed by Chris Dumez.

This adds notifyd callbacks that dump state about processes and pages. I&apos;ve found this useful
recently to debug issues with enabling App Nap and adopting RunningBoard on macOS. I also intend to
use this so that Membuster5 knows which domain is loaded into a given WebContent pid. This will
allow the benchmark to provide per-origin memory footprint data.

I also added logging to UserActivity as we&apos;ve needed this logging recently to debug and understand
issues with App Nap activation. As part of this I changed ProcessAssertion to take the description
string as a a string literal to make the logging marginally cheaper.

* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::MemoryPressureHandler::singleton):
(WTF::memoryPressureHandlerIfExists):
(WTF::MemoryPressureHandler::processStateDescription):
* Source/WTF/wtf/MemoryPressureHandler.h:
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::logMemoryStatistics):
* Source/WebCore/platform/CountedUserActivity.h:
(WebCore::CountedUserActivity::CountedUserActivity):
* Source/WebCore/platform/Logging.h:
* Source/WebCore/platform/UserActivity.cpp:
(WebCore::UserActivity::Impl::Impl):
(WebCore::UserActivity::UserActivity):
* Source/WebCore/platform/UserActivity.h:
* Source/WebCore/platform/mac/UserActivityMac.mm:
(WebCore::UserActivity::Impl::Impl):
(WebCore::UserActivity::Impl::beginActivity):
(WebCore::UserActivity::Impl::endActivity):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::DisplayCaptureSourceCocoa):
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::AuxiliaryProcess):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::logProcessPoolState):
(WebKit::WebProcessPool::platformInitialize):
* Source/WebKit/UIProcess/ProcessAssertion.cpp:
(WebKit::processAssertionTypeDescription):
* Source/WebKit/UIProcess/ProcessAssertion.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::activityNames):
(WebKit::operator&lt;&lt;):
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::operator&lt;&lt;):
* Source/WebKit/UIProcess/WebProcessProxy.h:
(WebKit::WebProcessProxy::throttler const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::activityState const):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::additionalStateForDiagnosticReport const):

Canonical link: <a href="https://commits.webkit.org/255239@main">https://commits.webkit.org/255239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31b812fb24828a996a0922ae68dc057b6dec8a0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101228 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161261 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/652 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29388 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83844 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97580 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/414 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78211 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27372 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81999 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70410 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82939 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35628 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16026 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77983 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33412 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17119 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26930 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3629 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39907 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80587 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36236 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17660 "Passed tests") | 
<!--EWS-Status-Bubble-End-->