### PR TITLE
[JSC] Accelerate baseline String#replace performance

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2651,11 +2651,19 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case StringReplace:
     case StringReplaceRegExp:
         if (node->child1().useKind() == StringUse
-            && (node->child2().useKind() == RegExpObjectUse || node->child2().useKind() == StringUse)
+            && node->child2().useKind() == RegExpObjectUse
             && node->child3().useKind() == StringUse) {
             // This doesn't clobber the world. It just reads and writes regexp state.
         } else
             clobberWorld();
+        setForNode(node, m_vm.stringStructure.get());
+        break;
+
+    case StringReplaceString:
+        if (node->child3().useKind() != StringUse) {
+            // child3 could be non String (e.g. function). In this case, any side effect can happen.
+            clobberWorld();
+        }
         setForNode(node, m_vm.stringStructure.get());
         break;
 

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3055,6 +3055,16 @@ bool ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, Intrinsic
             setResult(resultNode);
             return true;
         }
+
+        case StringPrototypeReplaceStringIntrinsic: {
+            if (argumentCountIncludingThis < 3)
+                return false;
+
+            insertChecks();
+            Node* resultNode = addToGraph(StringReplaceString, OpInfo(0), OpInfo(prediction), get(virtualRegisterForArgumentIncludingThis(0, registerOffset)), get(virtualRegisterForArgumentIncludingThis(1, registerOffset)), get(virtualRegisterForArgumentIncludingThis(2, registerOffset)));
+            setResult(resultNode);
+            return true;
+        }
             
         case RoundIntrinsic:
         case FloorIntrinsic:

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -1813,11 +1813,13 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
             write(RegExpState);
             write(RegExpObject_lastIndex);
             return;
-        } else if (node->child1().useKind() == StringUse
-            && node->child2().useKind() == StringUse
-            && node->child3().useKind() == StringUse) {
-            return;
         }
+        clobberTop();
+        return;
+
+    case StringReplaceString:
+        if (node->child3().useKind() == StringUse)
+            return;
         clobberTop();
         return;
 

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -398,6 +398,7 @@ bool doesGC(Graph& graph, Node* node)
     case StrCat:
     case StringReplace:
     case StringReplaceRegExp:
+    case StringReplaceString:
     case StringSlice:
     case StringValueOf:
     case CreateRest:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1511,11 +1511,12 @@ private:
             if (op == StringReplace
                 && node->child1()->shouldSpeculateString()
                 && node->child2()->shouldSpeculateString()
-                && node->child3()->shouldSpeculateString()
                 && m_graph.isWatchingStringSymbolReplaceWatchpoint(node)) {
+                node->setOp(StringReplaceString);
                 fixEdge<StringUse>(node->child1());
                 fixEdge<StringUse>(node->child2());
-                fixEdge<StringUse>(node->child3());
+                if (node->child3()->shouldSpeculateString())
+                    fixEdge<StringUse>(node->child3());
                 break;
             }
 
@@ -1541,6 +1542,14 @@ private:
                 fixEdge<StringUse>(node->child3());
                 break;
             }
+            break;
+        }
+
+        case StringReplaceString: {
+            fixEdge<StringUse>(node->child1());
+            fixEdge<StringUse>(node->child2());
+            if (node->child3()->shouldSpeculateString())
+                fixEdge<StringUse>(node->child3());
             break;
         }
             

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1758,6 +1758,7 @@ public:
         case GetGlobalLexicalVariable:
         case StringReplace:
         case StringReplaceRegExp:
