### PR TITLE
Implement ARIA id-ref reflection for ElementInternals

### DIFF
--- a/LayoutTests/accessibility/custom-elements/controls-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/controls-expected.txt
@@ -1,0 +1,16 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS labelForControl(accessibilityController.accessibleElementById("custom-tab-1").ariaControlsElementAtIndex(0)) is "AXValue: Panel 1"
+PASS labelForControl(accessibilityController.accessibleElementById("custom-tab-1").ariaControlsElementAtIndex(1)) is "AXValue: Panel 2"
+PASS labelForControl(accessibilityController.accessibleElementById("custom-tab-2").ariaControlsElementAtIndex(0)) is "AXValue: Panel 3"
+PASS accessibilityController.accessibleElementById("custom-tab-2").ariaControlsElementAtIndex(1) is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Panel 1
+Panel 2
+Panel 3
+Panel 4

--- a/LayoutTests/accessibility/custom-elements/controls.html
+++ b/LayoutTests/accessibility/custom-elements/controls.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-tab id="custom-tab-1"></custom-tab>
+<div class="control">Panel 1</div>
+<div class="control">Panel 2</div>
+<custom-tab id="custom-tab-2" aria-controls="panel3"></custom-tab>
+<div id="panel3" class="control">Panel 3</div>
+<div id="panel4" class="control">Panel 4</div>
+<script>
+
+customElements.define('custom-tab', class CustomElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'tab';
+        internals.ariaControlsElements = Array.from(document.querySelectorAll('.control'));
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    function labelForControl(control) {
+        if (accessibilityController.platformName == "mac")
+            return control.childAtIndex(0).stringValue;
+        return control.stringValue;
+    }
+    shouldBeEqualToString('labelForControl(accessibilityController.accessibleElementById("custom-tab-1").ariaControlsElementAtIndex(0))', 'AXValue: Panel 1');
+    shouldBeEqualToString('labelForControl(accessibilityController.accessibleElementById("custom-tab-1").ariaControlsElementAtIndex(1))', 'AXValue: Panel 2');
+    shouldBeEqualToString('labelForControl(accessibilityController.accessibleElementById("custom-tab-2").ariaControlsElementAtIndex(0))', 'AXValue: Panel 3');
+    shouldBe('accessibilityController.accessibleElementById("custom-tab-2").ariaControlsElementAtIndex(1)', 'null');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/describedby-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/describedby-expected.txt
@@ -1,0 +1,28 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("custom-1").role is "AXRole: AXCheckBox"
+PASS accessibilityController.accessibleElementById("custom-1").helpText is "AXHelp: some description other description"
+PASS accessibilityController.accessibleElementById("custom-1").detailsElements().length is 2
+PASS accessibilityController.accessibleElementById("custom-1").detailsElements()[0].domIdentifier is "details1"
+PASS accessibilityController.accessibleElementById("custom-1").detailsElements()[1].domIdentifier is "details2"
+PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements().length is 2
+PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements()[0].domIdentifier is "error1"
+PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements()[1].domIdentifier is "error2"
+PASS accessibilityController.accessibleElementById("custom-2").role is "AXRole: AXCheckBox"
+PASS accessibilityController.accessibleElementById("custom-2").helpText is "AXHelp: some description"
+PASS accessibilityController.accessibleElementById("custom-2").detailsElements().length is 1
+PASS accessibilityController.accessibleElementById("custom-2").detailsElements()[0].domIdentifier is "details2"
+PASS accessibilityController.accessibleElementById("custom-2").errorMessageElements().length is 1
+PASS accessibilityController.accessibleElementById("custom-2").errorMessageElements()[0].domIdentifier is "error2"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+some description
+other description
+some details
+other details
+some error
+other error

--- a/LayoutTests/accessibility/custom-elements/describedby.html
+++ b/LayoutTests/accessibility/custom-elements/describedby.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<body id="body">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-element id="custom-1"></custom-element>
+<custom-element id="custom-2" aria-describedby="some" aria-details="details2" aria-errormessage="error2"></custom-element>
+<div id="some" class="note">some description</div>
+<div class="note">other description</div>
+<div id="details1" class="details">some details</div>
+<div id="details2" class="details">other details</div>
+<div id="error1" class="error">some error</div>
+<div id="error2" class="error">other error</div>
+<script>
+
+customElements.define('custom-element', class CustomElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'checkbox';
+        internals.ariaDescribedByElements = Array.from(document.querySelectorAll('.note'));
+        internals.ariaDetailsElements = Array.from(document.querySelectorAll('.details'));
+        internals.ariaErrorMessageElements = Array.from(document.querySelectorAll('.error'));
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").role', 'AXRole: AXCheckBox');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").helpText', 'AXHelp: some description other description');
+    shouldBe('accessibilityController.accessibleElementById("custom-1").detailsElements().length', '2');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").detailsElements()[0].domIdentifier', 'details1');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").detailsElements()[1].domIdentifier', 'details2');
+    shouldBe('accessibilityController.accessibleElementById("custom-1").errorMessageElements().length', '2');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").errorMessageElements()[0].domIdentifier', 'error1');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").errorMessageElements()[1].domIdentifier', 'error2');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-2").role', 'AXRole: AXCheckBox');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-2").helpText', 'AXHelp: some description');
+    shouldBe('accessibilityController.accessibleElementById("custom-2").detailsElements().length', '1');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-2").detailsElements()[0].domIdentifier', 'details2');
+    shouldBe('accessibilityController.accessibleElementById("custom-2").errorMessageElements().length', '1');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-2").errorMessageElements()[0].domIdentifier', 'error2');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/flowto-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/flowto-expected.txt
@@ -1,0 +1,24 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("custom-1").role is "AXRole: AXCheckBox"
+PASS platformValueForW3CName(accessibilityController.accessibleElementById("custom-1")) is "label 1 label 2"
+PASS accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(0).role is "AXRole: AXButton"
+PASS accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(0).title is "AXTitle: FlowTo1"
+PASS accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(1).role is "AXRole: AXButton"
+PASS accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(1).title is "AXTitle: FlowTo2"
+PASS accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(2) is null
+PASS accessibilityController.accessibleElementById("custom-2").role is "AXRole: AXCheckBox"
+PASS platformValueForW3CName(accessibilityController.accessibleElementById("custom-2")) is "label 2"
+PASS accessibilityController.accessibleElementById("custom-2").ariaFlowToElementAtIndex(0).role is "AXRole: AXButton"
+PASS accessibilityController.accessibleElementById("custom-2").ariaFlowToElementAtIndex(0).title is "AXTitle: FlowTo2"
+PASS accessibilityController.accessibleElementById("custom-2").ariaFlowToElementAtIndex(1) is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+FlowTo1
+FlowTo2
+label 1
+label 2

