### PR TITLE
Fix strokeStyle changes not being applied for successive stroke line operations.

### DIFF
--- a/LayoutTests/fast/canvas/canvas-strokePath-strokeStyle-expected.html
+++ b/LayoutTests/fast/canvas/canvas-strokePath-strokeStyle-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <script>
+    var canvas = document.createElement('canvas');
+    document.body.appendChild(canvas);
+    var ctx = canvas.getContext('2d');
+
+    canvas.width = 200;
+    canvas.height = 200;
+
+    ctx.fillStyle = "#f00";
+    ctx.fillRect(0, 0, 100, 200);
+
+    ctx.fillStyle = "#000";
+    ctx.fillRect(100, 0, 100, 200);
+
+  </script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/canvas-strokePath-strokeStyle.html
+++ b/LayoutTests/fast/canvas/canvas-strokePath-strokeStyle.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <script>
+    var canvas = document.createElement('canvas');
+    document.body.appendChild(canvas);
+    var ctx = canvas.getContext('2d');
+
+    canvas.width = 200;
+    canvas.height = 200;
+    ctx.lineWidth = 100;
+
+    ctx.clearRect(0, 0, 200, 200);
+
+    // draw red line
+    ctx.strokeStyle = "#f00";
+    ctx.beginPath();
+    ctx.moveTo(50, 0);
+    ctx.lineTo(50, 200);
+    ctx.stroke();
+
+    // draw green line
+    ctx.strokeStyle = "#000";
+    ctx.beginPath();
+    ctx.moveTo(150, 0);
+    ctx.lineTo(150, 200);
+    ctx.stroke();
+  </script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -473,6 +473,8 @@ void Recorder::strokePath(const Path& path)
     auto& state = currentState().state;
     if (state.changes() && state.containsOnlyInlineChanges() && !state.changes().contains(GraphicsContextState::Change::FillBrush) && path.hasInlineData() && path.hasInlineData<LineData>()) {
         recordStrokeLineWithColorAndThickness(*strokeColor().tryGetAsSRGBABytes(), strokeThickness(), path.inlineData<LineData>());
+        state.didApplyChanges();
+        currentState().lastDrawingState = state;
         return;
     }
 


### PR DESCRIPTION
#### aabdfc49a52bb7286b4325975ccfaabdcf74d907
<pre>
Fix strokeStyle changes not being applied for successive stroke line operations.
<a href="https://bugs.webkit.org/show_bug.cgi?id=245465">https://bugs.webkit.org/show_bug.cgi?id=245465</a>

Reviewed by Darin Adler.

The recordStrokeLineWithColorAndThickness optimised path skips serialising the state object, but fails to mark that we&apos;ve applied the necessary changes.

This means that you can then change state back to it&apos;s original value, and we won&apos;t detect that it changed.

* LayoutTests/fast/canvas/canvas-strokePath-strokeStyle-expected.html: Added.
* LayoutTests/fast/canvas/canvas-strokePath-strokeStyle.html: Added.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::strokePath):

Canonical link: <a href="https://commits.webkit.org/254889@main">https://commits.webkit.org/254889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f12042996db43cc68d264d610bcd1aebc8a49e98

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99308 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156826 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33018 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28421 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82314 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93619 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26235 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76782 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26146 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69148 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34258 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14992 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32099 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15933 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3418 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/35843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38893 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35017 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->