### PR TITLE
[LBSE] Pixel snapping logic is incorrect for SVG, when elements are composited

### DIFF
--- a/LayoutTests/svg/compositing/inline-svg-non-integer-position-display-block-composited-expected.html
+++ b/LayoutTests/svg/compositing/inline-svg-non-integer-position-display-block-composited-expected.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+  <head>
+    <style>
+    .rect1 {
+      fill: blue;
+    }
+
+    .rect2 {
+      fill: green;
+    }
+
+    svg {
+      display: block;
+      overflow: hidden;
+    }
+
+    .show-overflow {
+      overflow: visible;
+    }
+
+    .scaled {
+      transform: scale(2);
+      transform-origin: 0 0;
+    }
+    </style>
+  </head>
+  <body>
+    <h1>Enforce non-integer SVG location</h1>
+    <svg width="50" height="50" class="show-overflow">
+      <rect x="0" y="0" width="50" height="50" class="rect1"/>
+    </svg>
+    <svg width="50" height="50" class="show-overflow">
+      <rect x="0" y="0" width="50" height="50" class="rect2"/>
+    </svg>
+    <h1>Effect of overflow: hidden</h1>
+    <svg width="50" height="50">
+      <rect x="0" y="0" width="50" height="50" class="rect1"/>
+    </svg>
+    <svg width="50" height="50">
+      <rect x="0" y="0" width="50" height="50" class="rect2"/>
+    </svg>
+    <h1>With transformation</h1>
+    <svg width="50" height="50" class="show-overflow">
+      <rect x="0" y="0" width="50" height="50" class="rect1"/>
+    </svg>
+    <svg width="50" height="50" class="show-overflow">
+      <rect x="0" y="0" width="50" height="50" class="rect2"/>
+    </svg>
+  </body>
+</html>

--- a/LayoutTests/svg/compositing/inline-svg-non-integer-position-display-block-composited.html
+++ b/LayoutTests/svg/compositing/inline-svg-non-integer-position-display-block-composited.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<!-- Based on svg/in-html/inline-svg-non-integer-position-display-block.html + compositing enabled either for <svg> or <rect> -->
+<html>
+  <head>
+    <style>
+    .rect1 {
+      fill: blue;
+    }
+
+    .rect2 {
+      fill: green;
+    }
+
+    svg {
+      display: block;
+      overflow: hidden;
+    }
+
+    .move-svg {
+      top: 25px;
+      position: relative;
+    }
+
+    .show-overflow {
+      overflow: visible;
+    }
+
+    .composited {
+      transform: translateZ(0);
+    }
+
+    .scaled {
+      transform: scale(2);
+      transform-origin: 0 0;
+    }
+    </style>
+  </head>
+  <body>
+    <h1>Enforce non-integer SVG location</h1>
+    <svg width="50" height="50" class="show-overflow composited">
+      <rect x="0" y="0" width="50" height="50" class="rect1"/>
+    </svg>
+    <svg width="50" height="50" class="show-overflow">
+      <rect x="0" y="0" width="50" height="50" class="rect2 composited"/>
+    </svg>
+    <h1>Effect of overflow: hidden</h1>
+    <svg width="50" height="50" class="composited">
+      <rect x="0" y="0" width="50" height="50" class="rect1"/>
+    </svg>
+    <svg width="50" height="50">
+      <rect x="0" y="0" width="50" height="50" class="rect2 composited"/>
+    </svg>
+    <h1>With transformation</h1>
+    <svg width="25" height="25" class="show-overflow composited scaled">
+      <rect x="0" y="0" width="25" height="25" class="rect1"/>
+    </svg>
+    <svg width="25" height="25" class="show-overflow move-svg scaled">
+      <rect x="0" y="0" width="25" height="25" class="rect2 composited"/>
+    </svg>
+  </body>
+</html>

--- a/LayoutTests/svg/compositing/inline-svg-non-integer-position-display-inline-composited-expected.html
+++ b/LayoutTests/svg/compositing/inline-svg-non-integer-position-display-inline-composited-expected.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+  <head>
+    <style>
+    .rect1 {
+      fill: blue;
+    }
+
+    .rect2 {
+      fill: green;
+    }
+
+    svg {
+      display: inline-block;
+      overflow: hidden;
+    }
+
+    .show-overflow {
+      overflow: visible;
+    }
+
+    .scaled {
+      transform: scale(2);
+      transform-origin: 0 0;
+    }
+    </style>
+  </head>
+  <body>
+    <h1>Enforce non-integer SVG location</h1>
+    <svg width="50" height="50" class="show-overflow">
+      <rect x="0" y="0" width="50" height="50" class="rect1"/>
+    </svg>
+    <svg width="50" height="50" class="show-overflow">
+      <rect x="0" y="0" width="50" height="50" class="rect2"/>
+    </svg>
+    <h1>Effect of overflow: hidden</h1>
+    <svg width="50" height="50">
+      <rect x="0" y="0" width="50" height="50" class="rect1"/>
+    </svg>
+    <svg width="50" height="50">
+      <rect x="0" y="0" width="50" height="50" class="rect2"/>
+    </svg>
+    <h1>With transformation</h1>
+    <svg width="50" height="50" class="show-overflow">
+      <rect x="0" y="0" width="50" height="50" class="rect1"/>
+    </svg>
+    <svg width="50" height="50" class="show-overflow">
+      <rect x="0" y="0" width="50" height="50" class="rect2"/>
+    </svg>
+  </body>
+</html>

