### PR TITLE
Open a color input with display:none via a label

### DIFF
--- a/LayoutTests/fast/forms/color/display-none-input-color-chooser-shown.html
+++ b/LayoutTests/fast/forms/color/display-none-input-color-chooser-shown.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<input id="colorPick" type="color" />
+<label for="colorPick" id="labelPick">Pick a color</label>
+<script>
+test (function() {
+    assert_true(window.eventSender !== null);
+}, "window.eventSender is required for the test to run");
+test (function() {
+    var input = document.createElement('input');
+    input.type = 'color';
+    input.value = '#000000';
+    document.body.appendChild(input);
+
+    var colorPicker = document.getElementById("colorPick");
+    colorPicker.style.display = "none";
+    var labelPick = document.getElementById("labelPick");
+    var x = labelPick.offsetLeft + labelPick.offsetWidth/2;
+    var y = labelPick.offsetTop + labelPick.offsetHeight/2;
+    eventSender.mouseMoveTo(x, y);
+    eventSender.mouseDown();
+    eventSender.mouseUp();
+    assert_true(internals.selectColorInColorChooser(input, '#ff0000'));
+}, "Tests click on label for color picker with display none should show chooser");
+</script>

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -178,7 +178,7 @@ void ColorInputType::attributeChanged(const QualifiedName& name)
 void ColorInputType::handleDOMActivateEvent(Event& event)
 {
     ASSERT(element());
-    if (element()->isDisabledFormControl() || !element()->renderer())
+    if (element()->isDisabledFormControl())
         return;
 
     if (!UserGestureIndicator::processingUserGesture())


### PR DESCRIPTION
<pre>
Open a color input with display:none via a label

<a href="https://bugs.webkit.org/show_bug.cgi?id=245449">https://bugs.webkit.org/show_bug.cgi?id=245449</a>

Reviewed by NOBODY (OOPS!).

This is to align Webkit behavior with all other browser engines Gecko / Firefox and Blink / Chromium.

It is to enable the 'color' input controls be able to accessed via label despite configured with 'display:none'.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/9447bd245501e7f1abb9b51f1420e8ef4f73c4dc">https://chromium.googlesource.com/chromium/src.git/+/9447bd245501e7f1abb9b51f1420e8ef4f73c4dc</a>

* Source/WebCore/html/ColorInputType.cpp:
(ColorInputType::attributeChanged): Removed condition to restrict the input to rendered elements only
* LayoutTests/fast/forms/color/display-none-color-chooser-shown.html: Added Test Case
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae82b898ff24569073e4eb87e3c0e3b391f2c896

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99771 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157240 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33522 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28721 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82801 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96215 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96092 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26653 "Found 1 new test failure: fast/forms/color/display-none-input-color-chooser-shown.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77289 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26524 "Found 1 new test failure: fast/forms/color/display-none-input-color-chooser-shown.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69536 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34616 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15291 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32439 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16259 "Found 1 new test failure: fast/forms/color/display-none-input-color-chooser-shown.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36203 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39193 "Found 1 new test failure: fast/forms/color/display-none-input-color-chooser-shown.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35348 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->