### PR TITLE
Thread safety analysis does not support run-time lock assertions

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -94,6 +94,10 @@
 		7A6EBA3420746C34004F9C44 /* MachSendRight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A6EBA3320746C34004F9C44 /* MachSendRight.cpp */; };
 		7AF023B52061E17000A8EFD6 /* ProcessPrivilege.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AF023B42061E16F00A8EFD6 /* ProcessPrivilege.cpp */; };
 		7AFEC6B11EB22B5900DADE36 /* UUID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AFEC6B01EB22B5900DADE36 /* UUID.cpp */; };
+		7B66F6B728DC586E00F498F8 /* CapabilityIsCurrent.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B66F6B628DC586E00F498F8 /* CapabilityIsCurrent.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7B6F855B28DC7059004365EA /* LockAssertion.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B6F855A28DC7058004365EA /* LockAssertion.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7B6F855D28DC710E004365EA /* LockAssertion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B6F855C28DC710E004365EA /* LockAssertion.cpp */; };
+		7B6F856828DC8609004365EA /* CapabilityLock.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B6F856728DC8609004365EA /* CapabilityLock.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8134013815B092FD001FF0B8 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8134013615B092FD001FF0B8 /* Base64.cpp */; };
 		8348BA0E21FBC0D500FD3054 /* ObjectIdentifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8348BA0D21FBC0D400FD3054 /* ObjectIdentifier.cpp */; };
 		93853DD328755A6C00FF4E2B /* EscapedFormsForJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 93853DD228755A6600FF4E2B /* EscapedFormsForJSON.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1176,6 +1180,10 @@
 		7AFEC6B01EB22B5900DADE36 /* UUID.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UUID.cpp; sourceTree = "<group>"; };
 		7B2739DC2624DAAA0040F182 /* ThreadSafetyAnalysis.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadSafetyAnalysis.h; sourceTree = "<group>"; };
 		7B2739F12632A8940040F182 /* ThreadAssertions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadAssertions.h; sourceTree = "<group>"; };
+		7B66F6B628DC586E00F498F8 /* CapabilityIsCurrent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CapabilityIsCurrent.h; sourceTree = "<group>"; };
+		7B6F855A28DC7058004365EA /* LockAssertion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LockAssertion.h; sourceTree = "<group>"; };
+		7B6F855C28DC710E004365EA /* LockAssertion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LockAssertion.cpp; sourceTree = "<group>"; };
+		7B6F856728DC8609004365EA /* CapabilityLock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CapabilityLock.h; sourceTree = "<group>"; };
 		7C137941222326C700D7A824 /* AUTHORS */ = {isa = PBXFileReference; lastKnownFileType = text; path = AUTHORS; sourceTree = "<group>"; };
 		7C137942222326D500D7A824 /* ieee.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ieee.h; sourceTree = "<group>"; };
 		7C137943222326D500D7A824 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -1948,6 +1956,8 @@
 				0F5F3D681F3FEBA600B115A2 /* CagedUniquePtr.h */,
 				413FE8F51F8D2EAB00F6D7D7 /* CallbackAggregator.h */,
 				46209A27266D543A007F8F4A /* CancellableTask.h */,
+				7B66F6B628DC586E00F498F8 /* CapabilityIsCurrent.h */,
+				7B6F856728DC8609004365EA /* CapabilityLock.h */,
 				A8A4726A151A825A004123FF /* CheckedArithmetic.h */,
 				A8A4726B151A825A004123FF /* CheckedBoolean.h */,
 				9BB91F512648EA4D00A56217 /* CheckedPtr.h */,
@@ -2087,6 +2097,8 @@
 				0FE164691B6FFC9600400E7C /* Lock.h */,
 				0F0FCDDD1DD167F900CCAB53 /* LockAlgorithm.h */,
 				0F31DD701F1308BC0072EB4A /* LockAlgorithmInlines.h */,
