### PR TITLE
Non-unified build fixes, mid September 2022 edition

### DIFF
--- a/Source/WebCore/css/FontFaceSet.cpp
+++ b/Source/WebCore/css/FontFaceSet.cpp
@@ -36,6 +36,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSFontFace.h"
 #include "JSFontFaceSet.h"
+#include "Quirks.h"
 #include "ScriptExecutionContext.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -38,6 +38,7 @@
 #include "Page.h"
 #include "RenderDescendantIterator.h"
 #include "RenderGeometryMap.h"
+#include "RenderImage.h"
 #include "RenderIterator.h"
 #include "RenderLayer.h"
 #include "RenderLayerBacking.h"

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -53,6 +53,8 @@
 
 namespace WebKit {
 
+using WebCore::FloatSize;
+
 static WebCore::IntRect screenRectOfContents(WebCore::Element* element)
 {
     ASSERT(element);

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFullScreenClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFullScreenClient.h
@@ -30,6 +30,7 @@
 
 #include "APIClient.h"
 #include "WKBundlePageFullScreenClient.h"
+#include <WebCore/FloatSize.h>
 #include <wtf/Forward.h>
 
 namespace API {


### PR DESCRIPTION
#### d9a0f6a4203678c657178ac297fb181d976ed69a
<pre>
Non-unified build fixes, mid September 2022 edition

Unreviewed non-unified build fixes.

* Source/WebCore/css/FontFaceSet.cpp: Add missing Quirks.h header
  inclusion.
* Source/WebCore/rendering/RenderView.cpp: Add missing RenderImage.h
  header inclusion.
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp: Add
  using WebCore::FloatSize, the type is used in a few places around,
  always without namespace prefix.
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFullScreenClient.h:
  Add missing WebCore/FloatSize.h header inclusion.

Canonical link: <a href="https://commits.webkit.org/254603@main">https://commits.webkit.org/254603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5288199b8ad5cfd9381e4c8ad31e8adfc8bcddeb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98880 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155469 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32633 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28105 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81944 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93290 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25921 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76447 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25869 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80674 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68860 "Found 3 new API test failures: /WebKit2Gtk/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/children-changed, /TestWTF:WTF_WordLock.ManyContendedLongSections, /WebKit2Gtk/TestWebKitVersion:/webkit/WebKitVersion/version (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30390 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14752 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30138 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15685 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3234 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38640 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34776 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->