### PR TITLE
[WK2] Remove uses of SendSyncLegacyResult-based MessageSender::sendSync() overload

### DIFF
--- a/Source/WebKit/Platform/IPC/MessageSender.h
+++ b/Source/WebKit/Platform/IPC/MessageSender.h
@@ -54,30 +54,6 @@ public:
     {
         return send(WTFMove(message), destinationID.toUInt64(), sendOptions);
     }
-    using SendSyncLegacyResult = Connection::SendSyncLegacyResult;
-
-    template<typename T>
-    SendSyncLegacyResult sendSync(T&& message, typename T::Reply&& reply, Timeout timeout = Seconds::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { })
-    {
-        static_assert(T::isSync, "Message is not sync!");
-
-        return sendSync(WTFMove(message), WTFMove(reply), messageSenderDestinationID(), timeout, sendSyncOptions);
-    }
-
-    template<typename T>
-    SendSyncLegacyResult sendSync(T&& message, typename T::Reply&& reply, uint64_t destinationID, Timeout timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { })
-    {
-        if (auto* connection = messageSenderConnection())
-            return connection->sendSync(WTFMove(message), WTFMove(reply), destinationID, timeout, sendSyncOptions);
-
-        return { };
-    }
-
-    template<typename T, typename U>
-    SendSyncLegacyResult sendSync(T&& message, typename T::Reply&& reply, ObjectIdentifier<U> destinationID, Timeout timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { })
-    {
-        return sendSync(WTFMove(message), WTFMove(reply), destinationID.toUInt64(), timeout, sendSyncOptions);
-    }
 
     template<typename T> using SendSyncResult = Connection::SendSyncResult<T>;
 
@@ -98,10 +74,10 @@ public:
         return { };
     }
 
-    template<typename U, typename T>
-    SendSyncResult<T> sendSync(U&& message, ObjectIdentifier<T> destinationID, Timeout timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { })
+    template<typename T, typename U>
+    SendSyncResult<T> sendSync(T&& message, ObjectIdentifier<U> destinationID, Timeout timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { })
     {
-        return sendSync<U>(std::forward<U>(message), destinationID.toUInt64(), timeout, sendSyncOptions);
+        return sendSync<T>(std::forward<T>(message), destinationID.toUInt64(), timeout, sendSyncOptions);
     }
 
     template<typename T, typename C>

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1063,8 +1063,8 @@ size_t WebPageProxy::computePagesForPrintingiOS(FrameIdentifier frameID, const P
     if (!hasRunningProcess())
         return 0;
 
-    size_t pageCount = 0;
-    sendSync(Messages::WebPage::ComputePagesForPrintingiOS(frameID, printInfo), Messages::WebPage::ComputePagesForPrintingiOS::Reply(pageCount), Seconds::infinity());
+    auto sendResult = sendSync(Messages::WebPage::ComputePagesForPrintingiOS(frameID, printInfo), Seconds::infinity());
+    auto [pageCount] = sendResult.takeReplyOr(0);
     return pageCount;
 }
 

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -210,12 +210,12 @@ void WebPageProxy::attributedSubstringForCharacterRangeAsync(const EditingRange&
 
 String WebPageProxy::stringSelectionForPasteboard()
 {
-    String value;
     if (!hasRunningProcess())
-        return value;
+        return { };
     
     const Seconds messageTimeout(20);
-    sendSync(Messages::WebPage::GetStringSelectionForPasteboard(), Messages::WebPage::GetStringSelectionForPasteboard::Reply(value), messageTimeout);
+    auto sendResult = sendSync(Messages::WebPage::GetStringSelectionForPasteboard(), messageTimeout);
+    auto [value] = sendResult.takeReplyOr(String { });
     return value;
 }
 
@@ -224,9 +224,9 @@ RefPtr<WebCore::SharedBuffer> WebPageProxy::dataSelectionForPasteboard(const Str
     if (!hasRunningProcess())
         return nullptr;
 
-    RefPtr<WebCore::SharedBuffer> buffer;
     const Seconds messageTimeout(20);
-    sendSync(Messages::WebPage::GetDataSelectionForPasteboard(pasteboardType), Messages::WebPage::GetDataSelectionForPasteboard::Reply(buffer), messageTimeout);
+    auto sendResult = sendSync(Messages::WebPage::GetDataSelectionForPasteboard(pasteboardType), messageTimeout);
+    auto [buffer] = sendResult.takeReplyOr(nullptr);
     return buffer;
 }
 
@@ -237,9 +237,9 @@ bool WebPageProxy::readSelectionFromPasteboard(const String& pasteboardName)
 
     grantAccessToCurrentPasteboardData(pasteboardName);
 
-    bool result = false;
     const Seconds messageTimeout(20);
-    sendSync(Messages::WebPage::ReadSelectionFromPasteboard(pasteboardName), Messages::WebPage::ReadSelectionFromPasteboard::Reply(result), messageTimeout);
+    auto sendResult = sendSync(Messages::WebPage::ReadSelectionFromPasteboard(pasteboardName), messageTimeout);
+    auto [result] = sendResult.takeReplyOr(false);
     return result;
 }
 
