### PR TITLE
Add leak tests for NodeIterator and TreeWalker

### DIFF
--- a/LayoutTests/fast/dom/NodeIterator/NodeIterator-dont-overcollect-expected.txt
+++ b/LayoutTests/fast/dom/NodeIterator/NodeIterator-dont-overcollect-expected.txt
@@ -1,0 +1,10 @@
+This test asserts that NodeIterator's callback is kept alive while NodeIterator is alive even if all JS references go away.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS callbackWasTriggered is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/NodeIterator/NodeIterator-dont-overcollect.html
+++ b/LayoutTests/fast/dom/NodeIterator/NodeIterator-dont-overcollect.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/gc.js"></script>
+<script>
+    description("This test asserts that NodeIterator's callback is kept alive while NodeIterator is alive even if all JS references go away.")
+    var callbackWasTriggered = false;
+    var callback = function(node) {
+        callbackWasTriggered = true;
+        return NodeFilter.FILTER_ACCEPT;
+    };
+    var nodeIterator = document.createNodeIterator(document, NodeFilter.SHOW_ELEMENT, callback, false);
+    gc();
+    callback = null;
+    gc();
+    nodeIterator.nextNode();
+    shouldBeTrue('callbackWasTriggered');
+    nodeIterator = null;
+    gc();
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/NodeIterator/NodeIterator-leak-document-expected.txt
+++ b/LayoutTests/fast/dom/NodeIterator/NodeIterator-leak-document-expected.txt
@@ -1,0 +1,10 @@
+This test asserts that document doesn't leak when a NodeFilter callback referencing the document is created.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS endingDocumentCount - startingDocumentCount < testingCount * 0.8 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/NodeIterator/NodeIterator-leak-document.html
+++ b/LayoutTests/fast/dom/NodeIterator/NodeIterator-leak-document.html
@@ -1,0 +1,16 @@
+<html>
+<body>
+    <script id='targetJS' type='text/html'>
+        keepNodeIterator = document.createNodeIterator(document, NodeFilter.SHOW_ELEMENT, function(node) { return NodeFilter.SHOW_ELEMENT; }, false);
+    </script>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/gc.js"></script>
+    <script src="../resources/leak-check.js"></script>
+    <script>
+        description("This test asserts that document doesn't leak when a NodeFilter callback referencing the document is created.");
+        var target = '<script>'+grabScriptText('targetJS')+'<'+'/script>';
+        doLeakTest(htmlToUrl(target));
+    </script>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/TreeWalker/TreeWalker-leak-document-expected.txt
+++ b/LayoutTests/fast/dom/TreeWalker/TreeWalker-leak-document-expected.txt
@@ -1,0 +1,10 @@
+This test asserts that document doesn't leak when a NodeFilter callback referencing the document is created.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS endingDocumentCount - startingDocumentCount < testingCount * 0.8 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/TreeWalker/TreeWalker-leak-document.html
+++ b/LayoutTests/fast/dom/TreeWalker/TreeWalker-leak-document.html
@@ -1,0 +1,16 @@
+<html>
+<body>
+    <script id='targetJS' type='text/html'>
+        keepTreeWalker = document.createTreeWalker(document, NodeFilter.SHOW_ELEMENT, function(node) { return NodeFilter.SHOW_ELEMENT; }, false);
+    </script>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/gc.js"></script>
+    <script src="../resources/leak-check.js"></script>
+    <script>
+        description("This test asserts that document doesn't leak when a NodeFilter callback referencing the document is created.");
+        var target = '<script>'+grabScriptText('targetJS')+'<'+'/script>';
+        doLeakTest(htmlToUrl(target));
+    </script>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/resources/leak-check.js
+++ b/LayoutTests/fast/dom/resources/leak-check.js
@@ -1,0 +1,43 @@
+// include fast/js/resources/js-test-pre.js before this file.
+jsTestIsAsync = true;
+let startingDocumentCount;
+let endingDocumentCount;
+const testingCount = 20;
+
+async function doLeakTest(src, tolerance) {
+    const frame = document.createElement('frame');
+    document.body.appendChild(frame);
+
+    function loadSourceIntoIframe(src) {
+        return new Promise((resolve) => {
+            var originalSrc = frame.src;
+            frame.onload = resolve;
+            frame.src = src;
+        })
+    }
+
+    if (!window.internals) {
+        debug("This test only runs on DumpRenderTree, as it requires existence of window.internals and cross-domain resource access check disabled.");
+        finishJSTest();
+    }
+
+    await loadSourceIntoIframe('about:blank');
+    startingDocumentCount = internals.numberOfLiveDocuments();
+    for (let i = 0; i < testingCount; ++i) {
+        await loadSourceIntoIframe(src);
+        await loadSourceIntoIframe('about:blank');
+        gc();
+    }
+    endingDocumentCount = internals.numberOfLiveDocuments();
+    shouldBeTrue('endingDocumentCount - startingDocumentCount < testingCount * 0.8');
+    finishJSTest();
+}
+
+function htmlToUrl(html) {
+    return 'data:text/html;charset=utf-8,' + html;
+}
+
+function grabScriptText(id) {
+    return document.getElementById(id).innerText;
+}
+// include fast/js/resources/js-test-post.js after this file.


### PR DESCRIPTION
#### b17ccd4f3712b8d42d1113ec3f26423005b28806
<pre>
Add leak tests for NodeIterator and TreeWalker
<a href="https://bugs.webkit.org/show_bug.cgi?id=119718">https://bugs.webkit.org/show_bug.cgi?id=119718</a>

Reviewed by Darin Adler, Geoffrey Garen and Chris Dumez.

Add the leak tests based on <a href="https://chromium.googlesource.com/chromium/blink/+/65db79784ecd4a7e744d10a26befe5159638a56c">https://chromium.googlesource.com/chromium/blink/+/65db79784ecd4a7e744d10a26befe5159638a56c</a>
These tests have been modified to account for the fact WebKit / JSC uses a conservative GC as opposed to V8&apos;s precise GC.

* LayoutTests/fast/dom/NodeIterator/NodeIterator-dont-overcollect-expected.txt: Added.
* LayoutTests/fast/dom/NodeIterator/NodeIterator-dont-overcollect.html: Added.
* LayoutTests/fast/dom/NodeIterator/NodeIterator-leak-document-expected.txt: Added.
* LayoutTests/fast/dom/NodeIterator/NodeIterator-leak-document.html: Added.
* LayoutTests/fast/dom/TreeWalker/TreeWalker-leak-document-expected.txt: Added.
* LayoutTests/fast/dom/TreeWalker/TreeWalker-leak-document.html: Added.
* LayoutTests/fast/dom/resources/leak-check.js: Added.
(getCounterValues):
(loadSourceIntoIframe):
(async doLeakTest):
(htmlToUrl):
(grabScriptText):

Canonical link: <a href="https://commits.webkit.org/254711@main">https://commits.webkit.org/254711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8db4a1ca8184fa0a9b1cbf386b780294bf1ac37f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99148 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155970 "Found 1 new test failure: fast/workers/worker-crash-with-invalid-location.html (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32870 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28310 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82203 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93498 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26118 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76651 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26064 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80838 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69071 "analyze-api-test-results") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30620 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14921 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30361 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15862 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38813 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1413 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34946 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->