### PR TITLE
[GTK] Do not use GLOB to collect po files

### DIFF
--- a/Source/WebCore/platform/gtk/po/CMakeLists.txt
+++ b/Source/WebCore/platform/gtk/po/CMakeLists.txt
@@ -1,5 +1,11 @@
 include(FindGettext)
 
+set(linguas
+    ar as bg ca cs da de el en_CA en_GB eo es et eu fi fr gl gu he hi hr hu id
+    it ja ka kn ko lt lv ml mr nb nl or pa pl pt pt_BR ro ru sl sr sr@latin sv
+    ta te tr uk vi zh_CN
+)
+
 # GETTEXT_CREATE_TRANSLATIONS automatically runs msgmerge, which is something we
 # didn't do in the old autotools build. This overwrites all the po files in the
 # Source directory. Perhaps we want this, but for now disable it to maintain compatibility.
@@ -34,5 +40,8 @@ add_custom_command(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
-file(GLOB po_files *.po)
+foreach (lingua ${linguas})
+    list(APPEND po_files ${CMAKE_CURRENT_SOURCE_DIR}/${lingua}.po)
+endforeach ()
+
 GETTEXT_CREATE_TRANSLATIONS(${pot_file} ALL ${po_files})


### PR DESCRIPTION
#### b657e124d9c92d70cdab6bc4b90b851562df360b
<pre>
[GTK] Do not use GLOB to collect po files
<a href="https://bugs.webkit.org/show_bug.cgi?id=245440">https://bugs.webkit.org/show_bug.cgi?id=245440</a>

Reviewed by Adrian Perez de Castro.

* Source/WebCore/platform/gtk/po/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/254706@main">https://commits.webkit.org/254706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f1750d96e897bec1c3abc71851d8584ac68b813

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99249 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156454 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32957 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28371 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82282 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93570 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26177 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76716 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26115 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80871 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/69118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30703 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14954 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30439 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15895 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3306 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38856 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32619 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34979 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->