### PR TITLE
Implement Temporal.PlainDate#{since, until}

### DIFF
--- a/JSTests/stress/temporal-calendar.js
+++ b/JSTests/stress/temporal-calendar.js
@@ -137,3 +137,14 @@ shouldBe(isoCalendar.dateAdd('2020-02-28', new Temporal.Duration(1, 1, 0, 1)).to
 shouldBe(isoCalendar.dateAdd('2020-03-30', { months: -1 }).toString(), '2020-02-29');
 shouldThrow(() => { isoCalendar.dateAdd('2020-03-30', { months: -1 }, { overflow: 'reject' }); }, RangeError);
 shouldThrow(() => { isoCalendar.dateAdd('2020-02-28', { years: -300000 }); }, RangeError);
+
+shouldBe(Temporal.Calendar.prototype.dateUntil.length, 2);
+shouldBe(isoCalendar.dateUntil('2020-02-28', '2019-02-28').toString(), '-P365D');
+shouldBe(isoCalendar.dateUntil('2020-02-28', '2019-02-28', { largestUnit: 'year' }).toString(), '-P1Y');
+shouldBe(isoCalendar.dateUntil('2020-02-28', '2021-02-28').toString(), 'P366D');
+shouldBe(isoCalendar.dateUntil('2020-02-28', '2021-02-28', { largestUnit: 'year' }).toString(), 'P1Y');
+shouldBe(isoCalendar.dateUntil('2020-02-28', '2020-04-28', { largestUnit: 'month' }).toString(), 'P2M');
+shouldBe(isoCalendar.dateUntil('2020-02-28', '2019-12-28', { largestUnit: 'month' }).toString(), '-P2M');
+shouldBe(isoCalendar.dateUntil('2020-02-28', '2020-03-15', { largestUnit: 'week' }).toString(), 'P2W2D');
+shouldBe(isoCalendar.dateUntil('2020-02-28', '2020-02-12', { largestUnit: 'week' }).toString(), '-P2W2D');
+shouldThrow(() => { isoCalendar.dateUntil('2020-02-28', '2019-02-28', { largestUnit: 'hour' }); }, RangeError);

--- a/JSTests/stress/temporal-plaindate.js
+++ b/JSTests/stress/temporal-plaindate.js
@@ -385,3 +385,34 @@ shouldBe(Temporal.PlainDate.prototype.with.length, 1);
     shouldBe(date.with({ month: 2 }).toString(), '2020-02-29');
     shouldThrow(() => { date.with({ month: 2 }, { overflow: 'reject' }); }, RangeError);
 }
+
+shouldBe(Temporal.PlainDate.prototype.since.length, 1);
+shouldBe(Temporal.PlainDate.prototype.until.length, 1);
+{
+    const date = Temporal.PlainDate.from('2020-02-28');
+
+    shouldBe(date.since('2019-02-28').toString(), 'P365D');
+    shouldBe(date.until('2019-02-28').toString(), '-P365D');
+    shouldBe(date.since('2019-02-28', { largestUnit: 'year' }).toString(), 'P1Y');
+    shouldBe(date.until('2019-02-28', { largestUnit: 'year' }).toString(), '-P1Y');
+    shouldBe(date.since('2021-02-28').toString(), '-P366D');
+    shouldBe(date.until('2021-02-28').toString(), 'P366D');
+    shouldBe(date.since('2021-02-28', { largestUnit: 'year' }).toString(), '-P1Y');
+    shouldBe(date.until('2021-02-28', { largestUnit: 'year' }).toString(), 'P1Y');
+
+    shouldBe(date.since('2020-04-28', { largestUnit: 'month' }).toString(), '-P2M');
+    shouldBe(date.until('2020-04-28', { largestUnit: 'month' }).toString(), 'P2M');
+    shouldBe(date.since('2019-12-28', { largestUnit: 'month' }).toString(), 'P2M');
+    shouldBe(date.until('2019-12-28', { largestUnit: 'month' }).toString(), '-P2M');
+
+    shouldBe(date.since('2020-03-15', { largestUnit: 'week' }).toString(), '-P2W2D');
+    shouldBe(date.until('2020-03-15', { largestUnit: 'week' }).toString(), 'P2W2D');
+    shouldBe(date.since('2020-03-15', { roundingMode: 'halfExpand', roundingIncrement: 3 }).toString(), '-P15D');
+    shouldBe(date.until('2020-03-15', { roundingMode: 'halfExpand', roundingIncrement: 3 }).toString(), 'P15D');
+    shouldBe(date.since('2020-02-12', { largestUnit: 'week' }).toString(), 'P2W2D');
+    shouldBe(date.until('2020-02-12', { largestUnit: 'week' }).toString(), '-P2W2D');
+
+    shouldThrow(() => { date.until('2019-02-28', { smallestUnit: 'hour' }); }, RangeError);
+    shouldThrow(() => { date.until('2019-02-28', { largestUnit: 'hour' }); }, RangeError);
+    shouldThrow(() => { date.until('2019-02-28', { largestUnit: 'day', smallestUnit: 'month' }); }, RangeError);
+}

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -36,11 +36,9 @@ skip:
     - test/built-ins/Temporal/Now/plainTimeISO
     - test/built-ins/Temporal/Now/zonedDateTime
     - test/built-ins/Temporal/Now/zonedDateTimeISO