--- a/LayoutTests/svg/compositing/inline-svg-non-integer-position-display-inline-composited.html
+++ b/LayoutTests/svg/compositing/inline-svg-non-integer-position-display-inline-composited.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<!-- Based on svg/in-html/inline-svg-non-integer-position-display-inline.html + compositing enabled either for <svg> or <rect> -->
+<html>
+  <head>
+    <style>
+    .rect1 {
+      fill: blue;
+    }
+
+    .rect2 {
+      fill: green;
+    }
+
+    svg {
+      display: inline-block;
+      overflow: hidden;
+    }
+
+    .move-svg {
+      left: 25px;
+      position: relative;
+    }
+
+    .show-overflow {
+      overflow: visible;
+    }
+
+    .composited {
+      transform: translateZ(0);
+    }
+
+    .scaled {
+      transform: scale(2);
+      transform-origin: 0 0;
+    }
+    </style>
+  </head>
+  <body>
+    <h1>Enforce non-integer SVG location</h1>
+    <svg width="50" height="50" class="show-overflow composited">
+      <rect x="0" y="0" width="50" height="50" class="rect1"/>
+    </svg>
+    <svg width="50" height="50" class="show-overflow">
+      <rect x="0" y="0" width="50" height="50" class="rect2 composited"/>
+    </svg>
+    <h1>Effect of overflow: hidden</h1>
+    <svg width="50" height="50" class="composited">
+      <rect x="0" y="0" width="50" height="50" class="rect1"/>
+    </svg>
+    <svg width="50" height="50">
+      <rect x="0" y="0" width="50" height="50" class="rect2 composited"/>
+    </svg>
+    <h1>With transformation</h1>
+    <svg width="25" height="25" class="show-overflow composited scaled">
+      <rect x="0" y="0" width="25" height="25" class="rect1"/>
+    </svg>
+    <svg width="25" height="25" class="show-overflow move-svg scaled">
+      <rect x="0" y="0" width="25" height="25" class="rect2 composited"/>
+    </svg>
+  </body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2484,10 +2484,17 @@ LayoutPoint RenderLayer::convertToLayerCoords(const RenderLayer* ancestorLayer, 
     if (ancestorLayer == this)
         return location;
 
-    const RenderLayer* currLayer = this;
-    LayoutPoint locationInLayerCoords = location;
+    const auto* currLayer = this;
+    auto locationInLayerCoords = location;
     while (currLayer && currLayer != ancestorLayer)
         currLayer = accumulateOffsetTowardsAncestor(currLayer, ancestorLayer, locationInLayerCoords, adjustForColumns);
+
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    // Pixel snap the whole SVG subtree as one "block" -- not individual layers down the SVG render tree.
+    if (renderer().isSVGRoot())
+        return LayoutPoint(roundPointToDevicePixels(locationInLayerCoords, renderer().document().deviceScaleFactor()));
+#endif
+
     return locationInLayerCoords;
 }
 


### PR DESCRIPTION
#### d2c0299eb83a36da49226c4c3696e8ae7382c39b
<pre>
[LBSE] Pixel snapping logic is incorrect for SVG, when elements are composited
<a href="https://bugs.webkit.org/show_bug.cgi?id=245416">https://bugs.webkit.org/show_bug.cgi?id=245416</a>

Reviewed by Rob Buis.

In bug webkit.org/b/244966 (&quot;[LBSE] Outermost &lt;svg&gt; elements are not device-pixel aligned&quot;)
the rendering was adapted in such a way that the outermost &lt;svg&gt; element is the only element
in the SVG subtree that is pixel snapped, delivering consistent results between e.g. HTML
&lt;div&gt; elements and SVG &lt;svg&gt; elements, embedded in a CSS formatting context. The &lt;div&gt; will
get pixel snapped upon painting -- the same was enforced for the outermost &lt;svg&gt;, however
without propagating/accumulating sub-pixel errors for the descendant layers, since no pixel
snapping is applied within the SVG subtree.

When elements are composited another logic is used (RenderLayerBacking), and the device-pixel
alignment is applied for all SVG layers -- effectively breaking content. By fixing that, the
pixel snapping logic is consistent for all painting modes we have, no matter if the outer
&lt;svg&gt; is composited, or any of its descendants.

Added two new reftests covering LBSE + compositing + sub-pixel locations in different display modes.
Doesn&apos;t affect any other existing tests.

* LayoutTests/svg/compositing/inline-svg-non-integer-position-display-block-composited-expected.html: Added.
* LayoutTests/svg/compositing/inline-svg-non-integer-position-display-block-composited.html: Added.
* LayoutTests/svg/compositing/inline-svg-non-integer-position-display-inline-composited-expected.html: Added.
* LayoutTests/svg/compositing/inline-svg-non-integer-position-display-inline-composited.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::convertToLayerCoords const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::snappedGraphicsLayer):
(WebCore::RenderLayerBacking::computeParentGraphicsLayerRect const):
(WebCore::RenderLayerBacking::updateGeometry):
(WebCore::RenderLayerBacking::adjustOverflowControlsPositionRelativeToAncestor):
(WebCore::RenderLayerBacking::updateMaskingLayerGeometry):
(WebCore::RenderLayerBacking::updateContentsRects):
(WebCore::RenderLayerBacking::updateClippingStackLayerGeometry):
(WebCore::RenderLayerBacking::setContentsNeedDisplayInRect):

Canonical link: <a href="https://commits.webkit.org/254863@main">https://commits.webkit.org/254863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43302affdd11ed4e0107511691ade43d672f9aab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99264 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156631 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32977 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28385 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82272 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93585 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26194 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76731 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26116 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81065 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69119 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30722 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14968 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30454 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15909 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3404 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38869 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34993 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->