### PR TITLE
Remove WebArchiveDebugMode

### DIFF
--- a/LayoutTests/platform/wk2/webarchive/loading/test-loading-archive-subresource-null-mimetype-expected.txt
+++ b/LayoutTests/platform/wk2/webarchive/loading/test-loading-archive-subresource-null-mimetype-expected.txt
@@ -6,11 +6,11 @@ frame "<!--frame1-->" - didStartProvisionalLoadForFrame
 resources/subresource-null-mimetype.webarchive - willSendRequest <NSURLRequest URL resources/subresource-null-mimetype.webarchive, main document URL test-loading-archive-subresource-null-mimetype.html, http method GET> redirectResponse (null)
 resources/subresource-null-mimetype.webarchive - didReceiveResponse <NSURLResponse resources/subresource-null-mimetype.webarchive, http status code 0>
 frame "<!--frame1-->" - didCommitLoadForFrame
-test.png - willSendRequest <NSURLRequest URL test.png, main document URL test-loading-archive-subresource-null-mimetype.html, http method GET> redirectResponse (null)
+webarchive+file:///test.png - willSendRequest <NSURLRequest URL webarchive+file:///test.png, main document URL test-loading-archive-subresource-null-mimetype.html, http method GET> redirectResponse (null)
 frame "<!--frame1-->" - didFinishDocumentLoadForFrame
 resources/subresource-null-mimetype.webarchive - didFinishLoading
-test.png - didReceiveResponse <NSURLResponse test.png, http status code 0>
-test.png - didFinishLoading
+webarchive+file:///test.png - didReceiveResponse <NSURLResponse webarchive+file:///test.png, http status code 0>
+webarchive+file:///test.png - didFinishLoading
 frame "<!--frame1-->" - didHandleOnloadEventsForFrame
 main frame - didHandleOnloadEventsForFrame
 frame "<!--frame1-->" - didFinishLoadForFrame

--- a/LayoutTests/webarchive/loading/test-loading-archive-subresource-null-mimetype-expected.txt
+++ b/LayoutTests/webarchive/loading/test-loading-archive-subresource-null-mimetype-expected.txt
@@ -6,11 +6,11 @@ main frame - didFinishDocumentLoadForFrame
 test-loading-archive-subresource-null-mimetype.html - didFinishLoading
 resources/subresource-null-mimetype.webarchive - didReceiveResponse <NSURLResponse resources/subresource-null-mimetype.webarchive, http status code 0>
 frame "<!--frame1-->" - didCommitLoadForFrame
-test.png - willSendRequest <NSURLRequest URL test.png, main document URL test-loading-archive-subresource-null-mimetype.html, http method GET> redirectResponse (null)
+webarchive+file:///test.png - willSendRequest <NSURLRequest URL webarchive+file:///test.png, main document URL test-loading-archive-subresource-null-mimetype.html, http method GET> redirectResponse (null)
 frame "<!--frame1-->" - didFinishDocumentLoadForFrame
 resources/subresource-null-mimetype.webarchive - didFinishLoading
-test.png - didReceiveResponse <NSURLResponse test.png, http status code 0>
-test.png - didFinishLoading
+webarchive+file:///test.png - didReceiveResponse <NSURLResponse webarchive+file:///test.png, http status code 0>
+webarchive+file:///test.png - didFinishLoading
 frame "<!--frame1-->" - didHandleOnloadEventsForFrame
 main frame - didHandleOnloadEventsForFrame
 frame "<!--frame1-->" - didFinishLoadForFrame

--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -2506,6 +2506,17 @@ WebArchiveDebugModeEnabled:
     WebCore:
       default: false
 
