### PR TITLE
[WK2] Store sync-message reply arguments inside the SendSyncResult object

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -611,9 +611,8 @@ void NetworkConnectionToWebProcess::performSynchronousLoad(NetworkResourceLoadPa
 
 void NetworkConnectionToWebProcess::testProcessIncomingSyncMessagesWhenWaitingForSyncReply(WebPageProxyIdentifier pageID, Messages::NetworkConnectionToWebProcess::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply::DelayedReply&& reply)
 {
-    bool handled = false;
-    if (!m_networkProcess->parentProcessConnection()->sendSync(Messages::NetworkProcessProxy::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(pageID), Messages::NetworkProcessProxy::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply::Reply(handled), 0))
-        return reply(false);
+    auto syncResult = m_networkProcess->parentProcessConnection()->sendSync(Messages::NetworkProcessProxy::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(pageID), 0);
+    auto [handled] = syncResult.takeReplyOr(false);
     reply(handled);
 }
 

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -96,9 +96,9 @@ public:
 
     template<typename T, typename U> bool send(T&& message, ObjectIdentifier<U> destinationID, Timeout);
 
-    using SendSyncResult = Connection::SendSyncResult;
+    template<typename T> using SendSyncResult = Connection::SendSyncResult<T>;
     template<typename T, typename U>
-    SendSyncResult sendSync(T&& message, typename T::Reply&&, ObjectIdentifier<U> destinationID, Timeout);
+    SendSyncResult<T> sendSync(T&& message, ObjectIdentifier<U> destinationID, Timeout);
 
     template<typename T, typename U>
     bool waitForAndDispatchImmediately(ObjectIdentifier<U> destinationID, Timeout, OptionSet<WaitForOption> = { });
@@ -119,7 +119,7 @@ private:
     template<typename T>
     bool trySendStream(T& message, Span&);
     template<typename T>
-    std::optional<SendSyncResult> trySendSyncStream(T& message, typename T::Reply&, Timeout, Span&);
+    std::optional<SendSyncResult<T>> trySendSyncStream(T& message, Timeout, Span&);
     bool trySendDestinationIDIfNeeded(uint64_t destinationID, Timeout);
     void sendProcessOutOfStreamMessage(Span&&);
 
@@ -198,7 +198,7 @@ bool StreamClientConnection::trySendStream(T& message, Span& span)
 }
 
 template<typename T, typename U>
-StreamClientConnection::SendSyncResult StreamClientConnection::sendSync(T&& message, typename T::Reply&& reply, ObjectIdentifier<U> destinationID, Timeout timeout)
+StreamClientConnection::SendSyncResult<T> StreamClientConnection::sendSync(T&& message, ObjectIdentifier<U> destinationID, Timeout timeout)
 {
     static_assert(T::isSync, "Message is not sync!");
     if (!trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout))
@@ -207,12 +207,12 @@ StreamClientConnection::SendSyncResult StreamClientConnection::sendSync(T&& mess
     if (!span)
         return { };
     if constexpr(T::isStreamEncodable) {
-        auto maybeSendResult = trySendSyncStream(message, reply, timeout, *span);
+        auto maybeSendResult = trySendSyncStream(message, timeout, *span);
         if (maybeSendResult)
             return WTFMove(*maybeSendResult);
     }
     sendProcessOutOfStreamMessage(WTFMove(*span));
-    return m_connection->sendSync(WTFMove(message), WTFMove(reply), destinationID.toUInt64(), timeout);
+    return m_connection->sendSync(WTFMove(message), destinationID.toUInt64(), timeout);
 }
 
 template<typename T, typename U>
@@ -222,15 +222,15 @@ bool StreamClientConnection::waitForAndDispatchImmediately(ObjectIdentifier<U> d
 }
 
 template<typename T>
-std::optional<StreamClientConnection::SendSyncResult> StreamClientConnection::trySendSyncStream(T& message, typename T::Reply& reply, Timeout timeout, Span& span)
+std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection::trySendSyncStream(T& message, Timeout timeout, Span& span)
 {
-    // In this function, SendSyncResult { } means error happened and caller should stop processing.
+    // In this function, SendSyncResult<T> { } means error happened and caller should stop processing.
     // std::nullopt means we couldn't send through the stream, so try sending out of stream.
     auto syncRequestID = m_connection->makeSyncRequestID();
     if (!m_connection->pushPendingSyncRequestID(syncRequestID))
-        return SendSyncResult { };
+        return SendSyncResult<T> { };
 
-    auto result = [&]() -> std::optional<SendSyncResult> {
+    auto decoderResult = [&]() -> std::optional<std::unique_ptr<Decoder>> {
         StreamConnectionEncoder messageEncoder { T::name(), span.data, span.size };
         if (!(messageEncoder << syncRequestID << message.arguments()))
             return std::nullopt;
@@ -239,7 +239,7 @@ std::optional<StreamClientConnection::SendSyncResult> StreamClientConnection::tr
         if constexpr(T::isReplyStreamEncodable) {
             auto replySpan = tryAcquireAll(timeout);
             if (!replySpan)
-                return SendSyncResult { };
+                return std::unique_ptr<Decoder> { };
             auto decoder = std::unique_ptr<Decoder> { new Decoder(replySpan->data, replySpan->size, m_currentDestinationID) };
             if (decoder->messageName() != MessageName::ProcessOutOfStreamMessage) {
                 ASSERT(decoder->messageName() == MessageName::SyncMessageReply);
@@ -250,13 +250,16 @@ std::optional<StreamClientConnection::SendSyncResult> StreamClientConnection::tr
         return m_connection->waitForSyncReply(syncRequestID, T::name(), timeout, { });
     }();
     m_connection->popPendingSyncRequestID(syncRequestID);
-    if (result && *result) {
-        auto& decoder = **result;
-        std::optional<typename T::ReplyArguments> replyArguments;
-        decoder >> replyArguments;
-        if (!replyArguments)
-            return SendSyncResult { };
-        moveTuple(WTFMove(*replyArguments), reply);
+
+    if (!decoderResult)
+        return std::nullopt;
+
+    SendSyncResult<T> result;
+    if (*decoderResult) {
+        auto& decoder = *decoderResult;
+        *decoder >> result.replyArguments;
+        if (result.replyArguments)
+            result.decoder = WTFMove(decoder);
     }
     return result;
 }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1369,7 +1369,7 @@ void NetworkProcessProxy::setPrivateClickMeasurementDebugMode(PAL::SessionID ses
 void NetworkProcessProxy::sendProcessWillSuspendImminentlyForTesting()
 {
     if (canSendMessage())
-        sendSync(Messages::NetworkProcess::ProcessWillSuspendImminentlyForTestingSync(), Messages::NetworkProcess::ProcessWillSuspendImminentlyForTestingSync::Reply(), 0);
+        sendSync(Messages::NetworkProcess::ProcessWillSuspendImminentlyForTestingSync(), 0);
 }
 
 static bool s_suspensionAllowedForTesting { true };
@@ -1607,9 +1607,8 @@ void NetworkProcessProxy::testProcessIncomingSyncMessagesWhenWaitingForSyncReply
     if (!page)
         return reply(false);
 
-    bool handled = false;
-    if (!page->sendSync(Messages::WebPage::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(), Messages::WebPage::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply::Reply(handled), Seconds::infinity(), IPC::SendSyncOption::ForceDispatchWhenDestinationIsWaitingForUnboundedSyncReply))
-        return reply(false);
+    auto syncResult = page->sendSync(Messages::WebPage::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(), Seconds::infinity(), IPC::SendSyncOption::ForceDispatchWhenDestinationIsWaitingForUnboundedSyncReply);
+    auto [handled] = syncResult.takeReplyOr(false);
     reply(handled);
 }
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1413,7 +1413,7 @@ void WebProcessPool::setCacheModelSynchronouslyForTesting(CacheModel cacheModel)
     updateBackForwardCacheCapacity();
 
     WebsiteDataStore::forEachWebsiteDataStore([cacheModel] (WebsiteDataStore& dataStore) {
-        dataStore.networkProcess().sendSync(Messages::NetworkProcess::SetCacheModelSynchronouslyForTesting(cacheModel), { }, 0);
+        dataStore.networkProcess().sendSync(Messages::NetworkProcess::SetCacheModelSynchronouslyForTesting(cacheModel), 0);
     });
 }
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -790,12 +790,12 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, const Ve
 
 void WebsiteDataStore::setServiceWorkerTimeoutForTesting(Seconds seconds)
 {
-    networkProcess().sendSync(Messages::NetworkProcess::SetServiceWorkerFetchTimeoutForTesting(seconds), Messages::NetworkProcess::SetServiceWorkerFetchTimeoutForTesting::Reply(), 0);
+    networkProcess().sendSync(Messages::NetworkProcess::SetServiceWorkerFetchTimeoutForTesting(seconds), 0);
 }
 
 void WebsiteDataStore::resetServiceWorkerTimeoutForTesting()
 {
-    networkProcess().sendSync(Messages::NetworkProcess::ResetServiceWorkerFetchTimeoutForTesting(), Messages::NetworkProcess::ResetServiceWorkerFetchTimeoutForTesting::Reply(), 0);
+    networkProcess().sendSync(Messages::NetworkProcess::ResetServiceWorkerFetchTimeoutForTesting(), 0);
 }
 
 bool WebsiteDataStore::hasServiceWorkerBackgroundActivityForTesting() const
@@ -1717,7 +1717,7 @@ void WebsiteDataStore::clearResourceLoadStatisticsInWebProcesses(CompletionHandl
 
 void WebsiteDataStore::setAllowsAnySSLCertificateForWebSocket(bool allows)
 {
-    networkProcess().sendSync(Messages::NetworkProcess::SetAllowsAnySSLCertificateForWebSocket(allows), Messages::NetworkProcess::SetAllowsAnySSLCertificateForWebSocket::Reply(), 0);
+    networkProcess().sendSync(Messages::NetworkProcess::SetAllowsAnySSLCertificateForWebSocket(allows), 0);
 }
 
 void WebsiteDataStore::clearCachedCredentials()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -350,9 +350,9 @@ protected:
         return m_streamConnection.send(WTFMove(message), m_graphicsContextGLIdentifier, defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return m_streamConnection.sendSync(WTFMove(message), WTFMove(reply), m_graphicsContextGLIdentifier, defaultSendTimeout);
+        return m_streamConnection.sendSync(WTFMove(message), m_graphicsContextGLIdentifier, defaultSendTimeout);
     }
 
     GraphicsContextGLIdentifier m_graphicsContextGLIdentifier { GraphicsContextGLIdentifier::generate() };

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -32,2375 +32,2858 @@ namespace WebKit {
 
 bool RemoteGraphicsContextGLProxy::moveErrorsToSyntheticErrorList()
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::MoveErrorsToSyntheticErrorList(), Messages::RemoteGraphicsContextGL::MoveErrorsToSyntheticErrorList::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::MoveErrorsToSyntheticErrorList());
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::activeTexture(GCGLenum texture)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ActiveTexture(texture));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ActiveTexture(texture));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::attachShader(PlatformGLObject program, PlatformGLObject shader)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::AttachShader(program, shader));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::AttachShader(program, shader));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::bindAttribLocation(PlatformGLObject arg0, GCGLuint index, const String& name)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BindAttribLocation(arg0, index, name));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindAttribLocation(arg0, index, name));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::bindBuffer(GCGLenum target, PlatformGLObject arg1)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBuffer(target, arg1));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBuffer(target, arg1));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::bindFramebuffer(GCGLenum target, PlatformGLObject arg1)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BindFramebuffer(target, arg1));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindFramebuffer(target, arg1));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::bindRenderbuffer(GCGLenum target, PlatformGLObject arg1)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BindRenderbuffer(target, arg1));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindRenderbuffer(target, arg1));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::bindTexture(GCGLenum target, PlatformGLObject arg1)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BindTexture(target, arg1));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindTexture(target, arg1));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::blendColor(GCGLclampf red, GCGLclampf green, GCGLclampf blue, GCGLclampf alpha)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendColor(red, green, blue, alpha));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendColor(red, green, blue, alpha));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::blendEquation(GCGLenum mode)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquation(mode));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquation(mode));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::blendEquationSeparate(GCGLenum modeRGB, GCGLenum modeAlpha)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationSeparate(modeRGB, modeAlpha));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationSeparate(modeRGB, modeAlpha));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::blendFunc(GCGLenum sfactor, GCGLenum dfactor)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFunc(sfactor, dfactor));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFunc(sfactor, dfactor));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::blendFuncSeparate(GCGLenum srcRGB, GCGLenum dstRGB, GCGLenum srcAlpha, GCGLenum dstAlpha)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 GCGLenum RemoteGraphicsContextGLProxy::checkFramebufferStatus(GCGLenum target)
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CheckFramebufferStatus(target), Messages::RemoteGraphicsContextGL::CheckFramebufferStatus::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CheckFramebufferStatus(target));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::clear(GCGLbitfield mask)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Clear(mask));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Clear(mask));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::clearColor(GCGLclampf red, GCGLclampf green, GCGLclampf blue, GCGLclampf alpha)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearColor(red, green, blue, alpha));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearColor(red, green, blue, alpha));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::clearDepth(GCGLclampf depth)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearDepth(depth));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearDepth(depth));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::clearStencil(GCGLint s)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearStencil(s));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearStencil(s));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::colorMask(GCGLboolean red, GCGLboolean green, GCGLboolean blue, GCGLboolean alpha)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ColorMask(static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ColorMask(static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::compileShader(PlatformGLObject arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompileShader(arg0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompileShader(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::copyTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLint border)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexImage2D(target, level, internalformat, x, y, width, height, border));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexImage2D(target, level, internalformat, x, y, width, height, border));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::copyTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createBuffer()
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateBuffer(), Messages::RemoteGraphicsContextGL::CreateBuffer::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateBuffer());
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createFramebuffer()
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateFramebuffer(), Messages::RemoteGraphicsContextGL::CreateFramebuffer::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateFramebuffer());
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createProgram()
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateProgram(), Messages::RemoteGraphicsContextGL::CreateProgram::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateProgram());
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createRenderbuffer()
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateRenderbuffer(), Messages::RemoteGraphicsContextGL::CreateRenderbuffer::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateRenderbuffer());
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createShader(GCGLenum arg0)
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateShader(arg0), Messages::RemoteGraphicsContextGL::CreateShader::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateShader(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createTexture()
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateTexture(), Messages::RemoteGraphicsContextGL::CreateTexture::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateTexture());
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::cullFace(GCGLenum mode)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CullFace(mode));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CullFace(mode));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::deleteBuffer(PlatformGLObject arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteBuffer(arg0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteBuffer(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::deleteFramebuffer(PlatformGLObject arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteFramebuffer(arg0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteFramebuffer(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::deleteProgram(PlatformGLObject arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteProgram(arg0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteProgram(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::deleteRenderbuffer(PlatformGLObject arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteRenderbuffer(arg0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteRenderbuffer(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::deleteShader(PlatformGLObject arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteShader(arg0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteShader(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::deleteTexture(PlatformGLObject arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteTexture(arg0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteTexture(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::depthFunc(GCGLenum func)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthFunc(func));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthFunc(func));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::depthMask(GCGLboolean flag)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthMask(static_cast<bool>(flag)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthMask(static_cast<bool>(flag)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::depthRange(GCGLclampf zNear, GCGLclampf zFar)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthRange(zNear, zFar));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthRange(zNear, zFar));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::detachShader(PlatformGLObject arg0, PlatformGLObject arg1)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DetachShader(arg0, arg1));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DetachShader(arg0, arg1));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::disable(GCGLenum cap)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Disable(cap));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Disable(cap));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::disableVertexAttribArray(GCGLuint index)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DisableVertexAttribArray(index));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DisableVertexAttribArray(index));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::drawArrays(GCGLenum mode, GCGLint first, GCGLsizei count)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArrays(mode, first, count));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArrays(mode, first, count));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::drawElements(GCGLenum mode, GCGLsizei count, GCGLenum type, GCGLintptr offset)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElements(mode, count, type, static_cast<uint64_t>(offset)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElements(mode, count, type, static_cast<uint64_t>(offset)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::enable(GCGLenum cap)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Enable(cap));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Enable(cap));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::enableVertexAttribArray(GCGLuint index)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::EnableVertexAttribArray(index));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::EnableVertexAttribArray(index));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::finish()
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Finish());
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Finish());
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::flush()
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Flush());
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Flush());
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::framebufferRenderbuffer(GCGLenum target, GCGLenum attachment, GCGLenum renderbuffertarget, PlatformGLObject arg3)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferRenderbuffer(target, attachment, renderbuffertarget, arg3));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferRenderbuffer(target, attachment, renderbuffertarget, arg3));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::framebufferTexture2D(GCGLenum target, GCGLenum attachment, GCGLenum textarget, PlatformGLObject arg3, GCGLint level)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferTexture2D(target, attachment, textarget, arg3, level));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferTexture2D(target, attachment, textarget, arg3, level));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::frontFace(GCGLenum mode)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::FrontFace(mode));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::FrontFace(mode));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::generateMipmap(GCGLenum target)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::GenerateMipmap(target));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::GenerateMipmap(target));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 bool RemoteGraphicsContextGLProxy::getActiveAttrib(PlatformGLObject program, GCGLuint index, struct WebCore::GraphicsContextGLActiveInfo& arg2)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveAttrib(program, index), Messages::RemoteGraphicsContextGL::GetActiveAttrib::Reply(returnValue, arg2));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveAttrib(program, index));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue, arg2Reply] = sendResult.reply();
+    arg2 = WTFMove(arg2Reply);
     return returnValue;
 }
 
 bool RemoteGraphicsContextGLProxy::getActiveUniform(PlatformGLObject program, GCGLuint index, struct WebCore::GraphicsContextGLActiveInfo& arg2)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniform(program, index), Messages::RemoteGraphicsContextGL::GetActiveUniform::Reply(returnValue, arg2));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniform(program, index));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue, arg2Reply] = sendResult.reply();
