### PR TITLE
`Clear-Site-Data: "cache"` HTTP header should clear the back/forward cache

### DIFF
--- a/LayoutTests/http/tests/clear-site-data/bfcache-expected.txt
+++ b/LayoutTests/http/tests/clear-site-data/bfcache-expected.txt
@@ -1,0 +1,11 @@
+Tests that the Clear-Site-Data can be used to clear the back/forward cache.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+pageshow - not from cache
+PASS wasRestoredFromPageCache is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/clear-site-data/bfcache.html
+++ b/LayoutTests/http/tests/clear-site-data/bfcache.html
@@ -1,0 +1,30 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that the Clear-Site-Data can be used to clear the back/forward cache.");
+jsTestIsAsync = true;
+
+addEventListener("pageshow", function(event) {
+    debug("pageshow - " + (event.persisted ? "" : "not ") + "from cache");
+
+    if (!window.sessionStorage.page_cache_clear_site_data_test_started)
+        return;
+
+    wasRestoredFromPageCache = event.persisted;
+    shouldBeFalse("wasRestoredFromPageCache");
+    finishJSTest();
+});
+
+onload = () => {
+    if (sessionStorage.page_cache_clear_site_data_test_started)
+        return;
+    setTimeout(() => {
+        sessionStorage.page_cache_clear_site_data_test_started = true;
+        location.href = "resources/clear-site-data-and-navigate-back.html";
+    }, 0);
+};
+</script>
+</html>

--- a/LayoutTests/http/tests/clear-site-data/resources/clear-site-data-and-navigate-back.html
+++ b/LayoutTests/http/tests/clear-site-data/resources/clear-site-data-and-navigate-back.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+window.addEventListener("load", function() {
+    fetch("clear-site-data-cache.py").then((r) => {
+        history.back();
+    });
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/clear-site-data/resources/clear-site-data-cache.py
+++ b/LayoutTests/http/tests/clear-site-data/resources/clear-site-data-cache.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    'Clear-Site-Data: "cache"\r\n'
+    'Content-Type: text/html\r\n\r\n'
+)
+
+print('FOO')

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -71,6 +71,7 @@ media/audio-session-category-at-most-recent-playback.html [ Skip ]
 
 # No support for the Clear-Site-Data header in WebKit1.
 imported/w3c/web-platform-tests/clear-site-data [ Skip ]
+http/tests/clear-site-data [ Skip ]
 
 # Shared workers are only implemented for WebKit2.
 http/tests/navigation/page-cache-shared-worker.html [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -139,6 +139,7 @@ http/tests/model [ Skip ]
 
 # No support for the Clear-Site-Data header in WebKit1.
 imported/w3c/web-platform-tests/clear-site-data [ Skip ]
+http/tests/clear-site-data [ Skip ]
 
 # color-filters are off by default
 webkit.org/b/185076 css3/color-filters [ Skip ]

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -60,6 +60,8 @@ public:
 
     void removeAllItemsForPage(Page&);
 
+    WEBCORE_EXPORT void clearEntriesForOrigins(const HashSet<RefPtr<SecurityOrigin>>&);
+
     unsigned pageCount() const { return m_items.size(); }
     WEBCORE_EXPORT unsigned frameCount() const;
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1415,6 +1415,7 @@ void WebProcess::deleteWebsiteDataForOrigins(OptionSet<WebsiteDataType> websiteD
             origins.add(originData.securityOrigin());
 
         MemoryCache::singleton().removeResourcesWithOrigins(sessionID(), origins);
+        BackForwardCache::singleton().clearEntriesForOrigins(origins);
     }
     completionHandler();
 }


### PR DESCRIPTION
#### 5e99c8f621c3966f7de0b5d4c407c26d458bbed1
<pre>
`Clear-Site-Data: &quot;cache&quot;` HTTP header should clear the back/forward cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=245553">https://bugs.webkit.org/show_bug.cgi?id=245553</a>

Reviewed by Brent Fulgham.

`Clear-Site-Data: &quot;cache&quot;` was clearing the HTTP disk cache and the memory cache
entries for the HTTP response origin. In addition to this, it now clear the
back/forward cache entries for this origin too.

* LayoutTests/http/tests/clear-site-data/bfcache-expected.txt: Added.
* LayoutTests/http/tests/clear-site-data/bfcache.html: Added.
* LayoutTests/http/tests/clear-site-data/resources/clear-site-data-and-navigate-back.html: Added.
* LayoutTests/http/tests/clear-site-data/resources/clear-site-data-cache.py: Added.
Add test coverage.

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::clearEntriesForOrigins):
* Source/WebCore/history/BackForwardCache.h:

* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::deleteWebsiteDataForOrigins):
Clear the back/forward cache too when we&apos;re asked to clear the memory cache. This matches the
behavior of WebProcess::deleteWebsiteData() where clearing the memory cache implies clearing
the back/forward cache too.

Canonical link: <a href="https://commits.webkit.org/254798@main">https://commits.webkit.org/254798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0c6c5c92ae057751ef475fa0b39fb276ad0baab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99542 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157034 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33267 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82561 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96009 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26460 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77062 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26348 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69347 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34392 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15144 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32229 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16094 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3370 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/35976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39050 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35180 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->