### PR TITLE
[WGSL] Implement parsing for array types and callable array constructors.

### DIFF
--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -31,6 +31,10 @@
 
 namespace WGSL {
 
+namespace AST {
+class ArrayType;
+}
+
 template<typename Lexer>
 class Parser {
 public:
@@ -50,6 +54,7 @@ public:
     Expected<AST::StructMember, Error> parseStructMember();
     Expected<UniqueRef<AST::TypeDecl>, Error> parseTypeDecl();
     Expected<UniqueRef<AST::TypeDecl>, Error> parseTypeDeclAfterIdentifier(StringView&&, SourcePosition start);
+    Expected<UniqueRef<AST::TypeDecl>, Error> parseArrayType();
     Expected<AST::VariableDecl, Error> parseVariableDecl();
     Expected<AST::VariableDecl, Error> parseVariableDeclWithAttributes(AST::Attributes&&);
     Expected<AST::VariableQualifier, Error> parseVariableQualifier();


### PR DESCRIPTION
#### d22295da2d69385297114b3985dbc255bdacadab
<pre>
[WGSL] Implement parsing for array types and callable array constructors.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244792">https://bugs.webkit.org/show_bug.cgi?id=244792</a>
rdar://99557526

Reviewed by Myles Maxfield.

* Source/WebGPU/WGSL/AST/TypeDecl.h:
(WGSL::AST::TypeDecl::isArray const):
Add kind and predicate for array types.
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseTypeDecl):
Begin parsing of an array type declaration. Defers to parseArrayType to do
actual parsing.
(WGSL::Parser&lt;Lexer&gt;::parseArrayType):
Parse an array type consisting of &apos;array&apos; (&apos;&lt;&apos; TypeDecl (&apos;,&apos;
AdditionExpression)? &apos;&gt;&apos;)?
This is different to the WGSL spec as this recursive descent parser can&apos;t handle
the grammar factored as AdditiveExpression | BitwiseExpression. Making the
element TypeDecl optional allows the code to parse array in
CallableExpression. Validity of array TypeDecls that require element TypeDecl
will be handled when type-checking the AST.
(WGSL::Parser&lt;Lexer&gt;::parsePrimaryExpression):
Accept array type as a CallableExpression.
* Source/WebGPU/WGSL/ParserPrivate.h:
Add prototype for parsing array type
* Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm:
- Test the parsing of a WebGPU example triangle vertex &amp; fragment shader that
contains ArrayType, ArrayAccess and CallableExpression of array.
- Add some macros to help alleviate the repeative AST matching patterns.

Canonical link: <a href="https://commits.webkit.org/254650@main">https://commits.webkit.org/254650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f60ee029b1b87b6feb2c77fe5ae11f0ce177879d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98973 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32725 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28195 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82048 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93378 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26001 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76531 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25961 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68952 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30479 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14839 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30229 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15772 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3247 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/frame-src/frame-src-sandboxed-allowed.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33677 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38716 "Found 1 new test failure: security/cannot-read-self-from-file.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1389 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34864 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->