+WebArchiveTestingModeEnabled:
+  type: bool
+  condition: ENABLE(WEB_ARCHIVE)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 WebAudioEnabled:
   type: bool
   condition: ENABLE(WEB_AUDIO)

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -429,7 +429,7 @@ struct MarkupAndArchive {
 
 static std::optional<MarkupAndArchive> extractMarkupAndArchive(SharedBuffer& buffer, const std::function<bool(const String)>& canShowMIMETypeAsHTML)
 {
-    auto archive = LegacyWebArchive::create(URL(), buffer);
+    auto archive = LegacyWebArchive::create(buffer);
     if (!archive)
         return std::nullopt;
 

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -510,6 +510,10 @@ private:
     void clearArchiveResources();
 #endif
 
+#if ENABLE(WEB_ARCHIVE) || ENABLE(MHTML)
+    bool isLoadingRemoteArchive() const;
+#endif
+
     void willSendRequest(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&);
     void finishedLoading();
     void mainReceivedError(const ResourceError&);

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -222,6 +222,16 @@ void ResourceLoader::start()
 #if ENABLE(WEB_ARCHIVE) || ENABLE(MHTML)
     if (m_documentLoader && m_documentLoader->scheduleArchiveLoad(*this, m_request))
         return;
+
+#if ENABLE(WEB_ARCHIVE)
+    constexpr auto webArchivePrefix { "webarchive+"_s };
+    if (m_request.url().protocol().startsWith(webArchivePrefix)) {
+        auto url { m_request.url() };
+        const auto unprefixedScheme { url.protocol().substring(webArchivePrefix.length()) };
+        url.setProtocol(unprefixedScheme);
+        m_request.setURL(url);
+    }
+#endif
 #endif
 
     if (m_documentLoader && m_documentLoader->applicationCacheHost().maybeLoadResource(*this, m_request, m_request.url()))

--- a/Source/WebCore/loader/archive/ArchiveResourceCollection.cpp
+++ b/Source/WebCore/loader/archive/ArchiveResourceCollection.cpp
@@ -33,6 +33,10 @@
 
 namespace WebCore {
 
+#if ENABLE(WEB_ARCHIVE) && USE(CF)
+constexpr auto webArchivePrefix { "webarchive+"_s };
+#endif
+
 void ArchiveResourceCollection::addAllResources(Archive& archive)
 {
     for (auto& subresource : archive.subresources())
@@ -53,19 +57,34 @@ void ArchiveResourceCollection::addAllResources(Archive& archive)
 // Can we change the design in a manner that will let us deprecate that API without reducing functionality of those apps?
 void ArchiveResourceCollection::addResource(Ref<ArchiveResource>&& resource)
 {
-    auto& url = resource->url();
-    m_subresources.set(url.string(), WTFMove(resource));
+#if ENABLE(WEB_ARCHIVE) && USE(CF)
+    const bool addPrefix = !resource->url().protocol().startsWith(webArchivePrefix);
+    const auto prefix { addPrefix ? webArchivePrefix : ""_s };
+    const auto subresourceKey { String { prefix + resource->url().string() } };
+#else
+    const auto& subresourceKey = resource->url().string();
+#endif
+    m_subresources.set(subresourceKey, WTFMove(resource));
 }
 
-ArchiveResource* ArchiveResourceCollection::archiveResourceForURL(const URL& url)
+ArchiveResource* ArchiveResourceCollection::archiveResourceForURL(URL url)
 {
+#if ENABLE(WEB_ARCHIVE) && USE(CF)
+    const auto httpsScheme = String { webArchivePrefix + "https"_str };
+    const auto httpScheme = String { webArchivePrefix + "http"_str };
+    if (!url.protocol().startsWith(webArchivePrefix))
+        url.setProtocol(String { webArchivePrefix + url.protocol() });
+#else
+    constexpr auto httpsScheme = "https"_s;
+    constexpr auto httpScheme = "http"_s;
+#endif
+
     if (auto* resource = m_subresources.get(url.string()))
         return resource;
-    if (!url.protocolIs("https"_s))
+    if (!url.protocolIs(httpsScheme))
         return nullptr;
-    URL httpURL = url;
-    httpURL.setProtocol("http"_s);
-    return m_subresources.get(httpURL.string());
+    url.setProtocol(httpScheme);
+    return m_subresources.get(url.string());
 }
 
 RefPtr<Archive> ArchiveResourceCollection::popSubframeArchive(const String& frameName, const URL& url)

--- a/Source/WebCore/loader/archive/ArchiveResourceCollection.h
+++ b/Source/WebCore/loader/archive/ArchiveResourceCollection.h
@@ -48,7 +48,7 @@ public:
     void addResource(Ref<ArchiveResource>&&);
     void addAllResources(Archive&);
     
-    WEBCORE_EXPORT ArchiveResource* archiveResourceForURL(const URL&);
+    WEBCORE_EXPORT ArchiveResource* archiveResourceForURL(URL);
     RefPtr<Archive> popSubframeArchive(const String& frameName, const URL&);
     
 private:    

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -172,7 +172,7 @@ ResourceResponse LegacyWebArchive::createResourceResponseFromPropertyListData(CF
     return ResourceResponse();
 }
 
-RefPtr<ArchiveResource> LegacyWebArchive::createResource(CFDictionaryRef dictionary)
+RefPtr<ArchiveResource> LegacyWebArchive::createResource(CFDictionaryRef dictionary, const UsePrefixedScheme usePrefixedScheme)
 {
     ASSERT(dictionary);
     if (!dictionary)
@@ -196,11 +196,15 @@ RefPtr<ArchiveResource> LegacyWebArchive::createResource(CFDictionaryRef diction
         return nullptr;
     }
 
-    auto url = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceURLKey));
-    if (url && CFGetTypeID(url) != CFStringGetTypeID()) {
+    const auto cfURL = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceURLKey));
+    if (cfURL && CFGetTypeID(cfURL) != CFStringGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - URL is not of type CFString, cannot create invalid resource");
         return nullptr;
     }
+
+    const String stringURL { cfURL };
+    const auto schemePrefix = usePrefixedScheme == UsePrefixedScheme::Yes ? "webarchive+"_s : ""_s;
+    const URL url { schemePrefix + stringURL };
 
     auto textEncoding = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceTextEncodingNameKey));
     if (textEncoding && CFGetTypeID(textEncoding) != CFStringGetTypeID()) {
@@ -225,7 +229,7 @@ RefPtr<ArchiveResource> LegacyWebArchive::createResource(CFDictionaryRef diction
         response = createResourceResponseFromPropertyListData(resourceResponseData, resourceResponseVersion);
     }
 
-    return ArchiveResource::create(SharedBuffer::create(resourceData), URL { url }, mimeType, textEncoding, frameName, response);
+    return ArchiveResource::create(SharedBuffer::create(resourceData), url, mimeType, textEncoding, frameName, response);
 }
 
 Ref<LegacyWebArchive> LegacyWebArchive::create()