--- a/LayoutTests/accessibility/custom-elements/flowto.html
+++ b/LayoutTests/accessibility/custom-elements/flowto.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<body id="body">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-element id="custom-1"></custom-element>
+<custom-element id="custom-2" aria-flowto="flowto2" aria-labelledby="label2"></custom-element>
+<div role="button" class="flowto">FlowTo1</div>
+<div id="flowto2" role="button" class="flowto">FlowTo2</div>
+<div class="label">label 1</div>
+<div id="label2" class="label">label 2</div>
+<script>
+
+customElements.define('custom-element', class CustomElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'checkbox';
+        internals.ariaFlowToElements = Array.from(document.querySelectorAll('.flowto'));
+        internals.ariaLabelledByElements = Array.from(document.querySelectorAll('.label'));
+    }
+});
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").role', 'AXRole: AXCheckBox');
+    shouldBeEqualToString('platformValueForW3CName(accessibilityController.accessibleElementById("custom-1"))', 'label 1 label 2');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(0).role', 'AXRole: AXButton');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(0).title', 'AXTitle: FlowTo1');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(1).role', 'AXRole: AXButton');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(1).title', 'AXTitle: FlowTo2');
+    shouldBe('accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(2)', 'null');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-2").role', 'AXRole: AXCheckBox');
+    shouldBeEqualToString('platformValueForW3CName(accessibilityController.accessibleElementById("custom-2"))', 'label 2');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-2").ariaFlowToElementAtIndex(0).role', 'AXRole: AXButton');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-2").ariaFlowToElementAtIndex(0).title', 'AXTitle: FlowTo2');
+    shouldBe('accessibilityController.accessibleElementById("custom-2").ariaFlowToElementAtIndex(1)', 'null');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/menuitem-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/menuitem-expected.txt
@@ -3,6 +3,12 @@ This tests that aria fallback roles work correctly.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS accessibilityController.accessibleElementById("menu-1").selectedChildrenCount is 1
+PASS platformValueForW3CName(accessibilityController.accessibleElementById("menu-1").selectedChildAtIndex(0)) is "item 2"
+PASS accessibilityController.accessibleElementById("menu-1").selectedChildAtIndex(0).isSelected is true
+PASS accessibilityController.accessibleElementById("menu-2").selectedChildrenCount is 1
+PASS platformValueForW3CName(accessibilityController.accessibleElementById("menu-2").selectedChildAtIndex(0)) is "item 3"
+PASS accessibilityController.accessibleElementById("menu-2").selectedChildAtIndex(0).isSelected is true
 PASS accessibilityController.accessibleElementById("item-1").isEnabled is false
 PASS accessibilityController.accessibleElementById("item-1").isExpanded is true
 PASS accessibilityController.accessibleElementById("item-1").hasPopup is true

--- a/LayoutTests/accessibility/custom-elements/menuitem.html
+++ b/LayoutTests/accessibility/custom-elements/menuitem.html
@@ -3,9 +3,26 @@
 <body>
 <script src="../../resources/js-test.js"></script>
 <script src="../../resources/accessibility-helper.js"></script>
