### PR TITLE
REGRESSION (iOS 16 Beta): Crash adding / removing ScriptMessageHandlers to WKUserContentController

### DIFF
--- a/Source/WebKit/Shared/WebUserContentControllerDataTypes.cpp
+++ b/Source/WebKit/Shared/WebUserContentControllerDataTypes.cpp
@@ -103,7 +103,7 @@ std::optional<WebScriptMessageHandlerData> WebScriptMessageHandlerData::decode(I
     if (!worldIdentifier)
         return std::nullopt;
     
-    std::optional<AtomString> name;
+    std::optional<String> name;
     decoder >> name;
     if (!name)
         return std::nullopt;

--- a/Source/WebKit/Shared/WebUserContentControllerDataTypes.h
+++ b/Source/WebKit/Shared/WebUserContentControllerDataTypes.h
@@ -60,7 +60,7 @@ struct WebScriptMessageHandlerData {
 
     uint64_t identifier;
     ContentWorldIdentifier worldIdentifier;
-    AtomString name;
+    String name;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.cpp
@@ -30,12 +30,12 @@
 
 namespace WebKit {
 
-Ref<WebScriptMessageHandler> WebScriptMessageHandler::create(std::unique_ptr<Client> client, const AtomString& name, API::ContentWorld& world)
+Ref<WebScriptMessageHandler> WebScriptMessageHandler::create(std::unique_ptr<Client> client, const String& name, API::ContentWorld& world)
 {
     return adoptRef(*new WebScriptMessageHandler(WTFMove(client), name, world));
 }
 
-WebScriptMessageHandler::WebScriptMessageHandler(std::unique_ptr<Client> client, const AtomString& name, API::ContentWorld& world)
+WebScriptMessageHandler::WebScriptMessageHandler(std::unique_ptr<Client> client, const String& name, API::ContentWorld& world)
     : m_client(WTFMove(client))
     , m_name(name)
     , m_world(world)

--- a/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h
+++ b/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h
@@ -58,20 +58,20 @@ public:
         virtual void didPostMessageWithAsyncReply(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, WebCore::SerializedScriptValue&, WTF::Function<void(API::SerializedScriptValue*, const String&)>&&) = 0;
     };
 
-    static Ref<WebScriptMessageHandler> create(std::unique_ptr<Client>, const AtomString& name, API::ContentWorld&);
+    static Ref<WebScriptMessageHandler> create(std::unique_ptr<Client>, const String& name, API::ContentWorld&);
     virtual ~WebScriptMessageHandler();
 
-    AtomString name() const { return m_name; }
+    String name() const { return m_name; }
 
     API::ContentWorld& world() { return m_world.get(); }
 
     Client& client() const { return *m_client; }
 
 private:
-    WebScriptMessageHandler(std::unique_ptr<Client>, const AtomString&, API::ContentWorld&);
+    WebScriptMessageHandler(std::unique_ptr<Client>, const String&, API::ContentWorld&);
 
     std::unique_ptr<Client> m_client;
-    AtomString m_name;
+    String m_name;
     Ref<API::ContentWorld> m_world;
 };
 

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -309,7 +309,7 @@ void WebUserContentController::addUserScriptMessageHandlers(const Vector<WebScri
             continue;
         }
 
-        addUserScriptMessageHandlerInternal(*it->value.first, handler.identifier, handler.name);
+        addUserScriptMessageHandlerInternal(*it->value.first, handler.identifier, AtomString(handler.name));
     }
 #else
     UNUSED_PARAM(scriptMessageHandlers);


### PR DESCRIPTION
#### e7898844fe5a7ac2ccc907df169803ed6fad3399
<pre>
REGRESSION (iOS 16 Beta): Crash adding / removing ScriptMessageHandlers to WKUserContentController
<a href="https://bugs.webkit.org/show_bug.cgi?id=243343">https://bugs.webkit.org/show_bug.cgi?id=243343</a>

Reviewed by Chris Dumez.

250289@main made WebScriptMessageHandler.m_name an AtomString instead of a String.
This makes it easier for the UI process to crash because of corrupted AtomString tables
due to either misusing APIs on background threads or constructing a JSContext before initializing threading,
which then calls SmallStrings::initializeCommonStrings in the VM constructor.
Unfortunately TestWebKitAPI initializes threading in the TestsController constructor before starting any test code,
so we don&apos;t have CI infrastructure that can prevent regressions like this right now.
I did, however, verify that the example app WKWebViewBridgeCrashJSContext asserts every time and crashes sometimes
before this fix but not after.

* Source/WebKit/Shared/WebUserContentControllerDataTypes.cpp:
(WebKit::WebScriptMessageHandlerData::decode):
* Source/WebKit/Shared/WebUserContentControllerDataTypes.h:
* Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.cpp:
(WebKit::WebScriptMessageHandler::create):
(WebKit::WebScriptMessageHandler::WebScriptMessageHandler):
* Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h:
(WebKit::WebScriptMessageHandler::name const):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::addUserScriptMessageHandlers):

Canonical link: <a href="https://commits.webkit.org/254599@main">https://commits.webkit.org/254599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/059076a0482360713170984d62a1c1ea6523bf42

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98888 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32641 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81952 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93298 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25928 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76455 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25875 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80806 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/80682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68867 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30398 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30146 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/15693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3231 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33595 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32304 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/34784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->