### PR TITLE
Make custom elements's default ARIA id-ref work with shadow DOM

### DIFF
--- a/LayoutTests/accessibility/custom-elements/controls-shadow-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/controls-shadow-expected.txt
@@ -1,0 +1,16 @@
+This tests that ElementInternals.ariaControlsElements can reference nodes outside the shadow tree.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.ariaControlsElements.length is 2
+PASS internals.ariaControlsElements[0] is document.querySelectorAll(".control")[0]
+PASS internals.ariaControlsElements[1] is document.querySelectorAll(".control")[1]
+PASS labelForControl(customTab.ariaControlsElementAtIndex(0)) is "AXValue: Panel 1"
+PASS labelForControl(customTab.ariaControlsElementAtIndex(1)) is "AXValue: Panel 2"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Panel 1
+Panel 2
+

--- a/LayoutTests/accessibility/custom-elements/controls-shadow.html
+++ b/LayoutTests/accessibility/custom-elements/controls-shadow.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<div class="control">Panel 1</div>
+<div class="control">Panel 2</div>
+<div id="host"></div>
+<script>
+
+class CustomTabElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        window.internals = this.attachInternals();
+        internals.role = 'tab';
+        internals.ariaControlsElements = Array.from(document.querySelectorAll('.control'));
+        shouldBe('internals.ariaControlsElements.length', '2');
+        shouldBe('internals.ariaControlsElements[0]', 'document.querySelectorAll(".control")[0]');
+        shouldBe('internals.ariaControlsElements[1]', 'document.querySelectorAll(".control")[1]');
+    }
+};
+customElements.define('custom-tab', CustomTabElement);
+
+const customElement = new CustomTabElement;
+customElement.id = 'custom-tab';
+const shadowRoot = host.attachShadow({'mode': 'closed'});
+shadowRoot.appendChild(customElement);
+
+description("This tests that ElementInternals.ariaControlsElements can reference nodes outside the shadow tree.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    function labelForControl(control) {
+        if (accessibilityController.platformName == "mac")
+            return control.childAtIndex(0).stringValue;
+        return control.stringValue;
+    }
+    window.customTab = accessibilityController.accessibleElementById('custom-tab');
+    shouldBeEqualToString('labelForControl(customTab.ariaControlsElementAtIndex(0))', 'AXValue: Panel 1');
+    shouldBeEqualToString('labelForControl(customTab.ariaControlsElementAtIndex(1))', 'AXValue: Panel 2');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/describedby-shadow-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/describedby-shadow-expected.txt
@@ -1,0 +1,31 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.ariaDescribedByElements.length is 2
+PASS internals.ariaDescribedByElements[0] is document.querySelectorAll(".note")[0]
+PASS internals.ariaDescribedByElements[1] is document.querySelectorAll(".note")[1]
+PASS internals.ariaDetailsElements.length is 2
+PASS internals.ariaDetailsElements[0] is document.querySelectorAll(".details")[0]
+PASS internals.ariaDetailsElements[1] is document.querySelectorAll(".details")[1]
+PASS internals.ariaErrorMessageElements.length is 2
+PASS internals.ariaErrorMessageElements[0] is document.querySelectorAll(".error")[0]
+PASS internals.ariaErrorMessageElements[1] is document.querySelectorAll(".error")[1]
+PASS accessibilityController.accessibleElementById("custom-1").role is "AXRole: AXCheckBox"
+PASS accessibilityController.accessibleElementById("custom-1").helpText is "AXHelp: some description other description"
+PASS accessibilityController.accessibleElementById("custom-1").detailsElements().length is 2
+PASS accessibilityController.accessibleElementById("custom-1").detailsElements()[0].domIdentifier is "details1"
+PASS accessibilityController.accessibleElementById("custom-1").detailsElements()[1].domIdentifier is "details2"
+PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements().length is 2
+PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements()[0].domIdentifier is "error1"
+PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements()[1].domIdentifier is "error2"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+some description
+other description
+some details
+other details
+some error
+other error

