### PR TITLE
Ignore <option> element while building accessibility tree when <select> is hidden

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -741,6 +741,8 @@ AccessibilityObject* AXObjectCache::getOrCreate(Node* node)
         if (select->usesMenuList()) {
             if (!isOptionElement)
                 return nullptr;
+            if (!select->renderer())
+                return nullptr;
             object = AccessibilityMenuListOption::create(downcast<HTMLOptionElement>(*node));
         } else
             object = AccessibilityListBoxOption::create(downcast<HTMLElement>(*node));


### PR DESCRIPTION
#### a9c99d1f4261bfa6d50692990f944d7e31cdb20e
<pre>
Ignore &lt;option&gt; element while building accessibility tree when &lt;select&gt; is hidden
<a href="https://bugs.webkit.org/show_bug.cgi?id=245578">https://bugs.webkit.org/show_bug.cgi?id=245578</a>

Reviewed by Carlos Garcia Campos.

When we insert `AccessibilityObject`&apos;s child, we check that its
`parentObject` is the `AccessiblityObject` we&apos;re inserting it into.

In normal circumstances `AccessibilityObject`&apos;s subclass representing
`HTMLSelectElement` is `AccessibilityMenuList`. It creates
`AccessiblityMenuListPopup` as its only accessibility child. All
`HTMLSelectElement`&apos;s node children accessibility objects are inserted
into the popup.

For non-multiple `HTMLSelectElement` the only possible node child class
that participates in accessibility tree is `HTMLOptionElement` with its
accessibility counterpart `AccessibilityMenuListOption`.
`AccessibilityMenuListOption`&apos;s `parentObject` is set explicitly to
`AccessiblityMenuListPopup` when it&apos;s being inserted into one.

Situation changes when `HTMLSelectElement` is hidden but `aria-hidden`
attribute set to `false`
(like in `accessibility/aria-visible-element-roles.html` layout test).
In this case, we don&apos;t have a renderer object associated with
`HTMLSelectElement` and simply create a regular `AccessiblityNodeObject`
for it. Then we insert `AccessibilityMenuListOption` as
`AccessiblityNodeObject`&apos;s child without setting its `parentObject`.
Thus, `child-&gt;parentObject() == this` assertion fails.

Since we can&apos;t present a menu without `HTMLSelectElement`&apos;s renderer
anyway (and this is what Chromium does), it&apos;s safe to skip
`HTMLSelectElement` while building the accessibility tree in such cases.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::getOrCreate):

Canonical link: <a href="https://commits.webkit.org/254970@main">https://commits.webkit.org/254970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/624bac7d06f45851a34990a128a64e2c5b02ea4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100007 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158328 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33770 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28904 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83051 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96405 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26882 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77515 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26717 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69747 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34862 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15463 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32674 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16443 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3464 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39380 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35532 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->