### PR TITLE
Blending between two rotateZ() transform values should serialize as rotate3d()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-computed-value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-computed-value-expected.txt
@@ -27,10 +27,10 @@ PASS Interpolation between translate(50px, -50px) and translate(100px, 50px) giv
 PASS Interpolation between translate(50px, -50px) and translate(100px, 50px) gives the correct computed value halfway according to computedStyleMap with zoom active.
 PASS Interpolation between rotate(30deg) and rotate(90deg) gives the correct computed value halfway according to computedStyleMap.
 PASS Interpolation between rotate(30deg) and rotate(90deg) gives the correct computed value halfway according to computedStyleMap with zoom active.
-FAIL Interpolation between rotateZ(30deg) and rotateZ(90deg) gives the correct computed value halfway according to computedStyleMap. assert_equals: The value at 50% progress is as expected expected "rotate3d(0, 0, 1, 60deg)" but got "rotate(60deg)"
-FAIL Interpolation between rotateZ(30deg) and rotateZ(90deg) gives the correct computed value halfway according to computedStyleMap with zoom active. assert_equals: The value at 50% progress is as expected expected "rotate3d(0, 0, 1, 60deg)" but got "rotate(60deg)"
-FAIL Interpolation between rotate(0deg) and rotateZ(90deg) gives the correct computed value halfway according to computedStyleMap. assert_equals: The value at 50% progress is as expected expected "rotate3d(0, 0, 1, 45deg)" but got "rotate(45deg)"
-FAIL Interpolation between rotate(0deg) and rotateZ(90deg) gives the correct computed value halfway according to computedStyleMap with zoom active. assert_equals: The value at 50% progress is as expected expected "rotate3d(0, 0, 1, 45deg)" but got "rotate(45deg)"
+PASS Interpolation between rotateZ(30deg) and rotateZ(90deg) gives the correct computed value halfway according to computedStyleMap.
+PASS Interpolation between rotateZ(30deg) and rotateZ(90deg) gives the correct computed value halfway according to computedStyleMap with zoom active.
+PASS Interpolation between rotate(0deg) and rotateZ(90deg) gives the correct computed value halfway according to computedStyleMap.
+PASS Interpolation between rotate(0deg) and rotateZ(90deg) gives the correct computed value halfway according to computedStyleMap with zoom active.
 PASS Interpolation between rotateX(0deg) and rotateX(90deg) gives the correct computed value halfway according to computedStyleMap.
 PASS Interpolation between rotateX(0deg) and rotateX(90deg) gives the correct computed value halfway according to computedStyleMap with zoom active.
 PASS Interpolation between rotate(0deg) and rotateX(90deg) gives the correct computed value halfway according to computedStyleMap.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-inline-value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-inline-value-expected.txt
@@ -13,8 +13,8 @@ PASS Interpolation between translate3d(0,0,-50px) and translateZ(50px) gives the
 PASS Interpolation between translate(50px, 0px) and translate(100px, 0px) gives the correct computed value halfway according to commitStyles.
 PASS Interpolation between translate(50px, -50px) and translate(100px, 50px) gives the correct computed value halfway according to commitStyles.
 PASS Interpolation between rotate(30deg) and rotate(90deg) gives the correct computed value halfway according to commitStyles.
-FAIL Interpolation between rotateZ(30deg) and rotateZ(90deg) gives the correct computed value halfway according to commitStyles. assert_equals: The value at 50% progress is as expected expected "rotateZ(60deg)" but got "rotate(60deg)"
-FAIL Interpolation between rotate(0deg) and rotateZ(90deg) gives the correct computed value halfway according to commitStyles. assert_equals: The value at 50% progress is as expected expected "rotate3d(0, 0, 1, 45deg)" but got "rotate(45deg)"
+FAIL Interpolation between rotateZ(30deg) and rotateZ(90deg) gives the correct computed value halfway according to commitStyles. assert_equals: The value at 50% progress is as expected expected "rotateZ(60deg)" but got "rotate3d(0, 0, 1, 60deg)"
+PASS Interpolation between rotate(0deg) and rotateZ(90deg) gives the correct computed value halfway according to commitStyles.
 FAIL Interpolation between rotateX(0deg) and rotateX(90deg) gives the correct computed value halfway according to commitStyles. assert_equals: The value at 50% progress is as expected expected "rotateX(45deg)" but got "rotate3d(1, 0, 0, 45deg)"
 PASS Interpolation between rotate(0deg) and rotateX(90deg) gives the correct computed value halfway according to commitStyles.
 FAIL Interpolation between scale(1) and scale(2) gives the correct computed value halfway according to commitStyles. assert_equals: The value at 50% progress is as expected expected "scale(1.5)" but got "scale(1.5, 1.5)"

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -806,11 +806,15 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
         // rotate
         case TransformOperation::ROTATE_X:
             functionValue = CSSFunctionValue::create(CSSValueRotateX);