+        case StringReplaceString:
         case ToNumber:
         case ToNumeric:
         case ToObject:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -329,6 +329,7 @@ namespace JSC { namespace DFG {
     macro(RegExpMatchFastGlobal, NodeResultJS) \
     macro(StringReplace, NodeResultJS | NodeMustGenerate) \
     macro(StringReplaceRegExp, NodeResultJS | NodeMustGenerate) \
+    macro(StringReplaceString, NodeResultJS | NodeMustGenerate) \
     \
     /* Optimizations for string access */ \
     macro(StringCharCodeAt, NodeResultInt32) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -249,6 +249,7 @@ JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringEmptyString, JSString*, (J
 JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringStringWithTable8, JSString*, (JSGlobalObject*, JSString*, JSString*, JSString*, const BoyerMooreHorspoolTable<uint8_t>*));
 JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringStringWithoutSubstitutionWithTable8, JSString*, (JSGlobalObject*, JSString*, JSString*, JSString*, const BoyerMooreHorspoolTable<uint8_t>*));
 JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringEmptyStringWithTable8, JSString*, (JSGlobalObject*, JSString*, JSString*, const BoyerMooreHorspoolTable<uint8_t>*));
+JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringGeneric, JSString*, (JSGlobalObject*, JSString*, JSString*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationToLowerCase, JSString*, (JSGlobalObject*, JSString*, uint32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationInt32ToString, char*, (JSGlobalObject*, int32_t, int32_t));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -873,6 +873,7 @@ private:
         case RegExpMatchFastGlobal:
         case StringReplace:
         case StringReplaceRegExp:
+        case StringReplaceString:
         case GetById:
         case GetByIdFlush:
         case GetByIdWithThis:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -695,12 +695,15 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case DataViewSet:
     case SetAdd:
     case MapSet:
-    case StringReplaceRegExp:
     case StringReplace:
+    case StringReplaceRegExp:
     case ArithRandom:
     case ArithIMul:
     case TryGetById:
         return false;
+
+    case StringReplaceString:
+        return node->child3().useKind() == StringUse;
 
     case Inc:
     case Dec:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -13299,10 +13299,65 @@ void SpeculativeJIT::compileStringReplace(Node* node)
             m_jit.decrementSuperSamplerCount();
     });
 