@@ -342,9 +342,9 @@ bool WebPageProxy::shouldDelayWindowOrderingForEvent(const WebKit::WebMouseEvent
     if (process().state() != WebProcessProxy::State::Running)
         return false;
 
-    bool result = false;
     const Seconds messageTimeout(3);
-    sendSync(Messages::WebPage::ShouldDelayWindowOrderingEvent(event), Messages::WebPage::ShouldDelayWindowOrderingEvent::Reply(result), messageTimeout);
+    auto sendResult = sendSync(Messages::WebPage::ShouldDelayWindowOrderingEvent(event), messageTimeout);
+    auto [result] = sendResult.takeReplyOr(false);
     return result;
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -2308,8 +2308,8 @@ bool PDFPlugin::handleContextMenuEvent(const WebMouseEvent& event)
     }
     PDFContextMenu contextMenu { point, WTFMove(items), WTFMove(openInPreviewIndex) };
 
-    std::optional<int> selectedIndex = -1;
-    webPage->sendSync(Messages::WebPageProxy::ShowPDFContextMenu(contextMenu, m_identifier), Messages::WebPageProxy::ShowPDFContextMenu::Reply(selectedIndex));
+    auto sendResult = webPage->sendSync(Messages::WebPageProxy::ShowPDFContextMenu(contextMenu, m_identifier));
+    auto [selectedIndex] = sendResult.takeReplyOr(-1);
 
     if (selectedIndex && *selectedIndex >= 0 && *selectedIndex < itemCount)
         [nsMenu performActionForItemAtIndex:*selectedIndex];

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -143,8 +143,8 @@ bool WebBackForwardListProxy::containsItem(const WebCore::HistoryItem& item) con
 {
     // Items are removed asynchronously from idToHistoryItemMap() via IPC from the UIProcess so we need to ask
     // the UIProcess to make sure this HistoryItem is still part of the back/forward list.
-    bool contains = false;
-    m_page->sendSync(Messages::WebPageProxy::BackForwardListContainsItem(item.identifier()), Messages::WebPageProxy::BackForwardListContainsItem::Reply(contains), m_page->identifier());
+    auto sendResult = m_page->sendSync(Messages::WebPageProxy::BackForwardListContainsItem(item.identifier()), m_page->identifier());
+    auto [contains] = sendResult.takeReplyOr(false);
     return contains;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -730,15 +730,15 @@ void WebPage::drawPagesToPDFFromPDFDocument(CGContextRef context, PDFDocument *p
 #if ENABLE(WEBGL)
 WebCore::WebGLLoadPolicy WebPage::webGLPolicyForURL(WebFrame*, const URL& url)
 {
-    WebGLLoadPolicy policyResult = WebGLLoadPolicy::WebGLAllowCreation;
-    sendSync(Messages::WebPageProxy::WebGLPolicyForURL(url), Messages::WebPageProxy::WebGLPolicyForURL::Reply(policyResult));
+    auto sendResult = sendSync(Messages::WebPageProxy::WebGLPolicyForURL(url));
+    auto [policyResult] = sendResult.takeReplyOr(WebGLLoadPolicy::WebGLAllowCreation);
     return policyResult;
 }
 
 WebCore::WebGLLoadPolicy WebPage::resolveWebGLPolicyForURL(WebFrame*, const URL& url)
 {
-    WebGLLoadPolicy policyResult = WebGLLoadPolicy::WebGLAllowCreation;
-    sendSync(Messages::WebPageProxy::ResolveWebGLPolicyForURL(url), Messages::WebPageProxy::ResolveWebGLPolicyForURL::Reply(policyResult));
+    auto sendResult = sendSync(Messages::WebPageProxy::ResolveWebGLPolicyForURL(url));
+    auto [policyResult] = sendResult.takeReplyOr(WebGLLoadPolicy::WebGLAllowCreation);
     return policyResult;
 }
 #endif // ENABLE(WEBGL)


### PR DESCRIPTION
#### 097a53775b155c4ff45d51d931ea1652a654c827
<pre>
[WK2] Remove uses of SendSyncLegacyResult-based MessageSender::sendSync() overload
<a href="https://bugs.webkit.org/show_bug.cgi?id=245596">https://bugs.webkit.org/show_bug.cgi?id=245596</a>

Reviewed by Kimmo Kinnunen.

Replace uses of the MessageSender::sendSync() method overload returning
SendSyncLegacyResult objects with the newer variant. The legacy methods
and type alias can then be removed.

* Source/WebKit/Platform/IPC/MessageSender.h:
(IPC::MessageSender::sendSync):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::computePagesForPrintingiOS):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::stringSelectionForPasteboard):
(WebKit::WebPageProxy::dataSelectionForPasteboard):
(WebKit::WebPageProxy::readSelectionFromPasteboard):
(WebKit::WebPageProxy::shouldDelayWindowOrderingForEvent):
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp:
(WebKit::WebPaymentCoordinator::canMakePayments):
(WebKit::WebPaymentCoordinator::showPaymentUI):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::handleContextMenuEvent):
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp:
(WebKit::WebSpeechSynthesisClient::voiceList):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebAlternativeTextClient.cpp:
(WebKit::WebAlternativeTextClient::dismissAlternativeSoon):
(WebKit::WebAlternativeTextClient::dictationAlternatives):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm:
(WebKit::WebEditorClient::substitutionsPanelIsShowing):
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::containsItem const):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::webGLPolicyForURL):
(WebKit::WebPage::resolveWebGLPolicyForURL):

Canonical link: <a href="https://commits.webkit.org/254898@main">https://commits.webkit.org/254898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61b2d049988e23f2b2e6a86e6d28305fc52e806e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99708 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33458 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28680 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96155 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26588 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77224 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26462 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69468 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34554 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15226 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32378 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16186 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3422 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39138 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35275 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->