### PR TITLE
DOMCache should use ObjectIdentifier

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -148,6 +148,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/cache/CacheQueryOptions.h
     Modules/cache/CacheStorageConnection.h
     Modules/cache/DOMCacheEngine.h
+    Modules/cache/DOMCacheIdentifier.h
     Modules/cache/RetrieveRecordsOptions.h
 
     Modules/compression/CompressionStreamEncoder.h

--- a/Source/WebCore/Modules/cache/CacheStorageConnection.cpp
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2017 Apple Inc. All rights reserved.
  *

--- a/Source/WebCore/Modules/cache/CacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.h
@@ -41,15 +41,15 @@ public:
     virtual ~CacheStorageConnection() = default;
 
     virtual void open(const ClientOrigin&, const String& cacheName, DOMCacheEngine::CacheIdentifierCallback&&) = 0;
-    virtual void remove(uint64_t cacheIdentifier, DOMCacheEngine::CacheIdentifierCallback&&) = 0;
+    virtual void remove(DOMCacheIdentifier, DOMCacheEngine::RemoveCacheIdentifierCallback&&) = 0;
     virtual void retrieveCaches(const ClientOrigin&, uint64_t updateCounter, DOMCacheEngine::CacheInfosCallback&&) = 0;
 
-    virtual void retrieveRecords(uint64_t cacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::RecordsCallback&&) = 0;
-    virtual void batchDeleteOperation(uint64_t cacheIdentifier, const ResourceRequest&, CacheQueryOptions&&, DOMCacheEngine::RecordIdentifiersCallback&&) = 0;
-    virtual void batchPutOperation(uint64_t cacheIdentifier, Vector<DOMCacheEngine::Record>&&, DOMCacheEngine::RecordIdentifiersCallback&&) = 0;
+    virtual void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::RecordsCallback&&) = 0;
+    virtual void batchDeleteOperation(DOMCacheIdentifier, const ResourceRequest&, CacheQueryOptions&&, DOMCacheEngine::RecordIdentifiersCallback&&) = 0;
+    virtual void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::Record>&&, DOMCacheEngine::RecordIdentifiersCallback&&) = 0;
 
-    virtual void reference(uint64_t /* cacheIdentifier */) = 0;
-    virtual void dereference(uint64_t /* cacheIdentifier */) = 0;
+    virtual void reference(DOMCacheIdentifier /* cacheIdentifier */) = 0;
+    virtual void dereference(DOMCacheIdentifier /* cacheIdentifier */) = 0;
 
     uint64_t computeRecordBodySize(const FetchResponse&, const DOMCacheEngine::ResponseBody&);
 