--- a/LayoutTests/accessibility/custom-elements/describedby-shadow.html
+++ b/LayoutTests/accessibility/custom-elements/describedby-shadow.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<body id="body">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<div id="host"></div>
+<div id="some" class="note">some description</div>
+<div class="note">other description</div>
+<div id="details1" class="details">some details</div>
+<div id="details2" class="details">other details</div>
+<div id="error1" class="error">some error</div>
+<div id="error2" class="error">other error</div>
+<script>
+
+class CustomElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        window.internals = this.attachInternals();
+        internals.role = 'checkbox';
+        internals.ariaDescribedByElements = Array.from(document.querySelectorAll('.note'));
+        internals.ariaDetailsElements = Array.from(document.querySelectorAll('.details'));
+        internals.ariaErrorMessageElements = Array.from(document.querySelectorAll('.error'));
+        shouldBe('internals.ariaDescribedByElements.length', '2');
+        shouldBe('internals.ariaDescribedByElements[0]', 'document.querySelectorAll(".note")[0]');
+        shouldBe('internals.ariaDescribedByElements[1]', 'document.querySelectorAll(".note")[1]');
+        shouldBe('internals.ariaDetailsElements.length', '2');
+        shouldBe('internals.ariaDetailsElements[0]', 'document.querySelectorAll(".details")[0]');
+        shouldBe('internals.ariaDetailsElements[1]', 'document.querySelectorAll(".details")[1]');
+        shouldBe('internals.ariaErrorMessageElements.length', '2');
+        shouldBe('internals.ariaErrorMessageElements[0]', 'document.querySelectorAll(".error")[0]');
+        shouldBe('internals.ariaErrorMessageElements[1]', 'document.querySelectorAll(".error")[1]');
+    }
+}
+customElements.define('custom-element', CustomElement);
+
+const shadowRoot = host.attachShadow({mode: 'closed'});
+const customElement = new CustomElement;
+customElement.id = 'custom-1';
+shadowRoot.appendChild(customElement);
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").role', 'AXRole: AXCheckBox');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").helpText', 'AXHelp: some description other description');
+    shouldBe('accessibilityController.accessibleElementById("custom-1").detailsElements().length', '2');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").detailsElements()[0].domIdentifier', 'details1');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").detailsElements()[1].domIdentifier', 'details2');
+    shouldBe('accessibilityController.accessibleElementById("custom-1").errorMessageElements().length', '2');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").errorMessageElements()[0].domIdentifier', 'error1');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").errorMessageElements()[1].domIdentifier', 'error2');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/flowto-shadow-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/flowto-shadow-expected.txt
@@ -1,0 +1,26 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.ariaFlowToElements.length is 2
+PASS internals.ariaFlowToElements[0] is document.querySelectorAll(".flowto")[0]
+PASS internals.ariaFlowToElements[1] is document.querySelectorAll(".flowto")[1]
+PASS internals.ariaLabelledByElements.length is 2
+PASS internals.ariaLabelledByElements[0] is document.querySelectorAll(".label")[0]
+PASS internals.ariaLabelledByElements[1] is document.querySelectorAll(".label")[1]
+PASS accessibilityController.accessibleElementById("custom-1").role is "AXRole: AXCheckBox"
+PASS platformValueForW3CName(accessibilityController.accessibleElementById("custom-1")) is "label 1 label 2"
+PASS accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(0).role is "AXRole: AXButton"
+PASS accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(0).title is "AXTitle: FlowTo1"
+PASS accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(1).role is "AXRole: AXButton"
+PASS accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(1).title is "AXTitle: FlowTo2"
+PASS accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(2) is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+FlowTo1
+FlowTo2
+label 1
+label 2
+