+    arg2 = WTFMove(arg2Reply);
     return returnValue;
 }
 
 GCGLint RemoteGraphicsContextGLProxy::getAttribLocation(PlatformGLObject arg0, const String& name)
 {
-    int32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetAttribLocation(arg0, name), Messages::RemoteGraphicsContextGL::GetAttribLocation::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetAttribLocation(arg0, name));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 GCGLint RemoteGraphicsContextGLProxy::getBufferParameteri(GCGLenum target, GCGLenum pname)
 {
-    int32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBufferParameteri(target, pname), Messages::RemoteGraphicsContextGL::GetBufferParameteri::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBufferParameteri(target, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 String RemoteGraphicsContextGLProxy::getString(GCGLenum name)
 {
-    String returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetString(name), Messages::RemoteGraphicsContextGL::GetString::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetString(name));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::getFloatv(GCGLenum pname, GCGLSpan<GCGLfloat> value)
 {
-    IPC::ArrayReference<float> valueReply;
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFloatv(pname, value.size()), Messages::RemoteGraphicsContextGL::GetFloatv::Reply(valueReply));
-        if (!sendResult)
-            markContextLost();
-        else
-            memcpy(value.data(), valueReply.data(), value.size() * sizeof(float));
+    if (isContextLost())
+        return;
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFloatv(pname, value.size()));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
+    auto& [valueReply] = sendResult.reply();
+    memcpy(value.data(), valueReply.data(), value.size() * sizeof(float));
 }
 
 void RemoteGraphicsContextGLProxy::getIntegerv(GCGLenum pname, GCGLSpan<GCGLint> value)
 {
-    IPC::ArrayReference<int32_t> valueReply;
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetIntegerv(pname, value.size()), Messages::RemoteGraphicsContextGL::GetIntegerv::Reply(valueReply));
-        if (!sendResult)
-            markContextLost();
-        else
-            memcpy(value.data(), valueReply.data(), value.size() * sizeof(int32_t));
+    if (isContextLost())
+        return;
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetIntegerv(pname, value.size()));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
+    auto& [valueReply] = sendResult.reply();
+    memcpy(value.data(), valueReply.data(), value.size() * sizeof(int32_t));
 }
 
 void RemoteGraphicsContextGLProxy::getIntegeri_v(GCGLenum pname, GCGLuint index, GCGLSpan<GCGLint, 4> value) // NOLINT
 {
-    constexpr std::array<int32_t, 4> valueReplyEmpty { };
-    IPC::ArrayReference<int32_t, 4> valueReply { valueReplyEmpty };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetIntegeri_v(pname, index), Messages::RemoteGraphicsContextGL::GetIntegeri_v::Reply(valueReply));
-        if (!sendResult)
-            markContextLost();
-        else
-            memcpy(value.data(), valueReply.data(), value.size() * sizeof(int32_t));
+    if (isContextLost())
+        return;
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetIntegeri_v(pname, index));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
+    auto& [valueReply] = sendResult.reply();
+    memcpy(value.data(), valueReply.data(), value.size() * sizeof(int32_t));
 }
 
 GCGLint64 RemoteGraphicsContextGLProxy::getInteger64(GCGLenum pname)
 {
-    int64_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInteger64(pname), Messages::RemoteGraphicsContextGL::GetInteger64::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInteger64(pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLint64>(returnValue);
 }
 
 GCGLint64 RemoteGraphicsContextGLProxy::getInteger64i(GCGLenum pname, GCGLuint index)
 {
-    int64_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInteger64i(pname, index), Messages::RemoteGraphicsContextGL::GetInteger64i::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInteger64i(pname, index));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLint64>(returnValue);
 }
 
 GCGLint RemoteGraphicsContextGLProxy::getProgrami(PlatformGLObject program, GCGLenum pname)
 {
-    int32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetProgrami(program, pname), Messages::RemoteGraphicsContextGL::GetProgrami::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetProgrami(program, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::getBooleanv(GCGLenum pname, GCGLSpan<GCGLboolean> value)
 {
-    IPC::ArrayReference<bool> valueReply;
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBooleanv(pname, value.size()), Messages::RemoteGraphicsContextGL::GetBooleanv::Reply(valueReply));
-        if (!sendResult)
-            markContextLost();
-        else
-            memcpy(value.data(), valueReply.data(), value.size() * sizeof(bool));
+    if (isContextLost())
+        return;
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBooleanv(pname, value.size()));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
+    auto& [valueReply] = sendResult.reply();
+    memcpy(value.data(), valueReply.data(), value.size() * sizeof(bool));
 }
 
 GCGLint RemoteGraphicsContextGLProxy::getFramebufferAttachmentParameteri(GCGLenum target, GCGLenum attachment, GCGLenum pname)
 {
-    int32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFramebufferAttachmentParameteri(target, attachment, pname), Messages::RemoteGraphicsContextGL::GetFramebufferAttachmentParameteri::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFramebufferAttachmentParameteri(target, attachment, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 String RemoteGraphicsContextGLProxy::getProgramInfoLog(PlatformGLObject arg0)
 {
-    String returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetProgramInfoLog(arg0), Messages::RemoteGraphicsContextGL::GetProgramInfoLog::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetProgramInfoLog(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 GCGLint RemoteGraphicsContextGLProxy::getRenderbufferParameteri(GCGLenum target, GCGLenum pname)
 {
-    int32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetRenderbufferParameteri(target, pname), Messages::RemoteGraphicsContextGL::GetRenderbufferParameteri::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetRenderbufferParameteri(target, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 GCGLint RemoteGraphicsContextGLProxy::getShaderi(PlatformGLObject arg0, GCGLenum pname)
 {
-    int32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderi(arg0, pname), Messages::RemoteGraphicsContextGL::GetShaderi::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderi(arg0, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 String RemoteGraphicsContextGLProxy::getShaderInfoLog(PlatformGLObject arg0)
 {
-    String returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderInfoLog(arg0), Messages::RemoteGraphicsContextGL::GetShaderInfoLog::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderInfoLog(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::getShaderPrecisionFormat(GCGLenum shaderType, GCGLenum precisionType, GCGLSpan<GCGLint, 2> range, GCGLint* precision)
 {
-    constexpr std::array<int32_t, 2> rangeReplyEmpty { };
-    IPC::ArrayReference<int32_t, 2> rangeReply { rangeReplyEmpty };
-    int32_t precisionReply = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderPrecisionFormat(shaderType, precisionType), Messages::RemoteGraphicsContextGL::GetShaderPrecisionFormat::Reply(rangeReply, precisionReply));
-        if (!sendResult)
-            markContextLost();
-        else {
-            memcpy(range.data(), rangeReply.data(), range.size() * sizeof(int32_t));
-            if (precision)
-                *precision = precisionReply;
-        }
+    if (isContextLost())
+        return;
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderPrecisionFormat(shaderType, precisionType));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
+    auto& [rangeReply, precisionReply] = sendResult.reply();
+    memcpy(range.data(), rangeReply.data(), range.size() * sizeof(int32_t));
+    if (precision)
+        *precision = precisionReply;
 }
 
 String RemoteGraphicsContextGLProxy::getShaderSource(PlatformGLObject arg0)
 {
-    String returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderSource(arg0), Messages::RemoteGraphicsContextGL::GetShaderSource::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderSource(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 GCGLfloat RemoteGraphicsContextGLProxy::getTexParameterf(GCGLenum target, GCGLenum pname)
 {
-    float returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTexParameterf(target, pname), Messages::RemoteGraphicsContextGL::GetTexParameterf::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTexParameterf(target, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 GCGLint RemoteGraphicsContextGLProxy::getTexParameteri(GCGLenum target, GCGLenum pname)
 {
-    int32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTexParameteri(target, pname), Messages::RemoteGraphicsContextGL::GetTexParameteri::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTexParameteri(target, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::getUniformfv(PlatformGLObject program, GCGLint location, GCGLSpan<GCGLfloat> value)
 {
-    IPC::ArrayReference<float> valueReply;
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformfv(program, location, value.size()), Messages::RemoteGraphicsContextGL::GetUniformfv::Reply(valueReply));
-        if (!sendResult)
-            markContextLost();
-        else
-            memcpy(value.data(), valueReply.data(), value.size() * sizeof(float));
+    if (isContextLost())
+        return;
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformfv(program, location, value.size()));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
+    auto& [valueReply] = sendResult.reply();
+    memcpy(value.data(), valueReply.data(), value.size() * sizeof(float));
 }
 
 void RemoteGraphicsContextGLProxy::getUniformiv(PlatformGLObject program, GCGLint location, GCGLSpan<GCGLint> value)
 {
-    IPC::ArrayReference<int32_t> valueReply;
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformiv(program, location, value.size()), Messages::RemoteGraphicsContextGL::GetUniformiv::Reply(valueReply));
-        if (!sendResult)
-            markContextLost();
-        else
-            memcpy(value.data(), valueReply.data(), value.size() * sizeof(int32_t));
+    if (isContextLost())
+        return;
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformiv(program, location, value.size()));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
+    auto& [valueReply] = sendResult.reply();
+    memcpy(value.data(), valueReply.data(), value.size() * sizeof(int32_t));
 }
 
 void RemoteGraphicsContextGLProxy::getUniformuiv(PlatformGLObject program, GCGLint location, GCGLSpan<GCGLuint> value)
 {
-    IPC::ArrayReference<uint32_t> valueReply;
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformuiv(program, location, value.size()), Messages::RemoteGraphicsContextGL::GetUniformuiv::Reply(valueReply));
-        if (!sendResult)
-            markContextLost();
-        else
-            memcpy(value.data(), valueReply.data(), value.size() * sizeof(uint32_t));
+    if (isContextLost())
+        return;
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformuiv(program, location, value.size()));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
+    auto& [valueReply] = sendResult.reply();
+    memcpy(value.data(), valueReply.data(), value.size() * sizeof(uint32_t));
 }
 
 GCGLint RemoteGraphicsContextGLProxy::getUniformLocation(PlatformGLObject arg0, const String& name)
 {
-    int32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformLocation(arg0, name), Messages::RemoteGraphicsContextGL::GetUniformLocation::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformLocation(arg0, name));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 GCGLsizeiptr RemoteGraphicsContextGLProxy::getVertexAttribOffset(GCGLuint index, GCGLenum pname)
 {
-    uint64_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetVertexAttribOffset(index, pname), Messages::RemoteGraphicsContextGL::GetVertexAttribOffset::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetVertexAttribOffset(index, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLsizeiptr>(returnValue);
 }
 
 void RemoteGraphicsContextGLProxy::hint(GCGLenum target, GCGLenum mode)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Hint(target, mode));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Hint(target, mode));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 GCGLboolean RemoteGraphicsContextGLProxy::isBuffer(PlatformGLObject arg0)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsBuffer(arg0), Messages::RemoteGraphicsContextGL::IsBuffer::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsBuffer(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLboolean>(returnValue);
 }
 
 GCGLboolean RemoteGraphicsContextGLProxy::isEnabled(GCGLenum cap)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsEnabled(cap), Messages::RemoteGraphicsContextGL::IsEnabled::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsEnabled(cap));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLboolean>(returnValue);
 }
 
 GCGLboolean RemoteGraphicsContextGLProxy::isFramebuffer(PlatformGLObject arg0)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsFramebuffer(arg0), Messages::RemoteGraphicsContextGL::IsFramebuffer::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsFramebuffer(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLboolean>(returnValue);
 }
 
 GCGLboolean RemoteGraphicsContextGLProxy::isProgram(PlatformGLObject arg0)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsProgram(arg0), Messages::RemoteGraphicsContextGL::IsProgram::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsProgram(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLboolean>(returnValue);
 }
 
 GCGLboolean RemoteGraphicsContextGLProxy::isRenderbuffer(PlatformGLObject arg0)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsRenderbuffer(arg0), Messages::RemoteGraphicsContextGL::IsRenderbuffer::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsRenderbuffer(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLboolean>(returnValue);
 }
 
 GCGLboolean RemoteGraphicsContextGLProxy::isShader(PlatformGLObject arg0)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsShader(arg0), Messages::RemoteGraphicsContextGL::IsShader::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsShader(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLboolean>(returnValue);
 }
 
 GCGLboolean RemoteGraphicsContextGLProxy::isTexture(PlatformGLObject arg0)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsTexture(arg0), Messages::RemoteGraphicsContextGL::IsTexture::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsTexture(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLboolean>(returnValue);
 }
 
 void RemoteGraphicsContextGLProxy::lineWidth(GCGLfloat arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::LineWidth(arg0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::LineWidth(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::linkProgram(PlatformGLObject arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::LinkProgram(arg0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::LinkProgram(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::pixelStorei(GCGLenum pname, GCGLint param)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::PixelStorei(pname, param));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::PixelStorei(pname, param));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::polygonOffset(GCGLfloat factor, GCGLfloat units)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::PolygonOffset(factor, units));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::PolygonOffset(factor, units));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::renderbufferStorage(GCGLenum target, GCGLenum internalformat, GCGLsizei width, GCGLsizei height)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::RenderbufferStorage(target, internalformat, width, height));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::RenderbufferStorage(target, internalformat, width, height));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::sampleCoverage(GCGLclampf value, GCGLboolean invert)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::SampleCoverage(value, static_cast<bool>(invert)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::SampleCoverage(value, static_cast<bool>(invert)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::scissor(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Scissor(x, y, width, height));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Scissor(x, y, width, height));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::shaderSource(PlatformGLObject arg0, const String& arg1)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ShaderSource(arg0, arg1));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ShaderSource(arg0, arg1));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::stencilFunc(GCGLenum func, GCGLint ref, GCGLuint mask)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilFunc(func, ref, mask));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilFunc(func, ref, mask));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::stencilFuncSeparate(GCGLenum face, GCGLenum func, GCGLint ref, GCGLuint mask)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilFuncSeparate(face, func, ref, mask));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilFuncSeparate(face, func, ref, mask));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::stencilMask(GCGLuint mask)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilMask(mask));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilMask(mask));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::stencilMaskSeparate(GCGLenum face, GCGLuint mask)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilMaskSeparate(face, mask));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilMaskSeparate(face, mask));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::stencilOp(GCGLenum fail, GCGLenum zfail, GCGLenum zpass)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilOp(fail, zfail, zpass));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilOp(fail, zfail, zpass));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::stencilOpSeparate(GCGLenum face, GCGLenum fail, GCGLenum zfail, GCGLenum zpass)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilOpSeparate(face, fail, zfail, zpass));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilOpSeparate(face, fail, zfail, zpass));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::texParameterf(GCGLenum target, GCGLenum pname, GCGLfloat param)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexParameterf(target, pname, param));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexParameterf(target, pname, param));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::texParameteri(GCGLenum target, GCGLenum pname, GCGLint param)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexParameteri(target, pname, param));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexParameteri(target, pname, param));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform1f(GCGLint location, GCGLfloat x)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1f(location, x));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1f(location, x));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform1fv(GCGLint location, GCGLSpan<const GCGLfloat> v)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform1i(GCGLint location, GCGLint x)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1i(location, x));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1i(location, x));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform1iv(GCGLint location, GCGLSpan<const GCGLint> v)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform2f(GCGLint location, GCGLfloat x, GCGLfloat y)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2f(location, x, y));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2f(location, x, y));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform2fv(GCGLint location, GCGLSpan<const GCGLfloat> v)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform2i(GCGLint location, GCGLint x, GCGLint y)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2i(location, x, y));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2i(location, x, y));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform2iv(GCGLint location, GCGLSpan<const GCGLint> v)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform3f(GCGLint location, GCGLfloat x, GCGLfloat y, GCGLfloat z)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3f(location, x, y, z));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3f(location, x, y, z));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform3fv(GCGLint location, GCGLSpan<const GCGLfloat> v)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform3i(GCGLint location, GCGLint x, GCGLint y, GCGLint z)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3i(location, x, y, z));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3i(location, x, y, z));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform3iv(GCGLint location, GCGLSpan<const GCGLint> v)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform4f(GCGLint location, GCGLfloat x, GCGLfloat y, GCGLfloat z, GCGLfloat w)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4f(location, x, y, z, w));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4f(location, x, y, z, w));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform4fv(GCGLint location, GCGLSpan<const GCGLfloat> v)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform4i(GCGLint location, GCGLint x, GCGLint y, GCGLint z, GCGLint w)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4i(location, x, y, z, w));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4i(location, x, y, z, w));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform4iv(GCGLint location, GCGLSpan<const GCGLint> v)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniformMatrix2fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> value)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniformMatrix3fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> value)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniformMatrix4fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> value)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::useProgram(PlatformGLObject arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UseProgram(arg0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UseProgram(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::validateProgram(PlatformGLObject arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ValidateProgram(arg0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ValidateProgram(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttrib1f(GCGLuint index, GCGLfloat x)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1f(index, x));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1f(index, x));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttrib1fv(GCGLuint index, GCGLSpan<const GCGLfloat, 1> values)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1fv(index, IPC::ArrayReference<float, 1>(reinterpret_cast<const float*>(values.data()), values.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1fv(index, IPC::ArrayReference<float, 1>(reinterpret_cast<const float*>(values.data()), values.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttrib2f(GCGLuint index, GCGLfloat x, GCGLfloat y)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2f(index, x, y));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2f(index, x, y));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttrib2fv(GCGLuint index, GCGLSpan<const GCGLfloat, 2> values)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2fv(index, IPC::ArrayReference<float, 2>(reinterpret_cast<const float*>(values.data()), values.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2fv(index, IPC::ArrayReference<float, 2>(reinterpret_cast<const float*>(values.data()), values.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttrib3f(GCGLuint index, GCGLfloat x, GCGLfloat y, GCGLfloat z)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3f(index, x, y, z));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3f(index, x, y, z));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttrib3fv(GCGLuint index, GCGLSpan<const GCGLfloat, 3> values)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3fv(index, IPC::ArrayReference<float, 3>(reinterpret_cast<const float*>(values.data()), values.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3fv(index, IPC::ArrayReference<float, 3>(reinterpret_cast<const float*>(values.data()), values.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttrib4f(GCGLuint index, GCGLfloat x, GCGLfloat y, GCGLfloat z, GCGLfloat w)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4f(index, x, y, z, w));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4f(index, x, y, z, w));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttrib4fv(GCGLuint index, GCGLSpan<const GCGLfloat, 4> values)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4fv(index, IPC::ArrayReference<float, 4>(reinterpret_cast<const float*>(values.data()), values.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4fv(index, IPC::ArrayReference<float, 4>(reinterpret_cast<const float*>(values.data()), values.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttribPointer(GCGLuint index, GCGLint size, GCGLenum type, GCGLboolean normalized, GCGLsizei stride, GCGLintptr offset)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribPointer(index, size, type, static_cast<bool>(normalized), stride, static_cast<uint64_t>(offset)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribPointer(index, size, type, static_cast<bool>(normalized), stride, static_cast<uint64_t>(offset)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::viewport(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Viewport(x, y, width, height));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Viewport(x, y, width, height));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::bufferData(GCGLenum target, GCGLsizeiptr arg1, GCGLenum usage)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData0(target, static_cast<uint64_t>(arg1), usage));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData0(target, static_cast<uint64_t>(arg1), usage));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::bufferData(GCGLenum target, GCGLSpan<const GCGLvoid> data, GCGLenum usage)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData1(target, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()), usage));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData1(target, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()), usage));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::bufferSubData(GCGLenum target, GCGLintptr offset, GCGLSpan<const GCGLvoid> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferSubData(target, static_cast<uint64_t>(offset), IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferSubData(target, static_cast<uint64_t>(offset), IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::texImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, GCGLSpan<const GCGLvoid> pixels)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D0(target, level, internalformat, width, height, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D0(target, level, internalformat, width, height, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::texImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, GCGLintptr offset)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D1(target, level, internalformat, width, height, border, format, type, static_cast<uint64_t>(offset)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D1(target, level, internalformat, width, height, border, format, type, static_cast<uint64_t>(offset)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::texSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, GCGLSpan<const GCGLvoid> pixels)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D0(target, level, xoffset, yoffset, width, height, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D0(target, level, xoffset, yoffset, width, height, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::texSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, GCGLintptr offset)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D1(target, level, xoffset, yoffset, width, height, format, type, static_cast<uint64_t>(offset)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D1(target, level, xoffset, yoffset, width, height, format, type, static_cast<uint64_t>(offset)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::compressedTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLsizei imageSize, GCGLSpan<const GCGLvoid> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D0(target, level, internalformat, width, height, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D0(target, level, internalformat, width, height, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::compressedTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLsizei imageSize, GCGLintptr offset)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D1(target, level, internalformat, width, height, border, imageSize, static_cast<uint64_t>(offset)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D1(target, level, internalformat, width, height, border, imageSize, static_cast<uint64_t>(offset)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLsizei imageSize, GCGLSpan<const GCGLvoid> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D0(target, level, xoffset, yoffset, width, height, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D0(target, level, xoffset, yoffset, width, height, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLsizei imageSize, GCGLintptr offset)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D1(target, level, xoffset, yoffset, width, height, format, imageSize, static_cast<uint64_t>(offset)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D1(target, level, xoffset, yoffset, width, height, format, imageSize, static_cast<uint64_t>(offset)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::drawArraysInstanced(GCGLenum mode, GCGLint first, GCGLsizei count, GCGLsizei primcount)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArraysInstanced(mode, first, count, primcount));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArraysInstanced(mode, first, count, primcount));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::drawElementsInstanced(GCGLenum mode, GCGLsizei count, GCGLenum type, GCGLintptr offset, GCGLsizei primcount)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElementsInstanced(mode, count, type, static_cast<uint64_t>(offset), primcount));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElementsInstanced(mode, count, type, static_cast<uint64_t>(offset), primcount));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttribDivisor(GCGLuint index, GCGLuint divisor)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribDivisor(index, divisor));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribDivisor(index, divisor));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createVertexArray()
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateVertexArray(), Messages::RemoteGraphicsContextGL::CreateVertexArray::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateVertexArray());
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::deleteVertexArray(PlatformGLObject arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteVertexArray(arg0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteVertexArray(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 GCGLboolean RemoteGraphicsContextGLProxy::isVertexArray(PlatformGLObject arg0)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsVertexArray(arg0), Messages::RemoteGraphicsContextGL::IsVertexArray::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsVertexArray(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLboolean>(returnValue);
 }
 
 void RemoteGraphicsContextGLProxy::bindVertexArray(PlatformGLObject arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BindVertexArray(arg0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindVertexArray(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::copyBufferSubData(GCGLenum readTarget, GCGLenum writeTarget, GCGLintptr readOffset, GCGLintptr writeOffset, GCGLsizeiptr arg4)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyBufferSubData(readTarget, writeTarget, static_cast<uint64_t>(readOffset), static_cast<uint64_t>(writeOffset), static_cast<uint64_t>(arg4)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyBufferSubData(readTarget, writeTarget, static_cast<uint64_t>(readOffset), static_cast<uint64_t>(writeOffset), static_cast<uint64_t>(arg4)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::getBufferSubData(GCGLenum target, GCGLintptr offset, GCGLSpan<GCGLvoid> data)
 {
-    IPC::ArrayReference<uint8_t> dataReply;
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBufferSubData(target, static_cast<uint64_t>(offset), data.size()), Messages::RemoteGraphicsContextGL::GetBufferSubData::Reply(dataReply));
-        if (!sendResult)
-            markContextLost();
-        else
-            memcpy(data.data(), dataReply.data(), data.size() * sizeof(uint8_t));
+    if (isContextLost())
+        return;
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBufferSubData(target, static_cast<uint64_t>(offset), data.size()));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
+    auto& [dataReply] = sendResult.reply();
+    memcpy(data.data(), dataReply.data(), data.size() * sizeof(uint8_t));
 }
 
 void RemoteGraphicsContextGLProxy::blitFramebuffer(GCGLint srcX0, GCGLint srcY0, GCGLint srcX1, GCGLint srcY1, GCGLint dstX0, GCGLint dstY0, GCGLint dstX1, GCGLint dstY1, GCGLbitfield mask, GCGLenum filter)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::framebufferTextureLayer(GCGLenum target, GCGLenum attachment, PlatformGLObject texture, GCGLint level, GCGLint layer)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferTextureLayer(target, attachment, texture, level, layer));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferTextureLayer(target, attachment, texture, level, layer));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::invalidateFramebuffer(GCGLenum target, GCGLSpan<const GCGLenum> attachments)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::invalidateSubFramebuffer(GCGLenum target, GCGLSpan<const GCGLenum> attachments, GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateSubFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size()), x, y, width, height));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateSubFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size()), x, y, width, height));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::readBuffer(GCGLenum src)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ReadBuffer(src));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ReadBuffer(src));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::renderbufferStorageMultisample(GCGLenum target, GCGLsizei samples, GCGLenum internalformat, GCGLsizei width, GCGLsizei height)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::RenderbufferStorageMultisample(target, samples, internalformat, width, height));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::RenderbufferStorageMultisample(target, samples, internalformat, width, height));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::texStorage2D(GCGLenum target, GCGLsizei levels, GCGLenum internalformat, GCGLsizei width, GCGLsizei height)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexStorage2D(target, levels, internalformat, width, height));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexStorage2D(target, levels, internalformat, width, height));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::texStorage3D(GCGLenum target, GCGLsizei levels, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexStorage3D(target, levels, internalformat, width, height, depth));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexStorage3D(target, levels, internalformat, width, height, depth));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::texImage3D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, GCGLSpan<const GCGLvoid> pixels)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D0(target, level, internalformat, width, height, depth, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D0(target, level, internalformat, width, height, depth, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::texImage3D(GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, GCGLintptr offset)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D1(target, level, internalformat, width, height, depth, border, format, type, static_cast<uint64_t>(offset)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D1(target, level, internalformat, width, height, depth, border, format, type, static_cast<uint64_t>(offset)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::texSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, GCGLSpan<const GCGLvoid> pixels)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::texSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLenum type, GCGLintptr offset)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D1(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, static_cast<uint64_t>(offset)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D1(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, static_cast<uint64_t>(offset)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::copyTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::compressedTexImage3D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLsizei imageSize, GCGLSpan<const GCGLvoid> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D0(target, level, internalformat, width, height, depth, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D0(target, level, internalformat, width, height, depth, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::compressedTexImage3D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLsizei imageSize, GCGLintptr offset)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D1(target, level, internalformat, width, height, depth, border, imageSize, static_cast<uint64_t>(offset)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D1(target, level, internalformat, width, height, depth, border, imageSize, static_cast<uint64_t>(offset)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLsizei imageSize, GCGLSpan<const GCGLvoid> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLsizei imageSize, GCGLintptr offset)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D1(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, static_cast<uint64_t>(offset)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D1(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, static_cast<uint64_t>(offset)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 GCGLint RemoteGraphicsContextGLProxy::getFragDataLocation(PlatformGLObject program, const String& name)
 {
-    int32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFragDataLocation(program, name), Messages::RemoteGraphicsContextGL::GetFragDataLocation::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFragDataLocation(program, name));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::uniform1ui(GCGLint location, GCGLuint v0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1ui(location, v0));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1ui(location, v0));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform2ui(GCGLint location, GCGLuint v0, GCGLuint v1)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2ui(location, v0, v1));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2ui(location, v0, v1));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform3ui(GCGLint location, GCGLuint v0, GCGLuint v1, GCGLuint v2)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3ui(location, v0, v1, v2));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3ui(location, v0, v1, v2));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform4ui(GCGLint location, GCGLuint v0, GCGLuint v1, GCGLuint v2, GCGLuint v3)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4ui(location, v0, v1, v2, v3));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4ui(location, v0, v1, v2, v3));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform1uiv(GCGLint location, GCGLSpan<const GCGLuint> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform2uiv(GCGLint location, GCGLSpan<const GCGLuint> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform3uiv(GCGLint location, GCGLSpan<const GCGLuint> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniform4uiv(GCGLint location, GCGLSpan<const GCGLuint> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniformMatrix2x3fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniformMatrix3x2fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniformMatrix2x4fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniformMatrix4x2fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniformMatrix3x4fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::uniformMatrix4x3fv(GCGLint location, GCGLboolean transpose, GCGLSpan<const GCGLfloat> data)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttribI4i(GCGLuint index, GCGLint x, GCGLint y, GCGLint z, GCGLint w)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4i(index, x, y, z, w));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4i(index, x, y, z, w));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttribI4iv(GCGLuint index, GCGLSpan<const GCGLint, 4> values)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4iv(index, IPC::ArrayReference<int32_t, 4>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4iv(index, IPC::ArrayReference<int32_t, 4>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttribI4ui(GCGLuint index, GCGLuint x, GCGLuint y, GCGLuint z, GCGLuint w)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4ui(index, x, y, z, w));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4ui(index, x, y, z, w));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttribI4uiv(GCGLuint index, GCGLSpan<const GCGLuint, 4> values)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4uiv(index, IPC::ArrayReference<uint32_t, 4>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4uiv(index, IPC::ArrayReference<uint32_t, 4>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::vertexAttribIPointer(GCGLuint index, GCGLint size, GCGLenum type, GCGLsizei stride, GCGLintptr offset)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribIPointer(index, size, type, stride, static_cast<uint64_t>(offset)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribIPointer(index, size, type, stride, static_cast<uint64_t>(offset)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::drawRangeElements(GCGLenum mode, GCGLuint start, GCGLuint end, GCGLsizei count, GCGLenum type, GCGLintptr offset)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawRangeElements(mode, start, end, count, type, static_cast<uint64_t>(offset)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawRangeElements(mode, start, end, count, type, static_cast<uint64_t>(offset)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::drawBuffers(GCGLSpan<const GCGLenum> bufs)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffers(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffers(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::clearBufferiv(GCGLenum buffer, GCGLint drawbuffer, GCGLSpan<const GCGLint> values)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferiv(buffer, drawbuffer, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferiv(buffer, drawbuffer, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::clearBufferuiv(GCGLenum buffer, GCGLint drawbuffer, GCGLSpan<const GCGLuint> values)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferuiv(buffer, drawbuffer, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferuiv(buffer, drawbuffer, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::clearBufferfv(GCGLenum buffer, GCGLint drawbuffer, GCGLSpan<const GCGLfloat> values)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfv(buffer, drawbuffer, IPC::ArrayReference<float>(reinterpret_cast<const float*>(values.data()), values.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfv(buffer, drawbuffer, IPC::ArrayReference<float>(reinterpret_cast<const float*>(values.data()), values.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::clearBufferfi(GCGLenum buffer, GCGLint drawbuffer, GCGLfloat depth, GCGLint stencil)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfi(buffer, drawbuffer, depth, stencil));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfi(buffer, drawbuffer, depth, stencil));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createQuery()
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateQuery(), Messages::RemoteGraphicsContextGL::CreateQuery::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateQuery());
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::deleteQuery(PlatformGLObject query)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteQuery(query));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteQuery(query));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 GCGLboolean RemoteGraphicsContextGLProxy::isQuery(PlatformGLObject query)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsQuery(query), Messages::RemoteGraphicsContextGL::IsQuery::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsQuery(query));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLboolean>(returnValue);
 }
 
 void RemoteGraphicsContextGLProxy::beginQuery(GCGLenum target, PlatformGLObject query)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginQuery(target, query));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginQuery(target, query));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::endQuery(GCGLenum target)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::EndQuery(target));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::EndQuery(target));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::getQuery(GCGLenum target, GCGLenum pname)
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQuery(target, pname), Messages::RemoteGraphicsContextGL::GetQuery::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQuery(target, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 GCGLuint RemoteGraphicsContextGLProxy::getQueryObjectui(PlatformGLObject query, GCGLenum pname)
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQueryObjectui(query, pname), Messages::RemoteGraphicsContextGL::GetQueryObjectui::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQueryObjectui(query, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createSampler()
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateSampler(), Messages::RemoteGraphicsContextGL::CreateSampler::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateSampler());
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::deleteSampler(PlatformGLObject sampler)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteSampler(sampler));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteSampler(sampler));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 GCGLboolean RemoteGraphicsContextGLProxy::isSampler(PlatformGLObject sampler)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsSampler(sampler), Messages::RemoteGraphicsContextGL::IsSampler::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsSampler(sampler));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLboolean>(returnValue);
 }
 
 void RemoteGraphicsContextGLProxy::bindSampler(GCGLuint unit, PlatformGLObject sampler)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BindSampler(unit, sampler));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindSampler(unit, sampler));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::samplerParameteri(PlatformGLObject sampler, GCGLenum pname, GCGLint param)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::SamplerParameteri(sampler, pname, param));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::SamplerParameteri(sampler, pname, param));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::samplerParameterf(PlatformGLObject sampler, GCGLenum pname, GCGLfloat param)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::SamplerParameterf(sampler, pname, param));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::SamplerParameterf(sampler, pname, param));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 GCGLfloat RemoteGraphicsContextGLProxy::getSamplerParameterf(PlatformGLObject sampler, GCGLenum pname)
 {
-    float returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetSamplerParameterf(sampler, pname), Messages::RemoteGraphicsContextGL::GetSamplerParameterf::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetSamplerParameterf(sampler, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 GCGLint RemoteGraphicsContextGLProxy::getSamplerParameteri(PlatformGLObject sampler, GCGLenum pname)
 {
-    int32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetSamplerParameteri(sampler, pname), Messages::RemoteGraphicsContextGL::GetSamplerParameteri::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetSamplerParameteri(sampler, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 GCGLsync RemoteGraphicsContextGLProxy::fenceSync(GCGLenum condition, GCGLbitfield flags)
 {
-    uint64_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::FenceSync(condition, flags), Messages::RemoteGraphicsContextGL::FenceSync::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::FenceSync(condition, flags));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return reinterpret_cast<GCGLsync>(static_cast<intptr_t>(returnValue));
 }
 
 GCGLboolean RemoteGraphicsContextGLProxy::isSync(GCGLsync arg0)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0))), Messages::RemoteGraphicsContextGL::IsSync::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0))));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLboolean>(returnValue);
 }
 
 void RemoteGraphicsContextGLProxy::deleteSync(GCGLsync arg0)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0))));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0))));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 GCGLenum RemoteGraphicsContextGLProxy::clientWaitSync(GCGLsync arg0, GCGLbitfield flags, GCGLuint64 timeout)
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::ClientWaitSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), flags, static_cast<uint64_t>(timeout)), Messages::RemoteGraphicsContextGL::ClientWaitSync::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::ClientWaitSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), flags, static_cast<uint64_t>(timeout)));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::waitSync(GCGLsync arg0, GCGLbitfield flags, GCGLint64 timeout)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::WaitSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), flags, static_cast<int64_t>(timeout)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::WaitSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), flags, static_cast<int64_t>(timeout)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 GCGLint RemoteGraphicsContextGLProxy::getSynci(GCGLsync arg0, GCGLenum pname)
 {
-    int32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetSynci(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), pname), Messages::RemoteGraphicsContextGL::GetSynci::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetSynci(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createTransformFeedback()
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateTransformFeedback(), Messages::RemoteGraphicsContextGL::CreateTransformFeedback::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateTransformFeedback());
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::deleteTransformFeedback(PlatformGLObject id)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteTransformFeedback(id));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteTransformFeedback(id));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 GCGLboolean RemoteGraphicsContextGLProxy::isTransformFeedback(PlatformGLObject id)
 {
-    bool returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsTransformFeedback(id), Messages::RemoteGraphicsContextGL::IsTransformFeedback::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsTransformFeedback(id));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return static_cast<GCGLboolean>(returnValue);
 }
 
 void RemoteGraphicsContextGLProxy::bindTransformFeedback(GCGLenum target, PlatformGLObject id)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BindTransformFeedback(target, id));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindTransformFeedback(target, id));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::beginTransformFeedback(GCGLenum primitiveMode)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginTransformFeedback(primitiveMode));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginTransformFeedback(primitiveMode));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::endTransformFeedback()
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::EndTransformFeedback());
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::EndTransformFeedback());
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::transformFeedbackVaryings(PlatformGLObject program, const Vector<String>& varyings, GCGLenum bufferMode)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::TransformFeedbackVaryings(program, varyings, bufferMode));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TransformFeedbackVaryings(program, varyings, bufferMode));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, struct WebCore::GraphicsContextGLActiveInfo& arg2)
 {
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTransformFeedbackVarying(program, index), Messages::RemoteGraphicsContextGL::GetTransformFeedbackVarying::Reply(arg2));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTransformFeedbackVarying(program, index));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
+    auto& [arg2Reply] = sendResult.reply();
+    arg2 = WTFMove(arg2Reply);
 }
 
 void RemoteGraphicsContextGLProxy::pauseTransformFeedback()
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::PauseTransformFeedback());
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::PauseTransformFeedback());
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::resumeTransformFeedback()
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ResumeTransformFeedback());
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ResumeTransformFeedback());
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::bindBufferBase(GCGLenum target, GCGLuint index, PlatformGLObject buffer)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBufferBase(target, index, buffer));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBufferBase(target, index, buffer));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::bindBufferRange(GCGLenum target, GCGLuint index, PlatformGLObject buffer, GCGLintptr offset, GCGLsizeiptr arg4)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBufferRange(target, index, buffer, static_cast<uint64_t>(offset), static_cast<uint64_t>(arg4)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBufferRange(target, index, buffer, static_cast<uint64_t>(offset), static_cast<uint64_t>(arg4)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 Vector<GCGLuint> RemoteGraphicsContextGLProxy::getUniformIndices(PlatformGLObject program, const Vector<String>& uniformNames)
 {
-    Vector<uint32_t> returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformIndices(program, uniformNames), Messages::RemoteGraphicsContextGL::GetUniformIndices::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformIndices(program, uniformNames));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 Vector<GCGLint> RemoteGraphicsContextGLProxy::getActiveUniforms(PlatformGLObject program, const Vector<GCGLuint>& uniformIndices, GCGLenum pname)
 {
-    Vector<int32_t> returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniforms(program, uniformIndices, pname), Messages::RemoteGraphicsContextGL::GetActiveUniforms::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniforms(program, uniformIndices, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 GCGLuint RemoteGraphicsContextGLProxy::getUniformBlockIndex(PlatformGLObject program, const String& uniformBlockName)
 {
-    uint32_t returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformBlockIndex(program, uniformBlockName), Messages::RemoteGraphicsContextGL::GetUniformBlockIndex::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformBlockIndex(program, uniformBlockName));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 String RemoteGraphicsContextGLProxy::getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex)
 {
-    String returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniformBlockName(program, uniformBlockIndex), Messages::RemoteGraphicsContextGL::GetActiveUniformBlockName::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniformBlockName(program, uniformBlockIndex));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::uniformBlockBinding(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLuint uniformBlockBinding)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::getActiveUniformBlockiv(GCGLuint program, GCGLuint uniformBlockIndex, GCGLenum pname, GCGLSpan<GCGLint> params)
 {
-    IPC::ArrayReference<int32_t> paramsReply;
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniformBlockiv(program, uniformBlockIndex, pname, params.size()), Messages::RemoteGraphicsContextGL::GetActiveUniformBlockiv::Reply(paramsReply));
-        if (!sendResult)
-            markContextLost();
-        else
-            memcpy(params.data(), paramsReply.data(), params.size() * sizeof(int32_t));
+    if (isContextLost())
+        return;
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniformBlockiv(program, uniformBlockIndex, pname, params.size()));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
+    auto& [paramsReply] = sendResult.reply();
+    memcpy(params.data(), paramsReply.data(), params.size() * sizeof(int32_t));
 }
 
 String RemoteGraphicsContextGLProxy::getTranslatedShaderSourceANGLE(PlatformGLObject arg0)
 {
-    String returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTranslatedShaderSourceANGLE(arg0), Messages::RemoteGraphicsContextGL::GetTranslatedShaderSourceANGLE::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTranslatedShaderSourceANGLE(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 
 void RemoteGraphicsContextGLProxy::drawBuffersEXT(GCGLSpan<const GCGLenum> bufs)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffersEXT(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffersEXT(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::enableiOES(GCGLenum target, GCGLuint index)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::EnableiOES(target, index));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::EnableiOES(target, index));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::disableiOES(GCGLenum target, GCGLuint index)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DisableiOES(target, index));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DisableiOES(target, index));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::blendEquationiOES(GCGLuint buf, GCGLenum mode)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationiOES(buf, mode));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationiOES(buf, mode));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::blendEquationSeparateiOES(GCGLuint buf, GCGLenum modeRGB, GCGLenum modeAlpha)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationSeparateiOES(buf, modeRGB, modeAlpha));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationSeparateiOES(buf, modeRGB, modeAlpha));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::blendFunciOES(GCGLuint buf, GCGLenum src, GCGLenum dst)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFunciOES(buf, src, dst));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFunciOES(buf, src, dst));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::blendFuncSeparateiOES(GCGLuint buf, GCGLenum srcRGB, GCGLenum dstRGB, GCGLenum srcAlpha, GCGLenum dstAlpha)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::colorMaskiOES(GCGLuint buf, GCGLboolean red, GCGLboolean green, GCGLboolean blue, GCGLboolean alpha)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ColorMaskiOES(buf, static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha)));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ColorMaskiOES(buf, static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha)));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::drawArraysInstancedBaseInstanceANGLE(GCGLenum mode, GCGLint first, GCGLsizei count, GCGLsizei instanceCount, GCGLuint baseInstance)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::drawElementsInstancedBaseVertexBaseInstanceANGLE(GCGLenum mode, GCGLsizei count, GCGLenum type, GCGLintptr offset, GCGLsizei instanceCount, GCGLint baseVertex, GCGLuint baseInstance)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, static_cast<uint64_t>(offset), instanceCount, baseVertex, baseInstance));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, static_cast<uint64_t>(offset), instanceCount, baseVertex, baseInstance));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
 void RemoteGraphicsContextGLProxy::getInternalformativ(GCGLenum target, GCGLenum internalformat, GCGLenum pname, GCGLSpan<GCGLint> params)
 {
-    IPC::ArrayReference<int32_t> paramsReply;
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInternalformativ(target, internalformat, pname, params.size()), Messages::RemoteGraphicsContextGL::GetInternalformativ::Reply(paramsReply));
-        if (!sendResult)
-            markContextLost();
-        else
-            memcpy(params.data(), paramsReply.data(), params.size() * sizeof(int32_t));
+    if (isContextLost())
+        return;
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInternalformativ(target, internalformat, pname, params.size()));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
+    auto& [paramsReply] = sendResult.reply();
+    memcpy(params.data(), paramsReply.data(), params.size() * sizeof(int32_t));
 }
 
 RefPtr<WebCore::PixelBuffer> RemoteGraphicsContextGLProxy::paintRenderingResultsToPixelBuffer()
 {
-    RefPtr<WebCore::PixelBuffer> returnValue = { };
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PaintRenderingResultsToPixelBuffer(), Messages::RemoteGraphicsContextGL::PaintRenderingResultsToPixelBuffer::Reply(returnValue));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PaintRenderingResultsToPixelBuffer());
+    if (!sendResult) {
+        markContextLost();
+        return { };
     }
