### PR TITLE
[macOS] Suspend cached WebContent processes

### DIFF
--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -182,6 +182,11 @@ protected:
     static RefPtr<WebCore::SharedBuffer> fetchAudioComponentServerRegistrations();
 #endif
 
+#if PLATFORM(MAC) && USE(RUNNINGBOARD)
+    void takeForegroundAssertion();
+    void dropForegroundAssertion();
+#endif
+
 private:
     virtual void connectionWillOpen(IPC::Connection&);
     virtual void processWillShutDown(IPC::Connection&) = 0;

--- a/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
@@ -80,12 +80,16 @@ void WebProcessProxy::setDisplayLinkPreferredFramesPerSecond(DisplayLinkObserver
 
 void WebProcessProxy::platformSuspendProcess()
 {
-    // FIXME: Adopt RunningBoard on macOS to support process suspension.
+#if USE(RUNNINGBOARD)
+    dropForegroundAssertion();
+#endif
 }
 
 void WebProcessProxy::platformResumeProcess()
 {
-    // FIXME: Adopt RunningBoard on macOS to support process suspension.
+#if USE(RUNNINGBOARD)
+    takeForegroundAssertion();
+#endif
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 5c80e52b79d196058c5522ab9faede67a08f6696
<pre>
[macOS] Suspend cached WebContent processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=245483">https://bugs.webkit.org/show_bug.cgi?id=245483</a>
rdar://100227252

Reviewed by NOBODY (OOPS!).

Use runningboard to suspend cached processes to avoid SIGTERM_TIMEOUT
crashes. This change depends on <a href="https://github.com/WebKit/WebKit/pull/4190">https://github.com/WebKit/WebKit/pull/4190</a>

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::didFinishLaunching):
(WebKit::AuxiliaryProcessProxy::takeForegroundAssertion):
(WebKit::AuxiliaryProcessProxy::dropForegroundAssertion):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm:
(WebKit::WebProcessProxy::platformSuspendProcess):
(WebKit::WebProcessProxy::platformResumeProcess):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c80e52b79d196058c5522ab9faede67a08f6696

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34775 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99541 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33266 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28591 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82568 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96008 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26459 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77061 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26355 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69355 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34391 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15143 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32228 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16093 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/35975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39051 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35179 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->