### PR TITLE
Do not launch network process for sending unregisterServiceWorkerClient

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2145,8 +2145,8 @@ void DocumentLoader::unregisterReservedServiceWorkerClient()
     if (!m_resultingClientId)
         return;
 
-    auto& serviceWorkerConnection = ServiceWorkerProvider::singleton().serviceWorkerConnection();
-    serviceWorkerConnection.unregisterServiceWorkerClient(m_resultingClientId);
+    if (auto* serviceWorkerConnection = ServiceWorkerProvider::singleton().existingServiceWorkerConnection())
+        serviceWorkerConnection->unregisterServiceWorkerClient(m_resultingClientId);
 #endif
 }
 

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -65,8 +65,10 @@ WorkerScriptLoader::~WorkerScriptLoader()
 
     scriptExecutionContextIdentifierToWorkerScriptLoaderMap().remove(m_clientIdentifier);
 #if ENABLE(SERVICE_WORKER)
-    if (m_activeServiceWorkerData)
-        ServiceWorkerProvider::singleton().serviceWorkerConnection().unregisterServiceWorkerClient(m_clientIdentifier);
+    if (m_activeServiceWorkerData) {
+        if (auto* serviceWorkerConnection = ServiceWorkerProvider::singleton().existingServiceWorkerConnection())
+            serviceWorkerConnection->unregisterServiceWorkerClient(m_clientIdentifier);
+    }
 #endif
 }
 

--- a/Source/WebCore/workers/service/ServiceWorkerProvider.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerProvider.cpp
@@ -46,6 +46,7 @@ ServiceWorkerProvider::~ServiceWorkerProvider()
 
 ServiceWorkerProvider& ServiceWorkerProvider::singleton()
 {
+    ASSERT(isMainThread());
     RELEASE_ASSERT(sharedProvider);
     return *sharedProvider;
 }

--- a/Source/WebCore/workers/service/ServiceWorkerProvider.h
+++ b/Source/WebCore/workers/service/ServiceWorkerProvider.h
@@ -43,6 +43,7 @@ public:
     static void setSharedProvider(ServiceWorkerProvider&);
 
     virtual SWClientConnection& serviceWorkerConnection() = 0;
+    virtual SWClientConnection* existingServiceWorkerConnection() = 0;
     virtual void terminateWorkerForTesting(ServiceWorkerIdentifier, CompletionHandler<void()>&&) = 0;
 
     void setMayHaveRegisteredServiceWorkers() { m_mayHaveRegisteredServiceWorkers = true; }

--- a/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
+++ b/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
@@ -195,7 +195,8 @@ void WorkerSWClientConnection::registerServiceWorkerClient(const ClientOrigin& c
 void WorkerSWClientConnection::unregisterServiceWorkerClient(ScriptExecutionContextIdentifier identifier)
 {
     callOnMainThread([identifier] {
-        ServiceWorkerProvider::singleton().serviceWorkerConnection().unregisterServiceWorkerClient(identifier);
+        if (auto* serviceWorkerConnection = ServiceWorkerProvider::singleton().existingServiceWorkerConnection())
+            serviceWorkerConnection->unregisterServiceWorkerClient(identifier);
     });
 }
 

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.cpp
@@ -58,6 +58,15 @@ WebCore::SWClientConnection& WebServiceWorkerProvider::serviceWorkerConnection()
     return WebProcess::singleton().ensureNetworkProcessConnection().serviceWorkerConnection();
 }
 
+WebCore::SWClientConnection* WebServiceWorkerProvider::existingServiceWorkerConnection()
+{
+    auto* networkProcessConnection = WebProcess::singleton().existingNetworkProcessConnection();
+    if (!networkProcessConnection)
+        return nullptr;
+
+    return &networkProcessConnection->serviceWorkerConnection();
+}
+
 void WebServiceWorkerProvider::updateThrottleState(bool isThrottleable)
 {
     auto* networkProcessConnection = WebProcess::singleton().existingNetworkProcessConnection();

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.h
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.h
@@ -53,6 +53,7 @@ private:
     WebServiceWorkerProvider();
 
     WebCore::SWClientConnection& serviceWorkerConnection() final;
+    WebCore::SWClientConnection* existingServiceWorkerConnection() final;
     void terminateWorkerForTesting(WebCore::ServiceWorkerIdentifier, CompletionHandler<void()>&&) final;
 }; // class WebServiceWorkerProvider
 


### PR DESCRIPTION
#### a189c5a83b2317bc64a054fb62a9c8cac6126c7c
<pre>
Do not launch network process for sending unregisterServiceWorkerClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=245434">https://bugs.webkit.org/show_bug.cgi?id=245434</a>
&lt;rdar://100177915&gt;

Reviewed by Youenn Fablet.

The newly launched network process will have no information about clients connected to previous network process.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::unregisterReservedServiceWorkerClient):
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::~WorkerScriptLoader):
* Source/WebCore/workers/service/ServiceWorkerProvider.cpp:
(WebCore::ServiceWorkerProvider::singleton):
* Source/WebCore/workers/service/ServiceWorkerProvider.h:
* Source/WebCore/workers/service/WorkerSWClientConnection.cpp:
(WebCore::WorkerSWClientConnection::unregisterServiceWorkerClient):
* Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.cpp:
(WebKit::WebServiceWorkerProvider::existingServiceWorkerConnection):
* Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm:
(waitAndGetNextMessage):
(TEST):
(terminateWorker):
(-[BroadcastChannelMessageHandler userContentController:didReceiveScriptMessage:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/254707@main">https://commits.webkit.org/254707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f65843ab93ad5463245dec305bb0550aece8926

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89920 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99248 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156478 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32956 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28368 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93569 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26175 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76715 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26096 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80869 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/69100 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30702 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14952 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30438 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15893 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3307 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38855 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34977 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->