### PR TITLE
Minor refactoring in CatchScope.

### DIFF
--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -57,7 +57,7 @@ public:
     // Sizes up to this amount get a size class for each size step.
     static constexpr size_t preciseCutoff = 80;
     
-    // The amount of available payload in a block is the block's size minus the footer.
+    // The amount of available payload in a block is the block's size minus the header.
     static constexpr size_t blockPayload = MarkedBlock::payloadSize;
     
     // The largest cell we're willing to allocate in a MarkedBlock the "normal way" (i.e. using size

--- a/Source/JavaScriptCore/runtime/CatchScope.h
+++ b/Source/JavaScriptCore/runtime/CatchScope.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,14 +44,8 @@ public:
 
     JS_EXPORT_PRIVATE ~CatchScope();
 
-    void clearException() { m_vm.clearException(); }
-    bool clearExceptionExceptTermination()
-    {
-        if (UNLIKELY(m_vm.hasPendingTerminationException()))
-            return false;
-        m_vm.clearException();
-        return true;
-    }
+    void clearException();
+    bool clearExceptionExceptTermination();
 };
 
 #define DECLARE_CATCH_SCOPE(vm__) \
@@ -67,20 +61,27 @@ public:
     CatchScope(const CatchScope&) = delete;
     CatchScope(CatchScope&&) = default;
 
-    ALWAYS_INLINE void clearException() { m_vm.clearException(); }
-    ALWAYS_INLINE bool clearExceptionExceptTermination()
-    {
-        if (UNLIKELY(m_vm.hasPendingTerminationException()))
-            return false;
-        m_vm.clearException();
-        return true;
-    }
+    ALWAYS_INLINE void clearException();
+    ALWAYS_INLINE bool clearExceptionExceptTermination();
 };
 
 #define DECLARE_CATCH_SCOPE(vm__) \
     JSC::CatchScope((vm__))
 
 #endif // ENABLE(EXCEPTION_SCOPE_VERIFICATION)
+
+ALWAYS_INLINE void CatchScope::clearException()
+{
+    m_vm.clearException();
+}
+
+ALWAYS_INLINE bool CatchScope::clearExceptionExceptTermination()
+{
+    if (UNLIKELY(m_vm.hasPendingTerminationException()))
+        return false;
+    m_vm.clearException();
+    return true;
+}
 
 #define CLEAR_AND_RETURN_IF_EXCEPTION(scope__, value__) do { \
         if (UNLIKELY((scope__).exception())) { \


### PR DESCRIPTION
#### 7451a72657e8f615954874bbbf9ebec08b577d64
<pre>
Minor refactoring in CatchScope.
<a href="https://bugs.webkit.org/show_bug.cgi?id=245337">https://bugs.webkit.org/show_bug.cgi?id=245337</a>
&lt;rdar://problem/100091910&gt;

Reviewed by Justin Michaud.

Refactor out common method implementations in CatchScope that is not dependent on
ENABLE(EXCEPTION_SCOPE_VERIFICATION) instead of duplicating them.

Also fixed a comment in MarkedSpace.h.

* Source/JavaScriptCore/heap/MarkedSpace.h:
* Source/JavaScriptCore/runtime/CatchScope.h:
(JSC::CatchScope::clearException):
(JSC::CatchScope::clearExceptionExceptTermination):

Canonical link: <a href="https://commits.webkit.org/254617@main">https://commits.webkit.org/254617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5682292f72de2bbd4f339998fe336756753f08df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98917 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155530 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32669 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28144 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93326 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25954 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76483 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25902 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80716 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68894 "Found 6 new API test failures: /WebKit2Gtk/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/children-changed, /WebKit2Gtk/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /TestWTF:WTF_WordLock.ManyContendedLongSections, /WebKit2Gtk/TestWebKitSettings:/webkit/WebKitSettings/webkit-settings, /WebKit2Gtk/TestWebKitVersion:/webkit/WebKitVersion/version, /WebKit2Gtk/TestUIClient:/webkit/WebKitWebView/allow-modal-dialogs (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81291 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30426 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/14794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/76164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30174 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15727 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/76164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3239 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33623 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38673 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/78710 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32332 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34818 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17261 "Passed tests") | 
<!--EWS-Status-Bubble-End-->