-    - test/built-ins/Temporal/PlainDate/prototype/since
     - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay
     - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth
     - test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime
-    - test/built-ins/Temporal/PlainDate/prototype/until
     - test/built-ins/Temporal/PlainDate/prototype/withCalendar
     - test/built-ins/Temporal/PlainDateTime/prototype/since
     - test/built-ins/Temporal/PlainDateTime/prototype/toPlainMonthDay
@@ -244,6 +242,7 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/add/timezone-getpossibleinstantsfor-iterable.js
     - test/built-ins/Temporal/Duration/prototype/add/timezone-string-datetime.js
     - test/built-ins/Temporal/Duration/prototype/add/timezone-string-leap-second.js
+    - test/built-ins/Temporal/Duration/prototype/add/timezone-string.js
     - test/built-ins/Temporal/Duration/prototype/add/timezone-wrong-type.js
     - test/built-ins/Temporal/Duration/prototype/round/calendar-dateadd-called-with-options-undefined.js
     - test/built-ins/Temporal/Duration/prototype/round/calendar-dateadd-called-with-plaindate-instance.js
@@ -252,6 +251,7 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/round/calendar-possibly-required.js
     - test/built-ins/Temporal/Duration/prototype/round/calendar-temporal-object.js
     - test/built-ins/Temporal/Duration/prototype/round/dateuntil-field.js
+    - test/built-ins/Temporal/Duration/prototype/round/february-leap-year.js
     - test/built-ins/Temporal/Duration/prototype/round/largestunit-smallestunit-default.js
     - test/built-ins/Temporal/Duration/prototype/round/nanoseconds-to-days-loop-indefinitely-1.js
     - test/built-ins/Temporal/Duration/prototype/round/nanoseconds-to-days-loop-indefinitely-2.js
@@ -262,6 +262,7 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-datefromfields-called-with-null-prototype-fields.js
     - test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-number.js
     - test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-invalid-offset-string.js
     - test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-no-time-units.js
     - test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-timezone-getoffsetnanosecondsfor-non-integer.js
     - test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-timezone-getoffsetnanosecondsfor-not-callable.js
@@ -273,11 +274,16 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/round/relativeto-string-zoneddatetime.js
     - test/built-ins/Temporal/Duration/prototype/round/relativeto-sub-minute-offset.js
     - test/built-ins/Temporal/Duration/prototype/round/relativeto-wrong-type.js
+    - test/built-ins/Temporal/Duration/prototype/round/roundingmode-ceil.js
+    - test/built-ins/Temporal/Duration/prototype/round/roundingmode-floor.js
+    - test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfExpand.js
+    - test/built-ins/Temporal/Duration/prototype/round/roundingmode-trunc.js
     - test/built-ins/Temporal/Duration/prototype/round/throws-in-balance-duration-when-sign-mismatched-with-zoned-date-time.js
     - test/built-ins/Temporal/Duration/prototype/round/throws-in-unbalance-duration-relative-when-sign-mismatched.js
     - test/built-ins/Temporal/Duration/prototype/round/timezone-getpossibleinstantsfor-iterable.js
     - test/built-ins/Temporal/Duration/prototype/round/timezone-string-datetime.js
     - test/built-ins/Temporal/Duration/prototype/round/timezone-string-leap-second.js
+    - test/built-ins/Temporal/Duration/prototype/round/timezone-string.js
     - test/built-ins/Temporal/Duration/prototype/round/timezone-wrong-type.js
     - test/built-ins/Temporal/Duration/prototype/round/total-duration-nanoseconds-too-large-with-zoned-datetime.js
     - test/built-ins/Temporal/Duration/prototype/round/year-zero.js
@@ -317,6 +323,7 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/subtract/timezone-getpossibleinstantsfor-iterable.js
     - test/built-ins/Temporal/Duration/prototype/subtract/timezone-string-datetime.js
     - test/built-ins/Temporal/Duration/prototype/subtract/timezone-string-leap-second.js
+    - test/built-ins/Temporal/Duration/prototype/subtract/timezone-string.js
     - test/built-ins/Temporal/Duration/prototype/subtract/timezone-wrong-type.js
     - test/built-ins/Temporal/Duration/prototype/total/calendar-dateadd-called-with-options-undefined.js
     - test/built-ins/Temporal/Duration/prototype/total/calendar-dateadd-called-with-plaindate-instance.js
@@ -344,7 +351,31 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/total/timezone-getpossibleinstantsfor-iterable.js
     - test/built-ins/Temporal/Duration/prototype/total/timezone-string-datetime.js
     - test/built-ins/Temporal/Duration/prototype/total/timezone-string-leap-second.js
