### PR TITLE
Land stubs for the Screen Wake Lock API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/idlharness.https.window-expected.txt
@@ -11,33 +11,33 @@ PASS Navigator includes NavigatorContentUtils: member names are unique
 PASS Navigator includes NavigatorCookies: member names are unique
 PASS Navigator includes NavigatorPlugins: member names are unique
 PASS Navigator includes NavigatorConcurrentHardware: member names are unique
-FAIL WakeLock interface: existence and properties of interface object assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
-FAIL WakeLock interface object length assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
-FAIL WakeLock interface object name assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
-FAIL WakeLock interface: existence and properties of interface prototype object assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
-FAIL WakeLock interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
-FAIL WakeLock interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
-FAIL WakeLock interface: operation request(optional WakeLockType) assert_own_property: self does not have own property "WakeLock" expected property "WakeLock" missing
-FAIL WakeLock must be primary interface of navigator.wakeLock assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL Stringification of navigator.wakeLock assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL WakeLock interface: navigator.wakeLock must inherit property "request(optional WakeLockType)" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL WakeLock interface: calling request(optional WakeLockType) on navigator.wakeLock with too few arguments must throw TypeError assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL WakeLockSentinel interface: existence and properties of interface object assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
-FAIL WakeLockSentinel interface object length assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
-FAIL WakeLockSentinel interface object name assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
-FAIL WakeLockSentinel interface: existence and properties of interface prototype object assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
-FAIL WakeLockSentinel interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
-FAIL WakeLockSentinel interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
-FAIL WakeLockSentinel interface: attribute released assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
-FAIL WakeLockSentinel interface: attribute type assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
-FAIL WakeLockSentinel interface: operation release() assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
-FAIL WakeLockSentinel interface: attribute onrelease assert_own_property: self does not have own property "WakeLockSentinel" expected property "WakeLockSentinel" missing
+PASS WakeLock interface: existence and properties of interface object
+PASS WakeLock interface object length
+PASS WakeLock interface object name
+PASS WakeLock interface: existence and properties of interface prototype object
+PASS WakeLock interface: existence and properties of interface prototype object's "constructor" property
+PASS WakeLock interface: existence and properties of interface prototype object's @@unscopables property
+PASS WakeLock interface: operation request(optional WakeLockType)
+PASS WakeLock must be primary interface of navigator.wakeLock
+PASS Stringification of navigator.wakeLock
+PASS WakeLock interface: navigator.wakeLock must inherit property "request(optional WakeLockType)" with the proper type
+PASS WakeLock interface: calling request(optional WakeLockType) on navigator.wakeLock with too few arguments must throw TypeError
+PASS WakeLockSentinel interface: existence and properties of interface object
+PASS WakeLockSentinel interface object length
+PASS WakeLockSentinel interface object name
+PASS WakeLockSentinel interface: existence and properties of interface prototype object
+PASS WakeLockSentinel interface: existence and properties of interface prototype object's "constructor" property
+PASS WakeLockSentinel interface: existence and properties of interface prototype object's @@unscopables property
+PASS WakeLockSentinel interface: attribute released
+PASS WakeLockSentinel interface: attribute type
+PASS WakeLockSentinel interface: operation release()
+PASS WakeLockSentinel interface: attribute onrelease
 FAIL WakeLockSentinel must be primary interface of sentinel assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
 FAIL Stringification of sentinel assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
 FAIL WakeLockSentinel interface: sentinel must inherit property "released" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
 FAIL WakeLockSentinel interface: sentinel must inherit property "type" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
 FAIL WakeLockSentinel interface: sentinel must inherit property "release()" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
 FAIL WakeLockSentinel interface: sentinel must inherit property "onrelease" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
-FAIL Navigator interface: attribute wakeLock assert_true: The prototype object must have a property "wakeLock" expected true got false
-FAIL Navigator interface: navigator must inherit property "wakeLock" with the proper type assert_inherits: property "wakeLock" not found in prototype chain
+PASS Navigator interface: attribute wakeLock
+PASS Navigator interface: navigator must inherit property "wakeLock" with the proper type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-active-document.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-active-document.https.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL navigator.wakeLock.request() aborts if the document is not active. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'wakeLock1.request')"
-FAIL navigator.wakeLock.request() aborts if the document is active, but not fully active. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'wakeLock.request')"
+FAIL navigator.wakeLock.request() aborts if the document is not active. promise_rejects_dom: Inactive document, so must throw NotAllowedError function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException NotAllowedError: property "code" is equal to 9, expected 0
+FAIL navigator.wakeLock.request() aborts if the document is active, but not fully active. promise_rejects_dom: Active, but not fully active, so must throw NotAllowedError function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException NotAllowedError: property "code" is equal to 9, expected 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub-expected.txt
@@ -3,7 +3,7 @@ Blocked access to external URL https://www.localhost:9443/feature-policy/resourc
 
 Harness Error (TIMEOUT), message = null
 
