### PR TITLE
`KeyboardScrollingAnimator::updateKeyboardScrollPosition` is called indefinitely when using keyboard smooth scrolling

### DIFF
--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-terminates-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-terminates-expected.txt
@@ -1,0 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-terminates.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-terminates.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
+
+<html>
+
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <meta name="viewport" content="initial-scale=1.5, user-scalable=no">
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+        
+        async function runTest()
+        {
+            if (window.eventSender) {
+                eventSender.monitorWheelEvents();
+                eventSender.keyDown("downArrow");
+
+                setTimeout(function() {
+                    eventSender.callAfterScrollingCompletes(() => {
+                        testRunner.notifyDone();
+                    });
+                }, 0);
+            }
+        }
+    </script>
+</head>
+
+<body onload="runTest()">
+    <div style="height: 5000px;">
+    </div>
+</body>
+
+</html>

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -343,6 +343,7 @@ void KeyboardScrollingAnimator::handleKeyUpEvent()
         return;
 
     stopKeyboardScrollAnimation();
+    m_scrollTriggeringKeyIsPressed = false;
 }
 
 void KeyboardScrollingAnimator::stopScrollingImmediately()


### PR DESCRIPTION
#### 3ed0f4e841a4a7adf1243ced93eb72604c7bb501
<pre>
`KeyboardScrollingAnimator::updateKeyboardScrollPosition` is called indefinitely when using keyboard smooth scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=245403">https://bugs.webkit.org/show_bug.cgi?id=245403</a>
rdar://100146415

Reviewed by Tim Horton and Simon Fraser.

When the `EventHandler driven smooth scrolling` flag is enabled,
`KeyboardScrollingAnimator::updateKeyboardScrollPosition` is called indefinitely,
causing the scroll to never terminate.

Regression from <a href="https://github.com/WebKit/WebKit/commit/8c822fa15adbdecd22d0c3ece07c9e9aa2260af1">https://github.com/WebKit/WebKit/commit/8c822fa15adbdecd22d0c3ece07c9e9aa2260af1</a>
which accidentally removed the logic of settng `m_scrollTriggeringKeyIsPressed` to `false`.

* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::KeyboardScrollingAnimator::handleKeyUpEvent):

Canonical link: <a href="https://commits.webkit.org/254685@main">https://commits.webkit.org/254685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3526c97e4b25640302a9f0aa5f38a81ad7708dc7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99131 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155948 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32848 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28293 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82156 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93481 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26102 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76634 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26028 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69027 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30600 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14907 "Found 1 new test failure: svg/text/append-text-node-to-tspan.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30342 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15846 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3289 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33798 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38795 "Found 2 new test failures: imported/w3c/web-platform-tests/content-security-policy/frame-src/frame-src-self-unique-origin.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-toggle-in-inactive-document-crash.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32511 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34932 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->