@@ -250,10 +254,15 @@ Ref<LegacyWebArchive> LegacyWebArchive::create(Ref<ArchiveResource>&& mainResour
 
 RefPtr<LegacyWebArchive> LegacyWebArchive::create(FragmentedSharedBuffer& data)
 {
-    return create(URL(), data);
+    return create(URL(), data, UsePrefixedScheme::No);
 }
 
 RefPtr<LegacyWebArchive> LegacyWebArchive::create(const URL&, FragmentedSharedBuffer& data)
+{
+    return create(URL(), data, UsePrefixedScheme::Yes);
+}
+
+RefPtr<LegacyWebArchive> LegacyWebArchive::create(const URL&, FragmentedSharedBuffer& data, const UsePrefixedScheme usePrefixedScheme)
 {
     LOG(Archives, "LegacyWebArchive - Creating from raw data");
 
@@ -282,13 +291,13 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const URL&, FragmentedSharedBu
         return nullptr;
     }
 
-    if (!archive->extract(plist.get()))
+    if (!archive->extract(plist.get(), usePrefixedScheme))
         return nullptr;
 
     return WTFMove(archive);
 }
 
-bool LegacyWebArchive::extract(CFDictionaryRef dictionary)
+bool LegacyWebArchive::extract(CFDictionaryRef dictionary, const UsePrefixedScheme usePrefixedScheme)
 {
     ASSERT(dictionary);
     if (!dictionary) {
@@ -306,7 +315,7 @@ bool LegacyWebArchive::extract(CFDictionaryRef dictionary)
         return false;
     }
 
-    auto mainResource = createResource(mainResourceDict);
+    auto mainResource = createResource(mainResourceDict, usePrefixedScheme);
     if (!mainResource) {
         LOG(Archives, "LegacyWebArchive - Failed to parse main resource from CFDictionary or main resource does not exist, aborting invalid WebArchive");
         return false;
@@ -334,7 +343,7 @@ bool LegacyWebArchive::extract(CFDictionaryRef dictionary)
                 return false;
             }
 
-            if (auto subresource = createResource(subresourceDict))
+            if (auto subresource = createResource(subresourceDict, usePrefixedScheme))
                 addSubresource(subresource.releaseNonNull());
         }
     }
@@ -355,7 +364,7 @@ bool LegacyWebArchive::extract(CFDictionaryRef dictionary)
             }
 
             auto subframeArchive = create();
-            if (subframeArchive->extract(subframeDict))
+            if (subframeArchive->extract(subframeDict, usePrefixedScheme))
                 addSubframeArchive(WTFMove(subframeArchive));
             else
                 LOG(Archives, "LegacyWebArchive - Invalid subframe archive skipped");

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
@@ -52,6 +52,8 @@ public:
     WEBCORE_EXPORT RetainPtr<CFDataRef> rawDataRepresentation();
 
 private:
