### PR TITLE
'text-transform' causes incorrect text placement in SVG due to Whitespace

### DIFF
--- a/LayoutTests/svg/text/text-transform-whitespace-rules-expected.svg
+++ b/LayoutTests/svg/text/text-transform-whitespace-rules-expected.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<text>
+<tspan x="0" y="1em">WORD1
+</tspan><tspan x="0" dy="1em">WORD2</tspan>
+</text>
+</svg>

--- a/LayoutTests/svg/text/text-transform-whitespace-rules.svg
+++ b/LayoutTests/svg/text/text-transform-whitespace-rules.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<style>
+svg {
+    text-transform: uppercase;
+}
+</style>
+<text>
+    <tspan x="0" y="1em">WORD1
+    </tspan><tspan x="0" dy="1em">WORD2</tspan>
+</text>
+</svg>

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -78,8 +78,13 @@ RenderSVGInlineText::RenderSVGInlineText(Text& textNode, const String& string)
 {
 }
 
-String RenderSVGInlineText::originalText() const
+RefPtr<StringImpl> RenderSVGInlineText::originalText() const
 {
+    RefPtr<StringImpl> result = RenderText::originalText();
+    if (!result)
+        return nullptr;
+    return applySVGWhitespaceRules(result, style() && style()->whiteSpace() == PRE);
+    } else {
     return textNode().data();
 }
 
@@ -97,13 +102,8 @@ void RenderSVGInlineText::styleDidChange(StyleDifference diff, const RenderStyle
 
     bool newPreserves = style().whiteSpace() == WhiteSpace::Pre;
     bool oldPreserves = oldStyle ? oldStyle->whiteSpace() == WhiteSpace::Pre : false;
-    if (oldPreserves && !newPreserves) {
-        setText(applySVGWhitespaceRules(originalText(), false), true);
-        return;
-    }
-
-    if (!oldPreserves && newPreserves) {
-        setText(applySVGWhitespaceRules(originalText(), true), true);
+    if (oldPreserves != newPreserves) {
+        setText(originalText(), true);
         return;
     }
 

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.h
@@ -49,11 +49,12 @@ public:
     FloatRect floatLinesBoundingBox() const;
 
     SVGInlineTextBox* firstTextBox() const;
+    
+    RefPtr<StringImpl> originalText() const override;
 
 private:
     ASCIILiteral renderName() const override { return "RenderSVGInlineText"_s; }
 
-    String originalText() const override;
     void setRenderedText(const String&) override;
     void styleDidChange(StyleDifference, const RenderStyle*) override;
 


### PR DESCRIPTION
<pre>
'text-transform' causes incorrect text placement in SVG due to Whitespace

<a href="https://bugs.webkit.org/show_bug.cgi?id=245248">https://bugs.webkit.org/show_bug.cgi?id=245248</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=184655">https://src.chromium.org/viewvc/blink?view=revision&revision=184655</a>

Override originalText method in RenderSVGInlineText so that RenderText::transformText uses it and gets the text with SVG whitespace rules applied.

* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(RenderSVGInlineText::RenderSVGInlineText): Updated to manage WhiteSpace in Original Text
(RenderSVGInlineText::styleDidChange): Update to logic of oldPreserves and newPreserves and response originalText
* Source/WebCore/rendering/svg/RenderSVGInlineText.h: Change String to PassRefPtr and out of private
* LayoutTests/svg/text/text-transform-whitespace-rules.svg: Added Test
* LayoutTests/svg/text/text-transform-whitespace-rules-expected.svg: Added Test Expectations

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88db2272c2b984f58fbf4a7a2e54635e72708baf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89394 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33949 "Hash 88db2272 for PR 4403 does not build (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/20146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/98719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/155025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93402 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32455 "Hash 88db2272 for PR 4403 does not build (failure)") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/27953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/81748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/93132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95041 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/64/builds/32455 "Hash 88db2272 for PR 4403 does not build (failure)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/76308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/81748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/64/builds/32455 "Hash 88db2272 for PR 4403 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/20146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/81748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/30215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/20146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29951 "Hash 88db2272 for PR 4403 does not build (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/20146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33399 "Hash 88db2272 for PR 4403 does not build (failure)") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/76308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32108 "Hash 88db2272 for PR 4403 does not build (failure)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/20146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->