### PR TITLE
Expose the Notification API to dedicated workers

### DIFF
--- a/LayoutTests/http/tests/notifications/show-notification-worker.js
+++ b/LayoutTests/http/tests/notifications/show-notification-worker.js
@@ -1,0 +1,20 @@
+onmessage = (e) => {
+    if (e.data == "check-initial-permission" || e.data == "check-permission-granted") {
+        self.postMessage(Notification.permission);
+        return;
+    }
+    if (e.data == "show-notification") {
+        notification = new Notification("foo");
+        timeoutHandle = setTimeout(() => {
+            self.postMessage("timeout");
+        }, 10000);
+        notification.onshow = (e) => {
+            clearTimeout(timeoutHandle);
+            self.postMessage("shown");
+        };
+        notification.onerror = (e) => {
+            clearTimeout(timeoutHandle);
+            self.postMessage("error");
+        };
+    }
+};

--- a/LayoutTests/http/tests/notifications/worker-show-notification-expected.txt
+++ b/LayoutTests/http/tests/notifications/worker-show-notification-expected.txt
@@ -1,0 +1,12 @@
+Tests checking notification permission and constructing a notification from a dedicated worker.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS initialPermissionState is "default"
+PASS updatedPermissionState is "granted"
+PASS showResult is "shown"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/notifications/worker-show-notification.html
+++ b/LayoutTests/http/tests/notifications/worker-show-notification.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests checking notification permission and constructing a notification from a dedicated worker.");
+jsTestIsAsync = true;
+
+let state = "check-initial-permission";
+let worker = new Worker("show-notification-worker.js");
+worker.onmessage = (event) => {
+    if (state == "check-initial-permission") {
+        // Permission should initially be default.
+        initialPermissionState = event.data;
+        shouldBeEqualToString("initialPermissionState", "default");
+
+        if (window.testRunner)
+            testRunner.grantWebNotificationPermission(self.origin);
+
+        state = "check-permission-granted";
+        worker.postMessage(state);
+        return;
+    }
+    if (state == "check-permission-granted") {
+        // Permission should now be granted.
+        updatedPermissionState = event.data;
+        shouldBeEqualToString("updatedPermissionState", "granted");
+
+        state = "show-notification"
+        worker.postMessage(state);
+        return;
+    }
+    if (state == "show-notification") {
+        showResult = event.data;
+        shouldBeEqualToString("showResult", "shown");
+        finishJSTest();
+        return;
+    }
+};
+worker.postMessage(state);
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/notifications/historical.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/notifications/historical.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Notification.get is obsolete Can't find variable: Notification
+PASS Notification.get is obsolete
 

--- a/LayoutTests/imported/w3c/web-platform-tests/notifications/idlharness.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/notifications/idlharness.https.any.worker-expected.txt
@@ -1,65 +1,65 @@
 
-FAIL idl_test setup promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Notification"
+PASS idl_test setup
 PASS idl_test validation
 PASS Partial interface ServiceWorkerRegistration: original interface defined
 PASS Partial interface ServiceWorkerRegistration: member names are unique
 PASS Partial interface ServiceWorkerGlobalScope: original interface defined
 PASS Partial interface ServiceWorkerGlobalScope: member names are unique
 PASS WorkerGlobalScope includes WindowOrWorkerGlobalScope: member names are unique
