### PR TITLE
text-transform:uppercase in SVG causes misplaced letters

### DIFF
--- a/LayoutTests/svg/text/text-transform-whitespace-rules-expected.svg
+++ b/LayoutTests/svg/text/text-transform-whitespace-rules-expected.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<text>
+<tspan x="0" y="1em">WORD1
+</tspan><tspan x="0" dy="1em">WORD2</tspan>
+</text>
+</svg>

--- a/LayoutTests/svg/text/text-transform-whitespace-rules.svg
+++ b/LayoutTests/svg/text/text-transform-whitespace-rules.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<style>
+svg {
+    text-transform: uppercase;
+}
+</style>
+<text>
+<tspan x="0" y="1em">Word1 
+</tspan><tspan x="0" dy="1em">Word2</tspan>
+</text>
+</svg>


### PR DESCRIPTION
<pre>
text-transform:uppercase in SVG causes misplaced letters

<a href="https://bugs.webkit.org/show_bug.cgi?id=171664">https://bugs.webkit.org/show_bug.cgi?id=171664</a>

Reviewed by NOBODY (OOPS!).

Patch Authored by Simon Fraser and

Partial Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=184655">https://src.chromium.org/viewvc/blink?view=revision&revision=184655</a>

Override setRenderText method in RenderSVGInlineText so that text with SVG whitespace rules can be applied.

* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(RenderSVGInlineText::originalText): Update setRenderedText to applySVGWhitespace rules
* LayoutTests/svg/text/text-transform-whitespace-rules.svg: Test Added
* LayoutTests/svg/text/text-transform-whitespace-rules-expected.svg: Added Test Expectations

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef5ea4777daa3d48ce7906c8ef983a8e029e668b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93899 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3090 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24471 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103532 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163868 "Hash ef5ea477 for PR 4405 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97892 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3107 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31326 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86222 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99535 "Hash ef5ea477 for PR 4405 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99565 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/3107 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80323 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/86222 "Hash ef5ea477 for PR 4405 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/3107 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/24471 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/86222 "Hash ef5ea477 for PR 4405 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37720 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/24471 "Hash ef5ea477 for PR 4405 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35586 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/24471 "Hash ef5ea477 for PR 4405 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39463 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/80323 "Hash ef5ea477 for PR 4405 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41399 "Hash ef5ea477 for PR 4405 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/24471 "Hash ef5ea477 for PR 4405 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->