+    auto& [returnValue] = sendResult.reply();
     return returnValue;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -156,9 +156,9 @@ private:
     IPC::StreamClientConnection& streamConnection();
 
     template<typename T>
-    auto sendSyncToStream(T&& message, typename T::Reply&& reply, IPC::Timeout timeout = { Seconds::infinity() })
+    auto sendSyncToStream(T&& message, IPC::Timeout timeout = { Seconds::infinity() })
     {
-        return streamConnection().sendSync(WTFMove(message), WTFMove(reply), renderingBackendIdentifier(), timeout);
+        return streamConnection().sendSync(WTFMove(message), renderingBackendIdentifier(), timeout);
     }
 
     // GPUProcessConnection::Client

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
@@ -55,12 +55,11 @@ void RemoteAdapterProxy::requestDevice(const PAL::WebGPU::DeviceDescriptor& desc
 
     auto identifier = WebGPUIdentifier::generate();
     auto queueIdentifier = WebGPUIdentifier::generate();
-    SupportedFeatures supportedFeatures;
-    SupportedLimits supportedLimits;
-    auto sendResult = sendSync(Messages::RemoteAdapter::RequestDevice(*convertedDescriptor, identifier, queueIdentifier), { supportedFeatures, supportedLimits });
+    auto sendResult = sendSync(Messages::RemoteAdapter::RequestDevice(*convertedDescriptor, identifier, queueIdentifier));
     if (!sendResult)
         return;
 
+    auto [supportedFeatures, supportedLimits] = sendResult.takeReply();
     auto resultSupportedFeatures = PAL::WebGPU::SupportedFeatures::create(WTFMove(supportedFeatures.features));
     auto resultSupportedLimits = PAL::WebGPU::SupportedLimits::create(
         supportedLimits.maxTextureDimension1D,

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
@@ -72,9 +72,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void requestDevice(const PAL::WebGPU::DeviceDescriptor&, CompletionHandler<void(Ref<PAL::WebGPU::Device>&&)>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -46,9 +46,8 @@ RemoteBufferProxy::~RemoteBufferProxy()
 
 void RemoteBufferProxy::mapAsync(PAL::WebGPU::MapModeFlags mapModeFlags, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size, CompletionHandler<void()>&& callback)
 {
-    std::optional<Vector<uint8_t>> data;
-    auto sendResult = sendSync(Messages::RemoteBuffer::MapAsync(mapModeFlags, offset, size), { data });
-    UNUSED_VARIABLE(sendResult);
+    auto sendResult = sendSync(Messages::RemoteBuffer::MapAsync(mapModeFlags, offset, size));
+    auto [data] = sendResult.takeReplyOr(std::nullopt);
     if (!data) {
         // FIXME: Implement error handling.
         return;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -68,9 +68,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void mapAsync(PAL::WebGPU::MapModeFlags, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> sizeForMap, CompletionHandler<void()>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     Ref<PAL::WebGPU::RenderPassEncoder> beginRenderPass(const PAL::WebGPU::RenderPassDescriptor&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void setPipeline(const PAL::WebGPU::ComputePipeline&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     Ref<PAL::WebGPU::BindGroupLayout> getBindGroupLayout(uint32_t index) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -228,7 +228,7 @@ void RemoteDeviceProxy::createComputePipelineAsync(const PAL::WebGPU::ComputePip
         return;
 
     auto identifier = WebGPUIdentifier::generate();
-    auto sendResult = sendSync(Messages::RemoteDevice::CreateComputePipelineAsync(*convertedDescriptor, identifier), { });
+    auto sendResult = sendSync(Messages::RemoteDevice::CreateComputePipelineAsync(*convertedDescriptor, identifier));
     if (!sendResult)
         return;
 
@@ -243,7 +243,7 @@ void RemoteDeviceProxy::createRenderPipelineAsync(const PAL::WebGPU::RenderPipel
         return;
 
     auto identifier = WebGPUIdentifier::generate();
-    auto sendResult = sendSync(Messages::RemoteDevice::CreateRenderPipelineAsync(*convertedDescriptor, identifier), { });
+    auto sendResult = sendSync(Messages::RemoteDevice::CreateRenderPipelineAsync(*convertedDescriptor, identifier));
     if (!sendResult)
         return;
 
@@ -306,9 +306,8 @@ void RemoteDeviceProxy::pushErrorScope(PAL::WebGPU::ErrorFilter errorFilter)
 
 void RemoteDeviceProxy::popErrorScope(CompletionHandler<void(std::optional<PAL::WebGPU::Error>&&)>&& callback)
 {
-    std::optional<Error> error;
-    auto sendResult = sendSync(Messages::RemoteDevice::PopErrorScope(), { error });
-    UNUSED_VARIABLE(sendResult);
+    auto sendResult = sendSync(Messages::RemoteDevice::PopErrorScope());
+    auto [error] = sendResult.takeReplyOr(std::nullopt);
 
     if (!error) {
         callback(std::nullopt);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -70,9 +70,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     PAL::WebGPU::Queue& queue() final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -107,13 +107,13 @@ void RemoteGPUProxy::requestAdapter(const PAL::WebGPU::RequestAdapterOptions& op
     }
 
     auto identifier = WebGPUIdentifier::generate();
-    std::optional<RemoteGPU::RequestAdapterResponse> response;
-    auto sendResult = sendSync(Messages::RemoteGPU::RequestAdapter(*convertedOptions, identifier), { response });
+    auto sendResult = sendSync(Messages::RemoteGPU::RequestAdapter(*convertedOptions, identifier));
     if (!sendResult) {
         m_lost = true;
         callback(nullptr);
         return;
     }
+    auto [response] = sendResult.takeReply();
     if (!response) {
         callback(nullptr);
         return;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -89,9 +89,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
     IPC::Connection& connection() const { return m_gpuProcessConnection->connection(); }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void destroy() final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -68,9 +68,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message, typename T::Reply&& reply)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void submit(Vector<std::reference_wrapper<PAL::WebGPU::CommandBuffer>>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void setPipeline(const PAL::WebGPU::RenderPipeline&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void setPipeline(const PAL::WebGPU::RenderPipeline&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     Ref<PAL::WebGPU::BindGroupLayout> getBindGroupLayout(uint32_t index) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
@@ -48,9 +48,8 @@ RemoteShaderModuleProxy::~RemoteShaderModuleProxy()
 
 void RemoteShaderModuleProxy::compilationInfo(CompletionHandler<void(Ref<PAL::WebGPU::CompilationInfo>&&)>&& callback)
 {
-    Vector<CompilationMessage> messages;
-    auto sendResult = sendSync(Messages::RemoteShaderModule::CompilationInfo(), { messages });
-    UNUSED_VARIABLE(sendResult);
+    auto sendResult = sendSync(Messages::RemoteShaderModule::CompilationInfo());
+    auto [messages] = sendResult.takeReplyOr(Vector<CompilationMessage> { });
 
     auto backingMessages = messages.map([] (CompilationMessage compilationMessage) {
         return PAL::WebGPU::CompilationMessage::create(WTFMove(compilationMessage.message), compilationMessage.type, compilationMessage.lineNum, compilationMessage.linePos, compilationMessage.offset, compilationMessage.length);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void compilationInfo(CompletionHandler<void(Ref<PAL::WebGPU::CompilationInfo>&&)>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -71,9 +71,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     Ref<PAL::WebGPU::TextureView> createView(const std::optional<PAL::WebGPU::TextureViewDescriptor>&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
@@ -67,9 +67,9 @@ private:
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult sendSync(T&& message, typename T::Reply&& reply)
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().streamClientConnection().sendSync(WTFMove(message), WTFMove(reply), backing(), defaultSendTimeout);
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
@@ -114,12 +114,12 @@ void RemoteGraphicsContextGLProxyCocoa::prepareForDisplay()
 {
     if (isContextLost())
         return;
-    MachSendRight displayBufferSendRight;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PrepareForDisplay(), Messages::RemoteGraphicsContextGL::PrepareForDisplay::Reply(displayBufferSendRight));
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PrepareForDisplay());
     if (!sendResult) {
         markContextLost();
         return;
     }
+    auto [displayBufferSendRight] = sendResult.takeReply();
     if (!displayBufferSendRight)
         return;
     m_displayBuffer = WTFMove(displayBufferSendRight);

--- a/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
@@ -125,13 +125,13 @@ void RemoteGraphicsContextGLProxyGBM::prepareForDisplay()
     if (isContextLost())
         return;
 
-    WebCore::DMABufObject dmabufObject(0);
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PrepareForDisplay(), Messages::RemoteGraphicsContextGL::PrepareForDisplay::Reply(dmabufObject));
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PrepareForDisplay());
     if (!sendResult) {
         markContextLost();
         return;
     }
 
+    auto& [dmabufObject] = sendResult.reply();
     m_layerContentsDisplayDelegate->present(WTFMove(dmabufObject));
     markLayerComposited();
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp
@@ -84,12 +84,12 @@ void RemoteGraphicsContextGLProxyWC::prepareForDisplay()
 {
     if (isContextLost())
         return;
-    std::optional<WCContentBufferIdentifier> contentBuffer;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PrepareForDisplay(), Messages::RemoteGraphicsContextGL::PrepareForDisplay::Reply(contentBuffer));
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PrepareForDisplay());
     if (!sendResult) {
         markContextLost();
         return;
     }
+    auto& [contentBuffer] = sendResult.reply();
     if (contentBuffer)
         static_cast<WCPlatformLayerGCGL*>(m_layerContentsDisplayDelegate->platformLayer())->addContentBufferIdentifier(*contentBuffer);
     markLayerComposited();

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFullScreenClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFullScreenClient.cpp
@@ -46,8 +46,8 @@ bool InjectedBundlePageFullScreenClient::supportsFullScreen(WebPage *page, bool 
     if (m_client.supportsFullScreen) 
         return m_client.supportsFullScreen(toAPI(page), withKeyboard);
 
-    bool supports = true;
-    page->sendSync(Messages::WebFullScreenManagerProxy::SupportsFullScreen(withKeyboard), Messages::WebFullScreenManagerProxy::SupportsFullScreen::Reply(supports));
+    auto sendResult = page->sendSync(Messages::WebFullScreenManagerProxy::SupportsFullScreen(withKeyboard));
+    auto [supports] = sendResult.takeReplyOr(true);
     return supports;
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -184,11 +184,8 @@ FloatRect WebChromeClient::windowRect()
         return m_page.windowFrameInUnflippedScreenCoordinates();
 #endif
 
-    FloatRect newWindowFrame;
-
-    if (!WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::GetWindowFrame(), Messages::WebPageProxy::GetWindowFrame::Reply(newWindowFrame), m_page.identifier()))
-        return FloatRect();
-
+    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::GetWindowFrame(), m_page.identifier());
+    auto [newWindowFrame] = sendResult.takeReplyOr(FloatRect { });
     return newWindowFrame;
 #endif
 }
@@ -294,11 +291,11 @@ Page* WebChromeClient::createWindow(Frame& frame, const WindowFeatures& windowFe
 
     WebFrame* webFrame = WebFrame::fromCoreFrame(frame);
 
-    std::optional<PageIdentifier> newPageID;
-    std::optional<WebPageCreationParameters> parameters;
-    if (!webProcess.parentProcessConnection()->sendSync(Messages::WebPageProxy::CreateNewPage(webFrame->info(), webFrame->page()->webPageProxyIdentifier(), navigationAction.resourceRequest(), windowFeatures, navigationActionData), Messages::WebPageProxy::CreateNewPage::Reply(newPageID, parameters), m_page.identifier(), IPC::Timeout::infinity(), IPC::SendSyncOption::MaintainOrderingWithAsyncMessages))
+    auto sendResult = webProcess.parentProcessConnection()->sendSync(Messages::WebPageProxy::CreateNewPage(webFrame->info(), webFrame->page()->webPageProxyIdentifier(), navigationAction.resourceRequest(), windowFeatures, navigationActionData), m_page.identifier(), IPC::Timeout::infinity(), IPC::SendSyncOption::MaintainOrderingWithAsyncMessages);
+    if (!sendResult)
         return nullptr;
 
+    auto [newPageID, parameters] = sendResult.takeReply();
     if (!newPageID)
         return nullptr;
     ASSERT(parameters);
@@ -312,9 +309,9 @@ Page* WebChromeClient::createWindow(Frame& frame, const WindowFeatures& windowFe
 bool WebChromeClient::testProcessIncomingSyncMessagesWhenWaitingForSyncReply()
 {
     IPC::UnboundedSynchronousIPCScope unboundedSynchronousIPCScope;
-    bool handled = false;
-    if (!WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(m_page.webPageProxyIdentifier()), Messages::NetworkConnectionToWebProcess::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply::Reply(handled), 0))
-        return false;
+
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(m_page.webPageProxyIdentifier()), 0);
+    auto [handled] = sendResult.takeReplyOr(false);
     return handled;
 }
 
@@ -349,10 +346,8 @@ bool WebChromeClient::toolbarsVisible()
     if (toolbarsVisibility != API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown)
         return toolbarsVisibility == API::InjectedBundle::PageUIClient::UIElementVisibility::Visible;
     
-    bool toolbarsAreVisible = true;
-    if (!WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::GetToolbarsAreVisible(), Messages::WebPageProxy::GetToolbarsAreVisible::Reply(toolbarsAreVisible), m_page.identifier()))
-        return true;
-
+    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::GetToolbarsAreVisible(), m_page.identifier());
+    auto [toolbarsAreVisible] = sendResult.takeReplyOr(true);
     return toolbarsAreVisible;
 }
 
@@ -367,10 +362,8 @@ bool WebChromeClient::statusbarVisible()
     if (statusbarVisibility != API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown)
         return statusbarVisibility == API::InjectedBundle::PageUIClient::UIElementVisibility::Visible;
 
-    bool statusBarIsVisible = true;
-    if (!WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::GetStatusBarIsVisible(), Messages::WebPageProxy::GetStatusBarIsVisible::Reply(statusBarIsVisible), m_page.identifier()))
-        return true;
-
+    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::GetStatusBarIsVisible(), m_page.identifier());
+    auto [statusBarIsVisible] = sendResult.takeReplyOr(true);
     return statusBarIsVisible;
 }
 
@@ -396,10 +389,8 @@ bool WebChromeClient::menubarVisible()
     if (menubarVisibility != API::InjectedBundle::PageUIClient::UIElementVisibility::Unknown)
         return menubarVisibility == API::InjectedBundle::PageUIClient::UIElementVisibility::Visible;
     
-    bool menuBarIsVisible = true;
-    if (!WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::GetMenuBarIsVisible(), Messages::WebPageProxy::GetMenuBarIsVisible::Reply(menuBarIsVisible), m_page.identifier()))
-        return true;
-
+    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::GetMenuBarIsVisible(), m_page.identifier());
+    auto [menuBarIsVisible] = sendResult.takeReplyOr(true);
     return menuBarIsVisible;
 }
 
@@ -428,13 +419,10 @@ bool WebChromeClient::runBeforeUnloadConfirmPanel(const String& message, Frame& 
 {
     WebFrame* webFrame = WebFrame::fromCoreFrame(frame);
 
-    bool shouldClose = false;
-
     HangDetectionDisabler hangDetectionDisabler;
 
-    if (!m_page.sendSyncWithDelayedReply(Messages::WebPageProxy::RunBeforeUnloadConfirmPanel(webFrame->frameID(), webFrame->info(), message), Messages::WebPageProxy::RunBeforeUnloadConfirmPanel::Reply(shouldClose)))
-        return false;
-
+    auto sendResult = m_page.sendSyncWithDelayedReply(Messages::WebPageProxy::RunBeforeUnloadConfirmPanel(webFrame->frameID(), webFrame->info(), message));
+    auto [shouldClose] = sendResult.takeReplyOr(false);
     return shouldClose;
 }
 
@@ -479,7 +467,7 @@ void WebChromeClient::runJavaScriptAlert(Frame& frame, const String& alertText)
     HangDetectionDisabler hangDetectionDisabler;
     IPC::UnboundedSynchronousIPCScope unboundedSynchronousIPCScope;
 
-    m_page.sendSyncWithDelayedReply(Messages::WebPageProxy::RunJavaScriptAlert(webFrame->frameID(), webFrame->info(), alertText), Messages::WebPageProxy::RunJavaScriptAlert::Reply(), IPC::SendSyncOption::MaintainOrderingWithAsyncMessages);
+    m_page.sendSyncWithDelayedReply(Messages::WebPageProxy::RunJavaScriptAlert(webFrame->frameID(), webFrame->info(), alertText), IPC::SendSyncOption::MaintainOrderingWithAsyncMessages);
 }
 
 bool WebChromeClient::runJavaScriptConfirm(Frame& frame, const String& message)
@@ -497,10 +485,8 @@ bool WebChromeClient::runJavaScriptConfirm(Frame& frame, const String& message)
     HangDetectionDisabler hangDetectionDisabler;
     IPC::UnboundedSynchronousIPCScope unboundedSynchronousIPCScope;
 
-    bool result = false;
-    if (!m_page.sendSyncWithDelayedReply(Messages::WebPageProxy::RunJavaScriptConfirm(webFrame->frameID(), webFrame->info(), message), Messages::WebPageProxy::RunJavaScriptConfirm::Reply(result), IPC::SendSyncOption::MaintainOrderingWithAsyncMessages))
-        return false;
-
+    auto sendResult = m_page.sendSyncWithDelayedReply(Messages::WebPageProxy::RunJavaScriptConfirm(webFrame->frameID(), webFrame->info(), message), IPC::SendSyncOption::MaintainOrderingWithAsyncMessages);
+    auto [result] = sendResult.takeReplyOr(false);
     return result;
 }
 
@@ -519,9 +505,11 @@ bool WebChromeClient::runJavaScriptPrompt(Frame& frame, const String& message, c
     HangDetectionDisabler hangDetectionDisabler;
     IPC::UnboundedSynchronousIPCScope unboundedSynchronousIPCScope;
 
-    if (!m_page.sendSyncWithDelayedReply(Messages::WebPageProxy::RunJavaScriptPrompt(webFrame->frameID(), webFrame->info(), message, defaultValue), Messages::WebPageProxy::RunJavaScriptPrompt::Reply(result), IPC::SendSyncOption::MaintainOrderingWithAsyncMessages))
+    auto sendResult = m_page.sendSyncWithDelayedReply(Messages::WebPageProxy::RunJavaScriptPrompt(webFrame->frameID(), webFrame->info(), message, defaultValue), IPC::SendSyncOption::MaintainOrderingWithAsyncMessages);
+    if (!sendResult)
         return false;
 
+    std::tie(result) = sendResult.takeReply();
     return !result.isNull();
 }
 
@@ -737,7 +725,7 @@ void WebChromeClient::print(Frame& frame, const StringWithDirection& title)
     auto truncatedTitle = truncateFromEnd(title, maxTitleLength);
 
     IPC::UnboundedSynchronousIPCScope unboundedSynchronousIPCScope;
-    m_page.sendSyncWithDelayedReply(Messages::WebPageProxy::PrintFrame(webFrame->frameID(), truncatedTitle.string, pdfFirstPageSize), Messages::WebPageProxy::PrintFrame::Reply());
+    m_page.sendSyncWithDelayedReply(Messages::WebPageProxy::PrintFrame(webFrame->frameID(), truncatedTitle.string, pdfFirstPageSize));
 }
 
 void WebChromeClient::reachedMaxAppCacheSize(int64_t)
@@ -756,8 +744,8 @@ void WebChromeClient::reachedApplicationCacheOriginQuota(SecurityOrigin& origin,
     if (!cacheStorage.calculateQuotaForOrigin(origin, currentQuota))
         return;
 
-    uint64_t newQuota = 0;
-    m_page.sendSyncWithDelayedReply(Messages::WebPageProxy::ReachedApplicationCacheOriginQuota(origin.data().databaseIdentifier(), currentQuota, totalBytesNeeded), Messages::WebPageProxy::ReachedApplicationCacheOriginQuota::Reply(newQuota));
+    auto sendResult = m_page.sendSyncWithDelayedReply(Messages::WebPageProxy::ReachedApplicationCacheOriginQuota(origin.data().databaseIdentifier(), currentQuota, totalBytesNeeded));
+    auto [newQuota] = sendResult.takeReplyOr(0);
 
     cacheStorage.storeUpdatedQuotaForOrigin(&origin, newQuota);
 }
@@ -1247,17 +1235,23 @@ void WebChromeClient::handleAutoplayEvent(AutoplayEvent event, OptionSet<Autopla
 
 bool WebChromeClient::wrapCryptoKey(const Vector<uint8_t>& key, Vector<uint8_t>& wrappedKey) const
 {
-    bool succeeded;
-    if (!WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::WrapCryptoKey(key), Messages::WebPageProxy::WrapCryptoKey::Reply(succeeded, wrappedKey), m_page.identifier()))
+    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::WrapCryptoKey(key), m_page.identifier());
+    if (!sendResult)
         return false;
+
+    bool succeeded;
+    std::tie(succeeded, wrappedKey) = sendResult.takeReply();
     return succeeded;
 }
 
 bool WebChromeClient::unwrapCryptoKey(const Vector<uint8_t>& wrappedKey, Vector<uint8_t>& key) const
 {
-    bool succeeded;
-    if (!WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::UnwrapCryptoKey(wrappedKey), Messages::WebPageProxy::UnwrapCryptoKey::Reply(succeeded, key), m_page.identifier()))
+    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::UnwrapCryptoKey(wrappedKey), m_page.identifier());
+    if (!sendResult)
         return false;
+
+    bool succeeded;
+    std::tie(succeeded, key) = sendResult.takeReply();
     return succeeded;
 }
 