-FAIL Notification interface: existence and properties of interface object assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface object length assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface object name assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: existence and properties of interface prototype object assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute permission assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: member requestPermission undefined is not an Object. (evaluating 'member.name in this.get_interface_object()')
-FAIL Notification interface: attribute maxActions assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute onclick assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute onshow assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute onerror assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute onclose assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute title assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute dir assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute lang assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute body assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute tag assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute image assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute icon assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute badge assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute vibrate assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute timestamp assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute renotify assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute silent assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute requireInteraction assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute data assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: attribute actions assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification interface: operation close() assert_own_property: self does not have own property "Notification" expected property "Notification" missing
-FAIL Notification must be primary interface of notification assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Stringification of notification assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "permission" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must not have property "requestPermission" assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "maxActions" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "onclick" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "onshow" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "onerror" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "onclose" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "title" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "dir" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "lang" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "body" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "tag" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "image" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "icon" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "badge" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "vibrate" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "timestamp" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "renotify" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "silent" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "requireInteraction" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "data" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "actions" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
-FAIL Notification interface: notification must inherit property "close()" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+PASS Notification interface: existence and properties of interface object
+PASS Notification interface object length
+PASS Notification interface object name
+PASS Notification interface: existence and properties of interface prototype object
+PASS Notification interface: existence and properties of interface prototype object's "constructor" property
+PASS Notification interface: existence and properties of interface prototype object's @@unscopables property
+PASS Notification interface: attribute permission
+PASS Notification interface: member requestPermission
+FAIL Notification interface: attribute maxActions assert_own_property: The interface object must have a property "maxActions" expected property "maxActions" missing
+PASS Notification interface: attribute onclick
+PASS Notification interface: attribute onshow
+PASS Notification interface: attribute onerror
+PASS Notification interface: attribute onclose
+PASS Notification interface: attribute title
+PASS Notification interface: attribute dir
+PASS Notification interface: attribute lang
+PASS Notification interface: attribute body
+PASS Notification interface: attribute tag
+FAIL Notification interface: attribute image assert_true: The prototype object must have a property "image" expected true got false
+PASS Notification interface: attribute icon
+FAIL Notification interface: attribute badge assert_true: The prototype object must have a property "badge" expected true got false
+FAIL Notification interface: attribute vibrate assert_true: The prototype object must have a property "vibrate" expected true got false
+FAIL Notification interface: attribute timestamp assert_true: The prototype object must have a property "timestamp" expected true got false
+FAIL Notification interface: attribute renotify assert_true: The prototype object must have a property "renotify" expected true got false
+FAIL Notification interface: attribute silent assert_true: The prototype object must have a property "silent" expected true got false
+FAIL Notification interface: attribute requireInteraction assert_true: The prototype object must have a property "requireInteraction" expected true got false
+PASS Notification interface: attribute data
+FAIL Notification interface: attribute actions assert_true: The prototype object must have a property "actions" expected true got false
+PASS Notification interface: operation close()
+PASS Notification must be primary interface of notification
+PASS Stringification of notification
+PASS Notification interface: notification must inherit property "permission" with the proper type
+PASS Notification interface: notification must not have property "requestPermission"
+PASS Notification interface: notification must inherit property "maxActions" with the proper type
+PASS Notification interface: notification must inherit property "onclick" with the proper type
+PASS Notification interface: notification must inherit property "onshow" with the proper type
+PASS Notification interface: notification must inherit property "onerror" with the proper type
+PASS Notification interface: notification must inherit property "onclose" with the proper type
+PASS Notification interface: notification must inherit property "title" with the proper type
+PASS Notification interface: notification must inherit property "dir" with the proper type
+PASS Notification interface: notification must inherit property "lang" with the proper type
+PASS Notification interface: notification must inherit property "body" with the proper type
+PASS Notification interface: notification must inherit property "tag" with the proper type
+FAIL Notification interface: notification must inherit property "image" with the proper type assert_inherits: property "image" not found in prototype chain
+PASS Notification interface: notification must inherit property "icon" with the proper type
+FAIL Notification interface: notification must inherit property "badge" with the proper type assert_inherits: property "badge" not found in prototype chain
+FAIL Notification interface: notification must inherit property "vibrate" with the proper type assert_inherits: property "vibrate" not found in prototype chain
+FAIL Notification interface: notification must inherit property "timestamp" with the proper type assert_inherits: property "timestamp" not found in prototype chain
+FAIL Notification interface: notification must inherit property "renotify" with the proper type assert_inherits: property "renotify" not found in prototype chain
+FAIL Notification interface: notification must inherit property "silent" with the proper type assert_inherits: property "silent" not found in prototype chain
+FAIL Notification interface: notification must inherit property "requireInteraction" with the proper type assert_inherits: property "requireInteraction" not found in prototype chain
+PASS Notification interface: notification must inherit property "data" with the proper type
+FAIL Notification interface: notification must inherit property "actions" with the proper type assert_inherits: property "actions" not found in prototype chain
+PASS Notification interface: notification must inherit property "close()" with the proper type
 PASS NotificationEvent interface: existence and properties of interface object
 PASS ServiceWorkerRegistration interface: operation showNotification(DOMString, optional NotificationOptions)
 PASS ServiceWorkerRegistration interface: operation getNotifications(optional GetNotificationOptions)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/serialization-via-notifications-api.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/serialization-via-notifications-api.any.worker-expected.txt
@@ -1,12 +1,4 @@
 
-FAIL WebAssembly.Module cloning via the Notifications API's data member: basic case assert_throws_dom: function "() => {
-    new Notification("Bob: Hi", { data: createEmptyWasmModule() });
-  }" threw object "ReferenceError: Can't find variable: Notification" that is not a DOMException DataCloneError: property "code" is equal to undefined, expected 25
-FAIL WebAssembly.Module cloning via the Notifications API's data member: is interleaved correctly assert_throws_dom: function "() => {
-    new Notification("Bob: Hi", { data: [
-      { get x() { getter1Called = true; return 5; } },
-      createEmptyWasmModule(),
-      { get x() { getter2Called = true; return 5; } }
-    ]});
-  }" threw object "ReferenceError: Can't find variable: Notification" that is not a DOMException DataCloneError: property "code" is equal to undefined, expected 25
+PASS WebAssembly.Module cloning via the Notifications API's data member: basic case
+PASS WebAssembly.Module cloning via the Notifications API's data member: is interleaved correctly
 

