### PR TITLE
Text Selection on flex and grid box items does not work as expected

### DIFF
--- a/LayoutTests/fast/text/flexbox-selection-gap-painting-expected.html
+++ b/LayoutTests/fast/text/flexbox-selection-gap-painting-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<div style="display: flex; background-color: #ddd; font-size: 24pt">
+   <div style="width: 100px ; display: inline-block">
+    <span id="a">aaa</span><br>
+    <span id="b">bbb</span>
+   </div>
+   <div style="width: 100px ; display: inline-block">
+    <span id="c">ccc</span>
+    <span id="d">ddd</span>
+   </div>
+</div>
+<script>
+    var b = document.querySelector('#b'),
+        d = document.querySelector('#d');
+    getSelection().setBaseAndExtent(b.firstChild, 0, d.firstChild, 2);
+    focus();
+</script>

--- a/LayoutTests/fast/text/flexbox-selection-gap-painting.html
+++ b/LayoutTests/fast/text/flexbox-selection-gap-painting.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<div style="display: flex; background-color: #ddd; font-size: 24pt">
+   <div style="width: 100px">
+    <span id="a">aaa</span><br>
+    <span id="b">bbb</span>
+   </div>
+   <div style="width: 100px">
+    <span id="c">ccc</span>
+    <span id="d">ddd</span>
+   </div>
+</div>
+<script>
+    var b = document.querySelector('#b'),
+        d = document.querySelector('#d');
+    getSelection().setBaseAndExtent(b.firstChild, 0, d.firstChild, 2);
+    focus();
+</script>

--- a/LayoutTests/fast/text/grid-selection-gap-painting-expected.html
+++ b/LayoutTests/fast/text/grid-selection-gap-painting-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<div style="display: grid; grid-template-columns: 20px 20px 20px; grid-gap: 40px; background-color: #ddd; font-size: 24pt">
+   <div style="width: 100px ; display: inline-block"">
+    <span id="a">aaa</span><br>
+    <span id="b">bbb</span>
+   </div>
+   <div style="width: 100px ; display: inline-block"">
+    <span id="c">ccc</span>
+    <span id="d">ddd</span>
+   </div>
+</div>
+<script>
+    var b = document.querySelector('#b'),
+        d = document.querySelector('#d');
+    getSelection().setBaseAndExtent(b.firstChild, 0, d.firstChild, 2);
+    focus();
+</script>

--- a/LayoutTests/fast/text/grid-selection-gap-painting.html
+++ b/LayoutTests/fast/text/grid-selection-gap-painting.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<div style="display: grid; grid-template-columns: 20px 20px 20px; grid-gap: 40px; background-color: #ddd; font-size: 24pt">
+   <div style="width: 100px">
+    <span id="a">aaa</span><br>
+    <span id="b">bbb</span>
+   </div>
+   <div style="width: 100px">
+    <span id="c">ccc</span>
+    <span id="d">ddd</span>
+   </div>
+</div>
+<script>
+    var b = document.querySelector('#b'),
+        d = document.querySelector('#d');
+    getSelection().setBaseAndExtent(b.firstChild, 0, d.firstChild, 2);
+    focus();
+</script>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1471,7 +1471,8 @@ bool RenderBlock::isSelectionRoot() const
         || isPositioned() || isFloating()
         || isTableCell() || isInlineBlockOrInlineTable()
         || hasTransform() || hasReflection() || hasMask() || isWritingModeRoot()
-        || isRenderFragmentedFlow() || style().columnSpan() == ColumnSpan::All)
+        || isRenderFragmentedFlow() || style().columnSpan() == ColumnSpan::All
+        || isFlexItemIncludingDeprecated() || isGridItem())
         return true;
     
     if (view().selection().start()) {


### PR DESCRIPTION
#### 48936aafec37b3b17c182f210f46e65bf6df9ba9
<pre>
Text Selection on flex and grid box items does not work as expected

Text Selection on flex and grid box items does not work as expected

<a href="https://bugs.webkit.org/show_bug.cgi?id=119878">https://bugs.webkit.org/show_bug.cgi?id=119878</a>

Reviewed by Alan Bujtas.

Merge &amp; Extend for Grid - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=171810

Webkit paints &quot;selection gaps&quot; that extend the selection to the bounds of the selection root.

If the selection spans two flex or grid items, and the selection root is the RenderBody, the selection gap for the first item is painted on top of the second item, obscuring its text.

By making each flex or grid item a selection root, the selection gap is painted only up to the bounds of the flex item.  This is the logic we use for table cells and positioned objects.

* Source/WebCore/rendering/RenderBlock.cpp:
(RednerBlock::isSelectionRoot) - Added isFlexItemIncludingDeprecated and isGridItem to behave similar for Selection paint as Table
* LayoutTests/fast/text/flexbox-selection-gap-painting.html: Added Test
 * LayoutTests/fast/text/flexbox-selection-gap-painting-expected.html: Added Test Expectations
* LayoutTests/fast/text/grid-selection-gap-painting.html: Added Test
* LayoutTests/fast/text/grid-selection-gap-painting-expected.html: Added Test Expectations

Canonical link: <a href="https://commits.webkit.org/254602@main">https://commits.webkit.org/254602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11953291ebf27e5202f47d87d3e1cd466ca47449

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98860 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155389 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32612 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28086 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81923 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93270 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25903 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76427 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25850 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68840 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30369 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14733 "Found 1 new test failure: inspector/debugger/symbolic-breakpoint-intrinsic-js-regex-case-sensitive.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30117 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15667 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3233 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38620 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34758 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->