### PR TITLE
AsyncScrolling: remove duplicated code in ScrollingCoordinator platform implementations

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1902,6 +1902,7 @@ page/scrolling/ScrollingTreeOverflowScrollingNode.cpp
 page/scrolling/ScrollingTreeScrollingNode.cpp
 page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp
 page/scrolling/ScrollingTreeStickyNode.cpp
+page/scrolling/ThreadedScrollingCoordinator.cpp
 page/scrolling/ThreadedScrollingTree.cpp
 platform/CommonAtomStrings.cpp
 platform/ContentType.cpp

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -517,6 +517,30 @@ void ScrollingTree::clearLatchedNode()
     m_latchingController.clearLatchedNode();
 }
 
+void ScrollingTree::receivedWheelEvent(const PlatformWheelEvent& event)
+{
+    if (m_wheelEventTestMonitor)
+        m_wheelEventTestMonitor->receivedWheelEvent(event);
+}
+
+void ScrollingTree::deferWheelEventTestCompletionForReason(WheelEventTestMonitor::ScrollableAreaIdentifier identifier, WheelEventTestMonitor::DeferReason reason)
+{
+    if (!m_wheelEventTestMonitor)
+        return;
+
+    LOG_WITH_STREAM(WheelEventTestMonitor, stream << "    (!) ScrollingTree::deferForReason: Deferring on " << identifier << " for reason " << reason);
+    m_wheelEventTestMonitor->deferForReason(identifier, reason);
+}
+
+void ScrollingTree::removeWheelEventTestCompletionDeferralForReason(WheelEventTestMonitor::ScrollableAreaIdentifier identifier, WheelEventTestMonitor::DeferReason reason)
+{
+    if (!m_wheelEventTestMonitor)
+        return;
+
+    LOG_WITH_STREAM(WheelEventTestMonitor, stream << "    (!) ScrollingTree::removeDeferralForReason: Removing deferral on " << identifier << " for reason " << reason);
+    m_wheelEventTestMonitor->removeDeferralForReason(identifier, reason);
+}
+
 FloatPoint ScrollingTree::mainFrameScrollPosition() const
 {
     ASSERT(m_treeStateLock.isLocked());

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -159,16 +159,14 @@ public:
 
     WEBCORE_EXPORT TrackingType eventTrackingTypeForPoint(EventTrackingRegions::EventType, IntPoint);
 
-    virtual WheelEventTestMonitor* wheelEventTestMonitor() { return nullptr; }
+    WheelEventTestMonitor* wheelEventTestMonitor() { return m_wheelEventTestMonitor.get(); }
+    void setWheelEventTestMonitor(RefPtr<WheelEventTestMonitor>&& monitor) { m_wheelEventTestMonitor = WTFMove(monitor); }
+    void deferWheelEventTestCompletionForReason(WheelEventTestMonitor::ScrollableAreaIdentifier, WheelEventTestMonitor::DeferReason);
+    void removeWheelEventTestCompletionDeferralForReason(WheelEventTestMonitor::ScrollableAreaIdentifier, WheelEventTestMonitor::DeferReason);
 
 #if PLATFORM(MAC)
     virtual void handleWheelEventPhase(ScrollingNodeID, PlatformWheelEventPhase) = 0;
     virtual void setActiveScrollSnapIndices(ScrollingNodeID, std::optional<unsigned> /*horizontalIndex*/, std::optional<unsigned> /*verticalIndex*/) { }
-
-    virtual void setWheelEventTestMonitor(RefPtr<WheelEventTestMonitor>&&) { }
-
-    virtual void deferWheelEventTestCompletionForReason(WheelEventTestMonitor::ScrollableAreaIdentifier, WheelEventTestMonitor::DeferReason) { }
-    virtual void removeWheelEventTestCompletionDeferralForReason(WheelEventTestMonitor::ScrollableAreaIdentifier, WheelEventTestMonitor::DeferReason) { }
 #else
     void handleWheelEventPhase(ScrollingNodeID, PlatformWheelEventPhase) { }
 #endif
@@ -278,7 +276,7 @@ private:
 
     OptionSet<WheelEventProcessingSteps> computeWheelProcessingSteps(const PlatformWheelEvent&) WTF_REQUIRES_LOCK(m_treeStateLock);
 
-    virtual void receivedWheelEvent(const PlatformWheelEvent&) { }
+    void receivedWheelEvent(const PlatformWheelEvent&);
 
     RefPtr<ScrollingTreeFrameScrollingNode> m_rootNode;
 
@@ -327,6 +325,8 @@ private:
 
     Lock m_lastWheelEventTimeLock;
     MonotonicTime m_lastWheelEventTime WTF_GUARDED_BY_LOCK(m_lastWheelEventTimeLock);
+
+    RefPtr<WheelEventTestMonitor> m_wheelEventTestMonitor;
 
 protected:
     bool m_allowLatching { true };

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2014-2015 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ThreadedScrollingCoordinator.h"
+
+#if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
+#include "Logging.h"
+#include "Page.h"
+#include "ScrollingThread.h"
+#include "ThreadedScrollingTree.h"
+#include "WheelEventTestMonitor.h"
+
+namespace WebCore {
+
+ThreadedScrollingCoordinator::ThreadedScrollingCoordinator(Page* page)
+    : AsyncScrollingCoordinator(page)
+{
+}
+
+ThreadedScrollingCoordinator::~ThreadedScrollingCoordinator() = default;
+
+void ThreadedScrollingCoordinator::pageDestroyed()
+{
+    AsyncScrollingCoordinator::pageDestroyed();
+
+    // Invalidating the scrolling tree will break the reference cycle between the ScrollingCoordinator and ScrollingTree objects.
+    RefPtr scrollingTree = static_pointer_cast<ThreadedScrollingTree>(releaseScrollingTree());
+    ScrollingThread::dispatch([scrollingTree = WTFMove(scrollingTree)] {
+        scrollingTree->invalidate();
+    });
+}
+
+void ThreadedScrollingCoordinator::commitTreeStateIfNeeded()
+{
+    willCommitTree();
+
+    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingCoordinator::commitTreeState, has changes " << scrollingStateTree()->hasChangedProperties());
+
+    if (!scrollingStateTree()->hasChangedProperties())
+        return;
+
+    LOG_WITH_STREAM(ScrollingTree, stream << "ThreadedScrollingCoordinator::commitTreeState: state tree " << scrollingStateTreeAsText(debugScrollingStateTreeAsTextBehaviors));
+
+    auto stateTree = scrollingStateTree()->commit(LayerRepresentation::PlatformLayerRepresentation);
+    scrollingTree()->commitTreeState(WTFMove(stateTree));
+}
+
+bool ThreadedScrollingCoordinator::handleWheelEventForScrolling(const PlatformWheelEvent& wheelEvent, ScrollingNodeID targetNodeID, std::optional<WheelScrollGestureState> gestureState)
+{
+    ASSERT(isMainThread());
+    ASSERT(m_page);
+    ASSERT(scrollingTree());
+
+    if (scrollingTree()->willWheelEventStartSwipeGesture(wheelEvent))
+        return false;
+
+    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingCoordinator::handleWheelEventForScrolling " << wheelEvent << " - sending event to scrolling thread, node " << targetNodeID << " gestureState " << gestureState);
+
+    auto deferrer = WheelEventTestMonitorCompletionDeferrer { m_page->wheelEventTestMonitor().get(), reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(targetNodeID), WheelEventTestMonitor::PostMainThreadWheelEventHandling };
+
+    RefPtr<ThreadedScrollingTree> threadedScrollingTree = downcast<ThreadedScrollingTree>(scrollingTree());
+    ScrollingThread::dispatch([threadedScrollingTree, wheelEvent, targetNodeID, gestureState, deferrer = WTFMove(deferrer)] {
+        threadedScrollingTree->handleWheelEventAfterMainThread(wheelEvent, targetNodeID, gestureState);
+    });
+    return true;
+}
+
+void ThreadedScrollingCoordinator::wheelEventWasProcessedByMainThread(const PlatformWheelEvent& wheelEvent, std::optional<WheelScrollGestureState> gestureState)
+{
+    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingCoordinator::wheelEventWasProcessedByMainThread " << gestureState);
+
+    RefPtr<ThreadedScrollingTree> threadedScrollingTree = downcast<ThreadedScrollingTree>(scrollingTree());
+    threadedScrollingTree->wheelEventWasProcessedByMainThread(wheelEvent, gestureState);
+}
+
+void ThreadedScrollingCoordinator::scheduleTreeStateCommit()
+{
+    scheduleRenderingUpdate();
+}
+
+void ThreadedScrollingCoordinator::didScheduleRenderingUpdate()
+{
+    RefPtr<ThreadedScrollingTree> threadedScrollingTree = downcast<ThreadedScrollingTree>(scrollingTree());
+    threadedScrollingTree->didScheduleRenderingUpdate();
+}
+
+void ThreadedScrollingCoordinator::willStartRenderingUpdate()
+{
+    RefPtr<ThreadedScrollingTree> threadedScrollingTree = downcast<ThreadedScrollingTree>(scrollingTree());
+    threadedScrollingTree->willStartRenderingUpdate();
+    commitTreeStateIfNeeded();
+    synchronizeStateFromScrollingTree();
+}
+
+void ThreadedScrollingCoordinator::didCompleteRenderingUpdate()
+{
+    downcast<ThreadedScrollingTree>(scrollingTree())->didCompleteRenderingUpdate();
+
+    // When scroll animations are running on the scrolling thread, we need something to continually tickle the
+    // DisplayRefreshMonitor so that ThreadedScrollingTree::displayDidRefresh() will get called to service those animations.
+    // We can achieve this by scheduling a rendering update; this won't cause extra work, since scrolling thread scrolls
+    // will end up triggering these anyway.
+    if (scrollingTree()->hasNodeWithActiveScrollAnimations())
+        scheduleRenderingUpdate();
+}
+
+void ThreadedScrollingCoordinator::hasNodeWithAnimatedScrollChanged(bool hasAnimatingNode)
+{
+    // This is necessary to trigger a rendering update, after which the code in
+    // AsyncScrollingCoordinator::didCompleteRenderingUpdate() triggers the rest.
+    if (hasAnimatingNode)
+        scheduleRenderingUpdate();
+}
+
+void ThreadedScrollingCoordinator::startMonitoringWheelEvents(bool clearLatchingState)
+{
+    if (clearLatchingState)
+        scrollingTree()->clearLatchedNode();
+    auto monitor = m_page->wheelEventTestMonitor();
+    scrollingTree()->setWheelEventTestMonitor(WTFMove(monitor));
+}
+
+void ThreadedScrollingCoordinator::stopMonitoringWheelEvents()
+{
+    scrollingTree()->setWheelEventTestMonitor(nullptr);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2014-2015 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
+
+#include "AsyncScrollingCoordinator.h"
+
+namespace WebCore {
+
+class ThreadedScrollingCoordinator : public AsyncScrollingCoordinator {
+protected:
+    explicit ThreadedScrollingCoordinator(Page*);
+    virtual ~ThreadedScrollingCoordinator();
+
+    void commitTreeStateIfNeeded() override;
+    WEBCORE_EXPORT void hasNodeWithAnimatedScrollChanged(bool) override;
+    WEBCORE_EXPORT void pageDestroyed() override;
+
+private:
+    WEBCORE_EXPORT void scheduleTreeStateCommit() final;
+    WEBCORE_EXPORT void didScheduleRenderingUpdate() final;
+    WEBCORE_EXPORT void willStartRenderingUpdate() final;
+    WEBCORE_EXPORT void didCompleteRenderingUpdate() final;
+
+    // Handle the wheel event on the scrolling thread. Returns whether the event was handled or not.
+    WEBCORE_EXPORT bool handleWheelEventForScrolling(const PlatformWheelEvent&, ScrollingNodeID, std::optional<WheelScrollGestureState>) final;
+    WEBCORE_EXPORT void wheelEventWasProcessedByMainThread(const PlatformWheelEvent&, std::optional<WheelScrollGestureState>) final;
+
+    WEBCORE_EXPORT void startMonitoringWheelEvents(bool clearLatchingState) final;
+    WEBCORE_EXPORT void stopMonitoringWheelEvents() final;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)

--- a/Source/WebCore/page/scrolling/mac/ScrollingCoordinatorMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingCoordinatorMac.h
@@ -27,40 +27,22 @@
 
 #if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
 
-#include "AsyncScrollingCoordinator.h"
+#include "ThreadedScrollingCoordinator.h"
 
 namespace WebCore {
 
-class WEBCORE_EXPORT ScrollingCoordinatorMac : public AsyncScrollingCoordinator {
+class WEBCORE_EXPORT ScrollingCoordinatorMac : public ThreadedScrollingCoordinator {
 public:
     explicit ScrollingCoordinatorMac(Page*);
     virtual ~ScrollingCoordinatorMac();
 
-    void pageDestroyed() override;
-
     void commitTreeStateIfNeeded() final;
 
-    // Handle the wheel event on the scrolling thread. Returns whether the event was handled or not.
-    bool handleWheelEventForScrolling(const PlatformWheelEvent&, ScrollingNodeID, std::optional<WheelScrollGestureState>) final;
-    void wheelEventWasProcessedByMainThread(const PlatformWheelEvent&, std::optional<WheelScrollGestureState>) final;
-
-protected:
-    void hasNodeWithAnimatedScrollChanged(bool) override;
-
 private:
-    void scheduleTreeStateCommit() final;
-
-    void didScheduleRenderingUpdate() final;
-    void willStartRenderingUpdate() final;
-    void didCompleteRenderingUpdate() final;
-
     void willStartPlatformRenderingUpdate() final;
     void didCompletePlatformRenderingUpdate() final;
 
     void updateTiledScrollingIndicator();
-
-    void startMonitoringWheelEvents(bool clearLatchingState) final;
-    void stopMonitoringWheelEvents() final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.h
@@ -51,14 +51,6 @@ private:
     OptionSet<EventListenerRegionType> eventListenerRegionTypesForPoint(FloatPoint) const final;
 #endif
 
-    void setWheelEventTestMonitor(RefPtr<WheelEventTestMonitor>&&) final;
-    WheelEventTestMonitor* wheelEventTestMonitor() final { return m_wheelEventTestMonitor.get(); }
-
-    void receivedWheelEvent(const PlatformWheelEvent&) final;
-
-    void deferWheelEventTestCompletionForReason(WheelEventTestMonitor::ScrollableAreaIdentifier, WheelEventTestMonitor::DeferReason) final;
-    void removeWheelEventTestCompletionDeferralForReason(WheelEventTestMonitor::ScrollableAreaIdentifier, WheelEventTestMonitor::DeferReason) final;
-
     void registerForPlatformRenderingUpdateCallback();
     void applyLayerPositionsInternal() final WTF_REQUIRES_LOCK(m_treeLock);
 
@@ -69,8 +61,6 @@ private:
 
     // This lock protects the CALayer/PlatformCALayer tree.
     mutable Lock m_layerHitTestMutex;
-    
-    RefPtr<WheelEventTestMonitor> m_wheelEventTestMonitor;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
@@ -273,36 +273,4 @@ void ScrollingTreeMac::registerForPlatformRenderingUpdateCallback()
     } forPhase:kCATransactionPhasePostCommit];
 }
 
-void ScrollingTreeMac::setWheelEventTestMonitor(RefPtr<WheelEventTestMonitor>&& monitor)
-{
-    m_wheelEventTestMonitor = WTFMove(monitor);
-}
-
-void ScrollingTreeMac::receivedWheelEvent(const PlatformWheelEvent& event)
-{
-    auto monitor = m_wheelEventTestMonitor;
-    if (monitor)
-        monitor->receivedWheelEvent(event);
-}
-
-void ScrollingTreeMac::deferWheelEventTestCompletionForReason(WheelEventTestMonitor::ScrollableAreaIdentifier identifier, WheelEventTestMonitor::DeferReason reason)
-{
-    auto monitor = m_wheelEventTestMonitor;
-    if (!monitor)
-        return;
-
-    LOG_WITH_STREAM(WheelEventTestMonitor, stream << "    (!) ScrollingTreeMac::deferForReason: Deferring on " << identifier << " for reason " << reason);
-    monitor->deferForReason(identifier, reason);
-}
-
-void ScrollingTreeMac::removeWheelEventTestCompletionDeferralForReason(WheelEventTestMonitor::ScrollableAreaIdentifier identifier, WheelEventTestMonitor::DeferReason reason)
-{
-    auto monitor = m_wheelEventTestMonitor;
-    if (!monitor)
-        return;
-
-    LOG_WITH_STREAM(WheelEventTestMonitor, stream << "    (!) ScrollingTreeMac::removeDeferralForReason: Removing deferral on " << identifier << " for reason " << reason);
-    monitor->removeDeferralForReason(identifier, reason);
-}
-
 #endif // ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingCoordinatorNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingCoordinatorNicosia.h
@@ -29,31 +29,14 @@
 
 #if ENABLE(ASYNC_SCROLLING) && USE(NICOSIA)
 
-#include "AsyncScrollingCoordinator.h"
-
-#include <wtf/RunLoop.h>
+#include "ThreadedScrollingCoordinator.h"
 
 namespace WebCore {
 
-class ScrollingCoordinatorNicosia final : public AsyncScrollingCoordinator {
+class ScrollingCoordinatorNicosia final : public ThreadedScrollingCoordinator {
 public:
     explicit ScrollingCoordinatorNicosia(Page*);
     virtual ~ScrollingCoordinatorNicosia();
-
-    void pageDestroyed() override;
-
-    void commitTreeStateIfNeeded() override;
-
-    bool handleWheelEventForScrolling(const PlatformWheelEvent&, ScrollingNodeID, std::optional<WheelScrollGestureState>) override;
-    void wheelEventWasProcessedByMainThread(const PlatformWheelEvent&, std::optional<WheelScrollGestureState>) override;
-
-private:
-    void scheduleTreeStateCommit() override;
-
-    void willStartRenderingUpdate() final;
-    void didCompleteRenderingUpdate() final;
-
-    void hasNodeWithAnimatedScrollChanged(bool) final;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 5065b24db42585ced050a5160fbf6c3c362670ba
<pre>
AsyncScrolling: remove duplicated code in ScrollingCoordinator platform implementations
<a href="https://bugs.webkit.org/show_bug.cgi?id=245474">https://bugs.webkit.org/show_bug.cgi?id=245474</a>

Reviewed by Martin Robinson.

Most of the code in Nicosia and Mac implementations is the same but
duplicated in both places. We can move common code to a shared cpp
file.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::receivedWheelEvent):
(WebCore::ScrollingTree::deferWheelEventTestCompletionForReason):
(WebCore::ScrollingTree::removeWheelEventTestCompletionDeferralForReason):
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::wheelEventTestMonitor):
(WebCore::ScrollingTree::setWheelEventTestMonitor):
(WebCore::ScrollingTree::setActiveScrollSnapIndices):
(WebCore::ScrollingTree::deferWheelEventTestCompletionForReason): Deleted.
(WebCore::ScrollingTree::removeWheelEventTestCompletionDeferralForReason): Deleted.
(WebCore::ScrollingTree::receivedWheelEvent): Deleted.
* Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp: Copied from Source/WebCore/page/scrolling/mac/ScrollingCoordinatorMac.mm.
(WebCore::ThreadedScrollingCoordinator::ThreadedScrollingCoordinator):
(WebCore::ThreadedScrollingCoordinator::pageDestroyed):
(WebCore::ThreadedScrollingCoordinator::commitTreeStateIfNeeded):
(WebCore::ThreadedScrollingCoordinator::handleWheelEventForScrolling):
(WebCore::ThreadedScrollingCoordinator::wheelEventWasProcessedByMainThread):
(WebCore::ThreadedScrollingCoordinator::scheduleTreeStateCommit):
(WebCore::ThreadedScrollingCoordinator::didScheduleRenderingUpdate):
(WebCore::ThreadedScrollingCoordinator::willStartRenderingUpdate):
(WebCore::ThreadedScrollingCoordinator::didCompleteRenderingUpdate):
(WebCore::ThreadedScrollingCoordinator::hasNodeWithAnimatedScrollChanged):
(WebCore::ThreadedScrollingCoordinator::startMonitoringWheelEvents):
(WebCore::ThreadedScrollingCoordinator::stopMonitoringWheelEvents):
* Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.h: Copied from Source/WebCore/page/scrolling/mac/ScrollingCoordinatorMac.h.
* Source/WebCore/page/scrolling/mac/ScrollingCoordinatorMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingCoordinatorMac.mm:
(WebCore::ScrollingCoordinatorMac::ScrollingCoordinatorMac):
(WebCore::ScrollingCoordinatorMac::commitTreeStateIfNeeded):
(WebCore::ScrollingCoordinatorMac::pageDestroyed): Deleted.
(WebCore::ScrollingCoordinatorMac::handleWheelEventForScrolling): Deleted.
(WebCore::ScrollingCoordinatorMac::wheelEventWasProcessedByMainThread): Deleted.
(WebCore::ScrollingCoordinatorMac::scheduleTreeStateCommit): Deleted.
(WebCore::ScrollingCoordinatorMac::didScheduleRenderingUpdate): Deleted.
(WebCore::ScrollingCoordinatorMac::willStartRenderingUpdate): Deleted.
(WebCore::ScrollingCoordinatorMac::didCompleteRenderingUpdate): Deleted.
(WebCore::ScrollingCoordinatorMac::hasNodeWithAnimatedScrollChanged): Deleted.
(WebCore::ScrollingCoordinatorMac::startMonitoringWheelEvents): Deleted.
(WebCore::ScrollingCoordinatorMac::stopMonitoringWheelEvents): Deleted.
* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm:
(ScrollingTreeMac::setWheelEventTestMonitor): Deleted.
(ScrollingTreeMac::receivedWheelEvent): Deleted.
(ScrollingTreeMac::deferWheelEventTestCompletionForReason): Deleted.
(ScrollingTreeMac::removeWheelEventTestCompletionDeferralForReason): Deleted.
* Source/WebCore/page/scrolling/nicosia/ScrollingCoordinatorNicosia.cpp:
(WebCore::ScrollingCoordinatorNicosia::ScrollingCoordinatorNicosia):
(WebCore::ScrollingCoordinatorNicosia::pageDestroyed): Deleted.
(WebCore::ScrollingCoordinatorNicosia::commitTreeStateIfNeeded): Deleted.
(WebCore::ScrollingCoordinatorNicosia::handleWheelEventForScrolling): Deleted.
(WebCore::ScrollingCoordinatorNicosia::wheelEventWasProcessedByMainThread): Deleted.
(WebCore::ScrollingCoordinatorNicosia::scheduleTreeStateCommit): Deleted.
(WebCore::ScrollingCoordinatorNicosia::willStartRenderingUpdate): Deleted.
(WebCore::ScrollingCoordinatorNicosia::didCompleteRenderingUpdate): Deleted.
(WebCore::ScrollingCoordinatorNicosia::hasNodeWithAnimatedScrollChanged): Deleted.
* Source/WebCore/page/scrolling/nicosia/ScrollingCoordinatorNicosia.h:

Canonical link: <a href="https://commits.webkit.org/254952@main">https://commits.webkit.org/254952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c69f24b97e77ee1e4868b9b717d471fc251a0832

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100102 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33887 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83154 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/96496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96467 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77614 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26796 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81489 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69825 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34974 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/15524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32775 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16505 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3455 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36551 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38476 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35594 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->