### PR TITLE
[Deprecation Reporting] Stub implementation

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -162,6 +162,7 @@
     "web-platform-tests/css/web-animations": "import", 
     "web-platform-tests/custom-elements": "import", 
     "web-platform-tests/custom-elements/v0": "skip", 
+    "web-platform-tests/deprecation-reporting": "import", 
     "web-platform-tests/docs": "import", 
     "web-platform-tests/dom": "import", 
     "web-platform-tests/dom/events": "import", 

--- a/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/deprecation-reporting/

--- a/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any-expected.txt
@@ -1,0 +1,17 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS DeprecationReportBody interface: existence and properties of interface object
+PASS DeprecationReportBody interface object length
+PASS DeprecationReportBody interface object name
+PASS DeprecationReportBody interface: existence and properties of interface prototype object
+PASS DeprecationReportBody interface: existence and properties of interface prototype object's "constructor" property
+PASS DeprecationReportBody interface: existence and properties of interface prototype object's @@unscopables property
+PASS DeprecationReportBody interface: operation toJSON()
+PASS DeprecationReportBody interface: attribute id
+PASS DeprecationReportBody interface: attribute anticipatedRemoval
+PASS DeprecationReportBody interface: attribute message
+PASS DeprecationReportBody interface: attribute sourceFile
+PASS DeprecationReportBody interface: attribute lineNumber
+PASS DeprecationReportBody interface: attribute columnNumber
+

--- a/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.js
@@ -1,0 +1,14 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+'use strict';
+
+idl_test(
+  ['deprecation-reporting'],
+  ['reporting'],
+  idl_array => {
+    idl_array.add_objects({
+      // TODO: objects
+    });
+  }
+);

--- a/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.worker-expected.txt
@@ -1,0 +1,17 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS DeprecationReportBody interface: existence and properties of interface object
+PASS DeprecationReportBody interface object length
+PASS DeprecationReportBody interface object name
+PASS DeprecationReportBody interface: existence and properties of interface prototype object
+PASS DeprecationReportBody interface: existence and properties of interface prototype object's "constructor" property
+PASS DeprecationReportBody interface: existence and properties of interface prototype object's @@unscopables property
+PASS DeprecationReportBody interface: operation toJSON()
+PASS DeprecationReportBody interface: attribute id
+PASS DeprecationReportBody interface: attribute anticipatedRemoval
+PASS DeprecationReportBody interface: attribute message
+PASS DeprecationReportBody interface: attribute sourceFile
+PASS DeprecationReportBody interface: attribute lineNumber
+PASS DeprecationReportBody interface: attribute columnNumber
+

--- a/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/w3c-import.log
@@ -1,0 +1,18 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.js

--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -581,6 +581,18 @@ DefaultARIAForCustomElementsEnabled:
     WebCore:
       default: false
 
+DeprecationReportingEnabled:
+  type: bool
+  humanReadableName: "Deprecation Reporting"
+  humanReadableDescription: "Enable Deprecation Reporting"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 DialogElementEnabled:
   type: bool
   humanReadableName: "Dialog Element"

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -552,6 +552,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/remoteplayback/RemotePlayback.idl
     Modules/remoteplayback/RemotePlaybackAvailabilityCallback.idl
 
+    Modules/reporting/DeprecationReportBody.idl
     Modules/reporting/Report.idl
     Modules/reporting/ReportBody.idl
     Modules/reporting/ReportingObserver.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -608,6 +608,7 @@ $(PROJECT_DIR)/Modules/push-api/ServiceWorkerRegistration+PushAPI.idl
 $(PROJECT_DIR)/Modules/remoteplayback/HTMLMediaElement+RemotePlayback.idl
 $(PROJECT_DIR)/Modules/remoteplayback/RemotePlayback.idl
 $(PROJECT_DIR)/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.idl
+$(PROJECT_DIR)/Modules/reporting/DeprecationReportBody.idl
 $(PROJECT_DIR)/Modules/reporting/Report.idl
 $(PROJECT_DIR)/Modules/reporting/ReportBody.idl
 $(PROJECT_DIR)/Modules/reporting/ReportingObserver.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -730,6 +730,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeprecatedCSSOMValue.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeprecatedCSSOMValue.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeprecatedCSSOMValueList.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeprecatedCSSOMValueList.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeprecationReportBody.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeprecationReportBody.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceMotionEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceMotionEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationEvent.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -530,6 +530,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/remoteplayback/HTMLMediaElement+RemotePlayback.idl \
     $(WebCore)/Modules/remoteplayback/RemotePlayback.idl \
     $(WebCore)/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.idl \
