### PR TITLE
[WTF] Implement convenience functions for CFArray <-> Vector conversions

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		337B2D6A26546EB300DDFD3D /* LikelyDenseUnsignedIntegerSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 337B2D6826546EAA00DDFD3D /* LikelyDenseUnsignedIntegerSet.cpp */; };
 		339B7B1127C45EF50072BF9A /* FixedWidthDouble.h in Headers */ = {isa = PBXBuildFile; fileRef = 33479C1C27236F2000B2E1B7 /* FixedWidthDouble.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4427C5AA21F6D6C300A612A4 /* ASCIICType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4427C5A921F6D6C300A612A4 /* ASCIICType.cpp */; };
+		4448265228D18CA600D916E8 /* VectorCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 4448265128D18CA600D916E8 /* VectorCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46449E8B2822E5680005A8BC /* WeakHashCountedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4655743627F5FC4A002D5522 /* ASCIILiteralCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */; };
 		46BEB6EB22FFE24900269867 /* RefCounted.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269867 /* RefCounted.cpp */; };
@@ -1086,6 +1087,7 @@
 		430B47871AAAAC1A001223DA /* StringCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringCommon.h; sourceTree = "<group>"; };
 		4427C5A921F6D6C300A612A4 /* ASCIICType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASCIICType.cpp; sourceTree = "<group>"; };
 		4434F91B27948A65007E3E8A /* TollFreeBridging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TollFreeBridging.h; sourceTree = "<group>"; };
+		4448265128D18CA600D916E8 /* VectorCF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VectorCF.h; sourceTree = "<group>"; };
 		4468567225094FE8008CCA05 /* ThreadSanitizerSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadSanitizerSupport.h; sourceTree = "<group>"; };
 		44CDE4D226EE6CDA009F6ACB /* TypeCastsCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeCastsCocoa.h; sourceTree = "<group>"; };
 		46209A27266D543A007F8F4A /* CancellableTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CancellableTask.h; sourceTree = "<group>"; };
@@ -1801,6 +1803,7 @@
 				BC3FEB5D267FCD340054006A /* SpanCF.h */,
 				1AFDE647195201C300C48FFA /* TypeCastsCF.h */,
 				5C1F0594216437B30039302C /* URLCF.cpp */,
+				4448265128D18CA600D916E8 /* VectorCF.h */,
 			);
 			path = cf;
 			sourceTree = "<group>";
@@ -3263,6 +3266,7 @@
 				DD3DC8C227A4BF8E007E5B61 /* UUID.h in Headers */,
 				DD3DC86D27A4BF8E007E5B61 /* ValueCheck.h in Headers */,
 				DD3DC90B27A4BF8E007E5B61 /* Vector.h in Headers */,
+				4448265228D18CA600D916E8 /* VectorCF.h in Headers */,
 				DDF3079727C086CD006A526F /* VectorCocoa.h in Headers */,
 				DD3DC8B127A4BF8E007E5B61 /* VectorHash.h in Headers */,
 				DD3DC95327A4BF8E007E5B61 /* VectorTraits.h in Headers */,

--- a/Source/WTF/wtf/PlatformMac.cmake
+++ b/Source/WTF/wtf/PlatformMac.cmake
@@ -15,6 +15,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     cf/CFURLExtras.h
     cf/SpanCF.h
     cf/TypeCastsCF.h
+    cf/VectorCF.h
 
     cocoa/CrashReporter.h
     cocoa/Entitlements.h

--- a/Source/WTF/wtf/PlatformWin.cmake
+++ b/Source/WTF/wtf/PlatformWin.cmake
@@ -38,6 +38,7 @@ if (USE_CF)
         cf/CFURLExtras.h
         cf/SpanCF.h
         cf/TypeCastsCF.h
+        cf/VectorCF.h
 
         text/cf/StringConcatenateCF.h
         text/cf/TextBreakIteratorCF.h

