### PR TITLE
Restrict PerformanceServerTiming and PerformanceResourceTiming.{transferSize,encodedBodySize,decodedBodySize} to same origin requests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/TAO-port-mismatch-means-crossorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/TAO-port-mismatch-means-crossorigin-expected.txt
@@ -4,5 +4,5 @@ This test validates that for a cross origin resource with different ports, the t
 
 
 PASS A port mismatch must fail the TAO check
-PASS An identical port must pass the TAO check
+FAIL An identical port must pass the TAO check assert_greater_than: transferSize should be greater than 0 expected a number greater than 0 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/cors-preflight.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/cors-preflight.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-PASS PerformanceResourceTiming sizes fetch with preflight test
+FAIL PerformanceResourceTiming sizes fetch with preflight test assert_greater_than: No-preflight transferSize expected a number greater than 0 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/sizes-redirect-img-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/sizes-redirect-img-expected.txt
@@ -1,7 +1,7 @@
 
 PASS PerformanceResourceTiming sizes redirect image - direct URL
 PASS PerformanceResourceTiming sizes redirect image - same origin redirect
-PASS PerformanceResourceTiming sizes redirect image - cross origin redirect
-PASS PerformanceResourceTiming sizes redirect image - cross origin to same origin redirect
-PASS PerformanceResourceTiming sizes redirect image - same origin to remote origin to same origin redirect
+FAIL PerformanceResourceTiming sizes redirect image - cross origin redirect assert_equals: decodedBodySize expected 1010 but got 0
+FAIL PerformanceResourceTiming sizes redirect image - cross origin to same origin redirect assert_equals: decodedBodySize expected 1010 but got 0
+FAIL PerformanceResourceTiming sizes redirect image - same origin to remote origin to same origin redirect assert_equals: decodedBodySize expected 1010 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/server-timing/cross_origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/server-timing/cross_origin-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Expected entry count for http://localhost:8800/server-timing/resources/blue.png: 1
 PASS Expected entry count for http://127.0.0.1:8800/server-timing/resources/blue.png: 0
-PASS Expected entry count for http://127.0.0.1:8800/server-timing/resources/blue_tao.png: 1
+FAIL Expected entry count for http://127.0.0.1:8800/server-timing/resources/blue_tao.png: 1 assert_equals: Expected entry count for http://127.0.0.1:8800/server-timing/resources/blue_tao.png: 1 expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/navigation-preload/resource-timing.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/navigation-preload/resource-timing.https-expected.txt
@@ -1,3 +1,4 @@
 
-PASS Navigation Preload Resource Timing.
+
+FAIL Navigation Preload Resource Timing. assert_greater_than: transferSize must greater then encodedBodySize. expected a number greater than 0 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resource-timing-cross-origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resource-timing-cross-origin.https-expected.txt
@@ -1,3 +1,4 @@
 
-PASS Test that timing allow check fails when service worker changes origin from same to cross origin.
+
+FAIL Test that timing allow check fails when service worker changes origin from same to cross origin. assert_unreached: unexpected rejection: assert_equals: decodedBodySize should be 0 in cross-origin request. expected 0 but got 18299 Reached unreachable code
 

--- a/Source/WebCore/loader/ResourceTiming.h
+++ b/Source/WebCore/loader/ResourceTiming.h
@@ -51,6 +51,7 @@ public:
     const NetworkLoadMetrics& networkLoadMetrics() const { return m_networkLoadMetrics; }
     NetworkLoadMetrics& networkLoadMetrics() { return m_networkLoadMetrics; }
     Vector<Ref<PerformanceServerTiming>> populateServerTiming() const;
+    bool isSameOriginRequest() const { return m_isSameOriginRequest; }
     ResourceTiming isolatedCopy() const &;
     ResourceTiming isolatedCopy() &&;
 
@@ -74,6 +75,7 @@ private:
     NetworkLoadMetrics m_networkLoadMetrics;
     Vector<ServerTiming> m_serverTiming;
     bool m_isLoadedFromServiceWorker { false };
+    bool m_isSameOriginRequest { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/ServerTimingParser.cpp
+++ b/Source/WebCore/loader/ServerTimingParser.cpp
@@ -38,7 +38,6 @@ namespace ServerTimingParser {
 
 Vector<ServerTiming> parseServerTiming(const String& headerValue)
 {
-    ASSERT(DeprecatedGlobalSettings::serverTimingEnabled());
     auto entries = Vector<ServerTiming>();
     if (headerValue.isNull())
         return entries;

--- a/Source/WebCore/page/PerformanceResourceTiming.cpp
+++ b/Source/WebCore/page/PerformanceResourceTiming.cpp
@@ -271,7 +271,9 @@ double PerformanceResourceTiming::responseEnd() const
 
 uint64_t PerformanceResourceTiming::transferSize() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    // This is intentionally stricter than a TAO check.
+    // See https://github.com/w3c/server-timing/issues/89
+    if (!m_resourceTiming.isSameOriginRequest())
         return 0;
 
     auto encodedBodySize = m_resourceTiming.networkLoadMetrics().responseBodyBytesReceived;
@@ -284,7 +286,9 @@ uint64_t PerformanceResourceTiming::transferSize() const
 
 uint64_t PerformanceResourceTiming::encodedBodySize() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    // This is intentionally stricter than a TAO check.
+    // See https://github.com/w3c/server-timing/issues/89
+    if (!m_resourceTiming.isSameOriginRequest())
         return 0;
 
     auto encodedBodySize = m_resourceTiming.networkLoadMetrics().responseBodyBytesReceived;
@@ -296,7 +300,9 @@ uint64_t PerformanceResourceTiming::encodedBodySize() const
 
 uint64_t PerformanceResourceTiming::decodedBodySize() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    // This is intentionally stricter than a TAO check.
+    // See https://github.com/w3c/server-timing/issues/89
+    if (!m_resourceTiming.isSameOriginRequest())
         return 0;
 
     auto decodedBodySize = m_resourceTiming.networkLoadMetrics().responseBodyDecodedSize;


### PR DESCRIPTION
#### 20108e3e4a2dbb9c82b4f0068ae546f09e90f381
<pre>
Restrict PerformanceServerTiming and PerformanceResourceTiming.{transferSize,encodedBodySize,decodedBodySize} to same origin requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=245501">https://bugs.webkit.org/show_bug.cgi?id=245501</a>
&lt;rdar://100236084&gt;

Reviewed by Ryosuke Niwa.

* Source/WebCore/loader/ResourceTiming.cpp:
(WebCore::ResourceTiming::ResourceTiming):
(WebCore::ResourceTiming::populateServerTiming const):
* Source/WebCore/loader/ResourceTiming.h:
(WebCore::ResourceTiming::isSameSiteRequest const):
* Source/WebCore/page/PerformanceResourceTiming.cpp:
(WebCore::PerformanceResourceTiming::transferSize const):
(WebCore::PerformanceResourceTiming::encodedBodySize const):
(WebCore::PerformanceResourceTiming::decodedBodySize const):

Canonical link: <a href="https://commits.webkit.org/254922@main">https://commits.webkit.org/254922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fe92198d2b28178408e8c2415fdd712ab8a6a00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35282 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/100015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33781 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/96412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96357 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/83059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/34871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36448 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1494 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38371 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->