### PR TITLE
[GTK] KeyBindingTranslator.m_nativeWidget is leaked

### DIFF
--- a/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp
+++ b/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp
@@ -173,20 +173,20 @@ static void moveCursorCallback(GtkWidget* widget, GtkMovementStep step, gint cou
 KeyBindingTranslator::KeyBindingTranslator()
     : m_nativeWidget(gtk_text_view_new())
 {
-    g_signal_connect(m_nativeWidget, "backspace", G_CALLBACK(backspaceCallback), this);
-    g_signal_connect(m_nativeWidget, "cut-clipboard", G_CALLBACK(cutClipboardCallback), this);
-    g_signal_connect(m_nativeWidget, "copy-clipboard", G_CALLBACK(copyClipboardCallback), this);
-    g_signal_connect(m_nativeWidget, "paste-clipboard", G_CALLBACK(pasteClipboardCallback), this);
-    g_signal_connect(m_nativeWidget, "select-all", G_CALLBACK(selectAllCallback), this);
-    g_signal_connect(m_nativeWidget, "move-cursor", G_CALLBACK(moveCursorCallback), this);
-    g_signal_connect(m_nativeWidget, "delete-from-cursor", G_CALLBACK(deleteFromCursorCallback), this);
-    g_signal_connect(m_nativeWidget, "toggle-overwrite", G_CALLBACK(toggleOverwriteCallback), this);
+    g_signal_connect(m_nativeWidget.get(), "backspace", G_CALLBACK(backspaceCallback), this);
+    g_signal_connect(m_nativeWidget.get(), "cut-clipboard", G_CALLBACK(cutClipboardCallback), this);
+    g_signal_connect(m_nativeWidget.get(), "copy-clipboard", G_CALLBACK(copyClipboardCallback), this);
+    g_signal_connect(m_nativeWidget.get(), "paste-clipboard", G_CALLBACK(pasteClipboardCallback), this);
+    g_signal_connect(m_nativeWidget.get(), "select-all", G_CALLBACK(selectAllCallback), this);
+    g_signal_connect(m_nativeWidget.get(), "move-cursor", G_CALLBACK(moveCursorCallback), this);
+    g_signal_connect(m_nativeWidget.get(), "delete-from-cursor", G_CALLBACK(deleteFromCursorCallback), this);
+    g_signal_connect(m_nativeWidget.get(), "toggle-overwrite", G_CALLBACK(toggleOverwriteCallback), this);
 #if !USE(GTK4)
-    g_signal_connect(m_nativeWidget, "popup-menu", G_CALLBACK(popupMenuCallback), this);
-    g_signal_connect(m_nativeWidget, "show-help", G_CALLBACK(showHelpCallback), this);
+    g_signal_connect(m_nativeWidget.get(), "popup-menu", G_CALLBACK(popupMenuCallback), this);
+    g_signal_connect(m_nativeWidget.get(), "show-help", G_CALLBACK(showHelpCallback), this);
 #endif
 #if GTK_CHECK_VERSION(3, 24, 0)
-    g_signal_connect(m_nativeWidget, "insert-emoji", G_CALLBACK(insertEmojiCallback), this);
+    g_signal_connect(m_nativeWidget.get(), "insert-emoji", G_CALLBACK(insertEmojiCallback), this);
 #endif
 }
 
@@ -242,7 +242,7 @@ Vector<String> KeyBindingTranslator::commandsForKeyEvent(GtkEventControllerKey* 
 {
     ASSERT(m_pendingEditorCommands.isEmpty());
 
-    gtk_event_controller_key_forward(GTK_EVENT_CONTROLLER_KEY(controller), m_nativeWidget);
+    gtk_event_controller_key_forward(GTK_EVENT_CONTROLLER_KEY(controller), m_nativeWidget.get());
     if (!m_pendingEditorCommands.isEmpty())
         return WTFMove(m_pendingEditorCommands);
 
@@ -254,7 +254,7 @@ Vector<String> KeyBindingTranslator::commandsForKeyEvent(GdkEventKey* event)
 {
     ASSERT(m_pendingEditorCommands.isEmpty());
 
-    gtk_bindings_activate_event(G_OBJECT(m_nativeWidget), event);
+    gtk_bindings_activate_event(G_OBJECT(m_nativeWidget.get()), event);
     if (!m_pendingEditorCommands.isEmpty())
         return WTFMove(m_pendingEditorCommands);
 

--- a/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.h
+++ b/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.h
@@ -36,7 +36,7 @@ public:
     KeyBindingTranslator();
     ~KeyBindingTranslator();
 
-    GtkWidget* widget() const { return m_nativeWidget; }
+    GtkWidget* widget() const { return m_nativeWidget.get(); }
     void invalidate() { m_nativeWidget = nullptr; }
 
 #if USE(GTK4)
@@ -49,7 +49,7 @@ public:
     void addPendingEditorCommand(const char* command) { m_pendingEditorCommands.append(String::fromLatin1(command)); }
 
 private:
-    GtkWidget* m_nativeWidget;
+    GRefPtr<GtkWidget> m_nativeWidget;
     Vector<String> m_pendingEditorCommands;
 };
 


### PR DESCRIPTION
#### 97f37b5b39e8853b1d5afdc3b3a46380ebb02336
<pre>
[GTK] KeyBindingTranslator.m_nativeWidget is leaked
<a href="https://bugs.webkit.org/show_bug.cgi?id=245384">https://bugs.webkit.org/show_bug.cgi?id=245384</a>

Reviewed by Adrian Perez de Castro.

* Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp:
(WebKit::KeyBindingTranslator::KeyBindingTranslator):
(WebKit::KeyBindingTranslator::commandsForKeyEvent):
* Source/WebKit/UIProcess/gtk/KeyBindingTranslator.h:
(WebKit::KeyBindingTranslator::widget const):

Canonical link: <a href="https://commits.webkit.org/254672@main">https://commits.webkit.org/254672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/679a11087c5a61a98f61d4251b03311044defa72

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99098 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32808 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28261 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82164 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93448 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26070 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76601 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26036 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69036 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30559 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14887 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30308 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15824 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-toggle-in-inactive-document-crash.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3281 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33759 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38775 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34912 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->