--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CF)
+
+#include <wtf/CheckedArithmetic.h>
+#include <wtf/Forward.h>
+#include <wtf/Vector.h>
+#include <wtf/cf/TypeCastsCF.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+
+template <typename A, typename... B>
+struct ParameterTypeTraits {
+    using firstParamType = A;
+};
+
+// Derive return type and parameters from lamba using decltype(&LambdaType::operator()).
+// See: <http://coliru.stacked-crooked.com/a/da415f1f536b1a31>
+// Via: <https://stackoverflow.com/questions/33222673/c11-template-programming-delegates-and-lambdas>
+
+template <typename LambdaType>
+struct LambdaTypeTraits : LambdaTypeTraits<decltype(&LambdaType::operator())> { };
+
+template <typename R, typename C, typename... Params>
+struct LambdaTypeTraits<R(C::*)(Params...)> {
+    using firstParamType = typename ParameterTypeTraits<Params...>::firstParamType;
+    using returnType = R;
+
+    static constexpr size_t paramCount = sizeof...(Params);
+};
+
+template <typename R, typename C, typename... Params>
+struct LambdaTypeTraits<R(C::*)(Params...) const> {
+    using firstParamType = typename ParameterTypeTraits<Params...>::firstParamType;
+    using returnType = R;
+
+    static constexpr size_t paramCount = sizeof...(Params);
+};
+
+// Specialize the behavior of these functions by overloading the makeCFArrayElement
+// functions and makeVectorElement functions. The makeCFArrayElement function takes
+// a const& to a collection element and can return either a RetainPtr<CFTypeRef> or a CFTypeRef
+// if the value is autoreleased. The makeVectorElement function takes an ignored
+// pointer to the vector element type, making argument-dependent lookup work, and a
+// CFTypeRef for the array element, and returns an std::optional<T> of the the vector element,
+// allowing us to filter out array elements that are not of the expected type.
+//
+//    RetainPtr<CFTypeRef> makeCFArrayElement(const CollectionElementType& collectionElement);
+//        -or-
+//    CFTypeRef makeCFArrayElement(const VectorElementType& vectorElement);
+//
+//    std::optional<VectorElementType> makeVectorElement(const VectorElementType*, CFTypeRef arrayElement);
+//
+// Note that a specific CF type may be used in place of the generic CFTypeRef above.
+
+template<typename CollectionType> RetainPtr<CFMutableArrayRef> createCFArray(CollectionType&&);
+template<typename VectorElementType, typename CFType> Vector<VectorElementType> makeVector(CFArrayRef);
+
+// Allow for abbreviated specializations like makeVector<String>(CFArrayRef) containing CFStringRef objects.
+template<typename VectorElementType> Vector<VectorElementType> makeVector(CFArrayRef);
+template<> inline Vector<String> makeVector<String>(CFArrayRef array) { return makeVector<String, CFStringRef>(array); }
+
+// This overload of createCFArray takes a function to map each vector element to an CF object.
+// The map function has the same interface as the makeCFArrayElement function above, but can be any
+// function including a lambda, a function-like object, or Function<>.
+template<typename CollectionType, typename MapFunctionType> RetainPtr<CFMutableArrayRef> createCFArray(CollectionType&&, MapFunctionType&&);
+
+// This overload of makeVector takes a function to map each CF object to a vector element.
+// Currently, the map function needs to return a std::optional<T>.
+template<typename MapLambdaType> Vector<typename LambdaTypeTraits<MapLambdaType>::returnType::value_type> makeVector(CFArrayRef, MapLambdaType&&);
+
+// Implementation details of the function templates above.
+
+inline void addUnlessNil(CFMutableArrayRef array, CFTypeRef value)
+{
+    if (value)
+        CFArrayAppendValue(array, value);
+}
+
+// Conversion function declarations must appear before use. See also WTFString.h.
+RetainPtr<CFNumberRef> makeCFArrayElement(const float&);
+std::optional<float> makeVectorElement(const float*, CFNumberRef);
+
+template<typename CollectionType> RetainPtr<CFMutableArrayRef> createCFArray(CollectionType&& collection)
+{
+    auto array = adoptCF(CFArrayCreateMutable(nullptr, Checked<CFIndex>(std::size(collection)), &kCFTypeArrayCallBacks));
+    for (auto&& element : collection)
+        addUnlessNil(array.get(), getPtr(makeCFArrayElement(std::forward<decltype(element)>(element))));
+    return array;
+}
+
+template<typename CollectionType, typename MapFunctionType> RetainPtr<CFMutableArrayRef> createCFArray(CollectionType&& collection, MapFunctionType&& function)
+{
+    auto array = adoptCF(CFArrayCreateMutable(nullptr, Checked<CFIndex>(std::size(collection)), &kCFTypeArrayCallBacks));
+    for (auto&& element : collection)
+        addUnlessNil(array.get(), getPtr(std::invoke(std::forward<MapFunctionType>(function), std::forward<decltype(element)>(element))));
+    return array;
+}
+
+template<typename VectorElementType, typename CFType> Vector<VectorElementType> makeVector(CFArrayRef array)
+{
+    Vector<VectorElementType> vector;
+    CFIndex count = CFArrayGetCount(array);
+    vector.reserveInitialCapacity(count);
+    for (CFIndex i = 0; i < count; ++i) {
+        constexpr const VectorElementType* typedNull = nullptr;
+        if (CFType element = dynamic_cf_cast<CFType>(CFArrayGetValueAtIndex(array, i))) {
+            if (auto vectorElement = makeVectorElement(typedNull, element))
+                vector.uncheckedAppend(WTFMove(*vectorElement));
+        }
+    }
+    vector.shrinkToFit();
+    return vector;
+}
+
+template<typename MapLambdaType> Vector<typename LambdaTypeTraits<MapLambdaType>::returnType::value_type> makeVector(CFArrayRef array, MapLambdaType&& lambda)
+{
+    using ElementType = typename LambdaTypeTraits<MapLambdaType>::returnType::value_type;
+    using CFType = typename LambdaTypeTraits<MapLambdaType>::firstParamType;
+
+    static_assert(std::is_same_v<typename LambdaTypeTraits<MapLambdaType>::returnType, std::optional<ElementType>>, "MapLambdaType returns std::optional<ElementType>");
+    static_assert(LambdaTypeTraits<MapLambdaType>::paramCount == 1, "MapLambdaType takes a single CFTypeRef argument");
+
+    Vector<ElementType> vector;
+    CFIndex count = CFArrayGetCount(array);
+    vector.reserveInitialCapacity(count);
+    for (CFIndex i = 0; i < count; ++i) {
+        if (CFType element = dynamic_cf_cast<CFType>(CFArrayGetValueAtIndex(array, i))) {
+            if (auto vectorElement = std::invoke(std::forward<MapLambdaType>(lambda), element))
+                vector.uncheckedAppend(WTFMove(*vectorElement));
+        }
+    }
+    vector.shrinkToFit();
+    return vector;
+}
+
+inline Vector<uint8_t> vectorFromCFData(CFDataRef data)
+{
+    return { reinterpret_cast<const uint8_t*>(CFDataGetBytePtr(data)), Checked<size_t>(CFDataGetLength(data)) };
+}
+
+// Conversion function implementations. See also StringCF.cpp.
+
+inline RetainPtr<CFNumberRef> makeCFArrayElement(const float& number)
+{
+    return adoptCF(CFNumberCreate(nullptr, kCFNumberFloatType, &number));
+}
+
+inline std::optional<float> makeVectorElement(const float*, CFNumberRef cfNumber)
+{
+    float number = 0;
+    CFNumberGetValue(cfNumber, kCFNumberFloatType, &number);
+    return { number };
+}
+
+} // namespace WTF
+
+using WTF::createCFArray;
+using WTF::makeVector;
+using WTF::vectorFromCFData;
+
+#endif // USE(CF)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -1,6 +1,6 @@
 /*
  * (C) 1999 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2004-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -403,10 +403,13 @@ template<> struct IntegerToStringConversionTrait<String> {
 };
 
 #ifdef __OBJC__
-
 WTF_EXPORT_PRIVATE RetainPtr<id> makeNSArrayElement(const String&);
 WTF_EXPORT_PRIVATE std::optional<String> makeVectorElement(const String*, id);
+#endif
 
+#if USE(CF)
+WTF_EXPORT_PRIVATE RetainPtr<CFStringRef> makeCFArrayElement(const String&);
+WTF_EXPORT_PRIVATE std::optional<String> makeVectorElement(const String*, CFStringRef);
 #endif
 
 // Definitions of string operations

--- a/Source/WTF/wtf/text/cf/StringCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringCF.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006, 2012 Apple Inc.
+ * Copyright (C) 2006-2022 Apple Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -61,6 +61,18 @@ RetainPtr<CFStringRef> String::createCFString() const
         return CFSTR("");
 
     return m_impl->createCFString();
+}
+
+RetainPtr<CFStringRef> makeCFArrayElement(const String& vectorElement)
+{
+    return vectorElement.createCFString();
+}
+
+std::optional<String> makeVectorElement(const String*, CFStringRef cfString)
+{
+    if (cfString)
+        return { { cfString } };
+    return std::nullopt;
 }
 
 }

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +44,7 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/SoftLinking.h>
 #include <wtf/URL.h>
+#include <wtf/cf/VectorCF.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringConcatenateNumbers.h>
@@ -592,14 +593,7 @@ Vector<String> CaptionUserPreferencesMediaAF::preferredLanguages() const
 Vector<String> CaptionUserPreferencesMediaAF::platformPreferredLanguages()
 {
     auto captionLanguages = adoptCF(MACaptionAppearanceCopySelectedLanguages(kMACaptionAppearanceDomainUser));
-    CFIndex captionLanguagesCount = captionLanguages ? CFArrayGetCount(captionLanguages.get()) : 0;
-
-    Vector<String> preferredLanguages;
-    preferredLanguages.reserveInitialCapacity(captionLanguagesCount);
-    for (CFIndex i = 0; i < captionLanguagesCount; i++)
-        preferredLanguages.uncheckedAppend(static_cast<CFStringRef>(CFArrayGetValueAtIndex(captionLanguages.get(), i)));
-
-    return preferredLanguages;
+    return captionLanguages ? makeVector<String>(captionLanguages.get()) : Vector<String> { };
 }
 
 void CaptionUserPreferencesMediaAF::setCachedPreferredLanguages(const Vector<String>& preferredLanguages)
@@ -626,12 +620,7 @@ Vector<String> CaptionUserPreferencesMediaAF::preferredAudioCharacteristics() co
     if (!characteristicCount)
         return CaptionUserPreferences::preferredAudioCharacteristics();
 
-    Vector<String> userPreferredAudioCharacteristics;
-    userPreferredAudioCharacteristics.reserveInitialCapacity(characteristicCount);
-    for (CFIndex i = 0; i < characteristicCount; i++)
-        userPreferredAudioCharacteristics.uncheckedAppend(static_cast<CFStringRef>(CFArrayGetValueAtIndex(characteristics.get(), i)));
-
-    return userPreferredAudioCharacteristics;
+    return makeVector<String>(characteristics.get());
 }
 #endif // HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 

--- a/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp
+++ b/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +35,7 @@
 #include <QuartzCore/CACFTimingFunction.h>
 #include <QuartzCore/CACFValueFunction.h>
 #include <QuartzCore/CACFVector.h>
+#include <wtf/cf/VectorCF.h>
 #include <wtf/text/WTFString.h>
 
 using namespace WebCore;
@@ -443,63 +444,45 @@ void PlatformCAAnimationWin::copyToValueFrom(const PlatformCAAnimation& value)
 }
 
 // Keyframe-animation properties.
-void PlatformCAAnimationWin::setValues(const Vector<float>& value)
+void PlatformCAAnimationWin::setValues(const Vector<float>& values)
 {
     if (animationType() != Keyframe)
         return;
 
-    RetainPtr<CFMutableArrayRef> array = adoptCF(CFArrayCreateMutable(0, value.size(), &kCFTypeArrayCallBacks));
-    for (size_t i = 0; i < value.size(); ++i) {
-        RetainPtr<CFNumberRef> v = adoptCF(CFNumberCreate(0, kCFNumberFloatType, &value[i]));
-        CFArrayAppendValue(array.get(), v.get());
-    }
-
-    CACFAnimationSetValues(m_animation.get(), array.get());
+    CACFAnimationSetValues(m_animation.get(), createCFArray(values).get());
 }
 
-void PlatformCAAnimationWin::setValues(const Vector<WebCore::TransformationMatrix>& value)
+void PlatformCAAnimationWin::setValues(const Vector<WebCore::TransformationMatrix>& values)
 {
     if (animationType() != Keyframe)
         return;
 
-    RetainPtr<CFMutableArrayRef> array = adoptCF(CFArrayCreateMutable(0, value.size(), &kCFTypeArrayCallBacks));
-    for (size_t i = 0; i < value.size(); ++i) {
-        RetainPtr<CACFVectorRef> v = adoptCF(CACFVectorCreateTransform(value[i]));
-        CFArrayAppendValue(array.get(), v.get());
-    }
-
-    CACFAnimationSetValues(m_animation.get(), array.get());
+    CACFAnimationSetValues(m_animation.get(), createCFArray(values, [] (auto& matrix) {
+        return adoptCF(CACFVectorCreateTransform(matrix));
+    }).get());
 }
 
-void PlatformCAAnimationWin::setValues(const Vector<FloatPoint3D>& value)
+void PlatformCAAnimationWin::setValues(const Vector<FloatPoint3D>& values)
 {
     if (animationType() != Keyframe)
         return;
-        
-    RetainPtr<CFMutableArrayRef> array = adoptCF(CFArrayCreateMutable(0, value.size(), &kCFTypeArrayCallBacks));
-    for (size_t i = 0; i < value.size(); ++i) {
-        CGFloat a[3] = { value[i].x(), value[i].y(), value[i].z() };
-        RetainPtr<CACFVectorRef> v = adoptCF(CACFVectorCreate(3, a));
-        CFArrayAppendValue(array.get(), v.get());
-    }
 
-    CACFAnimationSetValues(m_animation.get(), array.get());
+    CACFAnimationSetValues(m_animation.get(), createCFArray(values, [] (auto& point) {
+        CGFloat a[3] = { point.x(), point.y(), point.z() };
+        return adoptCF(CACFVectorCreate(3, a));
+    }).get());
 }
 
-void PlatformCAAnimationWin::setValues(const Vector<WebCore::Color>& value)
+void PlatformCAAnimationWin::setValues(const Vector<WebCore::Color>& values)
 {
     if (animationType() != Keyframe)
         return;
-        
-    RetainPtr<CFMutableArrayRef> array = adoptCF(CFArrayCreateMutable(0, value.size(), &kCFTypeArrayCallBacks));
-    for (size_t i = 0; i < value.size(); ++i) {
-        auto components = value[i].toColorTypeLossy<SRGBA<uint8_t>>().resolved();
-        CGFloat a[4] = { components.red, components.green, components.blue, components.alpha };
-        RetainPtr<CACFVectorRef> v = adoptCF(CACFVectorCreate(4, a));
-        CFArrayAppendValue(array.get(), v.get());
-    }
 
-    CACFAnimationSetValues(m_animation.get(), array.get());
+    CACFAnimationSetValues(m_animation.get(), createCFArray(values, [] (auto& color) {
+        auto [r, g, b, a] = color.template toColorTypeLossy<SRGBA<uint8_t>>().resolved();
+        CGFloat components[4] = { r, g, b, a };
+        return adoptCF(CACFVectorCreate(4, components));
+    }).get());
 }
 
 void PlatformCAAnimationWin::setValues(const Vector<RefPtr<FilterOperation> >&, int)
@@ -515,18 +498,12 @@ void PlatformCAAnimationWin::copyValuesFrom(const PlatformCAAnimation& value)
     CACFAnimationSetValues(m_animation.get(), CACFAnimationGetValues(downcast<PlatformCAAnimationWin>(value).platformAnimation()));
 }
 
-void PlatformCAAnimationWin::setKeyTimes(const Vector<float>& value)
+void PlatformCAAnimationWin::setKeyTimes(const Vector<float>& values)
 {
     if (animationType() != Keyframe)
         return;
-        
-    RetainPtr<CFMutableArrayRef> array = adoptCF(CFArrayCreateMutable(0, value.size(), &kCFTypeArrayCallBacks));
-    for (size_t i = 0; i < value.size(); ++i) {
-        RetainPtr<CFNumberRef> v = adoptCF(CFNumberCreate(0, kCFNumberFloatType, &value[i]));
-        CFArrayAppendValue(array.get(), v.get());
-    }
 
-    CACFAnimationSetKeyTimes(m_animation.get(), array.get());
+    CACFAnimationSetKeyTimes(m_animation.get(), createCFArray(values).get());
 }
 
 void PlatformCAAnimationWin::copyKeyTimesFrom(const PlatformCAAnimation& value)
@@ -542,11 +519,9 @@ void PlatformCAAnimationWin::setTimingFunctions(const Vector<Ref<const TimingFun
     if (animationType() != Keyframe)
         return;
 
-    RetainPtr<CFMutableArrayRef> array = adoptCF(CFArrayCreateMutable(0, timingFunctions.size(), &kCFTypeArrayCallBacks));
-    for (auto& timingFunction : timingFunctions)
-        CFArrayAppendValue(array.get(), toCACFTimingFunction(timingFunction.get(), reverse).get());
-
-    CACFAnimationSetTimingFunctions(m_animation.get(), array.get());
+    CACFAnimationSetTimingFunctions(m_animation.get(), createCFArray(timingFunctions, [&] (auto& function) {
+        return toCACFTimingFunction(function.get(), reverse);
+    }).get());
 }
 
 void PlatformCAAnimationWin::copyTimingFunctionsFrom(const PlatformCAAnimation& value)
@@ -554,15 +529,13 @@ void PlatformCAAnimationWin::copyTimingFunctionsFrom(const PlatformCAAnimation& 
     CACFAnimationSetTimingFunctions(m_animation.get(), CACFAnimationGetTimingFunctions(downcast<PlatformCAAnimationWin>(value).platformAnimation()));
 }
 
-void PlatformCAAnimationWin::setAnimations(const Vector<RefPtr<PlatformCAAnimation>>& value)
+void PlatformCAAnimationWin::setAnimations(const Vector<RefPtr<PlatformCAAnimation>>& values)
 {
-    auto array = adoptCF(CFArrayCreateMutable(0, value.size(), &kCFTypeArrayCallBacks));
-    for (auto& animation : value) {
+    CACFAnimationSetAnimations(m_animation.get(), createCFArray(values, [&] (auto& animation) -> CACFAnimationRef {
         if (is<PlatformCAAnimationWin>(animation))
-            CFArrayAppendValue(array.get(), downcast<PlatformCAAnimationWin>(*animation).m_animation.get());
-    }
-
-    CACFAnimationSetAnimations(m_animation.get(), array.get());
+            return downcast<PlatformCAAnimationWin>(*animation).m_animation.get();
+        return nullptr;
+    }).get());
 }
 
 void PlatformCAAnimationWin::copyAnimationsFrom(const PlatformCAAnimation& value)

--- a/Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm
+++ b/Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm
@@ -28,6 +28,7 @@
 
 #import <pal/spi/cocoa/NSURLConnectionSPI.h>
 #import <wtf/ProcessPrivilege.h>
+#import <wtf/cf/VectorCF.h>
 
 namespace WebKit {
 
@@ -49,12 +50,8 @@ Vector<uint8_t> identifyingDataFromCookieStorage(CFHTTPCookieStorageRef cookieSt
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
 
-    Vector<uint8_t> result;
-
     auto cfData = adoptCF(CFHTTPCookieStorageCreateIdentifyingData(kCFAllocatorDefault, cookieStorage));
-    result.append(CFDataGetBytePtr(cfData.get()), CFDataGetLength(cfData.get()));
-
-    return result;
+    return vectorFromCFData(cfData.get());
 }
 
 } // namespace WebKit

--- a/Source/WebKitLegacy/win/WebHistoryItem.cpp
+++ b/Source/WebKitLegacy/win/WebHistoryItem.cpp
@@ -34,6 +34,7 @@
 #include <WebCore/HistoryItem.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/URL.h>
+#include <wtf/cf/VectorCF.h>
 #include <wtf/text/CString.h>
 
 using namespace WebCore;
@@ -113,12 +114,8 @@ HRESULT WebHistoryItem::initFromDictionaryRepresentation(_In_opt_ void* dictiona
     bool lastVisitWasFailure = lastVisitWasFailureRef && CFBooleanGetValue(lastVisitWasFailureRef);
 
     std::unique_ptr<Vector<String>> redirectURLsVector;
-    if (CFArrayRef redirectURLsRef = static_cast<CFArrayRef>(CFDictionaryGetValue(dictionaryRef, redirectURLsKey))) {
-        CFIndex size = CFArrayGetCount(redirectURLsRef);
-        redirectURLsVector = makeUnique<Vector<String>>(size);
-        for (CFIndex i = 0; i < size; ++i)
-            (*redirectURLsVector)[i] = String(static_cast<CFStringRef>(CFArrayGetValueAtIndex(redirectURLsRef, i)));
-    }
+    if (CFArrayRef redirectURLsRef = dynamic_cf_cast<CFArrayRef>(CFDictionaryGetValue(dictionaryRef, redirectURLsKey)))
+        redirectURLsVector = makeUnique<Vector<String>>(makeVector<String>(redirectURLsRef));
 
     historyItemWrappers().remove(m_historyItem.get());
     m_historyItem = HistoryItem::create(urlStringRef, titleRef);

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -242,6 +242,10 @@
 		448110C2253F40300097FC33 /* WebPreferencesTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 448110C1253F40240097FC33 /* WebPreferencesTest.mm */; };
 		448D7E471EA6C55500ECC756 /* EnvironmentUtilitiesTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 448D7E451EA6C55500ECC756 /* EnvironmentUtilitiesTest.cpp */; };
 		44AC8BC621D0245A00CAFB34 /* RetainPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC029B161486AD6400817DA9 /* RetainPtr.cpp */; };
