### PR TITLE
Expose toggles for various WebCore technologies

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -372,16 +372,6 @@ CSSTransformStyleOptimized3DEnabled:
     WebCore:
       default: false
 
-# FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
-CacheAPIEnabled:
-  type: bool
-  webcoreBinding: DeprecatedGlobalSettings
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-
 CanvasUsesAcceleratedDrawing:
   type: bool
   defaultValue:

--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -142,6 +142,18 @@ CSSOMViewScrollingAPIEnabled:
     WebCore:
       default: false
 
+# FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
+CacheAPIEnabled:
+  type: bool
+  humanReadableName: "Cache API"
+  humanReadableDescription: "Cache API"
+  webcoreBinding: DeprecatedGlobalSettings
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: true
+
 CaptureAudioInGPUProcessEnabled:
   type: bool
   humanReadableName: "GPU Process: Audio Capture"
@@ -276,6 +288,30 @@ FasterClicksEnabled:
   exposed: [ WebKit ]
   defaultValue:
     WebKit:
+      default: true
+
+FetchAPIEnabled:
+  type: bool
+  humanReadableName: "Fetch API"
+  humanReadableDescription: "Fetch API"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
+FileReaderAPIEnabled:
+  type: bool
+  humanReadableName: "FileReader API"
+  humanReadableDescription: "FileReader API"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
       default: true
 
 FlexFormattingContextIntegrationEnabled:
@@ -894,6 +930,18 @@ SpeakerSelectionRequiresUserGesture:
   humanReadableName: "Require a user gesture for speaker selection"
   humanReadableDescription: "Require a user gesture for speaker selection"
   condition: ENABLE(MEDIA_STREAM)
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
+SpeechSynthesisAPIEnabled:
+  type: bool
+  humanReadableName: "SpeechSynthesis API"
+  humanReadableDescription: "SpeechSynthesis API"
   defaultValue:
     WebKitLegacy:
       default: true

