### PR TITLE
[Reporting API] Use WTFString instead of AtomString for report types

### DIFF
--- a/Source/WebCore/Modules/reporting/DeprecationReportBody.cpp
+++ b/Source/WebCore/Modules/reporting/DeprecationReportBody.cpp
@@ -35,12 +35,6 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(DeprecationReportBody);
 
-const AtomString& DeprecationReportBody::deprecationReportType()
-{
-    static NeverDestroyed<AtomString> reportType { "deprecation"_s };
-    return reportType;
-}
-
 DeprecationReportBody::DeprecationReportBody(String&& id, WallTime anticipatedRemoval, String&& message, String&& sourceFile, std::optional<unsigned> lineNumber, std::optional<unsigned> columnNumber)
     : ReportBody(ViolationReportType::Deprecation)
     , m_id(WTFMove(id))
@@ -57,9 +51,10 @@ Ref<DeprecationReportBody> DeprecationReportBody::create(String&& id, WallTime a
     return adoptRef(*new DeprecationReportBody(WTFMove(id), anticipatedRemoval, WTFMove(message), WTFMove(sourceFile), lineNumber, columnNumber));
 }
 
-const AtomString& DeprecationReportBody::type() const
+const String& DeprecationReportBody::type() const
 {
-    return deprecationReportType();
+    static NeverDestroyed<const String> reportType(MAKE_STATIC_STRING_IMPL("deprecation"));
+    return reportType;
 }
 
 Ref<FormData> DeprecationReportBody::createReportFormDataForViolation() const
@@ -77,7 +72,7 @@ Ref<FormData> DeprecationReportBody::createReportFormDataForViolation() const
     }
 
     auto reportObject = JSON::Object::create();
-    reportObject->setString("type"_s, deprecationReportType());
+    reportObject->setString("type"_s, type());
     reportObject->setString("url"_s, ""_s);
     reportObject->setObject("body"_s, WTFMove(reportBody));
 

