### PR TITLE
Add more logging to Tools/Scripts/delete-if-too-large

### DIFF
--- a/Tools/Scripts/delete-if-too-large
+++ b/Tools/Scripts/delete-if-too-large
@@ -29,21 +29,25 @@ from pathlib import Path
 
 
 def main():
-    directory = sys.argv[1]
-    directoryPath = Path(directory).resolve()
+     for directory in sys.argv[1:]:
+        print(f'Considering directory {directory} for deletion')
+        directoryPath = Path(directory).resolve()
 
-    if not directoryPath.exists():
-        print(directory + "does not exist")
-        return 1
+        if not directoryPath.exists():
+            print(f'{directory} does not exist')
+            return 1
 
-    if not directoryPath.is_dir():
-        print(directory + "is not a directory")
-        return 1
+        if not directoryPath.is_dir():
+            print(f'{directory} is not a directory')
+            return 1
 
-    tenGigabytes = 1024 * 1024 * 1024 * 10
-    if directoryPath.stat().st_size >= tenGigabytes:
-        os.remove(directory)
-        print("Deleted " + directory)
+        tenGigabytes = 1024 * 1024 * 1024 * 10
+        directorySize = sum(file.stat().st_size for file in directoryPath.rglob('*'))
+        if directorySize >= tenGigabytes:
+            os.remove(directory)
+            print(f'Deleted {directory}')
+        else:
+            print(f'{directory} is {directorySize}. Doing nothing') 
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### 738028099ce467df421c045d54dada3d9d1b9ff2
<pre>
Add more logging to Tools/Scripts/delete-if-too-large
<a href="https://bugs.webkit.org/show_bug.cgi?id=245489">https://bugs.webkit.org/show_bug.cgi?id=245489</a>
rdar://99293146

Reviewed by Aakash Jain.

* Tools/Scripts/delete-if-too-large:

Canonical link: <a href="https://commits.webkit.org/255737@main">https://commits.webkit.org/255737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fa7e4c5d61600f0db33600dfa9820b9dff44053

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101226 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161260 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/649 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29386 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83842 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97578 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/415 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78210 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27375 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70413 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35626 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16024 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33410 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17117 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37215 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1857 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36234 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->