+    enum class UsePrefixedScheme : bool { No, Yes };
+
     LegacyWebArchive() = default;
 
     bool shouldLoadFromArchiveOnly() const final { return false; }
@@ -61,15 +63,16 @@ private:
 
     enum MainResourceStatus { Subresource, MainResource };
 
+    static RefPtr<LegacyWebArchive> create(const URL&, FragmentedSharedBuffer&, const UsePrefixedScheme);
     static RefPtr<LegacyWebArchive> create(const String& markupString, Frame&, const Vector<Node*>& nodes, Function<bool(Frame&)>&& frameFilter);
-    static RefPtr<ArchiveResource> createResource(CFDictionaryRef);
+    static RefPtr<ArchiveResource> createResource(CFDictionaryRef, const UsePrefixedScheme);
     static ResourceResponse createResourceResponseFromMacArchivedData(CFDataRef);
     static ResourceResponse createResourceResponseFromPropertyListData(CFDataRef, CFStringRef responseDataType);
     static RetainPtr<CFDataRef> createPropertyListRepresentation(const ResourceResponse&);
     static RetainPtr<CFDictionaryRef> createPropertyListRepresentation(Archive&);
     static RetainPtr<CFDictionaryRef> createPropertyListRepresentation(ArchiveResource*, MainResourceStatus);
 
-    bool extract(CFDictionaryRef);
+    bool extract(CFDictionaryRef, const UsePrefixedScheme);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -119,6 +119,11 @@ static bool shouldTreatAsOpaqueOrigin(const URL& url)
         || url.protocolIs("x-apple-ql-id2"_s)
         || url.protocolIs("x-apple-ql-magic"_s)
 #endif
+#if ENABLE(WEB_ARCHIVE) && USE(CF)
+        || url.protocolIs("webarchive+http"_s)
+        || url.protocolIs("webarchive+https"_s)
+        || url.protocolIs("webarchive+ftp"_s)
+#endif
 #if PLATFORM(GTK) || PLATFORM(WPE)
         || url.protocolIs("resource"_s)
 #endif

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -568,14 +568,14 @@ bool WKPreferencesGetDOMTimersThrottlingEnabled(WKPreferencesRef preferencesRef)
     return toImpl(preferencesRef)->domTimersThrottlingEnabled();
 }
 
-void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef, bool enabled)
+void WKPreferencesSetWebArchiveTestingModeEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setWebArchiveDebugModeEnabled(enabled);
+    toImpl(preferencesRef)->setWebArchiveTestingModeEnabled(enabled);
 }
 
-bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef)
+bool WKPreferencesGetWebArchiveTestingModeEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->webArchiveDebugModeEnabled();
+    return toImpl(preferencesRef)->webArchiveTestingModeEnabled();
 }
 
 void WKPreferencesSetLocalFileContentSniffingEnabled(WKPreferencesRef preferencesRef, bool enabled)
@@ -2152,6 +2152,15 @@ void WKPreferencesSetXSSAuditorEnabled(WKPreferencesRef, bool)
 }
 
 bool WKPreferencesGetXSSAuditorEnabled(WKPreferencesRef)
+{
+    return false;
+}
+
+void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef, bool enabled)
+{
+}
+
+bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef)
 {
     return false;
 }

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
@@ -126,8 +126,8 @@ WK_EXPORT void WKPreferencesSetDOMTimersThrottlingEnabled(WKPreferencesRef prefe
 WK_EXPORT bool WKPreferencesGetDOMTimersThrottlingEnabled(WKPreferencesRef preferences);
 
 // Defaults to false.
-WK_EXPORT void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferences, bool enabled);
-WK_EXPORT bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferences);
+WK_EXPORT void WKPreferencesSetWebArchiveTestingModeEnabled(WKPreferencesRef preferences, bool enabled);
+WK_EXPORT bool WKPreferencesGetWebArchiveTestingModeEnabled(WKPreferencesRef preferences);
 
 // Defaults to false.
 WK_EXPORT void WKPreferencesSetLocalFileContentSniffingEnabled(WKPreferencesRef preferences, bool enabled);
@@ -565,6 +565,8 @@ WK_EXPORT void WKPreferencesSetResourceTimingEnabled(WKPreferencesRef, bool) WK_
 WK_EXPORT bool WKPreferencesGetResourceTimingEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
 WK_EXPORT void WKPreferencesSetSubpixelCSSOMElementMetricsEnabled(WKPreferencesRef, bool) WK_C_API_DEPRECATED;
 WK_EXPORT bool WKPreferencesGetSubpixelCSSOMElementMetricsEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
