### PR TITLE
Entering a To: address moves the viewpoint to the bottom right corner of the email

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm
@@ -32,9 +32,45 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 
+#if PLATFORM(IOS_FAMILY)
+@interface RestoreScrollPositionWithLargeContentInsetWebView : TestWKWebView
+@end
+
+@implementation RestoreScrollPositionWithLargeContentInsetWebView
+- (UIEdgeInsets)safeAreaInsets
+{
+    return UIEdgeInsetsMake(141, 0, 0, 0);
+}
+@end
+#endif
+
 namespace TestWebKitAPI {
 
 #if PLATFORM(IOS_FAMILY)
+
+TEST(RestoreScrollPositionTests, RestoreScrollPositionWithLargeContentInset)
+{
+    auto topInset = 1165;
+
+    auto webView = adoptNS([[RestoreScrollPositionWithLargeContentInsetWebView alloc] initWithFrame:CGRectMake(0, 0, 375, 1024)]);
+    
+    [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
+    
+    auto insets = UIEdgeInsetsMake(topInset, 0, 0, 0);
+    [webView scrollView].contentInset = insets;
+    [webView _setObscuredInsets:UIEdgeInsetsMake(141, 0, 0, 0)];
+    [webView scrollView].contentOffset = CGPointMake(0, -topInset);
+    
+    [webView waitForNextPresentationUpdate];
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(375, 727) maximumUnobscuredSizeOverride:CGSizeMake(375, 727)];
+
+    [webView scrollView].contentInset = UIEdgeInsetsMake(1024, 0, 0, 0);
+    [webView waitForNextPresentationUpdate];
+    
+    CGPoint contentOffsetAfterScrolling = [webView scrollView].contentOffset;
+    
+    EXPECT_EQ(-topInset, contentOffsetAfterScrolling.y);
+}
 
 TEST(RestoreScrollPositionTests, RestoreScrollPositionDuringResize)
 {


### PR DESCRIPTION
#### c5a7221120cea780897f84fff076b7d98b818b5a
<pre>
Entering a To: address moves the viewpoint to the bottom right corner of the email
<a href="https://bugs.webkit.org/show_bug.cgi?id=245297">https://bugs.webkit.org/show_bug.cgi?id=245297</a>
rdar://96703879

Reviewed by Tim Horton.

On iPad in the Mail app, when composing a message whose contents are taller
than the viewport size, and when the compose window is narrow enough such that
the contact picker appears as a modal when entering a contact in the `To:`
field, dismissing the contact picker causes the message to erroneously scroll
to the bottom right of the message.

This is because in this case, there is a large top inset on the web view&apos;s
scroll view. This causes the UIProcess to erroneously create a `CGRectNull`
and sends it to the web process in a visible content rect update. Because a
`CGRectNull` has an origin of `(INT_MAX, INT_MAX)`, the web view attempts to
scroll to that position.

This PR fixes this by using `FloatRect`s intersection behavior instead of using
`CGRectIntersection`, so that the resulting rect&apos;s origin stays the same instead
of becoming `CGRectNull` in the case the two rects don&apos;t intersect.

A change also had to be made to
`-[WKWebView _scrollToContentScrollPosition:scrollOrigin:animated:]` so that the
view scrolls to its original position with the inset, instead of `0`.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _scrollToContentScrollPosition:scrollOrigin:animated:]):
(-[WKWebView _updateVisibleContentRects]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm:
(-[RestoreScrollPositionWithLargeContentInsetWebView safeAreaInsets]):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/254640@main">https://commits.webkit.org/254640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dad9efb47f0b3ed7fbfe9ce4f42642b61764cb3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99061 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155879 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32767 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82090 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93418 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26041 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76568 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/25994 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/80916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/68985 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30520 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14868 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30269 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/15805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3257 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-inherit-to-blank-document-unsandboxed.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33719 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1378 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34893 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->