-<custom-menuitem id="item-1"></custom-menuitem>
-<custom-menuitem id="item-2" aria-disabled="false" aria-expanded="false" aria-haspopup="false"></custom-menuitem>
+<custom-menu id="menu-1">
+<custom-menuitem id="item-1" aria-label="item 1"></custom-menuitem>
+<custom-menuitem id="item-2" aria-label="item 2" aria-disabled="false" aria-expanded="false" aria-haspopup="false"></custom-menuitem>
+</custom-menu>
+<custom-menu id="menu-2" aria-activedescendant="item-3">
+<custom-menuitem id="item-3" aria-label="item 3"></custom-menuitem>
+<custom-menuitem id="item-4" aria-label="item 4"></custom-menuitem>
+</custom-menu>
 <script>
+
+customElements.define('custom-menu', class CustomElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'menubar';
+        internals.ariaActiveDescendantElement = document.getElementById('item-2');
+        window.customMenuInternals = internals;
+    }
+});
 
 customElements.define('custom-menuitem', class CustomElement extends HTMLElement {
     constructor()
@@ -23,6 +40,12 @@ description("This tests that aria fallback roles work correctly.");
 if (!window.accessibilityController)
     debug('This test requires accessibilityController');
 else {
+    shouldBe('accessibilityController.accessibleElementById("menu-1").selectedChildrenCount', '1');
+    shouldBeEqualToString('platformValueForW3CName(accessibilityController.accessibleElementById("menu-1").selectedChildAtIndex(0))', 'item 2');
+    shouldBeTrue('accessibilityController.accessibleElementById("menu-1").selectedChildAtIndex(0).isSelected');
+    shouldBe('accessibilityController.accessibleElementById("menu-2").selectedChildrenCount', '1');
+    shouldBeEqualToString('platformValueForW3CName(accessibilityController.accessibleElementById("menu-2").selectedChildAtIndex(0))', 'item 3');
+    shouldBeTrue('accessibilityController.accessibleElementById("menu-2").selectedChildAtIndex(0).isSelected');
     shouldBe('accessibilityController.accessibleElementById("item-1").isEnabled', 'false');
     shouldBe('accessibilityController.accessibleElementById("item-1").isExpanded', 'true');
     shouldBe('accessibilityController.accessibleElementById("item-1").hasPopup', 'true');

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-accessibility-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-accessibility-expected.txt
@@ -1,6 +1,6 @@
 
 PASS role is defined in ElementInternals
-FAIL ariaActiveDescendantElement is defined in ElementInternals assert_inherits: property "ariaActiveDescendantElement" not found in prototype chain
+PASS ariaActiveDescendantElement is defined in ElementInternals
 PASS ariaAtomic is defined in ElementInternals
 PASS ariaAutoComplete is defined in ElementInternals
 PASS ariaBusy is defined in ElementInternals
@@ -8,27 +8,27 @@ PASS ariaChecked is defined in ElementInternals
 PASS ariaColCount is defined in ElementInternals
 PASS ariaColIndex is defined in ElementInternals
 PASS ariaColSpan is defined in ElementInternals
-FAIL ariaControlsElements is defined in ElementInternals assert_inherits: property "ariaControlsElements" not found in prototype chain
+PASS ariaControlsElements is defined in ElementInternals
 PASS ariaCurrent is defined in ElementInternals
-FAIL ariaDescribedByElements is defined in ElementInternals assert_inherits: property "ariaDescribedByElements" not found in prototype chain
-FAIL ariaDetailsElements is defined in ElementInternals assert_inherits: property "ariaDetailsElements" not found in prototype chain
+PASS ariaDescribedByElements is defined in ElementInternals
+PASS ariaDetailsElements is defined in ElementInternals
 PASS ariaDisabled is defined in ElementInternals
 FAIL ariaErrorMessageElement is defined in ElementInternals assert_inherits: property "ariaErrorMessageElement" not found in prototype chain
 PASS ariaExpanded is defined in ElementInternals
-FAIL ariaFlowToElements is defined in ElementInternals assert_inherits: property "ariaFlowToElements" not found in prototype chain
+PASS ariaFlowToElements is defined in ElementInternals
 PASS ariaHasPopup is defined in ElementInternals
 PASS ariaHidden is defined in ElementInternals
 PASS ariaInvalid is defined in ElementInternals
 PASS ariaKeyShortcuts is defined in ElementInternals
 PASS ariaLabel is defined in ElementInternals
-FAIL ariaLabelledByElements is defined in ElementInternals assert_inherits: property "ariaLabelledByElements" not found in prototype chain
+PASS ariaLabelledByElements is defined in ElementInternals
 PASS ariaLevel is defined in ElementInternals
 PASS ariaLive is defined in ElementInternals
 PASS ariaModal is defined in ElementInternals
 PASS ariaMultiLine is defined in ElementInternals
 PASS ariaMultiSelectable is defined in ElementInternals
 PASS ariaOrientation is defined in ElementInternals
-FAIL ariaOwnsElements is defined in ElementInternals assert_inherits: property "ariaOwnsElements" not found in prototype chain
+PASS ariaOwnsElements is defined in ElementInternals
 PASS ariaPlaceholder is defined in ElementInternals
 PASS ariaPosInSet is defined in ElementInternals
 PASS ariaPressed is defined in ElementInternals

--- a/LayoutTests/platform/gtk/accessibility/custom-elements/describedby-expected.txt
+++ b/LayoutTests/platform/gtk/accessibility/custom-elements/describedby-expected.txt
@@ -1,0 +1,29 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS accessibilityController.accessibleElementById("custom-1").role is "AXRole: AXCheckBox"
+PASS accessibilityController.accessibleElementById("custom-1").helpText is "AXHelp: some description other description"
+FAIL accessibilityController.accessibleElementById("custom-1").detailsElements().length should be 2. Threw exception TypeError: undefined is not an object (evaluating 'accessibilityController.accessibleElementById("custom-1").detailsElements().length')
+FAIL accessibilityController.accessibleElementById("custom-1").detailsElements()[0].domIdentifier should be details1. Threw exception TypeError: undefined is not an object (evaluating 'accessibilityController.accessibleElementById("custom-1").detailsElements()[0]')
+FAIL accessibilityController.accessibleElementById("custom-1").detailsElements()[1].domIdentifier should be details2. Threw exception TypeError: undefined is not an object (evaluating 'accessibilityController.accessibleElementById("custom-1").detailsElements()[1]')
+FAIL accessibilityController.accessibleElementById("custom-1").errorMessageElements().length should be 2. Threw exception TypeError: undefined is not an object (evaluating 'accessibilityController.accessibleElementById("custom-1").errorMessageElements().length')
+FAIL accessibilityController.accessibleElementById("custom-1").errorMessageElements()[0].domIdentifier should be error1. Threw exception TypeError: undefined is not an object (evaluating 'accessibilityController.accessibleElementById("custom-1").errorMessageElements()[0]')
+FAIL accessibilityController.accessibleElementById("custom-1").errorMessageElements()[1].domIdentifier should be error2. Threw exception TypeError: undefined is not an object (evaluating 'accessibilityController.accessibleElementById("custom-1").errorMessageElements()[1]')
+PASS accessibilityController.accessibleElementById("custom-2").role is "AXRole: AXCheckBox"
+PASS accessibilityController.accessibleElementById("custom-2").helpText is "AXHelp: some description"
+FAIL accessibilityController.accessibleElementById("custom-2").detailsElements().length should be 1. Threw exception TypeError: undefined is not an object (evaluating 'accessibilityController.accessibleElementById("custom-2").detailsElements().length')
+FAIL accessibilityController.accessibleElementById("custom-2").detailsElements()[0].domIdentifier should be details2. Threw exception TypeError: undefined is not an object (evaluating 'accessibilityController.accessibleElementById("custom-2").detailsElements()[0]')
+FAIL accessibilityController.accessibleElementById("custom-2").errorMessageElements().length should be 1. Threw exception TypeError: undefined is not an object (evaluating 'accessibilityController.accessibleElementById("custom-2").errorMessageElements().length')
+FAIL accessibilityController.accessibleElementById("custom-2").errorMessageElements()[0].domIdentifier should be error2. Threw exception TypeError: undefined is not an object (evaluating 'accessibilityController.accessibleElementById("custom-2").errorMessageElements()[0]')
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+some description
+other description
+some details
+other details
+some error
+other error

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -314,7 +314,7 @@ fast/forms/datalist [ WontFix ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-datalist-element [ WontFix ]
 
 # Default ARIA for custom elements are not yet enabled
-accessibility/custom-elements/role.html [ Skip ]
+accessibility/custom-elements/ [ Skip ]
 
 # Missing necessary testing logic (AccessibilityController::{get,set}RetainedElement)
 accessibility/ax-object-destroyed-on-reload.html [ Skip ]

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -558,6 +558,7 @@ bindings/js/JSDeprecatedCSSOMValueCustom.cpp
 bindings/js/JSDocumentCustom.cpp
 bindings/js/JSDocumentFragmentCustom.cpp
 bindings/js/JSElementCustom.cpp
+bindings/js/JSElementInternalsCustom.cpp
 bindings/js/JSErrorEventCustom.cpp
 bindings/js/JSErrorHandler.cpp
 bindings/js/JSEventCustom.cpp

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -265,7 +265,7 @@ bool AXObjectCache::isModalElement(Element& element) const
     AtomString modalValue = element.attributeWithoutSynchronization(aria_modalAttr);
     if (modalValue.isNull()) {
         if (auto* defaultARIA = element.customElementDefaultARIAIfExists())
-            modalValue = defaultARIA->valueForAttribute(aria_modalAttr);
+            modalValue = defaultARIA->valueForAttribute(element, aria_modalAttr);
     }
     bool isAriaModal = equalLettersIgnoringASCIICase(modalValue, "true"_s);
     return (hasDialogRole && isAriaModal) || (is<HTMLDialogElement>(element) && downcast<HTMLDialogElement>(element).isModal());
@@ -541,10 +541,11 @@ bool nodeHasRole(Node* node, StringView role)
     if (!node || !is<Element>(node))
         return false;
 
-    AtomString roleValue = downcast<Element>(*node).attributeWithoutSynchronization(roleAttr);
+    auto& element = downcast<Element>(*node);
+    AtomString roleValue = element.attributeWithoutSynchronization(roleAttr);
     if (roleValue.isNull()) {
-        if (auto* defaultARIA = downcast<Element>(*node).customElementDefaultARIAIfExists())
-            roleValue = defaultARIA->valueForAttribute(roleAttr);
+        if (auto* defaultARIA = element.customElementDefaultARIAIfExists())
+            roleValue = defaultARIA->valueForAttribute(element, roleAttr);
     }
     if (role.isNull())
         return roleValue.isEmpty();
@@ -4042,22 +4043,30 @@ void AXObjectCache::updateRelationsIfNeeded()
     m_relationTargets.clear();
 
     struct RelationOrigin {
-        Element* originElement { nullptr };
+        RefPtr<Element> originElement;
         AtomString targetID;
         AXRelationType relationType;
     };
 
     struct RelationTarget {
-        Element* targetElement { nullptr };
+        RefPtr<Element> targetElement;
         AtomString targetID;
     };
 
     Vector<RelationOrigin> origins;
     Vector<RelationTarget> targets;
+    // FIXME: Make this code work with shadow DOM.
     for (auto& element : descendantsOfType<Element>(m_document.rootNode())) {
         // Collect all possible origins, i.e., elements with non-empty relation attributes.
         for (const auto& attribute : relationAttributes()) {
             auto& idsString = element.attributeWithoutSynchronization(attribute);
+            if (idsString.isNull()) {
+                if (auto* defaultARIA = element.customElementDefaultARIAIfExists()) {
+                    for (auto& targetElement : defaultARIA->elementsForAttribute(element, attribute))
+                        addRelation(&element, targetElement.get(), attributeToRelationType(attribute));
+                }
+                continue;
+            }
             SpaceSplitString ids(idsString, SpaceSplitString::ShouldFoldCase::No);
             for (size_t i = 0; i < ids.size(); ++i)
                 origins.append({ &element, ids[i], attributeToRelationType(attribute) });
@@ -4077,7 +4086,7 @@ void AXObjectCache::updateRelationsIfNeeded()
             }
 
             if (origin.targetID == target.targetID)
-                addRelation(origin.originElement, target.targetElement, origin.relationType);
+                addRelation(origin.originElement.get(), target.targetElement.get(), origin.relationType);
         }
     }
 }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2279,7 +2279,7 @@ const AtomString& AccessibilityObject::getAttribute(const QualifiedName& attribu
         if (!value.isNull())
             return value;
         if (auto* defaultARIA = element->customElementDefaultARIAIfExists())
-            return defaultARIA->valueForAttribute(attribute);
+            return defaultARIA->valueForAttribute(*element, attribute);
     }
     return nullAtom();
 }
@@ -3740,8 +3740,16 @@ Vector<Element*> AccessibilityObject::elementsFromAttribute(const QualifiedName&
         return { };
 
     auto& idsString = getAttribute(attribute);
-    if (idsString.isEmpty())
+    if (idsString.isEmpty()) {
+        auto& element = downcast<Element>(*node);
+        if (auto* defaultARIA = element.customElementDefaultARIAIfExists()) {
+            Vector<Element*> elements;
+            for (auto& element : defaultARIA->elementsForAttribute(element, attribute))
+                elements.append(element.get());
+            return elements;
+        }
         return { };
+    }
 
     Vector<Element*> elements;
     auto& treeScope = node->treeScope();

--- a/Source/WebCore/bindings/js/JSElementInternalsCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementInternalsCustom.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSElementInternals.h"
+
+#include "HTMLNames.h"
+
+namespace WebCore {
+using namespace JSC;
+
+static JSValue getElementsArrayAttribute(JSGlobalObject& lexicalGlobalObject, const JSElementInternals& thisObject, const QualifiedName& attributeName)
+{
+    auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* cachedObject = nullptr;
+    JSValue cachedObjectValue = thisObject.getDirect(vm, builtinNames(vm).cachedAttrAssociatedElementsPrivateName());
+    if (cachedObjectValue)
+        cachedObject = asObject(cachedObjectValue);
+    else {
+        cachedObject = constructEmptyObject(vm, thisObject.globalObject()->nullPrototypeObjectStructure());
+        const_cast<JSElementInternals&>(thisObject).putDirect(vm, builtinNames(vm).cachedAttrAssociatedElementsPrivateName(), cachedObject);
+    }
+
+    std::optional<Vector<RefPtr<Element>>> elements = thisObject.wrapped().getElementsArrayAttribute(attributeName);
+    auto propertyName = PropertyName(Identifier::fromString(vm, attributeName.toString()));
+    JSValue cachedValue = cachedObject->getDirect(vm, propertyName);
+    if (!cachedValue.isEmpty()) {
+        std::optional<Vector<RefPtr<Element>>> cachedElements = convert<IDLNullable<IDLFrozenArray<IDLInterface<Element>>>>(lexicalGlobalObject, cachedValue);
+        if (elements == cachedElements)
+            return cachedValue;
+    }
+
+    JSValue elementsValue = toJS<IDLNullable<IDLFrozenArray<IDLInterface<Element>>>>(lexicalGlobalObject, *thisObject.globalObject(), throwScope, elements);
+    cachedObject->putDirect(vm, propertyName, elementsValue);
+    return elementsValue;
+}
+
+JSValue JSElementInternals::ariaControlsElements(JSGlobalObject& lexicalGlobalObject) const
+{
+    return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_controlsAttr);
+}
+
+JSValue JSElementInternals::ariaDescribedByElements(JSGlobalObject& lexicalGlobalObject) const
+{
+    return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_describedbyAttr);
+}
+
+JSValue JSElementInternals::ariaDetailsElements(JSGlobalObject& lexicalGlobalObject) const
+{
+    return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_detailsAttr);
+}
+
+JSValue JSElementInternals::ariaErrorMessageElements(JSGlobalObject& lexicalGlobalObject) const
+{
+    return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_errormessageAttr);
+}
+
+JSValue JSElementInternals::ariaFlowToElements(JSGlobalObject& lexicalGlobalObject) const
+{
+    return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_flowtoAttr);
+}
+
+JSValue JSElementInternals::ariaLabelledByElements(JSGlobalObject& lexicalGlobalObject) const
+{
+    return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_labelledbyAttr);
+}
+
+JSValue JSElementInternals::ariaOwnsElements(JSGlobalObject& lexicalGlobalObject) const
+{
+    return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_ownsAttr);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/CustomElementDefaultARIA.h
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.h
@@ -28,9 +28,13 @@
 #include "QualifiedName.h"
 #include <wtf/HashMap.h>
 #include <wtf/IsoMalloc.h>