@@ -1279,9 +1273,11 @@ void WebChromeClient::setTextIndicator(const WebCore::TextIndicatorData& indicat
 
 String WebChromeClient::signedPublicKeyAndChallengeString(unsigned keySizeIndex, const String& challengeString, const URL& url) const
 {
-    String result;
-    if (!WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::SignedPublicKeyAndChallengeString(keySizeIndex, challengeString, url), Messages::WebPageProxy::SignedPublicKeyAndChallengeString::Reply(result), m_page.identifier()))
+    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::SignedPublicKeyAndChallengeString(keySizeIndex, challengeString, url), m_page.identifier());
+    if (!sendResult)
         return emptyString();
+
+    auto [result] = sendResult.takeReply();
     return result;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -1076,16 +1076,16 @@ JSValueRef JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero(JSCon
     }
 
     auto& streamConnection = jsStreamConnection->connection();
-    int32_t resultValue = 0;
     enum JSIPCStreamTesterIdentifierType { };
     auto destination = makeObjectIdentifier<JSIPCStreamTesterIdentifierType>(*destinationID);
 
-    auto result = streamConnection.sendSync(Messages::IPCStreamTester::SyncCrashOnZero(value), Messages::IPCStreamTester::SyncCrashOnZero::Reply(resultValue), destination, timeoutDuration);
+    auto result = streamConnection.sendSync(Messages::IPCStreamTester::SyncCrashOnZero(value), destination, timeoutDuration);
     if (!result) {
         *exception = createTypeError(context, "sync send failed"_s);
         return JSValueMakeUndefined(context);
     }
 
