### PR TITLE
Provide a runtime toggle for the IndexedDB APIs

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -379,6 +379,18 @@ ImageAnalysisDuringFindInPageEnabled:
     WebCore:
       default: false
 
+IndexedDBAPIEnabled:
+  type: bool
+  humanReadableName: "IndexedDB API"
+  humanReadableDescription: "IndexedDB API"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 InlineFormattingContextIntegrationEnabled:
   type: bool
   humanReadableName: "Next-generation inline layout integration (IFC)"

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled,
     CustomToJSObject,
     JSCustomMarkFunction,
     SkipVTableValidation,

--- a/Source/WebCore/Modules/indexeddb/IDBCursorDirection.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBCursorDirection.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled
 ] enum IDBCursorDirection {
     "next",
     "nextunique",

--- a/Source/WebCore/Modules/indexeddb/IDBCursorWithValue.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBCursorWithValue.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled,
     SkipVTableValidation,
     JSCustomMarkFunction,
     Exposed=(Window,Worker)

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled,
     ActiveDOMObject,
     SkipVTableValidation,
     Exposed=(Window,Worker)

--- a/Source/WebCore/Modules/indexeddb/IDBFactory.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBFactory.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled,
     SkipVTableValidation,
     Exposed=(Window,Worker)
 ] interface IDBFactory {

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.idl
@@ -28,6 +28,7 @@
 typedef (DOMString or sequence<DOMString>) IDBKeyPath;
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled,
     ActiveDOMObject,
     GenerateAddOpaqueRoot,
     GenerateIsReachable=Impl,

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRange.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRange.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled,
     Exposed=(Window,Worker)
 ] interface IDBKeyRange {
     readonly attribute [OverrideIDLType=IDLIDBKey] any lower;

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
@@ -28,6 +28,7 @@
 typedef (DOMString or sequence<DOMString>) IDBKeyPath;
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled,
     ActiveDOMObject,
     GenerateIsReachable=Impl,
     JSCustomMarkFunction,

--- a/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
     SkipVTableValidation,

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.idl
@@ -28,6 +28,7 @@
  */
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled,
     ActiveDOMObject,
     GenerateIsReachable=Impl,
     JSCustomMarkFunction,

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled,
     ActiveDOMObject,
     JSCustomMarkFunction,
     SkipVTableValidation,

--- a/Source/WebCore/Modules/indexeddb/IDBTransactionDurability.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBTransactionDurability.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled
 ] enum IDBTransactionDurability {
     "strict",
     "relaxed",

--- a/Source/WebCore/Modules/indexeddb/IDBTransactionMode.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBTransactionMode.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled
 ] enum IDBTransactionMode {
     "readonly",
     "readwrite",

--- a/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    EnabledBySetting=IndexedDBAPIEnabled,
     Exposed=(Window,Worker)
 ] interface IDBVersionChangeEvent : Event {
     constructor([AtomString] DOMString type, optional IDBVersionChangeEventInit eventInitDict);

--- a/Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScope+IndexedDatabase.idl
+++ b/Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScope+IndexedDatabase.idl
@@ -26,6 +26,7 @@
 
 // https://w3c.github.io/IndexedDB/#factory-interface
 [
+    EnabledBySetting=IndexedDBAPIEnabled,
     ImplementedBy=WindowOrWorkerGlobalScopeIndexedDatabase
 ] partial interface mixin WindowOrWorkerGlobalScope {
     [SameObject] readonly attribute IDBFactory indexedDB;


### PR DESCRIPTION
#### 431ab9f6ccbbc7b250ed0944d5e6a0d851c83cce
<pre>
Provide a runtime toggle for the IndexedDB APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=245484">https://bugs.webkit.org/show_bug.cgi?id=245484</a>
&lt;rdar://100265412&gt;

Reviewed by Geoffrey Garen.

Provide a runtime flag which lets us toggle on/off the IndexedDB APIs
exposed to JS.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
* Source/WebCore/Modules/indexeddb/IDBCursor.idl:
* Source/WebCore/Modules/indexeddb/IDBCursorDirection.idl:
* Source/WebCore/Modules/indexeddb/IDBCursorWithValue.idl:
* Source/WebCore/Modules/indexeddb/IDBDatabase.idl:
* Source/WebCore/Modules/indexeddb/IDBFactory.idl:
* Source/WebCore/Modules/indexeddb/IDBIndex.idl:
* Source/WebCore/Modules/indexeddb/IDBKeyRange.idl:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.idl:
* Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.idl:
* Source/WebCore/Modules/indexeddb/IDBRequest.idl:
* Source/WebCore/Modules/indexeddb/IDBTransaction.idl:
* Source/WebCore/Modules/indexeddb/IDBTransactionDurability.idl:
* Source/WebCore/Modules/indexeddb/IDBTransactionMode.idl:
* Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.idl:
* Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScope+IndexedDatabase.idl:

Canonical link: <a href="https://commits.webkit.org/254772@main">https://commits.webkit.org/254772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a91ce71036a9beb4636598d8c46061cf805f91d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99447 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156948 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94135 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33167 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28525 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82461 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/94736 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26373 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76956 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26269 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69268 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81745 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34323 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15079 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76645 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16024 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26521 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3350 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/35908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38991 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/79231 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35108 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17366 "Passed tests") | 
<!--EWS-Status-Bubble-End-->