### PR TITLE
Turn macOS smooth keyboard scrolling on by default

### DIFF
--- a/LayoutTests/css3/scroll-snap/scroll-padding-overflow-paging.html
+++ b/LayoutTests/css3/scroll-snap/scroll-padding-overflow-paging.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ScrollAnimatorEnabled=false ] -->
+<!DOCTYPE html>
 <html>
     <head>
         <style>
@@ -29,6 +29,7 @@
 
                 clickOnElement(container);
                 await UIHelper.keyDown("pageDown");
+                await UIHelper.waitForTargetScrollAnimationToSettle(container);
 
                 expectTrue(container.scrollTop != 0, "paging moved container");
                 let defaultPagePosition = container.scrollTop;
@@ -37,6 +38,7 @@
                 container.scrollTop = 0;
                 container.style.scrollPaddingTop = "10px";
                 await UIHelper.keyDown("pageDown");
+                await UIHelper.waitForTargetScrollAnimationToSettle(container);
 
                 let expected = (container.clientHeight - 10) * pageProportion;
                 expectTrue(container.scrollTop != 0, "paging moved padded container");
@@ -46,6 +48,7 @@
                 container.style.scrollPaddingTop = "0px";
                 container.style.scrollPaddingBottom = "10px";
                 await UIHelper.keyDown("pageDown");
+                await UIHelper.waitForTargetScrollAnimationToSettle(container);
 
                 expectTrue(container.scrollTop != 0, "paging moved padded container");
                 shouldBeCloseTo("container.scrollTop", expected, 1);
@@ -54,6 +57,7 @@
                 container.style.scrollPaddingTop = "10px";
                 container.style.scrollPaddingBottom = "10px";
                 await UIHelper.keyDown("pageDown");
+                await UIHelper.waitForTargetScrollAnimationToSettle(container);
 
                 expected = (container.clientHeight - 20) * pageProportion;
                 expectTrue(container.scrollTop != 0, "paging moved padded container");

--- a/LayoutTests/fast/repaint/resources/fixed-move-after-keyboard-scroll-iframe.html
+++ b/LayoutTests/fast/repaint/resources/fixed-move-after-keyboard-scroll-iframe.html
@@ -21,7 +21,12 @@
       }
       if (window.testRunner)
           window.testRunner.waitUntilDone();
-      document.addEventListener("scroll", scrollAndRepaint, false);
+
+      eventSender.monitorWheelEvents();
+
+      setTimeout(function() {
+          eventSender.callAfterScrollingCompletes(scrollAndRepaint);
+      }, 0);
   </script>
 </head>
   <body style="height: 820;">

--- a/LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document-expected.txt
+++ b/LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document-expected.txt
@@ -1,1 +1,1 @@
-PASS: scrollLeft is -120
+scrollLeft is -40

--- a/LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document.html
+++ b/LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document.html
@@ -28,12 +28,8 @@
 
         function checkForScroll()
         {
-            var expectedScrollLeft = -120;
             var scrollLeft = document.scrollingElement.scrollLeft;
-            if (scrollLeft != expectedScrollLeft)
-                document.getElementById('result').textContent = "FAIL: scrollLeft is " + scrollLeft +  ", expected " + expectedScrollLeft;
-            else
-                document.getElementById('result').textContent = "PASS: scrollLeft is " + scrollLeft;
+            document.getElementById('result').textContent = "scrollLeft is " + scrollLeft;
 
             if (window.testRunner)
                 testRunner.notifyDone();

--- a/LayoutTests/platform/mac-wk1/fast/scrolling/arrow-key-scroll-in-rtl-document-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/scrolling/arrow-key-scroll-in-rtl-document-expected.txt
@@ -1,0 +1,1 @@
+scrollLeft is -120

--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -275,7 +275,7 @@ EventHandlerDrivenSmoothKeyboardScrollingEnabled:
   WebKitLegacy:
    default: false
   WebKit:
-   default: false
+   default: true
   WebCore:
    default: false
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4411,8 +4411,11 @@ bool EventHandler::startKeyboardScrollAnimationOnEnclosingScrollableContainer(Sc
 
     if (node) {
         auto renderer = node->renderer();
+        if (!renderer)
+            return false;
+
         RenderBox& renderBox = renderer->enclosingBox();
-        if (renderer && !renderer->isListBox() && startKeyboardScrollAnimationOnRenderBoxAndItsAncestors(direction, granularity, &renderBox))
+        if (!renderer->isListBox() && startKeyboardScrollAnimationOnRenderBoxAndItsAncestors(direction, granularity, &renderBox))
             return true;
     }
     return false;


### PR DESCRIPTION
#### cd1dbd2ab3f6005242c7ba9db7356e538d09ad2d
<pre>
Turn macOS smooth keyboard scrolling on by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=228159">https://bugs.webkit.org/show_bug.cgi?id=228159</a>
rdar://80912063

Reviewed by Tim Horton and Wenson Hsieh.

No tests added.

Set the default value for EventHandlerDrivenSmoothKeyboardScrollingEnabled to true in WebKit.

* LayoutTests/css3/scroll-snap/scroll-padding-overflow-paging.html:
Updated to reflect non-instananeous scrolling.

* LayoutTests/fast/repaint/resources/fixed-move-after-keyboard-scroll-iframe.html:
Updated to reflect non-instananeous scrolling.

* LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document-expected.txt:
* LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document.html:
* LayoutTests/platform/mac-wk1/fast/scrolling/arrow-key-scroll-in-rtl-document-expected.txt: Added.
Updated these tests to reflect the new distance scrolled.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
`EventHandlerDrivenSmoothKeyboardScrollingEnabled` is now true on default for WebKit.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::startKeyboardScrollAnimationOnEnclosingScrollableContainer):
Added check if renderer is null to fix crash in LayoutTests/fast/forms/select/select-change-type-on-focus.

* Tools/TestWebKitAPI/Tests/WebKit/SpacebarScrolling.cpp:
(TestWebKitAPI::didRunJavascript):
(TestWebKitAPI::TEST):
Updated to reflect non-instananeous scrolling.

Canonical link: <a href="https://commits.webkit.org/255031@main">https://commits.webkit.org/255031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e5a42ee80b60cd4021af0a9db95f4c7d181ae90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/27 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100462 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/159410 "Found 1 new test failure: fast/workers/worker-crash-with-invalid-location.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/65 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29109 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83398 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97168 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96699 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/54 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77819 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27004 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/81642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70041 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82539 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35192 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15664 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77545 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32989 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16654 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26711 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3501 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36771 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80143 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35738 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17558 "Passed tests") | 
<!--EWS-Status-Bubble-End-->