+				7B6F855C28DC710E004365EA /* LockAssertion.cpp */,
+				7B6F855A28DC7058004365EA /* LockAssertion.h */,
 				0F60F32D1DFCBD1B00416D6C /* LockedPrintStream.cpp */,
 				0F60F32E1DFCBD1B00416D6C /* LockedPrintStream.h */,
 				A8A472C3151A825A004123FF /* Locker.h */,
@@ -2880,6 +2892,8 @@
 				DD3DC95527A4BF8E007E5B61 /* CagedUniquePtr.h in Headers */,
 				DD3DC8E927A4BF8E007E5B61 /* CallbackAggregator.h in Headers */,
 				DD3DC99B27A4BF8E007E5B61 /* CancellableTask.h in Headers */,
+				7B66F6B728DC586E00F498F8 /* CapabilityIsCurrent.h in Headers */,
+				7B6F856828DC8609004365EA /* CapabilityLock.h in Headers */,
 				DDF306DA27C08654006A526F /* CFBundleSPI.h in Headers */,
 				63F9BED42898D96400371416 /* CFPrivSPI.h in Headers */,
 				DDF306D927C08654006A526F /* CFRunLoopSPI.h in Headers */,
@@ -3022,6 +3036,7 @@
 				DD3DC89027A4BF8E007E5B61 /* Lock.h in Headers */,
 				DD3DC98827A4BF8E007E5B61 /* LockAlgorithm.h in Headers */,
 				DD3DC94427A4BF8E007E5B61 /* LockAlgorithmInlines.h in Headers */,
+				7B6F855B28DC7059004365EA /* LockAssertion.h in Headers */,
 				DD3DC93727A4BF8E007E5B61 /* LockedPrintStream.h in Headers */,
 				DD3DC97527A4BF8E007E5B61 /* Locker.h in Headers */,
 				DD3DC91027A4BF8E007E5B61 /* LocklessBag.h in Headers */,
@@ -3659,6 +3674,7 @@
 				E3B8E41D24E7CE92003655D8 /* LineBreakIteratorPoolICU.cpp in Sources */,
 				C2BCFC551F621F3F00C9222C /* LineEnding.cpp in Sources */,
 				0FE1646A1B6FFC9600400E7C /* Lock.cpp in Sources */,
