### PR TITLE
[CMake] PlayStation VSI needs to set language on C files

### DIFF
--- a/Source/JavaScriptCore/PlatformPlayStation.cmake
+++ b/Source/JavaScriptCore/PlatformPlayStation.cmake
@@ -1,39 +1,5 @@
 include(inspector/remote/Socket.cmake)
 
-if (${CMAKE_GENERATOR} MATCHES "Visual Studio")
-    # With the VisualStudio generator, the compiler complains about -std=c++* for C sources.
-    set_source_files_properties(
-        disassembler/zydis/Zydis/ZycoreAPIMemory.c
-        disassembler/zydis/Zydis/ZycoreAPIProcess.c
-        disassembler/zydis/Zydis/ZycoreAPISynchronization.c
-        disassembler/zydis/Zydis/ZycoreAPITerminal.c
-        disassembler/zydis/Zydis/ZycoreAPIThread.c
-        disassembler/zydis/Zydis/ZycoreAllocator.c
-        disassembler/zydis/Zydis/ZycoreArgParse.c
-        disassembler/zydis/Zydis/ZycoreBitset.c
-        disassembler/zydis/Zydis/ZycoreFormat.c
-        disassembler/zydis/Zydis/ZycoreList.c
-        disassembler/zydis/Zydis/ZycoreString.c
-        disassembler/zydis/Zydis/ZycoreVector.c
-        disassembler/zydis/Zydis/Zycore.c
-        disassembler/zydis/Zydis/Zydis.c
-        disassembler/zydis/Zydis/ZydisDecoder.c
-        disassembler/zydis/Zydis/ZydisDecoderData.c
-        disassembler/zydis/Zydis/ZydisFormatter.c
-        disassembler/zydis/Zydis/ZydisFormatterATT.c
-        disassembler/zydis/Zydis/ZydisFormatterBase.c
-        disassembler/zydis/Zydis/ZydisFormatterBuffer.c
-        disassembler/zydis/Zydis/ZydisFormatterIntel.c
-        disassembler/zydis/Zydis/ZydisMetaInfo.c
-        disassembler/zydis/Zydis/ZydisMnemonic.c
-        disassembler/zydis/Zydis/ZydisRegister.c
-        disassembler/zydis/Zydis/ZydisSharedData.c
-        disassembler/zydis/Zydis/ZydisString.c
-        disassembler/zydis/Zydis/ZydisUtils.c
-        PROPERTIES LANGUAGE CXX
-    )
-endif ()
-
 # This overrides the default value of 1GB for the structure heap address size
 list(APPEND JavaScriptCore_DEFINITIONS
     STRUCTURE_HEAP_ADDRESS_SIZE_IN_MB=128

--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -674,6 +674,16 @@ set(bmalloc_INTERFACE_DEPENDENCIES bmalloc_CopyHeaders)
 
 add_definitions(-D_GNU_SOURCE)
 
+set_source_files_properties(
+    libpas/src/libpas/pas_bitfit_page_config_kind.c
+    libpas/src/libpas/jit_heap.c
+    libpas/src/libpas/bmalloc_heap.c
+    libpas/src/libpas/bmalloc_heap_config.c
+    libpas/src/libpas/pas_heap_config_kind.c
+    libpas/src/libpas/pas_segregated_page_config_kind.c
+    PROPERTIES LANGUAGE CXX
+)
+
 WEBKIT_FRAMEWORK_DECLARE(bmalloc)
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 
@@ -685,15 +695,6 @@ WEBKIT_COPY_FILES(bmalloc_CopyHeaders
 
 WEBKIT_FRAMEWORK(bmalloc)
 WEBKIT_FRAMEWORK_TARGET(bmalloc)
-
-set_source_files_properties(
-    libpas/src/libpas/pas_bitfit_page_config_kind.c
-    libpas/src/libpas/jit_heap.c
-    libpas/src/libpas/bmalloc_heap.c
-    libpas/src/libpas/bmalloc_heap_config.c
-    libpas/src/libpas/pas_heap_config_kind.c
-    libpas/src/libpas/pas_segregated_page_config_kind.c
-    PROPERTIES LANGUAGE CXX)
 
 WEBKIT_ADD_TARGET_CXX_FLAGS(bmalloc
     -Wno-missing-field-initializers

--- a/Source/bmalloc/PlatformPlayStation.cmake
+++ b/Source/bmalloc/PlatformPlayStation.cmake
@@ -1,15 +1,1 @@
-WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(
-    -Wno-typedef-redefinition)
-
-if (${CMAKE_GENERATOR} MATCHES "Visual Studio")
-    set(bmalloc_C_SOURCES ${bmalloc_SOURCES})
-    list(FILTER bmalloc_C_SOURCES INCLUDE REGEX "\\.c$")
-
-    # With the VisualStudio generator, the compiler complains about -std=c++* for C sources.
-    set_source_files_properties(
-        ${bmalloc_C_SOURCES}
-        PROPERTIES LANGUAGE C
-        COMPILE_OPTIONS --std=gnu17
-    )
-endif ()
-
+WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-Wno-typedef-redefinition)

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -139,6 +139,17 @@ macro(_WEBKIT_TARGET _target_logical_name _target_cmake_name)
         ${${_target_logical_name}_HEADERS}
         ${${_target_logical_name}_SOURCES}
     )
+
+    if (PLAYSTATION AND CMAKE_GENERATOR MATCHES "Visual Studio")
+        set(${_target_logical_name}_SOURCES_C ${${_target_logical_name}_SOURCES})
+        list(FILTER ${_target_logical_name}_SOURCES_C INCLUDE REGEX "\\.c$")
+        set_source_files_properties(
+            ${${_target_logical_name}_SOURCES_C}
+            PROPERTIES LANGUAGE C
+            COMPILE_OPTIONS --std=gnu17
+        )
+    endif ()
+
     target_include_directories(${_target_cmake_name} PUBLIC "$<BUILD_INTERFACE:${${_target_logical_name}_INCLUDE_DIRECTORIES}>")
     target_include_directories(${_target_cmake_name} SYSTEM PRIVATE "$<BUILD_INTERFACE:${${_target_logical_name}_SYSTEM_INCLUDE_DIRECTORIES}>")
     target_include_directories(${_target_cmake_name} PRIVATE "$<BUILD_INTERFACE:${${_target_logical_name}_PRIVATE_INCLUDE_DIRECTORIES}>")


### PR DESCRIPTION
#### 219df29ea36a5845e7b2e55f592ab758e8c31857
<pre>
[CMake] PlayStation VSI needs to set language on C files
<a href="https://bugs.webkit.org/show_bug.cgi?id=245430">https://bugs.webkit.org/show_bug.cgi?id=245430</a>

Reviewed by Yusuke Suzuki.

The Visual Studio integration for PlayStation has issues around
compiling C files as C++, with Clang erroring about a `.c` file being
compiled by clang++. Modify the code in `_WEBKIT_MACRO` to set the
language and options for any C files found in `_SOURCES`.

Remove any PlayStation specific CMake code that explicitly sets the
language of a source file. Also move any setting of language of a source
file in common build code before the call the `_WEBKIT_TARGET`.

* Source/JavaScriptCore/PlatformPlayStation.cmake:
* Source/bmalloc/CMakeLists.txt:
* Source/bmalloc/PlatformPlayStation.cmake:
* Source/cmake/WebKitMacros.cmake:

Canonical link: <a href="https://commits.webkit.org/255436@main">https://commits.webkit.org/255436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/050d87583b17d7116f5da48a27af382a3c640858

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102232 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1696 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30071 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84893 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98382 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1136 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78979 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28063 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82745 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83859 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36482 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78885 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34259 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17858 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27341 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3770 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40472 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81507 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37010 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18436 "Passed tests") | 
<!--EWS-Status-Bubble-End-->