+WK_EXPORT void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferences, bool enabled) WK_C_API_DEPRECATED;
+WK_EXPORT bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferences) WK_C_API_DEPRECATED;
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -992,14 +992,14 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
     return _preferences->domTimersThrottlingEnabled();
 }
 
-- (void)_setWebArchiveDebugModeEnabled:(BOOL)enabled
+- (void)_setWebArchiveTestingModeEnabled:(BOOL)enabled
 {
-    _preferences->setWebArchiveDebugModeEnabled(enabled);
+    _preferences->setWebArchiveTestingModeEnabled(enabled);
 }
 
-- (BOOL)_webArchiveDebugModeEnabled
+- (BOOL)_webArchiveTestingModeEnabled
 {
-    return _preferences->webArchiveDebugModeEnabled();
+    return _preferences->webArchiveTestingModeEnabled();
 }
 
 - (void)_setLocalFileContentSniffingEnabled:(BOOL)enabled
@@ -1656,6 +1656,15 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 }
 
 - (BOOL)_subpixelCSSOMElementMetricsEnabled
+{
+    return NO;
+}
+
+- (void)_setWebArchiveDebugModeEnabled:(BOOL)enabled
+{
+}
+
+- (BOOL)_webArchiveDebugModeEnabled
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -189,7 +189,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setDefaultTextEncodingName:) NSString *_defaultTextEncodingName WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setAuthorAndUserStylesEnabled:) BOOL _authorAndUserStylesEnabled WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setDOMTimersThrottlingEnabled:) BOOL _domTimersThrottlingEnabled WK_API_AVAILABLE(macos(10.13.4));
-@property (nonatomic, setter=_setWebArchiveDebugModeEnabled:) BOOL _webArchiveDebugModeEnabled WK_API_AVAILABLE(macos(10.13.4));
+@property (nonatomic, setter=_setWebArchiveTestingModeEnabled:) BOOL _webArchiveTestingModeEnabled WK_API_AVAILABLE(macos(13.0));
 @property (nonatomic, setter=_setLocalFileContentSniffingEnabled:) BOOL _localFileContentSniffingEnabled WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setUsesPageCache:) BOOL _usesPageCache WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setPageCacheSupportsPlugins:) BOOL _pageCacheSupportsPlugins WK_API_AVAILABLE(macos(10.13.4));
@@ -234,6 +234,6 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setRequestAnimationFrameEnabled:) BOOL _requestAnimationFrameEnabled WK_API_DEPRECATED("requestAnimationFrame is always enabled", macos(10.15.4, 13.0), ios(13.4, 16.0));
 #if !TARGET_OS_IPHONE
 @property (nonatomic, setter=_setSubpixelCSSOMElementMetricsEnabled:) BOOL _subpixelCSSOMElementMetricsEnabled WK_API_DEPRECATED("Subpixel CSSOM element metrics are no longer supported", macos(10.13.4, 10.15));
+@property (nonatomic, setter=_setWebArchiveDebugModeEnabled:) BOOL _webArchiveDebugModeEnabled WK_API_DEPRECATED("WebArchive Debug Mode is no longer supported", macos(10.13.4, 13.0));
 #endif
-
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -3270,6 +3270,13 @@ IGNORE_WARNINGS_END
     if ([scheme _webkit_isCaseInsensitiveEqualToString:@"blob"])
         return YES;
 
+    NSString* webArchivePrefix = @"webarchive+";
+    if ([scheme _webkit_hasCaseInsensitivePrefix:webArchivePrefix]) {
+        auto url = [request URL];
+        NSString* modifiedURL = [[url absoluteString] substringFromIndex:[webArchivePrefix length]];
+        return [self _canHandleRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:modifiedURL]] forMainFrame:forMainFrame];
+    }
+
     return NO;
 }
 

--- a/Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm
@@ -32,6 +32,7 @@
 #import "TestWKWebView.h"
 #import <WebKit/WKDragDestinationAction.h>
 #import <WebKit/WKNavigationPrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
@@ -205,9 +206,9 @@ TEST(LoadWebArchive, DragNavigationReload)
     EXPECT_WK_STREQ(finalURL, "");
 }
 