+		44B28A0528D18AD20010172C /* RetainPtrHashing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0991C50143C7D68007998F2 /* RetainPtrHashing.cpp */; };
+		44B28A0628D18AD50010172C /* SpanCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC3FEB60267FCDB00054006A /* SpanCF.cpp */; };
+		44B28A0728D18ADA0010172C /* VectorCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44B289FC28D18AAA0010172C /* VectorCF.cpp */; };
+		44B28A0828D18AE70010172C /* SpanCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = BC3FEB63267FCF740054006A /* SpanCocoa.mm */; };
 		44CDE4D426EE6E4A009F6ACB /* TypeCastsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44CDE4D326EE6E41009F6ACB /* TypeCastsCocoa.mm */; };
 		44CF31FD249941E8009CB6CB /* ContextMenuAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44CF31FB24993F66009CB6CB /* ContextMenuAction.cpp */; };
 		44D5008E26FE9ED6000EB12F /* RetainPtrARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44D5008D26FE9ED6000EB12F /* RetainPtrARC.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -905,8 +909,6 @@
 		BC22D31914DC68B900FFB1DD /* UserMessage_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC22D31714DC68B800FFB1DD /* UserMessage_Bundle.cpp */; };
 		BC246D9C132F1FF000B56D7C /* CanHandleRequest_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC246D97132F1FE100B56D7C /* CanHandleRequest_Bundle.cpp */; };
 		BC2D006412AA04CE00E732A3 /* file-with-anchor.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = BC2D004A12A9FEB300E732A3 /* file-with-anchor.html */; };