-    if (node->op() == StringReplace
-        && node->child1().useKind() == StringUse
-        && node->child2().useKind() == StringUse
+    if (node->child1().useKind() == StringUse
+        && node->child2().useKind() == RegExpObjectUse
         && node->child3().useKind() == StringUse) {
+        if (JSString* replace = node->child3()->dynamicCastConstant<JSString*>(); replace && !replace->length()) {
+            SpeculateCellOperand string(this, node->child1());
+            SpeculateCellOperand regExp(this, node->child2());
+            GPRReg stringGPR = string.gpr();
+            GPRReg regExpGPR = regExp.gpr();
+            speculateString(node->child1(), stringGPR);
+            speculateRegExpObject(node->child2(), regExpGPR);
+
+            flushRegisters();
+            GPRFlushedCallResult result(this);
+            callOperation(operationStringProtoFuncReplaceRegExpEmptyStr, result.gpr(), JITCompiler::LinkableConstant(m_jit, m_graph.globalObjectFor(node->origin.semantic)), stringGPR, regExpGPR);
+            m_jit.exceptionCheck();
+            cellResult(result.gpr(), node);
+            return;
+        }
+
+        SpeculateCellOperand string(this, node->child1());
+        SpeculateCellOperand regExp(this, node->child2());
+        SpeculateCellOperand replace(this, node->child3());
+        GPRReg stringGPR = string.gpr();
+        GPRReg regExpGPR = regExp.gpr();
+        GPRReg replaceGPR = replace.gpr();
+        speculateString(node->child1(), stringGPR);
+        speculateRegExpObject(node->child2(), regExpGPR);
+        speculateString(node->child3(), replaceGPR);
+
+        flushRegisters();
+        GPRFlushedCallResult result(this);
+        callOperation(operationStringProtoFuncReplaceRegExpString, result.gpr(), JITCompiler::LinkableConstant(m_jit, m_graph.globalObjectFor(node->origin.semantic)), stringGPR, regExpGPR, replaceGPR);
+        m_jit.exceptionCheck();
+        cellResult(result.gpr(), node);
+        return;
+    }
+
+    // If we fixed up the edge of child2, we inserted a Check(@child2, String).
+    OperandSpeculationMode child2SpeculationMode = AutomaticOperandSpeculation;
+    if (node->child2().useKind() == StringUse)
+        child2SpeculationMode = ManualOperandSpeculation;
+
+    JSValueOperand string(this, node->child1());
+    JSValueOperand search(this, node->child2(), child2SpeculationMode);
+    JSValueOperand replace(this, node->child3());
+    JSValueRegs stringRegs = string.jsValueRegs();
+    JSValueRegs searchRegs = search.jsValueRegs();
+    JSValueRegs replaceRegs = replace.jsValueRegs();
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    callOperation(operationStringProtoFuncReplaceGeneric, result.gpr(), JITCompiler::LinkableConstant(m_jit, m_graph.globalObjectFor(node->origin.semantic)), stringRegs, searchRegs, replaceRegs);
+    m_jit.exceptionCheck();
+    cellResult(result.gpr(), node);
+}
+
+void SpeculativeJIT::compileStringReplaceString(Node* node)
+{
+    if (node->child3().useKind() == StringUse) {
         const BoyerMooreHorspoolTable<uint8_t>* tablePointer = nullptr;
         String searchString = node->child2()->tryGetString(m_graph);
         if (!!searchString)
@@ -13373,60 +13428,20 @@ void SpeculativeJIT::compileStringReplace(Node* node)
         return;
     }
 
-    if (node->child1().useKind() == StringUse
-        && node->child2().useKind() == RegExpObjectUse
-        && node->child3().useKind() == StringUse) {
-        if (JSString* replace = node->child3()->dynamicCastConstant<JSString*>()) {
-            if (!replace->length()) {
-                SpeculateCellOperand string(this, node->child1());
-                SpeculateCellOperand regExp(this, node->child2());
-                GPRReg stringGPR = string.gpr();
-                GPRReg regExpGPR = regExp.gpr();
-                speculateString(node->child1(), stringGPR);
-                speculateRegExpObject(node->child2(), regExpGPR);
-
-                flushRegisters();
-                GPRFlushedCallResult result(this);
-                callOperation(operationStringProtoFuncReplaceRegExpEmptyStr, result.gpr(), JITCompiler::LinkableConstant(m_jit, m_graph.globalObjectFor(node->origin.semantic)), stringGPR, regExpGPR);
-                m_jit.exceptionCheck();
-                cellResult(result.gpr(), node);
-                return;
-            }
-        }
-
-        SpeculateCellOperand string(this, node->child1());
-        SpeculateCellOperand regExp(this, node->child2());
-        SpeculateCellOperand replace(this, node->child3());
-        GPRReg stringGPR = string.gpr();
-        GPRReg regExpGPR = regExp.gpr();
-        GPRReg replaceGPR = replace.gpr();
-        speculateString(node->child1(), stringGPR);
-        speculateRegExpObject(node->child2(), regExpGPR);
-        speculateString(node->child3(), replaceGPR);
-
-        flushRegisters();
-        GPRFlushedCallResult result(this);
-        callOperation(operationStringProtoFuncReplaceRegExpString, result.gpr(), JITCompiler::LinkableConstant(m_jit, m_graph.globalObjectFor(node->origin.semantic)), stringGPR, regExpGPR, replaceGPR);
-        m_jit.exceptionCheck();
-        cellResult(result.gpr(), node);
-        return;
-    }
-
-    // If we fixed up the edge of child2, we inserted a Check(@child2, String).
-    OperandSpeculationMode child2SpeculationMode = AutomaticOperandSpeculation;
-    if (node->child2().useKind() == StringUse)
-        child2SpeculationMode = ManualOperandSpeculation;
-
-    JSValueOperand string(this, node->child1());
-    JSValueOperand search(this, node->child2(), child2SpeculationMode);
+    // Otherwise, maybe function. Let's call slow path.
+    SpeculateCellOperand string(this, node->child1());
+    SpeculateCellOperand search(this, node->child2());
     JSValueOperand replace(this, node->child3());
-    JSValueRegs stringRegs = string.jsValueRegs();
-    JSValueRegs searchRegs = search.jsValueRegs();
+
+    GPRReg stringGPR = string.gpr();
+    GPRReg searchGPR = search.gpr();
     JSValueRegs replaceRegs = replace.jsValueRegs();
+    speculateString(node->child1(), stringGPR);
+    speculateString(node->child2(), searchGPR);
 
     flushRegisters();
     GPRFlushedCallResult result(this);
-    callOperation(operationStringProtoFuncReplaceGeneric, result.gpr(), JITCompiler::LinkableConstant(m_jit, m_graph.globalObjectFor(node->origin.semantic)), stringRegs, searchRegs, replaceRegs);
+    callOperation(operationStringReplaceStringGeneric, result.gpr(), JITCompiler::LinkableConstant(m_jit, m_graph.globalObjectFor(node->origin.semantic)), stringGPR, searchGPR, replaceRegs);
     m_jit.exceptionCheck();
     cellResult(result.gpr(), node);
 }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1482,6 +1482,7 @@ public:
     void compileRegExpTest(Node*);
     void compileRegExpTestInline(Node*);
     void compileStringReplace(Node*);
