### PR TITLE
[JSC] DFG AI should attempt to remove @tryGetById for String.replace

### DIFF
--- a/JSTests/stress/string-replace-exit.js
+++ b/JSTests/stress/string-replace-exit.js
@@ -1,0 +1,15 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(target)
+{
+    var regexp = /OK/g;
+    regexp[Symbol.replace] = function() { return "Hello"; };
+    return "OKOK".replace(regexp, target);
+}
+noInline(test);
+
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(test("Replaced"), `Hello`);

--- a/JSTests/stress/string-replace-exit2.js
+++ b/JSTests/stress/string-replace-exit2.js
@@ -1,0 +1,15 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(target)
+{
+    return "OKOK".replace(/OK/g, target);
+}
+noInline(test);
+
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(test("Replaced"), `ReplacedReplaced`);
+RegExp.prototype[Symbol.replace] = function() { return "Hello"; }
+shouldBe(test("Replaced"), `Hello`);


### PR DESCRIPTION
#### e289c324e666c229a72012180c87f9a3829f9982
<pre>
[JSC] DFG AI should attempt to remove @tryGetById for String.replace
<a href="https://bugs.webkit.org/show_bug.cgi?id=245418">https://bugs.webkit.org/show_bug.cgi?id=245418</a>

Reviewed by Ross Kirsling.

@tryGetById is adhoc one: it is used only in builtin code and used in very limited places.
So this patch introduces adhoc folding rules for @tryGetById to remove TryGetById attached before
String.replace. Unfortunately these @tryGetById are not usually removed since it is adhocly attached
in DFG fixup phase.
In this patch,

1. Ensure RegExp.prototype&apos;s properties via watchpoints.
2. Check structure in AI, and ensure that this structure is one for RegExpObject, its [[Prototype]] is RegExp.prototype, it is cacheable,
   and it does not have properties for particular names.

Then we fold TryGetById to RegExp&apos;s specific properties values. It eliminates these TryGetById and improves String.replace in DFG / FTL
by 65% (e.g. string-replace).

                                                         ToT                     Patched

    string-replace-generic                         33.0472+-0.1132     ^     31.9405+-0.1483        ^ definitely 1.0346x faster
    string-replace                                  3.3774+-0.0951     ^      2.0387+-0.0476        ^ definitely 1.6566x faster
    put-by-val-with-string-replace-and-transition
                                                    4.4385+-0.0233            4.4319+-0.0188
    string-replace-benchmark                       83.8759+-0.1186     ^     83.4655+-0.2393        ^ definitely 1.0049x faster
    string-replace-string                         380.3462+-0.7600          379.2646+-1.0203
    string-replace-empty                            3.2455+-0.0406     ^      2.0051+-0.1350        ^ definitely 1.6186x faster

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):

Canonical link: <a href="https://commits.webkit.org/254717@main">https://commits.webkit.org/254717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc558c37d47ce5c2bb91a9d325ba7b3fe7b0985e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34521 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/20620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/99303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/156820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33013 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82309 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/93614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95622 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/76775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/26142 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/20620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/69143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81602 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/34254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/20620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76490 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/20620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26482 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3312 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/35839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/79076 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/37739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/20620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17332 "Passed tests") | 
<!--EWS-Status-Bubble-End-->