### PR TITLE
Fix unused warnings in WebCore

### DIFF
--- a/Source/WebCore/Modules/push-api/PushManager.cpp
+++ b/Source/WebCore/Modules/push-api/PushManager.cpp
@@ -140,8 +140,10 @@ void PushManager::subscribe(ScriptExecutionContext& context, std::optional<PushS
 
             auto* window = document.frame() ? document.frame()->window() : nullptr;
             if (!window || !window->consumeTransientActivation()) {
+#if !RELEASE_LOG_DISABLED
                 Seconds lastActivationDuration = window ? MonotonicTime::now() - window->lastActivationTimestamp() : Seconds::infinity();
                 RELEASE_LOG_ERROR(Push, "Failing PushManager.subscribe call due to failed transient activation check; last activated %.2f sec ago", lastActivationDuration.value());
+#endif
 
                 auto errorMessage = "Push notification prompting can only be done from a user gesture."_s;
                 document.addConsoleMessage(MessageSource::Security, MessageLevel::Error, errorMessage);

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -1347,6 +1347,7 @@ void VTTCue::toJSON(JSON::Object& object) const
     object.setString("align"_s, align());
 }
 
+#if ENABLE(SPEECH_SYNTHESIS)
 static float mapVideoRateToSpeechRate(float rate)
 {
     // WebSpeech says to go from .1 -> 10 (default 1)
@@ -1358,6 +1359,7 @@ static float mapVideoRateToSpeechRate(float rate)
 
     return rate;
 }
+#endif
 
 void VTTCue::prepareToSpeak(SpeechSynthesis& speechSynthesis, double rate, double volume, SpeakCueCompletionHandler&& completion)
 {
@@ -1387,6 +1389,7 @@ void VTTCue::prepareToSpeak(SpeechSynthesis& speechSynthesis, double rate, doubl
     m_speechUtterance->setVolume(volume);
     m_speechUtterance->setRate(mapVideoRateToSpeechRate(rate));
 #else
+    UNUSED_PARAM(speechSynthesis);
     UNUSED_PARAM(rate);
     UNUSED_PARAM(volume);
     UNUSED_PARAM(completion);

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -44,8 +44,13 @@ using namespace Inspector;
 PageNetworkAgent::PageNetworkAgent(PageAgentContext& context, InspectorClient* client)
     : InspectorNetworkAgent(context)
     , m_inspectedPage(context.inspectedPage)
+#if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     , m_client(client)
+#endif
 {
+#if !ENABLE(INSPECTOR_NETWORK_THROTTLING)
+    UNUSED_PARAM(client);
+#endif
 }
 
 PageNetworkAgent::~PageNetworkAgent() = default;

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.h
@@ -52,7 +52,9 @@ private:
     bool shouldForceBufferingNetworkResourceData() const { return false; }
 
     Page& m_inspectedPage;
+#if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     InspectorClient* m_client { nullptr };
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -2963,6 +2963,8 @@ bool FrameView::requestScrollPositionUpdate(const ScrollPosition& position, Scro
         return scrollingCoordinator->requestScrollPositionUpdate(*this, position, scrollType, clamping);
 #else
     UNUSED_PARAM(position);
+    UNUSED_PARAM(scrollType);
+    UNUSED_PARAM(clamping);
 #endif
 
     return false;
@@ -2977,6 +2979,7 @@ bool FrameView::requestAnimatedScrollToPosition(const ScrollPosition& destinatio
         return scrollingCoordinator->requestAnimatedScrollToPosition(*this, destinationPosition, clamping);
 #else
     UNUSED_PARAM(destinationPosition);
+    UNUSED_PARAM(clamping);
 #endif
 
     return false;

--- a/Source/WebCore/page/WheelEventDeltaFilter.cpp
+++ b/Source/WebCore/page/WheelEventDeltaFilter.cpp
@@ -58,6 +58,7 @@ bool WheelEventDeltaFilter::shouldApplyFilteringForEvent(const PlatformWheelEven
     auto phase = event.phase();
     return phase == PlatformWheelEventPhase::Began || phase == PlatformWheelEventPhase::Changed;
 #else
+    UNUSED_PARAM(event);
     return false;
 #endif
 }

--- a/Source/WebCore/page/WheelEventTestMonitor.cpp
+++ b/Source/WebCore/page/WheelEventTestMonitor.cpp
@@ -121,6 +121,8 @@ void WheelEventTestMonitor::receivedWheelEvent(const PlatformWheelEvent& event)
 
     if (event.momentumPhase() == PlatformWheelEventPhase::Ended)
         m_receivedMomentumEnd = true;
+#else
+    UNUSED_PARAM(event);
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -242,6 +242,7 @@ void GraphicsContextCairo::drawFocusRing(const Path& path, float width, float of
     UNUSED_PARAM(offset);
     return;
 #else
+    UNUSED_PARAM(offset);
     Cairo::drawFocusRing(*this, path, width, color);
 #endif
 }
@@ -254,6 +255,7 @@ void GraphicsContextCairo::drawFocusRing(const Vector<FloatRect>& rects, float w
     UNUSED_PARAM(offset);
     return;
 #else
+    UNUSED_PARAM(offset);
     Cairo::drawFocusRing(*this, rects, width, color);
 #endif
 }

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -249,6 +249,10 @@ bool RenderLayerScrollableArea::requestScrollPositionUpdate(const ScrollPosition
 
     if (auto* scrollingCoordinator = m_layer.page().scrollingCoordinator())
         return scrollingCoordinator->requestScrollPositionUpdate(*this, position, scrollType, clamping);
+#else
+    UNUSED_PARAM(position);
+    UNUSED_PARAM(scrollType);
+    UNUSED_PARAM(clamping);
 #endif
     return false;
 }
@@ -260,6 +264,9 @@ bool RenderLayerScrollableArea::requestAnimatedScrollToPosition(const ScrollPosi
 
     if (auto* scrollingCoordinator = m_layer.page().scrollingCoordinator())
         return scrollingCoordinator->requestAnimatedScrollToPosition(*this, destinationPosition, clamping);
+#else
+    UNUSED_PARAM(destinationPosition);
+    UNUSED_PARAM(clamping);
 #endif
     return false;
 }

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
@@ -168,6 +168,8 @@ void RenderSVGBlock::mapLocalToContainer(const RenderLayerModelObject* ancestorC
         RenderBlock::mapLocalToContainer(ancestorContainer, transformState, mode, wasFixed);
         return;
     }
+#else
+    UNUSED_PARAM(mode);
 #endif
     SVGRenderSupport::mapLocalToContainer(*this, ancestorContainer, transformState, wasFixed);
 }

--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -76,6 +76,8 @@ LayoutRect RenderSVGInline::clippedOverflowRect(const RenderLayerModelObject* re
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     if (document().settings().layerBasedSVGEngineEnabled())
         return RenderInline::clippedOverflowRect(repaintContainer, context);
+#else
+    UNUSED_PARAM(context);
 #endif
     return SVGRenderSupport::clippedOverflowRectForRepaint(*this, repaintContainer);
 }
@@ -98,6 +100,8 @@ void RenderSVGInline::mapLocalToContainer(const RenderLayerModelObject* ancestor
         RenderInline::mapLocalToContainer(ancestorContainer, transformState, mode, wasFixed);
         return;
     }
+#else
+    UNUSED_PARAM(mode);
 #endif
     SVGRenderSupport::mapLocalToContainer(*this, ancestorContainer, transformState, wasFixed);
 }


### PR DESCRIPTION
#### b1c9ea1fcb1eac9c9a31b4331fecaff051669fe0
<pre>
Fix unused warnings in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=245319">https://bugs.webkit.org/show_bug.cgi?id=245319</a>

Reviewed by Chris Dumez.

Fix unusued warnings around parameters, functions and member variables
reported by Clang.

* Source/WebCore/Modules/push-api/PushManager.cpp:
* Source/WebCore/html/track/VTTCue.cpp:
* Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp:
* Source/WebCore/inspector/agents/page/PageNetworkAgent.h:
* Source/WebCore/page/FrameView.cpp:
* Source/WebCore/page/WheelEventDeltaFilter.cpp:
* Source/WebCore/page/WheelEventTestMonitor.cpp:
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
* Source/WebCore/rendering/svg/RenderSVGBlock.cpp:
* Source/WebCore/rendering/svg/RenderSVGInline.cpp:

Canonical link: <a href="https://commits.webkit.org/254594@main">https://commits.webkit.org/254594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc99ab11b798cb0397d2670dd0a46bdedcf80f2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98873 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155449 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32626 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81937 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93283 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25915 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76441 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25860 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68850 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30383 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30131 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15678 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3228 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33580 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38633 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34769 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->