-		BC3FEB61267FCDB00054006A /* SpanCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC3FEB60267FCDB00054006A /* SpanCF.cpp */; };
-		BC3FEB64267FCF740054006A /* SpanCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = BC3FEB63267FCF740054006A /* SpanCocoa.mm */; };
 		BC575A97126E74F1006F0F12 /* InjectedBundleMain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC575946126E7351006F0F12 /* InjectedBundleMain.cpp */; };
 		BC575AA2126E7660006F0F12 /* InjectedBundleController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC575AA0126E7657006F0F12 /* InjectedBundleController.cpp */; };
 		BC575AB0126E83C8006F0F12 /* InjectedBundleBasic_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC575AAF126E83C8006F0F12 /* InjectedBundleBasic_Bundle.cpp */; };
@@ -2228,6 +2230,7 @@
 		44817A2E1F0486BF00003810 /* WKRequestActivatedElementInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKRequestActivatedElementInfo.mm; sourceTree = "<group>"; };
 		448D7E451EA6C55500ECC756 /* EnvironmentUtilitiesTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EnvironmentUtilitiesTest.cpp; sourceTree = "<group>"; };
 		44A622C114A0E2B60048515B /* WTFStringUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTFStringUtilities.h; sourceTree = "<group>"; };
+		44B289FC28D18AAA0010172C /* VectorCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VectorCF.cpp; sourceTree = "<group>"; };
 		44C2FBE125E7592C00ABC72F /* WKAppHighlights.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKAppHighlights.mm; sourceTree = "<group>"; };
 		44CDE4D326EE6E41009F6ACB /* TypeCastsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TypeCastsCocoa.mm; sourceTree = "<group>"; };
 		44CF31FB24993F66009CB6CB /* ContextMenuAction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ContextMenuAction.cpp; sourceTree = "<group>"; };
@@ -5383,6 +5386,7 @@
 				BC029B161486AD6400817DA9 /* RetainPtr.cpp */,
 				C0991C50143C7D68007998F2 /* RetainPtrHashing.cpp */,
 				BC3FEB60267FCDB00054006A /* SpanCF.cpp */,