-FAIL Feature-Policy header {"screen-wake-lock" : []} disallows the top-level document. undefined is not an object (evaluating 'navigator.wakeLock.request')
+FAIL Feature-Policy header {"screen-wake-lock" : []} disallows the top-level document. promise_rejects_dom: function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException NotAllowedError: property "code" is equal to 9, expected 0
 TIMEOUT Feature-Policy header {"screen-wake-lock" : []} disallows same-origin iframes. Test timed out
 TIMEOUT Feature-Policy header {"screen-wake-lock" : []} disallows cross-origin iframes. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Wake Lock API is not exposed in an insecure context
+FAIL Wake Lock API is not exposed in an insecure context assert_false: 'WakeLock' must not be exposed expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-type.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-type.https.window-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL 'type' parameter in WakeLock.request() defaults to 'screen' promise_test: Unhandled rejection with value: object "Error: unimplemented"
-FAIL 'TypeError' is thrown when set an invalid wake lock type undefined is not an object (evaluating 'navigator.wakeLock.request')
+PASS 'TypeError' is thrown when set an invalid wake lock type
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-insecure-context.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Wake Lock API is not exposed in an insecure context
+

--- a/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
@@ -29,6 +29,7 @@ navigator.storage is OK
 navigator.userAgent is OK
 navigator.vendor is OK
 navigator.vendorSub is OK
+navigator.wakeLock is OK
 navigator.webdriver is OK
 navigator.appCodeName is OK
 navigator.appName is OK
@@ -59,5 +60,6 @@ navigator.storage is OK
 navigator.userAgent is OK
 navigator.vendor is OK
 navigator.vendorSub is OK
+navigator.wakeLock is OK
 navigator.webdriver is OK
 

--- a/LayoutTests/platform/mac-wk1/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/dom/navigator-detached-no-crash-expected.txt
@@ -25,6 +25,7 @@ navigator.storage is OK
 navigator.userAgent is OK
 navigator.vendor is OK
 navigator.vendorSub is OK
+navigator.wakeLock is OK
 navigator.webdriver is OK
 navigator.xr is OK
 navigator.appCodeName is OK
@@ -52,6 +53,7 @@ navigator.storage is OK
 navigator.userAgent is OK
 navigator.vendor is OK
 navigator.vendorSub is OK
+navigator.wakeLock is OK
 navigator.webdriver is OK
 navigator.xr is OK
 

--- a/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
@@ -35,6 +35,7 @@ navigator.storage is OK
 navigator.userAgent is OK
 navigator.vendor is OK
 navigator.vendorSub is OK
+navigator.wakeLock is OK
 navigator.webdriver is OK
 navigator.xr is OK
 navigator.appCodeName is OK
@@ -72,6 +73,7 @@ navigator.storage is OK
 navigator.userAgent is OK
 navigator.vendor is OK
 navigator.vendorSub is OK
+navigator.wakeLock is OK
 navigator.webdriver is OK
 navigator.xr is OK
 

--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -1458,6 +1458,18 @@ ScreenCaptureEnabled:
       default: false
     WebCore:
       default: false
+
+ScreenWakeLockAPIEnabled:
+  type: bool
+  humanReadableName: "Screen Wake Lock API"
+  humanReadableDescription: "Enable Screen Wake Lock API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
       
 ScrollToTextFragmentEnabled:
   type: bool

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -59,6 +59,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/Modules/push-api"
     "${WEBCORE_DIR}/Modules/remoteplayback"
     "${WEBCORE_DIR}/Modules/reporting"
+    "${WEBCORE_DIR}/Modules/screen-wake-lock"
     "${WEBCORE_DIR}/Modules/speech"
     "${WEBCORE_DIR}/Modules/storage"
     "${WEBCORE_DIR}/Modules/streams"
