### PR TITLE
Add inspector console logging in case of worker script loader failure

### DIFF
--- a/LayoutTests/fast/workers/worker-constructor-expected.txt
+++ b/LayoutTests/fast/workers/worker-constructor-expected.txt
@@ -1,4 +1,5 @@
 CONSOLE MESSAGE: SyntaxError: Unexpected token '<'
+CONSOLE MESSAGE: Worker failed to load. The requested URL was not found on this server.
 Test Worker constructor functionality. Should print a series of PASS messages, followed with DONE.
 
 PASS: toString exception propagated correctly.

--- a/LayoutTests/fast/workers/worker-crash-with-invalid-location-expected.txt
+++ b/LayoutTests/fast/workers/worker-crash-with-invalid-location-expected.txt
@@ -1,5 +1,6 @@
 Blocked access to external URL http://example.com/worker.js
 CONSOLE MESSAGE: Cannot load http://example.com/worker.js due to access control checks.
+CONSOLE MESSAGE: Worker failed to load.
 Test worker fetch of blocked url. Should print a "PASS" statement.
 
 PASS

--- a/LayoutTests/fast/workers/worker-finish-crash-expected.txt
+++ b/LayoutTests/fast/workers/worker-finish-crash-expected.txt
@@ -1,1 +1,2 @@
+CONSOLE MESSAGE: Worker failed to load. The requested URL was not found on this server.
 Test to ensure that finishing a Worker won't re-enter. We pass if we don't crash.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-redirect-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/child-src/worker-redirect-blocked-expected.txt
@@ -1,6 +1,7 @@
 CONSOLE MESSAGE: Refused to load http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js because it does not appear in the worker-src directive of the Content Security Policy.
 CONSOLE MESSAGE: Blocked by Content Security Policy.
 CONSOLE MESSAGE: Cannot load http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js due to access control checks.
+CONSOLE MESSAGE: Worker failed to load. Blocked by Content Security Policy.
 This tests that the Content Security Policy of the page blocks loading a Web Worker's script from a different origin through a redirect.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/security/http-0.9/worker-connect-src-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/http-0.9/worker-connect-src-blocked-expected.txt
@@ -1,2 +1,3 @@
+CONSOLE MESSAGE: Worker failed to load. Cancelled load from 'http://127.0.0.1:8000/security/http-0.9/resources/nph-worker-fail.pl' because it is using HTTP/0.9.
 ALERT: PASS
 

--- a/LayoutTests/http/tests/security/isolatedWorld/bypass-main-world-csp-worker-redirect-expected.txt
+++ b/LayoutTests/http/tests/security/isolatedWorld/bypass-main-world-csp-worker-redirect-expected.txt
@@ -1,6 +1,8 @@
 CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
 
 CONSOLE MESSAGE: Cannot load http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js due to access control checks.
+CONSOLE MESSAGE: Worker failed to load. Unsafe attempt to load URL http://localhost:8000/security/contentSecurityPolicy/resources/alert-fail.js from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
+
 This tests that in an isolated world that the Content Security Policy of the parent origin (this page) is bypassed and a CSP violation is not triggered when a Web Worker's script URL loads a different origin through a redirect. This test PASSED if there is no CSP violation console message and the redirect fails (since Web Workers can only load a script from the same origin).
 
 PASS worker failed to load script URL.

--- a/LayoutTests/http/tests/security/worker-cross-origin-expected.txt
+++ b/LayoutTests/http/tests/security/worker-cross-origin-expected.txt
@@ -1,6 +1,8 @@
 CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/security/resources/worker-message-pass.js from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
 
 CONSOLE MESSAGE: Cannot load http://localhost:8000/security/resources/worker-message-pass.js due to access control checks.
+CONSOLE MESSAGE: Worker failed to load. Unsafe attempt to load URL http://localhost:8000/security/resources/worker-message-pass.js from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
+
 This tests that Web Worker script redirects are blocked if cross origin.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/workers/worker-redirect-expected.txt
+++ b/LayoutTests/http/tests/workers/worker-redirect-expected.txt
@@ -1,6 +1,8 @@
 CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/workers/resources/worker-redirect-target.js from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
 
 CONSOLE MESSAGE: Cannot load http://localhost:8000/workers/resources/worker-redirect-target.js due to access control checks.
