### PR TITLE
Rebaseline / unskip some tests now that we supported nested dedicated workers

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -973,8 +973,6 @@ fast/dom/connected-subframe-counter-overflow.html [ Slow ]
 
 # Skip workers tests that are timing out or are SharedWorker related only
 imported/w3c/web-platform-tests/workers/interfaces/WorkerUtils/importScripts/006.html [ Skip ]
-imported/w3c/web-platform-tests/workers/nested_worker.worker.html [ Skip ]
-imported/w3c/web-platform-tests/workers/semantics/multiple-workers/003.html [ Skip ]
 imported/w3c/web-platform-tests/workers/modules/dedicated-worker-options-credentials.html [ Skip ]
 imported/w3c/web-platform-tests/workers/modules/shared-worker-import-csp.html [ Skip ]
 
@@ -1747,7 +1745,6 @@ imported/w3c/web-platform-tests/resource-timing/cross-origin-status-codes.html [
 imported/w3c/web-platform-tests/resource-timing/nested-context-navigations-embed.html [ Skip ]
 imported/w3c/web-platform-tests/resource-timing/nested-context-navigations-iframe.html [ Skip ]
 imported/w3c/web-platform-tests/resource-timing/nested-context-navigations-object.html [ Skip ]
-imported/w3c/web-platform-tests/resource-timing/resource_nested_dedicated_worker.worker.html [ Skip ]
 imported/w3c/web-platform-tests/resource-timing/buffer-full-inspect-buffer-during-callback.html [ Skip ]
 imported/w3c/web-platform-tests/resource-timing/buffer-full-set-to-current-buffer.html [ Skip ]
 imported/w3c/web-platform-tests/resource-timing/document-domain-no-impact-opener.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reporting-to-worker-owner.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reporting-to-worker-owner.https-expected.txt
@@ -1,11 +1,10 @@
-CONSOLE MESSAGE: ReferenceError: Can't find variable: Worker
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: Worker
+Harness Error (TIMEOUT), message = null
 
-TIMEOUT Reporting to coep-none worker with coep-none worker Test timed out
-NOTRUN Reporting to coep-none worker with coep-report-only worker
-NOTRUN Reporting to coep-none worker with coep-require-corp worker
-NOTRUN Reporting to coep-report-only worker with coep-none worker
+PASS Reporting to coep-none worker with coep-none worker
+PASS Reporting to coep-none worker with coep-report-only worker
+PASS Reporting to coep-none worker with coep-require-corp worker
+TIMEOUT Reporting to coep-report-only worker with coep-none worker Test timed out
 NOTRUN Reporting to coep-report-only worker with coep-report-only worker
 NOTRUN Reporting to coep-report-only worker with coep-require-corp worker
 NOTRUN Reporting to coep-require-corp worker with coep-none worker

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-worker-success.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-worker-success.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL postMessaging to a dedicated sub-worker allows them to see each others' modifications Can't find variable: Worker
-FAIL Bonus: self.crossOriginIsolated assert_true: expected true got undefined
+PASS postMessaging to a dedicated sub-worker allows them to see each others' modifications
+PASS Bonus: self.crossOriginIsolated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8-expected.txt
@@ -1,10 +1,7 @@
 CONSOLE MESSAGE: WebSocket connection to 'ws://localhost:49001/echo-query?%C3%A5' failed: WebSocket is closed before the connection is established.
-CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=e3b4acc5-7a85-48f9-87f4-f1226f09bb31' because non CSS MIME types are not allowed in strict mode.
-CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=aff7d112-4148-4796-ba60-89c76804e540' because non CSS MIME types are not allowed in strict mode.
-CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=3be6dd2b-41f7-4251-bedf-91b97adac4c3' because non CSS MIME types are not allowed in strict mode.
-CONSOLE MESSAGE: ApplicationCache is deprecated. Please use ServiceWorkers instead.
-CONSOLE MESSAGE: ApplicationCache is deprecated. Please use ServiceWorkers instead.
-CONSOLE MESSAGE: ApplicationCache is deprecated. Please use ServiceWorkers instead.
+CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=bbbc95eb-4248-4abd-a3d9-37565b9230bb' because non CSS MIME types are not allowed in strict mode.
+CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=3a6546f1-03df-4f16-80a5-d54660d98ccd' because non CSS MIME types are not allowed in strict mode.
+CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=5dd7b0b7-1185-4558-b33a-4ac0e487b4e9' because non CSS MIME types are not allowed in strict mode.
 
 Harness Error (TIMEOUT), message = null
 
@@ -29,9 +26,7 @@ PASS submit form <input formaction>
 PASS submit form <button formaction>
 PASS <base href>
 PASS Worker constructor
-FAIL SharedWorker constructor null is not an object (evaluating 'worker.port.onmessage = this.step_func_done(function(e) {
-      assert_equals(e.data, expected_current);
-    })')
+PASS SharedWorker constructor
 PASS EventSource constructor
 PASS EventSource#url
 PASS window.open()
