### PR TITLE
Cleanup RenderLayer::updateLayerPosition()

### DIFF
--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5302,42 +5302,14 @@ void RenderBox::flipForWritingMode(FloatRect& rect) const
         rect.setX(width() - rect.maxX());
 }
 
-LayoutPoint RenderBox::topLeftLocation() const
+LayoutPoint RenderBox::topLeftLocationWithFlipping() const
 {
-    if (!view().frameView().hasFlippedBlockRenderers())
-        return location();
-    
-    RenderBlock* containerBlock = containingBlock();
+    ASSERT(view().frameView().hasFlippedBlockRenderers());
+
+    auto* containerBlock = containingBlock();
     if (!containerBlock || containerBlock == this)
         return location();
     return containerBlock->flipForWritingModeForChild(*this, location());
-}
-
-LayoutSize RenderBox::topLeftLocationOffset() const
-{
-    if (!view().frameView().hasFlippedBlockRenderers())
-        return locationOffset();
-
-    RenderBlock* containerBlock = containingBlock();
-    if (!containerBlock || containerBlock == this)
-        return locationOffset();
-    
-    LayoutRect rect(frameRect());
-    containerBlock->flipForWritingMode(rect); // FIXME: This is wrong if we are an absolutely positioned object enclosed by a relative-positioned inline.
-    return LayoutSize(rect.x(), rect.y());
-}
-
-void RenderBox::applyTopLeftLocationOffsetWithFlipping(LayoutPoint& point) const
-{
-    RenderBlock* containerBlock = containingBlock();
-    if (!containerBlock || containerBlock == this) {
-        point.move(m_frameRect.x(), m_frameRect.y());
-        return;
-    }
-    
-    LayoutRect rect(frameRect());
-    containerBlock->flipForWritingMode(rect); // FIXME: This is wrong if we are an absolutely positioned object  enclosed by a relative-positioned inline.
-    point.move(rect.x(), rect.y());
 }
 
 bool RenderBox::shouldIgnoreAspectRatio() const

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -590,15 +590,20 @@ override;
     void flipForWritingMode(FloatRect&) const;
     // These represent your location relative to your container as a physical offset.
     // In layout related methods you almost always want the logical location (e.g. x() and y()).
-    LayoutPoint topLeftLocation() const;
-    LayoutSize topLeftLocationOffset() const;
-    void applyTopLeftLocationOffset(LayoutPoint& point) const
+    LayoutPoint topLeftLocation() const
     {
         // This is inlined for speed, since it is used by updateLayerPosition() during scrolling.
         if (!document().view() || !document().view()->hasFlippedBlockRenderers())
-            point.move(m_frameRect.x(), m_frameRect.y());
-        else
-            applyTopLeftLocationOffsetWithFlipping(point);
+            return location();
+        return topLeftLocationWithFlipping();
+    }
+
+    LayoutSize topLeftLocationOffset() const
+    {
+        // This is inlined for speed, since it is used by updateLayerPosition() during scrolling.
+        if (!document().view() || !document().view()->hasFlippedBlockRenderers())
+            return locationOffset();
+        return toLayoutSize(topLeftLocationWithFlipping());
     }
 
     LayoutRect logicalVisualOverflowRectForPropagation(const RenderStyle*) const;
@@ -800,7 +805,7 @@ private:
 
     LayoutRect computeVisibleRectUsingPaintOffset(const LayoutRect&) const;
     
-    void applyTopLeftLocationOffsetWithFlipping(LayoutPoint&) const;
+    LayoutPoint topLeftLocationWithFlipping() const;
 
 private:
     // The width/height of the contents + borders + padding.  The x/y location is relative to our container (which is not always our parent).

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.h
@@ -75,7 +75,7 @@ public:
     bool hasVisualOverflow() const { return !borderBoxRectEquivalent().contains(visualOverflowRectEquivalent()); }
 
     // For RenderLayer only
-    void applyTopLeftLocationOffsetEquivalent(LayoutPoint& point) const { point.moveBy(currentSVGLayoutLocation()); }
+    LayoutPoint topLeftLocationEquivalent() const { return currentSVGLayoutLocation(); }
     LayoutRect borderBoxRectInFragmentEquivalent(RenderFragmentContainer*, RenderBox::RenderBoxFragmentInfoFlags = RenderBox::CacheRenderBoxFragmentInfo) const { return borderBoxRectEquivalent(); }
     virtual LayoutRect overflowClipRect(const LayoutPoint& location, RenderFragmentContainer* = nullptr, OverlayScrollbarSizeRelevancy = IgnoreOverlayScrollbarSize, PaintPhase = PaintPhase::BlockBackground) const;
     LayoutRect overflowClipRectForChildLayers(const LayoutPoint& location, RenderFragmentContainer* fragment, OverlayScrollbarSizeRelevancy relevancy) { return overflowClipRect(location, fragment, relevancy); }


### PR DESCRIPTION
#### 6eebc817120bbd8feeccb4d7fd74c5d948cfb908
<pre>
Cleanup RenderLayer::updateLayerPosition()
<a href="https://bugs.webkit.org/show_bug.cgi?id=245363">https://bugs.webkit.org/show_bug.cgi?id=245363</a>

Reviewed by Simon Fraser.

Apply several cleanups in RenderLayer:

- Use dynamicDowncast&lt;&gt; instead of if&lt;&gt;/downcast&lt;&gt; pairs, where possible.
- Re-use logic from RenderLayerCompositor to determine if a RenderWidget
  requires accelerated compositing or not, instead of duplicating the check.

- Get rid of unused &apos;inlineBoundingBoxOffset&apos; bookkeeping in updateLayerPosition().
  &apos;localPoint&apos; needed this adjustment in the past to support multi-column related
  computations, that are no longer present in updateLayerPosition(), thus the
  special handling for inlines is obsolete.

- Move code that computes the layer location and layer size into its own helper
  method, to make the code more readable and less error-prone.

- Remove the applyTopLeftLocationOffset() method from RenderBox, which was used
  by RenderLayer::updateLayerPosition() to apply the box top-left location offset
  to compute the layer location. Unlike topLeftLocation() / topLeftLocationOffset()
  the applyTopLeftLocationOffset() method is used in a hot code-path, and therefore
  inlined the most common case: returning frameRect().location(), if no coordinate
  flipping due to writing-mode is necessary.

  Extend that idea to the other accessors, and remove the need for
  applyTopLeftLocationOffset() alltogther. One slow-path for both topLeftLocation()
  and topLeftLocationOffset() is enough, as topLeftLocationOffsetWithFlipping() is
  equal to toLayoutSize(topLeftLocationWithFlipping) -- the additional round-trip
  is negligble compared to the work done for the coordinate flipping, so it&apos;s fine
  to stay with one slow-path for both topLeftLocation() / topLeftLocationOffset().

No change in functionality, covered by existing tests

Canonical link: <a href="https://commits.webkit.org/256880@main">https://commits.webkit.org/256880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c449f6288aa7980b37a744fe2b47ee99fca797a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106617 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166888 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6608 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35100 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89489 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103305 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102769 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83717 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31970 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86804 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74858 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/390 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/372 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21574 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4756 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5171 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1613 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40889 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->