### PR TITLE
[WGSL] Implement lexing for 'array' keyword

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -236,6 +236,8 @@ Token Lexer<T>::lex()
                 return makeToken(TokenType::KeywordWorkgroup);
             if (view == "write"_s)
                 return makeToken(TokenType::KeywordWrite);
+            if (view == "array"_s)
+                return makeToken(TokenType::KeywordArray);
             if (view == "asm"_s || view == "bf16"_s || view == "const"_s || view == "do"_s || view == "enum"_s
                 || view == "f16"_s || view == "f64"_s || view == "handle"_s || view == "i8"_s || view == "i16"_s
                 || view == "i64"_s || view == "mat"_s || view == "premerge"_s || view == "regardless"_s

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -49,6 +49,8 @@ String toString(TokenType type)
         return "Identifier"_s;
     case TokenType::ReservedWord:
         return "ReservedWord"_s;
+    case TokenType::KeywordArray:
+        return "array"_s;
     case TokenType::KeywordStruct:
         return "struct"_s;
     case TokenType::KeywordFn:

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -50,6 +50,7 @@ enum class TokenType: uint32_t {
     Identifier,
 
     ReservedWord,
+    KeywordArray,
     KeywordFn,
     KeywordFunction,
     KeywordPrivate,

--- a/Source/WebGPU/WGSLUnitTests/WGSLLexerTests.mm
+++ b/Source/WebGPU/WGSLUnitTests/WGSLLexerTests.mm
@@ -28,6 +28,14 @@
 
 #import <XCTest/XCTest.h>
 
+static WGSL::Token checkSingleToken(const String& string, WGSL::TokenType type)
+{
+    WGSL::Lexer<LChar> lexer(string);
+    WGSL::Token result = lexer.lex();
+    XCTAssertEqual(result.m_type, type);
+    return result;
+};
+
 @interface WGSLLexerTests : XCTestCase
 
 @end
@@ -65,14 +73,29 @@
     checkSingleLiteral("42e-a"_s, WGSL::TokenType::IntegerLiteral, 42);
 }
 
-- (void) testLexerOfSpecialTokens {
-    auto checkSingleToken = [] (const String& string, WGSL::TokenType type) {
-        WGSL::Lexer<LChar> lexer(string);
-        WGSL::Token result = lexer.lex();
-        XCTAssertEqual(result.m_type, type);
-        return result;
-    };
+- (void) testLexerOfKeywordTokens {
+    using WGSL::TokenType;
 
+    checkSingleToken("array"_s,      TokenType::KeywordArray);
+    checkSingleToken("fn"_s,         TokenType::KeywordFn);
+    checkSingleToken("function"_s,   TokenType::KeywordFunction);
+    checkSingleToken("private"_s,    TokenType::KeywordPrivate);
+    checkSingleToken("read"_s,       TokenType::KeywordRead);
+    checkSingleToken("read_write"_s, TokenType::KeywordReadWrite);
+    checkSingleToken("return"_s,     TokenType::KeywordReturn);
+    checkSingleToken("storage"_s,    TokenType::KeywordStorage);
+    checkSingleToken("struct"_s,     TokenType::KeywordStruct);
+    checkSingleToken("uniform"_s,    TokenType::KeywordUniform);
+    checkSingleToken("var"_s,        TokenType::KeywordVar);
+    checkSingleToken("workgroup"_s,  TokenType::KeywordWorkgroup);
+    checkSingleToken("write"_s,      TokenType::KeywordWrite);
+    checkSingleToken("i32"_s,        TokenType::KeywordI32);
+    checkSingleToken("u32"_s,        TokenType::KeywordU32);
+    checkSingleToken("f32"_s,        TokenType::KeywordF32);
+    checkSingleToken("bool"_s,       TokenType::KeywordBool);
+}
+
+- (void) testLexerOfSpecialTokens {
     checkSingleToken("->"_s, WGSL::TokenType::Arrow);
     checkSingleToken("@"_s,  WGSL::TokenType::Attribute);
     checkSingleToken("{"_s,  WGSL::TokenType::BraceLeft);
@@ -382,7 +405,7 @@
     checkNextTokenIs(WGSL::TokenType::KeywordVar);
     checkNextTokenIsIdentifier("pos"_s);
     checkNextTokenIs(WGSL::TokenType::Equal);
-    checkNextTokenIsIdentifier("array"_s);
+    checkNextTokenIs(WGSL::TokenType::KeywordArray);
     checkNextTokenIs(WGSL::TokenType::LT);
     checkNextTokenIsIdentifier("vec2"_s);
     checkNextTokenIs(WGSL::TokenType::LT);


### PR DESCRIPTION
#### 65c294da01838f07141cc6a6188b87a4702c5966
<pre>
[WGSL] Implement lexing for &apos;array&apos; keyword
<a href="https://bugs.webkit.org/show_bug.cgi?id=244791">https://bugs.webkit.org/show_bug.cgi?id=244791</a>
rdar://99557428

Reviewed by Myles Maxfield.

* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lex):
Lex &quot;array&quot; -&gt; TokenType::KeywordArray
* Source/WebGPU/WGSL/Token.cpp:
(WGSL::toString):
TokenType::KeywordArray -&gt; &quot;array&quot;
* Source/WebGPU/WGSL/Token.h:
Add token for &apos;array&apos; keyword
* Source/WebGPU/WGSLUnitTests/WGSLLexerTests.mm:
- Update for &quot;array&quot; -&gt; ArrayKeyword
- Add tests for lexing all recognized keywords

Canonical link: <a href="https://commits.webkit.org/254621@main">https://commits.webkit.org/254621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe5adf19dd6af5b17cb6c2e80ae98e286c270b9a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98854 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32606 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28076 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81916 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93264 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25898 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76421 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25844 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68834 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30363 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14727 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30111 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15659 "Found 1 new test failure: inspector/debugger/symbolic-breakpoint-intrinsic-js-regex-case-insensitive.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3243 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38613 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34750 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->