+				44B289FC28D18AAA0010172C /* VectorCF.cpp */,
 			);
 			path = cf;
 			sourceTree = "<group>";
@@ -5956,6 +5960,7 @@
 				44AC8BC621D0245A00CAFB34 /* RetainPtr.cpp in Sources */,
 				7C83DF241D0A590C00FEBCF3 /* RetainPtr.mm in Sources */,
 				44D5008E26FE9ED6000EB12F /* RetainPtrARC.mm in Sources */,
+				44B28A0528D18AD20010172C /* RetainPtrHashing.cpp in Sources */,
 				E355A6322615718F001C1129 /* RobinHoodHashMap.cpp in Sources */,
 				E355A63026157174001C1129 /* RobinHoodHashSet.cpp in Sources */,
 				7C83DF051D0A590C00FEBCF3 /* RunLoop.cpp in Sources */,
@@ -5969,6 +5974,8 @@
 				33C2C9C12651F5B900E407F6 /* SmallSet.cpp in Sources */,
 				93FCDB34263631560046DD7D /* SortedArrayMap.cpp in Sources */,
 				BCA30C7E266D2F43000D230C /* Span.cpp in Sources */,
+				44B28A0628D18AD50010172C /* SpanCF.cpp in Sources */,
+				44B28A0828D18AE70010172C /* SpanCocoa.mm in Sources */,
 				FE2BCDC72470FDA300DEC33B /* StdLibExtras.cpp in Sources */,
 				7C83DF321D0A590C00FEBCF3 /* StringBuilder.cpp in Sources */,
 				E3DE273C28A8D67800873DF2 /* StringCommon.cpp in Sources */,