-static NSData* constructArchive()
+static NSData* constructArchive(const char *script)
 {
-    NSString *js = @"alert('loaded http subresource successfully')";
+    auto *js = [NSString stringWithUTF8String:script];
     auto response = adoptNS([[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://download/script.js"] MIMEType:@"application/javascript" expectedContentLength:js.length textEncodingName:@"utf-8"]);
     auto responseArchiver = adoptNS([[NSKeyedArchiver alloc] initRequiringSecureCoding:YES]);
     [responseArchiver encodeObject:response.get() forKey:@"WebResourceResponse"];
@@ -232,7 +233,7 @@ static NSData* constructArchive()
 
 TEST(LoadWebArchive, HTTPSUpgrade)
 {
-    NSData *data = constructArchive();
+    NSData *data = constructArchive("alert('loaded http subresource successfully')");
 
     auto webView = adoptNS([WKWebView new]);
     [webView loadData:data MIMEType:@"application/x-webarchive" characterEncodingName:@"utf-8" baseURL:[NSURL URLWithString:@"http://download/"]];
@@ -241,7 +242,7 @@ TEST(LoadWebArchive, HTTPSUpgrade)
 
 TEST(LoadWebArchive, DisallowedNetworkHosts)
 {
-    NSData *data = constructArchive();
+    NSData *data = constructArchive("alert('loaded http subresource successfully')");
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get()._allowedNetworkHosts = [NSSet set];
@@ -252,3 +253,7 @@ TEST(LoadWebArchive, DisallowedNetworkHosts)
 }
 
 } // namespace TestWebKitAPI
+
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/LoadWebArchiveAdditions.mm>
+#endif


### PR DESCRIPTION
#### 1eb47513afb8f84f48d36c0daae0eff1bc9b9d03
<pre>
Remove WebArchiveDebugMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=245488">https://bugs.webkit.org/show_bug.cgi?id=245488</a>
&lt;rdar://problem/88406961&gt;

Reviewed by Geoffrey Garen.
Original patch by: Kate Cheney &lt;katherine_cheney@apple.com&gt;

Remove use case of WebArchiveDebugMode and deprecate it now that it
is no longer in use. Add a new temporary flag WebArchiveTestMode
that is more aptly named and will maintain existing behavior for
internal tests temporarily.

In addition, for clarity annotate resource URLs in WebArchive with
&quot;webarchive+&quot; prefix, but avoid breaking web content that transits the
pasteboard. If a requested resource has that scheme prefix, then strip it.

* LayoutTests/platform/wk2/webarchive/loading/test-loading-archive-subresource-null-mimetype-expected.txt:
* LayoutTests/webarchive/loading/test-loading-archive-subresource-null-mimetype-expected.txt:
* Source/WTF/Scripts/Preferences/WebPreferences.yaml:
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::extractMarkupAndArchive):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::isLoadingRemoteArchive const):
(WebCore::DocumentLoader::commitData):
(WebCore::DocumentLoader::scheduleArchiveLoad):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::start):
* Source/WebCore/loader/archive/ArchiveResourceCollection.cpp:
(WebCore::ArchiveResourceCollection::addResource):
(WebCore::ArchiveResourceCollection::archiveResourceForURL):
* Source/WebCore/loader/archive/ArchiveResourceCollection.h:
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::createResource):
(WebCore::LegacyWebArchive::create):
(WebCore::LegacyWebArchive::extract):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.h:
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::shouldTreatAsOpaqueOrigin):
* Source/WebKit/UIProcess/API/C/WKPreferences.cpp:
(WKPreferencesSetWebArchiveTestingModeEnabled):
(WKPreferencesGetWebArchiveTestingModeEnabled):
(WKPreferencesSetWebArchiveDebugModeEnabled):
(WKPreferencesGetWebArchiveDebugModeEnabled):
* Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _setWebArchiveTestingModeEnabled:]):
(-[WKPreferences _webArchiveTestingModeEnabled]):
(-[WKPreferences _setWebArchiveDebugModeEnabled:]):
(-[WKPreferences _webArchiveDebugModeEnabled]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(+[WebView _canHandleRequest:forMainFrame:]):
* Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm:
(TestWebKitAPI::constructArchive):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/255705@main">https://commits.webkit.org/255705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce32dd9dd5e75c254e938e9d0ec76bf4d6394feb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101220 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161246 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/635 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29384 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97572 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/408 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78205 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27366 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70404 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82930 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35619 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16020 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77974 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33404 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17113 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26928 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3947 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39903 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80578 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36230 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17659 "Passed tests") | 
<!--EWS-Status-Bubble-End-->