### PR TITLE
[webkit-patch] Make rebaseline-server Python 3 compatible

### DIFF
--- a/Tools/Scripts/webkitpy/tool/servers/rebaselineserver.py
+++ b/Tools/Scripts/webkitpy/tool/servers/rebaselineserver.py
@@ -257,7 +257,7 @@ class RebaselineHTTPRequestHandler(ReflectionHandler):
 
         self.send_header('Content-type', 'text/plain')
         self.end_headers()
-        self.wfile.write('\n'.join(log))
+        self.wfile.write('\n'.join(log).encode())
 
     def test_result(self):
         test_name, _ = os.path.splitext(self.query['test'][0])

--- a/Tools/Scripts/webkitpy/tool/servers/reflectionhandler.py
+++ b/Tools/Scripts/webkitpy/tool/servers/reflectionhandler.py
@@ -26,7 +26,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import cgi
 import codecs
 import datetime
 import json
@@ -40,9 +39,10 @@ import wsgiref.handlers
 
 if sys.version_info > (3, 0):
     from http.server import BaseHTTPRequestHandler
-
+    from urllib.parse import parse_qs
 else:
     from BaseHTTPServer import BaseHTTPRequestHandler
+    from cgi import parse_qs
 
 
 class ReflectionHandler(BaseHTTPRequestHandler):
@@ -74,7 +74,7 @@ class ReflectionHandler(BaseHTTPRequestHandler):
     def _handle_request(self):
         if "?" in self.path:
             path, query_string = self.path.split("?", 1)
-            self.query = cgi.parse_qs(query_string)
+            self.query = parse_qs(query_string)
         else:
             path = self.path
             self.query = {}
@@ -113,14 +113,14 @@ class ReflectionHandler(BaseHTTPRequestHandler):
         self._send_access_control_header()
         self.send_header("Content-type", "text/plain")
         self.end_headers()
-        self.wfile.write(text)
+        self.wfile.write(text.encode())
 
     def _serve_json(self, json_object):
         self.send_response(200)
         self._send_access_control_header()
         self.send_header('Content-type', 'application/json')
         self.end_headers()
-        json.dump(json_object, self.wfile)
+        self.wfile.write(json.dumps(json_object).encode())
 
     def _serve_file(self, file_path, cacheable_seconds=0, headers_only=False):
         if not os.path.exists(file_path):


### PR DESCRIPTION
#### 8530532661d8cdeb5c0686e633dbef5d1c7321c7
<pre>
[webkit-patch] Make rebaseline-server Python 3 compatible
<a href="https://bugs.webkit.org/show_bug.cgi?id=245524">https://bugs.webkit.org/show_bug.cgi?id=245524</a>
&lt;rdar://100243229&gt;

Reviewed by Alan Bujtas.

* Tools/Scripts/webkitpy/tool/servers/rebaselineserver.py:
(RebaselineHTTPRequestHandler.rebaseline): Encode content written to file.
* Tools/Scripts/webkitpy/tool/servers/reflectionhandler.py:
(ReflectionHandler._handle_request): Use parse_qs from either cgi or requests.
(ReflectionHandler._serve_text): Encode content written to file.
(ReflectionHandler._serve_json): Ditto.

Canonical link: <a href="https://commits.webkit.org/254757@main">https://commits.webkit.org/254757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a121050824871ce29ba1527868e1f2d0eca49bee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34696 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/20770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99468 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156970 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33189 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82482 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/95949 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95800 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/76991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26287 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/93730 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81236 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/20770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69286 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/34340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/20770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/20770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/35925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/76991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1425 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/37828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/20770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->