--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -40,14 +40,14 @@
 namespace WebCore {
 using namespace WebCore::DOMCacheEngine;
 
-Ref<DOMCache> DOMCache::create(ScriptExecutionContext& context, String&& name, uint64_t identifier, Ref<CacheStorageConnection>&& connection)
+Ref<DOMCache> DOMCache::create(ScriptExecutionContext& context, String&& name, DOMCacheIdentifier identifier, Ref<CacheStorageConnection>&& connection)
 {
     auto cache = adoptRef(*new DOMCache(context, WTFMove(name), identifier, WTFMove(connection)));
     cache->suspendIfNeeded();
     return cache;
 }
 
-DOMCache::DOMCache(ScriptExecutionContext& context, String&& name, uint64_t identifier, Ref<CacheStorageConnection>&& connection)
+DOMCache::DOMCache(ScriptExecutionContext& context, String&& name, DOMCacheIdentifier identifier, Ref<CacheStorageConnection>&& connection)
     : ActiveDOMObject(&context)
     , m_name(WTFMove(name))
     , m_identifier(identifier)

--- a/Source/WebCore/Modules/cache/DOMCache.h
+++ b/Source/WebCore/Modules/cache/DOMCache.h
@@ -37,7 +37,7 @@ class ScriptExecutionContext;
 
 class DOMCache final : public RefCounted<DOMCache>, public ActiveDOMObject {
 public:
-    static Ref<DOMCache> create(ScriptExecutionContext&, String&&, uint64_t, Ref<CacheStorageConnection>&&);
+    static Ref<DOMCache> create(ScriptExecutionContext&, String&&, DOMCacheIdentifier, Ref<CacheStorageConnection>&&);
     ~DOMCache();
 
     using RequestInfo = FetchRequest::Info;
@@ -56,7 +56,7 @@ public:
     void keys(std::optional<RequestInfo>&&, CacheQueryOptions&&, KeysPromise&&);
 
     const String& name() const { return m_name; }
-    uint64_t identifier() const { return m_identifier; }
+    DOMCacheIdentifier identifier() const { return m_identifier; }
 
     using MatchCallback = CompletionHandler<void(ExceptionOr<RefPtr<FetchResponse>>)>;
     void doMatch(RequestInfo&&, CacheQueryOptions&&, MatchCallback&&);
@@ -64,7 +64,7 @@ public:
     CacheStorageConnection& connection() { return m_connection.get(); }
 
 private:
-    DOMCache(ScriptExecutionContext&, String&& name, uint64_t identifier, Ref<CacheStorageConnection>&&);
+    DOMCache(ScriptExecutionContext&, String&& name, DOMCacheIdentifier, Ref<CacheStorageConnection>&&);
 
     ExceptionOr<Ref<FetchRequest>> requestFromInfo(RequestInfo&&, bool ignoreMethod);
 
@@ -86,7 +86,7 @@ private:
     DOMCacheEngine::Record toConnectionRecord(const FetchRequest&, FetchResponse&, DOMCacheEngine::ResponseBody&&);
 
     String m_name;
-    uint64_t m_identifier;
+    DOMCacheIdentifier m_identifier;
     Ref<CacheStorageConnection> m_connection;
 
     bool m_isStopped { false };

--- a/Source/WebCore/Modules/cache/DOMCacheEngine.h
+++ b/Source/WebCore/Modules/cache/DOMCacheEngine.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "DOMCacheIdentifier.h"
 #include "FetchHeaders.h"
 #include "FetchOptions.h"
 #include "ResourceRequest.h"
@@ -80,7 +81,7 @@ struct Record {
 };
 
 struct CacheInfo {
-    uint64_t identifier;
+    DOMCacheIdentifier identifier;
     String name;
 
     CacheInfo isolatedCopy() const & { return { identifier, name.isolatedCopy() }; }
@@ -102,13 +103,16 @@ struct CacheIdentifierOperationResult {
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<CacheIdentifierOperationResult> decode(Decoder&);
 
-    uint64_t identifier { 0 };
+    DOMCacheIdentifier identifier;
     // True in case storing cache list on the filesystem failed.
     bool hadStorageError { false };
 };
 
 using CacheIdentifierOrError = Expected<CacheIdentifierOperationResult, Error>;
 using CacheIdentifierCallback = CompletionHandler<void(const CacheIdentifierOrError&)>;
+
+using RemoveCacheIdentifierOrError = Expected<bool, Error>;
+using RemoveCacheIdentifierCallback = CompletionHandler<void(const RemoveCacheIdentifierOrError&)>;
 
 using RecordIdentifiersOrError = Expected<Vector<uint64_t>, Error>;
 using RecordIdentifiersCallback = CompletionHandler<void(RecordIdentifiersOrError&&)>;
@@ -151,7 +155,7 @@ template<class Encoder> inline void CacheIdentifierOperationResult::encode(Encod
 
 template<class Decoder> inline std::optional<CacheIdentifierOperationResult> CacheIdentifierOperationResult::decode(Decoder& decoder)
 {
-    std::optional<uint64_t> identifier;
+    std::optional<DOMCacheIdentifier> identifier;
     decoder >> identifier;
     if (!identifier)
         return std::nullopt;

--- a/Source/WebCore/Modules/cache/DOMCacheIdentifier.h
+++ b/Source/WebCore/Modules/cache/DOMCacheIdentifier.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ObjectIdentifier.h>
+
+namespace WebCore {
+
+enum DOMCacheIdentifierType { };
+using DOMCacheIdentifier = ObjectIdentifier<DOMCacheIdentifierType>;
+
+}

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
@@ -238,14 +238,11 @@ void DOMCacheStorage::doRemove(const String& name, DOMPromiseDeferred<IDLBoolean
         return;
     }
 
-    m_connection->remove(m_caches[position]->identifier(), [this, name, promise = WTFMove(promise), pendingActivity = makePendingActivity(*this)](const DOMCacheEngine::CacheIdentifierOrError& result) mutable {
+    m_connection->remove(m_caches[position]->identifier(), [this, name, promise = WTFMove(promise), pendingActivity = makePendingActivity(*this)](const auto& result) mutable {
         if (!result.has_value())
             promise.reject(DOMCacheEngine::convertToExceptionAndLog(scriptExecutionContext(), result.error()));
-        else {
-            if (result.value().hadStorageError)
-                logConsolePersistencyError(scriptExecutionContext(), name);
-            promise.resolve(!!result.value().identifier);
-        }
+        else
+            promise.resolve(result.value());
     });
 }
 

--- a/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
@@ -47,15 +47,15 @@ private:
 
     // WebCore::CacheStorageConnection.
     void open(const ClientOrigin&, const String& cacheName, DOMCacheEngine::CacheIdentifierCallback&&) final;
-    void remove(uint64_t cacheIdentifier, DOMCacheEngine::CacheIdentifierCallback&&) final;
+    void remove(DOMCacheIdentifier, DOMCacheEngine::RemoveCacheIdentifierCallback&&) final;
     void retrieveCaches(const ClientOrigin&, uint64_t updateCounter, DOMCacheEngine::CacheInfosCallback&&) final;
 
-    void retrieveRecords(uint64_t cacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::RecordsCallback&&) final;
-    void batchDeleteOperation(uint64_t cacheIdentifier, const ResourceRequest&, CacheQueryOptions&&, DOMCacheEngine::RecordIdentifiersCallback&&) final;
-    void batchPutOperation(uint64_t cacheIdentifier, Vector<DOMCacheEngine::Record>&&, DOMCacheEngine::RecordIdentifiersCallback&&) final;
+    void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::RecordsCallback&&) final;
+    void batchDeleteOperation(DOMCacheIdentifier, const ResourceRequest&, CacheQueryOptions&&, DOMCacheEngine::RecordIdentifiersCallback&&) final;
+    void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::Record>&&, DOMCacheEngine::RecordIdentifiersCallback&&) final;
 
-    void reference(uint64_t cacheIdentifier) final;
-    void dereference(uint64_t cacheIdentifier) final;
+    void reference(DOMCacheIdentifier) final;
+    void dereference(DOMCacheIdentifier) final;
 
     void doOpen(uint64_t requestIdentifier, const ClientOrigin&, const String& cacheName);
     void doRemove(uint64_t requestIdentifier, uint64_t cacheIdentifier);
@@ -64,7 +64,8 @@ private:
     void doBatchDeleteOperation(uint64_t requestIdentifier, uint64_t cacheIdentifier, const WebCore::ResourceRequest&, WebCore::CacheQueryOptions&&);
     void doBatchPutOperation(uint64_t requestIdentifier, uint64_t cacheIdentifier, Vector<DOMCacheEngine::Record>&&);
 
-    void openOrRemoveCompleted(uint64_t requestIdentifier, const DOMCacheEngine::CacheIdentifierOrError&);
+    void openCompleted(uint64_t requestIdentifier, const DOMCacheEngine::CacheIdentifierOrError&);
+    void removeCompleted(uint64_t requestIdentifier, const DOMCacheEngine::RemoveCacheIdentifierOrError&);
     void retrieveCachesCompleted(uint64_t requestIdentifier, DOMCacheEngine::CacheInfosOrError&&);
     void retrieveRecordsCompleted(uint64_t requestIdentifier, DOMCacheEngine::RecordsOrError&&);
     void deleteRecordsCompleted(uint64_t requestIdentifier, DOMCacheEngine::RecordIdentifiersOrError&&);
@@ -74,7 +75,8 @@ private:
 
     Ref<CacheStorageConnection> m_mainThreadConnection;
 
-    HashMap<uint64_t, DOMCacheEngine::CacheIdentifierCallback> m_openAndRemoveCachePendingRequests;
+    HashMap<uint64_t, DOMCacheEngine::CacheIdentifierCallback> m_openCachePendingRequests;
+    HashMap<uint64_t, DOMCacheEngine::RemoveCacheIdentifierCallback> m_removeCachePendingRequests;
     HashMap<uint64_t, DOMCacheEngine::CacheInfosCallback> m_retrieveCachesPendingRequests;
     HashMap<uint64_t, DOMCacheEngine::RecordsCallback> m_retrieveRecordsPendingRequests;
     HashMap<uint64_t, DOMCacheEngine::RecordIdentifiersCallback> m_batchDeleteAndPutPendingRequests;

--- a/Source/WebCore/page/CacheStorageProvider.h
+++ b/Source/WebCore/page/CacheStorageProvider.h
@@ -42,13 +42,13 @@ public:
         }
 
         void open(const ClientOrigin&, const String&, DOMCacheEngine::CacheIdentifierCallback&&) final { }
-        void remove(uint64_t, DOMCacheEngine::CacheIdentifierCallback&&) final { }
+        void remove(DOMCacheIdentifier, DOMCacheEngine::RemoveCacheIdentifierCallback&&) final { }
         void retrieveCaches(const ClientOrigin&, uint64_t, DOMCacheEngine::CacheInfosCallback&&) final { }
-        void retrieveRecords(uint64_t, RetrieveRecordsOptions&&, DOMCacheEngine::RecordsCallback&&) final { }
-        void batchDeleteOperation(uint64_t, const ResourceRequest&, CacheQueryOptions&&, DOMCacheEngine::RecordIdentifiersCallback&&) final { }
-        void batchPutOperation(uint64_t, Vector<DOMCacheEngine::Record>&&, DOMCacheEngine::RecordIdentifiersCallback&&) final { }
-        void reference(uint64_t) final { }
-        void dereference(uint64_t) final { }
+        void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::RecordsCallback&&) final { }
+        void batchDeleteOperation(DOMCacheIdentifier, const ResourceRequest&, CacheQueryOptions&&, DOMCacheEngine::RecordIdentifiersCallback&&) final { }
+        void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::Record>&&, DOMCacheEngine::RecordIdentifiersCallback&&) final { }
+        void reference(DOMCacheIdentifier) final { }
+        void dereference(DOMCacheIdentifier) final { }
     };
 
     static Ref<CacheStorageProvider> create() { return adoptRef(*new CacheStorageProvider); }

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngine.cpp
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngine.cpp
@@ -98,7 +98,7 @@ void Engine::open(NetworkSession& networkSession, WebCore::ClientOrigin&& origin
     networkSession.ensureCacheEngine().open(origin, cacheName, WTFMove(callback));
 }
 