+    - test/built-ins/Temporal/Duration/prototype/total/timezone-string.js
     - test/built-ins/Temporal/Duration/prototype/total/timezone-wrong-type.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/rounding-relative.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/roundingincrement.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-ceil.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-floor.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfExpand.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-trunc.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-undefined.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-wrong-type.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/smallestunit-higher-units.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/smallestunit-plurals-accepted.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/smallestunit-wrong-type.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/rounding-relative.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/roundingincrement.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-ceil.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-floor.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfExpand.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-trunc.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-undefined.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-wrong-type.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/smallestunit-higher-units.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/smallestunit-plurals-accepted.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/smallestunit-wrong-type.js
+    - test/built-ins/Temporal/PlainDateTime/datetime-math.js
     - test/intl402/Temporal/Duration/compare/relativeto-hour.js
     - test/intl402/Temporal/Duration/prototype/add/relativeto-infinity-throws-rangeerror.js
     - test/intl402/Temporal/Duration/prototype/add/relativeto-string-datetime.js
@@ -371,6 +402,7 @@ skip:
     - test/built-ins/Temporal/PlainDate/from/argument-calendar-datefromfields-called-with-null-prototype-fields.js
     - test/built-ins/Temporal/PlainDate/from/argument-plaindate.js
     - test/built-ins/Temporal/PlainDate/from/argument-plaindatetime.js
+    - test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-case-insensitive.js
     - test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-wrong-type.js
@@ -390,6 +422,7 @@ skip:
     - test/built-ins/Temporal/PlainDate/prototype/daysInYear/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-calendar-datefromfields-called-with-null-prototype-fields.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-object-valid.js
+    - test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-case-insensitive.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-wrong-type.js
@@ -404,10 +437,26 @@ skip:
     - test/built-ins/Temporal/PlainDate/prototype/inLeapYear/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/month/calendar-returns-infinity.js
     - test/built-ins/Temporal/PlainDate/prototype/monthsInYear/custom.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/argument-calendar-datefromfields-called-with-null-prototype-fields.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-case-insensitive.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-leap-second.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-number.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/argument-string-invalid.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/calendar-dateadd-called-with-plaindate-instance.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/calendar-datefromfields-called-with-options-undefined.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/calendar-dateuntil-called-with-null-prototype-options.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/calendar-dateuntil-called-with-singular-largestunit.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/calendar-fields-iterable.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/calendar-invalid-return.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/calendar-mismatch.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/subtract/balance-smaller-units.js
     - test/built-ins/Temporal/PlainDate/prototype/subtract/calendar-invalid-return.js
     - test/built-ins/Temporal/PlainDate/prototype/subtract/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-object.js
+    - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/basic.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/custom.js
@@ -418,6 +467,21 @@ skip:
     - test/built-ins/Temporal/PlainDate/prototype/toString/calendarname-undefined.js
     - test/built-ins/Temporal/PlainDate/prototype/toString/calendarname-wrong-type.js
     - test/built-ins/Temporal/PlainDate/prototype/toString/options-undefined.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-calendar-datefromfields-called-with-null-prototype-fields.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-case-insensitive.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-leap-second.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-number.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-propertybag-calendar-wrong-type.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-string-invalid.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/calendar-dateadd-called-with-plaindate-instance.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/calendar-datefromfields-called-with-options-undefined.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/calendar-dateuntil-called-with-null-prototype-options.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/calendar-dateuntil-called-with-singular-largestunit.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/calendar-fields-iterable.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/calendar-invalid-return.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/calendar-mismatch.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/weekOfYear/custom.js
     - test/built-ins/Temporal/PlainDate/prototype/with/calendar-fields-iterable.js
     - test/built-ins/Temporal/PlainDate/prototype/with/calendar-fromfields-called-with-null-prototype-fields.js
@@ -438,6 +502,8 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/compare/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDateTime/constructor-full.js
     - test/built-ins/Temporal/PlainDateTime/from/argument-plaindate.js
+    - test/built-ins/Temporal/PlainDateTime/from/argument-plaindatetime.js
+    - test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-case-insensitive.js
     - test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-wrong-type.js
@@ -454,6 +520,7 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/prototype/daysInMonth/custom.js
     - test/built-ins/Temporal/PlainDateTime/prototype/daysInWeek/custom.js
     - test/built-ins/Temporal/PlainDateTime/prototype/daysInYear/custom.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-case-insensitive.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-wrong-type.js
@@ -468,6 +535,7 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/prototype/round/smallestunit-plurals-accepted.js
     - test/built-ins/Temporal/PlainDateTime/prototype/round/smallestunit-string-shorthand.js
     - test/built-ins/Temporal/PlainDateTime/prototype/subtract/calendar-dateadd.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/toString/calendar-tostring.js
     - test/built-ins/Temporal/PlainDateTime/prototype/toString/calendarname-always.js
     - test/built-ins/Temporal/PlainDateTime/prototype/toString/calendarname-auto.js
     - test/built-ins/Temporal/PlainDateTime/prototype/toString/calendarname-invalid-string.js