+#include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
+
+class WeakPtrImplWithEventTargetData;
 
 class CustomElementDefaultARIA {
     WTF_MAKE_ISO_ALLOCATED(CustomElementDefaultARIA);
@@ -39,11 +43,16 @@ public:
     ~CustomElementDefaultARIA();
 
     bool hasAttribute(const QualifiedName&) const;
-    const AtomString& valueForAttribute(const QualifiedName&) const;
+    const AtomString& valueForAttribute(const Element& thisElement, const QualifiedName&) const;
     void setValueForAttribute(const QualifiedName&, const AtomString&);
+    Element* elementForAttribute(const Element& thisElement, const QualifiedName&) const;
+    void setElementForAttribute(const QualifiedName&, Element*);
+    Vector<RefPtr<Element>> elementsForAttribute(const Element& thisElement, const QualifiedName&) const;
+    void setElementsForAttribute(const QualifiedName&, std::optional<Vector<RefPtr<Element>>>&&);
 
 private:
-    HashMap<QualifiedName, AtomString> m_map;
+    using WeakElementPtr = WeakPtr<Element, WeakPtrImplWithEventTargetData>;
+    HashMap<QualifiedName, std::variant<AtomString, WeakElementPtr, Vector<WeakElementPtr>>> m_map;
 };
 
 }; // namespace WebCore

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -48,27 +48,72 @@ ShadowRoot* ElementInternals::shadowRoot() const
     return shadowRoot;
 }
 
