### PR TITLE
[webkitpy] Add option to disable crash log gathering of expected crashes

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -312,6 +312,7 @@ def parse_args(args):
         optparse.make_option("--world-leaks", action="store_true", default=False, help="Check for world leaks (currently, only documents). Differs from --leaks in that this uses internal instrumentation, rather than external tools."),
         optparse.make_option("--accessibility-isolated-tree", action="store_true", default=False, help="Runs tests in accessibility isolated tree mode."),
         optparse.make_option("--allowed-host", type="string", action="append", default=[], help="If specified, tests are allowed to make requests to the specified hostname."),
+        optparse.make_option("--disable-expected-crash-logs-gathering", action="store_false", default=True, dest="gather-expected-crash-logs", help="Disable crash logs gathering for tests expected to crash.")
     ]))
 
     option_group_definitions.append(("iOS Options", [

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -129,6 +129,8 @@ class Port(object):
         self._server_process_constructor = server_process.ServerProcess  # overridable for testing
         self._test_runner_process_constructor = server_process.ServerProcess
 
+        self.set_option_default('gather-expected-crash-logs', True)
+
         if not hasattr(options, 'configuration') or not options.configuration:
             self.set_option_default('configuration', self.default_configuration())
         self._test_configuration = None
@@ -487,6 +489,12 @@ class Port(object):
         if not self._filesystem.exists(baseline_path):
             return None
         return self._filesystem.read_binary_file(baseline_path)
+
+    def is_unexpected_crash(self, test_name):
+        from webkitpy.layout_tests.models.test_expectations import TestExpectations, CRASH
+        expectations = TestExpectations(self, [test_name, ])
+        expectations.parse_all_expectations()
+        return CRASH not in expectations.filtered_expectations_for_test(test_name, False, False)
 
     def expected_text(self, test_name, device_type=None):
         """Returns the text output we expect the test to produce, or None

--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -256,7 +256,13 @@ class Driver(object):
         if self._crash_report_from_driver:
             crash_log = self._crash_report_from_driver
         elif crashed:
-            self.error_from_test, crash_log = self._get_crash_log(text, self.error_from_test, newer_than=start_time)
+            gather_crash_log = True
+            if not self._port.get_option('gather-expected-crash-logs'):
+                gather_crash_log = self._port.is_unexpected_crash(driver_input.test_name)
+            gather_str = 'now' if gather_crash_log else 'not'
+            _log.debug('Test %s crashed, we will %s gather a crash log.', driver_input.test_name, gather_str)
+            if gather_crash_log:
+                self.error_from_test, crash_log = self._get_crash_log(text, self.error_from_test, newer_than=start_time)
             # If we don't find a crash log use a placeholder error message instead.
             if not crash_log:
                 pid_str = str(self._crashed_pid) if self._crashed_pid else "unknown pid"


### PR DESCRIPTION
#### 726a66a523232d66e076c5d92d4f3a87be94b28a
<pre>
[webkitpy] Add option to disable crash log gathering of expected crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=245615">https://bugs.webkit.org/show_bug.cgi?id=245615</a>

Reviewed by Adrian Perez de Castro.

Crash logs for tests flagged as expected crashes are not linked in the layout tests results html
page, so their utility seems a bit limited. Also on bots running on underpowered hardware, like WPE
Debug, crash logs gathering is very slow, so we want it only for unexpected crashes.

* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args):
* Tools/Scripts/webkitpy/port/base.py:
(Port.__init__):
(Port.is_unexpected_crash):
* Tools/Scripts/webkitpy/port/driver.py:
(Driver.run_test):

Canonical link: <a href="https://commits.webkit.org/255082@main">https://commits.webkit.org/255082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d53398f3b61e97fcd684f3627490f573603aa77b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99703 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157170 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33453 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28675 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82728 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96150 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26583 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77218 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26453 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/93948 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69459 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34549 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15219 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32373 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16179 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3530 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36136 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39132 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35268 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->