+    $(WebCore)/Modules/reporting/DeprecationReportBody.idl \
     $(WebCore)/Modules/reporting/Report.idl \
     $(WebCore)/Modules/reporting/ReportBody.idl \
     $(WebCore)/Modules/reporting/ReportingObserver.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -325,6 +325,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/push-api/PushSubscriptionData.h
     Modules/push-api/PushSubscriptionIdentifier.h
 
+    Modules/reporting/DeprecationReportBody.h
     Modules/reporting/Report.h
     Modules/reporting/ReportBody.h
     Modules/reporting/ReportingClient.h

--- a/Source/WebCore/Modules/reporting/DeprecationReportBody.cpp
+++ b/Source/WebCore/Modules/reporting/DeprecationReportBody.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DeprecationReportBody.h"
+
+#include "DateComponents.h"
+#include "FormData.h"
+#include <wtf/IsoMallocInlines.h>
+#include <wtf/JSONValues.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(DeprecationReportBody);
+
+const AtomString& DeprecationReportBody::deprecationReportType()
+{
+    static NeverDestroyed<AtomString> reportType { "deprecation"_s };
+    return reportType;
+}
+
+DeprecationReportBody::DeprecationReportBody(String&& id, WallTime anticipatedRemoval, String&& message, String&& sourceFile, std::optional<unsigned> lineNumber, std::optional<unsigned> columnNumber)
+    : ReportBody(ViolationReportType::Deprecation)
+    , m_id(WTFMove(id))
+    , m_anticipatedRemoval(anticipatedRemoval)
+    , m_message(WTFMove(message))
+    , m_sourceFile(WTFMove(sourceFile))
+    , m_lineNumber(lineNumber)
+    , m_columnNumber(columnNumber)
+{
+}
+
+Ref<DeprecationReportBody> DeprecationReportBody::create(String&& id, WallTime anticipatedRemoval, String&& message, String&& sourceFile, std::optional<unsigned> lineNumber, std::optional<unsigned> columnNumber)
+{
+    return adoptRef(*new DeprecationReportBody(WTFMove(id), anticipatedRemoval, WTFMove(message), WTFMove(sourceFile), lineNumber, columnNumber));
+}
+
+const AtomString& DeprecationReportBody::type() const
+{
+    return deprecationReportType();
+}
+
+Ref<FormData> DeprecationReportBody::createReportFormDataForViolation() const
+{
+    // https://wicg.github.io/deprecation-reporting/#deprecation-report
+    // Suitable for network endpoints.
+    auto reportBody = JSON::Object::create();
+    reportBody->setString("id"_s, m_id);
+    reportBody->setString("anticipatedRemoval"_s, DateComponents::fromMillisecondsSinceEpochForDate(m_anticipatedRemoval.secondsSinceEpoch().milliseconds())->toString());
+    reportBody->setString("message"_s, m_message);
+    if (!m_sourceFile.isNull()) {
+        reportBody->setString("sourceFile"_s, m_sourceFile);
+        reportBody->setInteger("lineNumber"_s, m_lineNumber.value_or(0));
+        reportBody->setInteger("columnNumber"_s, m_columnNumber.value_or(0));
+    }
+
+    auto reportObject = JSON::Object::create();
+    reportObject->setString("type"_s, deprecationReportType());
+    reportObject->setString("url"_s, ""_s);
+    reportObject->setObject("body"_s, WTFMove(reportBody));
+
+    return FormData::create(reportObject->toJSONString().utf8());
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/reporting/DeprecationReportBody.h
+++ b/Source/WebCore/Modules/reporting/DeprecationReportBody.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ReportBody.h"
+#include "ViolationReportType.h"
+#include <wtf/IsoMalloc.h>
+#include <wtf/WallTime.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class FormData;
+
+class DeprecationReportBody final : public ReportBody {
+    WTF_MAKE_ISO_ALLOCATED(DeprecationReportBody);
+public:
+    WEBCORE_EXPORT static Ref<DeprecationReportBody> create(String&& id, WallTime anticipatedRemoval, String&& message, String&& sourceFile, std::optional<unsigned> lineNumber, std::optional<unsigned> columnNumber);
+
+    const String& id() const { return m_id; };
+    WallTime anticipatedRemoval() const { return m_anticipatedRemoval; }
+    const String& message() const { return m_message; }
+    const String& sourceFile() const { return m_sourceFile; }
+    std::optional<unsigned> lineNumber() const { return m_lineNumber; }
+    std::optional<unsigned> columnNumber() const { return m_columnNumber; }
+
+    static const AtomString& deprecationReportType();
+
+    WEBCORE_EXPORT Ref<FormData> createReportFormDataForViolation() const;
+
+    template<typename Encoder> void encode(Encoder&) const;
+    template<typename Decoder> static std::optional<RefPtr<WebCore::DeprecationReportBody>> decode(Decoder&);
+
+private:
+    DeprecationReportBody(String&& id, WallTime anticipatedRemoval, String&& message, String&& sourceFile, std::optional<unsigned> lineNumber, std::optional<unsigned> columnNumber);
+
+    const AtomString& type() const final;
+
+    const String m_id;
+    const WallTime m_anticipatedRemoval;
+    const String m_message;
+    const String m_sourceFile;
+    const std::optional<unsigned> m_lineNumber;
+    const std::optional<unsigned> m_columnNumber;
+};
+
+template<typename Encoder>
+void DeprecationReportBody::encode(Encoder& encoder) const
+{
+    encoder << m_id << m_anticipatedRemoval << m_message << m_sourceFile << m_lineNumber << m_columnNumber;
+}
+
+template<typename Decoder>
+std::optional<RefPtr<DeprecationReportBody>> DeprecationReportBody::decode(Decoder& decoder)
+{
+    std::optional<String> reportId;
+    decoder >> reportId;
+    if (!reportId)
+        return std::nullopt;
+
+    std::optional<WallTime> anticipatedRemoval;
+    decoder >> anticipatedRemoval;
+    if (!anticipatedRemoval)
+        return std::nullopt;
+
+    std::optional<String> message;
+    decoder >> message;
+    if (!message)
+        return std::nullopt;
+
+    std::optional<String> sourceFile;
+    decoder >> sourceFile;
+    if (!sourceFile)
+        return std::nullopt;
+
+    std::optional<std::optional<unsigned>> lineNumber;
+    decoder >> lineNumber;
+    if (!lineNumber)
+        return std::nullopt;
+
+    std::optional<std::optional<unsigned>> columnNumber;
+    decoder >> columnNumber;
+    if (!columnNumber)
+        return std::nullopt;
+
+    return DeprecationReportBody::create(WTFMove(*reportId), *anticipatedRemoval, WTFMove(*message), WTFMove(*sourceFile), WTFMove(*lineNumber), WTFMove(*columnNumber));
+}
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::DeprecationReportBody)
+    static bool isType(const WebCore::ReportBody& reportBody) { return reportBody.reportBodyType() == WebCore::ViolationReportType::Deprecation; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/reporting/DeprecationReportBody.idl
+++ b/Source/WebCore/Modules/reporting/DeprecationReportBody.idl
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+// https://wicg.github.io/deprecation-reporting/
+[
+    EnabledBySetting=DeprecationReportingEnabled,
+    Exposed=(Window,Worker),
+] interface DeprecationReportBody : ReportBody {
+    readonly attribute DOMString id;
+    readonly attribute Date? anticipatedRemoval;
+    readonly attribute DOMString message;
+    readonly attribute DOMString? sourceFile;
+    readonly attribute unsigned long? lineNumber;
+    readonly attribute unsigned long? columnNumber;
+
+    [Default] object toJSON();
+};

--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -46,6 +46,7 @@ static bool isVisibleToReportingObservers(const AtomString& type)
     static NeverDestroyed<Vector<AtomString>> visibleTypes(std::initializer_list<AtomString> {
         AtomString { "csp-violation"_s },
         AtomString { "coep"_s },
+        AtomString { "deprecation"_s },
         AtomString { "test"_s },
     });
     return visibleTypes->contains(type);

--- a/Source/WebCore/Modules/reporting/TestReportBody.h
+++ b/Source/WebCore/Modules/reporting/TestReportBody.h
@@ -34,9 +34,6 @@ namespace WebCore {
 
 class FormData;
 
-struct CSPInfo;
-struct SecurityPolicyViolationEventInit;
-
 class WEBCORE_EXPORT TestReportBody final : public ReportBody {
     WTF_MAKE_ISO_ALLOCATED(TestReportBody);
 public:

--- a/Source/WebCore/Modules/reporting/ViolationReportType.h
+++ b/Source/WebCore/Modules/reporting/ViolationReportType.h
@@ -32,6 +32,7 @@ enum class ViolationReportType : uint8_t {
     CORPViolation, // https://fetch.spec.whatwg.org/#queue-a-cross-origin-embedder-policy-corp-violation-report
     ContentSecurityPolicy,
     CrossOriginOpenerPolicy,
+    Deprecation, // https://wicg.github.io/deprecation-reporting/
     StandardReportingAPIViolation, // https://www.w3.org/TR/reporting/#try-delivery
     Test, // https://www.w3.org/TR/reporting-1/#generate-test-report-command
     // More to come
@@ -48,6 +49,7 @@ template<> struct EnumTraits<WebCore::ViolationReportType> {
     WebCore::ViolationReportType::CORPViolation,
     WebCore::ViolationReportType::ContentSecurityPolicy,
     WebCore::ViolationReportType::CrossOriginOpenerPolicy,
+    WebCore::ViolationReportType::Deprecation,
     WebCore::ViolationReportType::StandardReportingAPIViolation,
     WebCore::ViolationReportType::Test
     >;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -279,6 +279,7 @@ Modules/push-api/PushSubscriptionOptions.cpp
 Modules/push-api/PushManager.cpp
 Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp
 Modules/remoteplayback/RemotePlayback.cpp
+Modules/reporting/DeprecationReportBody.cpp
 Modules/reporting/Report.cpp
 Modules/reporting/ReportBody.cpp
 Modules/reporting/ReportingObserver.cpp
@@ -3163,6 +3164,7 @@ JSDeprecatedCSSOMRGBColor.cpp
 JSDeprecatedCSSOMRect.cpp
 JSDeprecatedCSSOMValue.cpp
 JSDeprecatedCSSOMValueList.cpp
+JSDeprecationReportBody.cpp
 JSDeviceMotionEvent.cpp
 JSDeviceOrientationEvent.cpp
 JSDeviceOrientationOrMotionPermissionState.cpp

--- a/Source/WebCore/bindings/js/JSReportBodyCustom.cpp
+++ b/Source/WebCore/bindings/js/JSReportBodyCustom.cpp
@@ -29,10 +29,12 @@
 #include "COEPInheritenceViolationReportBody.h"
 #include "CORPViolationReportBody.h"
 #include "CSPViolationReportBody.h"
+#include "DeprecationReportBody.h"
 #include "JSCOEPInheritenceViolationReportBody.h"
 #include "JSCORPViolationReportBody.h"
 #include "JSCSPViolationReportBody.h"
 #include "JSDOMBinding.h"
+#include "JSDeprecationReportBody.h"
 #include "JSTestReportBody.h"
 #include "ReportBody.h"
 #include "TestReportBody.h"
@@ -49,6 +51,8 @@ JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, 
         return createWrapper<COEPInheritenceViolationReportBody>(globalObject, WTFMove(reportBody));
     if (is<CORPViolationReportBody>(reportBody))
         return createWrapper<CORPViolationReportBody>(globalObject, WTFMove(reportBody));
+    if (is<DeprecationReportBody>(reportBody))
+        return createWrapper<DeprecationReportBody>(globalObject, WTFMove(reportBody));
     if (is<TestReportBody>(reportBody))
         return createWrapper<TestReportBody>(globalObject, WTFMove(reportBody));
     return createWrapper<ReportBody>(globalObject, WTFMove(reportBody));

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -159,6 +159,7 @@ namespace WebCore {
     macro(DecompressionStreamDecoder) \
     macro(DecompressionStreamTransform) \
     macro(DelayNode) \
+    macro(DeprecationReportBody) \
     macro(DocumentTimeline) \
     macro(DynamicsCompressorNode) \
     macro(ExtendableEvent) \

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -180,6 +180,7 @@ void PingLoader::sendViolationReport(Frame& frame, const URL& reportURL, Ref<For
     case ViolationReportType::COEPInheritenceViolation:
     case ViolationReportType::CORPViolation:
     case ViolationReportType::CrossOriginOpenerPolicy:
+    case ViolationReportType::Deprecation:
     case ViolationReportType::StandardReportingAPIViolation:
     case ViolationReportType::Test:
         request.setHTTPContentType("application/reports+json"_s);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -49,6 +49,7 @@
 #include <WebCore/DOMCacheEngine.h>
 #include <WebCore/DatabaseDetails.h>
 #include <WebCore/DecomposedGlyphs.h>
+#include <WebCore/DeprecationReportBody.h>
 #include <WebCore/DictationAlternative.h>
 #include <WebCore/DictionaryPopupInfo.h>
 #include <WebCore/DisplayListItems.h>
@@ -2657,6 +2658,9 @@ void ArgumentCoder<RefPtr<WebCore::ReportBody>>::encode(Encoder& encoder, const 
     case ViolationReportType::CORPViolation:
         downcast<CORPViolationReportBody>(reportBody.get())->encode(encoder);
         return;
+    case ViolationReportType::Deprecation:
+        downcast<DeprecationReportBody>(reportBody.get())->encode(encoder);
+        return;
     case ViolationReportType::Test:
         downcast<TestReportBody>(reportBody.get())->encode(encoder);
         return;
@@ -2691,6 +2695,8 @@ std::optional<RefPtr<WebCore::ReportBody>> ArgumentCoder<RefPtr<WebCore::ReportB
         return COEPInheritenceViolationReportBody::decode(decoder);
     case ViolationReportType::CORPViolation:
         return CORPViolationReportBody::decode(decoder);
+    case ViolationReportType::Deprecation:
+        return DeprecationReportBody::decode(decoder);
     case ViolationReportType::Test:
         return TestReportBody::decode(decoder);
     case ViolationReportType::CrossOriginOpenerPolicy:


### PR DESCRIPTION
#### a01206bce956b19baa818f03a3f316dcdcba881a
<pre>
[Deprecation Reporting] Stub implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=245245">https://bugs.webkit.org/show_bug.cgi?id=245245</a>
&lt;rdar://problem/99988574&gt;

Reviewed by Chris Dumez.

Import the Web Platform Tests for Deprecation Reporting, create a new Experimental Feature to represent
the work, and provide a stub implementation of the report

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/META.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/idlharness.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/deprecation-reporting/w3c-import.log: Added.
* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/reporting/DeprecationReportBody.cpp: Added.
(WebCore::DeprecationReportBody::deprecationReportType):
(WebCore::DeprecationReportBody::DeprecationReportBody):
(WebCore::DeprecationReportBody::create):
(WebCore::DeprecationReportBody::type const):
(WebCore::DeprecationReportBody::id const):
(WebCore::DeprecationReportBody::anticipatedRemoval const):
(WebCore::DeprecationReportBody::message const):
(WebCore::DeprecationReportBody::sourceFile const):
(WebCore::DeprecationReportBody::lineNumber const):
(WebCore::DeprecationReportBody::columnNumber const):
(WebCore::DeprecationReportBody::createReportFormDataForViolation const):
* Source/WebCore/Modules/reporting/DeprecationReportBody.h: Copied from Source/WebCore/Modules/reporting/TestReportBody.h.
(WebCore::DeprecationReportBody::encode const):
(WebCore::DeprecationReportBody::decode):
(isType):
* Source/WebCore/Modules/reporting/DeprecationReportBody.idl: Copied from Source/WebCore/Modules/reporting/ViolationReportType.h.
* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
(WebCore::isVisibleToReportingObservers):
* Source/WebCore/Modules/reporting/TestReportBody.h:
* Source/WebCore/Modules/reporting/ViolationReportType.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSReportBodyCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::sendViolationReport):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ReportBody&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ReportBody&gt;&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/254634@main">https://commits.webkit.org/254634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f13c35e3d9c83f36cd7ea43c9dbf347c0bd6a9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98934 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155572 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32687 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28164 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93343 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25970 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76500 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25920 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80730 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68913 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81308 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30443 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14811 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76177 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30192 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15743 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26420 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3252 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38688 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/78743 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32350 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34834 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17265 "Passed tests") | 
<!--EWS-Status-Bubble-End-->