### PR TITLE
[build.webkit.org] GTK4 queue is independent from regular GTK queue

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -410,7 +410,7 @@
                       "name": "GTK-Linux-64-bit-Release-Build", "factory": "BuildAndGenerateJSCBundleFactory",
                       "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
                       "triggers": ["gtk-linux-64-release-tests", "gtk-linux-64-release-tests-js", "gtk-linux-64-release-tests-webdriver",
-                                   "gtk-linux-64-release-wayland-tests", "gtk-linux-64-release-perf-tests", "gtk-linux-64-release-gtk4-tests",
+                                   "gtk-linux-64-release-wayland-tests", "gtk-linux-64-release-perf-tests",
                                    "gtk-linux-64-release-skip-failing-tests"],
                       "workernames": ["gtk-linux-bot-2"]
                     },
@@ -640,6 +640,7 @@
                                        "GTK-Linux-64-bit-Release-Debian-Stable-Build",
                                        "GTK-Linux-64-bit-Release-Ubuntu-2004-Build",
                                        "GTK-Linux-64-bit-Release-Ubuntu-LTS-Build",
+                                       "GTK-Linux-64-bit-Release-GTK4-Tests",
                                        "WPE-Linux-64-bit-Release-Ubuntu-2004-Build",
                                        "WPE-Linux-64-bit-Release-Ubuntu-LTS-Build",
                                        "JSCOnly-Linux-AArch64-Release",
@@ -791,9 +792,6 @@
                     },
                     { "type": "Triggerable", "name": "gtk-linux-64-release-tests-webdriver",
                       "builderNames": ["GTK-Linux-64-bit-Release-WebDriver-Tests"]
-                    },
-                    { "type": "Triggerable", "name": "gtk-linux-64-release-gtk4-tests",
-                      "builderNames": ["GTK-Linux-64-bit-Release-GTK4-Tests"]
                     },
                     { "type": "Triggerable", "name": "gtk-linux-64-debug-tests",
                       "builderNames": ["GTK-Linux-64-bit-Debug-Tests"]


### PR DESCRIPTION
#### 8b56efe38bdb559f7173d2a287b35ebe6a814a8d
<pre>
[build.webkit.org] GTK4 queue is independent from regular GTK queue
<a href="https://bugs.webkit.org/show_bug.cgi?id=245470">https://bugs.webkit.org/show_bug.cgi?id=245470</a>

Reviewed by Carlos Alberto Lopez Perez.

* Tools/CISupport/build-webkit-org/config.json: Trigger GTK4 queue for
  every commit and remove dependency on regular GTK queue.

Canonical link: <a href="https://commits.webkit.org/254785@main">https://commits.webkit.org/254785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56185df0583bb7abb0b328f07b5f42a4ca415d90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99335 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156849 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33039 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28433 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82337 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93636 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26251 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76811 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26165 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80924 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69166 "Found 1 new API test failure: /WebKit2Gtk/TestWebKitWebView:/webkit/WebKitWebView/title-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34263 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15007 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/89051 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32104 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15948 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3365 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/35848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38907 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37748 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35032 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->