### PR TITLE
Improve compliance with current HTML and webappapis specifications for PDF Viewer

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -944,7 +944,6 @@ imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-
 imported/w3c/web-platform-tests/user-timing/clearMarks.html [ Failure Pass ]
 imported/w3c/web-platform-tests/user-timing/mark.html [ Failure Pass ]
 imported/w3c/web-platform-tests/user-timing/measure_associated_with_navigation_timing.html [ Failure Pass ]
-imported/w3c/web-platform-tests/html/webappapis/system-state-and-capabilities/the-navigator-object/plugins-and-mimetypes.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/sharedworker-partitioning.tentative.https.window.html [ Failure Pass ]
 imported/w3c/web-platform-tests/service-workers/service-worker/navigation-timing-extended.https.html [ Failure Pass ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSourceToScriptProcessorTest.html [ Failure Pass ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -4868,7 +4868,7 @@ PASS Navigator interface: attribute cookieEnabled
 PASS Navigator interface: attribute plugins
 PASS Navigator interface: attribute mimeTypes
 PASS Navigator interface: operation javaEnabled()
-FAIL Navigator interface: attribute pdfViewerEnabled assert_true: The prototype object must have a property "pdfViewerEnabled" expected true got false
+PASS Navigator interface: attribute pdfViewerEnabled
 PASS Navigator interface: attribute hardwareConcurrency
 PASS Navigator must be primary interface of window.navigator
 PASS Stringification of window.navigator
@@ -4894,7 +4894,7 @@ PASS Navigator interface: window.navigator must inherit property "cookieEnabled"
 PASS Navigator interface: window.navigator must inherit property "plugins" with the proper type
 PASS Navigator interface: window.navigator must inherit property "mimeTypes" with the proper type
 PASS Navigator interface: window.navigator must inherit property "javaEnabled()" with the proper type
-FAIL Navigator interface: window.navigator must inherit property "pdfViewerEnabled" with the proper type assert_inherits: property "pdfViewerEnabled" not found in prototype chain
+PASS Navigator interface: window.navigator must inherit property "pdfViewerEnabled" with the proper type
 PASS Navigator interface: window.navigator must inherit property "hardwareConcurrency" with the proper type
 PASS PluginArray interface: existence and properties of interface object
 PASS PluginArray interface object length

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/system-state-and-capabilities/the-navigator-object/plugins-and-mimetypes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/system-state-and-capabilities/the-navigator-object/plugins-and-mimetypes-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL navigator.pdfViewerEnabled exists assert_true: property exists expected true got false
-FAIL navigator.mimeTypes is empty assert_equals: length expected 0 but got 14
-FAIL navigator.plugins is empty assert_equals: length expected 0 but got 1
+PASS navigator.pdfViewerEnabled exists
+PASS navigator.mimeTypes contains the hard-coded list
+PASS navigator.plugins contains the hard-coded list
 

--- a/LayoutTests/platform/glib/fast/dom/collection-iterators-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/collection-iterators-expected.txt
@@ -48,6 +48,15 @@ PASS 'keys' in obj is false
 PASS 'forEach' in obj is false
 PASS 'values' in obj is false
 
+* Plugin
+PASS obj.__proto__ is Plugin.prototype
+PASS Symbol.iterator in obj is true
+PASS for..of did not throw an exception
+PASS 'entries' in obj is false
+PASS 'keys' in obj is false
+PASS 'forEach' in obj is false
+PASS 'values' in obj is false
+
 * PluginArray
 PASS obj.__proto__ is PluginArray.prototype
 PASS Symbol.iterator in obj is true

--- a/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
@@ -17,6 +17,7 @@ navigator.mediaCapabilities is OK
 navigator.mediaSession is OK
 navigator.mimeTypes is OK
 navigator.onLine is OK
+navigator.pdfViewerEnabled is OK
 navigator.permissions is OK
 navigator.platform is OK
 navigator.plugins is OK
@@ -48,6 +49,7 @@ navigator.mediaCapabilities is OK
 navigator.mediaSession is OK
 navigator.mimeTypes is OK
 navigator.onLine is OK
+navigator.pdfViewerEnabled is OK
 navigator.permissions is OK
 navigator.platform is OK
 navigator.plugins is OK

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -4868,7 +4868,7 @@ PASS Navigator interface: attribute cookieEnabled
 PASS Navigator interface: attribute plugins
 PASS Navigator interface: attribute mimeTypes
 PASS Navigator interface: operation javaEnabled()
-FAIL Navigator interface: attribute pdfViewerEnabled assert_true: The prototype object must have a property "pdfViewerEnabled" expected true got false
+PASS Navigator interface: attribute pdfViewerEnabled
 PASS Navigator interface: attribute hardwareConcurrency
 PASS Navigator must be primary interface of window.navigator
 PASS Stringification of window.navigator
@@ -4894,7 +4894,7 @@ PASS Navigator interface: window.navigator must inherit property "cookieEnabled"
 PASS Navigator interface: window.navigator must inherit property "plugins" with the proper type
 PASS Navigator interface: window.navigator must inherit property "mimeTypes" with the proper type
 PASS Navigator interface: window.navigator must inherit property "javaEnabled()" with the proper type
-FAIL Navigator interface: window.navigator must inherit property "pdfViewerEnabled" with the proper type assert_inherits: property "pdfViewerEnabled" not found in prototype chain
+PASS Navigator interface: window.navigator must inherit property "pdfViewerEnabled" with the proper type
 PASS Navigator interface: window.navigator must inherit property "hardwareConcurrency" with the proper type
 PASS PluginArray interface: existence and properties of interface object
 PASS PluginArray interface object length

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -4858,7 +4858,7 @@ PASS Navigator interface: attribute cookieEnabled
 PASS Navigator interface: attribute plugins
 PASS Navigator interface: attribute mimeTypes
 PASS Navigator interface: operation javaEnabled()
-FAIL Navigator interface: attribute pdfViewerEnabled assert_true: The prototype object must have a property "pdfViewerEnabled" expected true got false
+PASS Navigator interface: attribute pdfViewerEnabled
 PASS Navigator interface: attribute hardwareConcurrency
 PASS Navigator must be primary interface of window.navigator
 PASS Stringification of window.navigator
@@ -4884,7 +4884,7 @@ PASS Navigator interface: window.navigator must inherit property "cookieEnabled"
 PASS Navigator interface: window.navigator must inherit property "plugins" with the proper type
 PASS Navigator interface: window.navigator must inherit property "mimeTypes" with the proper type
 PASS Navigator interface: window.navigator must inherit property "javaEnabled()" with the proper type
-FAIL Navigator interface: window.navigator must inherit property "pdfViewerEnabled" with the proper type assert_inherits: property "pdfViewerEnabled" not found in prototype chain
+PASS Navigator interface: window.navigator must inherit property "pdfViewerEnabled" with the proper type
 PASS Navigator interface: window.navigator must inherit property "hardwareConcurrency" with the proper type
 PASS PluginArray interface: existence and properties of interface object
 PASS PluginArray interface object length

--- a/LayoutTests/platform/ios/fast/dom/collection-iterators-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/collection-iterators-expected.txt
@@ -48,6 +48,15 @@ PASS 'keys' in obj is false
 PASS 'forEach' in obj is false
 PASS 'values' in obj is false
 
+* Plugin
+PASS obj.__proto__ is Plugin.prototype
+PASS Symbol.iterator in obj is true
+PASS for..of did not throw an exception
+PASS 'entries' in obj is false
+PASS 'keys' in obj is false
+PASS 'forEach' in obj is false
+PASS 'values' in obj is false
+
 * PluginArray
 PASS obj.__proto__ is PluginArray.prototype
 PASS Symbol.iterator in obj is true

--- a/LayoutTests/platform/ipad/fast/dom/collection-iterators-expected.txt
+++ b/LayoutTests/platform/ipad/fast/dom/collection-iterators-expected.txt
@@ -48,6 +48,15 @@ PASS 'keys' in obj is false
 PASS 'forEach' in obj is false
 PASS 'values' in obj is false
 
+* Plugin
+PASS obj.__proto__ is Plugin.prototype
+PASS Symbol.iterator in obj is true
+PASS for..of did not throw an exception
+PASS 'entries' in obj is false
+PASS 'keys' in obj is false
+PASS 'forEach' in obj is false
+PASS 'values' in obj is false
+
 * PluginArray
 PASS obj.__proto__ is PluginArray.prototype
 PASS Symbol.iterator in obj is true

--- a/LayoutTests/platform/mac-wk1/fast/dom/collection-iterators-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/dom/collection-iterators-expected.txt
@@ -48,6 +48,15 @@ PASS 'keys' in obj is false
 PASS 'forEach' in obj is false
 PASS 'values' in obj is false
 
+* Plugin
+PASS obj.__proto__ is Plugin.prototype
+PASS Symbol.iterator in obj is true
+PASS for..of did not throw an exception
+PASS 'entries' in obj is false
+PASS 'keys' in obj is false
+PASS 'forEach' in obj is false
+PASS 'values' in obj is false
+
 * PluginArray
 PASS obj.__proto__ is PluginArray.prototype
 PASS Symbol.iterator in obj is true

--- a/LayoutTests/platform/mac-wk1/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/dom/navigator-detached-no-crash-expected.txt
@@ -15,6 +15,7 @@ navigator.mediaCapabilities is OK
 navigator.mediaSession is OK
 navigator.mimeTypes is OK
 navigator.onLine is OK
+navigator.pdfViewerEnabled is OK
 navigator.permissions is OK
 navigator.platform is OK
 navigator.plugins is OK
@@ -43,6 +44,7 @@ navigator.mediaCapabilities is OK
 navigator.mediaSession is OK
 navigator.mimeTypes is OK
 navigator.onLine is OK
+navigator.pdfViewerEnabled is OK
 navigator.permissions is OK
 navigator.platform is OK
 navigator.plugins is OK

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -4868,7 +4868,7 @@ PASS Navigator interface: attribute cookieEnabled
 PASS Navigator interface: attribute plugins
 PASS Navigator interface: attribute mimeTypes
 PASS Navigator interface: operation javaEnabled()
-FAIL Navigator interface: attribute pdfViewerEnabled assert_true: The prototype object must have a property "pdfViewerEnabled" expected true got false
+PASS Navigator interface: attribute pdfViewerEnabled
 PASS Navigator interface: attribute hardwareConcurrency
 PASS Navigator must be primary interface of window.navigator
 PASS Stringification of window.navigator
@@ -4894,7 +4894,7 @@ PASS Navigator interface: window.navigator must inherit property "cookieEnabled"
 PASS Navigator interface: window.navigator must inherit property "plugins" with the proper type
 PASS Navigator interface: window.navigator must inherit property "mimeTypes" with the proper type
 PASS Navigator interface: window.navigator must inherit property "javaEnabled()" with the proper type
-FAIL Navigator interface: window.navigator must inherit property "pdfViewerEnabled" with the proper type assert_inherits: property "pdfViewerEnabled" not found in prototype chain
+PASS Navigator interface: window.navigator must inherit property "pdfViewerEnabled" with the proper type
 PASS Navigator interface: window.navigator must inherit property "hardwareConcurrency" with the proper type
 PASS PluginArray interface: existence and properties of interface object
 PASS PluginArray interface object length

--- a/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
@@ -20,6 +20,7 @@ navigator.mediaCapabilities is OK
 navigator.mediaSession is OK
 navigator.mimeTypes is OK
 navigator.onLine is OK
+navigator.pdfViewerEnabled is OK
 navigator.permissions is OK
 navigator.platform is OK
 navigator.plugins is OK
@@ -58,6 +59,7 @@ navigator.mediaCapabilities is OK
 navigator.mediaSession is OK
 navigator.mimeTypes is OK
 navigator.onLine is OK
+navigator.pdfViewerEnabled is OK
 navigator.permissions is OK
 navigator.platform is OK
 navigator.plugins is OK

--- a/LayoutTests/platform/mac/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/navigator-detached-no-crash-expected.txt
@@ -16,6 +16,7 @@ navigator.languages is OK
 navigator.mediaCapabilities is OK
 navigator.mimeTypes is OK
 navigator.onLine is OK
+navigator.pdfViewerEnabled is OK
 navigator.platform is OK
 navigator.plugins is OK
 navigator.product is OK
@@ -43,6 +44,7 @@ navigator.languages is OK
 navigator.mediaCapabilities is OK
 navigator.mimeTypes is OK
 navigator.onLine is OK
+navigator.pdfViewerEnabled is OK
 navigator.platform is OK
 navigator.plugins is OK
 navigator.product is OK

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -43,6 +43,7 @@ public:
     String appVersion() const;
     DOMPluginArray& plugins();
     DOMMimeTypeArray& mimeTypes();
+    bool pdfViewerEnabled();
     bool cookieEnabled() const;
     bool javaEnabled() const { return false; }
     const String& userAgent() const final;
@@ -74,6 +75,7 @@ private:
 
     mutable RefPtr<ShareDataReader> m_loader;
     mutable bool m_hasPendingShare { false };
+    mutable bool m_pdfViewerEnabled { false };
     mutable RefPtr<DOMPluginArray> m_plugins;
     mutable RefPtr<DOMMimeTypeArray> m_mimeTypes;
     mutable String m_userAgent;

--- a/Source/WebCore/page/NavigatorPlugins.idl
+++ b/Source/WebCore/page/NavigatorPlugins.idl
@@ -28,4 +28,5 @@ interface mixin NavigatorPlugins {
     [SameObject] readonly attribute DOMPluginArray plugins;
     [SameObject] readonly attribute DOMMimeTypeArray mimeTypes;
     boolean javaEnabled();
+    readonly attribute boolean pdfViewerEnabled;
 };

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -544,7 +544,13 @@ String contextMenuItemTagSearchWeb()
 {
     return WEB_UI_STRING_WITH_MNEMONIC("Search the Web", "_Search the Web", "Search the Web context menu item");
 }
-#endif
+
+String pdfDocumentTypeDescription()
+{
+    // Also exposed to DOM.
+    return WEB_UI_STRING("Portable Document Format", "Description of the primary type supported by the PDF pseudo plug-in.");
+}
+#endif // !PLATFORM(COCOA)
 
 #endif // ENABLE(CONTEXT_MENUS)
 

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -270,9 +270,10 @@ namespace WebCore {
     String allFilesText();
 #endif
 
+    WEBCORE_EXPORT String pdfDocumentTypeDescription();
+
 #if PLATFORM(COCOA)
     WEBCORE_EXPORT String builtInPDFPluginName();
-    WEBCORE_EXPORT String pdfDocumentTypeDescription();
     WEBCORE_EXPORT String postScriptDocumentTypeDescription();
     String keygenMenuItem2048();
     WEBCORE_EXPORT String keygenKeychainItemName(const String& host);

--- a/Source/WebCore/plugins/PluginData.h
+++ b/Source/WebCore/plugins/PluginData.h
@@ -113,6 +113,10 @@ public:
 
     String pluginFileForWebVisibleMimeType(const String& mimeType) const;
 
+    const std::optional<PluginInfo>& builtInPDFPlugin() const { return m_builtInPDFPluginInfo; }
+
+    static PluginInfo dummyPDFPluginInfo();
+
 private:
     explicit PluginData(Page&);
     void initPlugins();
@@ -127,6 +131,7 @@ protected:
         std::optional<Vector<PluginInfo>> pluginList;
     };
     mutable CachedVisiblePlugins m_cachedVisiblePlugins;
+    std::optional<PluginInfo> m_builtInPDFPluginInfo;
 };
 
 inline bool isSupportedPlugin(const Vector<SupportedPluginIdentifier>& pluginIdentifiers, const URL& pageURL, const String& pluginIdentifier)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1279,6 +1279,8 @@ PluginInfo PDFPlugin::pluginInfo()
 {
     PluginInfo info;
     info.name = builtInPDFPluginName();
+    info.desc = pdfDocumentTypeDescription();
+    info.file = "internal-pdf-viewer"_s;
     info.isApplicationPlugin = true;
     info.clientLoadPolicy = PluginLoadClientPolicy::Undefined;
     info.bundleIdentifier = "com.apple.webkit.builtinpdfplugin"_s;


### PR DESCRIPTION
#### e6adcfb74700125e84be81d96f9ee16248145c82
<pre>
Improve compliance with current HTML and webappapis specifications for PDF Viewer
<a href="https://bugs.webkit.org/show_bug.cgi?id=245396">https://bugs.webkit.org/show_bug.cgi?id=245396</a>
&lt;rdar://100142265&gt;

Reviewed by Chris Dumez.

The HTML specification includes guidance for PDF Viewer handling (see
<a href="https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewing-support).">https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewing-support).</a>
We currently fail a number of tests in this area, even though we provide
proper features and handle PDF&apos;s properly.

We also failed to impleemnt the &apos;pdfViewerEnabled&apos; property on Navigator,
which might block sites in the future from offering inline PDF viewing.

This patch updates WebKit to supply the expected set of PDF Viewer plugins
(all aliases to the underlying PDF implementation) in the specified order
and with the specified descriptions and file names.

* LayoutTests/TestExpectations
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt: Update for new passes.
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/system-state-and-capabilities/the-navigator-object/plugins-and-mimetypes-expected.txt: Ditto.
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt: Ditto.
* LayoutTests/platform/mac-wk1/fast/dom/navigator-detached-no-crash-expected.txt: Ditto.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt: Ditto.
* LayoutTests/platform/mac/fast/dom/navigator-detached-no-crash-expected.txt: Ditto.
* Source/WebCore/page/Navigator.cpp:
(WebCore::dummyPDFPluginNamess): Added.
(WebCore::Navigator::initializePluginAndMimeTypeArrays): Revise to generate
relevant dummy entries as defined by the standard.
(WebCore::Navigator::pdfViewerEnabled): Added.
* Source/WebCore/page/Navigator.h:
* Source/WebCore/page/NavigatorPlugins.idl: Add the new &apos;pdfViewerEnabled&apos; property.
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::pdfDocumentTypeDescription): Added implementation for non-Cocoa ports (which
use the pdf.js implementation).
* Source/WebCore/platform/LocalizedStrings.h
* Source/WebCore/plugins/PluginData.cpp:
(WebCore::PluginData::initPlugins): Capture the PDF viewer plugin (if present).
* Source/WebCore/plugins/PluginData.h:
(WebCore::PluginData::builtInPDFPlugIn const): Added.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::pluginInfo): Update to provide the correct description
and &apos;file&apos; label, as defined by the spec.

Canonical link: <a href="https://commits.webkit.org/255052@main">https://commits.webkit.org/255052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b286364d5d5afb7a80730968ce035783f3ab9760

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91137 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/137 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/100646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/160109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/149 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96793 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/83499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/35285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/33081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36864 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1550 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38791 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->