### PR TITLE
Improve the logic in WebCore::scrollOffsetForFixedPosition()

### DIFF
--- a/LayoutTests/platform/gtk/fast/overflow/unreachable-overflow-rtl-bug-expected.txt
+++ b/LayoutTests/platform/gtk/fast/overflow/unreachable-overflow-rtl-bug-expected.txt
@@ -11,5 +11,5 @@ layer at (0,0) size 800x600
           text run at (0,0) width 35: "RTL:"
 layer at (8,26) size 106x106 clip at (11,29) size 85x85 scrollWidth 221 scrollHeight 268
   RenderBlock (relative positioned) {DIV} at (0,18) size 106x106 [border: (3px solid #000000)]
-layer at (8,150) size 106x106 clip at (26,153) size 85x85 scrollX 136 scrollWidth 221 scrollHeight 268
+layer at (8,150) size 106x106 clip at (26,153) size 85x85 scrollX 121 scrollWidth 206 scrollHeight 268
   RenderBlock (relative positioned) {DIV} at (0,142) size 106x106 [border: (3px solid #000000)]

--- a/LayoutTests/platform/ios/fast/overflow/unreachable-overflow-rtl-bug-expected.txt
+++ b/LayoutTests/platform/ios/fast/overflow/unreachable-overflow-rtl-bug-expected.txt
@@ -9,7 +9,7 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,126) size 784x20
         RenderText {#text} at (0,0) size 34x19
           text run at (0,0) width 34: "RTL:"
-layer at (8,28) size 106x106 clip at (11,31) size 100x100 scrollWidth 221 scrollHeight 270
+layer at (8,28) size 106x106 clip at (11,31) size 85x85 scrollWidth 221 scrollHeight 270
   RenderBlock (relative positioned) {DIV} at (0,20) size 106x106 [border: (3px solid #000000)]
-layer at (8,154) size 106x106 clip at (11,157) size 100x100 scrollX 121 scrollWidth 221 scrollHeight 270
+layer at (8,154) size 106x106 clip at (11,157) size 85x85 scrollX 121 scrollWidth 206 scrollHeight 270
   RenderBlock (relative positioned) {DIV} at (0,146) size 106x106 [border: (3px solid #000000)]

--- a/LayoutTests/platform/mac/fast/overflow/unreachable-overflow-rtl-bug-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/unreachable-overflow-rtl-bug-expected.txt
@@ -11,5 +11,5 @@ layer at (0,0) size 800x600
           text run at (0,0) width 34: "RTL:"
 layer at (8,26) size 106x106 clip at (11,29) size 85x85 scrollWidth 221 scrollHeight 268
   RenderBlock (relative positioned) {DIV} at (0,18) size 106x106 [border: (3px solid #000000)]
-layer at (8,150) size 106x106 clip at (26,153) size 85x85 scrollX 136 scrollWidth 221 scrollHeight 268
+layer at (8,150) size 106x106 clip at (26,153) size 85x85 scrollX 121 scrollWidth 206 scrollHeight 268
   RenderBlock (relative positioned) {DIV} at (0,142) size 106x106 [border: (3px solid #000000)]

--- a/LayoutTests/scrollbars/rtl/div-absolute.html
+++ b/LayoutTests/scrollbars/rtl/div-absolute.html
@@ -1,34 +1,30 @@
 <!DOCTYPE html>
-<html>
-<head>
-<title>Bug 91756</title>
-<script src="../../resources/js-test-pre.js"></script>
+<title>Bug 91756: Test if the widths of RTL elements are the same as the widths of the LTR elements when they include absolutely-positioned children.</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
 <style>
 div.outer { overflow: auto; width: 100px; position: relative; height: 100px; border: solid; }
 div.inner { position: absolute; top: 250px; }
 </style>
-</head>
 <body>
 <div id="outerLTR" class="outer"><div id="innerLTR" class="inner" style="left: 200px;">foo</div></div>
 <div id="outerRTL" class="outer" style="direction: rtl;"><div id="innerRTL" class="inner" style="right: 200px;">foo</div>
 </div>
-<script type="text/javascript">
-description('Test if the widths of RTL elements are the same as the widths of the LTR elements when they include absolutely-positioned children.');
+<script>
+test(function() {
+    // Verify the widths of the outer RTL element are the same as the widths of the outer LTR element.
+    var outerLTR = document.getElementById("outerLTR");
+    var outerRTL = document.getElementById("outerRTL");
+    assert_equals(outerLTR.offsetWidth, outerRTL.offsetWidth);
+    assert_equals(outerLTR.clientWidth, outerRTL.clientWidth);
+    assert_equals(outerLTR.scrollWidth, outerRTL.scrollWidth);
 
-debug('Verify the widths of the outer RTL element are the same as the widths of the outer LTR element.');
-var outerLTR = document.getElementById('outerLTR');
-var outerRTL = document.getElementById('outerRTL');
-shouldBeTrue('outerLTR.offsetWidth == outerRTL.offsetWidth');
-shouldBeTrue('outerLTR.clientWidth == outerRTL.clientWidth');
-shouldBeTrue('outerLTR.scrollWidth ==  outerRTL.scrollWidth');
-
-debug('Verify the widths of the inner RTL element are the same as the widths of the inner LTR element.');
-var innerLTR = document.getElementById('innerLTR');
-var innerRTL = document.getElementById('innerRTL');
-shouldBeTrue('innerLTR.offsetWidth == innerRTL.offsetWidth');
-shouldBeTrue('innerLTR.clientWidth == innerRTL.clientWidth');
-shouldBeTrue('innerLTR.scrollWidth ==  innerRTL.scrollWidth');
+    // Verify the widths of the inner RTL element are the same as the widths of the inner LTR element.
+    var innerLTR = document.getElementById("innerLTR");
+    var innerRTL = document.getElementById("innerRTL");
+    assert_equals(innerLTR.offsetWidth, innerRTL.offsetWidth);
+    assert_equals(innerLTR.clientWidth, innerRTL.clientWidth);
+    assert_equals(innerLTR.scrollWidth, innerRTL.scrollWidth);
+    });
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
-</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4220,6 +4220,9 @@ void RenderBox::computePositionedLogicalWidthUsing(SizeType widthType, Length lo
         }
     }
 
+    if (containerBlock.isBox() && downcast<RenderBox>(containerBlock).scrollsOverflowY() && containerBlock.style().shouldPlaceVerticalScrollbarOnLeft())
+        logicalLeftValue = logicalLeftValue + downcast<RenderBox>(containerBlock).verticalScrollbarWidth();
+
     computedValues.m_position = logicalLeftValue + marginLogicalLeftValue;
     computeLogicalLeftPositionedOffset(computedValues.m_position, this, computedValues.m_extent + bordersPlusPadding, containerBlock, containerLogicalWidth, style().logicalLeft().isAuto(), style().logicalRight().isAuto());
 }


### PR DESCRIPTION
<pre>
Improve the logic in WebCore::scrollOffsetForFixedPosition()

<a href="https://bugs.webkit.org/show_bug.cgi?id=108323">https://bugs.webkit.org/show_bug.cgi?id=108323</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=158423">https://src.chromium.org/viewvc/blink?view=revision&revision=158423</a>

Positioned elements should consider verticalScrollWidth while calculating position if shouldPlaceVerticalScrollbarOnLeft() is true.

* Source/WebCore/rendering/RenderBox.cpp:
(RenderBox::computePositionedLogicalWidthUsing): Updated to account for verticalScrollWidth to address "Position absolute is not working properly in RTL mode for vertical scroll contents"

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8650e709cdc67a8e75ccfcd9032173ba41726a2f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99400 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156905 "Found 1 new test failure: scrollbars/rtl/div-absolute.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33115 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28477 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82407 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93696 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95725 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26327 "Found 2 new test failures: fast/overflow/unreachable-overflow-rtl-bug.html, scrollbars/rtl/div-absolute.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76881 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26224 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-inline-block.html, scrollbars/rtl/div-absolute.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80970 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69225 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34298 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15051 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-inline-block.html, scrollbars/rtl/div-absolute.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32139 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15993 "Found 3 new test failures: compositing/scrolling/async-overflow-scrolling/position-inside-rtl-overflow.html, imported/w3c/web-platform-tests/css/css-scroll-snap/snap-inline-block.html, scrollbars/rtl/div-absolute.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/35883 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38960 "Found 3 new test failures: compositing/scrolling/async-overflow-scrolling/position-inside-rtl-overflow.html, imported/w3c/web-platform-tests/css/css-scroll-snap/snap-inline-block.html, scrollbars/rtl/div-absolute.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35077 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->