-void Engine::remove(NetworkSession& networkSession, uint64_t cacheIdentifier, WebCore::DOMCacheEngine::CacheIdentifierCallback&& callback)
+void Engine::remove(NetworkSession& networkSession, WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&& callback)
 {
     networkSession.ensureCacheEngine().remove(cacheIdentifier, WTFMove(callback));
 }
@@ -108,27 +108,27 @@ void Engine::retrieveCaches(NetworkSession& networkSession, WebCore::ClientOrigi
     networkSession.ensureCacheEngine().retrieveCaches(origin, updateCounter, WTFMove(callback));
 }
 
-void Engine::retrieveRecords(NetworkSession& networkSession, uint64_t cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::RecordsCallback&& callback)
+void Engine::retrieveRecords(NetworkSession& networkSession, WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::RecordsCallback&& callback)
 {
     networkSession.ensureCacheEngine().retrieveRecords(cacheIdentifier, WTFMove(options), WTFMove(callback));
 }
 
-void Engine::putRecords(NetworkSession& networkSession, uint64_t cacheIdentifier, Vector<WebCore::DOMCacheEngine::Record>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+void Engine::putRecords(NetworkSession& networkSession, WebCore::DOMCacheIdentifier cacheIdentifier, Vector<WebCore::DOMCacheEngine::Record>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     networkSession.ensureCacheEngine().putRecords(cacheIdentifier, WTFMove(records), WTFMove(callback));
 }
 
-void Engine::deleteMatchingRecords(NetworkSession& networkSession, uint64_t cacheIdentifier, WebCore::ResourceRequest&& request, WebCore::CacheQueryOptions&& options, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+void Engine::deleteMatchingRecords(NetworkSession& networkSession, WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::ResourceRequest&& request, WebCore::CacheQueryOptions&& options, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     networkSession.ensureCacheEngine().deleteMatchingRecords(cacheIdentifier, WTFMove(request), WTFMove(options), WTFMove(callback));
 }
 
-void Engine::lock(NetworkSession& networkSession, uint64_t cacheIdentifier)
+void Engine::lock(NetworkSession& networkSession, WebCore::DOMCacheIdentifier cacheIdentifier)
 {
     networkSession.ensureCacheEngine().lock(cacheIdentifier);
 }
 
-void Engine::unlock(NetworkSession& networkSession, uint64_t cacheIdentifier)
+void Engine::unlock(NetworkSession& networkSession, WebCore::DOMCacheIdentifier cacheIdentifier)
 {
     networkSession.ensureCacheEngine().unlock(cacheIdentifier);
 }
@@ -242,7 +242,7 @@ void Engine::open(const WebCore::ClientOrigin& origin, const String& cacheName, 
     });
 }
 
