### PR TITLE
Update named colors list to match CSS Color 4

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/system-color-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/system-color-valid-expected.txt
@@ -1,6 +1,6 @@
 
 PASS e.style['color'] = "ActiveText" should set the property value
-FAIL e.style['color'] = "ButtonBorder" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "ButtonBorder" should set the property value
 PASS e.style['color'] = "ButtonFace" should set the property value
 PASS e.style['color'] = "ButtonText" should set the property value
 PASS e.style['color'] = "Canvas" should set the property value
@@ -11,11 +11,11 @@ PASS e.style['color'] = "GrayText" should set the property value
 PASS e.style['color'] = "Highlight" should set the property value
 PASS e.style['color'] = "HighlightText" should set the property value
 PASS e.style['color'] = "LinkText" should set the property value
-FAIL e.style['color'] = "Mark" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "MarkText" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "Mark" should set the property value
+PASS e.style['color'] = "MarkText" should set the property value
 PASS e.style['color'] = "VisitedText" should set the property value
-FAIL e.style['color'] = "SelectedItem" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "SelectedItemText" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "AccentColor" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['color'] = "AccentColorText" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['color'] = "SelectedItem" should set the property value
+PASS e.style['color'] = "SelectedItemText" should set the property value
+PASS e.style['color'] = "AccentColor" should set the property value
+PASS e.style['color'] = "AccentColorText" should set the property value
 

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -174,7 +174,18 @@ system-ui
 //
 // CSS_PROP_*_COLOR
 //
+
+// https://drafts.csswg.org/css-color-4/#currentcolor-color
+currentcolor
+
+// https://drafts.csswg.org/css-color-4/#transparent-color
+transparent
+
+// Non-standard
 alpha
+
+// https://drafts.csswg.org/css-color-4/#named-colors
+// "16 of CSS’s named colors come from the VGA palette originally, and were then adopted into HTML"
 aqua
 black
 blue
@@ -192,34 +203,22 @@ silver
 teal
 white
 yellow
-transparent
--webkit-link
--webkit-activelink
+grey
+
+// https://drafts.csswg.org/css-color-4/#deprecated-system-colors
 activeborder
 activecaption
-activetext
 appworkspace
 background
-buttonface
 buttonhighlight
 buttonshadow
-buttontext
-activebuttontext
-canvas
-canvastext
 captiontext
-field
-fieldtext
-graytext
-highlight
-highlighttext
 inactiveborder
 inactivecaption
 inactivecaptiontext
 infobackground
 infotext
-linktext
-luminance
+// menu
 menutext
 scrollbar
 threeddarkshadow
@@ -227,10 +226,32 @@ threedface
 threedhighlight
 threedlightshadow
 threedshadow
-visitedtext
 window
 windowframe
 windowtext
+
+// https://drafts.csswg.org/css-color-4/#typedef-system-color
+canvas
+canvastext
+linktext
+visitedtext
+activetext
+buttonface
+buttontext
+buttonborder
+field
+fieldtext
+highlight
+highlighttext
+selecteditem
+selecteditemtext
+mark
+marktext
+graytext
+accentcolor
+accentcolortext
+
+// Non-standard system colors
 #if (defined(WTF_PLATFORM_MAC) && WTF_PLATFORM_MAC) || (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
 -apple-system-header-text
 -apple-system-text-background
@@ -286,12 +307,12 @@ windowtext
 #if (defined(WTF_PLATFORM_MAC) && WTF_PLATFORM_MAC) || (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY) || (defined(HAVE_OS_DARK_MODE_SUPPORT) && HAVE_OS_DARK_MODE_SUPPORT)
 -webkit-control-background
 #endif
+activebuttontext
+-webkit-activelink
+-webkit-link
 -webkit-focus-ring-color
-currentcolor
-//
-// colors in non strict mode
-grey
 -webkit-text
+
 //
 // CSS_PROP_BACKGROUND_REPEAT:
 //
@@ -1572,7 +1593,7 @@ compact
 
 // mask-type, mask-mode
 // alpha
