### PR TITLE
Do not launch network process for sending WebCacheStorageConnection::reference and WebCacheStorageConnection::dereference

### DIFF
--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
@@ -38,13 +38,14 @@ namespace WebKit {
 
 class WebCacheStorageProvider;
 
-class WebCacheStorageConnection final : public WebCore::CacheStorageConnection {
+class WebCacheStorageConnection final : public CanMakeWeakPtr<WebCacheStorageConnection>, public WebCore::CacheStorageConnection {
 public:
     static Ref<WebCacheStorageConnection> create(WebCacheStorageProvider& provider) { return adoptRef(*new WebCacheStorageConnection(provider)); }
 
     ~WebCacheStorageConnection();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void networkProcessConnectionClosed();
 
 private:
     WebCacheStorageConnection(WebCacheStorageProvider&);
@@ -68,6 +69,7 @@ private:
     void updateQuotaBasedOnSpaceUsage(const WebCore::ClientOrigin&) final;
 
     WebCacheStorageProvider& m_provider;
+    HashSet<uint64_t> m_connectedIdentifiers;
 };
 
 }

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageProvider.cpp
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageProvider.cpp
@@ -41,4 +41,10 @@ Ref<WebCore::CacheStorageConnection> WebCacheStorageProvider::createCacheStorage
     return *m_connection;
 }
 
+void WebCacheStorageProvider::networkProcessConnectionClosed()
+{
+    if (m_connection)
+        m_connection->networkProcessConnectionClosed();
+}
+
 }

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageProvider.h
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageProvider.h
@@ -41,6 +41,7 @@ public:
     static Ref<WebCacheStorageProvider> create() { return adoptRef(*new WebCacheStorageProvider); }
 
     Ref<WebCore::CacheStorageConnection> createCacheStorageConnection() final;
+    void networkProcessConnectionClosed();
 
 private:
     WebCacheStorageProvider() = default;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1281,6 +1281,8 @@ void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connec
         m_fileSystemStorageConnection->connectionClosed();
         m_fileSystemStorageConnection = nullptr;
     }
+
+    m_cacheStorageProvider->networkProcessConnectionClosed();
 }
 
 WebFileSystemStorageConnection& WebProcess::fileSystemStorageConnection()


### PR DESCRIPTION
#### 8cdd7d631bd4af28ac1135be960b5554f45419f2
<pre>
Do not launch network process for sending WebCacheStorageConnection::reference and WebCacheStorageConnection::dereference
<a href="https://bugs.webkit.org/show_bug.cgi?id=245370">https://bugs.webkit.org/show_bug.cgi?id=245370</a>
&lt;rdar://100132550&gt;

Reviewed by Youenn Fablet.

The newly launched network process will have no information about cache identifiers used in previous network process, so
there is no point sending these messages.

* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::open):
(WebKit::WebCacheStorageConnection::reference):
(WebKit::WebCacheStorageConnection::dereference):
(WebKit::WebCacheStorageConnection::networkProcessConnectionClosed):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h:
* Source/WebKit/WebProcess/Cache/WebCacheStorageProvider.cpp:
(WebKit::WebCacheStorageProvider::networkProcessConnectionClosed):
* Source/WebKit/WebProcess/Cache/WebCacheStorageProvider.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::networkProcessConnectionClosed):

Canonical link: <a href="https://commits.webkit.org/254660@main">https://commits.webkit.org/254660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9b1333f57cf0671e2fd5b4a42a9ce70d437e19e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99086 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32786 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28249 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82110 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93436 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26057 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76586 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26008 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69003 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30538 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14881 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30287 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15818 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3275 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38761 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34906 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->