@@ -45,22 +40,13 @@ PASS SVG <image>
 PASS SVG <use>
 PASS XMLHttpRequest#open()
 PASS importScripts() in a dedicated worker
-FAIL Worker() in a dedicated worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: Worker"
+PASS Worker() in a dedicated worker
 FAIL SharedWorker() in a dedicated worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: SharedWorker"
-FAIL importScripts() in a shared worker null is not an object (evaluating 'worker.port.onmessage = this.step_func_done(function(e) {
-      assert_equals(e.data, expected_utf8);
-    })')
-FAIL Worker() in a shared worker null is not an object (evaluating 'worker.port.onmessage = this.step_func_done(function(e) {
-      assert_equals(e.data, expected_utf8);
-    })')
-FAIL SharedWorker() in a shared worker null is not an object (evaluating 'worker.port.onmessage = this.step_func_done(function(e) {
-      assert_equals(e.data, expected_utf8);
-    })')
+FAIL importScripts() in a shared worker assert_equals: expected "%C3%A5" but got "importScripts failed to run"
+FAIL Worker() in a shared worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: Worker"
+FAIL SharedWorker() in a shared worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: SharedWorker"
 PASS WebSocket constructor
 PASS WebSocket#url
-PASS Parsing cache manifest (CACHE)
-PASS Parsing cache manifest (FALLBACK)
-PASS Parsing cache manifest (NETWORK)
 PASS CSS <link> (utf-8) #<id> { background-image:<url> }
 FAIL CSS <link> (windows-1252) #<id> { background-image:<url> } assert_equals: expected "%C3%A5" but got "%E5"
 PASS CSS <style> #<id> { background-image:<url> }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251-expected.txt
@@ -1,10 +1,7 @@
 CONSOLE MESSAGE: WebSocket connection to 'ws://localhost:49001/echo-query?%C3%A5' failed: WebSocket is closed before the connection is established.
-CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=1188282a-ca52-4f4d-bdf6-608096286893' because non CSS MIME types are not allowed in strict mode.
-CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=9ca7bfe6-3b53-4239-8cc6-ae919066b3fd' because non CSS MIME types are not allowed in strict mode.
-CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=9f7181df-04f9-4485-b25b-16c4c3895af3' because non CSS MIME types are not allowed in strict mode.
-CONSOLE MESSAGE: ApplicationCache is deprecated. Please use ServiceWorkers instead.
-CONSOLE MESSAGE: ApplicationCache is deprecated. Please use ServiceWorkers instead.
-CONSOLE MESSAGE: ApplicationCache is deprecated. Please use ServiceWorkers instead.
+CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=12eb74d2-e5c8-4006-8f5c-9e5bd9a46ec3' because non CSS MIME types are not allowed in strict mode.
+CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=7bde69cd-9652-4542-ad92-24cd4a8e366c' because non CSS MIME types are not allowed in strict mode.
+CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=70f80937-d86e-4654-aa5e-6427fcf69bca' because non CSS MIME types are not allowed in strict mode.
 
 Harness Error (TIMEOUT), message = null
 
@@ -19,41 +16,37 @@ TIMEOUT loading image <embed src> Test timed out
 TIMEOUT loading image <object data> Test timed out
 FAIL loading image <input src> assert_equals: expected substring %26%23229%3B got unknown query expected (undefined) undefined but got (number) 256
 FAIL loading image <video poster> assert_equals: expected substring %26%23229%3B got unknown query expected (undefined) undefined but got (number) 256
