### PR TITLE
[GPUP] Guard ANGLE specific code

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -44,8 +44,10 @@
 #include <WebCore/GraphicsContextGLCocoa.h>
 #elif USE(LIBGBM)
 #include <WebCore/GraphicsContextGLGBM.h>
-#else
+#elif USE(ANGLE)
 #include <WebCore/GraphicsContextGLTextureMapperANGLE.h>
+#else
+#include <WebCore/GraphicsContextGLTextureMapper.h>
 #endif
 
 #if PLATFORM(MAC)
@@ -153,8 +155,10 @@ protected:
     using GCGLContext = WebCore::GraphicsContextGLCocoa;
 #elif USE(LIBGBM)
     using GCGLContext = WebCore::GraphicsContextGLGBM;
-#else
+#elif USE(ANGLE)
     using GCGLContext = WebCore::GraphicsContextGLTextureMapperANGLE;
+#else
+    using GCGLContext = WebCore::GraphicsContextGLTextureMapper;
 #endif
     RefPtr<GCGLContext> m_context WTF_GUARDED_BY_CAPABILITY(workQueue());
     GraphicsContextGLIdentifier m_graphicsContextGLIdentifier;


### PR DESCRIPTION
#### 2c99942ca250e128b30efa035b58cf40e741c765
<pre>
[GPUP] Guard ANGLE specific code
<a href="https://bugs.webkit.org/show_bug.cgi?id=245259">https://bugs.webkit.org/show_bug.cgi?id=245259</a>

Reviewed by NOBODY (OOPS!).

Make sure all ANGLE specific code has a `USE(ANGLE)` check. Use
`GraphicsContextGLTextureMapper` as the default case for a TextureMapper
without ANGLE.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/ScopedWebGLRenderingResourcesRequest.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c99942ca250e128b30efa035b58cf40e741c765

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98746 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32485 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28173 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81779 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93158 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25800 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76332 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25726 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68713 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30244 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14657 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29982 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15598 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38558 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34689 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->