### PR TITLE
[GStreamer] Allow finishing seek on sync state change

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -457,7 +457,8 @@ private:
     MediaTime playbackPosition() const;
 
     virtual void updateStates();
-    virtual void asyncStateChangeDone();
+    void finishSeek();
+    virtual void asyncStateChangeDone() { }
 
     void createGSTPlayBin(const URL&);
 


### PR DESCRIPTION
#### a8ae25e11301ba67efa18134a925728e3f154b56
<pre>
[GStreamer] Allow finishing seek on sync state change
<a href="https://bugs.webkit.org/show_bug.cgi?id=245529">https://bugs.webkit.org/show_bug.cgi?id=245529</a>

Reviewed by Xabier Rodriguez-Calvar.

Some devices have audio sinks that don&apos;t not support async state changes i.e. it completes
transition to PAUSED state on preroll. In those cases, there&apos;s a need to be able to finish
seeks in sync state changes (currently, only seeks on async state changes are supported).

This patch adds support to handle that use case by finishing the seek from updateStates().
This new code makes the old processing in asyncStateChangeDone() redundant, because in those
circumstances the handling of the GST_MESSAGE_STATE_CHANGED message in handleMessage()
already calls updateStates(). Still, asyncStateChangeDone() has been preserved because it&apos;s
virtual and the MediaPlayerPrivateGStreamerMSE subclass still needs it for its own purpose.

The code to finish seek has been refactored to its own function. This isn&apos;t strictly needed
but would be really helpful for our downstream port, where
<a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/938">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/938</a> would benefit from it.

Original author: Pawel Lampe &lt;pawel.lampe@gmail.com&gt;
See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/926">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/926</a>

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleMessage): Added comment about super and subclass processing needs for GST_MESSAGE_ASYNC_DONE.
(WebCore::MediaPlayerPrivateGStreamer::finishSeek): Refactored code to finish seek.
(WebCore::MediaPlayerPrivateGStreamer::updateStates): Process finish seek from here.
(WebCore::MediaPlayerPrivateGStreamer::asyncStateChangeDone): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
(WebCore::MediaPlayerPrivateGStreamer::asyncStateChangeDone): Now empty implementation for the superclass.

Canonical link: <a href="https://commits.webkit.org/254923@main">https://commits.webkit.org/254923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d21df4a9cde78fcdda653f1a40117af22de1e509

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99848 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157938 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33599 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28791 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82880 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96284 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26736 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77361 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26584 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69600 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34698 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15364 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32513 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16341 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3438 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39261 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35431 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->