-// luminance
+luminance
 match-source
 
 // rotate

--- a/Source/WebCore/css/StyleColor.cpp
+++ b/Source/WebCore/css/StyleColor.cpp
@@ -52,7 +52,7 @@ static bool isVGAPaletteColor(CSSValueID id)
 {
     // https://drafts.csswg.org/css-color-4/#named-colors
     // "16 of CSS’s named colors come from the VGA palette originally, and were then adopted into HTML"
-    return (id >= CSSValueAqua && id <= CSSValueYellow) || id == CSSValueGrey;
+    return (id >= CSSValueAqua && id <= CSSValueGrey);
 }
 
 static bool isNonVGANamedColor(CSSValueID id)
@@ -70,8 +70,13 @@ bool StyleColor::isAbsoluteColorKeyword(CSSValueID id)
 bool StyleColor::isSystemColorKeyword(CSSValueID id)
 {
     // https://drafts.csswg.org/css-color-4/#css-system-colors
+    return (id >= CSSValueCanvas && id <= CSSValueWebkitText) || id == CSSValueText || isDeprecatedSystemColorKeyword(id);
+}
+
+bool StyleColor::isDeprecatedSystemColorKeyword(CSSValueID id)
+{
     // https://drafts.csswg.org/css-color-4/#deprecated-system-colors
-    return (id >= CSSValueWebkitLink && id <= CSSValueWebkitFocusRingColor) || id == CSSValueWebkitText || id == CSSValueMenu || id == CSSValueText;
+    return (id >= CSSValueActiveborder && id <= CSSValueWindowtext) || id == CSSValueMenu;
 }
 
 bool StyleColor::isColorKeyword(CSSValueID id, OptionSet<CSSColorType> allowedColorTypes)