@@ -488,6 +556,7 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-id.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar-same-object.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-plaindate-calendar.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-case-insensitive.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-wrong-type.js
@@ -497,14 +566,20 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/calendar-fields-iterable.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/non-compatible-calendars-throw.js
+    - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainDateTime/prototype/year/calendar-returns-infinity.js
+    - test/built-ins/Temporal/PlainTime/compare/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainTime/compare/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainTime/from/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainTime/from/argument-string-with-calendar.js
     - test/built-ins/Temporal/PlainTime/from/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainTime/prototype/equals/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainTime/prototype/since/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainTime/prototype/since/calendar-temporal-object.js
     - test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-calendar-datefromfields-called-with-null-prototype-fields.js
+    - test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-case-insensitive.js
     - test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-leap-second.js
     - test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-number.js
     - test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-wrong-type.js
@@ -512,6 +587,7 @@ skip:
     - test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/calendar-datefromfields-called-with-options-undefined.js
     - test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/calendar-fields-iterable.js
     - test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/calendar-temporal-object.js
+    - test/built-ins/Temporal/PlainTime/prototype/until/argument-string-time-designator-required-for-disambiguation.js
     - test/built-ins/Temporal/PlainTime/prototype/until/calendar-temporal-object.js
 
     # Depends on PlainMonthDay, PlainYearMonth
@@ -547,6 +623,7 @@ skip:
     - test/built-ins/Temporal/Instant/prototype/toString/timezone-string-datetime.js
     - test/built-ins/Temporal/Instant/prototype/toString/timezone-string-leap-second.js
     - test/built-ins/Temporal/Instant/prototype/toString/timezone-string-multiple-offsets.js
+    - test/built-ins/Temporal/Instant/prototype/toString/timezone-string.js
     - test/built-ins/Temporal/Instant/prototype/toString/timezone.js
     - test/intl402/Temporal/Instant/prototype/toString/timezone-offset.js
     - test/intl402/Temporal/Instant/prototype/toString/timezone-string-datetime.js
@@ -606,12 +683,24 @@ skip:
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-not-callable.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
     - test/built-ins/Temporal/PlainDate/prototype/equals/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-wrong-type.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/argument-zoneddatetime-convert.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/argument-zoneddatetime-slots.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-non-integer.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-not-callable.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-wrong-type.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-balance-negative-time-units.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-negative-epochnanoseconds.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-non-integer.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-not-callable.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
     - test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-wrong-type.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-zoneddatetime-convert.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-zoneddatetime-slots.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-non-integer.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-not-callable.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-wrong-type.js
     - test/built-ins/Temporal/PlainDateTime/compare/argument-zoneddatetime-negative-epochnanoseconds.js
     - test/built-ins/Temporal/PlainDateTime/compare/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-non-integer.js
     - test/built-ins/Temporal/PlainDateTime/compare/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-not-callable.js

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1053,54 +1053,24 @@ test/built-ins/RegExp/prototype/exec/u-lastindex-adv.js:
 test/built-ins/RegExp/quantifier-integer-limit.js:
   default: 'SyntaxError: Invalid regular expression: number too large in {} quantifier'
   strict mode: 'SyntaxError: Invalid regular expression: number too large in {} quantifier'
-test/built-ins/Temporal/Duration/prototype/add/timezone-string.js:
-  default: 'RangeError: Cannot add a duration of years, months, or weeks without a relativeTo option'
-  strict mode: 'RangeError: Cannot add a duration of years, months, or weeks without a relativeTo option'
-test/built-ins/Temporal/Duration/prototype/round/february-leap-year.js:
-  default: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
-  strict mode: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
-test/built-ins/Temporal/Duration/prototype/round/relativeto-propertybag-invalid-offset-string.js:
-  default: 'Test262Error: "00:00 is not a valid offset string Expected a RangeError but got a Error'
-  strict mode: 'Test262Error: "00:00 is not a valid offset string Expected a RangeError but got a Error'
-test/built-ins/Temporal/Duration/prototype/round/roundingmode-ceil.js:
-  default: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
-  strict mode: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
 test/built-ins/Temporal/Duration/prototype/round/roundingmode-expand.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Duration/prototype/round/roundingmode-floor.js:
-  default: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
-  strict mode: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
 test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfCeil.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
 test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfEven.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfExpand.js:
-  default: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
-  strict mode: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
 test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfFloor.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
 test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfTrunc.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Duration/prototype/round/roundingmode-trunc.js:
-  default: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
-  strict mode: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
-test/built-ins/Temporal/Duration/prototype/round/timezone-string.js:
-  default: 'RangeError: Cannot round a duration of years, months, or weeks without a relativeTo option'
-  strict mode: 'RangeError: Cannot round a duration of years, months, or weeks without a relativeTo option'
-test/built-ins/Temporal/Duration/prototype/subtract/timezone-string.js:
-  default: 'RangeError: Cannot subtract a duration of years, months, or weeks without a relativeTo option'
-  strict mode: 'RangeError: Cannot subtract a duration of years, months, or weeks without a relativeTo option'
 test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-non-integer.js:
   default: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
   strict mode: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
-test/built-ins/Temporal/Duration/prototype/total/timezone-string.js:
-  default: 'RangeError: Cannot total a duration of years, months, or weeks without a relativeTo option'
-  strict mode: 'RangeError: Cannot total a duration of years, months, or weeks without a relativeTo option'
 test/built-ins/Temporal/Duration/prototype/total/total-value-infinity.js:
   default: 'Test262Error: Expected SameValue(«NaN», «Infinity») to be true'
   strict mode: 'Test262Error: Expected SameValue(«NaN», «Infinity») to be true'
@@ -1167,9 +1137,6 @@ test/built-ins/Temporal/Instant/prototype/toString/roundingmode-halfFloor.js:
 test/built-ins/Temporal/Instant/prototype/toString/roundingmode-halfTrunc.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Instant/prototype/toString/timezone-string.js:
-  default: "Test262Error: Time zone created from string 'UTC' Expected SameValue(«00:00Z», «+00:00») to be true"
-  strict mode: "Test262Error: Time zone created from string 'UTC' Expected SameValue(«00:00Z», «+00:00») to be true"
 test/built-ins/Temporal/Instant/prototype/until/roundingmode-ceil.js:
   default: 'Test262Error: rounds to milliseconds (roundingMode = ceil, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
   strict mode: 'Test262Error: rounds to milliseconds (roundingMode = ceil, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
@@ -1197,30 +1164,39 @@ test/built-ins/Temporal/Instant/prototype/until/roundingmode-halfTrunc.js:
 test/built-ins/Temporal/Instant/prototype/until/roundingmode-trunc.js:
   default: 'Test262Error: rounds to hours (rounding mode = trunc, negative case) hours result Expected SameValue(«-376436», «-376435») to be true'
   strict mode: 'Test262Error: rounds to hours (rounding mode = trunc, negative case) hours result Expected SameValue(«-376436», «-376435») to be true'
-test/built-ins/Temporal/PlainDate/from/argument-propertybag-calendar-case-insensitive.js:
-  default: 'RangeError: invalid calendar ID'
-  strict mode: 'RangeError: invalid calendar ID'
-test/built-ins/Temporal/PlainDate/prototype/equals/argument-propertybag-calendar-case-insensitive.js:
-  default: 'RangeError: invalid calendar ID'
-  strict mode: 'RangeError: invalid calendar ID'
-test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-time-designator-required-for-disambiguation.js:
-  default: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix Expected a RangeError to be thrown but no exception was thrown at all"
-  strict mode: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix Expected a RangeError to be thrown but no exception was thrown at all"
-test/built-ins/Temporal/PlainDateTime/datetime-math.js:
-  default: "TypeError: later.since is not a function. (In 'later.since(earlier, { largestUnit })', 'later.since' is undefined)"
-  strict mode: "TypeError: later.since is not a function. (In 'later.since(earlier, { largestUnit })', 'later.since' is undefined)"
-test/built-ins/Temporal/PlainDateTime/from/argument-plaindatetime.js:
-  default: 'Test262Error: Calendar is copied Expected SameValue(«iso8601», «iso8601») to be true'
-  strict mode: 'Test262Error: Calendar is copied Expected SameValue(«iso8601», «iso8601») to be true'
-test/built-ins/Temporal/PlainDateTime/from/argument-propertybag-calendar-case-insensitive.js:
-  default: 'RangeError: invalid calendar ID'
-  strict mode: 'RangeError: invalid calendar ID'
+test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-expand.js:
+  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfCeil.js:
+  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfEven.js:
+  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfFloor.js:
+  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfTrunc.js:
+  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-expand.js:
+  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfCeil.js:
+  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfEven.js:
+  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfFloor.js:
+  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfTrunc.js:
+  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
 test/built-ins/Temporal/PlainDateTime/from/order-of-operations.js:
   default: 'Test262Error: Expected [get fields.calendar, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.year, get fields.year.valueOf, call fields.year.valueOf] and [get fields.calendar, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf, get fields.year, get fields.year.valueOf, call fields.year.valueOf] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get fields.calendar, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.year, get fields.year.valueOf, call fields.year.valueOf] and [get fields.calendar, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf, get fields.year, get fields.year.valueOf, call fields.year.valueOf] to have the same contents. order of operations'
-test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-propertybag-calendar-case-insensitive.js:
-  default: 'RangeError: invalid calendar ID'
-  strict mode: 'RangeError: invalid calendar ID'
 test/built-ins/Temporal/PlainDateTime/prototype/round/roundingmode-expand.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
