### PR TITLE
Implement import.meta.resolve()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -646,6 +646,7 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/mo
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-origin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-same-origin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-unsafe-url.sub.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-importmap.html [ Skip ]
 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-keyboard-enter.html [ Skip ]
 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-keyboard-escape.html [ Skip ]
 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-mouse-left.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-importmap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-importmap-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL import.meta.resolve() given an import mapped bare specifier import.meta.resolve is not a function. (In 'import.meta.resolve("bare")', 'import.meta.resolve' is undefined)
-FAIL import.meta.resolve() given an import mapped  URL-like specifier import.meta.resolve is not a function. (In 'import.meta.resolve("https://example.com/rewrite")', 'import.meta.resolve' is undefined)
-FAIL Testing the ToString() step of import.meta.resolve() via import maps import.meta.resolve is not a function. (In 'import.meta.resolve()', 'import.meta.resolve' is undefined)
+FAIL import.meta.resolve() given an import mapped bare specifier Module specifier, 'bare' does not start with "/", "./", or "../". Referenced from http://localhost:8800/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-importmap.html
+FAIL import.meta.resolve() given an import mapped  URL-like specifier assert_equals: expected "https://example.com/rewritten" but got "https://example.com/rewrite"
+FAIL Testing the ToString() step of import.meta.resolve() via import maps Module specifier, 'undefined' does not start with "/", "./", or "../". Referenced from http://localhost:8800/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-importmap.html
 FAIL import(import.meta.resolve(x)) can be different from import(x) promise_test: Unhandled rejection with value: object "TypeError: Importing a module script failed."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-multiple-scripts-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-multiple-scripts-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL import.meta.resolve resolves URLs relative to the import.meta.url, not relative to the active script when it is called: another global's inline script frames[0].importMetaResolve is not a function. (In 'frames[0].importMetaResolve("./x")', 'frames[0].importMetaResolve' is undefined)
-FAIL import.meta.resolve still works if its global has been destroyed (by detaching the iframe) otherFrameImportMetaResolve is not a function. (In 'otherFrameImportMetaResolve("./x")', 'otherFrameImportMetaResolve' is undefined)
-FAIL import.meta.resolve resolves URLs relative to the import.meta.url, not relative to the active script when it is called: another module script otherImportMeta.resolve is not a function. (In 'otherImportMeta.resolve("./x")', 'otherImportMeta.resolve' is undefined)
+PASS import.meta.resolve resolves URLs relative to the import.meta.url, not relative to the active script when it is called: another global's inline script
+PASS import.meta.resolve still works if its global has been destroyed (by detaching the iframe)
+PASS import.meta.resolve resolves URLs relative to the import.meta.url, not relative to the active script when it is called: another module script
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve.any.serviceworker-module-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve.any.serviceworker-module-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL import.meta.resolve is a function with the right properties assert_equals: expected "function" but got "undefined"
+PASS import.meta.resolve is a function with the right properties
 PASS import.meta.resolve is not a constructor
-FAIL import.meta.resolve ToString()s its argument import.meta.resolve is not a function. (In 'import.meta.resolve({ toString() { return "./x"; } })', 'import.meta.resolve' is undefined)
-FAIL Relative URL-like specifier resolution import.meta.resolve is not a function. (In 'import.meta.resolve("./x")', 'import.meta.resolve' is undefined)
-FAIL Absolute URL-like specifier resolution import.meta.resolve is not a function. (In 'import.meta.resolve("https://example.com/")', 'import.meta.resolve' is undefined)
+PASS import.meta.resolve ToString()s its argument
+PASS Relative URL-like specifier resolution
+PASS Absolute URL-like specifier resolution
 PASS Invalid module specifiers
-FAIL Works fine with no this value resolve is not a function. (In 'resolve("https://example.com/")', 'resolve' is undefined)
+PASS Works fine with no this value
 


### PR DESCRIPTION
#### 78c6d6d7b596a5953915f8066a5e75d19eda8411
<pre>
Implement import.meta.resolve()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242163">https://bugs.webkit.org/show_bug.cgi?id=242163</a>
rdar://96569044

Reviewed by Alexey Shvayka.

This patch implements import.meta.resolve[1], which exposes module specifier resolving feature through import.meta object.

[1]: <a href="https://whatpr.org/html/5572/webappapis.html#hostgetimportmetaproperties">https://whatpr.org/html/5572/webappapis.html#hostgetimportmetaproperties</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-importmap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-multiple-scripts-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve.any.serviceworker-module-expected.txt:
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::createImportMetaProperties):

Canonical link: <a href="https://commits.webkit.org/254691@main">https://commits.webkit.org/254691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f2d84b1f9c6d2cbbd638daedd0e009bdc89c2c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99143 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155960 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32865 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28305 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82169 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93493 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26113 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76646 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26040 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69040 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30615 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14917 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30356 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15858 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3292 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33813 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38807 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-toggle-in-inactive-document-crash.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1407 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34942 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->