+    void compileStringReplaceString(Node*);
     void compileIsObject(Node*);
     void compileTypeOfIsObject(Node*);
     void compileIsCallable(Node*, S_JITOperation_GC);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2717,6 +2717,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringReplaceString: {
+        compileStringReplaceString(node);
+        break;
+    }
+
     case GetRegExpObjectLastIndex: {
         compileGetRegExpObjectLastIndex(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3843,7 +3843,12 @@ void SpeculativeJIT::compile(Node* node)
         compileStringReplace(node);
         break;
     }
-        
+
+    case StringReplaceString: {
+        compileStringReplaceString(node);
+        break;
+    }
+
     case GetRegExpObjectLastIndex: {
         compileGetRegExpObjectLastIndex(node);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -345,7 +345,8 @@ inline CapabilityLevel canCompile(Node* node)
     case RegExpMatchFastGlobal:
     case NewRegexp:
     case StringReplace:
-    case StringReplaceRegExp: 
+    case StringReplaceRegExp:
+    case StringReplaceString:
     case GetRegExpObjectLastIndex:
     case SetRegExpObjectLastIndex:
     case RecordRegExpCachedResult:

--- a/Source/JavaScriptCore/interpreter/CachedCall.h
+++ b/Source/JavaScriptCore/interpreter/CachedCall.h
@@ -39,7 +39,7 @@ namespace JSC {
         WTF_MAKE_NONCOPYABLE(CachedCall);
         WTF_FORBID_HEAP_ALLOCATION;
     public:
-        CachedCall(JSGlobalObject* globalObject, CallFrame* callFrame, JSFunction* function, int argumentCount)
+        CachedCall(JSGlobalObject* globalObject, JSFunction* function, int argumentCount)
             : m_vm(globalObject->vm())
             , m_interpreter(m_vm.interpreter)
             , m_entryScope(m_vm, function->scope()->globalObject())
@@ -51,16 +51,18 @@ namespace JSC {
             if (LIKELY(vm.isSafeToRecurseSoft())) {
                 m_arguments.ensureCapacity(argumentCount);
                 if (LIKELY(!m_arguments.hasOverflowed()))
-                    m_closure = m_interpreter.prepareForRepeatCall(function->jsExecutable(), callFrame, &m_protoCallFrame, function, argumentCount + 1, function->scope(), m_arguments);
+                    m_closure = m_interpreter.prepareForRepeatCall(function->jsExecutable(), &m_protoCallFrame, function, argumentCount + 1, function->scope(), m_arguments);
                 else
                     throwOutOfMemoryError(globalObject, scope);
             } else
                 throwStackOverflowError(globalObject, scope);
+#if ASSERT_ENABLED
             m_valid = !scope.exception();
+#endif
         }
-        
+
         ALWAYS_INLINE JSValue call()
-        { 
+        {
             ASSERT(m_valid);
             ASSERT(m_arguments.size() == static_cast<size_t>(m_protoCallFrame.argumentCount()));
             return m_interpreter.execute(m_closure);
@@ -72,7 +74,9 @@ namespace JSC {
         bool hasOverflowedArguments() { return m_arguments.hasOverflowed(); }
 
     private:
+#if ASSERT_ENABLED
         bool m_valid { false };
+#endif
         VM& m_vm;
         Interpreter& m_interpreter;
         VMEntryScope m_entryScope;

--- a/Source/JavaScriptCore/interpreter/CallFrameClosure.h
+++ b/Source/JavaScriptCore/interpreter/CallFrameClosure.h
@@ -30,7 +30,6 @@
 namespace JSC {
 
 struct CallFrameClosure {
-    CallFrame* oldCallFrame;
     ProtoCallFrame* protoCallFrame;
     JSFunction* function;
     FunctionExecutable* functionExecutable;

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1154,7 +1154,7 @@ JSObject* Interpreter::executeConstruct(JSGlobalObject* lexicalGlobalObject, JSO
     return checkedReturn(asObject(result));
 }
 
-CallFrameClosure Interpreter::prepareForRepeatCall(FunctionExecutable* functionExecutable, CallFrame* callFrame, ProtoCallFrame* protoCallFrame, JSFunction* function, int argumentCountIncludingThis, JSScope* scope, const ArgList& args)
+CallFrameClosure Interpreter::prepareForRepeatCall(FunctionExecutable* functionExecutable, ProtoCallFrame* protoCallFrame, JSFunction* function, int argumentCountIncludingThis, JSScope* scope, const ArgList& args)
 {
     VM& vm = scope->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -1175,7 +1175,7 @@ CallFrameClosure Interpreter::prepareForRepeatCall(FunctionExecutable* functionE
 
     protoCallFrame->init(newCodeBlock, function->globalObject(), function, jsUndefined(), argsCount, args.data());
     // Return the successful closure:
-    CallFrameClosure result = { callFrame, protoCallFrame, function, functionExecutable, &vm, scope, newCodeBlock->numParameters(), argumentCountIncludingThis };
+    CallFrameClosure result = { protoCallFrame, function, functionExecutable, &vm, scope, newCodeBlock->numParameters(), argumentCountIncludingThis };
     return result;
 }
 

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -169,7 +169,7 @@ using JSOrWasmInstruction = std::variant<const JSInstruction*, const WasmInstruc
             return returnValue;
         }
 
-        CallFrameClosure prepareForRepeatCall(FunctionExecutable*, CallFrame*, ProtoCallFrame*, JSFunction*, int argumentCountIncludingThis, JSScope*, const ArgList&);
+        CallFrameClosure prepareForRepeatCall(FunctionExecutable*, ProtoCallFrame*, JSFunction*, int argumentCountIncludingThis, JSScope*, const ArgList&);
 
         JSValue execute(CallFrameClosure&);
 

--- a/Source/JavaScriptCore/interpreter/InterpreterInlines.h
+++ b/Source/JavaScriptCore/interpreter/InterpreterInlines.h
@@ -98,7 +98,6 @@ ALWAYS_INLINE JSValue Interpreter::execute(CallFrameClosure& closure)
     StackStats::CheckPoint stackCheckPoint;
 
     if (UNLIKELY(vm.traps().needHandling(VMTraps::NonDebuggerAsyncEvents))) {
-        ASSERT(vm.topCallFrame == closure.oldCallFrame);
         if (vm.hasExceptionsAfterHandlingTraps())
             return throwScope.exception();
     }

--- a/Source/JavaScriptCore/runtime/Intrinsic.cpp
+++ b/Source/JavaScriptCore/runtime/Intrinsic.cpp
@@ -181,6 +181,8 @@ const char* intrinsicName(Intrinsic intrinsic)
         return "StringPrototypeReplaceIntrinsic";
     case StringPrototypeReplaceRegExpIntrinsic:
         return "StringPrototypeReplaceRegExpIntrinsic";
+    case StringPrototypeReplaceStringIntrinsic:
+        return "StringPrototypeReplaceStringIntrinsic";
     case StringPrototypeSliceIntrinsic:
         return "StringPrototypeSliceIntrinsic";
     case StringPrototypeToLowerCaseIntrinsic:

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -106,6 +106,7 @@ enum Intrinsic : uint8_t {
     StringPrototypeValueOfIntrinsic,
     StringPrototypeReplaceIntrinsic,
     StringPrototypeReplaceRegExpIntrinsic,
+    StringPrototypeReplaceStringIntrinsic,
     StringPrototypeSliceIntrinsic,
     StringPrototypeToLowerCaseIntrinsic,
     NumberPrototypeToStringIntrinsic,


### PR DESCRIPTION
#### 195c7f139a84e0af36a5aaea6b61d7470b95a3b5
<pre>
[JSC] Accelerate baseline String#replace performance
<a href="https://bugs.webkit.org/show_bug.cgi?id=245349">https://bugs.webkit.org/show_bug.cgi?id=245349</a>

Reviewed by Ross Kirsling.

We found that C++ runtime String#replace implementation is too generic and doing various inefficient things.
This patch unifies the implementation with DFG operations for the fast path so that we do very simple and fast operations
for String#replace(String, String) case even in non DFG. It shows consistent improvement in VanillaXXX in Speedometer2.1 on Intel machines.

With --useDFGJIT=0, we see 35% improvement.

    string-replace-benchmark                      219.2726+-0.5822     ^    162.1922+-0.5799        ^ definitely 1.3519x faster

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasHeapPrediction):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
(JSC::DFG::stringReplaceStringString): Deleted.
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/interpreter/CachedCall.h:
(JSC::CachedCall::CachedCall):
(JSC::CachedCall::call):
* Source/JavaScriptCore/interpreter/CallFrameClosure.h:
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::prepareForRepeatCall):
* Source/JavaScriptCore/interpreter/Interpreter.h:
* Source/JavaScriptCore/interpreter/InterpreterInlines.h:
(JSC::Interpreter::execute):
* Source/JavaScriptCore/runtime/Intrinsic.cpp:
(JSC::intrinsicName):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):
(JSC::jsSpliceSubstrings):
(JSC::removeUsingRegExpSearch):
(JSC::replaceUsingRegExpSearch):
(JSC::JSC_DEFINE_JIT_OPERATION):
(JSC::replace):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::StringRange::StringRange): Deleted.
(JSC::jsSpliceSubstringsWithSeparators): Deleted.
(JSC::replaceUsingStringSearch): Deleted.
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::jsSpliceSubstringsWithSeparators):
(JSC::stringReplaceStringString):
(JSC::replaceUsingStringSearch):

Canonical link: <a href="https://commits.webkit.org/254659@main">https://commits.webkit.org/254659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9b83ff04c7d12b9858e0e17d246475790f7bd25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89814 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34361 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/20502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99133 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155950 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32852 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/82158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/93483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95461 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76636 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/82158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/80981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/20502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/82158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81464 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30603 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/20502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76336 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30344 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/20502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26446 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3272 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/frame-src/frame-src-self-unique-origin.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33801 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/78922 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1396 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32515 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/20502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17293 "Passed tests") | 
<!--EWS-Status-Bubble-End-->