-            functionValue->append(cssValuePool.createValue(downcast<RotateTransformOperation>(*operation).x(), CSSUnitType::CSS_NUMBER));
+            functionValue->append(cssValuePool.createValue(downcast<RotateTransformOperation>(*operation).angle(), CSSUnitType::CSS_DEG));
             break;
         case TransformOperation::ROTATE_Y:
             functionValue = CSSFunctionValue::create(CSSValueRotateX);
-            functionValue->append(cssValuePool.createValue(downcast<RotateTransformOperation>(*operation).y(), CSSUnitType::CSS_NUMBER));
+            functionValue->append(cssValuePool.createValue(downcast<RotateTransformOperation>(*operation).angle(), CSSUnitType::CSS_DEG));
+            break;
+        case TransformOperation::ROTATE_Z:
+            functionValue = CSSFunctionValue::create(CSSValueRotateZ);
+            functionValue->append(cssValuePool.createValue(downcast<RotateTransformOperation>(*operation).angle(), CSSUnitType::CSS_DEG));
             break;
         case TransformOperation::ROTATE: {
             auto& rotate = downcast<RotateTransformOperation>(*operation);

--- a/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
@@ -53,9 +53,7 @@ public:
     double z() const { return m_z; }
     double angle() const { return m_angle; }
 
-    // The 2D rotation primitive doesn't handle any direction vectors other than [0, 0, 1],
-    // so even if the rotation is representable in 2D, it might be a 3D rotation.
-    OperationType primitiveType() const final { return (isRepresentableIn2D() && z() == 1.0) ? ROTATE : ROTATE_3D; }
+    OperationType primitiveType() const final { return type() == ROTATE ? ROTATE : ROTATE_3D; }
 
     bool operator==(const RotateTransformOperation& other) const { return operator==(static_cast<const TransformOperation&>(other)); }
     bool operator==(const TransformOperation&) const override;

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.cpp
@@ -56,6 +56,7 @@ TextStream& operator<<(TextStream& ts, TransformOperation::OperationType type)
     case TransformOperation::TRANSLATE_3D: ts << "translate3d"; break;
     case TransformOperation::ROTATE_X: ts << "rotateX"; break;
     case TransformOperation::ROTATE_Y: ts << "rotateY"; break;
+    case TransformOperation::ROTATE_Z: ts << "rotateZ"; break;
     case TransformOperation::ROTATE_3D: ts << "rotate3d"; break;
     case TransformOperation::MATRIX_3D: ts << "matrix3d"; break;
     case TransformOperation::PERSPECTIVE: ts << "perspective"; break;

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.h
@@ -40,13 +40,12 @@ public:
     enum OperationType {
         SCALE_X, SCALE_Y, SCALE, 
         TRANSLATE_X, TRANSLATE_Y, TRANSLATE, 
-        ROTATE,
-        ROTATE_Z = ROTATE,
-        SKEW_X, SKEW_Y, SKEW, 
+        ROTATE_X, ROTATE_Y, ROTATE,
+        SKEW_X, SKEW_Y, SKEW,
         MATRIX,
         SCALE_Z, SCALE_3D,
         TRANSLATE_Z, TRANSLATE_3D,
-        ROTATE_X, ROTATE_Y, ROTATE_3D,
+        ROTATE_Z, ROTATE_3D,
         MATRIX_3D,
         PERSPECTIVE,
         IDENTITY, NONE


### PR DESCRIPTION
#### 1f231e23b766bea941685230a80dd4eae1776573
<pre>
Blending between two rotateZ() transform values should serialize as rotate3d()
<a href="https://bugs.webkit.org/show_bug.cgi?id=245527">https://bugs.webkit.org/show_bug.cgi?id=245527</a>

Reviewed by Antti Koivisto.

We didn&apos;t have a way to differentiate a rotation provided as rotateZ() rather than rotate().
We now keep a distinct OperationType value for ROTATE_Z and ensure we never simplify to the
ROTATE type in the primitiveType() override of RotateTransformOperation.

We also fix computedTransform() to correctly use the angle rather than the individual axis
for the rotateX/Y/Z functions.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-computed-value-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-inline-value-expected.txt:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::computedTransform):
* Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/TransformOperation.cpp:
* Source/WebCore/platform/graphics/transforms/TransformOperation.h:

Canonical link: <a href="https://commits.webkit.org/254782@main">https://commits.webkit.org/254782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b4a82bd56ae4a644dba83f75a26c8d77405c208

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99486 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/156987 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33207 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28552 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82499 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/95963 "Hash 9b4a82bd for PR 4598 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26409 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77010 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26303 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81038 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69302 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34350 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15112 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32191 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16060 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/35935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39016 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1434 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37838 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35144 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->