@@ -6000,6 +6007,7 @@
 				7C83E03B1D0A602700FEBCF3 /* UtilitiesCocoa.mm in Sources */,
 				41D2A21F27906F9F0088FCCE /* UUID.cpp in Sources */,
 				7C83DF4C1D0A590C00FEBCF3 /* Vector.cpp in Sources */,
+				44B28A0728D18ADA0010172C /* VectorCF.cpp in Sources */,
 				37C7CC2D1EA4146B007BD956 /* WeakLinking.cpp in Sources */,
 				57C3FA661F7C248F009D4B80 /* WeakPtr.cpp in Sources */,
 				46BBEA1B25F9835700D4987A /* WorkQueue.cpp in Sources */,
@@ -6312,8 +6320,6 @@
 				510A91F824D3622100BFD89C /* SonyDualShock3.mm in Sources */,
 				51EB126424CA6B66000CB030 /* SonyDualShock4.mm in Sources */,
 				7CCE7F151A411AE600447C4C /* SpacebarScrolling.cpp in Sources */,
-				BC3FEB61267FCDB00054006A /* SpanCF.cpp in Sources */,
-				BC3FEB64267FCF740054006A /* SpanCocoa.mm in Sources */,
 				F4CDF3D227E97C7E00191928 /* SpellCheckerDocumentTag.mm in Sources */,
 				57F4AAA0208FAEF000A68E9E /* SSLKeyGenerator.mm in Sources */,
 				83BC5AC020E6C0DF00F5879F /* StartLoadInDidFailProvisionalLoad.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/cf/VectorCF.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/cf/VectorCF.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/cf/VectorCF.h>
+
+namespace TestWebKitAPI {
+
+TEST(VectorCF, CreateCFArray_CFString)
+{
+    const size_t elementCount = 3;
+    Vector<String> strings = { "one"_str, "two"_str, "three"_str };
+
+    auto cfStrings = createCFArray(strings);
+
+    CFIndex count = CFArrayGetCount(cfStrings.get());
+    EXPECT_EQ(elementCount, Checked<size_t>(count));
+    EXPECT_EQ(elementCount, std::size(strings));
+    EXPECT_TRUE(CFStringCompare(checked_cf_cast<CFStringRef>(CFArrayGetValueAtIndex(cfStrings.get(), 0)), CFSTR("one"), 0) == kCFCompareEqualTo);
+    EXPECT_TRUE(CFStringCompare(checked_cf_cast<CFStringRef>(CFArrayGetValueAtIndex(cfStrings.get(), 1)), CFSTR("two"), 0) == kCFCompareEqualTo);
+    EXPECT_TRUE(CFStringCompare(checked_cf_cast<CFStringRef>(CFArrayGetValueAtIndex(cfStrings.get(), 2)), CFSTR("three"), 0) == kCFCompareEqualTo);
+}
+
+TEST(VectorCF, CreateCFArray_CFNumber)
+{
+    const size_t elementCount = 3;
+    Vector<float> floats = { 1, 2, 3 };
+
+    auto cfNumbers = createCFArray(floats);
+
+    CFIndex count = CFArrayGetCount(cfNumbers.get());
+    EXPECT_EQ(elementCount, Checked<size_t>(count));
+    EXPECT_EQ(elementCount, std::size(floats));
+    float number = 0;
+    CFNumberGetValue(checked_cf_cast<CFNumberRef>(CFArrayGetValueAtIndex(cfNumbers.get(), 0)), kCFNumberFloatType, &number);
+    EXPECT_EQ(1.0, number);
+    CFNumberGetValue(checked_cf_cast<CFNumberRef>(CFArrayGetValueAtIndex(cfNumbers.get(), 1)), kCFNumberFloatType, &number);
+    EXPECT_EQ(2.0, number);
+    CFNumberGetValue(checked_cf_cast<CFNumberRef>(CFArrayGetValueAtIndex(cfNumbers.get(), 2)), kCFNumberFloatType, &number);
+    EXPECT_EQ(3.0, number);
+}
+
+TEST(VectorCF, CreateCFArrayWithFunctor_CFNumber)
+{
+    const size_t elementCount = 3;
+    Vector<double> doubles = { 1, 2, 3 };
+
+    auto cfNumbers = createCFArray(doubles, [] (const double& number) {
+        return adoptCF(CFNumberCreate(nullptr, kCFNumberDoubleType, &number));
+    });
+
+    CFIndex count = CFArrayGetCount(cfNumbers.get());
+    EXPECT_EQ(elementCount, Checked<size_t>(count));
+    EXPECT_EQ(elementCount, std::size(doubles));
+    double number = 0;
+    CFNumberGetValue(checked_cf_cast<CFNumberRef>(CFArrayGetValueAtIndex(cfNumbers.get(), 0)), kCFNumberDoubleType, &number);
+    EXPECT_EQ(1.0, number);
+    CFNumberGetValue(checked_cf_cast<CFNumberRef>(CFArrayGetValueAtIndex(cfNumbers.get(), 1)), kCFNumberDoubleType, &number);
+    EXPECT_EQ(2.0, number);
+    CFNumberGetValue(checked_cf_cast<CFNumberRef>(CFArrayGetValueAtIndex(cfNumbers.get(), 2)), kCFNumberDoubleType, &number);
+    EXPECT_EQ(3.0, number);
+}
+
+TEST(VectorCF, MakeVector_CFString)
+{
+    const size_t elementCount = 3;
+    auto cfStrings = adoptCF(CFArrayCreateMutable(nullptr, elementCount, &kCFTypeArrayCallBacks));
+    CFArrayAppendValue(cfStrings.get(), CFSTR("one"));
+    CFArrayAppendValue(cfStrings.get(), CFSTR("two"));
+    CFArrayAppendValue(cfStrings.get(), CFSTR("three"));
+    CFIndex count = CFArrayGetCount(cfStrings.get());
+
+    auto strings = makeVector<String>(cfStrings.get());
+
+    EXPECT_EQ(elementCount, Checked<size_t>(count));
+    EXPECT_EQ(elementCount, std::size(strings));
+    EXPECT_EQ("one"_str, strings[0]);
+    EXPECT_EQ("two"_str, strings[1]);
+    EXPECT_EQ("three"_str, strings[2]);
+}
+
+TEST(VectorCF, MakeVector_CFNumber)
+{
+    const size_t elementCount = 3;
+    auto cfNumbers = adoptCF(CFArrayCreateMutable(nullptr, elementCount, &kCFTypeArrayCallBacks));
+    float number = 1;
+    CFArrayAppendValue(cfNumbers.get(), CFNumberCreate(nullptr, kCFNumberFloatType, &number));
+    number = 2;
+    CFArrayAppendValue(cfNumbers.get(), CFNumberCreate(nullptr, kCFNumberFloatType, &number));
+    number = 3;
+    CFArrayAppendValue(cfNumbers.get(), CFNumberCreate(nullptr, kCFNumberFloatType, &number));
+
+    auto floats = makeVector<float, CFNumberRef>(cfNumbers.get());
+
+    CFIndex count = CFArrayGetCount(cfNumbers.get());
+    EXPECT_EQ(elementCount, Checked<size_t>(count));
+    EXPECT_EQ(elementCount, std::size(floats));
+    EXPECT_EQ(1.0, floats[0]);
+    EXPECT_EQ(2.0, floats[1]);
+    EXPECT_EQ(3.0, floats[2]);
+}
+
+TEST(VectorCF, MakeVectorWithFunctor)
+{
+    const size_t elementCount = 3;
+    auto cfNumbers = adoptCF(CFArrayCreateMutable(nullptr, elementCount, &kCFTypeArrayCallBacks));
+    double number = 1;
+    CFArrayAppendValue(cfNumbers.get(), CFNumberCreate(nullptr, kCFNumberDoubleType, &number));
+    number = 2;
+    CFArrayAppendValue(cfNumbers.get(), CFNumberCreate(nullptr, kCFNumberDoubleType, &number));
+    number = 3;
+    CFArrayAppendValue(cfNumbers.get(), CFNumberCreate(nullptr, kCFNumberDoubleType, &number));
+
+    auto doubles = makeVector(cfNumbers.get(), [] (CFNumberRef cfNumber) -> std::optional<double> {
+        double number = 0;
+        CFNumberGetValue(cfNumber, kCFNumberDoubleType, &number);
+        return { number };
+    });
+
+    CFIndex count = CFArrayGetCount(cfNumbers.get());
+    EXPECT_EQ(elementCount, Checked<size_t>(count));
+    EXPECT_EQ(elementCount, std::size(doubles));
+    EXPECT_EQ(1.0, doubles[0]);
+    EXPECT_EQ(2.0, doubles[1]);
+    EXPECT_EQ(3.0, doubles[2]);
+}
+
+TEST(VectorCF, VectorFromCFData)
+{
+    const size_t elementCount = 4;
+    uint8_t bytes[] = { 0x01, 0x02, 0x03, 0x04 };
+    auto byteLength = sizeof(bytes);
+    EXPECT_EQ(elementCount, byteLength);
+    auto cfData = adoptCF(CFDataCreate(nullptr, static_cast<const UInt8*>(&bytes[0]), Checked<CFIndex>(byteLength)));
+
+    auto vectorData = vectorFromCFData(cfData.get());
+
+    CFIndex cfDataLength = CFDataGetLength(cfData.get());
+    EXPECT_EQ(byteLength, Checked<size_t>(cfDataLength));
+    EXPECT_EQ(byteLength, std::size(vectorData));
+    for (size_t i = 0; i < byteLength; ++i) {
+        EXPECT_EQ(bytes[i], CFDataGetBytePtr(cfData.get())[i]);
+        EXPECT_EQ(bytes[i], vectorData[i]);
+    }
+    EXPECT_TRUE(&bytes[0] != CFDataGetBytePtr(cfData.get()));
+    EXPECT_TRUE(&bytes[0] != &vectorData[0]);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 2f9450c601c6090870dcfe81c870bc54d880ebda
<pre>
[WTF] Implement convenience functions for CFArray &lt;-&gt; Vector conversions
<a href="https://bugs.webkit.org/show_bug.cgi?id=245284">https://bugs.webkit.org/show_bug.cgi?id=245284</a>
&lt;rdar://100032945&gt;

Reviewed by Darin Adler.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/PlatformMac.cmake:
* Source/WTF/wtf/PlatformWin.cmake:
- Add VectorCF.h to project files.

* Source/WTF/wtf/cf/VectorCF.h: Copied from Source/WTF/wtf/cocoa/VectorCocoa.h.
- Add convenience functions for CFArray &lt;-&gt; Vector conversions.
(WTF::ParameterTypeTraits): Add.
- Get the type of the first parameter of a lambda.
(WTF::LambdaTypeTraits): Add.
- Get type traits for a lambda like the return type and
  parameter count.
(WTF::addUnlessNil): Add.
(WTF::createCFArray): Add.
- This uses Checked&lt;&gt; to convert from size_t to CFIndex.
(WTF::makeVector&lt;String&gt;): Add specialization.
(WTF::makeVector): Add.
- Use dynamic_cf_cast&lt;&gt;() to avoid having to do it at the call
  site, and take a CFType template parameter so that helper
  functions use a specific CF type.
(WTF::vectorFromCFData): Add.
- Use Checked&lt;&gt; to convert from CFData to Vector&lt;uint8_t&gt;.
(WTF::makeVectorElement): Add.
(WTF::makeCFArrayElement): Add.
- Add convenience function for float &lt;-&gt; CFNumberRef.

* Source/WTF/wtf/text/WTFString.h:
(WTF::makeCFArrayElement):
(WTF::makeVectorElement):
* Source/WTF/wtf/text/cf/StringCF.cpp:
(WTF::makeCFArrayElement):
(WTF::makeVectorElement):
- Add helper functions for CFString &lt;-&gt; String conversions.

* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::CaptionUserPreferencesMediaAF::platformPreferredLanguages):
(WebCore::CaptionUserPreferencesMediaAF::preferredAudioCharacteristics const):
- Use makeVector&lt;String&gt;().
* Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp:
(PlatformCAAnimationWin::setValues):
(PlatformCAAnimationWin::setKeyTimes):
(PlatformCAAnimationWin::setTimingFunctions):
(PlatformCAAnimationWin::setAnimations):
- Use createCFArray().
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCResolverCocoa.cpp:
(WebKit::resolvedName):
- Use makeVector&lt;WebCore::IPAddress, CFDataRef&gt;().
* Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm:
(WebKit::identifyingDataFromCookieStorage):
- Use vectorFromCFData().
* Source/WebKitLegacy/win/WebHistoryItem.cpp:
(WebHistoryItem::initFromDictionaryRepresentation):
- Use makeVector&lt;String&gt;().

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
- Add missing RetainPtrHashing.cpp tests!
- Move tests for code in WTF into the TestWTF target.
- Add VectorCF.cpp tests.
* Tools/TestWebKitAPI/Tests/WTF/cf/VectorCF.cpp: Add.
(TestWebKitAPI::TEST):
- Add tests for VectorCF.h.

Canonical link: <a href="https://commits.webkit.org/254665@main">https://commits.webkit.org/254665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf6d9092f0d939a1a64ad7ec9e0b569d99aed0f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99085 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155901 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32785 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28248 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93435 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26054 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76585 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26007 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69001 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81402 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30537 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14880 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76261 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30286 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15817 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26431 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3279 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38763 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/78847 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34905 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17278 "Passed tests") | 
<!--EWS-Status-Bubble-End-->