+				7B6F855D28DC710E004365EA /* LockAssertion.cpp in Sources */,
 				0F60F32F1DFCBD1B00416D6C /* LockedPrintStream.cpp in Sources */,
 				1CF18F3B26BB579E004B1722 /* LogChannels.cpp in Sources */,
 				93B5B45122171EEA004B7AA7 /* Logger.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -29,6 +29,8 @@ set(WTF_PUBLIC_HEADERS
     CagedUniquePtr.h
     CallbackAggregator.h
     CancellableTask.h
+    CapabilityIsCurrent.h
+    CapabilityLock.h
     CheckedArithmetic.h
     CheckedBoolean.h
     CheckedPtr.h
@@ -133,6 +135,7 @@ set(WTF_PUBLIC_HEADERS
     ListHashSet.h
     Liveness.h
     Lock.h
+    LockAssertion.h
     LockAlgorithm.h
     LockAlgorithmInlines.h
     LockedPrintStream.h
@@ -446,6 +449,7 @@ set(WTF_SOURCES
     Language.cpp
     LikelyDenseUnsignedIntegerSet.cpp
     Lock.cpp
+    LockAssertion.cpp
     LockedPrintStream.cpp
     LogChannels.cpp
     LogInitialization.cpp

--- a/Source/WTF/wtf/CapabilityIsCurrent.h
+++ b/Source/WTF/wtf/CapabilityIsCurrent.h
@@ -1,0 +1,63 @@
+
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Ref.h>
+#include <wtf/RefPtr.h>
+#include <wtf/ThreadSafetyAnalysis.h>
+
+namespace WTF {
+
+// Functions implementing "is current" capability, declared by WTF_CAPABILITY("is current").
+
+// Implementation of "is current" capability for any such type. Types specialize this template.
+template<typename T> bool isCurrent(const T&);
+
+// Establishes the fact that `t` is current. The static analysis will use this fact to verify access
+// to functions and member variables depending on this fact.
+// On ASSERT_ENABLED builds, proves this claim during run-time by ASSERTing.
+template<typename T>
+inline void assertIsCurrent(const T& t) WTF_ASSERTS_ACQUIRED_CAPABILITY(t)
+{
+    ASSERT_UNUSED(t, isCurrent(t));
+}
+
+template<typename T>
+inline void assertIsCurrent(const Ref<T>& t) WTF_ASSERTS_ACQUIRED_CAPABILITY(t)
+{
+    ASSERT_UNUSED(t, isCurrent(t.get()));
+}
+
+template<typename T>
+inline void assertIsCurrent(const RefPtr<T>& t) WTF_ASSERTS_ACQUIRED_CAPABILITY(t)
+{
+    ASSERT_UNUSED(t, t && isCurrent(*t));
+}
+}
+
+using WTF::isCurrent;
+using WTF::assertIsCurrent;

--- a/Source/WTF/wtf/CapabilityLock.h
+++ b/Source/WTF/wtf/CapabilityLock.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ThreadSafetyAnalysis.h>
+
+namespace WTF {
+
+// Functions implementing "lock" capability, declared by WTF_CAPABILITY("lock") or WTF_CAPABILITY_LOCK.
+
+// Implementation of "lock" capability for any such type. Types specialize these templates.
+template<typename T> bool lockIsHeld(const T&);
+template<typename T> bool lockIsShared(const T&);
+
+
+// Establishes the fact that `t` is held exclusively. The static analysis will use this fact to verify access
+// to functions and member variables depending on this fact.
+// On ASSERT_ENABLED builds, proves this claim during run-time by ASSERTing.
+template<typename T>
+inline void assertIsHeld(const T& lock) WTF_ASSERTS_ACQUIRED_CAPABILITY(lock)
+{
+    ASSERT_UNUSED(lock, lockIsHeld(lock));
+}
+
+// Establishes the fact that `t` is held for reading. The static analysis will use this fact to verify access
+// to functions and member variables depending on this fact.
+// On ASSERT_ENABLED builds, proves this claim during run-time by ASSERTing.
+template<typename T>
+inline void assertIsShared(const T& lock) WTF_ASSERTS_ACQUIRED_SHARED_CAPABILITY(lock)
+{
+    ASSERT_UNUSED(lock, lockIsShared(lock));
+}
+
+}
+
+using WTF::assertIsHeld;
+using WTF::assertIsShared;

--- a/Source/WTF/wtf/Lock.h
+++ b/Source/WTF/wtf/Lock.h
@@ -26,11 +26,11 @@
 #pragma once
 
 #include <mutex>
+#include <wtf/CapabilityLock.h>
 #include <wtf/LockAlgorithm.h>
 #include <wtf/Locker.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Seconds.h>
-#include <wtf/ThreadSafetyAnalysis.h>
 
 namespace TestWebKitAPI {
 struct LockInspector;
@@ -143,7 +143,8 @@ private:
 // Asserts that the lock is held.
 // This can be used in cases where the annotations cannot be added to the function
 // declaration.
-inline void assertIsHeld(const Lock& lock) WTF_ASSERTS_ACQUIRED_LOCK(lock) { ASSERT_UNUSED(lock, lock.isHeld()); }
+template<>
+inline bool lockIsHeld<Lock>(const Lock& lock) { return lock.isHeld(); }
 
 // Locker specialization to use with Lock.
 // Non-movable simple scoped lock holder.

--- a/Source/WTF/wtf/LockAssertion.cpp
+++ b/Source/WTF/wtf/LockAssertion.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LockAssertion.h"
+
+namespace WTF {
+
+const LockAssertion LockAssertion::exclusive;
+const LockAssertion LockAssertion::shared;
+const LockAssertion LockAssertion::unlocked;
+const LockAssertion LockAssertion::unused;
+
+}

--- a/Source/WTF/wtf/LockAssertion.h
+++ b/Source/WTF/wtf/LockAssertion.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/CapabilityLock.h>
+#include <wtf/Noncopyable.h>
+
+namespace WTF {
+
+// A type to use for asserting that a locking condition for a member function or a variable
+// is held.
+// Used as:
+// struct MyClass {
+//      const LockAssertion& myVariableLock() const;
+//      int myVariable WTF_GUARDED_BY(myVariableLock()) { 0 };
+// };
+// MyClass d;
+// assertIsShared(d.myVariableLock());
+// print(d.myVariable + 6);
+// assertIsHeld(d.myVariableLock());
+// d.myVariable = 7;
+//
+// In the above, the myVariableLock() runs the if conditions wrt which access is allowed in the scenario
+// and returns the respective LockAssertion. See LockAssertionTests for examples.
+class WTF_CAPABILITY_LOCK LockAssertion {
+    WTF_MAKE_NONCOPYABLE(LockAssertion);
+public:
+    WTF_EXPORT_PRIVATE static const LockAssertion exclusive;
+    WTF_EXPORT_PRIVATE static const LockAssertion shared;
+    WTF_EXPORT_PRIVATE static const LockAssertion unlocked;
+    WTF_EXPORT_PRIVATE static const LockAssertion unused; // To be used for cases where condition is not defined for !ASSERT_ENABLED.
+    bool operator==(const LockAssertion& other) const { return this == &other; }
+private:
+    LockAssertion() = default;
+};
+
+template<>
+inline bool lockIsHeld<LockAssertion>(const LockAssertion& lock)
+{
+    return lock == LockAssertion::exclusive;
+}
+
+template<>
+inline bool lockIsShared<LockAssertion>(const LockAssertion& lock)
+{
+    return lock == LockAssertion::shared || lock == LockAssertion::exclusive;
+}
+
+}
+
+using WTF::LockAssertion;

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -33,6 +33,7 @@
 #include <mutex>
 #include <stdint.h>
 #include <wtf/Atomics.h>
+#include <wtf/CapabilityIsCurrent.h>
 #include <wtf/Expected.h>
 #include <wtf/FastTLS.h>
 #include <wtf/Function.h>
@@ -45,7 +46,6 @@
 #include <wtf/StackBounds.h>
 #include <wtf/StackStats.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/ThreadSafetyAnalysis.h>
 #include <wtf/Vector.h>
 #include <wtf/WordLock.h>
 #include <wtf/text/AtomStringTable.h>
@@ -433,13 +433,10 @@ inline Thread& Thread::current()
     return initializeCurrentTLS();
 }
 
-inline void assertIsCurrent(const Thread& thread) WTF_ASSERTS_ACQUIRED_CAPABILITY(thread)
+template<>
+inline bool isCurrent<Thread>(const Thread& thread)
 {
-#if ASSERT_ENABLED
-    ASSERT(&thread == &Thread::current());
-#else
-    UNUSED_PARAM(thread);
-#endif
+    return &thread == &Thread::current();
 }
 
 } // namespace WTF
@@ -448,4 +445,3 @@ using WTF::ThreadSuspendLocker;
 using WTF::Thread;
 using WTF::ThreadType;
 using WTF::GCThreadType;
-using WTF::assertIsCurrent;

--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -27,10 +27,10 @@
 
 #pragma once
 
+#include <wtf/CapabilityIsCurrent.h>
 #include <wtf/Forward.h>
 #include <wtf/FunctionDispatcher.h>
 #include <wtf/Seconds.h>
-#include <wtf/ThreadSafetyAnalysis.h>
 #include <wtf/Threading.h>
 
 #if USE(COCOA_EVENT_LOOP)
@@ -82,6 +82,9 @@ protected:
 #endif
 };
 
+class WorkQueue;
+template<> WTF_EXPORT_PRIVATE bool isCurrent<WorkQueue>(const WorkQueue&);
+
 /**
  * A WorkQueue is a function dispatching interface like FunctionDispatcher.
  * Runnables dispatched to a WorkQueue are required to execute serially.
@@ -112,20 +115,9 @@ private:
 #endif
     static Ref<WorkQueue> constructMainWorkQueue();
 
-#if ASSERT_ENABLED
-    WTF_EXPORT_PRIVATE void assertIsCurrent() const;
-    friend void assertIsCurrent(const WorkQueue&);
-#endif
+    friend bool isCurrent<WorkQueue>(const WorkQueue&);
 };
 
-inline void assertIsCurrent(const WorkQueue& workQueue) WTF_ASSERTS_ACQUIRED_CAPABILITY(workQueue)
-{
-#if ASSERT_ENABLED
-    workQueue.assertIsCurrent();
-#else
-    UNUSED_PARAM(workQueue);
-#endif
-}
 
 /**
  * A ConcurrentWorkQueue unlike a WorkQueue doesn't guarantee the order in which the dispatched runnable will run
@@ -146,4 +138,3 @@ private:
 
 using WTF::WorkQueue;
 using WTF::ConcurrentWorkQueue;
-using WTF::assertIsCurrent;

--- a/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
+++ b/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
@@ -88,11 +88,15 @@ Ref<WorkQueue> WorkQueue::constructMainWorkQueue()
     return adoptRef(*new WorkQueue(RunLoop::main()));
 }
 
-#if ASSERT_ENABLED
-void WorkQueue::assertIsCurrent() const
+template<> bool isCurrent<WorkQueue>(const WorkQueue& workQueue)
 {
-    ASSERT(m_threadID == Thread::current().uid());
-}
+#if ASSERT_ENABLED
+    return workQueue.m_threadID == Thread::current().uid();
+#else
+    UNUSED_PARAM(workQueue);
+    RELEASE_ASSERT_NOT_REACHED();
+    return false;
 #endif
+}
 
 }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -543,6 +543,7 @@
 		7B2739F32632AB640040F182 /* ThreadAssertionsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B2739F22632AB640040F182 /* ThreadAssertionsTest.cpp */; };
 		7B397C0628BE0EAD00239202 /* ConnectionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */; };
 		7B397C0828BE394B00239202 /* UtilitiesCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C83E0391D0A602700FEBCF3 /* UtilitiesCocoa.mm */; };