+CONSOLE MESSAGE: Worker failed to load. Unsafe attempt to load URL http://localhost:8000/workers/resources/worker-redirect-target.js from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
+
 Test that loading the worker's script does not allow a cross origin redirect (bug 26146)
 
 SUCCESS: threw exception (SecurityError: The operation is insecure.) when attempting to cross origin while loading the worker script.

--- a/LayoutTests/http/tests/workers/worker-workerScriptNotThere-expected.txt
+++ b/LayoutTests/http/tests/workers/worker-workerScriptNotThere-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: Worker failed to load. Response is not 2xx
 Test worker file does not exist error. Should print two "PASS" statements followed by "DONE".
 
 The order of the error events should be onerror and then error event, and this test should be improved to verify that when bug https://bugs.webkit.org/show_bug.cgi?id=62485 is fixed.

--- a/LayoutTests/imported/blink/http/tests/websocket/workers/worker-shutdown-race-expected.txt
+++ b/LayoutTests/imported/blink/http/tests/websocket/workers/worker-shutdown-race-expected.txt
@@ -1,1 +1,2 @@
+CONSOLE MESSAGE: Worker failed to load. The requested URL was not found on this server.
 Done.

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/dedicated-worker-cache-storage.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/dedicated-worker-cache-storage.https-expected.txt
@@ -1,9 +1,11 @@
 CONSOLE MESSAGE: Refused to load 'https://localhost:9443/html/cross-origin-embedder-policy/resources/universal-worker.js?pipe=' worker because of Cross-Origin-Embedder-Policy.
 CONSOLE MESSAGE: Worker load was blocked by Cross-Origin-Embedder-Policy
 CONSOLE MESSAGE: Cannot load https://localhost:9443/html/cross-origin-embedder-policy/resources/universal-worker.js?pipe= due to access control checks.
+CONSOLE MESSAGE: Worker failed to load. Worker load was blocked by Cross-Origin-Embedder-Policy
 CONSOLE MESSAGE: Refused to load 'https://localhost:9443/html/cross-origin-embedder-policy/resources/universal-worker.js?pipe=' worker because of Cross-Origin-Embedder-Policy.
 CONSOLE MESSAGE: Worker load was blocked by Cross-Origin-Embedder-Policy
 CONSOLE MESSAGE: Cannot load https://localhost:9443/html/cross-origin-embedder-policy/resources/universal-worker.js?pipe= due to access control checks.
+CONSOLE MESSAGE: Worker failed to load. Worker load was blocked by Cross-Origin-Embedder-Policy
 
 PASS coep-none coep-none corp-cross-origin
 PASS coep-none coep-none corp-undefined

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/dedicated-worker.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/dedicated-worker.https-expected.txt
@@ -1,11 +1,13 @@
 CONSOLE MESSAGE: Refused to load 'https://localhost:9443/html/cross-origin-embedder-policy/resources/dedicated-worker.js' worker because of Cross-Origin-Embedder-Policy.
 CONSOLE MESSAGE: Worker load was blocked by Cross-Origin-Embedder-Policy
 CONSOLE MESSAGE: Cannot load https://localhost:9443/html/cross-origin-embedder-policy/resources/dedicated-worker.js due to access control checks.
+CONSOLE MESSAGE: Worker failed to load. Worker load was blocked by Cross-Origin-Embedder-Policy
 CONSOLE MESSAGE: Cancelled load to https://127.0.0.1:9443/common/blank.html because it violates the resource's Cross-Origin-Resource-Policy response header.
 CONSOLE MESSAGE: Cancelled load to https://127.0.0.1:9443/common/blank.html because it violates the resource's Cross-Origin-Resource-Policy response header.
 CONSOLE MESSAGE: Refused to load 'https://localhost:9443/html/cross-origin-embedder-policy/resources/dedicated-worker.js' worker because of Cross-Origin-Embedder-Policy.
 CONSOLE MESSAGE: Worker load was blocked by Cross-Origin-Embedder-Policy
 CONSOLE MESSAGE: Cannot load https://localhost:9443/html/cross-origin-embedder-policy/resources/dedicated-worker.js due to access control checks.
