### PR TITLE
Replace checks for effectiveAccentColor().isValid()

### DIFF
--- a/Source/WebCore/rendering/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/RenderThemeAdwaita.cpp
@@ -103,9 +103,8 @@ static inline Color getSystemAccentColor()
 
 static inline Color getAccentColor(const RenderObject& renderObject)
 {
-    auto accentColor = renderObject.style().effectiveAccentColor();
-    if (accentColor.isValid())
-        return accentColor;
+    if (!renderObject.style().hasAutoAccentColor())
+        return renderObject.style().effectiveAccentColor();
 
     return getSystemAccentColor();
 }

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -1218,8 +1218,8 @@ void RenderThemeIOS::adjustButtonLikeControlStyle(RenderStyle& style, const Elem
     if (element.isDisabledFormControl())
         return;
 
-    auto tintColor = style.effectiveAccentColor();
-    if (tintColor.isValid()) {
+    if (!style.hasAutoAccentColor()) {
+        auto tintColor = style.effectiveAccentColor();
         if (isSubmitStyleButton(element))
             style.setBackgroundColor(tintColor);
         else
@@ -1572,9 +1572,8 @@ Color RenderThemeIOS::systemColor(CSSValueID cssValueID, OptionSet<StyleColorOpt
 
 Color RenderThemeIOS::controlTintColor(const RenderStyle& style, OptionSet<StyleColorOptions> options) const
 {
-    Color tintColor = style.effectiveAccentColor();
-    if (tintColor.isValid())
-        return tintColor;
+    if (!style.hasAutoAccentColor())
+        return style.effectiveAccentColor();
 
     return systemColor(CSSValueAppleSystemBlue, options);
 }


### PR DESCRIPTION
#### 4af3e6bf9f7427082d76f1366a341e7aa5152c29
<pre>
Replace checks for effectiveAccentColor().isValid()
<a href="https://bugs.webkit.org/show_bug.cgi?id=245435">https://bugs.webkit.org/show_bug.cgi?id=245435</a>
&lt;rdar://100178048&gt;

Reviewed by Aditya Keerthi.

The intent of these checks is to check if the accent-color is not auto, so we should use hasAutoAccentColor() instead.

This is in preparation of the refactoring changing Color to StyleColor.

* Source/WebCore/rendering/RenderThemeAdwaita.cpp:
(WebCore::getAccentColor):
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::adjustButtonLikeControlStyle const):
(WebCore::RenderThemeIOS::controlTintColor const):

Canonical link: <a href="https://commits.webkit.org/254700@main">https://commits.webkit.org/254700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92669a769fd3725644b6a57ba32c241403484fe9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99235 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156353 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93908 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32939 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28356 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/82267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93555 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26162 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76701 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26082 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80863 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/69086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30686 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14946 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30423 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15887 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3300 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33885 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34971 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->