### PR TITLE
[Win] Base WebsiteDataStore defaults on data and cache directory

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/win/WebsiteDataStoreWin.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/win/WebsiteDataStoreWin.cpp
@@ -48,72 +48,52 @@ void WebsiteDataStore::platformRemoveRecentSearches(WallTime)
 
 String WebsiteDataStore::defaultApplicationCacheDirectory(const String& baseCacheDirectory)
 {
-    if (!baseCacheDirectory.isNull())
-        return FileSystem::pathByAppendingComponent(baseCacheDirectory, "ApplicationCache"_s);
-    return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "ApplicationCache"_s);
+    return cacheDirectoryFileSystemRepresentation("ApplicationCache"_s, baseCacheDirectory);
 }
 
 String WebsiteDataStore::defaultCacheStorageDirectory(const String& baseCacheDirectory)
 {
-    if (!baseCacheDirectory.isNull())
-        return FileSystem::pathByAppendingComponent(baseCacheDirectory, "CacheStorage"_s);
-    return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "CacheStorage"_s);
+    return cacheDirectoryFileSystemRepresentation("CacheStorage"_s, baseCacheDirectory);
 }
 
 String WebsiteDataStore::defaultNetworkCacheDirectory(const String& baseCacheDirectory)
 {
-    if (!baseCacheDirectory.isNull())
-        return FileSystem::pathByAppendingComponent(baseCacheDirectory, "NetworkCache"_s);
-    return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "NetworkCache"_s);
+    return cacheDirectoryFileSystemRepresentation("NetworkCache"_s, baseCacheDirectory);
 }
 
 String WebsiteDataStore::defaultGeneralStorageDirectory(const String& baseDataDirectory)
 {
-    if (!baseDataDirectory.isNull())
-        return FileSystem::pathByAppendingComponent(baseDataDirectory, "Storage"_s);
-    return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "Storage"_s);
+    return websiteDataDirectoryFileSystemRepresentation("Storage"_s, baseDataDirectory);
 }
 
 String WebsiteDataStore::defaultIndexedDBDatabaseDirectory(const String& baseDataDirectory)
 {
-    if (!baseDataDirectory.isNull())
-        return FileSystem::pathByAppendingComponent(baseDataDirectory, "IndexedDB"_s);
-    return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "IndexedDB"_s);
+    return websiteDataDirectoryFileSystemRepresentation("IndexedDB"_s, baseDataDirectory);
 }
 
 String WebsiteDataStore::defaultServiceWorkerRegistrationDirectory(const String& baseDataDirectory)
 {
-    if (!baseDataDirectory.isNull())
-        return FileSystem::pathByAppendingComponent(baseDataDirectory, "ServiceWorkers"_s);
-    return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "ServiceWorkers"_s);
+    return websiteDataDirectoryFileSystemRepresentation("ServiceWorkers"_s, baseDataDirectory);
 }
 
 String WebsiteDataStore::defaultLocalStorageDirectory(const String& baseDataDirectory)
 {
-    if (!baseDataDirectory.isNull())
-        return FileSystem::pathByAppendingComponent(baseDataDirectory, "LocalStorage"_s);
-    return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "LocalStorage"_s);
+    return websiteDataDirectoryFileSystemRepresentation("LocalStorage"_s, baseDataDirectory);
 }
 
 String WebsiteDataStore::defaultMediaKeysStorageDirectory(const String& baseDataDirectory)
 {
-    if (!baseDataDirectory.isNull())
-        return FileSystem::pathByAppendingComponent(baseDataDirectory, "MediaKeyStorage"_s);
-    return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "MediaKeyStorage"_s);
+    return websiteDataDirectoryFileSystemRepresentation("MediaKeyStorage"_s, baseDataDirectory);
 }
 
 String WebsiteDataStore::defaultWebSQLDatabaseDirectory(const String& baseDataDirectory)
 {
-    if (!baseDataDirectory.isNull())
-        return FileSystem::pathByAppendingComponent(baseDataDirectory, "WebSQL"_s);
-    return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "WebSQL"_s);
+    return websiteDataDirectoryFileSystemRepresentation("WebSQL"_s, baseDataDirectory);
 }
 
 String WebsiteDataStore::defaultResourceLoadStatisticsDirectory(const String& baseDataDirectory)
 {
-    if (!baseDataDirectory.isNull())
-        return FileSystem::pathByAppendingComponent(baseDataDirectory, "ResourceLoadStatistics"_s);
-    return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "ResourceLoadStatistics"_s);
+    return websiteDataDirectoryFileSystemRepresentation("ResourceLoadStatistics"_s, baseDataDirectory);
 }
 
 String WebsiteDataStore::cacheDirectoryFileSystemRepresentation(const String& directoryName, const String& baseCacheDirectory, ShouldCreateDirectory)


### PR DESCRIPTION
#### 0de8aa8a0a6d9758b9136bbce0129ab0fd73873d
<pre>
[Win] Base WebsiteDataStore defaults on data and cache directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=245311">https://bugs.webkit.org/show_bug.cgi?id=245311</a>

Reviewed by Ross Kirsling.

Base defaults on `websiteDataDirectoryFileSystemRepresentation` and
`cacheDirectoryFileSystemRepresentation`. Removes a bunch of checks for
whether base directories are null.

* Source/WebKit/UIProcess/WebsiteData/win/WebsiteDataStoreWin.cpp:

Canonical link: <a href="https://commits.webkit.org/254595@main">https://commits.webkit.org/254595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c94f80ef762ee86d3898d0982e6bd59c74e9c4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98861 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32613 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28087 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81924 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93271 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25904 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76428 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25851 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68841 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30370 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14732 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30118 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15666 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3229 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38621 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34757 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->