### PR TITLE
[JSC] HeapBigInt CompareStrictEq should call use after speculation checks

### DIFF
--- a/JSTests/stress/osr-exit-check-node-liveness-heap-bigint-strict-eq.js
+++ b/JSTests/stress/osr-exit-check-node-liveness-heap-bigint-strict-eq.js
@@ -1,0 +1,28 @@
+//@ runDefault("--validateOptions=true", "--useConcurrentJIT=false", "--useFTLJIT=false")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function main() {
+    let v37;
+    let v20 = 129n << 129n;
+    const v21 = v20++;
+
+    function v29(v30) {
+        switch (v21) {
+        default:
+            for (let v34 = 1; v34 < 65536; v34++) { }
+            break;
+        case v30:
+            v37 = 1; // should never be reached, however this is executed in baseline
+        }
+    }
+
+    v29(BigInt(129n));
+    v29([1]);
+    return v37;
+}
+noInline(main);
+shouldBe(main(), undefined);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -12860,9 +12860,10 @@ void SpeculativeJIT::emitSwitchString(Node* node, SwitchData* data)
         
         GPRReg op1GPR = op1.gpr();
         
+        speculateString(node->child1(), op1GPR);
+
         op1.use();
 
-        speculateString(node->child1(), op1GPR);
         emitSwitchStringOnString(node, data, op1GPR);
         noResult(node, UseChildrenCalledExplicitly);
         break;
@@ -16070,11 +16071,11 @@ void SpeculativeJIT::compileHeapBigIntEquality(Node* node)
     GPRReg rightGPR = right.gpr();
     GPRReg resultGPR = result.gpr();
 
-    left.use();
-    right.use();
-
     speculateHeapBigInt(node->child1(), leftGPR);
     speculateHeapBigInt(node->child2(), rightGPR);
+
+    left.use();
+    right.use();
 
     JITCompiler::Jump notEqualCase = m_jit.branchPtr(JITCompiler::NotEqual, leftGPR, rightGPR);
 


### PR DESCRIPTION
#### 662e9f67690eac1d94556207cea3186159996337
<pre>
[JSC] HeapBigInt CompareStrictEq should call use after speculation checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=233682">https://bugs.webkit.org/show_bug.cgi?id=233682</a>
rdar://86192953

Reviewed by Saam Barati.

Because we call use() before speculation check, in OSR exit, these nodes may be counted as dead, which can make
OSR exit recovering for these node&apos;s loc to undefined. We should call `use()` after possible OSR exit (in this case,
speculation).

* JSTests/stress/osr-exit-check-node-liveness-heap-bigint-strict-eq.js: Added.
(shouldBe):
(main.v29):
(main):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/254655@main">https://commits.webkit.org/254655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83d1308377514884c5c4c5449c38da17413c9f94

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34353 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/20496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/99128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/155945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32844 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/82153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/93478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95453 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76631 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/82153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/80974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/20496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/82153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81458 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30596 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/20496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76328 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30339 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/20496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26444 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33794 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/78914 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1391 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32507 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/20496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17291 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode (failure)") | 
<!--EWS-Status-Bubble-End-->