### PR TITLE
ANGLE builtin metal shader compilation outputs during build time

### DIFF
--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -3669,7 +3669,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"${ACTION}\" = \"analyze\" ] || [ \"${ACTION}\" = \"build\" ] || [ \"${ACTION}\" = \"install\" ]; then\n echo python3 \"${SRCROOT}/src/libANGLE/renderer/metal/shaders/create_mtl_internal_shaders.py\" \"$SCRIPT_INPUT_FILE_0\" \"$SCRIPT_OUTPUT_FILE_0\"\n  python3 \"${SRCROOT}/src/libANGLE/renderer/metal/shaders/create_mtl_internal_shaders.py\" \"$SCRIPT_INPUT_FILE_0\" \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
+			shellScript = "if [ \"${ACTION}\" = \"analyze\" ] || [ \"${ACTION}\" = \"build\" ] || [ \"${ACTION}\" = \"install\" ]; then\n  python3 \"${SRCROOT}/src/libANGLE/renderer/metal/shaders/create_mtl_internal_shaders.py\" \"$SCRIPT_INPUT_FILE_0\" \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
#### 53f84db88a67e7772fde6336984c139591ed1ade
<pre>
ANGLE builtin metal shader compilation outputs during build time
<a href="https://bugs.webkit.org/show_bug.cgi?id=245413">https://bugs.webkit.org/show_bug.cgi?id=245413</a>
rdar://problem/100159634

Reviewed by Alexey Proskuryakov.

Remove the &quot;echo&quot; command that was probably used for debugging.

* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/254718@main">https://commits.webkit.org/254718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cdb3f1193f2db474c2940d382e09f3d48cd04d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99146 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155967 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32868 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28308 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82172 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93496 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26115 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76649 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26041 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80836 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69041 "Found 36 new API test failures: /WebKit2Gtk/TestWebKitAccessibility:/webkit/WebKitAccessibility/collection/get-matches, /WebKit2Gtk/TestWebKitVersion:/webkit/WebKitVersion/version, /WebKit2Gtk/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/basic, /WebKit2Gtk/TestWebKitSettings:/webkit/WebKitSettings/webkit-settings, /WebKit2Gtk/TestWebKitAccessibility:/webkit/WebKitAccessibility/component/hit-test, /WebKit2Gtk/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKit2Gtk/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKit2Gtk/TestWebKitAccessibility:/webkit/WebKitAccessibility/component/scroll-to, /WebKit2Gtk/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/children-changed, /WebKit2Gtk/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/list-markers ... (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30618 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14919 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30359 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15860 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3314 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38811 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34944 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->