### PR TITLE
Move iOS EWS queues to iOS 16

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -38,7 +38,7 @@
     { "name": "ews106", "platform": "mac-bigsur" },
     { "name": "ews107", "platform": "mac-bigsur" },
     { "name": "ews108", "platform": "*" },
-    { "name": "ews109", "platform": "ios-15" },
+    { "name": "ews109", "platform": "ios-16" },
     { "name": "ews112", "platform": "mac-bigsur" },
     { "name": "ews113", "platform": "mac-bigsur" },
     { "name": "ews114", "platform": "mac-bigsur" },
@@ -48,16 +48,16 @@
     { "name": "ews118", "platform": "mac-bigsur" },
     { "name": "ews119", "platform": "mac-bigsur" },
     { "name": "ews120", "platform": "mac-bigsur" },
-    { "name": "ews121", "platform": "ios-simulator-15" },
-    { "name": "ews122", "platform": "ios-simulator-15" },
-    { "name": "ews123", "platform": "ios-simulator-15" },
-    { "name": "ews124", "platform": "ios-simulator-15" },
-    { "name": "ews125", "platform": "ios-simulator-15" },
-    { "name": "ews126", "platform": "ios-simulator-15" },
+    { "name": "ews121", "platform": "ios-simulator-16" },
+    { "name": "ews122", "platform": "ios-simulator-16" },
+    { "name": "ews123", "platform": "ios-simulator-16" },
+    { "name": "ews124", "platform": "ios-simulator-16" },
+    { "name": "ews125", "platform": "ios-simulator-16" },
+    { "name": "ews126", "platform": "ios-simulator-16" },
     { "name": "ews127", "platform": "mac-bigsur" },
     { "name": "ews128", "platform": "mac-bigsur" },
     { "name": "ews130", "platform": "*" },
-    { "name": "ews131", "platform": "ios-15" },
+    { "name": "ews131", "platform": "ios-16" },
     { "name": "ews132", "platform": "*" },
     { "name": "ews133", "platform": "*" },
     { "name": "ews134", "platform": "*" },
@@ -96,8 +96,8 @@
     { "name": "ews181", "platform": "mac-bigsur" },
     { "name": "ews182", "platform": "mac-bigsur" },
     { "name": "ews183", "platform": "*" },
-    { "name": "ews184", "platform": "ios-simulator-15" },
-    { "name": "ews185", "platform": "ios-simulator-15" },
+    { "name": "ews184", "platform": "ios-simulator-16" },
+    { "name": "ews185", "platform": "ios-simulator-16" },
     { "name": "ews210", "platform": "win" },
     { "name": "ews211", "platform": "win" },
     { "name": "ews212", "platform": "win" },
