### PR TITLE
Unreviewed, suppress exception check warning

### DIFF
--- a/Source/JavaScriptCore/runtime/CatchScope.h
+++ b/Source/JavaScriptCore/runtime/CatchScope.h
@@ -77,8 +77,12 @@ ALWAYS_INLINE void CatchScope::clearException()
 
 ALWAYS_INLINE bool CatchScope::clearExceptionExceptTermination()
 {
-    if (UNLIKELY(m_vm.hasPendingTerminationException()))
+    if (UNLIKELY(m_vm.hasPendingTerminationException())) {
+#if ENABLE(EXCEPTION_SCOPE_VERIFICATION)
+        m_vm.exception();
+#endif
         return false;
+    }
     m_vm.clearException();
     return true;
 }


### PR DESCRIPTION
#### 94217a6eb57626c46d67099b4a9ccd8f2c83eee0
<pre>
Unreviewed, suppress exception check warning
<a href="https://bugs.webkit.org/show_bug.cgi?id=245354">https://bugs.webkit.org/show_bug.cgi?id=245354</a>

When clearExceptionExceptTermination is called, we should treat it as &quot;exception is checked&quot;.

* Source/JavaScriptCore/runtime/CatchScope.h:
(JSC::CatchScope::clearExceptionExceptTermination):

Canonical link: <a href="https://commits.webkit.org/254628@main">https://commits.webkit.org/254628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35c3789dd15eba77727cd34715cbe2eaf8791fb2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98967 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155772 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32721 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28191 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82039 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93374 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25997 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76528 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25949 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68943 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81341 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30475 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14834 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76199 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30225 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15767 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26424 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3245 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-inherit-to-blank-document-unsandboxed.html, security/cannot-read-self-from-file.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33673 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38713 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-inherit-to-blank-document-unsandboxed.html (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/78784 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1362 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34859 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17271 "Passed tests") | 
<!--EWS-Status-Bubble-End-->