@@ -558,6 +559,11 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/reporting/ReportingObserver.idl
     Modules/reporting/ReportingObserverCallback.idl
     Modules/reporting/TestReportBody.idl
+
+    Modules/screen-wake-lock/Navigator+ScreenWakeLock.idl
+    Modules/screen-wake-lock/WakeLock.idl
+    Modules/screen-wake-lock/WakeLockSentinel.idl
+    Modules/screen-wake-lock/WakeLockType.idl
 
     Modules/speech/DOMWindow+SpeechSynthesis.idl
     Modules/speech/SpeechRecognitionErrorEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -614,6 +614,10 @@ $(PROJECT_DIR)/Modules/reporting/ReportBody.idl
 $(PROJECT_DIR)/Modules/reporting/ReportingObserver.idl
 $(PROJECT_DIR)/Modules/reporting/ReportingObserverCallback.idl
 $(PROJECT_DIR)/Modules/reporting/TestReportBody.idl
+$(PROJECT_DIR)/Modules/screen-wake-lock/Navigator+ScreenWakeLock.idl
+$(PROJECT_DIR)/Modules/screen-wake-lock/WakeLock.idl
+$(PROJECT_DIR)/Modules/screen-wake-lock/WakeLockSentinel.idl
+$(PROJECT_DIR)/Modules/screen-wake-lock/WakeLockType.idl
 $(PROJECT_DIR)/Modules/speech/DOMWindow+SpeechSynthesis.idl
 $(PROJECT_DIR)/Modules/speech/SpeechRecognition.idl
 $(PROJECT_DIR)/Modules/speech/SpeechRecognitionAlternative.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1748,6 +1748,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+MediaSession.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+MediaSession.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Permissions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Permissions.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+ScreenWakeLock.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+ScreenWakeLock.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+WebDriver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+WebDriver.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+WebXR.cpp
@@ -2756,6 +2758,12 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVisualViewport.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVisualViewport.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVoidCallback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVoidCallback.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWakeLock.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWakeLock.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWakeLockSentinel.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWakeLockSentinel.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWakeLockType.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWakeLockType.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWaveShaperNode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWaveShaperNode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWaveShaperOptions.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -536,6 +536,10 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/reporting/ReportingObserver.idl \
     $(WebCore)/Modules/reporting/ReportingObserverCallback.idl \
     $(WebCore)/Modules/reporting/TestReportBody.idl \
+    $(WebCore)/Modules/screen-wake-lock/Navigator+ScreenWakeLock.idl \
+    $(WebCore)/Modules/screen-wake-lock/WakeLock.idl \
+    $(WebCore)/Modules/screen-wake-lock/WakeLockSentinel.idl \
+    $(WebCore)/Modules/screen-wake-lock/WakeLockType.idl \
     $(WebCore)/Modules/speech/DOMWindow+SpeechSynthesis.idl \
     $(WebCore)/Modules/speech/SpeechSynthesis.idl \
     $(WebCore)/Modules/speech/SpeechSynthesisErrorCode.idl \

--- a/Source/WebCore/Modules/screen-wake-lock/Navigator+ScreenWakeLock.idl
+++ b/Source/WebCore/Modules/screen-wake-lock/Navigator+ScreenWakeLock.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    EnabledBySetting=ScreenWakeLockAPIEnabled,
+    ImplementedBy=NavigatorScreenWakeLock
+    SecureContext
+] partial interface Navigator {
+    [SameObject] readonly attribute WakeLock wakeLock;
+};