--- a/Source/WebCore/Modules/reporting/DeprecationReportBody.h
+++ b/Source/WebCore/Modules/reporting/DeprecationReportBody.h
@@ -40,14 +40,13 @@ class DeprecationReportBody final : public ReportBody {
 public:
     WEBCORE_EXPORT static Ref<DeprecationReportBody> create(String&& id, WallTime anticipatedRemoval, String&& message, String&& sourceFile, std::optional<unsigned> lineNumber, std::optional<unsigned> columnNumber);
 
+    const String& type() const final;
     const String& id() const { return m_id; };
     WallTime anticipatedRemoval() const { return m_anticipatedRemoval; }
     const String& message() const { return m_message; }
     const String& sourceFile() const { return m_sourceFile; }
     std::optional<unsigned> lineNumber() const { return m_lineNumber; }
     std::optional<unsigned> columnNumber() const { return m_columnNumber; }
-
-    static const AtomString& deprecationReportType();
 
     WEBCORE_EXPORT Ref<FormData> createReportFormDataForViolation() const;
 
@@ -56,8 +55,6 @@ public:
 
 private:
     DeprecationReportBody(String&& id, WallTime anticipatedRemoval, String&& message, String&& sourceFile, std::optional<unsigned> lineNumber, std::optional<unsigned> columnNumber);
-
-    const AtomString& type() const final;
 
     const String m_id;
     const WallTime m_anticipatedRemoval;

--- a/Source/WebCore/Modules/reporting/Report.cpp
+++ b/Source/WebCore/Modules/reporting/Report.cpp
@@ -35,12 +35,12 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(Report);
 
-Ref<Report> Report::create(const AtomString& type, const String& url, RefPtr<ReportBody>&& body)
+Ref<Report> Report::create(const String& type, const String& url, RefPtr<ReportBody>&& body)
 {
     return adoptRef(*new Report(type, url, WTFMove(body)));
 }
 
-Report::Report(const AtomString& type, const String& url, RefPtr<ReportBody>&& body)
+Report::Report(const String& type, const String& url, RefPtr<ReportBody>&& body)
     : m_type(type)
     , m_url(url)
     , m_body(WTFMove(body))
@@ -49,7 +49,7 @@ Report::Report(const AtomString& type, const String& url, RefPtr<ReportBody>&& b
 
 Report::~Report() = default;
 
-const AtomString& Report::type() const
+const String& Report::type() const
 {
     return m_type;
 }

--- a/Source/WebCore/Modules/reporting/Report.h
+++ b/Source/WebCore/Modules/reporting/Report.h
@@ -37,11 +37,11 @@ class FormData;
 class WEBCORE_EXPORT Report : public RefCounted<Report> {
     WTF_MAKE_ISO_ALLOCATED(Report);
 public:
-    static Ref<Report> create(const AtomString& type, const String& url, RefPtr<ReportBody>&&);
+    static Ref<Report> create(const String& type, const String& url, RefPtr<ReportBody>&&);
 
     ~Report();
 
-    const AtomString& type() const;
+    const String& type() const;
     const String& url() const;
     const RefPtr<ReportBody>& body();
 
@@ -51,9 +51,9 @@ public:
     template<typename Decoder> static WEBCORE_EXPORT std::optional<Ref<WebCore::Report>> decode(Decoder&);
 
 private:
-    explicit Report(const AtomString& type, const String& url, RefPtr<ReportBody>&&);
+    explicit Report(const String& type, const String& url, RefPtr<ReportBody>&&);
 
-    AtomString m_type;
+    String m_type;
     String m_url;
     RefPtr<ReportBody> m_body;
 };
@@ -61,15 +61,13 @@ private:
 template<typename Encoder>
 void Report::encode(Encoder& encoder) const
 {
-    encoder << m_type;
-    encoder << m_url;
-    encoder << m_body;
+    encoder << m_type << m_url << m_body;
 }
 
 template<typename Decoder>
 std::optional<Ref<WebCore::Report>> Report::decode(Decoder& decoder)
 {
-    std::optional<AtomString> type;
+    std::optional<String> type;
     decoder >> type;
     if (!type)
         return std::nullopt;

--- a/Source/WebCore/Modules/reporting/ReportBody.h
+++ b/Source/WebCore/Modules/reporting/ReportBody.h
@@ -37,7 +37,7 @@ class WEBCORE_EXPORT ReportBody : public RefCounted<ReportBody> {
 public:
     virtual ~ReportBody();
 
-    virtual const AtomString& type() const = 0;
+    virtual const String& type() const = 0;
     ViolationReportType reportBodyType() const;
 
 protected:

--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -41,13 +41,13 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ReportingObserver);
 
-static bool isVisibleToReportingObservers(const AtomString& type)
+static bool isVisibleToReportingObservers(const String& type)
 {
-    static NeverDestroyed<Vector<AtomString>> visibleTypes(std::initializer_list<AtomString> {
-        AtomString { "csp-violation"_s },
-        AtomString { "coep"_s },
-        AtomString { "deprecation"_s },
-        AtomString { "test"_s },
+    static NeverDestroyed<Vector<String>> visibleTypes(std::initializer_list<String> {
+        String { "csp-violation"_s },
+        String { "coep"_s },
+        String { "deprecation"_s },
+        String { "test"_s },
     });
     return visibleTypes->contains(type);
 }

--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -170,7 +170,8 @@ void ReportingScope::generateTestReport(String&& message, String&& group)
         reportURL = document->url().strippedForUseAsReferrer();
 
     // https://w3c.github.io/reporting/#generate-test-report-command, step 7.1.10.
-    notifyReportObservers(Report::create(TestReportBody::testReportType(), WTFMove(reportURL), TestReportBody::create(WTFMove(message))));
+    auto reportBody = TestReportBody::create(WTFMove(message));
+    notifyReportObservers(Report::create(reportBody->type(), WTFMove(reportURL), WTFMove(reportBody)));
 
     // FIXME(244907): We should call sendReportToEndpoints here.
 }

--- a/Source/WebCore/Modules/reporting/TestReportBody.cpp
+++ b/Source/WebCore/Modules/reporting/TestReportBody.cpp
@@ -33,12 +33,6 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(TestReportBody);
 
-const AtomString& TestReportBody::testReportType()
-{
-    static NeverDestroyed<AtomString> reportType { "test"_s };
-    return reportType;
-}
-
 TestReportBody::TestReportBody(String&& message)
     : ReportBody(ViolationReportType::Test)
     , m_bodyMessage(WTFMove(message))
@@ -50,9 +44,10 @@ Ref<TestReportBody> TestReportBody::create(String&& message)
     return adoptRef(*new TestReportBody(WTFMove(message)));
 }
 
-const AtomString& TestReportBody::type() const
+const String& TestReportBody::type() const
 {
-    return testReportType();
+    static NeverDestroyed<const String> testReportType(MAKE_STATIC_STRING_IMPL("test"));
+    return testReportType;
 }
 
 const String& TestReportBody::message() const
@@ -61,15 +56,15 @@ const String& TestReportBody::message() const
     return m_bodyMessage;
 }
 
-Ref<FormData> TestReportBody::createReportFormDataForViolation(const String& bodyMessage)
+Ref<FormData> TestReportBody::createReportFormDataForViolation() const
 {
     // https://w3c.github.io/reporting/#generate-test-report-command, Step 7.1.10
     // Suitable for network endpoints.
     auto reportBody = JSON::Object::create();
-    reportBody->setString("body_message"_s, bodyMessage);
+    reportBody->setString("body_message"_s, message());
 
     auto reportObject = JSON::Object::create();
-    reportObject->setString("type"_s, testReportType());
+    reportObject->setString("type"_s, type());
     reportObject->setString("url"_s, ""_s);
     reportObject->setObject("body"_s, WTFMove(reportBody));
 

--- a/Source/WebCore/Modules/reporting/TestReportBody.h
+++ b/Source/WebCore/Modules/reporting/TestReportBody.h
@@ -34,24 +34,21 @@ namespace WebCore {
 
 class FormData;
 
-class WEBCORE_EXPORT TestReportBody final : public ReportBody {
+class TestReportBody final : public ReportBody {
     WTF_MAKE_ISO_ALLOCATED(TestReportBody);
 public:
-    static Ref<TestReportBody> create(String&& message);
+    WEBCORE_EXPORT static Ref<TestReportBody> create(String&& message);
 
+    const String& type() const final;
     const String& message() const;
 
-    static const AtomString& testReportType();
-
-    static Ref<FormData> createReportFormDataForViolation(const String& bodyMessage);
+    WEBCORE_EXPORT Ref<FormData> createReportFormDataForViolation() const;
 
     template<typename Encoder> void encode(Encoder&) const;
     template<typename Decoder> static std::optional<RefPtr<WebCore::TestReportBody>> decode(Decoder&);
 
 private:
     TestReportBody(String&& message);
-
-    const AtomString& type() const final;
 
     const String m_bodyMessage;
 };
@@ -70,7 +67,7 @@ std::optional<RefPtr<TestReportBody>> TestReportBody::decode(Decoder& decoder)
     if (!bodymessage)
         return std::nullopt;
 
-    return adoptRef(new TestReportBody(WTFMove(*bodymessage)));
+    return TestReportBody::create(WTFMove(*bodymessage));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/COEPInheritenceViolationReportBody.cpp
+++ b/Source/WebCore/loader/COEPInheritenceViolationReportBody.cpp
@@ -33,12 +33,12 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(COEPInheritenceViolationReportBody);
 
-Ref<COEPInheritenceViolationReportBody> COEPInheritenceViolationReportBody::create(COEPDisposition disposition, const URL& blockedURL, const AtomString& type)
+Ref<COEPInheritenceViolationReportBody> COEPInheritenceViolationReportBody::create(COEPDisposition disposition, const URL& blockedURL, const String& type)
 {
     return adoptRef(*new COEPInheritenceViolationReportBody(disposition, blockedURL, type));
 }
 
-COEPInheritenceViolationReportBody::COEPInheritenceViolationReportBody(COEPDisposition disposition, const URL& blockedURL, const AtomString& type)
+COEPInheritenceViolationReportBody::COEPInheritenceViolationReportBody(COEPDisposition disposition, const URL& blockedURL, const String& type)
     : ReportBody(ViolationReportType::COEPInheritenceViolation)
     , m_disposition(disposition)
     , m_blockedURL(blockedURL)

--- a/Source/WebCore/loader/COEPInheritenceViolationReportBody.h
+++ b/Source/WebCore/loader/COEPInheritenceViolationReportBody.h
@@ -34,21 +34,21 @@ namespace WebCore {
 class COEPInheritenceViolationReportBody : public ReportBody {
     WTF_MAKE_ISO_ALLOCATED(COEPInheritenceViolationReportBody);
 public:
-    WEBCORE_EXPORT static Ref<COEPInheritenceViolationReportBody> create(COEPDisposition, const URL& blockedURL, const AtomString& type);
+    WEBCORE_EXPORT static Ref<COEPInheritenceViolationReportBody> create(COEPDisposition, const URL& blockedURL, const String& type);
 
     String disposition() const;
-    const AtomString& type() const final { return m_type; }
+    const String& type() const final { return m_type; }
     const String& blockedURL() const { return m_blockedURL.string(); }
 
     template<typename Encoder> void encode(Encoder&) const;
     template<typename Decoder> static std::optional<RefPtr<COEPInheritenceViolationReportBody>> decode(Decoder&);
 
 private:
-    COEPInheritenceViolationReportBody(COEPDisposition, const URL& blockedURL, const AtomString& type);
+    COEPInheritenceViolationReportBody(COEPDisposition, const URL& blockedURL, const String& type);
 
     COEPDisposition m_disposition;
     URL m_blockedURL;
-    AtomString m_type;
+    String m_type;
 };
 
 template<typename Encoder>
@@ -70,7 +70,7 @@ std::optional<RefPtr<COEPInheritenceViolationReportBody>> COEPInheritenceViolati
     if (!blockedURL)
         return std::nullopt;
 
-    std::optional<AtomString> type;
+    std::optional<String> type;
     decoder >> type;
     if (!type)
         return std::nullopt;

--- a/Source/WebCore/loader/CORPViolationReportBody.cpp
+++ b/Source/WebCore/loader/CORPViolationReportBody.cpp
@@ -45,9 +45,9 @@ CORPViolationReportBody::CORPViolationReportBody(COEPDisposition disposition, co
 {
 }
 
-const AtomString& CORPViolationReportBody::type() const
+const String& CORPViolationReportBody::type() const
 {
-    static MainThreadNeverDestroyed<const AtomString> corpType("corp"_s);
+    static NeverDestroyed<const String> corpType(MAKE_STATIC_STRING_IMPL("corp"));
     return corpType;
 }
 

--- a/Source/WebCore/loader/CORPViolationReportBody.h
+++ b/Source/WebCore/loader/CORPViolationReportBody.h
@@ -38,7 +38,7 @@ public:
     WEBCORE_EXPORT static Ref<CORPViolationReportBody> create(COEPDisposition, const URL& blockedURL, FetchOptions::Destination);
 
     String disposition() const;
-    const AtomString& type() const final;
+    const String& type() const final;
     const String& blockedURL() const { return m_blockedURL.string(); }
     FetchOptions::Destination destination() const { return m_destination; }
 

--- a/Source/WebCore/page/csp/CSPViolationReportBody.cpp
+++ b/Source/WebCore/page/csp/CSPViolationReportBody.cpp
@@ -37,12 +37,6 @@ using Init = SecurityPolicyViolationEventInit;
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSPViolationReportBody);
 
-const AtomString& CSPViolationReportBody::cspReportType()
-{
-    static NeverDestroyed<AtomString> reportType { "csp-violation"_s };
-    return reportType;
-}
-
 CSPViolationReportBody::CSPViolationReportBody(Init&& init)
     : ReportBody(ViolationReportType::ContentSecurityPolicy)
     , m_documentURL(WTFMove(init.documentURI))
@@ -64,69 +58,13 @@ Ref<CSPViolationReportBody> CSPViolationReportBody::create(Init&& init)
     return adoptRef(*new CSPViolationReportBody(WTFMove(init)));
 }
 
-const AtomString& CSPViolationReportBody::type() const
+const String& CSPViolationReportBody::type() const
 {
-    return cspReportType();
+    static NeverDestroyed<const String> cspReportType(MAKE_STATIC_STRING_IMPL("csp-violation"));
+    return cspReportType;
 }
 
-const String& CSPViolationReportBody::documentURL() const
-{
-    return m_documentURL;
-}
-
-const String& CSPViolationReportBody::referrer() const
-{
-    return m_referrer;
-}
-
-const String& CSPViolationReportBody::blockedURL() const
-{
-    return m_blockedURL;
-}
-
-const String& CSPViolationReportBody::effectiveDirective() const
-{
-    return m_effectiveDirective;
-}
-
-const String& CSPViolationReportBody::originalPolicy() const
-{
-    return m_originalPolicy;
-}
-
-const String& CSPViolationReportBody::sourceFile() const
-{
-    return m_sourceFile;
-}
-
-const String& CSPViolationReportBody::sample() const
-{
-    return m_sample;
-}
-
-SecurityPolicyViolationEventDisposition CSPViolationReportBody::disposition() const
-{
-    return m_disposition;
-}
-
-unsigned short CSPViolationReportBody::statusCode() const
-{
-    return m_statusCode;
-}
-
-unsigned long CSPViolationReportBody::lineNumber() const
-{
-    return m_lineNumber;
-}
-
-unsigned long CSPViolationReportBody::columnNumber() const
-{
-    return m_columnNumber;
-}
-
-Ref<FormData> CSPViolationReportBody::createReportFormDataForViolation(const CSPInfo& info, bool usesReportTo, bool isReportOnly,
-    const String& effectiveViolatedDirective, const String& referrer, const String& originalPolicy, const String& blockedURI,
-    unsigned short httpStatusCode)
+Ref<FormData> CSPViolationReportBody::createReportFormDataForViolation(bool usesReportTo, bool isReportOnly) const
 {
     // We need to be careful here when deciding what information to send to the
     // report-uri. Currently, we send only the current document's URL and the
@@ -144,38 +82,38 @@ Ref<FormData> CSPViolationReportBody::createReportFormDataForViolation(const CSP
         // It looks like WPT expect the body for modern reports to use the same
         // syntax as the JSON object (not the hyphenated versions in the original
         // CSP spec.
-        cspReport->setString("documentURL"_s, info.documentURI);
+        cspReport->setString("documentURL"_s, documentURL());
         cspReport->setString("disposition"_s, isReportOnly ? "report"_s : "enforce"_s);
-        cspReport->setString("referrer"_s, referrer);
-        cspReport->setString("effectiveDirective"_s, effectiveViolatedDirective);
-        cspReport->setString("blockedURL"_s, blockedURI);
-        cspReport->setString("originalPolicy"_s, originalPolicy);
-        cspReport->setInteger("statusCode"_s, httpStatusCode);
-        cspReport->setString("sample"_s, info.sample);
-        if (!info.sourceFile.isNull()) {
-            cspReport->setString("sourceFile"_s, info.sourceFile);
-            cspReport->setInteger("lineNumber"_s, info.lineNumber);
-            cspReport->setInteger("columnNumber"_s, info.columnNumber);
+        cspReport->setString("referrer"_s, referrer());
+        cspReport->setString("effectiveDirective"_s, effectiveDirective());
+        cspReport->setString("blockedURL"_s, blockedURL());
+        cspReport->setString("originalPolicy"_s, originalPolicy());
+        cspReport->setInteger("statusCode"_s, statusCode());
+        cspReport->setString("sample"_s, sample());
+        if (!sourceFile().isNull()) {
+            cspReport->setString("sourceFile"_s, sourceFile());
+            cspReport->setInteger("lineNumber"_s, lineNumber());
+            cspReport->setInteger("columnNumber"_s, columnNumber());
         }
     } else {
-        cspReport->setString("document-uri"_s, info.documentURI);
-        cspReport->setString("referrer"_s, referrer);
-        cspReport->setString("violated-directive"_s, effectiveViolatedDirective);
-        cspReport->setString("effective-directive"_s, effectiveViolatedDirective);
-        cspReport->setString("original-policy"_s, originalPolicy);
-        cspReport->setString("blocked-uri"_s, blockedURI);
-        cspReport->setInteger("status-code"_s, httpStatusCode);
-        if (!info.sourceFile.isNull()) {
-            cspReport->setString("source-file"_s, info.sourceFile);
-            cspReport->setInteger("line-number"_s, info.lineNumber);
-            cspReport->setInteger("column-number"_s, info.columnNumber);
+        cspReport->setString("document-uri"_s, documentURL());
+        cspReport->setString("referrer"_s, referrer());
+        cspReport->setString("violated-directive"_s, effectiveDirective());
+        cspReport->setString("effective-directive"_s, effectiveDirective());
+        cspReport->setString("original-policy"_s, originalPolicy());
+        cspReport->setString("blocked-uri"_s, blockedURL());
+        cspReport->setInteger("status-code"_s, statusCode());
+        if (!sourceFile().isNull()) {
+            cspReport->setString("source-file"_s, sourceFile());
+            cspReport->setInteger("line-number"_s, lineNumber());
+            cspReport->setInteger("column-number"_s, columnNumber());
         }
     }
 
     auto reportObject = JSON::Object::create();
     if (usesReportTo) {
-        reportObject->setString("type"_s, cspReportType());
-        reportObject->setString("url"_s, info.documentURI);
+        reportObject->setString("type"_s, type());
+        reportObject->setString("url"_s, documentURL());
         reportObject->setObject("body"_s, WTFMove(cspReport));
     } else
         reportObject->setObject("csp-report"_s, WTFMove(cspReport));

--- a/Source/WebCore/page/csp/CSPViolationReportBody.h
+++ b/Source/WebCore/page/csp/CSPViolationReportBody.h
@@ -37,37 +37,33 @@ class FormData;
 struct CSPInfo;
 struct SecurityPolicyViolationEventInit;
 
-class WEBCORE_EXPORT CSPViolationReportBody final : public ReportBody {
+class CSPViolationReportBody final : public ReportBody {
     WTF_MAKE_ISO_ALLOCATED(CSPViolationReportBody);
 public:
     using Init = SecurityPolicyViolationEventInit;
 
-    static Ref<CSPViolationReportBody> create(Init&&);
+    WEBCORE_EXPORT static Ref<CSPViolationReportBody> create(Init&&);
 
-    const String& documentURL() const;
-    const String& referrer() const;
-    const String& blockedURL() const;
-    const String& effectiveDirective() const;
-    const String& originalPolicy() const;
-    const String& sourceFile() const;
-    const String& sample() const;
-    SecurityPolicyViolationEventDisposition disposition() const;
-    unsigned short statusCode() const;
-    unsigned long lineNumber() const;
-    unsigned long columnNumber() const;
-
-    static const AtomString& cspReportType();
-    static Ref<FormData> createReportFormDataForViolation(const CSPInfo&, bool usesReportTo, bool isReportOnly,
-        const String& effectiveViolatedDirective, const String& referrer, const String& originalPolicy, const String& blockedURI,
-        unsigned short httpStatusCode);
+    const String& type() const final;
+    const String& documentURL() const { return m_documentURL; }
+    const String& referrer() const { return m_referrer; }
+    const String& blockedURL() const { return m_blockedURL; }
+    const String& effectiveDirective() const { return m_effectiveDirective; }
+    const String& originalPolicy() const { return m_originalPolicy; }
+    const String& sourceFile() const { return m_sourceFile; }
+    const String& sample() const { return m_sample; }
+    SecurityPolicyViolationEventDisposition disposition() const { return m_disposition; }
+    unsigned short statusCode() const { return m_statusCode; }
+    unsigned long lineNumber() const { return m_lineNumber; }
+    unsigned long columnNumber() const { return m_columnNumber; }
+    
+    WEBCORE_EXPORT Ref<FormData> createReportFormDataForViolation(bool usesReportTo, bool isReportOnly) const;
 
     template<typename Encoder> void encode(Encoder&) const;
     template<typename Decoder> static std::optional<RefPtr<WebCore::CSPViolationReportBody>> decode(Decoder&);
 
 private:
     CSPViolationReportBody(Init&&);
-
-    const AtomString& type() const final;
 
     const String m_documentURL;
     const String m_referrer;
@@ -109,7 +105,7 @@ std::optional<RefPtr<CSPViolationReportBody>> CSPViolationReportBody::decode(Dec
     if (!Init::decode(decoder, init))
         return std::nullopt;
 
-    return adoptRef(new CSPViolationReportBody(WTFMove(init)));
+    return CSPViolationReportBody::create(WTFMove(init));
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 552bfd33df1642d5d889a7d649cb7b91eafb27b7
<pre>
[Reporting API] Use WTFString instead of AtomString for report types
<a href="https://bugs.webkit.org/show_bug.cgi?id=245368">https://bugs.webkit.org/show_bug.cgi?id=245368</a>
&lt;rdar://problem/100130509&gt;

Reviewed by Chris Dumez.

Since we want most reports to be usable from Workers, we should use a
thread-safe string, instead of the more efficient AtomString.

* Source/WebCore/Modules/reporting/DeprecationReportBody.cpp:
(WebCore::DeprecationReportBody::deprecationReportType): Deleted.
* Source/WebCore/Modules/reporting/DeprecationReportBody.h:
* Source/WebCore/Modules/reporting/TestReportBody.cpp:
(WebCore::TestReportBody::testReportType): Deleted.
* Source/WebCore/Modules/reporting/TestReportBody.h:
* Source/WebCore/loader/COEPInheritenceViolationReportBody.cpp:
(WebCore::COEPInheritenceViolationReportBody::create):
(WebCore::COEPInheritenceViolationReportBody::COEPInheritenceViolationReportBody):
* Source/WebCore/loader/COEPInheritenceViolationReportBody.h:
(WebCore::COEPInheritenceViolationReportBody::decode):
* Source/WebCore/loader/CORPViolationReportBody.cpp:
(WebCore::CORPViolationReportBody::type const):
* Source/WebCore/loader/CORPViolationReportBody.h:
* Source/WebCore/page/csp/CSPViolationReportBody.cpp:
* Source/WebCore/page/csp/CSPViolationReportBody.cpp:
(WebCore::CSPViolationReportBody::cspReportType):
* Source/WebCore/page/csp/CSPViolationReportBody.h:

Canonical link: <a href="https://commits.webkit.org/254680@main">https://commits.webkit.org/254680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2568f6e92b5e3419b2d0d5ce5232db167def0942

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34435 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/20552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/99222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/156200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32926 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/82222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/93545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95535 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/76691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/82222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/20552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/82222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/30674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/20552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/30413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/20552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/33874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/76691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1402 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/32589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/20552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->