### PR TITLE
Provide a mechanism for NSAttributedString to extend file access to WebContent process

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedStringPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedStringPrivate.h
@@ -31,6 +31,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /*!
+ @abstract Indicates additional local paths WebKit can read from when loading content.
+*/
+WK_EXTERN NSAttributedStringDocumentReadingOptionKey const _WKReadAccessFileURLsOption
+    NS_SWIFT_NAME(readAccessPaths) WK_API_AVAILABLE(macos(13.1), ios(16.2));
+
+/*!
  @discussion Private extension of @link //apple_ref/occ/NSAttributedString NSAttributedString @/link to
  translate HTML content into attributed strings using WebKit.
  */

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdditionalReadAccessAllowedURLs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdditionalReadAccessAllowedURLs.mm
@@ -33,12 +33,31 @@
 #import "PlatformUtilities.h"
 #import "Utilities.h"
 #import "WKWebViewConfigurationExtras.h"
+#import <WebKit/NSAttributedStringPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKit/_WKRemoteObjectInterface.h>
 #import <WebKit/_WKRemoteObjectRegistry.h>
 #import <wtf/RetainPtr.h>
+
+static std::pair<RetainPtr<NSURL>, RetainPtr<NSURL>> readableAndUnreadableDirectories()
+{
+    char temporaryDirectory[PATH_MAX];
+    confstr(_CS_DARWIN_USER_TEMP_DIR, temporaryDirectory, sizeof(temporaryDirectory));
+
+    char readableDirectory[PATH_MAX];
+    strlcpy(readableDirectory, [[[NSFileManager defaultManager] stringWithFileSystemRepresentation:temporaryDirectory length:strlen(temporaryDirectory)] stringByAppendingPathComponent:@"WebKitTestRunner.AdditionalReadAccessAllowedURLs-XXXXXX"].fileSystemRepresentation, sizeof(temporaryDirectory));
+    mkdtemp(readableDirectory);
+    NSURL *readableDirectoryURL = [NSURL fileURLWithFileSystemRepresentation:readableDirectory isDirectory:YES relativeToURL:nil];
+
+    char unreadableDirectory[PATH_MAX];
+    strlcpy(unreadableDirectory, [[[NSFileManager defaultManager] stringWithFileSystemRepresentation:temporaryDirectory length:strlen(temporaryDirectory)] stringByAppendingPathComponent:@"WebKitTestRunner.AdditionalReadAccessAllowedURLs-XXXXXX"].fileSystemRepresentation, sizeof(temporaryDirectory));
+    mkdtemp(unreadableDirectory);
+    NSURL *unreadableDirectoryURL = [NSURL fileURLWithFileSystemRepresentation:unreadableDirectory isDirectory:YES relativeToURL:nil];
+
+    return std::make_pair(readableDirectoryURL, unreadableDirectoryURL);
+}
 
 TEST(WebKit, AdditionalReadAccessAllowedURLs)
 {
@@ -59,20 +78,9 @@ TEST(WebKit, AdditionalReadAccessAllowedURLs)
     processPoolConfiguration.additionalReadAccessAllowedURLs = @[ fileURLWithNonLatin1Path ];
     EXPECT_TRUE([processPoolConfiguration.additionalReadAccessAllowedURLs.firstObject isEqual:fileURLWithNonLatin1Path]);
 
-    char temporaryDirectory[PATH_MAX];
-    confstr(_CS_DARWIN_USER_TEMP_DIR, temporaryDirectory, sizeof(temporaryDirectory));
+    auto [readableDirectoryURL, unreadableDirectoryURL] = readableAndUnreadableDirectories();
 
-    char readableDirectory[PATH_MAX];
-    strlcpy(readableDirectory, [[[NSFileManager defaultManager] stringWithFileSystemRepresentation:temporaryDirectory length:strlen(temporaryDirectory)] stringByAppendingPathComponent:@"WebKitTestRunner.AdditionalReadAccessAllowedURLs-XXXXXX"].fileSystemRepresentation, sizeof(temporaryDirectory));
-    mkdtemp(readableDirectory);
-    NSURL *readableDirectoryURL = [NSURL fileURLWithFileSystemRepresentation:readableDirectory isDirectory:YES relativeToURL:nil];
-
-    char unreadableDirectory[PATH_MAX];
-    strlcpy(unreadableDirectory, [[[NSFileManager defaultManager] stringWithFileSystemRepresentation:temporaryDirectory length:strlen(temporaryDirectory)] stringByAppendingPathComponent:@"WebKitTestRunner.AdditionalReadAccessAllowedURLs-XXXXXX"].fileSystemRepresentation, sizeof(temporaryDirectory));
-    mkdtemp(unreadableDirectory);
-    NSURL *unreadableDirectoryURL = [NSURL fileURLWithFileSystemRepresentation:unreadableDirectory isDirectory:YES relativeToURL:nil];
-
-    processPoolConfiguration.additionalReadAccessAllowedURLs = @[ readableDirectoryURL ];
+    processPoolConfiguration.additionalReadAccessAllowedURLs = @[ readableDirectoryURL.get() ];
 
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration]);
     [processPool _setObject:@"AdditionalReadAccessAllowedURLsPlugIn" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
@@ -103,6 +111,212 @@ TEST(WebKit, AdditionalReadAccessAllowedURLs)
         EXPECT_EQ(NSFileReadNoPermissionError, error.code);
     }];
     TestWebKitAPI::Util::run(&done);