--- a/Source/WebCore/Modules/notifications/Notification.idl
+++ b/Source/WebCore/Modules/notifications/Notification.idl
@@ -29,14 +29,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// FIXME: Notification should be exposed to all Worker contexts, not just ServiceWorker.
+// FIXME: Notification should be exposed to all Worker contexts, not just ServiceWorker and DedicatedWorker.
 // https://notifications.spec.whatwg.org/#notification
 [
     Conditional=NOTIFICATIONS,
     ActiveDOMObject,
     EnabledBySetting=NotificationsEnabled,
     ExportMacro=WEBCORE_EXPORT,
-    Exposed=(Window,ServiceWorker)
+    Exposed=(Window,DedicatedWorker,ServiceWorker)
 ] interface Notification : EventTarget {
     [CallWith=CurrentScriptExecutionContext] constructor(DOMString title, optional NotificationOptions options);
 

--- a/Source/WebCore/Modules/notifications/NotificationClient.h
+++ b/Source/WebCore/Modules/notifications/NotificationClient.h
@@ -36,10 +36,12 @@
 
 namespace WebCore {
 
-class Notification;
 class NotificationPermissionCallback;
+class NotificationResources;
 class Page;
 class ScriptExecutionContext;
+
+struct NotificationData;
 
 class NotificationClient {
 public:
@@ -47,15 +49,15 @@ public:
     using PermissionHandler = CompletionHandler<void(Permission)>;
 
     // Requests that a notification be shown.
-    virtual bool show(Notification&, CompletionHandler<void()>&&) = 0;
+    virtual bool show(ScriptExecutionContext&, NotificationData&&, RefPtr<NotificationResources>&&, CompletionHandler<void()>&&) = 0;
 
     // Requests that a notification that has already been shown be canceled.
-    virtual void cancel(Notification&) = 0;
+    virtual void cancel(NotificationData&&) = 0;
 
     // Informs the presenter that a Notification object has been destroyed
     // (such as by a page transition). The presenter may continue showing
     // the notification, but must not attempt to call the event handlers.
-    virtual void notificationObjectDestroyed(Notification&) = 0;
+    virtual void notificationObjectDestroyed(NotificationData&&) = 0;
 
     // Informs the presenter the controller attached to the page has been destroyed.
     virtual void notificationControllerDestroyed() = 0;

--- a/Source/WebCore/Modules/notifications/NotificationData.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationData.cpp
@@ -30,12 +30,12 @@ namespace WebCore {
 
 NotificationData NotificationData::isolatedCopy() const &
 {
-    return { title.isolatedCopy(), body.isolatedCopy(), iconURL.isolatedCopy(), tag.isolatedCopy(), language.isolatedCopy(), direction, originString.isolatedCopy(), serviceWorkerRegistrationURL.isolatedCopy(), notificationID, sourceSession, creationTime, data };
+    return { title.isolatedCopy(), body.isolatedCopy(), iconURL.isolatedCopy(), tag.isolatedCopy(), language.isolatedCopy(), direction, originString.isolatedCopy(), serviceWorkerRegistrationURL.isolatedCopy(), notificationID, contextIdentifier, sourceSession, creationTime, data };
 }
 
 NotificationData NotificationData::isolatedCopy() &&
 {
-    return { WTFMove(title).isolatedCopy(), WTFMove(body).isolatedCopy(), WTFMove(iconURL).isolatedCopy(), WTFMove(tag).isolatedCopy(), WTFMove(language).isolatedCopy(), direction, WTFMove(originString).isolatedCopy(), WTFMove(serviceWorkerRegistrationURL).isolatedCopy(), notificationID, sourceSession, creationTime, WTFMove(data) };
+    return { WTFMove(title).isolatedCopy(), WTFMove(body).isolatedCopy(), WTFMove(iconURL).isolatedCopy(), WTFMove(tag).isolatedCopy(), WTFMove(language).isolatedCopy(), direction, WTFMove(originString).isolatedCopy(), WTFMove(serviceWorkerRegistrationURL).isolatedCopy(), notificationID, contextIdentifier, sourceSession, creationTime, WTFMove(data) };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2826,6 +2826,7 @@ workers/WorkerGlobalScope.cpp
 workers/WorkerInspectorProxy.cpp
 workers/WorkerLocation.cpp
 workers/WorkerMessagingProxy.cpp
+workers/WorkerNotificationClient.cpp
 workers/WorkerOrWorkletGlobalScope.cpp
 workers/WorkerOrWorkletScriptController.cpp
 workers/WorkerOrWorkletThread.cpp

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -43,11 +43,16 @@
 #include "SecurityOrigin.h"
 #include "StructuredSerializeOptions.h"
 #include "Worker.h"
+#include "WorkerObjectProxy.h"
+#include <wtf/IsoMallocInlines.h>
+
+#if ENABLE(NOTIFICATIONS)
+#include "WorkerNotificationClient.h"
+#endif
+
 #if ENABLE(OFFSCREEN_CANVAS)
 #include "WorkerAnimationController.h"
 #endif
-#include "WorkerObjectProxy.h"
-#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
@@ -136,6 +141,15 @@ RefPtr<RTCRtpScriptTransformer> DedicatedWorkerGlobalScope::createRTCRtpScriptTr
     auto transformer = transformerOrException.releaseReturnValue();
     dispatchEvent(RTCTransformEvent::create(eventNames().rtctransformEvent, transformer.copyRef(), Event::IsTrusted::Yes));
     return transformer;
+}
+#endif
+
+#if ENABLE(NOTIFICATIONS)
+NotificationClient* DedicatedWorkerGlobalScope::notificationClient()
+{
+    if (!m_notificationClient)
+        m_notificationClient = WorkerNotificationClient::create(*this);
+    return m_notificationClient.get();
 }
 #endif
 

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
@@ -48,8 +48,11 @@ class JSRTCRtpScriptTransformerConstructor;
 class RTCRtpScriptTransformer;
 class RequestAnimationFrameCallback;
 class SerializedScriptValue;
-
 struct StructuredSerializeOptions;
+
+#if ENABLE(NOTIFICATIONS)
+class WorkerNotificationClient;
+#endif
 
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
 class WorkerAnimationController;
@@ -70,6 +73,10 @@ public:
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
 
     DedicatedWorkerThread& thread();
+
+#if ENABLE(NOTIFICATIONS)
+    NotificationClient* notificationClient() final;
+#endif
 
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
     CallbackId requestAnimationFrame(Ref<RequestAnimationFrameCallback>&&);
@@ -98,6 +105,9 @@ private:
 
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
     RefPtr<WorkerAnimationController> m_workerAnimationController;
+#endif
+#if ENABLE(NOTIFICATIONS)
+    RefPtr<WorkerNotificationClient> m_notificationClient;
 #endif
 };
 

--- a/Source/WebCore/workers/WorkerNotificationClient.cpp
+++ b/Source/WebCore/workers/WorkerNotificationClient.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(NOTIFICATIONS)
+#include "WorkerNotificationClient.h"
+
+#include <wtf/threads/BinarySemaphore.h>
+
+namespace WebCore {
+
+Ref<WorkerNotificationClient> WorkerNotificationClient::create(WorkerGlobalScope& workerScope)
+{
+    return adoptRef(*new WorkerNotificationClient(workerScope));
+}
+
+WorkerNotificationClient::WorkerNotificationClient(WorkerGlobalScope& workerScope)
+    : m_workerScopeIdentifier(workerScope.identifier())
+    , m_workerScope(workerScope)
+{
+}
+
+bool WorkerNotificationClient::show(ScriptExecutionContext& workerContext, NotificationData&& notification, RefPtr<NotificationResources>&& resources, CompletionHandler<void()>&& completionHandler)
+{
+    auto callbackID = workerContext.addNotificationCallback(WTFMove(completionHandler));
+    postToMainThread([protectedThis = Ref { *this }, notification = WTFMove(notification).isolatedCopy(), resources = WTFMove(resources), callbackID](auto* client, auto& context) mutable {
+        if (!client) {
+            protectedThis->postToWorkerThread([callbackID](auto& workerContext) {
+                if (auto callback = workerContext.takeNotificationCallback(callbackID))
+                    callback();
+            });
+            return;
+        }
+        client->show(context, WTFMove(notification), WTFMove(resources), [protectedThis = WTFMove(protectedThis), callbackID]() mutable {
+            protectedThis->postToWorkerThread([callbackID](auto& workerContext) {
+                if (auto callback = workerContext.takeNotificationCallback(callbackID))
+                    callback();
+            });
+        });
+    });
+    return true;
+}
+
+void WorkerNotificationClient::cancel(NotificationData&& notification)
+{
+    postToMainThread([notification = WTFMove(notification).isolatedCopy()](auto* client, auto&) mutable {
+        if (client)
+            client->cancel(WTFMove(notification));
+    });
+}
+
+void WorkerNotificationClient::notificationObjectDestroyed(NotificationData&& notification)
+{
+    postToMainThread([notification = WTFMove(notification).isolatedCopy()](auto* client, auto&) mutable {
+        if (client)
+            client->notificationObjectDestroyed(WTFMove(notification));
+    });
+}
+
+void WorkerNotificationClient::notificationControllerDestroyed()
+{
+}
+
+void WorkerNotificationClient::requestPermission(ScriptExecutionContext&, PermissionHandler&& completionHandler)
+{
+    // Workers cannot request permission at the moment.
+    ASSERT_NOT_REACHED();
+    completionHandler(Permission::Default);
+}
+
+auto WorkerNotificationClient::checkPermission(ScriptExecutionContext*) -> Permission
+{
+    Permission permission { Permission::Default };
+    BinarySemaphore semaphore;
+    postToMainThread([&permission, &semaphore](auto* client, auto& context) {
+        if (client)
+            permission = client->checkPermission(&context);
+        semaphore.signal();
+    });
+    semaphore.wait();
+    return permission;
+}
+
+void WorkerNotificationClient::postToMainThread(Function<void(NotificationClient*, ScriptExecutionContext& context)>&& task)
+{
+    m_workerScope.thread().workerLoaderProxy().postTaskToLoader([task = WTFMove(task)](auto& context) mutable {
+        task(context.notificationClient(), context);
+    });
+}
+
+void WorkerNotificationClient::postToWorkerThread(Function<void(ScriptExecutionContext&)>&& task)
+{
+    ScriptExecutionContext::postTaskTo(m_workerScopeIdentifier, WTFMove(task));
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(NOTIFICATIONS)

--- a/Source/WebCore/workers/WorkerNotificationClient.h
+++ b/Source/WebCore/workers/WorkerNotificationClient.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(NOTIFICATIONS)
+
+#include "NotificationClient.h"
+#include "ScriptExecutionContextIdentifier.h"
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+
+class WorkerGlobalScope;
+
+class WorkerNotificationClient : public NotificationClient, public ThreadSafeRefCounted<WorkerNotificationClient> {
+public:
+    static Ref<WorkerNotificationClient> create(WorkerGlobalScope&);
+
+    // NotificationClient.
+    bool show(ScriptExecutionContext&, NotificationData&&, RefPtr<NotificationResources>&&, CompletionHandler<void()>&&) final;
+    void cancel(NotificationData&&) final;
+    void notificationObjectDestroyed(NotificationData&&) final;
+    void notificationControllerDestroyed() final;
+    void requestPermission(ScriptExecutionContext&, PermissionHandler&&) final;
+    Permission checkPermission(ScriptExecutionContext*) final;
+
+private:
+    explicit WorkerNotificationClient(WorkerGlobalScope&);
+
+    void postToMainThread(Function<void(NotificationClient*, ScriptExecutionContext& context)>&&);
+    void postToWorkerThread(Function<void(ScriptExecutionContext&)>&&);
+
+    ScriptExecutionContextIdentifier m_workerScopeIdentifier;
+    WorkerGlobalScope& m_workerScope;
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
@@ -28,6 +28,7 @@
 #include "MessageReceiver.h"
 #include "WebProcessSupplement.h"
 #include <WebCore/NotificationClient.h>
+#include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <optional>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
@@ -38,8 +39,9 @@
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
-class Notification;
 class SecurityOrigin;
+
+struct NotificationData;
 }
 
 namespace WebKit {
@@ -56,11 +58,11 @@ public:
 
     static const char* supplementName();
     
-    bool show(WebCore::Notification&, WebPage*, CompletionHandler<void()>&&);
-    void cancel(WebCore::Notification&, WebPage*);
+    bool show(WebCore::NotificationData&&, RefPtr<WebCore::NotificationResources>&&, WebPage*, CompletionHandler<void()>&&);
+    void cancel(WebCore::NotificationData&&, WebPage*);
 
     // This callback comes from WebCore, not messaged from the UI process.
-    void didDestroyNotification(WebCore::Notification&, WebPage*);
+    void didDestroyNotification(WebCore::NotificationData&&, WebPage*);
 
     void didUpdateNotificationDecision(const String& originString, bool allowed);
 
@@ -82,13 +84,13 @@ private:
     void didCloseNotifications(const Vector<UUID>& notificationIDs);
     void didRemoveNotificationDecisions(const Vector<String>& originStrings);
 
-    template<typename U> bool sendNotificationMessage(U&& message, WebCore::Notification&, WebPage*);
-    template<typename U> bool sendNotificationMessageWithAsyncReply(U&& message, WebCore::Notification&, WebPage*, CompletionHandler<void()>&&);
+    template<typename U> bool sendNotificationMessage(U&& message, WebPage*);
+    template<typename U> bool sendNotificationMessageWithAsyncReply(U&& message, WebPage*, CompletionHandler<void()>&&);
 
     WebProcess& m_process;
 
 #if ENABLE(NOTIFICATIONS)
-    HashMap<UUID, Ref<WebCore::Notification>> m_nonPersistentNotifications;    
+    HashMap<UUID, WebCore::ScriptExecutionContextIdentifier> m_nonPersistentNotificationsContexts;
     HashMap<String, bool> m_permissionsMap;
 #endif
 };

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h
@@ -23,18 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef WebNotificationClient_h
-#define WebNotificationClient_h
+#pragma once
 
 #if ENABLE(NOTIFICATIONS)
 
 #include <WebCore/NotificationClient.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/HashSet.h>
-
-namespace WebCore {
-class ScriptExecutionContext;
-} // namespace WebCore
 
 namespace WebKit {
 
@@ -48,9 +43,9 @@ public:
     void clearNotificationPermissionState();
 
 private:
-    bool show(WebCore::Notification&, CompletionHandler<void()>&&) final;
-    void cancel(WebCore::Notification&) final;
-    void notificationObjectDestroyed(WebCore::Notification&) final;
+    bool show(WebCore::ScriptExecutionContext&, WebCore::NotificationData&&, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&&) final;
+    void cancel(WebCore::NotificationData&&) final;
+    void notificationObjectDestroyed(WebCore::NotificationData&&) final;
     void notificationControllerDestroyed() final;
     void requestPermission(WebCore::ScriptExecutionContext&, PermissionHandler&&) final;
     WebCore::NotificationClient::Permission checkPermission(WebCore::ScriptExecutionContext*) final;
@@ -62,5 +57,3 @@ private:
 } // namespace WebKit
 
 #endif // ENABLE(NOTIFICATIONS)
-
-#endif // WebNotificationClient_h

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.h
@@ -25,12 +25,13 @@
 
 #if ENABLE(NOTIFICATIONS)
 
-#import <WebCore/Notification.h>
 #import <WebCore/NotificationClient.h>
+#import <WebCore/NotificationData.h>
 #import <WebCore/SecurityOriginData.h>
 #import <wtf/HashMap.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/UUID.h>
 
 @class WebNotification;
 @class WebNotificationPolicyListener;
@@ -43,13 +44,10 @@ public:
     WebView *webView() { return m_webView; }
     void clearNotificationPermissionState();
 
-    // For testing purposes.
-    uint64_t notificationIDForTesting(WebCore::Notification*);
-
 private:
-    bool show(WebCore::Notification&, CompletionHandler<void()>&&) final;
-    void cancel(WebCore::Notification&) final;
-    void notificationObjectDestroyed(WebCore::Notification&) final;
+    bool show(WebCore::ScriptExecutionContext&, WebCore::NotificationData&&, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&&) final;
+    void cancel(WebCore::NotificationData&&) final;
+    void notificationObjectDestroyed(WebCore::NotificationData&&) final;
     void notificationControllerDestroyed() final;
     void requestPermission(WebCore::ScriptExecutionContext&, PermissionHandler&&) final;
     WebCore::NotificationClient::Permission checkPermission(WebCore::ScriptExecutionContext*) final;
@@ -57,7 +55,7 @@ private:
     void requestPermission(WebCore::ScriptExecutionContext&, WebNotificationPolicyListener *);
 
     WebView *m_webView;
-    HashMap<RefPtr<WebCore::Notification>, RetainPtr<WebNotification>> m_notificationMap;
+    HashMap<UUID, RetainPtr<WebNotification>> m_notificationMap;
     HashSet<WebCore::SecurityOriginData> m_notificationPermissionRequesters;
 
     bool m_everRequestedPermission { false };

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm
@@ -133,6 +133,12 @@ using namespace WebCore;
     return self;
 }
 
+- (id)_initWithString:(NSString *)originString
+{
+    auto origin = SecurityOrigin::createFromString(originString);
+    return adoptNS([[WebSecurityOrigin alloc] _initWithWebCoreSecurityOrigin:origin.ptr()]).autorelease();
+}
+
 - (SecurityOrigin *)_core
 {
     return reinterpret_cast<SecurityOrigin*>(_private);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOriginInternal.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOriginInternal.h
@@ -37,6 +37,7 @@ typedef WebCore::SecurityOrigin WebCoreSecurityOrigin;
 @interface WebSecurityOrigin (WebInternal)
 
 - (id)_initWithWebCoreSecurityOrigin:(WebCoreSecurityOrigin *)origin;
+- (id)_initWithString:(NSString *)originString;
 - (WebCoreSecurityOrigin *)_core;
 
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebNotification.h
+++ b/Source/WebKitLegacy/mac/WebView/WebNotification.h
@@ -44,7 +44,7 @@
 - (NSString *)lang;
 - (NSString *)dir;
 - (WebSecurityOrigin *)origin;
-- (uint64_t)notificationID;
+- (NSString *)notificationID;
 
 - (void)dispatchShowEvent;
 - (void)dispatchCloseEvent;

--- a/Source/WebKitLegacy/mac/WebView/WebNotificationInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebNotificationInternal.h
@@ -33,12 +33,11 @@
 
 namespace WebCore {
 class Notification;
+struct NotificationData;
 }
 
-WebCore::Notification* core(WebNotification *);
-
 @interface WebNotification (WebNotificationInternal)
-- (id)initWithCoreNotification:(NakedPtr<WebCore::Notification>)coreNotification notificationID:(uint64_t)notificationID;
+- (id)initWithCoreNotification:(WebCore::NotificationData&&)coreNotification;
 @end
 
 #endif

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -9759,12 +9759,12 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
     return nil;
 }
 
-- (void)_notificationDidShow:(uint64_t)notificationID
+- (void)_notificationDidShow:(NSString *)notificationID
 {
     [[self _notificationProvider] webView:self didShowNotification:notificationID];
 }
 
-- (void)_notificationDidClick:(uint64_t)notificationID
+- (void)_notificationDidClick:(NSString *)notificationID
 {
     [[self _notificationProvider] webView:self didClickNotification:notificationID];
 }
@@ -9774,7 +9774,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
     [[self _notificationProvider] webView:self didCloseNotifications:notificationIDs];
 }
 
-- (uint64_t)_notificationIDForTesting:(JSValueRef)jsNotification
+- (NSString *)_notificationIDForTesting:(JSValueRef)jsNotification
 {
 #if ENABLE(NOTIFICATIONS)
     auto* page = _private->page;
@@ -9782,9 +9782,9 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
         return 0;
     JSContextRef context = [[self mainFrame] globalContext];
     auto* notification = WebCore::JSNotification::toWrapped(toJS(context)->vm(), toJS(toJS(context), jsNotification));
-    return static_cast<WebNotificationClient*>(WebCore::NotificationController::clientFrom(*page))->notificationIDForTesting(notification);
+    return notification->identifier().toString();
 #else
-    return 0;
+    return nil;
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
@@ -1015,8 +1015,8 @@ typedef struct WebEdgeInsets {
 - (void)clearNotifications:(NSArray *)notificationIDs;
 - (WebNotificationPermission)policyForOrigin:(WebSecurityOrigin *)origin;
 
-- (void)webView:(WebView *)webView didShowNotification:(uint64_t)notificationID;
-- (void)webView:(WebView *)webView didClickNotification:(uint64_t)notificationID;
+- (void)webView:(WebView *)webView didShowNotification:(NSString *)notificationID;
+- (void)webView:(WebView *)webView didClickNotification:(NSString *)notificationID;
 - (void)webView:(WebView *)webView didCloseNotifications:(NSArray *)notificationIDs;
 @end
 
@@ -1035,11 +1035,11 @@ typedef struct WebEdgeInsets {
 - (void)_setNotificationProvider:(id<WebNotificationProvider>)notificationProvider;
 - (id<WebNotificationProvider>)_notificationProvider;
 
-- (void)_notificationDidShow:(uint64_t)notificationID;
-- (void)_notificationDidClick:(uint64_t)notificationID;
+- (void)_notificationDidShow:(NSString *)notificationID;
+- (void)_notificationDidClick:(NSString *)notificationID;
 - (void)_notificationsDidClose:(NSArray *)notificationIDs;
 
-- (uint64_t)_notificationIDForTesting:(JSValueRef)jsNotification;
+- (NSString *)_notificationIDForTesting:(JSValueRef)jsNotification;
 - (void)_clearNotificationPermissionState;
 @end
 

--- a/Tools/DumpRenderTree/mac/MockWebNotificationProvider.h
+++ b/Tools/DumpRenderTree/mac/MockWebNotificationProvider.h
@@ -31,9 +31,10 @@
 #import <wtf/HashMap.h>
 #import <wtf/HashSet.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/text/WTFString.h>
 
-using NotificationIDMap = HashMap<uint64_t, RetainPtr<WebNotification>>;
-using NotificationViewMap = HashMap<uint64_t, CFTypeRef>;
+using NotificationIDMap = HashMap<String, RetainPtr<WebNotification>>;
+using NotificationViewMap = HashMap<String, CFTypeRef>;
 
 @interface MockWebNotificationProvider : NSObject <WebNotificationProvider> {
     HashSet<CFTypeRef> _registeredWebViews;
@@ -44,7 +45,7 @@ using NotificationViewMap = HashMap<uint64_t, CFTypeRef>;
 
 + (MockWebNotificationProvider *)shared;
 
-- (void)simulateWebNotificationClick:(uint64_t)notificationID;
+- (void)simulateWebNotificationClick:(NSString *)notificationID;
 - (void)setWebNotificationOrigin:(NSString *)origin permission:(BOOL)allowed;
 - (WebNotificationPermission)policyForOrigin:(WebSecurityOrigin *)origin;
 - (void)removeAllWebNotificationPermissions;

--- a/Tools/DumpRenderTree/mac/TestRunnerMac.mm
+++ b/Tools/DumpRenderTree/mac/TestRunnerMac.mm
@@ -1166,7 +1166,7 @@ void TestRunner::removeAllWebNotificationPermissions()
 
 void TestRunner::simulateWebNotificationClick(JSValueRef jsNotification)
 {
-    uint64_t notificationID = [[mainFrame webView] _notificationIDForTesting:jsNotification];
+    NSString *notificationID = [[mainFrame webView] _notificationIDForTesting:jsNotification];
     m_hasPendingWebNotificationClick = true;
     dispatch_async(dispatch_get_main_queue(), ^{
         if (!m_hasPendingWebNotificationClick)


### PR DESCRIPTION
#### aab63a24c2e8666462d8ceb81083c54a102964bc
<pre>
Expose the Notification API to dedicated workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=245531">https://bugs.webkit.org/show_bug.cgi?id=245531</a>

Reviewed by Geoffrey Garen.

Expose the Notification API to dedicated workers as per the specification:
- <a href="https://notifications.spec.whatwg.org/#api">https://notifications.spec.whatwg.org/#api</a>

Blink and Gecko already support this.

We&apos;re supposed to expose the API to shared workers as well but I haven&apos;t
done so in this patch to decrease patch complexity and size.

* LayoutTests/http/tests/notifications/show-notification-worker.js: Added.
(onmessage):
* LayoutTests/http/tests/notifications/worker-show-notification-expected.txt: Added.
* LayoutTests/http/tests/notifications/worker-show-notification.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/notifications/historical.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/notifications/idlharness.https.any.worker-expected.txt:
* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::Notification::create):
(WebCore::Notification::Notification):
(WebCore::Notification::~Notification):
(WebCore::Notification::show):
(WebCore::Notification::close):
(WebCore::Notification::stop):
(WebCore::Notification::dispatchShowEvent):
(WebCore::Notification::dispatchClickEvent):
(WebCore::Notification::dispatchCloseEvent):
(WebCore::Notification::dispatchErrorEvent):
(WebCore::Notification::data const):
(WebCore::Notification::ensureOnNotificationThread):
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/notifications/Notification.idl:
* Source/WebCore/Modules/notifications/NotificationClient.h:
* Source/WebCore/Modules/notifications/NotificationData.cpp:
(WebCore::NotificationData::isolatedCopy const):
(WebCore::NotificationData::isolatedCopy):
* Source/WebCore/Modules/notifications/NotificationData.h:
(WebCore::NotificationData::isPersistent const):
(WebCore::NotificationData::encode const):
(WebCore::NotificationData::decode):
* Source/WebCore/Modules/notifications/NotificationDataCocoa.mm:
(WebCore::NotificationData::fromDictionary):
(WebCore::NotificationData::dictionaryRepresentation const):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
(WebCore::DedicatedWorkerGlobalScope::notificationClient):
* Source/WebCore/workers/DedicatedWorkerGlobalScope.h:
* Source/WebCore/workers/WorkerNotificationClient.cpp: Added.
(WebCore::WorkerNotificationClient::create):
(WebCore::WorkerNotificationClient::WorkerNotificationClient):
(WebCore::WorkerNotificationClient::show):
(WebCore::WorkerNotificationClient::cancel):
(WebCore::WorkerNotificationClient::notificationObjectDestroyed):
(WebCore::WorkerNotificationClient::notificationControllerDestroyed):
(WebCore::WorkerNotificationClient::requestPermission):
(WebCore::WorkerNotificationClient::checkPermission):
(WebCore::WorkerNotificationClient::postToMainThread):
(WebCore::WorkerNotificationClient::postToWorkerThread):
* Source/WebCore/workers/WorkerNotificationClient.h: Copied from Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h.
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::sendMessage):
(WebKit::WebNotificationManager::sendNotificationMessage):
(WebKit::WebNotificationManager::sendNotificationMessageWithAsyncReply):
(WebKit::WebNotificationManager::show):
(WebKit::WebNotificationManager::cancel):
(WebKit::WebNotificationManager::didDestroyNotification):
(WebKit::WebNotificationManager::didShowNotification):
(WebKit::WebNotificationManager::didClickNotification):
(WebKit::WebNotificationManager::didCloseNotifications):
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp:
(WebKit::WebNotificationClient::show):
(WebKit::WebNotificationClient::cancel):
(WebKit::WebNotificationClient::notificationObjectDestroyed):
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm:
(WebNotificationClient::show):
(WebNotificationClient::cancel):
(WebNotificationClient::notificationObjectDestroyed):
(generateNotificationID): Deleted.
(WebNotificationClient::notificationIDForTesting): Deleted.
* Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm:
(-[WebSecurityOrigin _initWithString:]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOriginInternal.h:
* Source/WebKitLegacy/mac/WebView/WebNotification.h:
* Source/WebKitLegacy/mac/WebView/WebNotification.mm:
(-[WebNotification initWithCoreNotification:]):
(-[WebNotification title]):
(-[WebNotification body]):
(-[WebNotification tag]):
(-[WebNotification iconURL]):
(-[WebNotification lang]):
(-[WebNotification dir]):
(-[WebNotification origin]):
(-[WebNotification notificationID]):
(-[WebNotification dispatchShowEvent]):
(-[WebNotification dispatchCloseEvent]):
(-[WebNotification dispatchClickEvent]):
(-[WebNotification dispatchErrorEvent]):
(-[WebNotification finalize]):
(core): Deleted.
(-[WebNotification initWithCoreNotification:notificationID:]): Deleted.
* Source/WebKitLegacy/mac/WebView/WebNotificationInternal.h:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _notificationDidShow:]):
(-[WebView _notificationDidClick:]):
(-[WebView _notificationIDForTesting:]):
* Source/WebKitLegacy/mac/WebView/WebViewPrivate.h:
* Tools/DumpRenderTree/mac/MockWebNotificationProvider.h:
* Tools/DumpRenderTree/mac/MockWebNotificationProvider.mm:
(-[MockWebNotificationProvider showNotification:fromWebView:]):
(-[MockWebNotificationProvider cancelNotification:]):
(-[MockWebNotificationProvider notificationDestroyed:]):
(-[MockWebNotificationProvider clearNotifications:]):
(-[MockWebNotificationProvider webView:didShowNotification:]):
(-[MockWebNotificationProvider webView:didClickNotification:]):
(-[MockWebNotificationProvider webView:didCloseNotifications:]):
(-[MockWebNotificationProvider simulateWebNotificationClick:]):
* Tools/DumpRenderTree/mac/TestRunnerMac.mm:
(TestRunner::simulateWebNotificationClick):

Canonical link: <a href="https://commits.webkit.org/254805@main">https://commits.webkit.org/254805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1ce6de5a9e9e23ded475b8774d6d521bf48ab2a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99529 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157022 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94227 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33254 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28587 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82545 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/95997 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26450 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77051 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26333 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69333 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34381 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15137 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32222 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16086 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3371 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/35966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39045 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35170 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->