### PR TITLE
WebNotificationManager: fix build if SERVICE_WORKER=OFF

### DIFF
--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -136,11 +136,13 @@ static bool sendMessage(Notification& notification, WebPage* page, const Functio
     std::optional<WebCore::PageIdentifier> pageIdentifier;
     if (page)
         pageIdentifier = page->identifier();
+#if ENABLE(SERVICE_WORKER)
     else if (auto* connection = SWContextManager::singleton().connection()) {
         // Pageless notification messages are, by default, on behalf of a service worker.
         // So use the service worker connection's page identifier.
         pageIdentifier = connection->pageIdentifier();
     }
+#endif
 
     ASSERT(pageIdentifier);
     return sendMessage(*WebProcess::singleton().parentProcessConnection(), pageIdentifier->toUInt64());


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=244796

Reviewed by NOBODY (OOPS!).

/home/thomas/Documents/nd_falcon/buildroot/output/build/webkitgtk-2.37.1/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:139:33: error: ‘SWContextManager’ has not been declared
     else if (auto* connection = SWContextManager::singleton().connection()) {
                                 ^~~~~~~~~~~~~~~~

Signed-off-by: Thomas Devoogdt <thomas.devoogdt@barco.com>

Canonical link: https://commits.webkit.org/254163@main

(cherry picked from commit a91ffd1fa487cd535befba40a75ff538191275ec)
Signed-off-by: Thomas Devoogdt <thomas.devoogdt@barco.com><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61b96ebfddcb157fcc5a48627c5ed43d9fe0c199

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89852 "22 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20533 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/99230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32890 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28325 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/82235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93513 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26130 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76666 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25957 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68948 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30639 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14929 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30381 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15870 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33838 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34954 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->