### PR TITLE
jsc-only CMake build fails to link due to _initializeLibraryPathDiagnostics

### DIFF
--- a/Source/WTF/wtf/PlatformMac.cmake
+++ b/Source/WTF/wtf/PlatformMac.cmake
@@ -83,6 +83,8 @@ list(APPEND WTF_SOURCES
     cocoa/URLCocoa.mm
     cocoa/WorkQueueCocoa.cpp
 
+    darwin/LibraryPathDiagnostics.mm
+
     mac/FileSystemMac.mm
     mac/SchedulePairMac.mm
 

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -45,7 +45,7 @@
 #include <wtf/linux/RealTimeThreads.h>
 #endif
 
-#if OS(DARWIN)
+#if PLATFORM(COCOA)
 #include <wtf/darwin/LibraryPathDiagnostics.h>
 #endif
 
@@ -485,7 +485,7 @@ void initialize()
 #if USE(PTHREADS) && HAVE(MACHINE_CONTEXT)
         SignalHandlers::initialize();
 #endif
-#if OS(DARWIN)
+#if PLATFORM(COCOA)
         initializeLibraryPathDiagnostics();
 #endif
     });

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -463,10 +463,6 @@ list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
     UIProcess/API/Cocoa/_WKTextManipulationItem.h
     UIProcess/API/Cocoa/_WKTextManipulationToken.h
     UIProcess/API/Cocoa/_WKThumbnailView.h
-    UIProcess/API/Cocoa/_WKUserContentExtensionStore.h
-    UIProcess/API/Cocoa/_WKUserContentExtensionStorePrivate.h
-    UIProcess/API/Cocoa/_WKUserContentFilter.h
-    UIProcess/API/Cocoa/_WKUserContentFilterPrivate.h
     UIProcess/API/Cocoa/_WKUserContentWorld.h
     UIProcess/API/Cocoa/_WKUserInitiatedAction.h
     UIProcess/API/Cocoa/_WKUserStyleSheet.h

--- a/Source/WebKitLegacy/CMakeLists.txt
+++ b/Source/WebKitLegacy/CMakeLists.txt
@@ -9,7 +9,7 @@ include(target/WebCore)
 set_property(DIRECTORY . PROPERTY FOLDER "WebKitLegacy")
 
 set(WebKitLegacy_SOURCES
-    Storage/InprocessIDBServer.cpp
+    Storage/InProcessIDBServer.cpp
     Storage/StorageAreaImpl.cpp
     Storage/StorageAreaSync.cpp
     Storage/StorageNamespaceImpl.cpp


### PR DESCRIPTION
#### ca2a874adf3db606fa16fe32e420ffbe6ca5d5ac
<pre>
jsc-only CMake build fails to link due to _initializeLibraryPathDiagnostics
<a href="https://bugs.webkit.org/show_bug.cgi?id=245589">https://bugs.webkit.org/show_bug.cgi?id=245589</a>

Reviewed by Yusuke Suzuki.

* Source/WTF/wtf/PlatformMac.cmake:
    Include LibraryPathDiagnostics.mm in the list of Mac/Cocoa-specific sources built in the full
    macOS CMake build.
* Source/WTF/wtf/Threading.cpp:
    Only enable the LibraryPathDiagnostics codepaths under PLATFORM(COCOA). This excludes
    the JSC-only build.

* Source/WebKit/PlatformMac.cmake:
* Source/WebKitLegacy/CMakeLists.txt:
    Make other fixes to the CMake configuration that allow me to start building with
    `build-webkit --cmake`. Fix the capitalization of &quot;InprocessIDBServer.cpp&quot;, and remove
    some `_WKUserContent…` headers that were removed in <a href="https://commits.webkit.org/254090@main.">https://commits.webkit.org/254090@main.</a>
    This doesn&apos;t fully fix the Mac CMake build (there are still some compiler errors in libwebrtc),
    but I got far enough into the build to verify that the change to PlatformMac.cmake fixes the
    ability to link WTF with the LibraryPathDiagnostics content in a CMake build.

Canonical link: <a href="https://commits.webkit.org/254842@main">https://commits.webkit.org/254842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a881ed1da8eb31c410908c97a5d28e83b45d0a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99651 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157120 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33400 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28640 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96101 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26531 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77168 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26412 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69419 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81905 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34498 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15192 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76834 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32321 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16147 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26577 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3389 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39098 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/79420 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/37996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35235 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17417 "Passed tests") | 
<!--EWS-Status-Bubble-End-->