+    auto [resultValue] = result.takeReply();
     return JSValueMakeNumber(context, resultValue);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -109,8 +109,8 @@ void WebBackForwardListProxy::goToItem(HistoryItem& item)
     if (!m_page)
         return;
 
-    WebBackForwardListCounts backForwardListCounts;
-    m_page->sendSync(Messages::WebPageProxy::BackForwardGoToItem(item.identifier()), Messages::WebPageProxy::BackForwardGoToItem::Reply(backForwardListCounts));
+    auto sendResult = m_page->sendSync(Messages::WebPageProxy::BackForwardGoToItem(item.identifier()));
+    auto [backForwardListCounts] = sendResult.takeReplyOr(WebBackForwardListCounts { });
     m_cachedBackForwardListCounts = backForwardListCounts;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1373,11 +1373,11 @@ public:
     void didReceiveWebPageMessage(IPC::Connection&, IPC::Decoder&);
 
     template<typename T>
-    SendSyncResult sendSyncWithDelayedReply(T&& message, typename T::Reply&& reply, OptionSet<IPC::SendSyncOption> sendSyncOptions = { })
+    SendSyncResult<T> sendSyncWithDelayedReply(T&& message, OptionSet<IPC::SendSyncOption> sendSyncOptions = { })
     {
         cancelCurrentInteractionInformationRequest();
         sendSyncOptions = sendSyncOptions | IPC::SendSyncOption::InformPlatformProcessWillSuspend;
-        return sendSync(WTFMove(message), WTFMove(reply), Seconds::infinity(), sendSyncOptions);
+        return sendSync(WTFMove(message), Seconds::infinity(), sendSyncOptions);
     }
 
     WebCore::DOMPasteAccessResponse requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, const String& originIdentifier);

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
@@ -66,10 +66,11 @@ void WebURLSchemeHandlerProxy::startNewTask(ResourceLoader& loader, WebFrame& we
 void WebURLSchemeHandlerProxy::loadSynchronously(WebCore::ResourceLoaderIdentifier loadIdentifier, WebFrame& webFrame, const ResourceRequest& request, ResourceResponse& response, ResourceError& error, Vector<uint8_t>& data)
 {
     data.shrink(0);
-    if (!m_webPage.sendSync(Messages::WebPageProxy::LoadSynchronousURLSchemeTask(URLSchemeTaskParameters { m_identifier, loadIdentifier, request, webFrame.info() }), Messages::WebPageProxy::LoadSynchronousURLSchemeTask::Reply(response, error, data))) {
+    auto sendResult = m_webPage.sendSync(Messages::WebPageProxy::LoadSynchronousURLSchemeTask(URLSchemeTaskParameters { m_identifier, loadIdentifier, request, webFrame.info() }));
+    if (sendResult)
+        std::tie(response, error, data) = sendResult.takeReply();
+    else
         error = failedCustomProtocolSyncLoad(request);
-        return;
-    }
 }
 
 void WebURLSchemeHandlerProxy::stopAllTasks()

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -873,12 +873,9 @@ bool WebProcess::shouldTerminate()
     ASSERT(m_pageMap.isEmpty());
 
     // FIXME: the ShouldTerminate message should also send termination parameters, such as any session cookies that need to be preserved.
-    bool shouldTerminate = false;
-    if (parentProcessConnection()->sendSync(Messages::WebProcessProxy::ShouldTerminate(), Messages::WebProcessProxy::ShouldTerminate::Reply(shouldTerminate), 0)
-        && !shouldTerminate)
-        return false;
-
-    return true;
+    auto sendResult = parentProcessConnection()->sendSync(Messages::WebProcessProxy::ShouldTerminate(), 0);
+    auto [shouldTerminate] = sendResult.takeReplyOr(true);
+    return shouldTerminate;
 }
 
 void WebProcess::terminate()
