### PR TITLE
[run-webkit-tests] Add performance signposts

### DIFF
--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1068,6 +1068,8 @@ static void runTestingServerLoop()
     char filenameBuffer[2048];
     unsigned testCount = 0;
     while (fgets(filenameBuffer, sizeof(filenameBuffer), stdin)) {
+        WTR::Signpost::enabled = false;
+
         char *newLineCharacter = strchr(filenameBuffer, '\n');
         if (newLineCharacter)
             *newLineCharacter = '\0';

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
@@ -108,7 +108,11 @@ class SingleTestRunner(object):
         image_hash = None
         if self._should_fetch_expected_checksum():
             image_hash = self._port.expected_checksum(self._test_name, device_type=self._driver.host.device_type)
-        return DriverInput(self._test_name, self._timeout, image_hash, self._should_run_pixel_test, self._should_dump_jsconsolelog_in_stderr)
+        return DriverInput(
+            self._test_name, self._timeout, image_hash,
+            self._should_run_pixel_test, self._should_dump_jsconsolelog_in_stderr,
+            signposts=self._options.signposts,
+        )
 
     def run(self):
         self_comparison_header = self._port.get_option('self_compare_with_header')
@@ -355,7 +359,7 @@ class SingleTestRunner(object):
         for expectation, reference_filename in putAllMismatchBeforeMatch(self._reference_files):
             reference_test_name = self._port.relative_test_filename(reference_filename)
             reference_test_names.append(reference_test_name)
-            reference_output = self._driver.run_test(DriverInput(reference_test_name, self._timeout, None, should_run_pixel_test=True), self._stop_when_done)
+            reference_output = self._driver.run_test(DriverInput(reference_test_name, self._timeout, None, should_run_pixel_test=True, signposts=self._options.signposts), self._stop_when_done)
             test_result = self._compare_output_with_reference(reference_output, test_output, reference_filename, expectation == '!=')
 
             if (expectation == '!=' and test_result.failures) or (expectation == '==' and not test_result.failures):

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -312,6 +312,8 @@ def parse_args(args):
         optparse.make_option("--world-leaks", action="store_true", default=False, help="Check for world leaks (currently, only documents). Differs from --leaks in that this uses internal instrumentation, rather than external tools."),
         optparse.make_option("--accessibility-isolated-tree", action="store_true", default=False, help="Runs tests in accessibility isolated tree mode."),
         optparse.make_option("--allowed-host", type="string", action="append", default=[], help="If specified, tests are allowed to make requests to the specified hostname."),
+        optparse.make_option("--signposts", action="store_true", default=False,
+            help="Gather data from performance signposts in the test-runner."),
     ]))
 
     option_group_definitions.append(("iOS Options", [

--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -36,7 +36,7 @@ import time
 import os
 
 from collections import defaultdict
-from webkitcorepy import string_utils
+from webkitcorepy import string_utils, TaskPool
 
 from webkitpy.common.system import path
 from webkitpy.common.system.profiler import ProfilerFactory
@@ -45,8 +45,31 @@ from webkitpy.common.system.profiler import ProfilerFactory
 _log = logging.getLogger(__name__)
 
 
+class PerformanceSignposts(TaskPool.Message):
+    signposts = dict(total=0)
+
+    class Measure(object):
+        def __init__(self, name):
+            self.name = name
+            self.start = time.time()
+
+        def __enter__(self):
+            self.start = time.time()
+
+        def __exit__(self, *args, **kwargs):
+            PerformanceSignposts.signposts[self.name] = PerformanceSignposts.signposts.get(self.name, 0) + time.time() - self.start
+
+    def __init__(self):
+        super(PerformanceSignposts, self).__init__()
+        self.data = self.signposts
+
+    def __call__(self, caller):
+        for key, value in self.data.items():
+            self.signposts[key] = self.signposts.get(key, 0) + value
+
+
 class DriverInput(object):
-    def __init__(self, test_name, timeout, image_hash, should_run_pixel_test, should_dump_jsconsolelog_in_stderr=None, args=None, self_comparison_header=None, force_dump_pixels=False):
+    def __init__(self, test_name, timeout, image_hash, should_run_pixel_test, should_dump_jsconsolelog_in_stderr=None, args=None, self_comparison_header=None, force_dump_pixels=False, signposts=False):
         self.test_name = test_name
         self.timeout = timeout  # in ms
         self.image_hash = image_hash
@@ -55,6 +78,7 @@ class DriverInput(object):
         self.args = args or []
         self.self_comparison_header = self_comparison_header
         self.force_dump_pixels = force_dump_pixels
+        self.signposts = signposts
 
     def __repr__(self):
         return "DriverInput(test_name='{}', timeout={}, image_hash={}, should_run_pixel_test={}, should_dump_jsconsolelog_in_stderr={}, self_comparison_header={}, force_dump_pixels={}'".format(self.test_name, self.timeout, self.image_hash, self.should_run_pixel_test, self.should_dump_jsconsolelog_in_stderr, self.self_comparison_header, self.force_dump_pixels)
@@ -146,6 +170,12 @@ class DriverPostTestOutput(object):
 
 class Driver(object):
     """object for running test(s) using DumpRenderTree/WebKitTestRunner."""
+
+    HTTP_DIR = "http/tests/"
+    HTTP_LOCAL_DIR = "http/tests/local/"
+    WEBKIT_SPECIFIC_WEB_PLATFORM_TEST_SUBDIR = "http/wpt/"
+    WEBKIT_WEB_PLATFORM_TEST_SERVER_ROUTE = "WebKit/"
+    SIGNPOST_RE = re.compile(br'^SIGNPOST (?P<name>\S+) (?P<time>\d+\.\d+)$')
 
     def __init__(self, port, worker_number, pixel_tests, no_timeout=False):
         """Initialize a Driver to subsequently run tests.
@@ -335,11 +365,6 @@ class Driver(object):
         if self._port.get_option('wrapper'):
             return shlex.split(self._port.get_option('wrapper')) + wrapper_arguments
         return wrapper_arguments
-
-    HTTP_DIR = "http/tests/"
-    HTTP_LOCAL_DIR = "http/tests/local/"
-    WEBKIT_SPECIFIC_WEB_PLATFORM_TEST_SUBDIR = "http/wpt/"
-    WEBKIT_WEB_PLATFORM_TEST_SERVER_ROUTE = "WebKit/"
 
     def is_http_test(self, test_name):
         return test_name.startswith(self.HTTP_DIR) and not test_name.startswith(self.HTTP_LOCAL_DIR)
@@ -625,6 +650,17 @@ class Driver(object):
             return True
         return self.has_crashed()
 
+    @classmethod
+    def _extract_signpost(cls, error_line):
+
+        match = cls.SIGNPOST_RE.match(error_line)
+        if not match:
+            return False
+        name = string_utils.decode(match.group('name'), target_type=str)
+        tm = float(match.group('time'))
+        PerformanceSignposts.signposts[name] = PerformanceSignposts.signposts.get(name, 0) + tm
+        return True
+
     def _command_from_driver_input(self, driver_input):
         # FIXME: performance tests pass in full URLs instead of test names.
         if driver_input.test_name.startswith('http://') or driver_input.test_name.startswith('https://')  or driver_input.test_name == ('about:blank'):
@@ -652,6 +688,8 @@ class Driver(object):
             command += "'--self-compare-with-header'%s" % driver_input.self_comparison_header
         if driver_input.force_dump_pixels:
             command += "'--force-dump-pixels"
+        if driver_input.signposts:
+            command += "'--signposts'"
 
         # --pixel-test must be the last argument, because the hash is optional,
         # and any argument put in its place will be incorrectly consumed as the hash.
@@ -766,7 +804,7 @@ class Driver(object):
                     deadline += 10 * 60 * 1000
                 if asan_violation_detected:
                     self._crash_report_from_driver += string_utils.decode(err_line, target_type=str)
-                else:
+                elif not self._extract_signpost(err_line):
                     self.error_from_test += string_utils.decode(err_line, target_type=str)
 
         if asan_violation_detected and not self._crashed_process_name:

--- a/Tools/TestRunnerShared/TestCommand.cpp
+++ b/Tools/TestRunnerShared/TestCommand.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "TestCommand.h"
+#include "TestFeatures.h"
 
 namespace WTR {
 
@@ -109,6 +110,8 @@ TestCommand parseInputLine(const std::string& inputLine)
             result.absolutePath = tokenizer.next();
         else if (arg == "--force-dump-pixels")
             result.forceDumpPixels = true;
+        else if (arg == "--signposts")
+            Signpost::enabled = true;
         else
             die(inputLine);
     }

--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -316,4 +316,30 @@ TestFeatures featureDefaultsFromSelfComparisonHeader(const TestCommand& command,
     return parseTestHeaderString(command.selfComparisonHeader, command.absolutePath, keyTypeMap);
 }
 
+bool Signpost::enabled = false;
+
+Signpost::Signpost(const char* const arg)
+    : name(arg)
+{
+    gettimeofday(&m_start, nullptr);
+}
+Signpost::~Signpost()
+{
+    if (!enabled)
+        return;
+    struct timeval stop;
+    gettimeofday(&stop, nullptr);
+
+    struct timeval elapsed;
+    elapsed.tv_sec = stop.tv_sec - m_start.tv_sec;
+    if (m_start.tv_usec > stop.tv_usec) {
+        elapsed.tv_sec -= 1;
+        stop.tv_usec += 1000000;
+    }
+    elapsed.tv_usec = stop.tv_usec - m_start.tv_usec;
+
+    fprintf(stderr, "SIGNPOST %s %ld.%06d\n", name, elapsed.tv_sec, elapsed.tv_usec);
+    
+}
+
 } // namespace WTF

--- a/Tools/TestRunnerShared/TestFeatures.h
+++ b/Tools/TestRunnerShared/TestFeatures.h
@@ -27,6 +27,7 @@
 
 #include <optional>
 #include <string>
+#include <sys/time.h>
 #include <unordered_map>
 #include <vector>
 
@@ -70,5 +71,17 @@ enum class TestHeaderKeyType : uint8_t {
 };
 TestFeatures featureDefaultsFromTestHeaderForTest(const TestCommand&, const std::unordered_map<std::string, TestHeaderKeyType>&);
 TestFeatures featureDefaultsFromSelfComparisonHeader(const TestCommand&, const std::unordered_map<std::string, TestHeaderKeyType>&);
+
+class Signpost {
+    struct timeval m_start;
+
+public:
+    static bool enabled;
+
+    const char* const name;
+
+    Signpost(const char* const);
+    ~Signpost();
+};
 
 }

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -150,17 +150,20 @@ WKRetainPtr<WKMutableDictionaryRef> TestInvocation::createTestSettingsDictionary
 
 void TestInvocation::invoke()
 {
-    TestController::singleton().configureViewForTest(*this);
-
-    WKPageSetAddsVisitedLinks(TestController::singleton().mainWebView()->page(), false);
-
-    m_textOutput.clear();
-
-    TestController::singleton().setShouldLogHistoryClientCallbacks(shouldLogHistoryClientCallbacks());
-
-    WKHTTPCookieStoreSetHTTPCookieAcceptPolicy(WKWebsiteDataStoreGetHTTPCookieStore(TestController::singleton().websiteDataStore()), kWKHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain, nullptr, nullptr);
-
-    // FIXME: We should clear out visited links here.
+    {
+        Signpost pst("pre-test");
+        TestController::singleton().configureViewForTest(*this);
+        
+        WKPageSetAddsVisitedLinks(TestController::singleton().mainWebView()->page(), false);
+        
+        m_textOutput.clear();
+        
+        TestController::singleton().setShouldLogHistoryClientCallbacks(shouldLogHistoryClientCallbacks());
+        
+        WKHTTPCookieStoreSetHTTPCookieAcceptPolicy(WKWebsiteDataStoreGetHTTPCookieStore(TestController::singleton().websiteDataStore()), kWKHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain, nullptr, nullptr);
+        
+        // FIXME: We should clear out visited links here.
+    }
 
     postPageMessage("BeginTest", createTestSettingsDictionary());
 


### PR DESCRIPTION
#### 7b136b96495d5f2a03251711552a84e4bcee9697
<pre>
[run-webkit-tests] Add performance signposts
<a href="https://bugs.webkit.org/show_bug.cgi?id=245283">https://bugs.webkit.org/show_bug.cgi?id=245283</a>
&lt;rdar://100032177&gt;

Reviewed by NOBODY (OOPS!).

* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(runTestingServerLoop): Reset Signpost enabled flag.
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py:
(setup_shard): Start worker global timer.
(teardown_shard): Forward timers to parent process.
(LayoutTestRunner.run_tests): Print signpost results if signpost flag enabled.
* Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py:
(SingleTestRunner._driver_input): Pass signpost flag to driver.
(SingleTestRunner._run_reftest): Ditto.
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args): Add --signpost flag.
* Tools/Scripts/webkitpy/port/driver.py:
(PerformanceSignposts): Handle performance signposts for worker process.
(PerformanceSignposts.Measure): Measure performance for a block of Python code.
(DriverInput.__init__): Add signpost flag.
(Driver._extract_signpost): Extract and measure possible SIGNPOST line from
(Driver._command_from_driver_input): Pass --signpost flag.
(Driver._read_block): Extract and ignore SIGNPOST lines.
* Tools/TestRunnerShared/TestCommand.cpp:
(WTR::parseInputLine): Parse --signpost flag.
* Tools/TestRunnerShared/TestFeatures.cpp:
(WTR::Signpost::Signpost): Start signpost timer.
(WTR::Signpost::~Signpost): End signpost timer, print SIGNPOST if enabled.
* Tools/TestRunnerShared/TestFeatures.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::runTest): Add &apos;setup&apos; and &apos;invoke&apos; signposts.
(WTR::TestController::runTestingServerLoop): Reset Signpost enabled flag.
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::invoke): Add &apos;pre-test&apos; signpost.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b136b96495d5f2a03251711552a84e4bcee9697

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89495 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98804 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155112 "Hash 7b136b96 for PR 4422 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32546 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28029 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81852 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93217 "Hash 7b136b96 for PR 4422 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25857 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76380 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25790 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/93080 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68781 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30305 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14700 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30049 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15636 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33496 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38592 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34727 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->