+		7B6F856628DC7A93004365EA /* LockAssertionTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B6F855E28DC7A92004365EA /* LockAssertionTest.cpp */; };
 		7B6FF89728C22D9400CA76B0 /* WebKit.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 2B648DBA28C1C1F700791F2B /* WebKit.framework */; };
 		7B774906267CCE72009873B4 /* TestRunnerTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B774904267CCE68009873B4 /* TestRunnerTests.cpp */; };
 		7B7D096A2519F8F90017A078 /* WebGLNoCrashOnOtherThreadAccess.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7B7D09692519F8F90017A078 /* WebGLNoCrashOnOtherThreadAccess.mm */; };
@@ -2638,6 +2639,7 @@
 		7B18417B2673860200ED4F8D /* ImageBufferTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferTests.cpp; sourceTree = "<group>"; };
 		7B2739F22632AB640040F182 /* ThreadAssertionsTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadAssertionsTest.cpp; sourceTree = "<group>"; };
 		7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConnectionTests.cpp; sourceTree = "<group>"; };
+		7B6F855E28DC7A92004365EA /* LockAssertionTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LockAssertionTest.cpp; sourceTree = "<group>"; };
 		7B774904267CCE68009873B4 /* TestRunnerTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TestRunnerTests.cpp; sourceTree = "<group>"; };
 		7B7D09692519F8F90017A078 /* WebGLNoCrashOnOtherThreadAccess.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebGLNoCrashOnOtherThreadAccess.mm; sourceTree = "<group>"; };
 		7B9FC57E28A26137007570E7 /* TestIPC */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = TestIPC; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -4913,6 +4915,7 @@
 				93E2C5541FD3204100E1DF6A /* LineEnding.cpp */,
 				26300B1716755CD90066886D /* ListHashSet.cpp */,
 				0FFC45A41B73EBE20085BD62 /* Lock.cpp */,