@@ -1137,10 +1134,12 @@ static NetworkProcessConnectionInfo getNetworkProcessConnection(IPC::Connection&
 {
     NetworkProcessConnectionInfo connectionInfo;
     auto requestConnection = [&]() -> bool {
-        if (!connection.sendSync(Messages::WebProcessProxy::GetNetworkProcessConnection(), Messages::WebProcessProxy::GetNetworkProcessConnection::Reply(connectionInfo), 0)) {
+        auto sendResult = connection.sendSync(Messages::WebProcessProxy::GetNetworkProcessConnection(), 0);
+        if (!sendResult) {
             RELEASE_LOG_ERROR(Process, "getNetworkProcessConnection: Failed to send message or receive invalid message");
             failedToGetNetworkProcessConnection();
         }
+        std::tie(connectionInfo) = sendResult.takeReply();
         return !!connectionInfo.connection;
     };
 

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -610,24 +610,33 @@ class webkit_ipc_cpp_proxy_impl(object):
         in_exprs = ", ".join([str(i) for i in self.in_exprs])
         out_exprs = ", ".join(str(o) for o in self.out_exprs)
         is_async = self.return_type.is_void() and len(out_exprs) == 0
-        self.call_stmts += [ "if (!isContextLost()) {" ]
+        self.call_stmts += [ "if (isContextLost())" ]
+        if self.return_type.is_void():
+            self.call_stmts += [ "    return;" ]
+        else:
+            self.call_stmts += [ "    return { };"]
         if is_async:
             self.call_stmts += [
-                f"    auto sendResult = send(Messages::RemoteGraphicsContextGL::{self.msg_name}({in_exprs}));",
+                f"auto sendResult = send(Messages::RemoteGraphicsContextGL::{self.msg_name}({in_exprs}));",
             ]
         else:
             self.call_stmts += [
-                f"    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::{self.msg_name}({in_exprs}), Messages::RemoteGraphicsContextGL::{self.msg_name}::Reply({out_exprs}));"
+                f"auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::{self.msg_name}({in_exprs}));"
             ]
-        self.call_stmts += [
-            "    if (!sendResult)",
-            "        markContextLost();",
-        ]
-        if self.post_call_stmts:
-            self.call_stmts += ["    else {"] if len(self.post_call_stmts) > 1 else [ "    else"]
-            self.post_call_stmts = [ "    " + l for l in self.post_call_stmts ]
-            self.post_call_stmts += [ "    }" ] if len(self.post_call_stmts) > 1 else []
-        self.post_call_stmts += [ "}" ]
+        if self.return_type.is_void():
+            self.call_stmts += [
+                "if (!sendResult) {",
+                "    markContextLost();",
+                "    return;",
+                "}",
+            ]
+        else:
+            self.call_stmts += [
+                "if (!sendResult) {",
+                "    markContextLost();",
+                "    return { };",
+                "}",
+            ]
 
 
     def process_in_args(self, in_args: List[cpp_arg]):
@@ -643,34 +652,40 @@ class webkit_ipc_cpp_proxy_impl(object):
                 value_type = o.type.get_value_type()
                 webkit_ipc_value_type = webkit_ipc_types[value_type]
                 v = cpp_arg(webkit_ipc_value_type, o.name + "Reply")
-                self.pre_call_stmts += [f"{str(v.type)} {str(v.name)} = {{ }};"]
                 e = cpp_expr(v.type, v.name)
                 self.out_exprs += [e]
                 self.post_call_stmts += [
                     #fmt: off
-                    f"    if ({o.name})",
-                    f"        *{o.name} = {webkit_ipc_convert_expr(e, value_type)};"
+                    f"if ({o.name})",
+                    f"    *{o.name} = {webkit_ipc_convert_expr(e, value_type)};"
                     #fmt: on
+                ]
+            elif o.type.is_reference():
+                value_type = o.type.get_value_type()
+                v = cpp_arg(value_type, o.name + "Reply")
+                e = cpp_expr(v.type, v.name)
+                self.out_exprs += [e]
+                self.post_call_stmts += [
+                    f"{o.name} = WTFMove({v.name});",
                 ]
             elif o.type.is_span():
                 webkit_ipc_type = webkit_ipc_types[o.type]
                 assert(isinstance(webkit_ipc_type, cpp_type_container))
                 v = cpp_arg(webkit_ipc_type, o.name + "Reply")
-                if o.type.is_dynamic_span():
-                    self.pre_call_stmts += [f"{str(v.type)} {str(v.name)};"]
-                else:
-                    self.pre_call_stmts += [
-                        f"constexpr std::array<{str(v.type.get_contained_type())}, {str(v.type.get_arity())}> {str(v.name)}Empty {{ }};",
-                        f"{str(v.type)} {str(v.name)} {{ {str(v.name)}Empty }};"
-                    ]
                 self.out_exprs += [cpp_expr(v.type, v.name)]
                 if o.type.is_dynamic_span():
                     self.in_exprs += [cpp_expr(get_cpp_type("size_t"), f"{o.name}.size()")]
                 self.post_call_stmts += [
-                    f"    memcpy({o.name}.data(), {v.name}.data(), {o.name}.size() * sizeof({str(webkit_ipc_type.get_contained_type())}));"
+                    f"memcpy({o.name}.data(), {v.name}.data(), {o.name}.size() * sizeof({str(webkit_ipc_type.get_contained_type())}));"
                 ]
             else:
                 self.out_exprs += [cpp_expr(o.type, o.name)]
+
+        if self.out_exprs:
+            out_exprs = ", ".join(str(o) for o in self.out_exprs)
+            self.post_call_stmts = [
+                    f"auto& [{out_exprs}] = sendResult.reply();",
+                ] + self.post_call_stmts
 
     def process_return_value(self, return_type: cpp_type):
         if return_type.is_void():
@@ -678,7 +693,6 @@ class webkit_ipc_cpp_proxy_impl(object):
         self.return_type = return_type
         ipc_return_type = webkit_ipc_types[return_type]
         return_value_expr = cpp_expr(ipc_return_type, "returnValue")
-        self.pre_call_stmts += [f"{return_value_expr.type} {return_value_expr.expr} = {{ }};"]
         self.out_exprs = [return_value_expr] + self.out_exprs
         self.return_stmts = [f"return {str(webkit_ipc_convert_expr(return_value_expr, return_type))};"]
 


### PR DESCRIPTION
#### c3ae481a1d055b6ea88737cd11041ba0f0446dea
<pre>
[WK2] Store sync-message reply arguments inside the SendSyncResult object
<a href="https://bugs.webkit.org/show_bug.cgi?id=238993">https://bugs.webkit.org/show_bug.cgi?id=238993</a>

Reviewed by Kimmo Kinnunen.

Provide a IPC::Connection::sendSync() variant that doesn&apos;t accept a separate
tuple for reply values. Instead, the return value for this overload is a struct
containing both the Decoder instance as well as the reply-values tuple.

The explicit boolean operator is provided on this struct to validate the outcome
of the message (i.e. if the sync message was successful), and helper methods are
available to retrieve the reply values.

After the result is validated, the user can reference values inside the tuple or
move those values out. Without validation it&apos;s possible to move the values out
or fall back onto user-provided default values. This can be combined with C++
tuple-oriented features like std::tie() and structured binding declarations.

The previous sendSync() overload has its return value type alias renamed to
SendSyncLegacyResult. Remaining uses of this method will be switched over to the
new version. Most derivatives of previous IPC::Connection::sendSync() are
already ported over to the new overload, along with some standalone uses of this
method. The GPUProcess IPC handling code is re-generated due to related changes
in the generation script.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::testProcessIncomingSyncMessagesWhenWaitingForSyncReply):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendSync):
(IPC::Connection::SendSyncResult::operator bool const):
(IPC::Connection::SendSyncResult::reply):
(IPC::Connection::SendSyncResult::takeReply):
(IPC::Connection::SendSyncResult::takeReplyOr):
* Source/WebKit/Platform/IPC/MessageSender.h:
(IPC::MessageSender::sendSync):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::sendSync):
(IPC::StreamClientConnection::trySendSyncStream):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::sendSync):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::sendProcessWillSuspendImminentlyForTesting):
(WebKit::NetworkProcessProxy::testProcessIncomingSyncMessagesWhenWaitingForSyncReply):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::setCacheModelSynchronouslyForTesting):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::setServiceWorkerTimeoutForTesting):
(WebKit::WebsiteDataStore::resetServiceWorkerTimeoutForTesting):
(WebKit::WebsiteDataStore::setAllowsAnySSLCertificateForWebSocket):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::paintRenderingResultsToCanvas):
(WebKit::RemoteGraphicsContextGLProxy::paintCompositedResultsToCanvas):
(WebKit::RemoteGraphicsContextGLProxy::paintCompositedResultsToVideoFrame):
(WebKit::RemoteGraphicsContextGLProxy::copyTextureFromMedia):
(WebKit::RemoteGraphicsContextGLProxy::getError):
(WebKit::RemoteGraphicsContextGLProxy::readnPixels):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
(WebKit::RemoteGraphicsContextGLProxy::sendSync):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::moveErrorsToSyntheticErrorList):
(WebKit::RemoteGraphicsContextGLProxy::activeTexture):
(WebKit::RemoteGraphicsContextGLProxy::attachShader):
(WebKit::RemoteGraphicsContextGLProxy::bindAttribLocation):
(WebKit::RemoteGraphicsContextGLProxy::bindBuffer):
(WebKit::RemoteGraphicsContextGLProxy::bindFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::bindRenderbuffer):
(WebKit::RemoteGraphicsContextGLProxy::bindTexture):
(WebKit::RemoteGraphicsContextGLProxy::blendColor):
(WebKit::RemoteGraphicsContextGLProxy::blendEquation):
(WebKit::RemoteGraphicsContextGLProxy::blendEquationSeparate):
(WebKit::RemoteGraphicsContextGLProxy::blendFunc):
(WebKit::RemoteGraphicsContextGLProxy::blendFuncSeparate):
(WebKit::RemoteGraphicsContextGLProxy::checkFramebufferStatus):
(WebKit::RemoteGraphicsContextGLProxy::clear):
(WebKit::RemoteGraphicsContextGLProxy::clearColor):
(WebKit::RemoteGraphicsContextGLProxy::clearDepth):
(WebKit::RemoteGraphicsContextGLProxy::clearStencil):
(WebKit::RemoteGraphicsContextGLProxy::colorMask):
(WebKit::RemoteGraphicsContextGLProxy::compileShader):
(WebKit::RemoteGraphicsContextGLProxy::copyTexImage2D):
(WebKit::RemoteGraphicsContextGLProxy::copyTexSubImage2D):
(WebKit::RemoteGraphicsContextGLProxy::createBuffer):
(WebKit::RemoteGraphicsContextGLProxy::createFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::createProgram):
(WebKit::RemoteGraphicsContextGLProxy::createRenderbuffer):
(WebKit::RemoteGraphicsContextGLProxy::createShader):
(WebKit::RemoteGraphicsContextGLProxy::createTexture):
(WebKit::RemoteGraphicsContextGLProxy::cullFace):
(WebKit::RemoteGraphicsContextGLProxy::deleteBuffer):
(WebKit::RemoteGraphicsContextGLProxy::deleteFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::deleteProgram):
(WebKit::RemoteGraphicsContextGLProxy::deleteRenderbuffer):
(WebKit::RemoteGraphicsContextGLProxy::deleteShader):
(WebKit::RemoteGraphicsContextGLProxy::deleteTexture):
(WebKit::RemoteGraphicsContextGLProxy::depthFunc):
(WebKit::RemoteGraphicsContextGLProxy::depthMask):
(WebKit::RemoteGraphicsContextGLProxy::depthRange):
(WebKit::RemoteGraphicsContextGLProxy::detachShader):
(WebKit::RemoteGraphicsContextGLProxy::disable):
(WebKit::RemoteGraphicsContextGLProxy::disableVertexAttribArray):
(WebKit::RemoteGraphicsContextGLProxy::drawArrays):
(WebKit::RemoteGraphicsContextGLProxy::drawElements):
(WebKit::RemoteGraphicsContextGLProxy::enable):
(WebKit::RemoteGraphicsContextGLProxy::enableVertexAttribArray):
(WebKit::RemoteGraphicsContextGLProxy::finish):
(WebKit::RemoteGraphicsContextGLProxy::flush):
(WebKit::RemoteGraphicsContextGLProxy::framebufferRenderbuffer):
(WebKit::RemoteGraphicsContextGLProxy::framebufferTexture2D):
(WebKit::RemoteGraphicsContextGLProxy::frontFace):
(WebKit::RemoteGraphicsContextGLProxy::generateMipmap):
(WebKit::RemoteGraphicsContextGLProxy::getActiveAttrib):
(WebKit::RemoteGraphicsContextGLProxy::getActiveUniform):
(WebKit::RemoteGraphicsContextGLProxy::getAttribLocation):
(WebKit::RemoteGraphicsContextGLProxy::getBufferParameteri):
(WebKit::RemoteGraphicsContextGLProxy::getString):
(WebKit::RemoteGraphicsContextGLProxy::getFloatv):
(WebKit::RemoteGraphicsContextGLProxy::getIntegerv):
(WebKit::RemoteGraphicsContextGLProxy::getIntegeri_v):
(WebKit::RemoteGraphicsContextGLProxy::getInteger64):
(WebKit::RemoteGraphicsContextGLProxy::getInteger64i):
(WebKit::RemoteGraphicsContextGLProxy::getProgrami):
(WebKit::RemoteGraphicsContextGLProxy::getBooleanv):
(WebKit::RemoteGraphicsContextGLProxy::getFramebufferAttachmentParameteri):
(WebKit::RemoteGraphicsContextGLProxy::getProgramInfoLog):
(WebKit::RemoteGraphicsContextGLProxy::getRenderbufferParameteri):
(WebKit::RemoteGraphicsContextGLProxy::getShaderi):
(WebKit::RemoteGraphicsContextGLProxy::getShaderInfoLog):
(WebKit::RemoteGraphicsContextGLProxy::getShaderPrecisionFormat):
(WebKit::RemoteGraphicsContextGLProxy::getShaderSource):
(WebKit::RemoteGraphicsContextGLProxy::getTexParameterf):
(WebKit::RemoteGraphicsContextGLProxy::getTexParameteri):
(WebKit::RemoteGraphicsContextGLProxy::getUniformfv):
(WebKit::RemoteGraphicsContextGLProxy::getUniformiv):
(WebKit::RemoteGraphicsContextGLProxy::getUniformuiv):
(WebKit::RemoteGraphicsContextGLProxy::getUniformLocation):
(WebKit::RemoteGraphicsContextGLProxy::getVertexAttribOffset):
(WebKit::RemoteGraphicsContextGLProxy::hint):
(WebKit::RemoteGraphicsContextGLProxy::isBuffer):
(WebKit::RemoteGraphicsContextGLProxy::isEnabled):
(WebKit::RemoteGraphicsContextGLProxy::isFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::isProgram):
(WebKit::RemoteGraphicsContextGLProxy::isRenderbuffer):
(WebKit::RemoteGraphicsContextGLProxy::isShader):
(WebKit::RemoteGraphicsContextGLProxy::isTexture):
(WebKit::RemoteGraphicsContextGLProxy::lineWidth):
(WebKit::RemoteGraphicsContextGLProxy::linkProgram):
(WebKit::RemoteGraphicsContextGLProxy::pixelStorei):
(WebKit::RemoteGraphicsContextGLProxy::polygonOffset):
(WebKit::RemoteGraphicsContextGLProxy::renderbufferStorage):
(WebKit::RemoteGraphicsContextGLProxy::sampleCoverage):
(WebKit::RemoteGraphicsContextGLProxy::scissor):
(WebKit::RemoteGraphicsContextGLProxy::shaderSource):
(WebKit::RemoteGraphicsContextGLProxy::stencilFunc):
(WebKit::RemoteGraphicsContextGLProxy::stencilFuncSeparate):
(WebKit::RemoteGraphicsContextGLProxy::stencilMask):
(WebKit::RemoteGraphicsContextGLProxy::stencilMaskSeparate):
(WebKit::RemoteGraphicsContextGLProxy::stencilOp):
(WebKit::RemoteGraphicsContextGLProxy::stencilOpSeparate):
(WebKit::RemoteGraphicsContextGLProxy::texParameterf):
(WebKit::RemoteGraphicsContextGLProxy::texParameteri):
(WebKit::RemoteGraphicsContextGLProxy::uniform1f):
(WebKit::RemoteGraphicsContextGLProxy::uniform1fv):
(WebKit::RemoteGraphicsContextGLProxy::uniform1i):
(WebKit::RemoteGraphicsContextGLProxy::uniform1iv):
(WebKit::RemoteGraphicsContextGLProxy::uniform2f):
(WebKit::RemoteGraphicsContextGLProxy::uniform2fv):
(WebKit::RemoteGraphicsContextGLProxy::uniform2i):
(WebKit::RemoteGraphicsContextGLProxy::uniform2iv):
(WebKit::RemoteGraphicsContextGLProxy::uniform3f):
(WebKit::RemoteGraphicsContextGLProxy::uniform3fv):
(WebKit::RemoteGraphicsContextGLProxy::uniform3i):
(WebKit::RemoteGraphicsContextGLProxy::uniform3iv):
(WebKit::RemoteGraphicsContextGLProxy::uniform4f):
(WebKit::RemoteGraphicsContextGLProxy::uniform4fv):
(WebKit::RemoteGraphicsContextGLProxy::uniform4i):
(WebKit::RemoteGraphicsContextGLProxy::uniform4iv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix2fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix3fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix4fv):
(WebKit::RemoteGraphicsContextGLProxy::useProgram):
(WebKit::RemoteGraphicsContextGLProxy::validateProgram):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib1f):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib1fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib2f):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib2fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib3f):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib3fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib4f):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib4fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribPointer):
(WebKit::RemoteGraphicsContextGLProxy::viewport):
(WebKit::RemoteGraphicsContextGLProxy::bufferData):
(WebKit::RemoteGraphicsContextGLProxy::bufferSubData):
(WebKit::RemoteGraphicsContextGLProxy::texImage2D):
(WebKit::RemoteGraphicsContextGLProxy::texSubImage2D):
(WebKit::RemoteGraphicsContextGLProxy::compressedTexImage2D):
(WebKit::RemoteGraphicsContextGLProxy::compressedTexSubImage2D):
(WebKit::RemoteGraphicsContextGLProxy::drawArraysInstanced):
(WebKit::RemoteGraphicsContextGLProxy::drawElementsInstanced):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribDivisor):
(WebKit::RemoteGraphicsContextGLProxy::createVertexArray):
(WebKit::RemoteGraphicsContextGLProxy::deleteVertexArray):
(WebKit::RemoteGraphicsContextGLProxy::isVertexArray):
(WebKit::RemoteGraphicsContextGLProxy::bindVertexArray):
(WebKit::RemoteGraphicsContextGLProxy::copyBufferSubData):
(WebKit::RemoteGraphicsContextGLProxy::getBufferSubData):
(WebKit::RemoteGraphicsContextGLProxy::blitFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::framebufferTextureLayer):
(WebKit::RemoteGraphicsContextGLProxy::invalidateFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::invalidateSubFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::readBuffer):
(WebKit::RemoteGraphicsContextGLProxy::renderbufferStorageMultisample):
(WebKit::RemoteGraphicsContextGLProxy::texStorage2D):
(WebKit::RemoteGraphicsContextGLProxy::texStorage3D):
(WebKit::RemoteGraphicsContextGLProxy::texImage3D):
(WebKit::RemoteGraphicsContextGLProxy::texSubImage3D):
(WebKit::RemoteGraphicsContextGLProxy::copyTexSubImage3D):
(WebKit::RemoteGraphicsContextGLProxy::compressedTexImage3D):
(WebKit::RemoteGraphicsContextGLProxy::compressedTexSubImage3D):
(WebKit::RemoteGraphicsContextGLProxy::getFragDataLocation):
(WebKit::RemoteGraphicsContextGLProxy::uniform1ui):
(WebKit::RemoteGraphicsContextGLProxy::uniform2ui):
(WebKit::RemoteGraphicsContextGLProxy::uniform3ui):
(WebKit::RemoteGraphicsContextGLProxy::uniform4ui):
(WebKit::RemoteGraphicsContextGLProxy::uniform1uiv):
(WebKit::RemoteGraphicsContextGLProxy::uniform2uiv):
(WebKit::RemoteGraphicsContextGLProxy::uniform3uiv):
(WebKit::RemoteGraphicsContextGLProxy::uniform4uiv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix2x3fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix3x2fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix2x4fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix4x2fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix3x4fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix4x3fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribI4i):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribI4iv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribI4ui):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribI4uiv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribIPointer):
(WebKit::RemoteGraphicsContextGLProxy::drawRangeElements):
(WebKit::RemoteGraphicsContextGLProxy::drawBuffers):
(WebKit::RemoteGraphicsContextGLProxy::clearBufferiv):
(WebKit::RemoteGraphicsContextGLProxy::clearBufferuiv):
(WebKit::RemoteGraphicsContextGLProxy::clearBufferfv):
(WebKit::RemoteGraphicsContextGLProxy::clearBufferfi):
(WebKit::RemoteGraphicsContextGLProxy::createQuery):
(WebKit::RemoteGraphicsContextGLProxy::deleteQuery):
(WebKit::RemoteGraphicsContextGLProxy::isQuery):
(WebKit::RemoteGraphicsContextGLProxy::beginQuery):
(WebKit::RemoteGraphicsContextGLProxy::endQuery):
(WebKit::RemoteGraphicsContextGLProxy::getQuery):
(WebKit::RemoteGraphicsContextGLProxy::getQueryObjectui):
(WebKit::RemoteGraphicsContextGLProxy::createSampler):
(WebKit::RemoteGraphicsContextGLProxy::deleteSampler):
(WebKit::RemoteGraphicsContextGLProxy::isSampler):
(WebKit::RemoteGraphicsContextGLProxy::bindSampler):
(WebKit::RemoteGraphicsContextGLProxy::samplerParameteri):
(WebKit::RemoteGraphicsContextGLProxy::samplerParameterf):
(WebKit::RemoteGraphicsContextGLProxy::getSamplerParameterf):
(WebKit::RemoteGraphicsContextGLProxy::getSamplerParameteri):
(WebKit::RemoteGraphicsContextGLProxy::fenceSync):
(WebKit::RemoteGraphicsContextGLProxy::isSync):
(WebKit::RemoteGraphicsContextGLProxy::deleteSync):
(WebKit::RemoteGraphicsContextGLProxy::clientWaitSync):
(WebKit::RemoteGraphicsContextGLProxy::waitSync):
(WebKit::RemoteGraphicsContextGLProxy::getSynci):
(WebKit::RemoteGraphicsContextGLProxy::createTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::deleteTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::isTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::bindTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::beginTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::endTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::transformFeedbackVaryings):
(WebKit::RemoteGraphicsContextGLProxy::getTransformFeedbackVarying):
(WebKit::RemoteGraphicsContextGLProxy::pauseTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::resumeTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::bindBufferBase):
(WebKit::RemoteGraphicsContextGLProxy::bindBufferRange):
(WebKit::RemoteGraphicsContextGLProxy::getUniformIndices):
(WebKit::RemoteGraphicsContextGLProxy::getActiveUniforms):
(WebKit::RemoteGraphicsContextGLProxy::getUniformBlockIndex):
(WebKit::RemoteGraphicsContextGLProxy::getActiveUniformBlockName):
(WebKit::RemoteGraphicsContextGLProxy::uniformBlockBinding):
(WebKit::RemoteGraphicsContextGLProxy::getActiveUniformBlockiv):
(WebKit::RemoteGraphicsContextGLProxy::getTranslatedShaderSourceANGLE):
(WebKit::RemoteGraphicsContextGLProxy::drawBuffersEXT):
(WebKit::RemoteGraphicsContextGLProxy::enableiOES):
(WebKit::RemoteGraphicsContextGLProxy::disableiOES):
(WebKit::RemoteGraphicsContextGLProxy::blendEquationiOES):
(WebKit::RemoteGraphicsContextGLProxy::blendEquationSeparateiOES):
(WebKit::RemoteGraphicsContextGLProxy::blendFunciOES):
(WebKit::RemoteGraphicsContextGLProxy::blendFuncSeparateiOES):
(WebKit::RemoteGraphicsContextGLProxy::colorMaskiOES):
(WebKit::RemoteGraphicsContextGLProxy::drawArraysInstancedBaseInstanceANGLE):
(WebKit::RemoteGraphicsContextGLProxy::drawElementsInstancedBaseVertexBaseInstanceANGLE):
(WebKit::RemoteGraphicsContextGLProxy::getInternalformativ):
(WebKit::RemoteGraphicsContextGLProxy::paintRenderingResultsToPixelBuffer):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::getPixelBufferForImageBuffer):
(WebKit::RemoteRenderingBackendProxy::getShareableBitmap):
(WebKit::RemoteRenderingBackendProxy::getFilteredImage):
(WebKit::RemoteRenderingBackendProxy::prepareBuffersForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
(WebKit::RemoteRenderingBackendProxy::sendSyncToStream):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp:
(WebKit::WebGPU::RemoteAdapterProxy::requestDevice):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
(WebKit::WebGPU::RemoteBufferProxy::mapAsync):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::createComputePipelineAsync):
(WebKit::WebGPU::RemoteDeviceProxy::createRenderPipelineAsync):
(WebKit::WebGPU::RemoteDeviceProxy::popErrorScope):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::requestAdapter):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp:
(WebKit::WebGPU::RemoteShaderModuleProxy::compilationInfo):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm:
* Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp:
(WebKit::RemoteGraphicsContextGLProxyGBM::prepareForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFullScreenClient.cpp:
(WebKit::InjectedBundlePageFullScreenClient::supportsFullScreen):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::windowRect):
(WebKit::WebChromeClient::createWindow):
(WebKit::WebChromeClient::testProcessIncomingSyncMessagesWhenWaitingForSyncReply):
(WebKit::WebChromeClient::toolbarsVisible):
(WebKit::WebChromeClient::statusbarVisible):
(WebKit::WebChromeClient::menubarVisible):
(WebKit::WebChromeClient::runBeforeUnloadConfirmPanel):
(WebKit::WebChromeClient::runJavaScriptAlert):
(WebKit::WebChromeClient::runJavaScriptConfirm):
(WebKit::WebChromeClient::runJavaScriptPrompt):
(WebKit::WebChromeClient::print):
(WebKit::WebChromeClient::reachedApplicationCacheOriginQuota):
(WebKit::WebChromeClient::wrapCryptoKey const):
(WebKit::WebChromeClient::unwrapCryptoKey const):
(WebKit::WebChromeClient::signedPublicKeyAndChallengeString const):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::serializedAttachmentDataForIdentifiers):
(WebKit::WebEditorClient::canUndo const):
(WebKit::WebEditorClient::canRedo const):
(WebKit::WebEditorClient::undo):
(WebKit::WebEditorClient::redo):
(WebKit::WebEditorClient::checkSpellingOfString):
(WebKit::WebEditorClient::checkGrammarOfString):
(WebKit::WebEditorClient::checkTextOfParagraph):
(WebKit::WebEditorClient::spellingUIIsShowing):
(WebKit::WebEditorClient::getGuessesForWord):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero):
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::goToItem):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::screenToRootView):
(WebKit::WebPage::rootViewToScreen):
(WebKit::WebPage::accessibilityScreenToRootView):
(WebKit::WebPage::rootViewToAccessibilityScreen):
(WebKit::WebPage::isSpeaking):
(WebKit::WebPage::postSynchronousMessageForTesting):
(WebKit::WebPage::requestDOMPasteAccess):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::sendSyncWithDelayedReply):
* Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp:
(WebKit::WebURLSchemeHandlerProxy::loadSynchronously):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::shouldTerminate):
(WebKit::getNetworkProcessConnection):
* Tools/Scripts/generate-gpup-webgl:

Canonical link: <a href="https://commits.webkit.org/254783@main">https://commits.webkit.org/254783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e64e8fb26a8647ab122223e192ce22f4f306380f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99548 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33273 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96015 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26465 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77069 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26356 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69356 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34398 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/15150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32235 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16101 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3362 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/35983 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35188 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->