@@ -1236,9 +1212,6 @@ test/built-ins/Temporal/PlainDateTime/prototype/round/roundingmode-halfFloor.js:
 test/built-ins/Temporal/PlainDateTime/prototype/round/roundingmode-halfTrunc.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDateTime/prototype/toString/calendar-tostring.js:
-  default: 'Test262Error: calendarName = always: expected 2000-05-02T12:34:56.987654321[u-ca=custom] Expected SameValue(«2000-05-02T12:34:56.987654321», «2000-05-02T12:34:56.987654321[u-ca=custom]») to be true'
-  strict mode: 'Test262Error: calendarName = always: expected 2000-05-02T12:34:56.987654321[u-ca=custom] Expected SameValue(«2000-05-02T12:34:56.987654321», «2000-05-02T12:34:56.987654321[u-ca=custom]») to be true'
 test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-non-integer.js:
   default: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
   strict mode: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
@@ -1263,21 +1236,6 @@ test/built-ins/Temporal/PlainDateTime/prototype/with/order-of-operations.js:
 test/built-ins/Temporal/PlainDateTime/prototype/with/overflow-wrong-type.js:
   default: 'Test262Error: Expected [get overflow.toString, call overflow.toString] and [get overflow.toString, call overflow.toString, get overflow.toString, call overflow.toString] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get overflow.toString, call overflow.toString] and [get overflow.toString, call overflow.toString, get overflow.toString, call overflow.toString] to have the same contents. order of operations'
-test/built-ins/Temporal/PlainDateTime/prototype/withPlainDate/argument-propertybag-calendar-case-insensitive.js:
-  default: 'RangeError: invalid calendar ID'
-  strict mode: 'RangeError: invalid calendar ID'
-test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-time-designator-required-for-disambiguation.js:
-  default: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix Expected a RangeError to be thrown but no exception was thrown at all"
-  strict mode: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix Expected a RangeError to be thrown but no exception was thrown at all"
-test/built-ins/Temporal/PlainTime/compare/argument-string-time-designator-required-for-disambiguation.js:
-  default: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix (first argument) Expected a RangeError to be thrown but no exception was thrown at all"
-  strict mode: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix (first argument) Expected a RangeError to be thrown but no exception was thrown at all"
-test/built-ins/Temporal/PlainTime/from/argument-string-time-designator-required-for-disambiguation.js:
-  default: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix Expected a RangeError to be thrown but no exception was thrown at all"
-  strict mode: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix Expected a RangeError to be thrown but no exception was thrown at all"
-test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-time-designator-required-for-disambiguation.js:
-  default: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix Expected a RangeError to be thrown but no exception was thrown at all"
-  strict mode: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix Expected a RangeError to be thrown but no exception was thrown at all"
 test/built-ins/Temporal/PlainTime/prototype/round/roundingmode-expand.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
@@ -1293,9 +1251,6 @@ test/built-ins/Temporal/PlainTime/prototype/round/roundingmode-halfFloor.js:
 test/built-ins/Temporal/PlainTime/prototype/round/roundingmode-halfTrunc.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/since/argument-string-time-designator-required-for-disambiguation.js:
-  default: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix Expected a RangeError to be thrown but no exception was thrown at all"
-  strict mode: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix Expected a RangeError to be thrown but no exception was thrown at all"
 test/built-ins/Temporal/PlainTime/prototype/since/roundingmode-expand.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
@@ -1311,9 +1266,6 @@ test/built-ins/Temporal/PlainTime/prototype/since/roundingmode-halfFloor.js:
 test/built-ins/Temporal/PlainTime/prototype/since/roundingmode-halfTrunc.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/toPlainDateTime/argument-propertybag-calendar-case-insensitive.js:
-  default: 'RangeError: invalid calendar ID'
-  strict mode: 'RangeError: invalid calendar ID'
 test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-non-integer.js:
   default: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
   strict mode: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
@@ -1332,9 +1284,6 @@ test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-halfFloor.js:
 test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-halfTrunc.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/until/argument-string-time-designator-required-for-disambiguation.js:
-  default: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix Expected a RangeError to be thrown but no exception was thrown at all"
-  strict mode: "Test262Error: '2021-12[u-ca=iso8601]' is ambiguous and requires T prefix Expected a RangeError to be thrown but no exception was thrown at all"
 test/built-ins/Temporal/PlainTime/prototype/until/roundingmode-expand.js:
   default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
   strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.h
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.h
@@ -52,6 +52,8 @@ public:
     static ISO8601::PlainDate isoDateFromFields(JSGlobalObject*, JSObject*, TemporalOverflow);
     static ISO8601::PlainDate isoDateFromFields(JSGlobalObject*, double year, double month, double day, TemporalOverflow);
     static ISO8601::PlainDate isoDateAdd(JSGlobalObject*, const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
+    static ISO8601::Duration isoDateDifference(JSGlobalObject*, const ISO8601::PlainDate&, const ISO8601::PlainDate&, TemporalUnit);
+    static int32_t isoDateCompare(const ISO8601::PlainDate&, const ISO8601::PlainDate&);
 
     CalendarID identifier() const { return m_identifier; }
     bool isISO8601() const { return m_identifier == iso8601CalendarID(); }

--- a/Source/JavaScriptCore/runtime/TemporalObject.h
+++ b/Source/JavaScriptCore/runtime/TemporalObject.h
@@ -109,6 +109,12 @@ struct PrecisionData {
     unsigned increment;
 };
 
+enum class UnitGroup : uint8_t {
+    DateTime,
+    Date,
+    Time,
+};
+
 double nonNegativeModulo(double x, double y);
 WTF::String ellipsizeAt(unsigned maxLength, const WTF::String&);
 PropertyName temporalUnitPluralPropertyName(VM&, TemporalUnit);
@@ -116,9 +122,11 @@ PropertyName temporalUnitSingularPropertyName(VM&, TemporalUnit);
 std::optional<TemporalUnit> temporalUnitType(StringView);
 std::optional<TemporalUnit> temporalLargestUnit(JSGlobalObject*, JSObject* options, std::initializer_list<TemporalUnit> disallowedUnits, TemporalUnit autoValue);
 std::optional<TemporalUnit> temporalSmallestUnit(JSGlobalObject*, JSObject* options, std::initializer_list<TemporalUnit> disallowedUnits);
+std::tuple<TemporalUnit, TemporalUnit, RoundingMode, double> extractDifferenceOptions(JSGlobalObject*, JSValue, UnitGroup, TemporalUnit defaultSmallestUnit, TemporalUnit defaultLargestUnit);
 std::optional<unsigned> temporalFractionalSecondDigits(JSGlobalObject*, JSObject* options);
 PrecisionData secondsStringPrecision(JSGlobalObject*, JSObject* options);
 RoundingMode temporalRoundingMode(JSGlobalObject*, JSObject*, RoundingMode);
+RoundingMode negateTemporalRoundingMode(RoundingMode);
 void formatSecondsStringFraction(StringBuilder&, unsigned fraction, std::tuple<Precision, unsigned>);
 void formatSecondsStringPart(StringBuilder&, unsigned second, unsigned fraction, PrecisionData);
 std::optional<double> maximumRoundingIncrement(TemporalUnit);

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.h
@@ -52,7 +52,6 @@ public:
     static std::array<std::optional<double>, 3> toPartialDate(JSGlobalObject*, JSObject*);
 
     static TemporalPlainDate* from(JSGlobalObject*, JSValue, std::optional<TemporalOverflow>);
-    static int32_t compare(const ISO8601::PlainDate&, const ISO8601::PlainDate&);
 
     TemporalCalendar* calendar() { return m_calendar.get(this); }
     ISO8601::PlainDate plainDate() const { return m_plainDate; }
@@ -74,6 +73,9 @@ public:
     {
         return ISO8601::temporalDateToString(m_plainDate);
     }
+
+    ISO8601::Duration until(JSGlobalObject*, TemporalPlainDate*, JSValue options);
+    ISO8601::Duration since(JSGlobalObject*, TemporalPlainDate*, JSValue options);
 
     DECLARE_VISIT_CHILDREN;
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
@@ -159,7 +159,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateConstructorFuncCompare, (JSGlobalObjec
     auto* two = TemporalPlainDate::from(globalObject, callFrame->argument(1), std::nullopt);
     RETURN_IF_EXCEPTION(scope, { });
 
-    return JSValue::encode(jsNumber(TemporalPlainDate::compare(one->plainDate(), two->plainDate())));
+    return JSValue::encode(jsNumber(TemporalCalendar::isoDateCompare(one->plainDate(), two->plainDate())));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -41,6 +41,8 @@ static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncGetISOFields);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncAdd);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncSubtract);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncWith);
+static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncUntil);
+static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncSince);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncEquals);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainDateTime);
 static JSC_DECLARE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToString);