--- a/Source/WebCore/Modules/fetch/FetchBody.idl
+++ b/Source/WebCore/Modules/fetch/FetchBody.idl
@@ -27,6 +27,7 @@
  */
 
 [
+    EnabledBySetting=FetchAPIEnabled,
     Exposed=(Window,Worker),
     InterfaceName=Body,
 ] interface mixin FetchBody {

--- a/Source/WebCore/Modules/fetch/FetchRequest.idl
+++ b/Source/WebCore/Modules/fetch/FetchRequest.idl
@@ -29,6 +29,7 @@
 typedef (FetchRequest or USVString) RequestInfo;
 
 [
+    EnabledBySetting=FetchAPIEnabled,
     ActiveDOMObject,
     ExportMacro=WEBCORE_EXPORT,
     Exposed=(Window,Worker),

--- a/Source/WebCore/Modules/fetch/FetchResponse.idl
+++ b/Source/WebCore/Modules/fetch/FetchResponse.idl
@@ -38,6 +38,7 @@ dictionary FetchResponseInit {
 };
 
 [
+    EnabledBySetting=FetchAPIEnabled,
     ActiveDOMObject,
     ExportMacro=WEBCORE_EXPORT,
     Exposed=(Window,Worker),

--- a/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScope+Fetch.idl
+++ b/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScope+Fetch.idl
@@ -27,6 +27,7 @@ typedef (FetchRequest or USVString) RequestInfo;
 
 // https://fetch.spec.whatwg.org/#fetch-method
 [
+    EnabledBySetting=FetchAPIEnabled,
     ImplementedBy=WindowOrWorkerGlobalScopeFetch
 ] partial interface mixin WindowOrWorkerGlobalScope {
     [NewObject] Promise<FetchResponse> fetch(RequestInfo input, optional FetchRequestInit init);

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.idl
@@ -25,6 +25,7 @@
 
 // https://wicg.github.io/speech-api/#speechsynthesis
 [
+    EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS,
     Exposed=Window,
 ] interface SpeechSynthesis : EventTarget {

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorCode.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorCode.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS
 ] enum SpeechSynthesisErrorCode {
     "canceled",

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.idl
@@ -25,6 +25,7 @@
 
 // https://wicg.github.io/speech-api/#speechsynthesiserrorevent
 [
+    EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS,
     Exposed=Window
 ] interface SpeechSynthesisErrorEvent : SpeechSynthesisEvent {

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorEventInit.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorEventInit.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS
 ] dictionary SpeechSynthesisErrorEventInit : SpeechSynthesisEventInit {
     required SpeechSynthesisErrorCode error;

--- a/Source/WebCore/Modules/speech/SpeechSynthesisEvent.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisEvent.idl
@@ -25,6 +25,7 @@
 
 // https://wicg.github.io/speech-api/#speechsynthesisevent
 [
+    EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS,
     Exposed=Window
 ] interface SpeechSynthesisEvent : Event {

--- a/Source/WebCore/Modules/speech/SpeechSynthesisEventInit.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisEventInit.idl
@@ -25,6 +25,7 @@
 
 // https://wicg.github.io/speech-api/#speechsynthesiseventinit
 [
+    EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS
 ] dictionary SpeechSynthesisEventInit : EventInit {
     required SpeechSynthesisUtterance utterance;

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.idl
@@ -25,6 +25,7 @@
 
 // https://wicg.github.io/speech-api/#speechsynthesisutterance
 [
+    EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS,
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,

--- a/Source/WebCore/Modules/speech/SpeechSynthesisVoice.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisVoice.idl
@@ -25,6 +25,7 @@
 
 // https://wicg.github.io/speech-api/#speechsynthesisvoice
 [
+    EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS,
     Exposed=Window
 ] interface SpeechSynthesisVoice {

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -498,6 +498,8 @@ namespace WebCore {
     macro(fatal) \
     macro(fetch) \
     macro(fetchRequest) \
+    macro(FileReader) \
+    macro(FileReaderSync) \
     macro(fillFromJS) \
     macro(finishConsumingStream) \
     macro(flush) \
@@ -587,6 +589,11 @@ namespace WebCore {
     macro(setBodyFromInputRequest) \
     macro(setStatus) \
     macro(showModalDialog) \
+    macro(SpeechSynthesis) \
+    macro(SpeechSynthesisErrorEvent) \
+    macro(SpeechSynthesisEvent) \
+    macro(SpeechSynthesisUtterance) \
+    macro(SpeechSynthesisVoice) \
     macro(start) \
     macro(startConsumingStream) \
     macro(started) \

--- a/Source/WebCore/fileapi/FileReader.idl
+++ b/Source/WebCore/fileapi/FileReader.idl
@@ -30,6 +30,7 @@
  */
 
 [
+    EnabledBySetting=FileReaderAPIEnabled,
     Exposed=(Window,Worker),
     ActiveDOMObject,
 ] interface FileReader : EventTarget {

--- a/Source/WebCore/fileapi/FileReaderSync.idl
+++ b/Source/WebCore/fileapi/FileReaderSync.idl
@@ -29,6 +29,7 @@
  */
 
 [
+    EnabledBySetting=FileReaderAPIEnabled,
     Exposed=(DedicatedWorker,SharedWorker),
 ] interface FileReaderSync {
     constructor();


### PR DESCRIPTION
#### 676cef498e74fc6da682f34a2e1b398a9198efc4
<pre>
Expose toggles for various WebCore technologies
<a href="https://bugs.webkit.org/show_bug.cgi?id=245569">https://bugs.webkit.org/show_bug.cgi?id=245569</a>
&lt;rdar://100318108&gt;

Reviewed by Geoffrey Garen.

Expose toggles for various WebCore technologies including:
     * FileReader,
     * SpeechSynthesis &amp;
     * Fetch.

* Source/WTF/Scripts/Preferences/WebPreferences.yaml:
* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
* Source/WebCore/Modules/fetch/FetchBody.idl:
* Source/WebCore/Modules/fetch/FetchRequest.idl:
* Source/WebCore/Modules/fetch/FetchResponse.idl:
* Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScope+Fetch.idl:
* Source/WebCore/Modules/speech/SpeechSynthesis.idl:
* Source/WebCore/Modules/speech/SpeechSynthesisErrorCode.idl:
* Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.idl:
* Source/WebCore/Modules/speech/SpeechSynthesisErrorEventInit.idl:
* Source/WebCore/Modules/speech/SpeechSynthesisEvent.idl:
* Source/WebCore/Modules/speech/SpeechSynthesisEventInit.idl:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.idl:
* Source/WebCore/Modules/speech/SpeechSynthesisVoice.idl:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/fileapi/FileReader.idl:
* Source/WebCore/fileapi/FileReaderSync.idl:

Canonical link: <a href="https://commits.webkit.org/254804@main">https://commits.webkit.org/254804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9eb69ce61915f98e06ad5010df51d13b056ada43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99569 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157074 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33296 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82591 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96034 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95915 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26485 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77085 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26377 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69383 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81865 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34420 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/15163 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76775 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32253 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16116 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26563 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3372 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39066 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/79362 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35203 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17403 "Passed tests") | 
<!--EWS-Status-Bubble-End-->