--- a/Source/WebCore/css/StyleColor.h
+++ b/Source/WebCore/css/StyleColor.h
@@ -53,6 +53,7 @@ struct StyleColor {
     static bool isCurrentColor(const CSSPrimitiveValue& value) { return isCurrentColorKeyword(value.valueID()); }
 
     WEBCORE_EXPORT static bool isSystemColorKeyword(CSSValueID);
+    static bool isDeprecatedSystemColorKeyword(CSSValueID);
 
     enum class CSSColorType : uint8_t {
         Absolute = 1 << 0,

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1236,8 +1236,8 @@ pre, xmp, plaintext, listing {
 }
 
 mark {
-    background-color: yellow;
-    color: black;
+    background-color: Mark;
+    color: MarkText;
 }
 
 big {

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1321,83 +1321,246 @@ auto RenderTheme::colorCache(OptionSet<StyleColorOptions> options) const -> Colo
 Color RenderTheme::systemColor(CSSValueID cssValueId, OptionSet<StyleColorOptions> options) const
 {
     switch (cssValueId) {
-    case CSSValueWebkitLink:
-        return options.contains(StyleColorOptions::ForVisitedLink) ? SRGBA<uint8_t> { 85, 26, 139 } : SRGBA<uint8_t> { 0, 0, 238 };
-    case CSSValueWebkitActivelink:
-    case CSSValueActivetext:
-        return Color::red;
-    case CSSValueLinktext:
-        return SRGBA<uint8_t> { 0, 0, 238 };
-    case CSSValueVisitedtext:
-        return SRGBA<uint8_t> { 85, 26, 139 };
-    case CSSValueActiveborder:
-        return Color::white;
-    case CSSValueActivebuttontext:
-        return Color::black;
-    case CSSValueActivecaption:
-        return SRGBA<uint8_t> { 204, 204, 204 };
-    case CSSValueAppworkspace:
-        return Color::white;
-    case CSSValueBackground:
-        return SRGBA<uint8_t> { 99, 99, 206 };
-    case CSSValueButtonface:
-        return Color::lightGray;
-    case CSSValueButtonhighlight:
-        return SRGBA<uint8_t> { 221, 221, 221 };
-    case CSSValueButtonshadow:
-        return SRGBA<uint8_t> { 136, 136, 136 };
-    case CSSValueButtontext:
-        return Color::black;
-    case CSSValueCaptiontext:
-        return Color::black;
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-canvas
+    // Background of application content or documents.
     case CSSValueCanvas:
         return Color::white;
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-canvastext
+    // Text in application content or documents.
     case CSSValueCanvastext:
         return Color::black;
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-linktext
+    // Text in non-active, non-visited links. For light backgrounds, traditionally blue.
+    case CSSValueLinktext:
+        return SRGBA<uint8_t> { 0, 0, 238 };
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-visitedtext
+    // Text in visited links. For light backgrounds, traditionally purple.
+    case CSSValueVisitedtext:
+        return SRGBA<uint8_t> { 85, 26, 139 };
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-activetext
+    // Text in active links. For light backgrounds, traditionally red.
+    case CSSValueActivetext:
+    case CSSValueWebkitActivelink: // Non-standard addition.
+        return Color::red;
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-buttonface
+    // The face background color for push buttons.
+    case CSSValueButtonface:
+        return Color::lightGray;
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-buttontext
+    // Text on push buttons.
+    case CSSValueButtontext:
+        return Color::black;
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-buttonborder
+    // The base border color for push buttons.
+    case CSSValueButtonborder:
+        return Color::white;
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-field
+    // Background of input fields.
     case CSSValueField:
         return Color::white;
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-fieldtext
+    // Text in input fields.
     case CSSValueFieldtext:
         return Color::black;
-    case CSSValueGraytext:
-        return Color::darkGray;
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-highlight
+    // Background of selected text, for example from ::selection.
     case CSSValueHighlight:
         return SRGBA<uint8_t> { 181, 213, 255 };
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-highlighttext
+    // Text of selected text.
     case CSSValueHighlighttext:
         return Color::black;
-    case CSSValueInactiveborder:
-        return Color::white;
-    case CSSValueInactivecaption:
-        return Color::white;
-    case CSSValueInactivecaptiontext:
-        return SRGBA<uint8_t> { 127, 127, 127 };
-    case CSSValueInfobackground:
-        return SRGBA<uint8_t> { 251, 252, 197 };
-    case CSSValueInfotext:
-        return Color::black;
-    case CSSValueMenu:
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-selecteditem
+    // Background of selected items, for example a selected checkbox.
+    case CSSValueSelecteditem:
         return Color::lightGray;
-    case CSSValueMenutext:
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-selecteditemtext
+    // Text of selected items.
+    case CSSValueSelecteditemtext:
         return Color::black;
-    case CSSValueScrollbar:
-        return Color::white;
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-mark
+    // Background of text that has been specially marked (such as by the HTML mark element).
+    case CSSValueMark:
+        return Color::yellow;
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-marktext
+    // Text that has been specially marked (such as by the HTML mark element).
+    case CSSValueMarktext:
+        return Color::black;
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-graytext
+    // Disabled text. (Often, but not necessarily, gray.)
+    case CSSValueGraytext:
+        return Color::darkGray;
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-accentcolor
+    // Background of accented user interface controls.
+    case CSSValueAccentcolor:
+        return SRGBA<uint8_t> { 0, 122, 255 };
+
+    // https://drafts.csswg.org/css-color-4/#valdef-system-color-accentcolortext
+    // Text of accented user interface controls.
+    case CSSValueAccentcolortext:
+        return Color::black;
+
+    // Non-standard addition.
+    case CSSValueActivebuttontext:
+        return Color::black;
+
+    // Non-standard addition.
     case CSSValueText:
         return Color::black;
+
+    // Non-standard addition.
+    case CSSValueWebkitLink:
+        return options.contains(StyleColorOptions::ForVisitedLink) ? SRGBA<uint8_t> { 85, 26, 139 } : SRGBA<uint8_t> { 0, 0, 238 };
+
+    // Deprecated system-colors:
+    // https://drafts.csswg.org/css-color-4/#deprecated-system-colors
+
+    // FIXME: CSS Color 4 imposes same-as requirements on all the deprecated
+    // system colors - https://webkit.org/b/245609.
+
+    // https://drafts.csswg.org/css-color-4/#activeborder
+    // DEPRECATED: Active window border.
+    case CSSValueActiveborder:
+        return Color::white;
+
+    // https://drafts.csswg.org/css-color-4/#activecaption
+    // DEPRECATED: Active window caption.
+    case CSSValueActivecaption:
+        return SRGBA<uint8_t> { 204, 204, 204 };
+
+    // https://drafts.csswg.org/css-color-4/#appworkspace
+    // DEPRECATED: Background color of multiple document interface.
+    case CSSValueAppworkspace:
+        return Color::white;
+
+    // https://drafts.csswg.org/css-color-4/#background
+    // DEPRECATED: Desktop background.
+    case CSSValueBackground:
+        return SRGBA<uint8_t> { 99, 99, 206 };
+
+    // https://drafts.csswg.org/css-color-4/#buttonhighlight
+    // DEPRECATED: The color of the border facing the light source for 3-D elements that
+    // appear 3-D due to one layer of surrounding border.
+    case CSSValueButtonhighlight:
+        return SRGBA<uint8_t> { 221, 221, 221 };
+
+    // https://drafts.csswg.org/css-color-4/#buttonshadow
+    // DEPRECATED: The color of the border away from the light source for 3-D elements that
+    // appear 3-D due to one layer of surrounding border.
+    case CSSValueButtonshadow:
+        return SRGBA<uint8_t> { 136, 136, 136 };
+
+    // https://drafts.csswg.org/css-color-4/#captiontext
+    // DEPRECATED: Text in caption, size box, and scrollbar arrow box.
+    case CSSValueCaptiontext:
+        return Color::black;
+
+    // https://drafts.csswg.org/css-color-4/#inactiveborder
+    // DEPRECATED: Inactive window border.
+    case CSSValueInactiveborder:
+        return Color::white;
+
+    // https://drafts.csswg.org/css-color-4/#inactivecaption
+    // DEPRECATED: Inactive window caption.
+    case CSSValueInactivecaption:
+        return Color::white;
+
+    // https://drafts.csswg.org/css-color-4/#inactivecaptiontext
+    // DEPRECATED: Color of text in an inactive caption.
+    case CSSValueInactivecaptiontext:
+        return SRGBA<uint8_t> { 127, 127, 127 };
+
+    // https://drafts.csswg.org/css-color-4/#infobackground
+    // DEPRECATED: Background color for tooltip controls.
+    case CSSValueInfobackground:
+        return SRGBA<uint8_t> { 251, 252, 197 };
+
+    // https://drafts.csswg.org/css-color-4/#infotext
+    // DEPRECATED: Text color for tooltip controls.
+    case CSSValueInfotext:
+        return Color::black;
+
+    // https://drafts.csswg.org/css-color-4/#menu
+    // DEPRECATED: Menu background.
+    case CSSValueMenu:
+        return Color::lightGray;
+
+    // https://drafts.csswg.org/css-color-4/#menutext
+    // DEPRECATED: Text in menus.
+    case CSSValueMenutext:
+        return Color::black;
+
+    // https://drafts.csswg.org/css-color-4/#scrollbar
+    // DEPRECATED: Scroll bar gray area.
+    case CSSValueScrollbar:
+        return Color::white;
+
+    // https://drafts.csswg.org/css-color-4/#threeddarkshadow
+    // DEPRECATED: The color of the darker (generally outer) of the two borders away from
+    // thelight source for 3-D elements that appear 3-D due to two concentric layers of
+    // surrounding border.
     case CSSValueThreeddarkshadow:
         return SRGBA<uint8_t> { 102, 102, 102 };
+
+    // https://drafts.csswg.org/css-color-4/#threedface
+    // DEPRECATED: The face background color for 3-D elements that appear 3-D due to two
+    // concentric layers of surrounding border
     case CSSValueThreedface:
         return Color::lightGray;
+
+    // https://drafts.csswg.org/css-color-4/#threedhighlight
+    // DEPRECATED: The color of the lighter (generally outer) of the two borders facing
+    // the light source for 3-D elements that appear 3-D due to two concentric layers of
+    // surrounding border.
     case CSSValueThreedhighlight:
         return SRGBA<uint8_t> { 221, 221, 221 };
+
+    // https://drafts.csswg.org/css-color-4/#threedlightshadow
+    // DEPRECATED: The color of the darker (generally inner) of the two borders facing
+    // the light source for 3-D elements that appear 3-D due to two concentric layers of
+    // surrounding border
     case CSSValueThreedlightshadow:
         return Color::lightGray;
+
+    // https://drafts.csswg.org/css-color-4/#threedshadow
+    // DEPRECATED: The color of the lighter (generally inner) of the two borders away
+    // from the light source for 3-D elements that appear 3-D due to two concentric layers
+    // of surrounding border.
     case CSSValueThreedshadow:
         return SRGBA<uint8_t> { 136, 136, 136 };
+
+    // https://drafts.csswg.org/css-color-4/#window
+    // DEPRECATED: Window background.
     case CSSValueWindow:
         return Color::white;
+
+    // https://drafts.csswg.org/css-color-4/#windowframe
+    // DEPRECATED: Window frame.
     case CSSValueWindowframe:
         return SRGBA<uint8_t> { 204, 204, 204 };
+
+    // https://drafts.csswg.org/css-color-4/#windowtext
+    // DEPRECATED: Text in windows.
     case CSSValueWindowtext:
         return Color::black;
+
     default:
         return { };
     }


### PR DESCRIPTION
#### 09df074a4a8861c5fa7ba160368f6fb1ea1890b0
<pre>
Update named colors list to match CSS Color 4
<a href="https://bugs.webkit.org/show_bug.cgi?id=245533">https://bugs.webkit.org/show_bug.cgi?id=245533</a>
&lt;rdar://100287586&gt;

Reviewed by Darin Adler.

Added new system colors from CSS Color 4 with the following default
platform agnostic values:

  ButtonBorder
    white (matching existing ActiveBorder and InactiveBorder values).
  SelectedItem
    lightGray (matching existing Menu value)
  SelectedItemText
    black (matching existing *Text values)
  Mark
    yellow (matching background-color of &lt;mark&gt; in UA stylesheet)
  MarkText
    black (matching color of &lt;mark&gt; in UA stylesheet)
  AccentColor
    sRGB { 0, 122, 255 } (matching color of system-control-accent)
  AccentColorText
    black (matching existing *Text values)

As with other system colors, it may make sense to specialize
these per-platform, but this change does not aim to do that.

Also re-organized CSSValueKeywords.in to group some related
color names together, and added comments to help clarify what
set things belong to.

As a way of organizing, and in preparation for an upcoming
change to deprecated system colors, the deprecated system
colors were grouped together and a helper function added.

As we now have a named colors Mark and MarkText, the UA stylesheet
for &lt;mark&gt; was updated to use the named colors (no observable
change in behavior though, as the colors still resolve to yellow
and black).

* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/StyleColor.cpp:
(WebCore::isVGAPaletteColor):
(WebCore::StyleColor::isAbsoluteColorKeyword):
(WebCore::StyleColor::isSystemColorKeyword):
(WebCore::StyleColor::isDeprecatedSystemColorKeyword):
* Source/WebCore/css/StyleColor.h:
* Source/WebCore/css/html.css:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::systemColor const):

Canonical link: <a href="https://commits.webkit.org/254840@main">https://commits.webkit.org/254840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cffb7fe5fe41e3e0ac8c3d5a965c8b3242eef3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99748 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157213 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33499 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28706 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82777 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96193 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26628 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77264 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26503 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69515 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34593 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15263 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32417 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16226 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36180 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39174 "Found 1 new test failure: css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-relayouts.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1462 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35315 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->