### PR TITLE
Suppress zero-length text SVG inline renderers

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -34,6 +34,14 @@
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGInline);
+
+bool RenderSVGInline::isChildAllowed(RenderObject* child, RenderStyle* style) const
+{
+    if (SVGRenderSupport::isEmptySVGInlineText(child))
+    return false;
+
+    return RenderInline::isChildAllowed(child, style);
+}
     
 RenderSVGInline::RenderSVGInline(SVGGraphicsElement& element, RenderStyle&& style)
     : RenderInline(element, WTFMove(style))

--- a/Source/WebCore/rendering/svg/RenderSVGInline.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.h
@@ -40,6 +40,8 @@ private:
     bool requiresLayer() const final { return false; }
     bool isSVGInline() const final { return true; }
 
+    bool isChildAllowed(RenderObject*, const RenderStyle&) const;
+
     void updateFromStyle() final;
 
     // Chapter 10.4 of the SVG Specification say that we should use the

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -73,7 +73,7 @@ SVGTextElement& RenderSVGText::textElement() const
 
 bool RenderSVGText::isChildAllowed(const RenderObject& child, const RenderStyle&) const
 {
-    return child.isInline();
+    return child.isInline() && !SVGRenderSupport::isEmptySVGInlineText(child);
 }
 
 RenderSVGText* RenderSVGText::locateRenderSVGTextAncestor(RenderObject& start)

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -38,6 +38,7 @@
 #include "RenderGeometryMap.h"
 #include "RenderIterator.h"
 #include "RenderLayer.h"
+#include "RenderSVGInlineText.h"
 #include "RenderSVGResourceClipper.h"
 #include "RenderSVGResourceFilter.h"
 #include "RenderSVGResourceMarker.h"
@@ -480,6 +481,14 @@ void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const
         else
             context.setStrokeStyle(SolidStroke);
     }
+}
+
+bool SVGRenderSupport::isEmptySVGInlineText(const RenderObject* object)
+{
+    // RenderSVGInlineText performs whitespace filtering in order to support xml:space
+    // (http://www.w3.org/TR/SVG/struct.html#LangSpaceAttrs), and can end up with an empty string
+    // even when its original constructor argument is non-empty.
+    return object.isSVGInlineText() && toRenderSVGInlineText(object).hasEmptyText();
 }
 
 void SVGRenderSupport::styleChanged(RenderElement& renderer, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -90,6 +90,9 @@ public:
     static LegacyRenderSVGRoot* findTreeRootObject(RenderElement&);
     static const LegacyRenderSVGRoot* findTreeRootObject(const RenderElement&);
 
+    // Helper method for determing whether an RenderSVGInlineText object has zero text length.
+    static bool isEmptySVGInlineText(const RenderObject*);
+
 private:
     // This class is not constructable.
     SVGRenderSupport();

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -376,9 +376,6 @@ bool SVGTextLayoutEngine::currentVisualCharacterMetrics(const SVGInlineTextBox& 
     unsigned boxStart = textBox.start();
     unsigned boxLength = textBox.len();
 
-    if (m_visualMetricsListOffset == textMetricsSize)
-        return false;
-
     while (m_visualMetricsListOffset < textMetricsSize) {
         // Advance to text box start location.
         if (m_visualCharacterOffset < boxStart) {


### PR DESCRIPTION
<pre>
Suppress zero-length text SVG inline renderers

<a href="https://bugs.webkit.org/show_bug.cgi?id=119719">https://bugs.webkit.org/show_bug.cgi?id=119719</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/e4c158a33d34264796abfa683d0413568dfdcde0">https://chromium.googlesource.com/chromium/blink/+/e4c158a33d34264796abfa683d0413568dfdcde0</a>

The SVG text layout functions assert non-zero metrics for SVG inline text (see SVGTextLayoutEngine::layoutTextOnLineOrPath, for example). Normally, we don't instantiate renderers for zero-length inline text (see Text::textRendererIsNeeded), but the RenderSVGInlineText constructor performs whitespace filtering to support xml:space semantics (http://www.w3.org/TR/SVG/struct.html#LangSpaceAttrs) and can end up with empty text while still passing the non-zero length test in Text::textRendererIsNeeded (for example a single newline gets deleted when xml:space="default").

Enter RenderText::positionLineBox() which attempts to fix things up by removing zero length inline boxes. But removing boxes at this point is bad for business because it invalidates (marks as dirty and clears computed metrics) parent boxes and sibling boxes during layout, and throws subsequent computations off.

The patch adds isChildAllowed()-based validation for SVG inline text. This prevents zero-len-text renderers from being inserted into the tree in the first place.

Most test result diffs are zero-lenght DRT RenderSVGInlineText variance, but some reveal prior issues:

* svg/W3C-SVG-1.1/text-align-08-b-diffs.html has incorrect results checked in (one text group is missing due to this bug).
* svg/dom/altGlyph-dom.xhtml(altGlyph-dom.js) also has incorrect results hardcoded in.
* svg/animations/length-list-animation.svg is failing miserably without this patch, but the failure is only visible when testing manually because the reference SVG is failing in the same manner.

Also removing a redundant test in SVGTextLayoutEngine::currentVisualCharacterMetrics(): the while loop condition handles that case in an equivalent manner.

* Source/WebCore/rendering/svg/SVGRenderSupport.cpp: (SVGRenderSupport::applyStrokeStyleToContext): Added isEmptySVGInlineText to manage "hasEmptyText" condition
* Source/WebCore/rendering/svg/RenderSVGInline.cpp: Added "isChildAllowed" based validation for SVG inline text
* Source/WebCore/rendering/svg/RenderSVGInline.h: Added "isChildAllowed" bool
* Source/WebCore/rendering/svg/RenderSVGText.cpp: (RenderSVGText::textElement): Amended to add "and" condition to return values when the child value is not isEmptySVGInlineText
* Source/WebCore/rendering/svg/SVGRenderSupport.h: Added "isEmptySVGInlineText" bool
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(SVGTextLayoutEngine::currentVisualCharacterMetrics): Removed "textMetricsSize"

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bff1ded61b473a4fc0d49dd35b09218ad32c87eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91519 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/665 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22157 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101241 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161281 "Hash bff1ded6 for PR 4609 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95524 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/679 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29399 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83857 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97593 "Hash bff1ded6 for PR 4609 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97177 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/679 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78223 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/83857 "Hash bff1ded6 for PR 4609 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/679 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/22157 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/83857 "Hash bff1ded6 for PR 4609 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35648 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/22157 "Hash bff1ded6 for PR 4609 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33425 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/22157 "Hash bff1ded6 for PR 4609 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37238 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/78223 "Hash bff1ded6 for PR 4609 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39153 "Hash bff1ded6 for PR 4609 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/22157 "Hash bff1ded6 for PR 4609 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->