### PR TITLE
Error: redefinition of 'gigacageEnabledForProcess' in JSCOnly MacOS Ports

### DIFF
--- a/Source/bmalloc/bmalloc/ProcessCheck.mm
+++ b/Source/bmalloc/bmalloc/ProcessCheck.mm
@@ -31,7 +31,7 @@
 
 namespace bmalloc {
 
-#if !BPLATFORM(WATCHOS)
+#if BPLATFORM(COCOA) && !BPLATFORM(WATCHOS)
 bool gigacageEnabledForProcess()
 {
     // Note that this function is only called once.
@@ -52,7 +52,7 @@ bool gigacageEnabledForProcess()
 
     return isOptInBinary;
 }
-#endif // !BPLATFORM(WATCHOS)
+#endif // BPLATFORM(COCOA) && !BPLATFORM(WATCHOS)
 
 bool shouldAllowMiniMode()
 {


### PR DESCRIPTION
#### b2518c25355d2196ed1335a289ec76258f3796cf
<pre>
Error: redefinition of &apos;gigacageEnabledForProcess&apos; in JSCOnly MacOS Ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=245295">https://bugs.webkit.org/show_bug.cgi?id=245295</a>
rdar://problem/100133724

Reviewed by Mark Lam.

The BPLATFORM guard around `gigacageEnabledForProcess()` in ProcessCheck.h does not match the guard
in ProcessCheck.mm. This breaks the JSCOnly variant of the bmalloc build on Darwin since the JSCOnly
variant doesn&apos;t define a BPLATFORM macro.

Fix this by making the guards match.

* Source/bmalloc/bmalloc/ProcessCheck.mm:

Canonical link: <a href="https://commits.webkit.org/254658@main">https://commits.webkit.org/254658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1340603f41056810d2c8e786d52ec618b24fe840

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99088 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155904 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32788 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28251 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82112 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93438 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26055 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76588 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26005 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68999 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81405 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30540 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14882 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76264 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30289 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15819 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26432 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3274 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33740 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/78850 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34907 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17279 "Passed tests") | 
<!--EWS-Status-Bubble-End-->