@@ -136,23 +136,23 @@
       "workernames": ["igalia5-gtk-wk2-ews", "igalia6-gtk-wk2-ews", "igalia7-gtk-wk2-ews", "igalia8-gtk-wk2-ews", "igalia9-gtk-wk2-ews", "igalia10-gtk-wk2-ews", "igalia11-gtk-wk2-ews", "igalia12-gtk-wk2-ews"]
     },
     {
-      "name": "iOS-15-Build-EWS", "shortname": "ios", "icon": "buildOnly",
-      "factory": "iOSEmbeddedBuildFactory", "platform": "ios-15",
+      "name": "iOS-16-Build-EWS", "shortname": "ios", "icon": "buildOnly",
+      "factory": "iOSEmbeddedBuildFactory", "platform": "ios-16",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews152", "ews154", "ews108", "ews109", "ews130", "ews131", "ews132", "ews133"]
     },
     {
-      "name": "iOS-15-Simulator-Build-EWS", "shortname": "ios-sim", "icon": "buildOnly",
-      "factory": "iOSBuildFactory", "platform": "ios-simulator-15",
+      "name": "iOS-16-Simulator-Build-EWS", "shortname": "ios-sim", "icon": "buildOnly",
+      "factory": "iOSBuildFactory", "platform": "ios-simulator-16",
       "configuration": "release", "architectures": ["x86_64"],
-      "triggers": ["api-tests-ios-sim-ews", "ios-15-sim-wk2-tests-ews"],
+      "triggers": ["api-tests-ios-sim-ews", "ios-16-sim-wk2-tests-ews"],
       "workernames": ["ews152", "ews154", "ews156", "ews157", "ews108", "ews130", "ews132", "ews133", "ews134", "ews135"]
     },
     {
-      "name": "iOS-15-Simulator-WK2-Tests-EWS", "shortname": "ios-wk2", "icon": "testOnly",
-      "factory": "iOSTestsFactory", "platform": "ios-simulator-15",
+      "name": "iOS-16-Simulator-WK2-Tests-EWS", "shortname": "ios-wk2", "icon": "testOnly",
+      "factory": "iOSTestsFactory", "platform": "ios-simulator-16",
       "configuration": "release", "architectures": ["x86_64"],
-      "triggered_by": ["ios-15-sim-build-ews"],
+      "triggered_by": ["ios-16-sim-build-ews"],
       "workernames": ["ews121", "ews122", "ews123", "ews124", "ews125", "ews126", "ews184", "ews185"]
     },
     {
@@ -312,7 +312,7 @@
     {
       "name": "API-Tests-iOS-Simulator-EWS", "shortname": "api-ios", "icon": "testOnly",
       "factory": "APITestsFactory", "platform": "*",
-      "triggered_by": ["ios-15-sim-build-ews"],
+      "triggered_by": ["ios-16-sim-build-ews"],
       "workernames": ["ews156", "ews157", "ews158", "ews159", "ews183"]
     },
     {
@@ -356,7 +356,7 @@
     {
       "type": "Try_Userpass", "name": "try", "port": 5555,
       "builderNames": [
-            "Apply-WatchList-EWS", "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-15-Build-EWS", "iOS-15-Simulator-Build-EWS",
+            "Apply-WatchList-EWS", "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-16-Build-EWS", "iOS-16-Simulator-Build-EWS",
             "JSC-ARMv7-32bits-Build-EWS", "JSC-i386-32bits-EWS", "JSC-MIPSEL-32bits-Build-EWS", "JSC-Tests-EWS",
             "macOS-AppleSilicon-Big-Sur-Debug-Build-EWS", "macOS-BigSur-Debug-Build-EWS", "macOS-BigSur-Release-Build-EWS",
             "Services-EWS", "Style-EWS", "tvOS-15-Build-EWS", "tvOS-15-Simulator-Build-EWS", "watchOS-8-Build-EWS",
@@ -370,7 +370,7 @@
     {
       "type": "AnyBranchScheduler", "name": "pull_request",
       "builderNames": [
-            "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-15-Build-EWS", "iOS-15-Simulator-Build-EWS",
+            "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-16-Build-EWS", "iOS-16-Simulator-Build-EWS",
             "JSC-ARMv7-32bits-Build-EWS", "JSC-i386-32bits-EWS", "JSC-MIPSEL-32bits-Build-EWS", "JSC-Tests-EWS",
             "macOS-AppleSilicon-Big-Sur-Debug-Build-EWS", "macOS-BigSur-Debug-Build-EWS", "macOS-BigSur-Release-Build-EWS",
             "Services-EWS", "Style-EWS", "Style-EWS", "tvOS-15-Build-EWS", "tvOS-15-Simulator-Build-EWS", "watchOS-8-Build-EWS",
@@ -418,12 +418,12 @@
       "builderNames": ["macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS"]
     },
     {
-      "type": "Triggerable", "name": "ios-15-sim-build-ews",
-      "builderNames": ["iOS-15-Simulator-Build-EWS"]
+      "type": "Triggerable", "name": "ios-16-sim-build-ews",
+      "builderNames": ["iOS-16-Simulator-Build-EWS"]
     },
     {
-      "type": "Triggerable", "name": "ios-15-sim-wk2-tests-ews",
-      "builderNames": ["iOS-15-Simulator-WK2-Tests-EWS"]
+      "type": "Triggerable", "name": "ios-16-sim-wk2-tests-ews",
+      "builderNames": ["iOS-16-Simulator-WK2-Tests-EWS"]
     },
     {
       "type": "Triggerable", "name": "api-tests-ios-sim-ews",

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -91,7 +91,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'layout-tests',
             'set-build-summary'
         ],
-        'iOS-15-Build-EWS': [
+        'iOS-16-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -105,7 +105,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'kill-old-processes',
             'compile-webkit'
         ],
-        'iOS-15-Simulator-Build-EWS': [
+        'iOS-16-Simulator-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -119,7 +119,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'kill-old-processes',
             'compile-webkit'
         ],
-        'iOS-15-Simulator-WK2-Tests-EWS': [
+        'iOS-16-Simulator-WK2-Tests-EWS': [
             'configure-build',
             'validate-change',
             'configuration',


### PR DESCRIPTION
#### 427faeb56e0fde8b68487fd77306e356e7a13658
<pre>
Move iOS EWS queues to iOS 16
<a href="https://bugs.webkit.org/show_bug.cgi?id=245451">https://bugs.webkit.org/show_bug.cgi?id=245451</a>
rdar://99766383

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):

Canonical link: <a href="https://commits.webkit.org/254792@main">https://commits.webkit.org/254792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de589bca61ff23478802ebdfb17d98c2306cc5a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99275 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156783 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32993 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28394 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82286 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93596 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26204 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76742 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26119 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69122 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34238 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14975 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/89005 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32080 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15916 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/35822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38875 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1437 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35000 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->