+CONSOLE MESSAGE: Worker failed to load. Worker load was blocked by Cross-Origin-Embedder-Policy
 CONSOLE MESSAGE: Cancelled load to https://127.0.0.1:9443/common/blank.html because it violates the resource's Cross-Origin-Resource-Policy response header.
 CONSOLE MESSAGE: Cancelled load to https://127.0.0.1:9443/common/blank.html because it violates the resource's Cross-Origin-Resource-Policy response header.
 CONSOLE MESSAGE: Cancelled load to https://127.0.0.1:9443/common/blank.html because it violates the resource's Cross-Origin-Resource-Policy response header.

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/Worker_NosniffErr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/Worker_NosniffErr-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: Worker failed to load. Refused to execute http://localhost:8800/workers/support/nosiniff-error-worker.py as script because "X-Content-Type-Options: nosniff" was given and its Content-Type is not a script MIME type.
 
 PASS  Worker with nosniff X-Content-Type-Options header
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/Worker_script_mimetype-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/Worker_script_mimetype-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: Worker failed to load. Refused to execute http://localhost:8800/workers/support/WorkerText.txt as script because text/plain is not a script MIME type.
 
 PASS HTTP(S) URLs which respond with text/plain MIME type must not work
 PASS blob: URLs should load, despite no MIME type for the backing Blob

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/Worker-constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/Worker-constructor-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: Worker failed to load. Refused to execute http://localhost:8800/workers/constructors/Worker/Worker-constructor.html as script because text/html is not a script MIME type.
+CONSOLE MESSAGE: Worker failed to load. Response is not 2xx
 
 PASS Test toString propagation exception.
 PASS Test recursive Worker creation.

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-failure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-failure-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: Worker failed to load. Response is not 2xx
 CONSOLE MESSAGE: Importing a module script failed.
 
 PASS importScripts() on module worker should throw an exception.

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/run-a-worker/003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/run-a-worker/003-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: Worker failed to load. Response is not 2xx
 
 PASS worker
 PASS shared

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -209,6 +209,9 @@ void Worker::notifyFinished()
         return;
 
     if (m_scriptLoader->failed()) {
+        auto& error = m_scriptLoader->error();
+        if ((error.isAccessControl() || error.isGeneral()) && is<Document>(context))
+            downcast<Document>(context)->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Worker failed to load. ", error.localizedDescription()));
         queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::Yes));
         return;
     }


### PR DESCRIPTION
#### f1c0b624fdff2bb0bcb0b5ef95c4a48cf000dc2c
<pre>
Add inspector console logging in case of worker script loader failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=245530">https://bugs.webkit.org/show_bug.cgi?id=245530</a>
rdar://problem/100285306

Reviewed by NOBODY (OOPS!).

Inspector console error messages will help web developers fiugre out what is wrong more easily.

* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::notifyFinished):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b22be8915495b16d04eff7c08d7022e44dbb567

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99820 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157465 "Found 8 new test failures: fast/spatial-navigation/snav-textarea.html, fast/workers/empty-worker-nocrash.html, http/tests/security/contentSecurityPolicy/1.1/child-src/worker-redirect-blocked.html, http/tests/security/isolatedWorld/bypass-main-world-csp-worker-redirect.html, http/tests/security/worker-cross-origin.html, http/tests/workers/worker-redirect.html, imported/blink/http/tests/websocket/workers/worker-shutdown-race.html, svg/W3C-SVG-1.2-Tiny/struct-use-recursion-02-t.svg (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33569 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28773 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82848 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96261 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26706 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77338 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26559 "Found 12 new test failures: fast/workers/empty-worker-nocrash.html, fast/workers/worker-constructor.html, fast/workers/worker-finish-crash.html, http/tests/security/http-0.9/worker-connect-src-blocked.html, imported/blink/http/tests/websocket/workers/worker-shutdown-race.html, imported/w3c/web-platform-tests/fetch/nosniff/worker.html, imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/dedicated-worker-cache-storage.https.html, imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/dedicated-worker.https.html, imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https.html, imported/w3c/web-platform-tests/workers/Worker_NosniffErr.htm ... (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69575 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34669 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15346 "Found 5 new test failures: http/tests/security/contentSecurityPolicy/1.1/child-src/worker-redirect-blocked.html, http/tests/security/isolatedWorld/bypass-main-world-csp-worker-redirect.html, http/tests/security/worker-cross-origin.html, http/tests/workers/worker-redirect.html, imported/w3c/web-platform-tests/workers/semantics/run-a-worker/003.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32486 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16323 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39237 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35412 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->