-void Engine::remove(uint64_t cacheIdentifier, CacheIdentifierCallback&& callback)
+void Engine::remove(WebCore::DOMCacheIdentifier cacheIdentifier, RemoveCacheIdentifierCallback&& callback)
 {
     Caches* cachesToModify = nullptr;
     for (auto& caches : m_caches.values()) {
@@ -272,7 +272,7 @@ void Engine::retrieveCaches(const WebCore::ClientOrigin& origin, uint64_t update
     });
 }
 
-void Engine::retrieveRecords(uint64_t cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, RecordsCallback&& callback)
+void Engine::retrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, RecordsCallback&& callback)
 {
     readCache(cacheIdentifier, [options = WTFMove(options), callback = WTFMove(callback)](CacheOrError&& result) mutable {
         if (!result.has_value()) {
@@ -283,7 +283,7 @@ void Engine::retrieveRecords(uint64_t cacheIdentifier, WebCore::RetrieveRecordsO
     });
 }
 
-void Engine::putRecords(uint64_t cacheIdentifier, Vector<Record>&& records, RecordIdentifiersCallback&& callback)
+void Engine::putRecords(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<Record>&& records, RecordIdentifiersCallback&& callback)
 {
     readCache(cacheIdentifier, [records = WTFMove(records), callback = WTFMove(callback)](CacheOrError&& result) mutable {
         if (!result.has_value()) {
@@ -295,7 +295,7 @@ void Engine::putRecords(uint64_t cacheIdentifier, Vector<Record>&& records, Reco
     });
 }
 
-void Engine::deleteMatchingRecords(uint64_t cacheIdentifier, WebCore::ResourceRequest&& request, WebCore::CacheQueryOptions&& options, RecordIdentifiersCallback&& callback)
+void Engine::deleteMatchingRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::ResourceRequest&& request, WebCore::CacheQueryOptions&& options, RecordIdentifiersCallback&& callback)
 {
     readCache(cacheIdentifier, [request = WTFMove(request), options = WTFMove(options), callback = WTFMove(callback)](CacheOrError&& result) mutable {
         if (!result.has_value()) {
@@ -376,7 +376,7 @@ void Engine::readCachesFromDisk(const WebCore::ClientOrigin& origin, CachesCallb
     });
 }
 
-void Engine::readCache(uint64_t cacheIdentifier, CacheCallback&& callback)
+void Engine::readCache(WebCore::DOMCacheIdentifier cacheIdentifier, CacheCallback&& callback)
 {
     auto* cache = this->cache(cacheIdentifier);
     if (!cache) {
@@ -403,7 +403,7 @@ void Engine::readCache(uint64_t cacheIdentifier, CacheCallback&& callback)
     callback(std::reference_wrapper<Cache> { *cache });
 }
 
-Cache* Engine::cache(uint64_t cacheIdentifier)
+Cache* Engine::cache(WebCore::DOMCacheIdentifier cacheIdentifier)
 {
     Cache* result = nullptr;
     for (auto& caches : m_caches.values()) {
@@ -723,7 +723,7 @@ void Engine::clearMemoryRepresentation(const WebCore::ClientOrigin& origin, WebC
     });
 }
 
-void Engine::lock(uint64_t cacheIdentifier)
+void Engine::lock(CacheIdentifier cacheIdentifier)
 {
     auto& counter = m_cacheLocks.ensure(cacheIdentifier, []() {
         return 0;
@@ -732,7 +732,7 @@ void Engine::lock(uint64_t cacheIdentifier)
     ++counter;
 }
 
-void Engine::unlock(uint64_t cacheIdentifier)
+void Engine::unlock(CacheIdentifier cacheIdentifier)
 {
     auto lockCount = m_cacheLocks.find(cacheIdentifier);
     if (lockCount == m_cacheLocks.end())

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp
@@ -107,7 +107,7 @@ RecordInformation Cache::toRecordInformation(const Record& record)
     return recordInformation;
 }
 
-Cache::Cache(Caches& caches, uint64_t identifier, State state, String&& name, String&& uniqueName)
+Cache::Cache(Caches& caches, DOMCacheIdentifier identifier, State state, String&& name, String&& uniqueName)
     : m_caches(caches)
     , m_state(state)
     , m_identifier(identifier)
@@ -134,7 +134,7 @@ RecordInformation RecordInformation::isolatedCopy() &&
 }
 
 struct TraversalResult {
-    uint64_t cacheIdentifier;
+    WebCore::DOMCacheIdentifier cacheIdentifier;
     HashMap<String, Vector<RecordInformation>> records;
     Vector<Key> failedRecords;
 

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.h
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.h
@@ -62,12 +62,12 @@ class ReadRecordTaskCounter;
 class Cache {
 public:
     enum class State { Uninitialized, Opening, Open };
-    Cache(Caches&, uint64_t identifier, State, String&& name, String&& uniqueName);
+    Cache(Caches&, WebCore::DOMCacheIdentifier, State, String&& name, String&& uniqueName);
 
     bool isOpened() const { return m_state == State::Open; }
     void open(WebCore::DOMCacheEngine::CompletionCallback&&);
 
-    uint64_t identifier() const { return m_identifier; }
+    WebCore::DOMCacheIdentifier identifier() const { return m_identifier; }
     const String& name() const { return m_name; }
     const String& uniqueName() const { return m_uniqueName; }
     bool isActive() const { return m_state != State::Uninitialized; }
@@ -122,7 +122,7 @@ private:
 
     Caches& m_caches;
     State m_state;
-    uint64_t m_identifier { 0 };
+    WebCore::DOMCacheIdentifier m_identifier;
     String m_name;
     String m_uniqueName;
     HashMap<String, Vector<RecordInformation>> m_records;

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCaches.cpp
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCaches.cpp
@@ -286,7 +286,7 @@ Cache* Caches::find(const String& name)
     return (position != notFound) ? &m_caches[position] : nullptr;
 }
 
-Cache* Caches::find(uint64_t identifier)
+Cache* Caches::find(WebCore::DOMCacheIdentifier identifier)
 {
     auto position = m_caches.findIf([&](const auto& item) { return item.identifier() == identifier; });
     if (position != notFound)
@@ -325,7 +325,7 @@ void Caches::open(const String& name, CacheIdentifierCallback&& callback)
 
     makeDirty();
 
-    uint64_t cacheIdentifier = m_engine->nextCacheIdentifier();
+    auto cacheIdentifier = WebCore::DOMCacheIdentifier::generate();
     m_caches.append(Cache { *this, cacheIdentifier, Cache::State::Open, String { name }, createVersion4UUIDString() });
 
     writeCachesToDisk([callback = WTFMove(callback), cacheIdentifier](std::optional<Error>&& error) mutable {
@@ -333,7 +333,7 @@ void Caches::open(const String& name, CacheIdentifierCallback&& callback)
     });
 }
 
-void Caches::remove(uint64_t identifier, CacheIdentifierCallback&& callback)
+void Caches::remove(WebCore::DOMCacheIdentifier identifier, RemoveCacheIdentifierCallback&& callback)
 {
     ASSERT(m_isInitialized);
     ASSERT(m_engine);
@@ -353,7 +353,7 @@ void Caches::remove(uint64_t identifier, CacheIdentifierCallback&& callback)
 
     if (position == notFound) {
         ASSERT(m_removedCaches.findIf([&](const auto& item) { return item.identifier() == identifier; }) != notFound);
-        callback(CacheIdentifierOperationResult { 0, false });
+        callback(false);
         return;
     }
 
@@ -362,8 +362,8 @@ void Caches::remove(uint64_t identifier, CacheIdentifierCallback&& callback)
     m_removedCaches.append(WTFMove(m_caches[position]));
     m_caches.remove(position);
 
-    writeCachesToDisk([callback = WTFMove(callback), identifier](std::optional<Error>&& error) mutable {
-        callback(CacheIdentifierOperationResult { identifier, !!error });
+    writeCachesToDisk([callback = WTFMove(callback)](std::optional<Error>&&) mutable {
+        callback(true);
     });
 }
 
@@ -473,7 +473,7 @@ void Caches::readCachesFromDisk(WTF::Function<void(Expected<Vector<Cache>, Error
             return;
         }
         callback(WTF::map(WTFMove(result.value()), [this] (auto&& pair) {
-            return Cache { *this, m_engine->nextCacheIdentifier(), Cache::State::Uninitialized, WTFMove(pair.first), WTFMove(pair.second) };
+            return Cache { *this, WebCore::DOMCacheIdentifier::generate(), Cache::State::Uninitialized, WTFMove(pair.first), WTFMove(pair.second) };
         }));
     });
 }

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCaches.h
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCaches.h
@@ -51,7 +51,7 @@ public:
 
     void initialize(WebCore::DOMCacheEngine::CompletionCallback&&);
     void open(const String& name, WebCore::DOMCacheEngine::CacheIdentifierCallback&&);
-    void remove(uint64_t identifier, WebCore::DOMCacheEngine::CacheIdentifierCallback&&);
+    void remove(WebCore::DOMCacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&&);
     void dispose(Cache&);
 
     void detach();
@@ -59,7 +59,7 @@ public:
     bool isInitialized() const { return m_isInitialized; }
     void cacheInfos(uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&);
 
-    Cache* find(uint64_t identifier);
+    Cache* find(WebCore::DOMCacheIdentifier);
     void appendRepresentation(StringBuilder&) const;
 
     void readRecordsList(Cache&, NetworkCache::Storage::TraverseHandler&&);

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineConnection.cpp
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineConnection.cpp
@@ -68,20 +68,20 @@ void CacheStorageEngineConnection::open(WebCore::ClientOrigin&& origin, String&&
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
 
     Engine::open(*session, WTFMove(origin), WTFMove(cacheName), [callback = WTFMove(callback), sessionID = this->sessionID()](auto& result) mutable {
-        CACHE_STORAGE_RELEASE_LOG_FUNCTION_IN_CALLBACK("open", "cache identifier is %" PRIu64, [](const auto& value) { return value.identifier; });
+        CACHE_STORAGE_RELEASE_LOG_FUNCTION_IN_CALLBACK("open", "cache identifier is %" PRIu64, [](const auto& value) { return value.identifier.toUInt64(); });
         callback(result);
     });
 }
 
-void CacheStorageEngineConnection::remove(uint64_t cacheIdentifier, CacheIdentifierCallback&& callback)
+void CacheStorageEngineConnection::remove(WebCore::DOMCacheIdentifier cacheIdentifier, RemoveCacheIdentifierCallback&& callback)
 {
-    CACHE_STORAGE_RELEASE_LOG("remove cache %" PRIu64, cacheIdentifier);
+    CACHE_STORAGE_RELEASE_LOG("remove cache %" PRIu64, cacheIdentifier.toUInt64());
     auto* session = m_connection.networkSession();
     if (!session)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
 
     Engine::remove(*session, cacheIdentifier, [callback = WTFMove(callback), sessionID = this->sessionID()](auto& result) mutable {
-        CACHE_STORAGE_RELEASE_LOG_FUNCTION_IN_CALLBACK("remove", "removed cache %" PRIu64, [](const auto& value) { return value.identifier; });
+        CACHE_STORAGE_RELEASE_LOG_FUNCTION_IN_CALLBACK("caches", "removed cache %d", [](const auto& value) { return value; });
         callback(result);
     });
 }
@@ -99,9 +99,9 @@ void CacheStorageEngineConnection::caches(WebCore::ClientOrigin&& origin, uint64
     });
 }
 
-void CacheStorageEngineConnection::retrieveRecords(uint64_t cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, RecordsCallback&& callback)
+void CacheStorageEngineConnection::retrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, RecordsCallback&& callback)
 {
-    CACHE_STORAGE_RELEASE_LOG("retrieveRecords in cache %" PRIu64, cacheIdentifier);
+    CACHE_STORAGE_RELEASE_LOG("retrieveRecords in cache %" PRIu64, cacheIdentifier.toUInt64());
     auto* session = m_connection.networkSession();
     if (!session)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
@@ -112,9 +112,9 @@ void CacheStorageEngineConnection::retrieveRecords(uint64_t cacheIdentifier, Web
     });
 }
 
-void CacheStorageEngineConnection::deleteMatchingRecords(uint64_t cacheIdentifier, WebCore::ResourceRequest&& request, WebCore::CacheQueryOptions&& options, RecordIdentifiersCallback&& callback)
+void CacheStorageEngineConnection::deleteMatchingRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::ResourceRequest&& request, WebCore::CacheQueryOptions&& options, RecordIdentifiersCallback&& callback)
 {
-    CACHE_STORAGE_RELEASE_LOG("deleteMatchingRecords in cache %" PRIu64, cacheIdentifier);
+    CACHE_STORAGE_RELEASE_LOG("deleteMatchingRecords in cache %" PRIu64, cacheIdentifier.toUInt64());
     auto* session = m_connection.networkSession();
     if (!session)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
@@ -125,9 +125,9 @@ void CacheStorageEngineConnection::deleteMatchingRecords(uint64_t cacheIdentifie
     });
 }
 
-void CacheStorageEngineConnection::putRecords(uint64_t cacheIdentifier, Vector<Record>&& records, RecordIdentifiersCallback&& callback)
+void CacheStorageEngineConnection::putRecords(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<Record>&& records, RecordIdentifiersCallback&& callback)
 {
-    CACHE_STORAGE_RELEASE_LOG("putRecords in cache %" PRIu64 ", %lu records", cacheIdentifier, records.size());
+    CACHE_STORAGE_RELEASE_LOG("putRecords in cache %" PRIu64 ", %lu records", cacheIdentifier.toUInt64(), records.size());
     auto* session = m_connection.networkSession();
     if (!session)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
@@ -138,9 +138,9 @@ void CacheStorageEngineConnection::putRecords(uint64_t cacheIdentifier, Vector<R
     });
 }
 
-void CacheStorageEngineConnection::reference(uint64_t cacheIdentifier)
+void CacheStorageEngineConnection::reference(WebCore::DOMCacheIdentifier cacheIdentifier)
 {
-    CACHE_STORAGE_RELEASE_LOG("reference cache %" PRIu64, cacheIdentifier);
+    CACHE_STORAGE_RELEASE_LOG("reference cache %" PRIu64, cacheIdentifier.toUInt64());
     auto* session = m_connection.networkSession();
     if (!session)
         return;
@@ -156,9 +156,9 @@ void CacheStorageEngineConnection::reference(uint64_t cacheIdentifier)
         Engine::lock(*session, cacheIdentifier);
 }
 
-void CacheStorageEngineConnection::dereference(uint64_t cacheIdentifier)
+void CacheStorageEngineConnection::dereference(WebCore::DOMCacheIdentifier cacheIdentifier)
 {
-    CACHE_STORAGE_RELEASE_LOG("dereference cache %" PRIu64, cacheIdentifier);
+    CACHE_STORAGE_RELEASE_LOG("dereference cache %" PRIu64, cacheIdentifier.toUInt64());
     auto* session = m_connection.networkSession();
     if (!session)
         return;

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineConnection.h
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineConnection.h
@@ -64,15 +64,15 @@ private:
     explicit CacheStorageEngineConnection(NetworkConnectionToWebProcess&);
 
     void open(WebCore::ClientOrigin&&, String&& cacheName, WebCore::DOMCacheEngine::CacheIdentifierCallback&&);
-    void remove(uint64_t cacheIdentifier, WebCore::DOMCacheEngine::CacheIdentifierCallback&&);
+    void remove(WebCore::DOMCacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&&);
     void caches(WebCore::ClientOrigin&&, uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&);
 
-    void retrieveRecords(uint64_t cacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::RecordsCallback&&);
-    void deleteMatchingRecords(uint64_t cacheIdentifier, WebCore::ResourceRequest&&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
-    void putRecords(uint64_t cacheIdentifier, Vector<WebCore::DOMCacheEngine::Record>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void retrieveRecords(WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::RecordsCallback&&);
+    void deleteMatchingRecords(WebCore::DOMCacheIdentifier, WebCore::ResourceRequest&&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void putRecords(WebCore::DOMCacheIdentifier, Vector<WebCore::DOMCacheEngine::Record>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
 
-    void reference(uint64_t cacheIdentifier);
-    void dereference(uint64_t cacheIdentifier);
+    void reference(WebCore::DOMCacheIdentifier);
+    void dereference(WebCore::DOMCacheIdentifier);
 
     void clearMemoryRepresentation(WebCore::ClientOrigin&&, CompletionHandler<void(std::optional<WebCore::DOMCacheEngine::Error>&&)>&&);
     void engineRepresentation( CompletionHandler<void(String&&)>&&);

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineConnection.messages.in
@@ -21,16 +21,16 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 messages -> CacheStorageEngineConnection {
-    Reference(uint64_t cacheIdentifier)
-    Dereference(uint64_t cacheIdentifier)
+    Reference(WebCore::DOMCacheIdentifier cacheIdentifier)
+    Dereference(WebCore::DOMCacheIdentifier cacheIdentifier)
 
     Open(struct WebCore::ClientOrigin origin, String cacheName) -> (WebCore::DOMCacheEngine::CacheIdentifierOrError result)
-    Remove(uint64_t cacheIdentifier) -> (WebCore::DOMCacheEngine::CacheIdentifierOrError result)
+    Remove(WebCore::DOMCacheIdentifier cacheIdentifier) -> (WebCore::DOMCacheEngine::RemoveCacheIdentifierOrError result)
     Caches(struct WebCore::ClientOrigin origin, uint64_t updateCounter) -> (WebCore::DOMCacheEngine::CacheInfosOrError result)
 
-    RetrieveRecords(uint64_t cacheIdentifier, struct WebCore::RetrieveRecordsOptions options) -> (WebCore::DOMCacheEngine::RecordsOrError result)
-    DeleteMatchingRecords(uint64_t cacheIdentifier, WebCore::ResourceRequest request, struct WebCore::CacheQueryOptions options) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
-    PutRecords(uint64_t cacheIdentifier, Vector<WebCore::DOMCacheEngine::Record> record) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
+    RetrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, struct WebCore::RetrieveRecordsOptions options) -> (WebCore::DOMCacheEngine::RecordsOrError result)
+    DeleteMatchingRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::ResourceRequest request, struct WebCore::CacheQueryOptions options) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
+    PutRecords(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<WebCore::DOMCacheEngine::Record> record) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
 
     ClearMemoryRepresentation(struct WebCore::ClientOrigin origin) -> (std::optional<WebCore::DOMCacheEngine::Error> error)
     EngineRepresentation() -> (String representation)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -258,6 +258,7 @@ def forward_declarations_for_namespace(namespace, kind_and_types):
 def serialized_identifiers():
     return [
         'WebCore::BroadcastChannelIdentifier',
+        'WebCore::DOMCacheIdentifier',
         'WebCore::DisplayList::ItemBufferIdentifier',
         'WebCore::FetchIdentifier',
         'WebCore::FileSystemHandleIdentifier',

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -69,6 +69,7 @@
 #include "WebPageProxyIdentifier.h"
 #include "WebURLSchemeHandlerIdentifier.h"
 #include <WebCore/BroadcastChannelIdentifier.h>
+#include <WebCore/DOMCacheIdentifier.h>
 #include <WebCore/DisplayList.h>
 #include <WebCore/FetchIdentifier.h>
 #include <WebCore/FileSystemHandleIdentifier.h>
@@ -370,6 +371,7 @@ std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject* global
 Vector<ASCIILiteral> serializedIdentifiers()
 {
     static_assert(sizeof(uint64_t) == sizeof(WebCore::BroadcastChannelIdentifier));
+    static_assert(sizeof(uint64_t) == sizeof(WebCore::DOMCacheIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::DisplayList::ItemBufferIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::FetchIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::FileSystemHandleIdentifier));
@@ -442,6 +444,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebURLSchemeHandlerIdentifier));
     return {
         "WebCore::BroadcastChannelIdentifier"_s,
+        "WebCore::DOMCacheIdentifier"_s,
         "WebCore::DisplayList::ItemBufferIdentifier"_s,
         "WebCore::FetchIdentifier"_s,
         "WebCore::FileSystemHandleIdentifier"_s,

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -22,7 +22,7 @@
 
 header: <WebCore/DOMCacheEngine.h>
 struct WebCore::DOMCacheEngine::CacheInfo {
-    uint64_t identifier
+    WebCore::DOMCacheIdentifier identifier
     String name
 }
 

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
@@ -67,7 +67,7 @@ void WebCacheStorageConnection::open(const WebCore::ClientOrigin& origin, const 
     connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::Open(origin, cacheName), WTFMove(newCallback));
 }
 
-void WebCacheStorageConnection::remove(uint64_t cacheIdentifier, WebCore::DOMCacheEngine::CacheIdentifierCallback&& callback)
+void WebCacheStorageConnection::remove(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&& callback)
 {
     connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::Remove(cacheIdentifier), WTFMove(callback));
 }
@@ -77,22 +77,22 @@ void WebCacheStorageConnection::retrieveCaches(const WebCore::ClientOrigin& orig
     connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::Caches(origin, updateCounter), WTFMove(callback));
 }
 
-void WebCacheStorageConnection::retrieveRecords(uint64_t cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::RecordsCallback&& callback)
+void WebCacheStorageConnection::retrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::RecordsCallback&& callback)
 {
     connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::RetrieveRecords(cacheIdentifier, options), WTFMove(callback));
 }
 
-void WebCacheStorageConnection::batchDeleteOperation(uint64_t cacheIdentifier, const WebCore::ResourceRequest& request, WebCore::CacheQueryOptions&& options, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+void WebCacheStorageConnection::batchDeleteOperation(WebCore::DOMCacheIdentifier cacheIdentifier, const WebCore::ResourceRequest& request, WebCore::CacheQueryOptions&& options, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::DeleteMatchingRecords(cacheIdentifier, request, options), WTFMove(callback));
 }
 
-void WebCacheStorageConnection::batchPutOperation(uint64_t cacheIdentifier, Vector<Record>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+void WebCacheStorageConnection::batchPutOperation(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<Record>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::PutRecords(cacheIdentifier, records), WTFMove(callback));
 }
 
-void WebCacheStorageConnection::reference(uint64_t cacheIdentifier)
+void WebCacheStorageConnection::reference(WebCore::DOMCacheIdentifier cacheIdentifier)
 {
     if (!m_connectedIdentifiers.contains(cacheIdentifier))
         return;
@@ -100,7 +100,7 @@ void WebCacheStorageConnection::reference(uint64_t cacheIdentifier)
     connection().send(Messages::CacheStorageEngineConnection::Reference(cacheIdentifier), 0);
 }
 
-void WebCacheStorageConnection::dereference(uint64_t cacheIdentifier)
+void WebCacheStorageConnection::dereference(WebCore::DOMCacheIdentifier cacheIdentifier)
 {
     if (!m_connectedIdentifiers.contains(cacheIdentifier))
         return;

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
@@ -54,22 +54,22 @@ private:
 
     // WebCore::CacheStorageConnection
     void open(const WebCore::ClientOrigin&, const String& cacheName, WebCore::DOMCacheEngine::CacheIdentifierCallback&&) final;
-    void remove(uint64_t cacheIdentifier, WebCore::DOMCacheEngine::CacheIdentifierCallback&&) final;
+    void remove(WebCore::DOMCacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&&) final;
     void retrieveCaches(const WebCore::ClientOrigin&, uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&) final;
 
-    void retrieveRecords(uint64_t cacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::RecordsCallback&&) final;
-    void batchDeleteOperation(uint64_t cacheIdentifier, const WebCore::ResourceRequest&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&) final;
-    void batchPutOperation(uint64_t cacheIdentifier, Vector<WebCore::DOMCacheEngine::Record>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&) final;
+    void retrieveRecords(WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::RecordsCallback&&) final;
+    void batchDeleteOperation(WebCore::DOMCacheIdentifier, const WebCore::ResourceRequest&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&) final;
+    void batchPutOperation(WebCore::DOMCacheIdentifier, Vector<WebCore::DOMCacheEngine::Record>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&) final;
 
-    void reference(uint64_t cacheIdentifier) final;
-    void dereference(uint64_t cacheIdentifier) final;
+    void reference(WebCore::DOMCacheIdentifier) final;
+    void dereference(WebCore::DOMCacheIdentifier) final;
 
     void clearMemoryRepresentation(const WebCore::ClientOrigin&, WebCore::DOMCacheEngine::CompletionCallback&&) final;
     void engineRepresentation(CompletionHandler<void(const String&)>&&) final;
     void updateQuotaBasedOnSpaceUsage(const WebCore::ClientOrigin&) final;
 
     WebCacheStorageProvider& m_provider;
-    HashSet<uint64_t> m_connectedIdentifiers;
+    HashSet<WebCore::DOMCacheIdentifier> m_connectedIdentifiers;
 };
 
 }


