### PR TITLE
[RISCV64] Build fix in RISCV64Disassembler

### DIFF
--- a/Source/JavaScriptCore/disassembler/RISCV64Disassembler.cpp
+++ b/Source/JavaScriptCore/disassembler/RISCV64Disassembler.cpp
@@ -635,7 +635,7 @@ CString disassembleOpcode(uint32_t *pc)
 
 bool tryToDisassemble(const CodePtr<DisassemblyPtrTag>& codePtr, size_t size, void*, void*, const char* prefix, PrintStream& out)
 {
-    uint32_t* currentPC = codePtr.untaggedExecutableAddress<uint32_t*>();
+    uint32_t* currentPC = codePtr.untaggedPtr<uint32_t*>();
     size_t byteCount = size;
 
     while (byteCount) {


### PR DESCRIPTION
#### 6a3ee1f889e94f6e03de924b18238184faeb56e3
<pre>
[RISCV64] Build fix in RISCV64Disassembler
<a href="https://bugs.webkit.org/show_bug.cgi?id=245274">https://bugs.webkit.org/show_bug.cgi?id=245274</a>

Unreviewed build fix in RISCV64Disassembler, adjusting to the adoption of WTF::CodePtr.

* Source/JavaScriptCore/disassembler/RISCV64Disassembler.cpp:
(JSC::tryToDisassemble):

Canonical link: <a href="https://commits.webkit.org/254553@main">https://commits.webkit.org/254553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbe0bcfe2b64a17476fdf4503fcf0c06deace3a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34003 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/20190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98769 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/155075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32508 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81806 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93181 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95096 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/25821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/76350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/25752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/80697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/20190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/68740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81137 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30267 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/20190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74947 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30005 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/20190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/26379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33452 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/76350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/77815 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1339 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32162 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/20190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/17218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->