-TIMEOUT loading video <video> Test timed out
-TIMEOUT loading video <video><source> Test timed out
-TIMEOUT loading video <audio> Test timed out
-TIMEOUT loading video <audio><source> Test timed out
+FAIL loading video <video> assert_equals: expected substring %26%23229%3B got unknown query expected (undefined) undefined but got (number) 300
+FAIL loading video <video><source> assert_equals: expected substring %26%23229%3B got unknown query expected (undefined) undefined but got (number) 300
+FAIL loading video <audio> assert_equals: expected substring %26%23229%3B got unknown query expected (undefined) undefined but got (number) 300
+FAIL loading video <audio><source> assert_equals: expected substring %26%23229%3B got unknown query expected (undefined) undefined but got (number) 300
 PASS loading webvtt <track>
 PASS submit form <form action>
 PASS submit form <input formaction>
 PASS submit form <button formaction>
 FAIL <base href> assert_true: expected substring %26%23229%3B got http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/resource.py?q=%C3%A5&encoding=windows-1251&type= expected true got false
 PASS Worker constructor
-FAIL SharedWorker constructor Can't find variable: SharedWorker
+PASS SharedWorker constructor
 PASS EventSource constructor
 PASS EventSource#url
-FAIL XMLDocument#load() doc.load is not a function. (In 'doc.load(input_url_svg)', 'doc.load' is undefined)
 PASS window.open()
 FAIL <a>.search assert_true: href content attribute expected substring %26%23229%3B got http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/resource.py?q=%C3%A5&encoding=windows-1251&type=html expected true got false
 FAIL <area>.search assert_true: href content attribute expected substring %26%23229%3B got http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/resource.py?q=%C3%A5&encoding=windows-1251&type=html expected true got false
 FAIL history.pushState assert_equals: url was resolved against the iframe's URL instead of the settings object's API base URL expected -1 but got 76
 FAIL history.replaceState assert_equals: url was resolved against the iframe's URL instead of the settings object's API base URL expected -1 but got 76
 PASS SVG <a>
-TIMEOUT SVG <feImage>
+TIMEOUT SVG <feImage> Test timed out
 FAIL SVG <image> assert_equals: expected "%26%23229%3B" but got "%C3%A5"
 PASS SVG <use>
 FAIL XMLHttpRequest#open() assert_equals: expected "%C3%A5" but got "%26%23229%3B"
 PASS importScripts() in a dedicated worker
-FAIL Worker() in a dedicated worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: Worker"
+PASS Worker() in a dedicated worker
 FAIL SharedWorker() in a dedicated worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: SharedWorker"
-FAIL importScripts() in a shared worker Can't find variable: SharedWorker
-FAIL Worker() in a shared worker Can't find variable: SharedWorker
-FAIL SharedWorker() in a shared worker Can't find variable: SharedWorker
+FAIL importScripts() in a shared worker assert_equals: expected "%C3%A5" but got "importScripts failed to run"
+FAIL Worker() in a shared worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: Worker"
+FAIL SharedWorker() in a shared worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: SharedWorker"
 PASS WebSocket constructor
 PASS WebSocket#url
-PASS Parsing cache manifest (CACHE)
-PASS Parsing cache manifest (FALLBACK)
-PASS Parsing cache manifest (NETWORK)
 FAIL CSS <link> (windows-1251) #<id> { background-image:<url> } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
 PASS CSS <link> (utf-8) #<id> { background-image:<url> }
 FAIL CSS <style> #<id> { background-image:<url> } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
@@ -80,7 +73,7 @@ PASS URL constructor, url
 PASS URL constructor, base
 PASS Scheme ftp (getting <a>.href)
 PASS Scheme file (getting <a>.href)
-PASS Scheme gopher (getting <a>.href)
+FAIL Scheme gopher (getting <a>.href) assert_true: expected substring %26%23229%3B got gopher://example.invalid/?x=%C3%A5 expected true got false
 PASS Scheme http (getting <a>.href)
 PASS Scheme https (getting <a>.href)
 PASS Scheme ws (getting <a>.href)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252-expected.txt
@@ -1,10 +1,7 @@
 CONSOLE MESSAGE: WebSocket connection to 'ws://localhost:49001/echo-query?%C3%A5' failed: WebSocket is closed before the connection is established.
-CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=3283dc28-d7a4-4f0b-ae55-4c0b4e136c85' because non CSS MIME types are not allowed in strict mode.
-CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=ba150eb8-2b9f-47d0-a7b4-2ef8adb5f947' because non CSS MIME types are not allowed in strict mode.
-CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=d7967ae9-19f3-488d-9036-e2935d95cef1' because non CSS MIME types are not allowed in strict mode.
-CONSOLE MESSAGE: ApplicationCache is deprecated. Please use ServiceWorkers instead.
-CONSOLE MESSAGE: ApplicationCache is deprecated. Please use ServiceWorkers instead.
-CONSOLE MESSAGE: ApplicationCache is deprecated. Please use ServiceWorkers instead.
+CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=437b5a4c-2b68-45ac-8386-405489ffdb4b' because non CSS MIME types are not allowed in strict mode.
+CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=ab013cbe-45f7-41e3-9f26-34ef8d27edeb' because non CSS MIME types are not allowed in strict mode.
+CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/stash.py?q=%C3%A5&action=put&id=949b61b3-4871-4824-bb6e-66bc3881530f' because non CSS MIME types are not allowed in strict mode.
 
 Harness Error (TIMEOUT), message = null
 