### PR DESCRIPTION
#### 5d697791f2e1fb3991e441fbd79f412fcff93c75
<pre>
DOMCache should use ObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=245378">https://bugs.webkit.org/show_bug.cgi?id=245378</a>
rdar://problem/100146730

Reviewed by Chris Dumez.

Move from uint64_t to DOMCacheIdentifier to identify DOMCache.
Update WebCore and WebKit structures, as well as the IPC needed bits.

* Source/WebCore/Modules/cache/CacheStorageConnection.cpp:
* Source/WebCore/Modules/cache/CacheStorageConnection.h:
* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::create):
(WebCore::DOMCache::DOMCache):
* Source/WebCore/Modules/cache/DOMCache.h:
* Source/WebCore/Modules/cache/DOMCacheEngine.h:
(WebCore::DOMCacheEngine::CacheIdentifierOperationResult::decode):
* Source/WebCore/Modules/cache/DOMCacheIdentifier.h: Added.
* Source/WebCore/Modules/cache/DOMCacheStorage.cpp:
(WebCore::DOMCacheStorage::doRemove):
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp:
(WebCore::WorkerCacheStorageConnection::open):
(WebCore::WorkerCacheStorageConnection::openCompleted):
(WebCore::WorkerCacheStorageConnection::remove):
(WebCore::WorkerCacheStorageConnection::removeCompleted):
(WebCore::WorkerCacheStorageConnection::retrieveRecords):
(WebCore::WorkerCacheStorageConnection::batchDeleteOperation):
(WebCore::WorkerCacheStorageConnection::batchPutOperation):
(WebCore::WorkerCacheStorageConnection::reference):
(WebCore::WorkerCacheStorageConnection::dereference):
(WebCore::WorkerCacheStorageConnection::clearPendingRequests):
(WebCore::WorkerCacheStorageConnection::openOrRemoveCompleted): Deleted.
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/CacheStorageProvider.h:
* Source/WebKit/NetworkProcess/cache/CacheStorageEngine.cpp:
(WebKit::CacheStorage::Engine::remove):
(WebKit::CacheStorage::Engine::retrieveRecords):
(WebKit::CacheStorage::Engine::putRecords):
(WebKit::CacheStorage::Engine::deleteMatchingRecords):
(WebKit::CacheStorage::Engine::lock):
(WebKit::CacheStorage::Engine::unlock):
(WebKit::CacheStorage::Engine::readCache):
(WebKit::CacheStorage::Engine::cache):
* Source/WebKit/NetworkProcess/cache/CacheStorageEngine.h:
(WebKit::CacheStorage::Engine::salt const):
(WebKit::CacheStorage::Engine::nextCacheIdentifier): Deleted.
* Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp:
(WebKit::CacheStorage::Cache::Cache):
* Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.h:
(WebKit::CacheStorage::Cache::identifier const):
* Source/WebKit/NetworkProcess/cache/CacheStorageEngineCaches.cpp:
(WebKit::CacheStorage::Caches::find):
(WebKit::CacheStorage::Caches::open):
(WebKit::CacheStorage::Caches::remove):
(WebKit::CacheStorage::Caches::readCachesFromDisk):
* Source/WebKit/NetworkProcess/cache/CacheStorageEngineCaches.h:
* Source/WebKit/NetworkProcess/cache/CacheStorageEngineConnection.cpp:
(WebKit::CacheStorageEngineConnection::open):
(WebKit::CacheStorageEngineConnection::remove):
(WebKit::CacheStorageEngineConnection::retrieveRecords):
(WebKit::CacheStorageEngineConnection::deleteMatchingRecords):
(WebKit::CacheStorageEngineConnection::putRecords):
(WebKit::CacheStorageEngineConnection::reference):
(WebKit::CacheStorageEngineConnection::dereference):
* Source/WebKit/NetworkProcess/cache/CacheStorageEngineConnection.h:
* Source/WebKit/NetworkProcess/cache/CacheStorageEngineConnection.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::serializedIdentifiers):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::remove):
(WebKit::WebCacheStorageConnection::retrieveRecords):
(WebKit::WebCacheStorageConnection::batchDeleteOperation):
(WebKit::WebCacheStorageConnection::batchPutOperation):
(WebKit::WebCacheStorageConnection::reference):
(WebKit::WebCacheStorageConnection::dereference):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h:

Canonical link: <a href="https://commits.webkit.org/254857@main">https://commits.webkit.org/254857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/575075265aff38310e0cfa0b290d9d3072f244e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90487 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99824 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157492 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33573 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28775 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82860 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96265 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96142 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26711 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77341 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26572 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/94067 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81308 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/69587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34673 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15348 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32490 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/16325 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3403 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36253 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39240 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35414 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->