### PR TITLE
[ New Test ] (254561@main): [ macOS wk2 ] fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html is a flaky failure (245482)

### DIFF
--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html
@@ -14,6 +14,7 @@
         
         async function runTest()
         {
+            eventSender.monitorWheelEvents();
             if (!window.testRunner || !testRunner.runUIScript)
                 return;
 
@@ -21,13 +22,15 @@
             
             setTimeout(async () => {
                 await UIHelper.rawKeyUp("downArrow");
-                await UIHelper.mouseWheelScrollAt(10, 10, 0, 1, 0, 10);
+                const startingPosition = window.scrollY;
+
+                await UIHelper.mouseWheelScrollAt(0, 0, 0, 0, 0, 0);
 
                 const position = window.scrollY;
-                if (position <= 1) 
+                if (Math.abs(startingPosition - position) < 20)
                     debug("Successful.");
                 else
-                    debug("Unsuccessful. window.scrollY == " + position);
+                    debug("Unsuccessful. window.scrollY after wheel event == " + position + "; window.scrollY before wheel event == " + startingPosition);
 
                 testRunner.notifyDone();
             }, 100);

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1127,8 +1127,6 @@ webkit.org/b/229076 [ BigSur Debug ] webrtc/video-interruption.html [ Pass Crash
 
 webkit.org/b/213804 fast/scrolling/mac/scroll-snapping-in-progress.html [ Pass Failure ]
 
-webkit.org/b/245482 fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html [ Pass Failure ]
-
 webkit.org/b/229206 [ Debug ] http/wpt/webrtc/sframe-transform-error.html [ Pass Failure ]
 
 webkit.org/b/214478 [ Debug ] http/wpt/webrtc/generateCertificate.html [ Skip ]


### PR DESCRIPTION
#### 7e2faa9cf5dc8594be90a966883eada469238a7f
<pre>
[ New Test ] (254561@main): [ macOS wk2 ] fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html is a flaky failure (245482)
<a href="https://bugs.webkit.org/show_bug.cgi?id=245503">https://bugs.webkit.org/show_bug.cgi?id=245503</a>
rdar://100227233

Reviewed by Aditya Keerthi.

The original test was flaky because it depended on the scroll position after
a duration of time using `setTimeout`. However, because this is not guaranteed,
the scroll position could vary, causing the test assertion to fail.

This PR fixes this issue by measuring the scroll position relative to the
position immediately after the key up event, which gets rid of this possible
variation.

Additionally, this PR improves upon the original test by having the wheel event
have no delta scroll position; it is only important for the test that the wheel
event properly interrupts the keyboard scrolling. This also removes a possible
vector of variation.

* LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/254771@main">https://commits.webkit.org/254771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49d5558eb4655ee9e11fc7ee3415f3f7907e84e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99401 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156906 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33116 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28478 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93697 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26324 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76882 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26225 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69226 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34299 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15048 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15990 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3349 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/35884 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38963 "Failed to checkout and rebase branch from PR 4581") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35074 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->