### PR TITLE
[Live Text] Avoid injecting recognized text consisting of single words or letters in tiny images

### DIFF
--- a/LayoutTests/fast/images/text-recognition/avoid-image-overlay-in-small-image-expected.txt
+++ b/LayoutTests/fast/images/text-recognition/avoid-image-overlay-in-small-image-expected.txt
@@ -1,0 +1,6 @@
+
+PASS internals.shadowRoot(image)?.getElementById("div#image-overlay") is undefined.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/images/text-recognition/avoid-image-overlay-in-small-image.html
+++ b/LayoutTests/fast/images/text-recognition/avoid-image-overlay-in-small-image.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    margin: 0;
+}
+img {
+    width: 32px;
+    height: 32px;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+</style>
+</head>
+<body>
+<img src="../resources/green-400x400.png"></img>
+<pre id="console"></pre>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", () => {
+    image = document.querySelector("img");
+    internals.installImageOverlay(image, [
+        {
+            topLeft : new DOMPointReadOnly(0, 0),
+            topRight : new DOMPointReadOnly(0.9, 0),
+            bottomRight : new DOMPointReadOnly(0.9, 0.9),
+            bottomLeft : new DOMPointReadOnly(0, 0.9),
+            children: [
+                {
+                    text : "e",
+                    topLeft : new DOMPointReadOnly(0, 0),
+                    topRight : new DOMPointReadOnly(0.9, 0),
+                    bottomRight : new DOMPointReadOnly(0.9, 0.9),
+                    bottomLeft : new DOMPointReadOnly(0, 0.9),
+                }
+            ]
+        }
+    ]);
+
+    shouldBeUndefined(`internals.shadowRoot(image)?.getElementById("div#image-overlay")`);
+    finishJSTest();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 03e0d55a928634777319de1b93a82558ab94bba7
<pre>
[Live Text] Avoid injecting recognized text consisting of single words or letters in tiny images
<a href="https://bugs.webkit.org/show_bug.cgi?id=245404">https://bugs.webkit.org/show_bug.cgi?id=245404</a>
rdar://99490753

Reviewed by Tim Horton.

Add a basic heuristic to avoid injecting Live Text in small images, if the recognized text consists
of only a single word or letter. Currently, this causes images to become selectable in many
instances where there&apos;s little to no utility in being able to select text — for instance, in image
buttons or links that consist of an icon, such as an &quot;x&quot;.

Test: fast/images/text-recognition/avoid-image-overlay-in-small-image.html

* LayoutTests/fast/images/text-recognition/avoid-image-overlay-in-small-image-expected.txt: Added.
* LayoutTests/fast/images/text-recognition/avoid-image-overlay-in-small-image.html: Added.
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::updateWithTextRecognitionResult):

To do this, we shuffle around some logic for creating and appending the UA shadow DOM elements used
to implement Live Text, such that we exit early and avoid installing a shadow root altogether in the
case where the image is smaller than an arbitrary threshold (64px), and the text we&apos;re about to
inject consists of a single piece of child text.

Canonical link: <a href="https://commits.webkit.org/254671@main">https://commits.webkit.org/254671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9a99f8627f51230fef6063433f0fa2c49f467dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99132 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155949 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32849 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28294 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82157 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93482 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26103 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76635 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26031 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69030 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30601 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14908 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30343 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15847 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3282 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33799 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38796 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34933 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->