+}
+
+TEST(WebKit, NSAttributedStringWithReadOnlyPaths)
+{
+    __block bool done = false;
+
+    auto [readableDirectoryURL, unreadableDirectoryURL] = readableAndUnreadableDirectories();
+
+    NSURL *iconImagePath = [[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *readableFileURL = [readableDirectoryURL URLByAppendingPathComponent:@"readable.png"];
+    NSError *error;
+    if (![NSFileManager.defaultManager copyItemAtURL:iconImagePath toURL:readableFileURL error:&error])
+        EXPECT_TRUE(error.code == NSFileWriteFileExistsError);
+
+    NSURL *redImagePath = [[NSBundle mainBundle] URLForResource:@"large-red-square" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *unreadableFileURL = [unreadableDirectoryURL URLByAppendingPathComponent:@"unreadable.png"];
+    if (![NSFileManager.defaultManager copyItemAtURL:redImagePath toURL:unreadableFileURL error:&error])
+        EXPECT_TRUE(error.code == NSFileWriteFileExistsError);
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+    auto options = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ readableDirectoryURL.get() ], _WKReadAccessFileURLsOption, nil]);
+#pragma clang diagnostic pop
+
+    NSString *testString = [NSString stringWithFormat:@"<p>Hello<img src='%@'></p><p>World<img src='%@'></p>", [readableFileURL absoluteString], [unreadableFileURL absoluteString]];
+
+    [NSAttributedString loadFromHTMLWithString:testString options:options.get() completionHandler:^(NSAttributedString *attributedString, NSDictionary<NSAttributedStringDocumentAttributeKey, id> *attributes, NSError *error) {
+
+        __block Vector<NSTextAttachment *> attachments;
+        [attributedString enumerateAttributesInRange:NSMakeRange(0, attributedString.length) options:0 usingBlock:^(NSDictionary<NSString *, id> *attrs, NSRange range, BOOL *stop) {
+            id attachment = [attrs objectForKey:NSAttachmentAttributeName];
+            if (attachment)
+                attachments.append(attachment);
+        }];
+            
+        EXPECT_EQ(attachments.size(), 2ul);
+
+        // Sandbox allows access, so get reference to image path:
+        EXPECT_TRUE(attachments[0]);
+        EXPECT_TRUE([attachments[0].fileType isEqualToString:@"public.png"]);
+        EXPECT_TRUE([attachments[0].fileWrapper.preferredFilename isEqualToString:@"readable.png"]);
+        EXPECT_NULL(attachments[0].image); // Image is to be loaded from the path
+
+        // Sandbox prohibits access, so get placeholder image:
+        EXPECT_TRUE(attachments[1]);
+        EXPECT_NULL(attachments[1].fileType);
+        EXPECT_TRUE([attachments[1].fileWrapper.preferredFilename isEqualToString:@"Attachment.png"]); // Placeholder attachment image
+        EXPECT_TRUE(attachments[1].image); // Placeholder image
+
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(WebKit, NSAttributedStringWithAndWithoutReadOnlyPaths)
+{
+    __block bool done = false;
+
+    auto [readableDirectoryURL, unreadableDirectoryURL] = readableAndUnreadableDirectories();
+
+    NSURL *iconImagePath = [[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *readableFileURL = [readableDirectoryURL URLByAppendingPathComponent:@"readable.png"];
+    NSError *error;
+    if (![NSFileManager.defaultManager copyItemAtURL:iconImagePath toURL:readableFileURL error:&error])
+        EXPECT_TRUE(error.code == NSFileWriteFileExistsError);
+
+    NSURL *redImagePath = [[NSBundle mainBundle] URLForResource:@"large-red-square" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *unreadableFileURL = [unreadableDirectoryURL URLByAppendingPathComponent:@"unreadable.png"];
+    if (![NSFileManager.defaultManager copyItemAtURL:redImagePath toURL:unreadableFileURL error:&error])
+        EXPECT_TRUE(error.code == NSFileWriteFileExistsError);
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+    auto options = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ readableDirectoryURL.get() ], _WKReadAccessFileURLsOption, nil]);
+#pragma clang diagnostic pop
+
+    NSString *testString = [NSString stringWithFormat:@"<p>Hello<img src='%@'></p><p>World<img src='%@'></p>", [readableFileURL absoluteString], [unreadableFileURL absoluteString]];
+
+    [NSAttributedString loadFromHTMLWithString:testString options:options.get() completionHandler:^(NSAttributedString *attributedString, NSDictionary<NSAttributedStringDocumentAttributeKey, id> *attributes, NSError *error) {
+
+        __block Vector<NSTextAttachment *> attachments;
+        [attributedString enumerateAttributesInRange:NSMakeRange(0, attributedString.length) options:0 usingBlock:^(NSDictionary<NSString *, id> *attrs, NSRange range, BOOL *stop) {
+            id attachment = [attrs objectForKey:NSAttachmentAttributeName];
+            if (attachment)
+                attachments.append(attachment);
+        }];
+            
+        EXPECT_EQ(attachments.size(), 2ul);
+
+        // Sandbox allows access, so get reference to image path:
+        EXPECT_TRUE(attachments[0]);
+        EXPECT_TRUE([attachments[0].fileType isEqualToString:@"public.png"]);
+        EXPECT_TRUE([attachments[0].fileWrapper.preferredFilename isEqualToString:@"readable.png"]);
+        EXPECT_NULL(attachments[0].image); // Image is to be loaded from the path
+
+        // Sandbox prohibits access, so get placeholder image:
+        EXPECT_TRUE(attachments[1]);
+        EXPECT_NULL(attachments[1].fileType);
+        EXPECT_TRUE([attachments[1].fileWrapper.preferredFilename isEqualToString:@"Attachment.png"]); // Placeholder attachment image
+        EXPECT_TRUE(attachments[1].image); // Placeholder image
+
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    done = false;
+    [NSAttributedString loadFromHTMLWithString:testString options:@{ } completionHandler:^(NSAttributedString *attributedString, NSDictionary<NSAttributedStringDocumentAttributeKey, id> *attributes, NSError *error) {
+
+        __block Vector<NSTextAttachment *> attachments;
+        [attributedString enumerateAttributesInRange:NSMakeRange(0, attributedString.length) options:0 usingBlock:^(NSDictionary<NSString *, id> *attrs, NSRange range, BOOL *stop) {
+            if (id attachment = [attrs objectForKey:NSAttachmentAttributeName])
+                attachments.append(attachment);
+        }];
+
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(WebKit, NSAttributedStringWithoutReadOnlyPaths)
+{
+    __block bool done = false;
+    [NSAttributedString loadFromHTMLWithString:@"Hello World" options:@{ } completionHandler:^(NSAttributedString *attributedString, NSDictionary<NSAttributedStringDocumentAttributeKey, id> *attributes, NSError *error) {
+        EXPECT_EQ([[attributedString attribute:NSFontAttributeName atIndex:0 effectiveRange:nil] pointSize], 12.0);
+        
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    
+    done = false;
+    [NSAttributedString loadFromHTMLWithString:@"Hello Again!" options:@{ } completionHandler:^(NSAttributedString *attributedString, NSDictionary<NSAttributedStringDocumentAttributeKey, id> *attributes, NSError *error) {
+        EXPECT_EQ([[attributedString attribute:NSFontAttributeName atIndex:0 effectiveRange:nil] pointSize], 12.0);
+
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(WebKit, NSAttributedStringWithTooManyReadOnlyPaths)
+{
+    __block bool done = false;
+
+    auto [readableDirectoryURL, unreadableDirectoryURL] = readableAndUnreadableDirectories();
+    NSURL *bundlePathURL = [NSURL fileURLWithPath:[[NSBundle mainBundle] bundlePath]];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+    auto options = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ readableDirectoryURL.get(), unreadableDirectoryURL.get(), bundlePathURL ], _WKReadAccessFileURLsOption, nil]);
+#pragma clang diagnostic pop
+
+    bool exceptionRaised = false;
+    @try {
+        [NSAttributedString loadFromHTMLWithString:@"Hello World" options:options.get() completionHandler:^(NSAttributedString *attributedString, NSDictionary<NSAttributedStringDocumentAttributeKey, id> *attributes, NSError *error) {
+            EXPECT_EQ([[attributedString attribute:NSFontAttributeName atIndex:0 effectiveRange:nil] pointSize], 12.0);
+
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+    } @catch (NSException *exception) {
+        EXPECT_WK_STREQ(NSInvalidArgumentException, exception.name);
+        exceptionRaised = true;
+    }
+    EXPECT_TRUE(exceptionRaised);
+}
+
+TEST(WebKit, NSAttributedStringWithInvalidReadOnlyPaths)
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+    auto options = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ @"/some/random/path" ], _WKReadAccessFileURLsOption, nil]);
+#pragma clang diagnostic pop
+
+    bool exceptionRaised = false;
+    @try {
+        [NSAttributedString loadFromHTMLWithString:@"Hello World" options:options.get() completionHandler:^(NSAttributedString *attributedString, NSDictionary<NSAttributedStringDocumentAttributeKey, id> *attributes, NSError *error) {
+            EXPECT_EQ([[attributedString attribute:NSFontAttributeName atIndex:0 effectiveRange:nil] pointSize], 12.0);
+
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+    } @catch (NSException *exception) {
+        EXPECT_WK_STREQ(NSInvalidArgumentException, exception.name);
+        exceptionRaised = true;
+    }
+    EXPECT_TRUE(exceptionRaised);
+
+    done = false;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+    NSURL* testURL = [NSURL URLWithString:@"https://example.com"];
+    auto options2 = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ testURL ], _WKReadAccessFileURLsOption, nil]);
+#pragma clang diagnostic pop
+    exceptionRaised = false;
+    @try {
+        [NSAttributedString loadFromHTMLWithString:@"Hello World" options:options2.get() completionHandler:^(NSAttributedString *attributedString, NSDictionary<NSAttributedStringDocumentAttributeKey, id> *attributes, NSError *error) {
+            EXPECT_EQ([[attributedString attribute:NSFontAttributeName atIndex:0 effectiveRange:nil] pointSize], 12.0);
+
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+    } @catch (NSException *exception) {
+        EXPECT_WK_STREQ(NSInvalidArgumentException, exception.name);
+        exceptionRaised = true;
+    }
+    EXPECT_TRUE(exceptionRaised);
 }
 
 #endif


### PR DESCRIPTION
#### 3c74d31715ca854fa0e02299d79c5756144d0d84
<pre>
Provide a mechanism for NSAttributedString to extend file access to WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=245538">https://bugs.webkit.org/show_bug.cgi?id=245538</a>
&lt;rdar://98333507&gt;

Reviewed by David Kilzer.

NSAttributedString in recent Cocoa OS releases makes use of the modern WebKit architecture,
and renders HTML content in a separate WebContent process from the main application. This
security improvement has created problems when an author attempts to create an NSAttributedString
from an HTML String that includes references to files in an application&apos;s bundle.

We need a way for WebKit&apos;s NSAttributedString extensions to pass file permission to the WebContent
process, otherwise the strings cannot be properly rendered.

Tests: New API test.

* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
(+[_WKAttributedStringWebViewCache readOnlyAccessPaths]): Added.
(+[_WKAttributedStringWebViewCache configuration]): Update to incorporate access paths
if relevant.
(+[_WKAttributedStringWebViewCache maybeConsumeBundlePaths:]): Added.
(+[NSAttributedString _loadFromHTMLWithOptions:contentLoader:completionHandler:]): Inititalize
access paths if relevant.
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedStringPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AdditionalReadAccessAllowedURLs.mm:
(TEST): Added.

Canonical link: <a href="https://commits.webkit.org/254968@main">https://commits.webkit.org/254968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22cf55e23894f4cd21e0fac10e0a232785114253

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90722 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100034 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158354 "Failed to checkout and rebase branch from PR 4608") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33801 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28926 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83079 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96427 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26923 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77542 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26741 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81683 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81445 "Found 2 new API test failures: TestWebKitAPI.WebKit.NSAttributedStringWithReadOnlyPaths, TestWebKitAPI.WebKit.NSAttributedStringWithAndWithoutReadOnlyPaths (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69772 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34891 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15482 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32702 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16462 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39402 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1515 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35551 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->