+				7B6F855E28DC7A92004365EA /* LockAssertionTest.cpp */,
 				A57D54F41F3395D000A97AA7 /* Logger.cpp */,
 				A57D54F51F3395D000A97AA7 /* Logger.h */,
 				EC79F168BE454E579E417B05 /* Markable.cpp */,
@@ -5829,6 +5832,7 @@
 				93E2C5551FD3204100E1DF6A /* LineEnding.cpp in Sources */,
 				7C83DEE81D0A590C00FEBCF3 /* ListHashSet.cpp in Sources */,
 				7C83DF1D1D0A590C00FEBCF3 /* Lock.cpp in Sources */,
+				7B6F856628DC7A93004365EA /* LockAssertionTest.cpp in Sources */,
 				A57D54F61F3395D000A97AA7 /* Logger.cpp in Sources */,
 				D04CF93F285C77CA005D6337 /* MachSendRight.cpp in Sources */,
 				4909EE3A2D09480C88982D56 /* Markable.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/LockAssertionTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/LockAssertionTest.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Utilities.h"
+#include <wtf/LockAssertion.h> // NOLINT: check-webkit-style has problems with files that do not have primary header.
+#include <wtf/RunLoop.h>
+#include <wtf/ThreadAssertions.h>
+#include <wtf/WorkQueue.h>
+
+namespace TestWebKitAPI {
+namespace {
+// Example of how to use LockAssertion for a common WebKit locking use-case:
+//  The owner thread reads and writes a shared variable, and a work queue just reads it.
+class MyClass {
+public:
+    void doInitialTask(int n)
+    {
+        assertIsHeld(valueLock());
+        m_value = n;
+        m_workQueue = WorkQueue::create("read queue");
+        m_workQueue->dispatch([this] { readValueFromQueue(); }); // NOLINT
+    }
+
+    void doSecondTask(int n)
+    {
+        Locker lock { m_lock };
+        assertIsHeld(valueLock());
+        m_value = n;
+        m_workQueue->dispatch([this] { readValueFromQueue(); }); // NOLINT
+    }
+
+    void doInvalidRead(int n)
+    {
+        assertIsHeld(valueLock());
+        m_value = n;
+        m_workQueue = WorkQueue::create("read queue");
+        m_workQueue->dispatch([this] { readValueFromQueueWithoutLock(); }); // NOLINT
+    }
+
+    int value() const
+    {
+        assertIsShared(valueLock());
+        return m_value;
+    }
+
+    void waitForWorkQueue() const
+    {
+        assertIsShared(valueLock());
+        while (m_workQueueValue != m_value) { }
+    }
+
+private:
+    void readValueFromQueue()
+    {
+        Locker lock { m_lock };
+        assertIsShared(valueLock());
+        m_workQueueValue = m_value;
+    }
+
+    void readValueFromQueueWithoutLock()
+    {
+        // No lock causes an ASSERT.
+        assertIsShared(valueLock());
+        m_workQueueValue = m_value;
+    }
+
+    // Function describing m_value access.
+    const LockAssertion& valueLock() const
+    {
+        if constexpr(ASSERT_ENABLED) {
+            if (isCurrent(m_ownerThread)) {
+                // When the work queue does not exist, writes are can be done without locks from owner thread.
+                // After work queue starts, writes can be done with m_lock held.
+                if (!m_workQueue || m_lock.isLocked())
+                    return LockAssertion::exclusive;
+                // Since owner thread is the only one writing, it can read without locks.
+                return LockAssertion::shared;
+            }
+            assertIsCurrent(m_workQueue);
+            // Work queue can read with m_lock held.
+            return m_lock.isLocked() ? LockAssertion::shared : LockAssertion::unlocked;
+        }
+        return LockAssertion::unused;
+    }
+    Lock m_lock;
+    int m_value WTF_GUARDED_BY_LOCK(valueLock()) { 0 };
+    std::atomic<int> m_workQueueValue { 0 };
+    RefPtr<WorkQueue> m_workQueue;
+    NO_UNIQUE_ADDRESS ThreadAssertion m_ownerThread;
+};
+}
+
+TEST(WTF_LockAssertionTests, TestLockAssertions)
+{
+    WTF::initializeMainThread();
+
+    MyClass instance;
+    instance.doInitialTask(77);
+    EXPECT_EQ(77, instance.value());
+    instance.waitForWorkQueue();
+
+    instance.doSecondTask(88);
+    EXPECT_EQ(88, instance.value());
+    instance.waitForWorkQueue();
+}
+
+#if ASSERT_ENABLED
+#define MAYBE_TestLockAssertionsNegativeDeathTest TestLockAssertionsNegativeDeathTest
+#else
+#define MAYBE_TestLockAssertionsNegativeDeathTest DISABLED_TestLockAssertionsNegativeDeathTest
+#endif
+
+TEST(WTF_LockAssertionTests, MAYBE_TestLockAssertionsNegativeDeathTest)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    ASSERT_DEATH_IF_SUPPORTED({
+        WTF::initializeMainThread();
+        MyClass instance;
+        instance.doInvalidRead(88);
+        EXPECT_EQ(88, instance.value());
+        instance.waitForWorkQueue();
+    }, "ASSERTION FAILED: lockIsShared");
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 7a72a8331f37b5c3e36dbf237be101296a8c8e4d
<pre>
Thread safety analysis does not support run-time lock assertions
<a href="https://bugs.webkit.org/show_bug.cgi?id=245564">https://bugs.webkit.org/show_bug.cgi?id=245564</a>
rdar://problem/100313162

Reviewed by NOBODY (OOPS!).

Currently sometimes code resorts to comments or non-explanation when
a variable is sometimes shared between two threads, but the access
pattern is not as simple as &quot;only used in this thread&quot;.

Add WTF::LockAssertion that can be used to express run-time conditions
about when the particular variable is usable.

Uses thread safety analysis to establish that every access is sound
if the condition is sound.

Uses run-time ASSERTs to establish that the condition is sound.

This is exactly the same concept as with &quot;assert that this thread
is current&quot;, with the same semantics and similar implementation.

Separates base implementaiton of the existing &quot;is current&quot; and
&quot;lock&quot; capabilities to their own header files.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/CapabilityIsCurrent.h: Added.
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):
* Source/WTF/wtf/CapabilityLock.h: Added.
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):
(WTF::WTF_ASSERTS_ACQUIRED_SHARED_CAPABILITY):
* Source/WTF/wtf/Lock.h:
(WTF::lockIsHeld&lt;Lock&gt;):
(WTF::WTF_ASSERTS_ACQUIRED_LOCK): Deleted.
* Source/WTF/wtf/LockAssertion.cpp: Added.
* Source/WTF/wtf/LockAssertion.h: Added.
(WTF::lockIsHeld&lt;LockAssertion&gt;):
(WTF::lockIsShared&lt;LockAssertion&gt;):
* Source/WTF/wtf/ThreadAssertions.h:
(WTF::isCurrent&lt;ThreadAssertion&gt;):
* Source/WTF/wtf/Threading.h:
(WTF::isCurrent&lt;Thread&gt;):
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY): Deleted.
* Source/WTF/wtf/WorkQueue.h:
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY): Deleted.
* Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp:
(WTF::WorkQueueBase::platformInitialize):
(WTF::isCurrent&lt;WorkQueue&gt;):
(WTF::WorkQueue::assertIsCurrent const): Deleted.
* Source/WTF/wtf/generic/WorkQueueGeneric.cpp:
(WTF::isCurrent&lt;WorkQueue&gt;):
(WTF::WorkQueue::assertIsCurrent const): Deleted.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/LockAssertionTest.cpp: Added.
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b788df3031775b0cf105d956a37b4a5956370fe2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34812 "Built successfully") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 🧪 win ](https://ews-build.webkit.org/#/builders/Windows-EWS "Waiting in queue, processing has not started yet") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33303 "Built successfully") | [⏳ 🛠 mac-debug ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95922 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81315 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-15-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-15-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-8-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-8-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | | 
<!--EWS-Status-Bubble-End-->