@@ -75,6 +77,8 @@ const ClassInfo TemporalPlainDatePrototype::s_info = { "Temporal.PlainDate"_s, &
   add              temporalPlainDatePrototypeFuncAdd                DontEnum|Function 1
   subtract         temporalPlainDatePrototypeFuncSubtract           DontEnum|Function 1
   with             temporalPlainDatePrototypeFuncWith               DontEnum|Function 1
+  until            temporalPlainDatePrototypeFuncUntil              DontEnum|Function 1
+  since            temporalPlainDatePrototypeFuncSince              DontEnum|Function 1
   equals           temporalPlainDatePrototypeFuncEquals             DontEnum|Function 1
   toPlainDateTime  temporalPlainDatePrototypeFuncToPlainDateTime    DontEnum|Function 0
   toString         temporalPlainDatePrototypeFuncToString           DontEnum|Function 0
@@ -207,6 +211,44 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncWith, (JSGlobalObject* gl
     RETURN_IF_EXCEPTION(scope, { });
 
     return JSValue::encode(TemporalPlainDate::create(vm, globalObject->plainDateStructure(), WTFMove(result)));
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.until
+JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncUntil, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    if (!plainDate)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.until called on value that's not a PlainDate"_s);
+
+    auto* other = TemporalPlainDate::from(globalObject, callFrame->argument(0), std::nullopt);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    auto result = plainDate->until(globalObject, other, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTFMove(result), globalObject->durationStructure())));
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.since
+JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncSince, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    if (!plainDate)
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.since called on value that's not a PlainDate"_s);
+
+    auto* other = TemporalPlainDate::from(globalObject, callFrame->argument(0), std::nullopt);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    auto result = plainDate->since(globalObject, other, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTFMove(result), globalObject->durationStructure())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.equals

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -165,7 +165,7 @@ TemporalPlainDateTime* TemporalPlainDateTime::from(JSGlobalObject* globalObject,
 // https://tc39.es/proposal-temporal/#sec-temporal-compareisodatetime
 int32_t TemporalPlainDateTime::compare(TemporalPlainDateTime* plainDateTime1, TemporalPlainDateTime* plainDateTime2)
 {
-    if (auto dateResult = TemporalPlainDate::compare(plainDateTime1->plainDate(), plainDateTime2->plainDate()))
+    if (auto dateResult = TemporalCalendar::isoDateCompare(plainDateTime1->plainDate(), plainDateTime2->plainDate()))
         return dateResult;
 
     return TemporalPlainTime::compare(plainDateTime1->plainTime(), plainDateTime2->plainTime());


### PR DESCRIPTION
#### 0c4378330b67f1dc802edd25a80a78f446b3be09
<pre>
Implement Temporal.PlainDate#{since, until}
<a href="https://bugs.webkit.org/show_bug.cgi?id=245550">https://bugs.webkit.org/show_bug.cgi?id=245550</a>

Reviewed by Yusuke Suzuki.

This patch implements the `since` / `until` methods for PlainDate (and accordingly the `dateUntil` method for Calendar).

Since we haven&apos;t implemented `relativeTo` support for Duration yet, we must postpone implementation of:
  1. the path where `smallestUnit` is set to `year`, `month`, or `week`
  2. the entirety of `since` / `until` for PlainDateTime

Otherwise, this completes the &quot;ISO8601-only&quot; implementation for PlainDate and PlainDateTime.

* JSTests/stress/temporal-calendar.js:
* JSTests/stress/temporal-plaindate.js:
* JSTests/test262/config.yaml:
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/TemporalCalendar.cpp:
(JSC::TemporalCalendar::isoDateDifference): Added.
(JSC::TemporalCalendar::isoDateCompare): Moved from TemporalPlainDate.
* Source/JavaScriptCore/runtime/TemporalCalendar.h:
* Source/JavaScriptCore/runtime/TemporalCalendarPrototype.cpp:
* Source/JavaScriptCore/runtime/TemporalObject.cpp:
(JSC::extractDifferenceOptions): Moved from TemporalPlainTime.
(JSC::negateTemporalRoundingMode): Added.
* Source/JavaScriptCore/runtime/TemporalObject.h:
* Source/JavaScriptCore/runtime/TemporalPlainDate.cpp:
(JSC::TemporalPlainDate::until): Added.
(JSC::TemporalPlainDate::since): Added.
(JSC::TemporalPlainDate::compare): Moved to TemporalCalendar.
* Source/JavaScriptCore/runtime/TemporalPlainDate.h:
* Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp:
* Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp:
* Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp:
(JSC::TemporalPlainDateTime::compare):
* Source/JavaScriptCore/runtime/TemporalPlainTime.cpp:
(JSC::TemporalPlainTime::until const):
(JSC::TemporalPlainTime::since const):
(JSC::extractDifferenceOptions): Moved to TemporalObject.

Canonical link: <a href="https://commits.webkit.org/254780@main">https://commits.webkit.org/254780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e7cabf8531ba2ad810fcad7608b4e32395f0f6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99547 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157039 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33272 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82567 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96014 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26464 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77068 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26353 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69353 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81844 "Found 18 new JSC stress test failures: stress/temporal-plaindate.js.bytecode-cache, stress/temporal-plaindate.js.default, stress/temporal-plaindate.js.dfg-eager, stress/temporal-plaindate.js.dfg-eager-no-cjit-validate, stress/temporal-plaindate.js.eager-jettison-no-cjit, stress/temporal-plaindate.js.ftl-eager, stress/temporal-plaindate.js.ftl-eager-no-cjit, stress/temporal-plaindate.js.ftl-eager-no-cjit-b3o1, stress/temporal-plaindate.js.ftl-no-cjit-b3o0, stress/temporal-plaindate.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34397 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/15148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76752 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32234 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/16099 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26554 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3359 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/35982 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/79338 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35186 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17394 "Passed tests") | 
<!--EWS-Status-Bubble-End-->