### PR TITLE
Change unclear Color::isValid() to explicit isCurrentColor().

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -1590,12 +1590,12 @@ protected:
         Color fromColor = value(a);
         Color toColor = value(b);
 
-        if (!fromColor.isValid() && !toColor.isValid())
+        if (RenderStyle::isCurrentColor(fromColor) && RenderStyle::isCurrentColor(toColor))
             return true;
 
-        if (!fromColor.isValid())
+        if (RenderStyle::isCurrentColor(fromColor))
             fromColor = a.color();
-        if (!toColor.isValid())
+        if (RenderStyle::isCurrentColor(toColor))
             toColor = b.color();
 
         return fromColor == toColor;
@@ -1606,13 +1606,14 @@ protected:
         Color fromColor = value(from);
         Color toColor = value(to);
 
-        if (!fromColor.isValid() && !toColor.isValid())
+        if (RenderStyle::isCurrentColor(fromColor) && RenderStyle::isCurrentColor(toColor))
             return;
 
-        if (!fromColor.isValid())
+        if (RenderStyle::isCurrentColor(fromColor))
             fromColor = from.color();
-        if (!toColor.isValid())
+        if (RenderStyle::isCurrentColor(toColor))
             toColor = to.color();
+
         (destination.*m_setter)(blendFunc(fromColor, toColor, context));
     }
 
@@ -2250,12 +2251,12 @@ private:
             Color fromColor = (a.*m_getter)();
             Color toColor = (b.*m_getter)();
 
-            if (!fromColor.isValid() && !toColor.isValid())
+            if (RenderStyle::isCurrentColor(fromColor) && RenderStyle::isCurrentColor(toColor))
                 return true;
 
-            if (!fromColor.isValid())
+            if (RenderStyle::isCurrentColor(fromColor))
                 fromColor = a.color();
-            if (!toColor.isValid())
+            if (RenderStyle::isCurrentColor(toColor))
                 toColor = b.color();
 
             return fromColor == toColor;
@@ -2275,13 +2276,14 @@ private:
         Color fromColor = (from.*m_getter)();
         Color toColor = (to.*m_getter)();
 
-        if (!fromColor.isValid() && !toColor.isValid())
+        if (RenderStyle::isCurrentColor(fromColor) && RenderStyle::isCurrentColor(toColor))
             return;
 
-        if (!fromColor.isValid())
+        if (RenderStyle::isCurrentColor(fromColor))
             fromColor = from.color();
-        if (!toColor.isValid())
+        if (RenderStyle::isCurrentColor(toColor))
             toColor = to.color();
+
         (destination.*m_setter)(blendFunc(fromColor, toColor, context));
     }
 

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
@@ -48,10 +48,11 @@ Color SVGAnimationColorFunction::colorFromString(SVGElement& targetElement, cons
 std::optional<float> SVGAnimationColorFunction::calculateDistance(SVGElement&, const String& from, const String& to) const
 {
     Color fromColor = CSSParser::parseColorWithoutContext(from.stripWhiteSpace());
-    if (!fromColor.isValid())
+    if (RenderStyle::isCurrentColor(fromColor))
         return { };
+
     Color toColor = CSSParser::parseColorWithoutContext(to.stripWhiteSpace());
-    if (!toColor.isValid())
+    if (RenderStyle::isCurrentColor(toColor))
         return { };
 
     auto simpleFrom = fromColor.toColorTypeLossy<SRGBA<uint8_t>>().resolved();


### PR DESCRIPTION
#### 0b28244472f04925b48519bbe131ad84739c621e
<pre>
Change unclear Color::isValid() to explicit isCurrentColor().
<a href="https://bugs.webkit.org/show_bug.cgi?id=245424">https://bugs.webkit.org/show_bug.cgi?id=245424</a>

Reviewed by Antoine Quint.

Due to the representation of &quot;current color&quot; as &quot;invalid color&quot; in WebCore,
they are two functionally equivalent functions in the codebase:
- Color::isValid()
- RenderStyle::isCurrentColor(Color) which is implemented as &quot;return !color.isValid()&quot;.

The second one makes the intention of the check clearer and should be preferred.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
* Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp:
(WebCore::SVGAnimationColorFunction::calculateDistance const):

Canonical link: <a href="https://commits.webkit.org/254683@main">https://commits.webkit.org/254683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87eef41a4862af2244458bfed9f4e31dbecc04af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34412 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/20537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99183 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156105 "Found 1 new test failure: fast/workers/worker-crash-with-invalid-location.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32903 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28330 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82202 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93523 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26136 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76673 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26061 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/20537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/69066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30651 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/20537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30391 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/20537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3286 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33851 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32566 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/20537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->