+static const AtomString& computeValueForAttribute(Element& element, const QualifiedName& name)
+{
+    auto& value = element.attributeWithoutSynchronization(name);
+    if (auto* defaultARIA = element.customElementDefaultARIAIfExists(); value.isNull() && defaultARIA)
+        return defaultARIA->valueForAttribute(element, name);
+    return value;
+}
+
 void ElementInternals::setAttributeWithoutSynchronization(const QualifiedName& name, const AtomString& value)
 {
     RefPtr element = m_element.get();
-
-    auto* defaultARIA = m_element->customElementDefaultARIAIfExists();
-    auto oldValue = defaultARIA ? defaultARIA->valueForAttribute(name) : nullAtom();
-    if (oldValue.isNull())
-        oldValue = element->attributeWithoutSynchronization(name);
+    auto oldValue = computeValueForAttribute(*element, name);
 
     element->customElementDefaultARIA().setValueForAttribute(name, value);
 
     if (AXObjectCache* cache = element->document().existingAXObjectCache())
-        cache->deferAttributeChangeIfNeeded(element.get(), name, oldValue, value);
+        cache->deferAttributeChangeIfNeeded(element.get(), name, oldValue, computeValueForAttribute(*element, name));
 }
 
 const AtomString& ElementInternals::attributeWithoutSynchronization(const QualifiedName& name) const
 {
-    auto* defaultARIA = m_element->customElementDefaultARIAIfExists();
+    RefPtr element = m_element.get();
+    auto* defaultARIA = element->customElementDefaultARIAIfExists();
     if (!defaultARIA)
         return nullAtom();
-    return defaultARIA->valueForAttribute(name);
+    return defaultARIA->valueForAttribute(*element, name);
+}
+
+Element* ElementInternals::getElementAttribute(const QualifiedName& name) const
+{
+    RefPtr element = m_element.get();
+    auto* defaultARIA = m_element->customElementDefaultARIAIfExists();
+    if (!defaultARIA)
+        return nullptr;
+    return defaultARIA->elementForAttribute(*element, name);
+}
+
+void ElementInternals::setElementAttribute(const QualifiedName& name, Element* value)
+{
+    RefPtr element = m_element.get();
+    auto oldValue = computeValueForAttribute(*element, name);
+
+    element->customElementDefaultARIA().setElementForAttribute(name, value);
+
+    if (AXObjectCache* cache = element->document().existingAXObjectCache())
+        cache->deferAttributeChangeIfNeeded(element.get(), name, oldValue, computeValueForAttribute(*element, name));
+}
+
+std::optional<Vector<RefPtr<Element>>> ElementInternals::getElementsArrayAttribute(const QualifiedName& name) const
+{
+    RefPtr element = m_element.get();
+    auto* defaultARIA = m_element->customElementDefaultARIAIfExists();
+    if (!defaultARIA)
+        return std::nullopt;
+    return defaultARIA->elementsForAttribute(*element, name);
+}
+
+void ElementInternals::setElementsArrayAttribute(const QualifiedName& name, std::optional<Vector<RefPtr<Element>>>&& value)
+{
+    RefPtr element = m_element.get();
+    auto oldValue = computeValueForAttribute(*element, name);
+
+    element->customElementDefaultARIA().setElementsForAttribute(name, WTFMove(value));
+
+    if (AXObjectCache* cache = element->document().existingAXObjectCache())
+        cache->deferAttributeChangeIfNeeded(element.get(), name, oldValue, computeValueForAttribute(*element, name));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ElementInternals.h
+++ b/Source/WebCore/dom/ElementInternals.h
@@ -47,6 +47,11 @@ public:
     const AtomString& attributeWithoutSynchronization(const QualifiedName&) const;
     void setAttributeWithoutSynchronization(const QualifiedName&, const AtomString& value);
 
+    Element* getElementAttribute(const QualifiedName&) const;
+    void setElementAttribute(const QualifiedName&, Element*);
+    std::optional<Vector<RefPtr<Element>>> getElementsArrayAttribute(const QualifiedName&) const;
+    void setElementsArrayAttribute(const QualifiedName&, std::optional<Vector<RefPtr<Element>>>&&);
+
 private:
     ElementInternals(HTMLElement& element)
         : m_element(element)

--- a/Source/WebCore/dom/ElementInternals.idl
+++ b/Source/WebCore/dom/ElementInternals.idl
@@ -31,6 +31,7 @@
     readonly attribute ShadowRoot? shadowRoot;
 
     [CEReactions, Reflect, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? role;
+    [CEReactions, Reflect=aria_activedescendant, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute Element? ariaActiveDescendantElement;
     [CEReactions, Reflect=aria_atomic, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaAtomic;
     [CEReactions, Reflect=aria_autocomplete, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaAutoComplete;
     [CEReactions, Reflect=aria_busy, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaBusy;
@@ -38,26 +39,27 @@
     [CEReactions, Reflect=aria_colcount, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaColCount;
     [CEReactions, Reflect=aria_colindex, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaColIndex;
     [CEReactions, Reflect=aria_colspan, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaColSpan;
-
+    [CEReactions, CustomGetter, Reflect=aria_controls, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute FrozenArray<Element>? ariaControlsElements;
     [CEReactions, Reflect=aria_current, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaCurrent;
-
+    [CEReactions, CustomGetter, Reflect=aria_describedby, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute FrozenArray<Element>? ariaDescribedByElements;
+    [CEReactions, CustomGetter, Reflect=aria_details, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute FrozenArray<Element>? ariaDetailsElements;
     [CEReactions, Reflect=aria_disabled, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaDisabled;
-
+    [CEReactions, CustomGetter, Reflect=aria_errormessage, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute FrozenArray<Element>? ariaErrorMessageElements;
     [CEReactions, Reflect=aria_expanded, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaExpanded;
-
+    [CEReactions, CustomGetter, Reflect=aria_flowto, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute FrozenArray<Element>? ariaFlowToElements;
     [CEReactions, Reflect=aria_haspopup, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaHasPopup;
     [CEReactions, Reflect=aria_hidden, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaHidden;
     [CEReactions, Reflect=aria_invalid, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaInvalid;
     [CEReactions, Reflect=aria_keyshortcuts, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaKeyShortcuts;
     [CEReactions, Reflect=aria_label, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaLabel;
-
+    [CEReactions, CustomGetter, Reflect=aria_labelledby, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute FrozenArray<Element>? ariaLabelledByElements;
     [CEReactions, Reflect=aria_level, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaLevel;
     [CEReactions, Reflect=aria_live, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaLive;
     [CEReactions, Reflect=aria_modal, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaModal;
     [CEReactions, Reflect=aria_multiline, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaMultiLine;
     [CEReactions, Reflect=aria_multiselectable, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaMultiSelectable;
     [CEReactions, Reflect=aria_orientation, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaOrientation;
-
+    [CEReactions, CustomGetter, Reflect=aria_owns, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute FrozenArray<Element>? ariaOwnsElements;
     [CEReactions, Reflect=aria_placeholder, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaPlaceholder;
     [CEReactions, Reflect=aria_posinset, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaPosInSet;
     [CEReactions, Reflect=aria_pressed, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaPressed;


### PR DESCRIPTION
#### 6989a5b880ac9b18befc8e0c921bac4f778a2189
<pre>
Implement ARIA id-ref reflection for ElementInternals
<a href="https://bugs.webkit.org/show_bug.cgi?id=245328">https://bugs.webkit.org/show_bug.cgi?id=245328</a>

Reviewed by Manuel Rego Casasnovas.

This patch adds the support for id-ref ARIA attributes to ElementInternals.

* LayoutTests/accessibility/custom-elements/controls-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/controls.html: Added.
* LayoutTests/accessibility/custom-elements/describedby-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/describedby.html: Added.
* LayoutTests/accessibility/custom-elements/flowto-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/flowto.html: Added.
* LayoutTests/accessibility/custom-elements/menuitem-expected.txt:
* LayoutTests/accessibility/custom-elements/menuitem.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-accessibility-expected.txt:
* LayoutTests/platform/gtk/accessibility/custom-elements/describedby-expected.txt: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::isModalElement const):
(WebCore::nodeHasRole):
(WebCore::AXObjectCache::updateRelationsIfNeeded): Add the support for defining relations via ElementInternals.

* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::getAttribute const):
(WebCore::AccessibilityObject::elementsFromAttribute const): Ditto.

* Source/WebCore/bindings/js/JSElementInternalsCustom.cpp: Added.
(WebCore::getElementsArrayAttribute): Added.
(WebCore::JSElementInternals::ariaControlsElements const): Added.
(WebCore::JSElementInternals::ariaDescribedByElements const): Added.
(WebCore::JSElementInternals::ariaDetailsElements const): Added.
(WebCore::JSElementInternals::ariaErrorMessageElements const):
(WebCore::JSElementInternals::ariaFlowToElements const): Added.
(WebCore::JSElementInternals::ariaLabelledByElements const): Added.
(WebCore::JSElementInternals::ariaOwnsElements const): Added.

* Source/WebCore/dom/CustomElementDefaultARIA.cpp:
(WebCore::isElementVisible): Added.
(WebCore::CustomElementDefaultARIA::valueForAttribute const): Added the support for converting
WeakPtr&lt;Element&gt; and Vector&lt;WeakPtr&lt;Element&gt;&gt; to ID strings.
(WebCore::CustomElementDefaultARIA::elementForAttribute const): Added.
(WebCore::CustomElementDefaultARIA::setElementForAttribute): Added.
(WebCore::CustomElementDefaultARIA::elementsForAttribute const): Added.
(WebCore::CustomElementDefaultARIA::setElementsForAttribute): Added.

* Source/WebCore/dom/CustomElementDefaultARIA.h:

* Source/WebCore/dom/ElementInternals.cpp:
(WebCore::computeValueForAttribute): Extracted out of setAttributeWithoutSynchronization.
(WebCore::ElementInternals::setAttributeWithoutSynchronization):
(WebCore::ElementInternals::attributeWithoutSynchronization const):
(WebCore::ElementInternals::getElementAttribute const): Added.
(WebCore::ElementInternals::setElementAttribute): Added.
(WebCore::ElementInternals::getElementsArrayAttribute const): Added.
(WebCore::ElementInternals::setElementsArrayAttribute): Added.

* Source/WebCore/dom/ElementInternals.h:
* Source/WebCore/dom/ElementInternals.idl:

Canonical link: <a href="https://commits.webkit.org/254709@main">https://commits.webkit.org/254709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/985cac217a5a97a627899435da2c5de8c0be953a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99229 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156261 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32933 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28352 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82228 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93550 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26153 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76696 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26075 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69078 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30680 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14941 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30418 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15882 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38841 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1411 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34966 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->