--- a/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NavigatorScreenWakeLock.h"
+
+#include "Navigator.h"
+#include "WakeLock.h"
+
+namespace WebCore {
+
+NavigatorScreenWakeLock::NavigatorScreenWakeLock(Navigator&)
+{
+}
+
+NavigatorScreenWakeLock::~NavigatorScreenWakeLock() = default;
+
+NavigatorScreenWakeLock* NavigatorScreenWakeLock::from(Navigator& navigator)
+{
+    auto* supplement = static_cast<NavigatorScreenWakeLock*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    if (!supplement) {
+        auto newSupplement = makeUnique<NavigatorScreenWakeLock>(navigator);
+        supplement = newSupplement.get();
+        provideTo(&navigator, supplementName(), WTFMove(newSupplement));
+    }
+    return supplement;
+}
+
+const char* NavigatorScreenWakeLock::supplementName()
+{
+    return "NavigatorScreenWakeLock";
+}
+
+WakeLock& NavigatorScreenWakeLock::wakeLock(Navigator& navigator)
+{
+    return NavigatorScreenWakeLock::from(navigator)->wakeLock();
+}
+
+WakeLock& NavigatorScreenWakeLock::wakeLock()
+{
+    if (!m_wakeLock)
+        m_wakeLock = WakeLock::create();
+    return *m_wakeLock;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.h
+++ b/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Supplementable.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class Navigator;
+class WakeLock;
+
+class NavigatorScreenWakeLock final : public Supplement<Navigator> {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit NavigatorScreenWakeLock(Navigator&);
+    ~NavigatorScreenWakeLock();
+
+    static WakeLock& wakeLock(Navigator&);
+
+    WEBCORE_EXPORT static NavigatorScreenWakeLock* from(Navigator&);
+
+private:
+    WakeLock& wakeLock();
+
+    static const char* supplementName();
+
+    RefPtr<WakeLock> m_wakeLock;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WakeLock.h"
+
+#include "Exception.h"
+#include "JSDOMPromiseDeferred.h"
+
+namespace WebCore {
+
+WakeLock::WakeLock() = default;
+
+void WakeLock::request(WakeLockType, Ref<DeferredPromise>&& promise)
+{
+    promise->reject(Exception { NotSupportedError });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WakeLockType.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+class WakeLockSentinel;
+
+class WakeLock : public RefCounted<WakeLock> {
+public:
+    static Ref<WakeLock> create()
+    {
+        return adoptRef(*new WakeLock);
+    }
+
+    void request(WakeLockType, Ref<DeferredPromise>&&);
+
+private:
+    WakeLock();
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.idl
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    EnabledBySetting=ScreenWakeLockAPIEnabled,
+    Exposed=(Window),
+    SecureContext
+] interface WakeLock {
+    Promise<WakeLockSentinel> request(optional WakeLockType type = "screen");
+};

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WakeLockSentinel.h"
+
+#include "Exception.h"
+#include "JSDOMPromiseDeferred.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(WakeLockSentinel);
+
+WakeLockSentinel::WakeLockSentinel(Document& document, WakeLockType type)
+    : ActiveDOMObject(&document)
+    , m_type(type)
+{
+}
+
+void WakeLockSentinel::release(Ref<DeferredPromise>&& promise)
+{
+    promise->reject(Exception { NotSupportedError });
+}
+
+const char* WakeLockSentinel::activeDOMObjectName() const
+{
+    return "WakeLockSentinel";
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ActiveDOMObject.h"
+#include "EventTarget.h"
+#include "WakeLockType.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+
+class WakeLockSentinel final : public RefCounted<WakeLockSentinel>, public ActiveDOMObject, public EventTarget {
+    WTF_MAKE_ISO_ALLOCATED(WakeLockSentinel);
+public:
+    static Ref<WakeLockSentinel> create(Document& document, WakeLockType type)
+    {
+        auto sentinel = adoptRef(*new WakeLockSentinel(document, type));
+        sentinel->suspendIfNeeded();
+        return sentinel;
+    }
+
+    using RefCounted::ref;
+    using RefCounted::deref;
+
+    bool released() const { return m_wasReleased; }
+    WakeLockType type() const { return m_type; }
+    void release(Ref<DeferredPromise>&&);
+
+private:
+    WakeLockSentinel(Document&, WakeLockType);
+
+    // ActiveDOMObject
+    const char* activeDOMObjectName() const final;
+
+    // EventTarget
+    EventTargetInterface eventTargetInterface() const final { return WakeLockSentinelEventTargetInterfaceType; }
+    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    void refEventTarget() final { RefCounted::ref(); }
+    void derefEventTarget() final { RefCounted::deref(); }
+
+    WakeLockType m_type;
+    bool m_wasReleased { false };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.idl
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.idl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ActiveDOMObject,
+    EnabledBySetting=ScreenWakeLockAPIEnabled,
+    Exposed=(Window),
+    SecureContext
+] interface WakeLockSentinel : EventTarget {
+    readonly attribute boolean released;
+    readonly attribute WakeLockType type;
+    Promise<undefined> release();
+    attribute EventHandler onrelease;
+};

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockType.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockType.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore  {
+
+enum class WakeLockType : bool { Screen };
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockType.idl
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockType.idl
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+enum WakeLockType { "screen" };

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -285,6 +285,9 @@ Modules/reporting/ReportBody.cpp
 Modules/reporting/ReportingObserver.cpp
 Modules/reporting/ReportingScope.cpp
 Modules/reporting/TestReportBody.cpp
+Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
+Modules/screen-wake-lock/WakeLock.cpp
+Modules/screen-wake-lock/WakeLockSentinel.cpp
 Modules/speech/SpeechRecognition.cpp
 Modules/speech/SpeechRecognitionAlternative.cpp
 Modules/speech/SpeechRecognitionErrorEvent.cpp
@@ -4104,6 +4107,9 @@ JSVideoTransferCharacteristics.cpp
 JSVisibilityState.cpp
 JSVisualViewport.cpp
 JSVoidCallback.cpp
+JSWakeLock.cpp
+JSWakeLockSentinel.cpp
+JSWakeLockType.cpp
 JSWaveShaperNode.cpp
 JSWaveShaperOptions.cpp
 JSWebAnimation.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -396,6 +396,8 @@ namespace WebCore {
     macro(UndoItem) \
     macro(UndoManager) \
     macro(VisualViewport) \
+    macro(WakeLock) \
+    macro(WakeLockSentinel) \
     macro(WaveShaperNode) \
     macro(WebGL2RenderingContext) \
     macro(WebGLActiveInfo) \

--- a/Source/WebCore/dom/EventNames.h
+++ b/Source/WebCore/dom/EventNames.h
@@ -223,6 +223,7 @@ namespace WebCore {
     macro(ratechange) \
     macro(readystatechange) \
     macro(rejectionhandled) \
+    macro(release) \
     macro(remove) \
     macro(removesourcebuffer) \
     macro(removestream) \

--- a/Source/WebCore/dom/EventTargetFactory.in
+++ b/Source/WebCore/dom/EventTargetFactory.in
@@ -64,6 +64,7 @@ TextTrackCueGeneric conditional=VIDEO
 TextTrackList conditional=VIDEO
 VideoTrackList conditional=VIDEO
 VisualViewport
+WakeLockSentinel
 WebAnimation
 WebKitMediaKeySession conditional=LEGACY_ENCRYPTED_MEDIA
 WebSocket


### PR DESCRIPTION
#### 4500a5a19d5349da167b2adff6b9d32edb097f01
<pre>
Land stubs for the Screen Wake Lock API
<a href="https://bugs.webkit.org/show_bug.cgi?id=245551">https://bugs.webkit.org/show_bug.cgi?id=245551</a>

Reviewed by Brent Fulgham.

Land stubs for the Screen Wake Lock API:
- <a href="https://www.w3.org/TR/screen-wake-lock">https://www.w3.org/TR/screen-wake-lock</a>

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/screen-wake-lock/Navigator+ScreenWakeLock.idl: Added.
* Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp: Added.
(WebCore::NavigatorScreenWakeLock::NavigatorScreenWakeLock):
(WebCore::NavigatorScreenWakeLock::from):
(WebCore::NavigatorScreenWakeLock::supplementName):
(WebCore::NavigatorScreenWakeLock::wakeLock):
* Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.h: Added.
* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp: Added.
(WebCore::WakeLock::request):
* Source/WebCore/Modules/screen-wake-lock/WakeLock.h: Added.
(WebCore::WakeLock::create):
* Source/WebCore/Modules/screen-wake-lock/WakeLock.idl: Added.
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp: Added.
(WebCore::WakeLockSentinel::WakeLockSentinel):
(WebCore::WakeLockSentinel::release):
(WebCore::WakeLockSentinel::activeDOMObjectName const):
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h: Added.
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.idl: Added.
* Source/WebCore/Modules/screen-wake-lock/WakeLockType.h: Added.
* Source/WebCore/Modules/screen-wake-lock/WakeLockType.idl: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/EventNames.h:
* Source/WebCore/dom/EventTargetFactory.in:

Canonical link: <a href="https://commits.webkit.org/254825@main">https://commits.webkit.org/254825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6997669744a3e1a5d66ba6c23be5822e7020401

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99690 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157157 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33440 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82715 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96137 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26570 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77206 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26446 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69452 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81939 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/imports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34536 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15211 "Found 1 new test failure: css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-relayouts.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76876 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32360 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16168 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26584 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39123 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/79462 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1460 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35257 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17424 "Passed tests") | 
<!--EWS-Status-Bubble-End-->