### PR TITLE
[Mail Compose] Attachment goes missing after wrapping an image in a block quote

### DIFF
--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -158,6 +158,17 @@ const String& HTMLAttachmentElement::ensureUniqueIdentifier()
     return m_uniqueIdentifier;
 }
 
+void HTMLAttachmentElement::setUniqueIdentifier(const String& uniqueIdentifier)
+{
+    if (m_uniqueIdentifier == uniqueIdentifier)
+        return;
+
+    m_uniqueIdentifier = uniqueIdentifier;
+
+    if (auto image = enclosingImageElement())
+        image->didUpdateAttachmentIdentifier();
+}
+
 RefPtr<HTMLImageElement> HTMLAttachmentElement::enclosingImageElement() const
 {
     if (auto hostElement = shadowHost(); is<HTMLImageElement>(hostElement))

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -52,7 +52,7 @@ public:
     void setFile(RefPtr<File>&&, UpdateDisplayAttributes = UpdateDisplayAttributes::No);
 
     const String& uniqueIdentifier() const { return m_uniqueIdentifier; }
-    void setUniqueIdentifier(const String& uniqueIdentifier) { m_uniqueIdentifier = uniqueIdentifier; }
+    void setUniqueIdentifier(const String&);
 
     void copyNonAttributePropertiesFromElement(const Element&) final;
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -795,6 +795,11 @@ void HTMLImageElement::resetAllowsAnimation()
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
+void HTMLImageElement::didUpdateAttachmentIdentifier()
+{
+    m_pendingClonedAttachmentID = { };
+}
+
 void HTMLImageElement::setAttachmentElement(Ref<HTMLAttachmentElement>&& attachment)
 {
     if (auto existingAttachment = attachmentElement())

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -111,6 +111,7 @@ public:
     void setAttachmentElement(Ref<HTMLAttachmentElement>&&);
     RefPtr<HTMLAttachmentElement> attachmentElement() const;
     const String& attachmentIdentifier() const;
+    void didUpdateAttachmentIdentifier();
 #endif
 
     WEBCORE_EXPORT size_t pendingDecodePromisesCountForTesting() const;


### PR DESCRIPTION
#### 47fb3d640ece77b046fe2d13a5f1a45823262346
<pre>
[Mail Compose] Attachment goes missing after wrapping an image in a block quote
<a href="https://bugs.webkit.org/show_bug.cgi?id=245432">https://bugs.webkit.org/show_bug.cgi?id=245432</a>
rdar://98012376

Reviewed by Ryosuke Niwa.

After duplicating an existing attachment-backed image element in the DOM using `cloneNode()` (or
similar DOM functions), `HTMLImageElement.attachmentIdentifier` returns the old attachment
identifier of the cloned attachment rather than the identifier of the clone. This breaks Mail&apos;s
bookkeepping around attachment data in Mail compose, and leads to the attachment being lost upon
sending or saving a draft.

This happens because:

1. `HTMLImageElement` has an internal mechanism for keeping track of the attachment ID of the
attachment-backed image it was cloned from, by storing the ID in `m_pendingClonedAttachmentID` and
returning it when asked for the `attachmentIdentifier`, even if the attachment element hasn&apos;t been
created yet. This is used to ensure that after cloning an attachment element, removing the original,
and inserting the clone, the cloned attachment-backed image will preserve the unique attachment ID
of the attachment-backed image it was cloned from.

2. `Document` has logic to maintain the invariant that no two attachment elements that are connected
to it ever have the same unique identifier; to do this, we automatically adjust the identifier of
an attachment element upon insertion into the DOM, if the ID collides with that of an existing
attachment in the DOM.

In this bug, (2) adjusts the unique ID of the attachment underneath the image, but the image still
has a `m_pendingClonedAttachmentID` that points to the old ID, creating an inconsistency. To fix
this, we add a mechanism to invalidate the pending cloned attachment ID when the ID of the
attachment under an attachment-backed image changes.

Test: WKAttachmentTests.DuplicateImageWithAttachment

* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::setUniqueIdentifier):

Move the definition out of line into the implementation so that we can call into `HTMLImageElement`.

* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::didUpdateAttachmentIdentifier):

Clear out the `m_pendingClonedAttachmentID`.

* Source/WebCore/html/HTMLImageElement.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/254696@main">https://commits.webkit.org/254696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0df6a88c48982c48878e44a204cab59c94750c20

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99224 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156229 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32928 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28349 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82224 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93547 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26149 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76693 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26074 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80856 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69077 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30676 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14939 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30415 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15880 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3298 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38838 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34964 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->