--- a/LayoutTests/accessibility/custom-elements/flowto-shadow.html
+++ b/LayoutTests/accessibility/custom-elements/flowto-shadow.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<body id="body">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<div role="button" class="flowto">FlowTo1</div>
+<div id="flowto2" role="button" class="flowto">FlowTo2</div>
+<div class="label">label 1</div>
+<div id="label2" class="label">label 2</div>
+<div id="host"></div>
+<script>
+
+class CustomElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        window.internals = this.attachInternals();
+        internals.role = 'checkbox';
+        internals.ariaFlowToElements = Array.from(document.querySelectorAll('.flowto'));
+        internals.ariaLabelledByElements = Array.from(document.querySelectorAll('.label'));
+        shouldBe('internals.ariaFlowToElements.length', '2');
+        shouldBe('internals.ariaFlowToElements[0]', 'document.querySelectorAll(".flowto")[0]');
+        shouldBe('internals.ariaFlowToElements[1]', 'document.querySelectorAll(".flowto")[1]');
+        shouldBe('internals.ariaLabelledByElements.length', '2');
+        shouldBe('internals.ariaLabelledByElements[0]', 'document.querySelectorAll(".label")[0]');
+        shouldBe('internals.ariaLabelledByElements[1]', 'document.querySelectorAll(".label")[1]');
+    }
+};
+customElements.define('custom-element', CustomElement);
+
+const shadowRoot = host.attachShadow({'mode': 'closed'});
+const customElement = new CustomElement;
+customElement.id = 'custom-1';
+shadowRoot.appendChild(customElement);
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").role', 'AXRole: AXCheckBox');
+    shouldBeEqualToString('platformValueForW3CName(accessibilityController.accessibleElementById("custom-1"))', 'label 1 label 2');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(0).role', 'AXRole: AXButton');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(0).title', 'AXTitle: FlowTo1');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(1).role', 'AXRole: AXButton');
+    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(1).title', 'AXTitle: FlowTo2');
+    shouldBe('accessibilityController.accessibleElementById("custom-1").ariaFlowToElementAtIndex(2)', 'null');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/custom-elements/menuitem-shadow-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/menuitem-shadow-expected.txt
@@ -1,0 +1,14 @@
+This tests that aria fallback roles work correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS customMenuInternals.ariaActiveDescendantElement is document.getElementById("item-2")
+PASS customMenuInternals.ariaActiveDescendantElement is document.getElementById("item-2")
+PASS accessibilityController.accessibleElementById("menu-1").selectedChildrenCount is 1
+PASS platformValueForW3CName(accessibilityController.accessibleElementById("menu-1").selectedChildAtIndex(0)) is "item 2"
+PASS accessibilityController.accessibleElementById("menu-1").selectedChildAtIndex(0).isSelected is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/custom-elements/menuitem-shadow.html
+++ b/LayoutTests/accessibility/custom-elements/menuitem-shadow.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<custom-menu id="menu-1">
+<div id="host">
+<custom-menuitem id="item-1" aria-label="item 1"></custom-menuitem>
+<custom-menuitem id="item-2" aria-label="item 2"></custom-menuitem>
+</div>
+<script>
+
+class CustomMenuElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'menubar';
+        internals.ariaActiveDescendantElement = document.getElementById('item-2');
+        window.customMenuInternals = internals;
+        shouldBe('customMenuInternals.ariaActiveDescendantElement', 'document.getElementById("item-2")');
+    }
+};
+customElements.define('custom-menu', CustomMenuElement);
+
+class CustomMenuItemElement extends HTMLElement {
+    constructor()
+    {
+        super();
+        const internals = this.attachInternals();
+        internals.role = 'menuitem';
+    }
+}
+customElements.define('custom-menuitem', CustomMenuItemElement);
+
+const shadowRoot = host.attachShadow({mode: 'closed'});
+shadowRoot.innerHTML = '<custom-menu id="menu-1"><slot></slot></custom-menu>';
+
+description("This tests that aria fallback roles work correctly.");
+if (!window.accessibilityController)
+    debug('This test requires accessibilityController');
+else {
+    shouldBe('accessibilityController.accessibleElementById("menu-1").selectedChildrenCount', '1');
+    shouldBeEqualToString('platformValueForW3CName(accessibilityController.accessibleElementById("menu-1").selectedChildAtIndex(0))', 'item 2');
+    shouldBeTrue('accessibilityController.accessibleElementById("menu-1").selectedChildAtIndex(0).isSelected');
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -524,6 +524,7 @@ private:
     void addRelation(Element*, Element*, AXRelationType);
     void addRelation(AccessibilityObject*, AccessibilityObject*, AXRelationType, AddingSymmetricRelation = AddingSymmetricRelation::No);
     void updateRelationsIfNeeded();
+    void updateRelationsForTree(ContainerNode&);
     void relationsNeedUpdate(bool);
     HashMap<AXID, AXRelations> relations();
     const HashSet<AXID>& relationTargetIDs();

--- a/Source/WebCore/dom/CustomElementDefaultARIA.cpp
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.cpp
@@ -43,7 +43,7 @@ void CustomElementDefaultARIA::setValueForAttribute(const QualifiedName& name, c
 
 static bool isElementVisible(const Element& element, const Element& thisElement)
 {
-    return !element.isConnected() || thisElement.isDescendantOrShadowDescendantOf(element.rootNode());
+    return !element.isConnected() || element.isInDocumentTree() || thisElement.isDescendantOrShadowDescendantOf(element.rootNode());
 }
 
 const AtomString& CustomElementDefaultARIA::valueForAttribute(const Element& thisElement, const QualifiedName& name) const


### PR DESCRIPTION
#### 8f927ad0d4312332b9c76c0b2219e02da04a202b
<pre>
Make custom elements&apos;s default ARIA id-ref work with shadow DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=245467">https://bugs.webkit.org/show_bug.cgi?id=245467</a>

Reviewed by Manuel Rego Casasnovas.

Make ElementInternals&apos;s id-ref ARIA attributes work with shadow DOM by recursively updating
relations between AX objects in AXObjectCache::updateRelationsIfNeeded.

* LayoutTests/accessibility/custom-elements/controls-shadow-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/controls-shadow.html: Added.
* LayoutTests/accessibility/custom-elements/describedby-shadow-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/describedby-shadow.html: Added.
* LayoutTests/accessibility/custom-elements/flowto-shadow-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/flowto-shadow.html: Added.
* LayoutTests/accessibility/custom-elements/menuitem-shadow-expected.txt: Added.
* LayoutTests/accessibility/custom-elements/menuitem-shadow.html: Added.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::updateRelationsIfNeeded):
(WebCore::AXObjectCache::updateRelationsForTree): Extracted from updateRelationsIfNeeded.
* Source/WebCore/accessibility/AXObjectCache.h:

* Source/WebCore/dom/CustomElementDefaultARIA.cpp:
(WebCore::isElementVisible): Fixed a bug that this function returns false when
&quot;thisElement&quot; is disconnected but element is in the document tree.

Canonical link: <a href="https://commits.webkit.org/254762@main">https://commits.webkit.org/254762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0be5846bbc8c95d9ec057f270e68deea3a29ef29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99429 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156932 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33150 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82442 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/94270 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26362 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76932 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26251 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69251 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/34316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15068 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16011 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/35901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38981 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1426 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/37803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35095 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->