### PR TITLE
Import the Screen Wake Lock API tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6022,6 +6022,13 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/cs
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/cors-crossorigin-requests.html [ Pass Failure ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests.html [ Pass Failure ]
 
+# Screen Wake Lock tests that are timing out since their import.
+imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html [ Skip ]
+imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub.html [ Skip ]
+imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub.html [ Skip ]
+imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html [ Skip ]
+imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html [ Skip ]
+
 # Disable ShadowRealm (while running to ensure we do not crash)
 http/tests/misc/iframe-shadow-realm.html [ Pass Failure ]
 inspector/shadow-realm-console.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -413,6 +413,7 @@
     "web-platform-tests/resources/chromium": "skip", 
     "web-platform-tests/resources/test": "skip", 
     "web-platform-tests/screen-orientation": "skip", 
+    "web-platform-tests/screen-wake-lock": "import", 
     "web-platform-tests/scroll-anchoring": "skip", 
     "web-platform-tests/scroll-into-view": "skip", 
     "web-platform-tests/scroll-to-text-fragment": "import", 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/META.yml
@@ -1,0 +1,6 @@
+spec: https://w3c.github.io/screen-wake-lock/
+suggested_reviewers:
+  - Honry
+  - marcoscaceres
+  - rakuco
+  - reillyeon

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/idlharness.https.window-expected.txt
@@ -1,0 +1,43 @@
+
+FAIL idl_test setup promise_test: Unhandled rejection with value: object "Error: unimplemented"
+PASS idl_test validation
+PASS Partial interface Navigator: original interface defined
+PASS Partial interface Navigator: member names are unique
+PASS Partial interface mixin NavigatorID: member names are unique
+PASS Navigator includes NavigatorID: member names are unique
+PASS Navigator includes NavigatorLanguage: member names are unique
+PASS Navigator includes NavigatorOnLine: member names are unique
+PASS Navigator includes NavigatorContentUtils: member names are unique
+PASS Navigator includes NavigatorCookies: member names are unique
+PASS Navigator includes NavigatorPlugins: member names are unique
+PASS Navigator includes NavigatorConcurrentHardware: member names are unique
+FAIL WakeLock interface: existence and properties of interface object assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
+FAIL WakeLock interface object length assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
+FAIL WakeLock interface object name assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
+FAIL WakeLock interface: existence and properties of interface prototype object assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
+FAIL WakeLock interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
+FAIL WakeLock interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
+FAIL WakeLock interface: operation request(optional WakeLockType) assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
+FAIL WakeLock must be primary interface of navigator.wakeLock assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL Stringification of navigator.wakeLock assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL WakeLock interface: navigator.wakeLock must inherit property "request(optional WakeLockType)" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL WakeLock interface: calling request(optional WakeLockType) on navigator.wakeLock with too few arguments must throw TypeError assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL WakeLockSentinel interface: existence and properties of interface object assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
+FAIL WakeLockSentinel interface object length assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
+FAIL WakeLockSentinel interface object name assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
+FAIL WakeLockSentinel interface: existence and properties of interface prototype object assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
+FAIL WakeLockSentinel interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
+FAIL WakeLockSentinel interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
+FAIL WakeLockSentinel interface: attribute released assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
+FAIL WakeLockSentinel interface: attribute type assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
+FAIL WakeLockSentinel interface: operation release() assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
+FAIL WakeLockSentinel interface: attribute onrelease assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
+FAIL WakeLockSentinel must be primary interface of sentinel assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
+FAIL Stringification of sentinel assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
+FAIL WakeLockSentinel interface: sentinel must inherit property "released" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
+FAIL WakeLockSentinel interface: sentinel must inherit property "type" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
+FAIL WakeLockSentinel interface: sentinel must inherit property "release()" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
+FAIL WakeLockSentinel interface: sentinel must inherit property "onrelease" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
+FAIL Navigator interface: attribute wakeLock assert_true: The prototype object must have a property "wakeLock" expected true got false
+FAIL Navigator interface: navigator must inherit property "wakeLock" with the proper type assert_inherits: property "wakeLock" not found in prototype chain
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/idlharness.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/idlharness.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/idlharness.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/idlharness.https.window.js
@@ -1,0 +1,27 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+// META: script=/resources/testdriver.js
+// META: script=/resources/testdriver-vendor.js
+// META: timeout=long
+
+// https://w3c.github.io/screen-wake-lock/
+
+'use strict';
+
+idl_test(
+  ['screen-wake-lock'],
+  ['dom', 'html'],
+  async idl_array => {
+    idl_array.add_objects({ Navigator: ['navigator'] });
+
+    idl_array.add_objects({
+      WakeLock: ['navigator.wakeLock'],
+      WakeLockSentinel: ['sentinel'],
+    });
+
+    await test_driver.set_permission(
+        { name: 'screen-wake-lock' }, 'granted');
+    self.sentinel = await navigator.wakeLock.request('screen');
+    self.sentinel.release();
+  }
+);

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/resources/page1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/resources/page1.html
@@ -1,0 +1,1 @@
+<meta charset="utf-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/resources/page2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/resources/page2.html
@@ -1,0 +1,1 @@
+<meta charset="utf-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/resources/w3c-import.log
@@ -1,0 +1,18 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/resources/page1.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/resources/page2.html

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/w3c-import.log
@@ -1,0 +1,35 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/idlharness.https.window.js
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-active-document.https.window.js
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html.headers
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html.headers
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html.headers
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any.js
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-onrelease.https.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-released.https.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-request-denied.https.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-screen-type-on-worker.https.worker.js
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-supported-by-feature-policy.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-type.https.window.js
+/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelockpermissiondescriptor.https.html

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-active-document.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-active-document.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL navigator.wakeLock.request() aborts if the document is not active. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'wakeLock1.request')"
+FAIL navigator.wakeLock.request() aborts if the document is active, but not fully active. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'wakeLock.request')"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-active-document.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-active-document.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-active-document.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-active-document.https.window.js
@@ -1,0 +1,87 @@
+function getWakeLockObject(iframe, url) {
+  return new Promise(resolve => {
+    iframe.addEventListener(
+      "load",
+      () => {
+        const { wakeLock } = iframe.contentWindow.navigator;
+        resolve(wakeLock);
+      },
+      { once: true }
+    );
+    iframe.src = url;
+  });
+}
+
+promise_test(async t => {
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  // We first got to page1.html, grab a WakeLock object.
+  const wakeLock1 = await getWakeLockObject(
+    iframe,
+    "/screen-wake-lock/resources/page1.html"
+  );
+  // Save the DOMException of page1.html before navigating away.
+  const frameDOMException1 = iframe.contentWindow.DOMException;
+  // We navigate the iframe again, putting wakeLock1's document into an inactive state.
+  const wakeLock2 = await getWakeLockObject(
+    iframe,
+    "/screen-wake-lock/resources/page2.html"
+  );
+  // Now, wakeLock1's relevant global object's document is no longer active.
+  // So, call .request(), and make sure it rejects appropriately.
+  await promise_rejects_dom(
+    t,
+    "NotAllowedError",
+    frameDOMException1,
+    wakeLock1.request('screen'),
+    "Inactive document, so must throw NotAllowedError"
+  );
+  // We are done, so clean up.
+  iframe.remove();
+}, "navigator.wakeLock.request() aborts if the document is not active.");
+
+promise_test(async t => {
+  // We nest two iframes and wait for them to load.
+  const outerIframe = document.createElement("iframe");
+  document.body.appendChild(outerIframe);
+  // Load the outer iframe (we don't care about the awaited request)
+  await getWakeLockObject(
+    outerIframe,
+    "/screen-wake-lock/resources/page1.html"
+  );
+
+  // Now we create the inner iframe
+  const innerIframe = outerIframe.contentDocument.createElement("iframe");
+
+  // nest them
+  outerIframe.contentDocument.body.appendChild(innerIframe);
+
+  // load innerIframe, and get the WakeLock instance
+  const wakeLock = await getWakeLockObject(
+    innerIframe,
+    "/screen-wake-lock/resources/page2.html"
+  );
+  // Save DOMException from innerIframe before navigating away.
+  const innerIframeDOMException = innerIframe.contentWindow.DOMException;
+
+  // Navigate the outer iframe to a new location.
+  // Wait for the load event to fire.
+  await new Promise(resolve => {
+    outerIframe.addEventListener("load", resolve);
+    outerIframe.src = "/screen-wake-lock/resources/page2.html";
+  });
+
+  // Now, request's relevant global object's document is still active
+  // (it is the active document of the inner iframe), but is not fully active
+  // (since the parent of the inner iframe is itself no longer active).
+  // So, call request.show() and make sure it rejects appropriately.
+  await promise_rejects_dom(
+    t,
+    "NotAllowedError",
+    innerIframeDOMException,
+    wakeLock.request('screen'),
+    "Active, but not fully active, so must throw NotAllowedError"
+  );
+  // We are done, so clean up.
+  outerIframe.remove();
+}, "navigator.wakeLock.request() aborts if the document is active, but not fully active.");

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub-expected.txt
@@ -1,0 +1,9 @@
+Blocked access to external URL https://www.localhost:9443/feature-policy/resources/feature-policy-screen-wakelock.html
+
+
+Harness Error (TIMEOUT), message = null
+
+FAIL Feature-Policy header {"screen-wake-lock" : []} disallows the top-level document. undefined is not an object (evaluating 'navigator.wakeLock.request')
+TIMEOUT Feature-Policy header {"screen-wake-lock" : []} disallows same-origin iframes. Test timed out
+TIMEOUT Feature-Policy header {"screen-wake-lock" : []} disallows cross-origin iframes. Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script>
+  "use strict";
+
+  const same_origin_src =
+    "/feature-policy/resources/feature-policy-screen-wakelock.html";
+  const cross_origin_src =
+    "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
+
+  promise_test(t => {
+    return promise_rejects_dom(t, "NotAllowedError", navigator.wakeLock.request("screen"));
+  }, 'Feature-Policy header {"screen-wake-lock" : []} disallows the top-level document.');
+
+  async_test(t => {
+    test_feature_availability(
+      'navigator.wakeLock.request("screen")',
+      t,
+      same_origin_src,
+      expect_feature_unavailable_default
+    );
+  }, 'Feature-Policy header {"screen-wake-lock" : []} disallows same-origin iframes.');
+
+  async_test(t => {
+    test_feature_availability(
+      'navigator.wakeLock.request("screen")',
+      t,
+      cross_origin_src,
+      expect_feature_unavailable_default
+    );
+  }, 'Feature-Policy header {"screen-wake-lock" : []} disallows cross-origin iframes.');
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html.headers
@@ -1,0 +1,1 @@
+Feature-Policy: screen-wake-lock 'none'

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,0 +1,8 @@
+Blocked access to external URL https://www.localhost:9443/feature-policy/resources/feature-policy-screen-wakelock.html
+
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Feature-Policy allow="screen-wake-lock" allows same-origin relocation Test timed out
+TIMEOUT Feature-Policy allow="screen-wake-lock" disallows cross-origin relocation Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script>
+  "use strict";
+
+  const relative_path = "/feature-policy/resources/feature-policy-screen-wakelock.html";
+  const base_src = "/feature-policy/resources/redirect-on-load.html#";
+  const same_origin_src = base_src + relative_path;
+  const cross_origin_src =
+    base_src + "https://{{domains[www]}}:{{ports[https][0]}}" + relative_path;
+
+  async_test(t => {
+    test_feature_availability(
+      'navigator.wakeLock.request("screen")',
+      t,
+      same_origin_src,
+      expect_feature_available_default,
+      "screen-wake-lock"
+    );
+  }, 'Feature-Policy allow="screen-wake-lock" allows same-origin relocation');
+
+  async_test(t => {
+    test_feature_availability(
+      'navigator.wakeLock.request("screen")',
+      t,
+      cross_origin_src,
+      expect_feature_unavailable_default,
+      "screen-wake-lock"
+    );
+  }, 'Feature-Policy allow="screen-wake-lock" disallows cross-origin relocation');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub-expected.txt
@@ -1,0 +1,8 @@
+Blocked access to external URL https://www.localhost:9443/feature-policy/resources/feature-policy-screen-wakelock.html
+
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Feature policy "screen-wake-lock" can be enabled in same-origin iframe using allow="screen-wake-lock" attribute Test timed out
+TIMEOUT Feature policy "screen-wake-lock" can be enabled in cross-origin iframe using allow="screen-wake-lock" attribute Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script>
+  "use strict";
+
+  const same_origin_src =
+    "/feature-policy/resources/feature-policy-screen-wakelock.html";
+  const cross_origin_src =
+    "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
+
+  async_test(t => {
+    test_feature_availability(
+      'navigator.wakeLock.request("screen")',
+      t,
+      same_origin_src,
+      expect_feature_available_default,
+      "screen-wake-lock"
+    );
+  }, 'Feature policy "screen-wake-lock" can be enabled in same-origin iframe using allow="screen-wake-lock" attribute');
+
+  async_test(t => {
+    test_feature_availability(
+      'navigator.wakeLock.request("screen")',
+      t,
+      cross_origin_src,
+      expect_feature_available_default,
+      "screen-wake-lock"
+    );
+  }, 'Feature policy "screen-wake-lock" can be enabled in cross-origin iframe using allow="screen-wake-lock" attribute');
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub-expected.txt
@@ -1,0 +1,9 @@
+Blocked access to external URL https://www.localhost:9443/feature-policy/resources/feature-policy-screen-wakelock.html
+
+
+Harness Error (TIMEOUT), message = null
+
+FAIL Feature-Policy header {"screen-wake-lock" : ["*"]} allows the top-level document. promise_test: Unhandled rejection with value: object "Error: unimplemented"
+TIMEOUT Feature-Policy header {"screen-wake-lock" : ["*"]} allows same-origin iframes. Test timed out
+TIMEOUT Feature-Policy header {"screen-wake-lock" : ["*"]} allows cross-origin iframes. Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/feature-policy/resources/featurepolicy.js"></script>
+<script>
+  "use strict";
+
+  const same_origin_src =
+    "/feature-policy/resources/feature-policy-screen-wakelock.html";
+  const cross_origin_src =
+    "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
+
+  promise_test(async t => {
+    await test_driver.set_permission(
+        { name: 'screen-wake-lock' }, 'granted');
+    await navigator.wakeLock.request('screen').then(lock => lock.release());
+  }, 'Feature-Policy header {"screen-wake-lock" : ["*"]} allows the top-level document.');
+
+  async_test(t => {
+    test_feature_availability(
+      'navigator.wakeLock.request("screen")',
+      t,
+      same_origin_src,
+      expect_feature_available_default
+    );
+  }, 'Feature-Policy header {"screen-wake-lock" : ["*"]} allows same-origin iframes.');
+
+  // Set allow="screen-wake-lock" on iframe element to delegate
+  // 'screen-wake-lock' to cross origin subframe.
+  async_test(t => {
+    test_feature_availability(
+      'navigator.wakeLock.request("screen")',
+      t,
+      cross_origin_src,
+      expect_feature_available_default,
+      'screen-wake-lock'
+    );
+  }, 'Feature-Policy header {"screen-wake-lock" : ["*"]} allows cross-origin iframes.');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html.headers
@@ -1,0 +1,1 @@
+Feature-Policy: screen-wake-lock *

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub-expected.txt
@@ -1,0 +1,9 @@
+Blocked access to external URL https://www.localhost:9443/feature-policy/resources/feature-policy-screen-wakelock.html
+
+
+Harness Error (TIMEOUT), message = null
+
+FAIL Feature-Policy header screen-wake-lock "self" allows the top-level document. promise_test: Unhandled rejection with value: object "Error: unimplemented"
+TIMEOUT Feature-Policy header screen-wake-lock "self" allows same-origin iframes. Test timed out
+TIMEOUT Feature-Policy header screen-wake-lock "self" disallows cross-origin iframes. Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/feature-policy/resources/featurepolicy.js"></script>
+
+<script>
+  "use strict";
+
+  const same_origin_src =
+    "/feature-policy/resources/feature-policy-screen-wakelock.html";
+  const cross_origin_src =
+    "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
+
+  promise_test(async t => {
+    await test_driver.set_permission(
+        { name: 'screen-wake-lock' }, 'granted');
+    await navigator.wakeLock.request('screen').then(lock => lock.release());
+  }, 'Feature-Policy header screen-wake-lock "self" allows the top-level document.');
+
+  async_test(t => {
+    test_feature_availability(
+      'navigator.wakeLock.request("screen")',
+      t,
+      same_origin_src,
+      expect_feature_available_default
+    );
+  }, 'Feature-Policy header screen-wake-lock "self" allows same-origin iframes.');
+
+  async_test(t => {
+    test_feature_availability(
+      'navigator.wakeLock.request("screen")',
+      t,
+      cross_origin_src,
+      expect_feature_unavailable_default
+    );
+  }, 'Feature-Policy header screen-wake-lock "self" disallows cross-origin iframes.');
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html.headers
@@ -1,0 +1,1 @@
+Feature-Policy: screen-wake-lock 'self'

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Wake Lock API is not exposed in an insecure context
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any.js
@@ -1,0 +1,5 @@
+//META: title=Wake Lock API is not exposed in an insecure context
+
+test(() => {
+  assert_false("WakeLock" in self, "'WakeLock' must not be exposed");
+}, "Wake Lock API is not exposed in an insecure context");

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Wake Lock API is not exposed in an insecure context
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-onrelease.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-onrelease.https-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Test onreleased event's basic properties promise_test: Unhandled rejection with value: object "Error: unimplemented"
+FAIL Ensure onreleased is called before WakeLockSentinel.release() resolves promise_test: Unhandled rejection with value: object "Error: unimplemented"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-onrelease.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-onrelease.https.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<link rel="help" href="https://w3c.github.io/screen-wake-lock/#the-onrelease-attribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+promise_test(async t => {
+  await test_driver.set_permission({name: 'screen-wake-lock'}, 'granted');
+
+  const lock = await navigator.wakeLock.request("screen");
+  return new Promise(resolve => {
+    lock.onrelease = resolve;
+    lock.release();
+  }).then(ev => {
+    assert_class_string(ev, "Event", "release() must fire an Event object");
+    assert_equals(ev.target, lock, "The event's target must be the lock that was acquired");
+    assert_true(ev.isTrusted);
+    assert_false(ev.bubbles);
+    assert_false(ev.cancelable);
+  });
+}, "Test onreleased event's basic properties");
+
+promise_test(async t => {
+  await test_driver.set_permission({ name: 'screen-wake-lock' }, 'granted');
+
+  const lock = await navigator.wakeLock.request("screen");
+
+  let releaseFired = false;
+  lock.onrelease = t.step_func(() => {
+    releaseFired = true;
+  });
+
+  const releasePromise = lock.release();
+  assert_true(releaseFired, "The 'release' event fires immediately after release() is called");
+
+  return releasePromise;
+}, "Ensure onreleased is called before WakeLockSentinel.release() resolves");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-released.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-released.https-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL The released attribute inside an event handler promise_test: Unhandled rejection with value: object "Error: unimplemented"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-released.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-released.https.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="help" href="https://w3c.github.io/screen-wake-lock/#dom-wakelocksentinel-released">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+promise_test(async t => {
+  await test_driver.set_permission({ name: 'screen-wake-lock' }, 'granted');
+
+  const lock = await navigator.wakeLock.request("screen");
+  assert_false(lock.released, "lock.released must be false on creation");
+
+  lock.onrelease = t.step_func(() => {
+    assert_true(lock.released, "WakeLockSentinel.released is true in an onrelease event handler");
+  });
+  await lock.release();
+  assert_true(lock.released, "WakeLockSentinel.released remains true outside the event handler");
+}, "The released attribute inside an event handler");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-request-denied.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-request-denied.https-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Denied requests should abort with NotAllowedError promise_test: Unhandled rejection with value: object "Error: unimplemented"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-request-denied.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-request-denied.https.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+'use strict';
+
+promise_test(async t => {
+  await test_driver.set_permission({name: 'screen-wake-lock'}, 'denied');
+  return promise_rejects_dom(t, "NotAllowedError", navigator.wakeLock.request('screen'));
+}, 'Denied requests should abort with NotAllowedError');
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-screen-type-on-worker.https.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-screen-type-on-worker.https.worker-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Screen wake lock should not be allowed in dedicated worker undefined is not an object (evaluating 'navigator.wakeLock.request')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-screen-type-on-worker.https.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-screen-type-on-worker.https.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-screen-type-on-worker.https.worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-screen-type-on-worker.https.worker.js
@@ -1,0 +1,8 @@
+//META: title=Screen wake lock should not be allowed in dedicated worker
+importScripts("/resources/testharness.js");
+
+promise_test(t => {
+  return promise_rejects_dom(t, "NotAllowedError", navigator.wakeLock.request('screen'));
+}, "Screen wake lock should not be allowed in dedicated worker");
+
+done();

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-supported-by-feature-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-supported-by-feature-policy-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL document.featurePolicy.features should advertise screen-wake-lock. undefined is not an object (evaluating 'document.featurePolicy.features')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-supported-by-feature-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-supported-by-feature-policy.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Test that wake-lock is advertised in the feature list</title>
+<link rel="help" href="https://w3c.github.io/webappsec-feature-policy/#dom-featurepolicy-features">
+<link rel="help" href="https://w3c.github.io/screen-wake-lock/#dfn-wake-lock-feature">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+    assert_in_array('screen-wake-lock', document.featurePolicy.features());
+}, 'document.featurePolicy.features should advertise screen-wake-lock.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-type.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-type.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL 'type' parameter in WakeLock.request() defaults to 'screen' promise_test: Unhandled rejection with value: object "Error: unimplemented"
+FAIL 'TypeError' is thrown when set an invalid wake lock type undefined is not an object (evaluating 'navigator.wakeLock.request')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-type.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-type.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-type.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-type.https.window.js
@@ -1,0 +1,21 @@
+// META: script=/resources/testdriver.js
+// META: script=/resources/testdriver-vendor.js
+
+promise_test(async t => {
+  await test_driver.set_permission(
+      {name: 'screen-wake-lock'}, 'granted');
+
+  const lock = await navigator.wakeLock.request();
+  t.add_cleanup(() => {
+    lock.release();
+  });
+  assert_equals(lock.type, 'screen');
+}, '\'type\' parameter in WakeLock.request() defaults to \'screen\'');
+
+promise_test(t => {
+  const invalidTypes = ['invalid', null, 123, {}, '', true];
+  return Promise.all(invalidTypes.map(invalidType => {
+    return promise_rejects_js(
+        t, TypeError, navigator.wakeLock.request(invalidType));
+  }));
+}, '\'TypeError\' is thrown when set an invalid wake lock type');

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelockpermissiondescriptor.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelockpermissiondescriptor.https-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL PermissionDescriptor with name='screen-wake-lock' works promise_test: Unhandled rejection with value: object "Error: unimplemented"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelockpermissiondescriptor.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelockpermissiondescriptor.https.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://w3c.github.io/screen-wake-lock/#the-screen-wake-lock-powerful-feature">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+promise_test(async t => {
+  await test_driver.set_permission({name: 'screen-wake-lock'}, 'denied');
+
+  return navigator.permissions.query({name:'screen-wake-lock'}).then(status => {
+    assert_class_string(status, "PermissionStatus");
+    assert_equals(status.state, "denied");
+  });
+}, "PermissionDescriptor with name='screen-wake-lock' works");
+</script>


### PR DESCRIPTION
#### 7b1a4e7e5fb469b0eea41fe131f2f190d08f2383
<pre>
Import the Screen Wake Lock API tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=245537">https://bugs.webkit.org/show_bug.cgi?id=245537</a>

Reviewed by Tim Nguyen.

Import the Screen Wake Lock API WPT tests from upstream 834bda497115a2be24a0d.

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/*: Added.

Canonical link: <a href="https://commits.webkit.org/254779@main">https://commits.webkit.org/254779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74a887857e51de10d980605f320f97958d86b09b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99505 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157005 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33229 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/95980 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95848 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26427 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77030 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26315 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69313 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34364 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/15124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16072 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3356 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/35949 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35156 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->