### PR TITLE
Add script for finding feature defines

### DIFF
--- a/Tools/Scripts/find-feature-flags
+++ b/Tools/Scripts/find-feature-flags
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 Sony Interactive Entertainment
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+import webkitpy.featuredefines.search as search
+
+_DESCRIPTION = """
+Find feature flags within portions of the source code.
+"""
+
+_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+_CHOICES = [
+    "definitions",
+    "platform",
+    "perl",
+    "cmake",
+    "code",
+    "native-code",
+    "cmake-code",
+    "idl-code",
+]
+
+
+def _search_with(choice):
+    mapping = {
+        "platform": search.FeatureDefinesPlatform,
+        "perl": search.FeatureDefinesPerl,
+        "cmake": search.FeatureDefinesCMake,
+        "native-code": search.FeatureDefinesUsageNativeCode,
+        "cmake-code": search.FeatureDefinesUsageCMakeCode,
+        "idl-code": search.FeatureDefinesUsageIdlCode,
+    }
+
+    return mapping[choice]()
+
+
+def _parse_args(argv):
+    parser = argparse.ArgumentParser(description=_DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("find", help="the code to search", choices=_CHOICES, nargs="*")
+    parser.add_argument("--diff", choices=_CHOICES, action="append")
+    parser.add_argument("--macro", choices=["ENABLE", "USE", "HAVE"], default="ENABLE")
+    return parser.parse_args(argv)
+
+
+def _choice_set(choices):
+    choices_set = set(choices)
+
+    if "definitions" in choices_set:
+        choices_set.remove("definitions")
+
+        choices_set.update(["platform", "perl", "cmake"])
+
+    if "all-code" in choices_set:
+        choices_set.remove("all-code")
+
+        choices_set.update(["native-code", "cmake-code", "idl-code"])
+
+    return choices_set
+
+
+def _search_for(choices, macro):
+    found = set()
+
+    for choice in _choice_set(choices):
+        search_with = _search_with(choice)
+        search_with.search(_ROOT, macro)
+        found.update(search_with.definitions())
+
+    return found
+
+
+def main(argv):
+    args = _parse_args(argv)
+
+    find_defines = _search_for(args.find, args.macro)
+
+    if args.diff:
+        diff_defines = _search_for(args.diff, args.macro)
+
+        only_find = find_defines.difference(diff_defines)
+
+        print("Only in Source (" + ",".join(args.find) + ")")
+        for item in sorted(only_find):
+            print(item)
+
+        only_diff = diff_defines.difference(find_defines)
+
+        print("Only in Diff (" + ",".join(args.diff) + ")")
+        for item in sorted(only_diff):
+            print(item)
+    else:
+        for item in sorted(find_defines):
+            print(item)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/Tools/Scripts/webkitpy/featuredefines/__init__.py
+++ b/Tools/Scripts/webkitpy/featuredefines/__init__.py
@@ -1,0 +1,1 @@
+# Required for Python to search this directory for module files

--- a/Tools/Scripts/webkitpy/featuredefines/matcher.py
+++ b/Tools/Scripts/webkitpy/featuredefines/matcher.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2022 Sony Interactive Entertainment
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Matches feature defines in source code."""
+
+import re
+
+from functools import total_ordering
+
+
+@total_ordering
+class FeatureDefine:
+    def __init__(self, flag, value=False, description="", files=None):
+        self.flag = flag
+        self.value = value
+        self.description = description
+
+        self.files = files if files else set()
+
+    def __hash__(self):
+        return hash(self.flag)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.flag == other.flag
+
+        return NotImplemented
+
+    def __lt__(self, other):
+        if isinstance(other, self.__class__):
+            return self.flag < other.flag
+
+        return NotImplemented
+
+
+class _FeatureDefineMatcher:
+    def __init__(self, pattern, prefix=''):
+        self._regex = re.compile(pattern)
+        self._prefix = prefix
+
+    def __call__(self, line):
+        match = self._regex.search(line)
+
+        if not match:
+            return None
+
+        groups = match.groupdict()
+
+        flag = self._prefix + groups['flag']
+        description = groups.get('description', '')
+        value = groups.get('value', '') in ['1', 'ON']
+
+        return FeatureDefine(flag, value=value, description=description)
+
+
+def usage_matcher(macro='ENABLE'):
+    """ Matches MACRO(FLAG) """
+    pattern = macro + r'\((?P<flag>[0-9A-Z_]+)\)'
+    prefix = macro + '_'
+
+    return _FeatureDefineMatcher(pattern, prefix=prefix)
+
+
+def flag_matcher(macro='ENABLE'):
+    """ Matches MACRO_FLAG """
+    pattern = r'(?P<flag>' + macro + r'_[0-9A-Z_]+)'
+
+    return _FeatureDefineMatcher(pattern)
+
+
+def declaration_matcher(macro='ENABLE'):
+    """ Matches #define MACRO_FLAG VALUE """
+    pattern = r'#define (?P<flag>' + macro + r'_[0-9A-Z_]+) (?P<value>[0,1])'
+
+    return _FeatureDefineMatcher(pattern)
+
+
+def idl_usage_matcher():
+    """ Matches Conditional=(FLAG) """
+    pattern = r'Conditional=(?P<flag>[0-9A-Z_]+)'
+
+    return _FeatureDefineMatcher(pattern, prefix='ENABLE_')
+
+
+def cmake_options_matcher(macro='ENABLE'):
+    """ Matches WEBKIT_OPTION_DEFINE(MACRO_FLAG) """
+    pattern = r'WEBKIT_OPTION_DEFINE\((?P<flag>' + macro + r'_[0-9A-Z_]+) "(?P<description>.*)" (PUBLIC|PRIVATE) (?P<value>.*)\)'
+
+    return _FeatureDefineMatcher(pattern)

--- a/Tools/Scripts/webkitpy/featuredefines/matcher_unittest.py
+++ b/Tools/Scripts/webkitpy/featuredefines/matcher_unittest.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2022 Sony Interactive Entertainment
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for matcher.py."""
+
+
+from __future__ import print_function
+
+import unittest
+
+from webkitpy.featuredefines.matcher import flag_matcher, usage_matcher, idl_usage_matcher, cmake_options_matcher, declaration_matcher
+
+
+class TestFeatureDefineMatcher(unittest.TestCase):
+    def test_usage_matcher(self):
+        matcher = usage_matcher()
+
+        self._not_a_match(matcher, 'ENABLE_FOO')
+        self._not_a_match(matcher, '#define ENABLE_FOO 1')
+        self._not_a_match(matcher, '[Conditional=FOO]')
+        self._not_a_match(matcher, 'ENABLE_FOO =')
+        self._not_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_FOO "Info" PUBLIC ON)')
+        self._not_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_FOO "Info" PRIVATE ON)')
+
+        self._not_a_match(matcher, 'USE(FOO)')
+
+        self._is_a_match(matcher, 'ENABLE(FOO)', 'ENABLE_FOO')
+        self._is_a_match(matcher, 'ENABLE(BAR)', 'ENABLE_BAR')
+
+        # Test with different prefix
+        matcher = usage_matcher('USE')
+
+        self._not_a_match(matcher, 'ENABLE(FOO)')
+
+        self._is_a_match(matcher, 'USE(FOO)', 'USE_FOO')
+        self._is_a_match(matcher, 'USE(BAR)', 'USE_BAR')
+
+    def test_declaration_matcher(self):
+        matcher = declaration_matcher()
+
+        self._not_a_match(matcher, 'ENABLE(FOO)')
+        self._not_a_match(matcher, 'ENABLE_FOO')
+        self._not_a_match(matcher, '[Conditional=FOO]')
+        self._not_a_match(matcher, 'ENABLE_FOO =')
+        self._not_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_FOO "Info" PUBLIC ON)')
+        self._not_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_FOO "Info" PRIVATE ON)')
+
+        self._not_a_match(matcher, '#define USE_FOO 1')
+
+        self._is_a_match(matcher, '#define ENABLE_FOO 1', 'ENABLE_FOO', value=True)
+        self._is_a_match(matcher, '#define ENABLE_BAR 0', 'ENABLE_BAR', value=False)
+
+        # Test with different prefix
+        matcher = declaration_matcher('USE')
+
+        self._not_a_match(matcher, '#define ENABLE_FOO 1')
+
+        self._is_a_match(matcher, '#define USE_FOO 1', 'USE_FOO', value=True)
+        self._is_a_match(matcher, '#define USE_BAR 0', 'USE_BAR', value=False)
+
+    def test_flag_matcher(self):
+        matcher = flag_matcher()
+
+        self._not_a_match(matcher, 'ENABLE(FOO)')
+        self._not_a_match(matcher, '[Conditional=FOO]')
+
+        self._not_a_match(matcher, 'USE_FOO')
+
+        self._is_a_match(matcher, 'ENABLE_FOO', 'ENABLE_FOO')
+        self._is_a_match(matcher, 'ENABLE_BAR', 'ENABLE_BAR')
+
+        # Still would match these
+        self._is_a_match(matcher, '#define ENABLE_FOO 1', 'ENABLE_FOO')
+        self._is_a_match(matcher, 'ENABLE_FOO =', 'ENABLE_FOO')
+        self._is_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_FOO "Info" PUBLIC ON)', 'ENABLE_FOO')
+        self._is_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_FOO "Info" PRIVATE ON)', 'ENABLE_FOO')
+
+        # Test with different prefix
+        matcher = flag_matcher('USE')
+
+        self._not_a_match(matcher, 'ENABLE_FOO')
+
+        self._is_a_match(matcher, 'USE_FOO', 'USE_FOO')
+        self._is_a_match(matcher, 'USE_BAR', 'USE_BAR')
+
+    def test_idl_matcher(self):
+        matcher = idl_usage_matcher()
+
+        self._not_a_match(matcher, 'ENABLE(FOO)')
+        self._not_a_match(matcher, 'ENABLE_FOO')
+        self._not_a_match(matcher, '#define ENABLE_FOO 1')
+        self._not_a_match(matcher, 'ENABLE_FOO =')
+        self._not_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_FOO "Info" PUBLIC ON)')
+        self._not_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_FOO "Info" PRIVATE ON)')
+
+        self._is_a_match(matcher, '[Conditional=FOO]', 'ENABLE_FOO')
+        self._is_a_match(matcher, '[Conditional=BAR]', 'ENABLE_BAR')
+
+    def test_cmake_options_matcher(self):
+        matcher = cmake_options_matcher()
+
+        self._not_a_match(matcher, 'ENABLE(FOO)')
+        self._not_a_match(matcher, 'ENABLE_FOO')
+        self._not_a_match(matcher, '#define ENABLE_FOO 1')
+        self._not_a_match(matcher, 'ENABLE_FOO =')
+
+        self._not_a_match(matcher, 'WEBKIT_OPTION_DEFINE(USE_FOO "Info" PRIVATE ON)')
+
+        self._is_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_FOO "Info" PUBLIC ON)', 'ENABLE_FOO', value=True, description='Info')
+        self._is_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_BAR "Mesg" PUBLIC OFF)', 'ENABLE_BAR', value=False, description='Mesg')
+        self._is_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_FOO "Info" PRIVATE ON)', 'ENABLE_FOO', value=True, description='Info')
+        self._is_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_BAR "Mesg" PRIVATE OFF)', 'ENABLE_BAR', value=False, description='Mesg')
+
+        # Test with different prefix
+        matcher = cmake_options_matcher('USE')
+
+        self._not_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_FOO "Info" PUBLIC ON)')
+        self._not_a_match(matcher, 'WEBKIT_OPTION_DEFINE(ENABLE_FOO "Info" PRIVATE ON)')
+
+        self._is_a_match(matcher, 'WEBKIT_OPTION_DEFINE(USE_FOO "Info" PRIVATE ON)', 'USE_FOO', value=True, description='Info')
+        self._is_a_match(matcher, 'WEBKIT_OPTION_DEFINE(USE_BAR "Mesg" PRIVATE OFF)', 'USE_BAR', value=False, description='Mesg')
+
+    def _not_a_match(self, matcher, line):
+        self.assertIsNone(matcher(line))
+
+    def _is_a_match(self, matcher, line, flag, value=False, description=""):
+        match = matcher(line)
+
+        self.assertIsNotNone(match)
+        self.assertEqual(match.flag, flag)
+        self.assertEqual(match.value, value)
+        self.assertEqual(match.description, description)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tools/Scripts/webkitpy/featuredefines/search.py
+++ b/Tools/Scripts/webkitpy/featuredefines/search.py
@@ -1,0 +1,165 @@
+# Copyright (C) 2022 Sony Interactive Entertainment
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Searches files for feature defines."""
+
+import fnmatch
+import os
+import re
+
+from abc import abstractmethod, ABCMeta
+from io import open
+from webkitpy.featuredefines.matcher import flag_matcher, usage_matcher, idl_usage_matcher, cmake_options_matcher, declaration_matcher
+
+
+class FeatureDefinesSearch(object):
+    """ Base class for searching for feature defines. """
+
+    ___metaclass___ = ABCMeta
+
+    def __init__(self):
+        self._defines = {}
+
+    def definitions(self):
+        """ Retrieve the definitions from the search as a set. """
+        definitions = set()
+        for k in self._defines:
+            definitions.add(k)
+
+        return definitions
+
+    def references(self, define):
+        """ Retrieves any references to the define found. """
+        return self._defines[define]
+
+    @abstractmethod
+    def search(self, root, macro):
+        """ Search for feature defines within the root """
+
+    def _search_file(self, matcher, path):
+        with open(path, encoding="latin-1") as contents:
+            for line in contents:
+                value = matcher(line)
+
+                if value:
+                    flag = value.flag
+
+                    if flag not in self._defines:
+                        self._defines[flag] = set()
+
+                    self._defines[flag].add(path)
+
+    def _search_directory(self, matcher, path, patterns):
+        for root, __, files in os.walk(path):
+            for file in files:
+                for patten in patterns:
+                    if fnmatch.fnmatch(file, patten):
+                        self._search_file(matcher, os.path.join(root, file))
+
+    @classmethod
+    def _source_directories(cls, root):
+        return [
+            os.path.join(root, "Source", "WTF"),
+            os.path.join(root, "Source", "WebDriver"),
+            os.path.join(root, "Source", "WebCore"),
+            os.path.join(root, "Source", "WebKit"),
+            os.path.join(root, "Source", "WebKitLegacy"),
+            os.path.join(root, "Source", "JavaScriptCore"),
+            os.path.join(root, "Tools"),
+        ]
+
+
+class FeatureDefinesCMake(FeatureDefinesSearch):
+    """ Find feature defines in WebKitFeatures.cmake. """
+
+    def search(self, root, macro='ENABLE'):
+        matcher = cmake_options_matcher(macro)
+        path = os.path.join(root, "Source", "cmake", "WebKitFeatures.cmake")
+
+        # Look in port definitions
+        self._search_directory(matcher, os.path.join(root, "Source", "cmake"), ["Options*.cmake"])
+
+        self._search_file(matcher, path)
+
+
+class FeatureDefinesPlatform(FeatureDefinesSearch):
+    """ Find feature defines in wtf/PlatformEnable headers """
+
+    def search(self, root, macro='ENABLE'):
+        matcher = declaration_matcher(macro)
+        path = os.path.join("Source", "WTF", "wtf")
+
+        # Look in port definitions
+        self._search_directory(matcher, path, ["Platform*.h"])
+
+
+class FeatureDefinesPerl(FeatureDefinesSearch):
+    """ Find feature defines in FeatureList.pm. """
+
+    def search(self, root, macro='ENABLE'):
+        matcher = flag_matcher(macro)
+        path = os.path.join(root, "Tools", "Scripts", "webkitperl", "FeatureList.pm")
+
+        self._search_file(matcher, path)
+
+
+class FeatureDefinesUsageNativeCode(FeatureDefinesSearch):
+    """ Find feature defines in native source code. """
+
+    def search(self, root, macro='ENABLE'):
+        matcher = usage_matcher(macro)
+        directories = FeatureDefinesSearch._source_directories(root)
+        patterns = ['*.h', '*.c', '*.cpp', '*.mm', '*.messages.in']
+
+        for directory in directories:
+            self._search_directory(matcher, directory, patterns)
+
+
+class FeatureDefinesUsageIdlCode(FeatureDefinesSearch):
+    """ Find feature defines in IDL source code. """
+
+    def search(self, root, macro='ENABLE'):
+        matcher = idl_usage_matcher()
+        directories = FeatureDefinesSearch._source_directories(root)
+        patterns = ['*.idl']
+
+        for directory in directories:
+            self._search_directory(matcher, directory, patterns)
+
+
+class FeatureDefinesUsageCMakeCode(FeatureDefinesSearch):
+    """ Find feature defines used in CMake source code. """
+
+    def search(self, root, macro='ENABLE'):
+        matcher = flag_matcher(macro)
+        directories = FeatureDefinesSearch._source_directories(root)
+        patterns = ['CMakeLists.txt', '*.cmake']
+
+        for directory in directories:
+            self._search_directory(matcher, directory, patterns)
+
+        # Look in port definitions
+        self._search_directory(matcher, os.path.join(root, "Source", "cmake"), ["Options*.cmake"])
+
+        # Explicitly search root CMakeLists.txt files
+        self._search_file(matcher, os.path.join(root, "CMakeLists.txt"))
+        self._search_file(matcher, os.path.join(root, "Source", "CMakeLists.txt"))


### PR DESCRIPTION
#### b6841b91605ea8d2efd8dd163cf9560e5f55e215
<pre>
Add script for finding feature defines
<a href="https://bugs.webkit.org/show_bug.cgi?id=245290">https://bugs.webkit.org/show_bug.cgi?id=245290</a>

Reviewed by Darin Adler.

Adds a script for determining what feature defines (ENABLE, USE, HAVE)
are present in portions of WebKit code. As an example the script can
search all native code for all `ENABLE(flag)` and report back a full
listing. In addition it can also find differences between sections of
code which can be used to find stale build options.

* Tools/Scripts/find-feature-flags: Added.
* Tools/Scripts/webkitpy/featuredefines/__init__.py: Added.
* Tools/Scripts/webkitpy/featuredefines/matcher.py: Added.
* Tools/Scripts/webkitpy/featuredefines/matcher_unittest.py: Added.
* Tools/Scripts/webkitpy/featuredefines/search.py: Added.

Canonical link: <a href="https://commits.webkit.org/257596@main">https://commits.webkit.org/257596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/498fc656da279a68399d27f0b4aa5914b02e87d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108780 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169021 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85907 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106703 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105152 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33900 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/102916 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23327 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2368 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5226 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42802 "Passed tests") | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->