@@ -29,9 +26,7 @@ PASS submit form <input formaction>
 PASS submit form <button formaction>
 FAIL <base href> assert_true: expected substring %E5 got http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/resources/resource.py?q=%C3%A5&encoding=windows-1252&type= expected true got false
 PASS Worker constructor
-FAIL SharedWorker constructor null is not an object (evaluating 'worker.port.onmessage = this.step_func_done(function(e) {
-      assert_equals(e.data, expected_current);
-    })')
+PASS SharedWorker constructor
 PASS EventSource constructor
 PASS EventSource#url
 PASS window.open()
@@ -45,22 +40,13 @@ FAIL SVG <image> assert_equals: expected "%E5" but got "%C3%A5"
 PASS SVG <use>
 FAIL XMLHttpRequest#open() assert_equals: expected "%C3%A5" but got "%E5"
 PASS importScripts() in a dedicated worker
-FAIL Worker() in a dedicated worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: Worker"
+PASS Worker() in a dedicated worker
 FAIL SharedWorker() in a dedicated worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: SharedWorker"
-FAIL importScripts() in a shared worker null is not an object (evaluating 'worker.port.onmessage = this.step_func_done(function(e) {
-      assert_equals(e.data, expected_utf8);
-    })')
-FAIL Worker() in a shared worker null is not an object (evaluating 'worker.port.onmessage = this.step_func_done(function(e) {
-      assert_equals(e.data, expected_utf8);
-    })')
-FAIL SharedWorker() in a shared worker null is not an object (evaluating 'worker.port.onmessage = this.step_func_done(function(e) {
-      assert_equals(e.data, expected_utf8);
-    })')
+FAIL importScripts() in a shared worker assert_equals: expected "%C3%A5" but got "importScripts failed to run"
+FAIL Worker() in a shared worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: Worker"
+FAIL SharedWorker() in a shared worker assert_equals: expected "%C3%A5" but got "ReferenceError: Can't find variable: SharedWorker"
 PASS WebSocket constructor
 PASS WebSocket#url
-PASS Parsing cache manifest (CACHE)
-PASS Parsing cache manifest (FALLBACK)
-PASS Parsing cache manifest (NETWORK)
 FAIL CSS <link> (windows-1252) #<id> { background-image:<url> } assert_equals: expected "%C3%A5" but got "%E5"
 PASS CSS <link> (utf-8) #<id> { background-image:<url> }
 FAIL CSS <style> #<id> { background-image:<url> } assert_equals: expected "%C3%A5" but got "%E5"

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_nested_dedicated_worker.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_nested_dedicated_worker.worker-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Resource timing for nested dedicated workers Test timed out
+PASS Resource timing for nested dedicated workers
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Nested worker Can't find variable: Worker
+PASS Nested worker
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/multiple-workers/003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/multiple-workers/003-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: ReferenceError: Can't find variable: Worker
 
-FAIL creating 3 nested dedicated workers assert_unreached: error Reached unreachable code
+PASS creating 3 nested dedicated workers
 


### PR DESCRIPTION
#### f5b26fd2d6829003be638f031ae9df4fee77e979
<pre>
Rebaseline / unskip some tests now that we supported nested dedicated workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=245327">https://bugs.webkit.org/show_bug.cgi?id=245327</a>

Unreviewed, rebaseline / unskip some tests now that we supported nested dedicated workers.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reporting-to-worker-owner.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-worker-success.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_nested_dedicated_worker.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/nested_worker.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/multiple-workers/003-expected.txt:

Canonical link: <a href="https://commits.webkit.org/254629@main">https://commits.webkit.org/254629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e45b2dbf94c92620e4eaddbf966027670821afc0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98891 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155483 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32644 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28112 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81955 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93301 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25932 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76458 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25878 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68870 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30401 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14765 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30149 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15698 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38653 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1363 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34789 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->