### PR TITLE
[Xcode] Add a style check to keep xcschemes in sync

### DIFF
--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -58,6 +58,7 @@ from webkitpy.style.checkers.test_expectations import TestExpectationsChecker
 from webkitpy.style.checkers.text import TextChecker
 from webkitpy.style.checkers.watchlist import WatchListChecker
 from webkitpy.style.checkers.xcodeproj import XcodeProjectFileChecker
+from webkitpy.style.checkers.xcscheme import XcodeSchemeChecker
 from webkitpy.style.checkers.xml import XMLChecker
 from webkitpy.style.error_handlers import DefaultStyleErrorHandler
 from webkitpy.style.filter import FilterConfiguration
@@ -363,6 +364,8 @@ _TEXT_FILE_EXTENSIONS = [
 
 _XCODEPROJ_FILE_EXTENSION = 'pbxproj'
 
+_XCSCHEME_FILE_EXTENSION = 'xcscheme'
+
 _XML_FILE_EXTENSIONS = [
     'vcproj',
     'vsprops',
@@ -470,6 +473,7 @@ def _all_categories():
     categories = categories.union(ChangeLogChecker.categories)
     categories = categories.union(PNGChecker.categories)
     categories = categories.union(FeatureDefinesChecker.categories)
+    categories = categories.union(XcodeSchemeChecker.categories)
 
     # FIXME: Consider adding all of the pep8 categories.  Since they
     #        are not too meaningful for documentation purposes, for
@@ -624,6 +628,7 @@ class FileType:
     CMAKE = 11
     FEATUREDEFINES = 12
     SDKVARIANT = 13
+    XCSCHEME = 14
 
 
 class CheckerDispatcher(object):
@@ -709,6 +714,8 @@ class CheckerDispatcher(object):
             return FileType.WATCHLIST
         elif file_extension == _XCODEPROJ_FILE_EXTENSION:
             return FileType.XCODEPROJ
+        elif file_extension == _XCSCHEME_FILE_EXTENSION:
+            return FileType.XCSCHEME
         elif file_extension == _PNG_FILE_EXTENSION:
             return FileType.PNG
         elif ((file_extension == _CMAKE_FILE_EXTENSION) or os.path.basename(file_path) == 'CMakeLists.txt'):
@@ -768,6 +775,11 @@ class CheckerDispatcher(object):
                 checker = PythonChecker(file_path, handle_style_error)
         elif file_type == FileType.XML:
             checker = XMLChecker(file_path, handle_style_error)
+        elif file_type == FileType.XCSCHEME:
+            if apple_additions():
+                checker = apple_additions().xcscheme_checker(file_path, handle_style_error)
+            else:
+                checker = XcodeSchemeChecker(file_path, handle_style_error)
         elif file_type == FileType.XCODEPROJ:
             checker = XcodeProjectFileChecker(file_path, handle_style_error)
         elif file_type == FileType.PNG:

--- a/Tools/Scripts/webkitpy/style/checkers/xcscheme.py
+++ b/Tools/Scripts/webkitpy/style/checkers/xcscheme.py
@@ -1,0 +1,103 @@
+from __future__ import absolute_import
+from collections import namedtuple
+from webkitpy.port.config import apple_additions
+from xml.dom import minidom
+import os
+
+
+class Buildable(namedtuple('Buildable', ('id', 'name', 'project_name', 'action_set'))):
+    def __str__(self):
+        return "{} (in project '{}', built for: {})".format(self.name, self.project_name, self.action_set)
+
+
+class BuildActionSet(namedtuple('BuildActionSet', ('analyze', 'test', 'run', 'profile', 'archive'))):
+    def __str__(self):
+        return ' '.join(
+            key for key, enabled in self._asdict().items() if enabled
+        ) or 'nothing'
+
+
+def targets_built_for_scheme(scheme_path):
+    dom = minidom.parse(scheme_path)
+    targets = set()
+    for entry_node in dom.getElementsByTagName('BuildActionEntry'):
+        action_set = BuildActionSet(
+            analyze=entry_node.getAttribute('buildForAnalyzing') == 'YES',
+            test=entry_node.getAttribute('buildForTesting') == 'YES',
+            run=entry_node.getAttribute('buildForRunning') == 'YES',
+            profile=entry_node.getAttribute('buildForProfiling') == 'YES',
+            archive=entry_node.getAttribute('buildForArchiving') == 'YES',
+        )
+        for buildable_node in entry_node.getElementsByTagName('BuildableReference'):
+            target_id = buildable_node.getAttribute('BlueprintIdentifier')
+            target_name = buildable_node.getAttribute('BlueprintName')
+            container = buildable_node.getAttribute('ReferencedContainer')
+            project_name, _ = os.path.splitext(os.path.basename(container))
+            targets.add(Buildable(target_id, target_name, project_name, action_set))
+    return targets
+
+
+class XcodeSchemeChecker:
+    categories = ['xcscheme/sync']
+
+    RULES = {
+        # A scheme rule is a 3-tuple:
+        #       (SCHEME, RELATION, SCHEMES)
+        # where SCHEME is a path to an xcscheme file. RELATION is either ">="
+        # (superset) or "==" (equality), and relates the lefthand SCHEME to one
+        # or more SCHEMES.
+        #
+        # When SCHEMES is multiple schemes, the union of those schemes'
+        # buildable targets is compared.
+        #
+        # For brevity, rules for schemes in the same workspace are organized
+        # into prefixes, which are the path to the directory containing the
+        # SCHEME.
+
+        'WebKit.xcworkspace/xcshareddata/xcschemes/': (
+            ('Everything up to WebKit + Tools.xcscheme', '>=', 'Everything up to WebKit.xcscheme'),
+            ('Everything up to WebKit + Tools.xcscheme', '>=', 'All WebKit Tools.xcscheme'),
+            ('Everything up to WebKit + Tools.xcscheme', '==', ('Everything up to WebKit.xcscheme', 'All WebKit Tools.xcscheme')),
+        ),
+    }
+
+    def __init__(self, file_path, handle_style_error):
+        self._handle_style_error = handle_style_error
+        self._file_path = file_path
+
+    def check(self, lines, rules=None):
+        rules = rules or self.RULES
+        targets = None  # lazily computed below
+        for path_prefix, predicates in rules.items():
+            if not self._file_path.startswith(path_prefix):
+                continue
+            for path_suffix, relation, other_schemes in predicates:
+                if self._file_path != path_prefix + path_suffix:
+                    continue
+
+                targets = targets or targets_built_for_scheme(self._file_path)
+                if isinstance(other_schemes, str):
+                    # If the rule relates a single scheme, parse its targets,
+                    # then convert it to a tuple so it can be iterated over.
+                    other_targets = targets_built_for_scheme(os.path.join(path_prefix, other_schemes))
+                    other_schemes = (other_schemes,)
+                else:
+                    # If the rule relates to multiple schemes, parse its
+                    # targets into a union set.
+                    other_targets = {target
+                                     for scheme in other_schemes
+                                     for target in targets_built_for_scheme(os.path.join(path_prefix, scheme))}
+
+                comparator, verb_phrase = {
+                    '>=': (set.issuperset, 'be a superset of'),
+                    '==': (set.__eq__, 'be equal to')
+                }[relation]
+
+                if not comparator(targets, other_targets):
+                    msg = "targets should {} the targets in '{}'".format(verb_phrase, "' + '".join(other_schemes))
+                    difference = other_targets - targets
+                    if difference:
+                        msg += '\n\tAdd:\n\t- {}'.format('\n\t- '.join(map(str, difference)))
+                    if relation == '==' and targets - other_targets:
+                        msg += '\n\tRemove:\n\t- {}'.format('\n\t- '.join(map(str, targets - other_targets)))
+                    self._handle_style_error(0, 'xcscheme/sync', 5, msg)

--- a/WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme
+++ b/WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme
@@ -70,9 +70,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8DD76F960486AA7600D96B5E"
-               BuildableName = "TestWebKitAPI"
-               BlueprintName = "TestWebKitAPI"
+               BlueprintIdentifier = "7C83E02B1D0A5E1000FEBCF3"
+               BuildableName = "All"
+               BlueprintName = "All"
                ReferencedContainer = "container:Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit.xcscheme
+++ b/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "14F271BD18EA3963008C152F"
-               BuildableName = "libbmalloc.a"
-               BlueprintName = "bmalloc"
+               BlueprintIdentifier = "0F7EB8501F95504B00F1ABCB"
+               BuildableName = "All"
+               BlueprintName = "All"
                ReferencedContainer = "container:Source/bmalloc/bmalloc.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -162,10 +162,10 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "14F271BD18EA3963008C152F"
-            BuildableName = "libbmalloc.a"
-            BlueprintName = "bmalloc"
-            ReferencedContainer = "container:Source/bmalloc/bmalloc.xcodeproj">
+            BlueprintIdentifier = "5D247B6114689B8600E78B76"
+            BuildableName = "libWTF.a"
+            BlueprintName = "WTF"
+            ReferencedContainer = "container:Source/WTF/WTF.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
    </ProfileAction>


### PR DESCRIPTION
#### f07375f48dbcfcd9dd3af8271ad9dfbaac22f4e4
<pre>
[Xcode] Add a style check to keep xcschemes in sync
<a href="https://bugs.webkit.org/show_bug.cgi?id=245587">https://bugs.webkit.org/show_bug.cgi?id=245587</a>

Reviewed by Jonathan Bedard.

XcodeSchemeChecker defines relationships between schemes using set
algebra, e.g.: &quot;Everything up to WebKit + Tools&quot; is a union of &quot;Everything
up to WebKit&quot; and &quot;All WebKit Tools&quot;. When given an xcscheme file, it
parses it and verifies that its relationships hold.

This helps keep the list of buildable targets in sync between schemes,
which is a challenge for WebKit since we have multiple listings of the
WebKit and Tools targets (and many more internally).

Here&apos;s an example failure message, which revealed that &quot;All WebKit
Tools&quot; depends on the TestWebKitAPI executable and not the entire
project, so it was skipping building TestIPC, TestWTF, etc.:

    ERROR: WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme:0:  targets should be equal to the targets in &apos;Everything up to WebKit.xcscheme&apos; + &apos;All WebKit Tools.xcscheme&apos;
        Add:
        - TestWebKitAPI (in project &apos;TestWebKitAPI&apos;, built for: analyze test run profile archive)
        Remove:
        - All (in project &apos;TestWebKitAPI&apos;, built for: analyze test run profile archive)  [xcscheme/sync] [5]

Currently, the rules are evaluated one-way, so a change to one scheme
_will not_ invalidate other schemes that define rules on it. However,
the whole scheme graph can easily be checked at once with:

    check-webkit-style WebKit.xcworkspace/xcshareddata/xcschemes/*

* Tools/Scripts/webkitpy/style/checker.py: Add xcscheme file type and
  XcodeSchemeChecker instantiation.
* Tools/Scripts/webkitpy/style/checkers/xcscheme.py: Added.

Fix a few small discrepencies revealed by the checker.

* WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme:
  Build the &quot;All&quot; aggregate from TestWebKitAPI, not just the main
  executable.
* WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme:
  Build the &quot;All&quot; aggregate from bmalloc and explicitly depend on WTF.
  Both of these are probably unnecessary, since all the needed target
  are found by Xcode implicitly. We can clean these up from all schemes
  in a follow-up.

Canonical link: <a href="https://commits.webkit.org/255464@main">https://commits.webkit.org/255464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b63ba8620b07e8f7b3185f9bf01865a41023cf75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99674 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157143 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33424 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28658 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82700 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96124 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26557 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77192 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26437 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/93919 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69444 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34521 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15207 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32344 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16163 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3790 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39115 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35252 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->