### PR TITLE
Don't suppress click event on textarea resize

### DIFF
--- a/LayoutTests/fast/events/mouse-events-on-textarea-resize-expected.txt
+++ b/LayoutTests/fast/events/mouse-events-on-textarea-resize-expected.txt
@@ -1,0 +1,25 @@
+
+
+Verifies that correct mouse events are fired and when resizing an element
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+--- test with preventDefault on 'mousedown' ---
+--- move mouse into target ---
+--- start resizing ---
+Received mousedown
+--- mouse released ---
+
+--- test with preventDefault on '' ---
+--- move mouse into target ---
+--- start resizing ---
+Received mousedown
+--- mouse released ---
+Received mouseup
+Received click
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/mouse-events-on-textarea-resize.html
+++ b/LayoutTests/fast/events/mouse-events-on-textarea-resize.html
@@ -1,0 +1,50 @@
+<!DOCTYPE HTML>
+<script src="../../resources/js-test.js"></script>
+<style>
+textarea {
+  width: 100px;
+  height: 100px;
+  margin: 10px;
+}
+</style>
+<textarea id="target"></textarea>
+<div id="console"></div>
+<script>
+description("Verifies that correct mouse events are fired and when resizing an element");
+var testEventList = ['focus', 'mousedown', 'mouseup', 'click'];
+var preventDefaultList = ['mousedown', ''];
+var eventToPreventDefault = '';
+function init() {
+  var targetDiv = document.getElementById("target");
+  testEventList.forEach(function(eventName) {
+    targetDiv.addEventListener(eventName, function(event) {
+      if (event.type == eventToPreventDefault) {
+        event.preventDefault();
+      }
+      debug("Received " + event.type);
+    });
+  });
+}
+function runTests() {
+  var rect = document.getElementById("target").getBoundingClientRect();
+  var x = rect.right - 5;
+  var y = rect.bottom - 5;
+  preventDefaultList.forEach(function(eventName) {
+    eventToPreventDefault = eventName;
+    debug("--- test with preventDefault on '" + eventName + "' ---");
+    debug("--- move mouse into target ---");
+    eventSender.mouseMoveTo(x, y);
+    debug("--- start resizing ---");
+    eventSender.mouseDown();
+    eventSender.mouseMoveTo(x + 30, y + 30);
+    debug("--- mouse released ---");
+    eventSender.mouseUp();
+    debug("");
+  });
+}
+init();
+if (window.eventSender)
+  runTests();
+else
+  debug("This test requires eventSender");
+</script>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1790,7 +1790,6 @@ bool EventHandler::handleMousePressEvent(const PlatformMouseEvent& platformMouse
         layer->setInResizeMode(true);
         m_resizeLayer = WeakPtr { layer };
         m_offsetFromResizeCorner = layer->offsetFromResizeCorner(localPoint);
-        invalidateClick();
         return true;
     }
 


### PR DESCRIPTION
<pre>
Don't supress click event on textarea resize

<a href="https://bugs.webkit.org/show_bug.cgi?id=245617">https://bugs.webkit.org/show_bug.cgi?id=245617</a>

Reviewed by NOBODY (OOPS!).

This is to align Webkit behavior with all other browser engines Gecko / Firefox and Blink / Chromium.

As Webkit does send both mousedown and mouseup for a textarea while resizing it might as well send the click event.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/add02c1e965eccadef4ee43d99d5dfc0083afa23">https://chromium.googlesource.com/chromium/src.git/+/add02c1e965eccadef4ee43d99d5dfc0083afa23</a>

* Source/WebCore/page/EventHandler.cpp:
(EventHandler::handlerMousePressEvent): Remove "invalidateClick" to enable "Click" events
* LayoutTests/fast/event/mouse-events-on-textarea-resize.html: Added Test Case
* LayoutTests/fast/event/mouse-events-on-textarea-resize-expected.html: Added Test Case Expectations

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d91b19a76db73e74f30c5c6882a5a8ac3ec2c828

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99705 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157172 "Found 1 new test failure: fast/events/mouse-events-on-textarea-resize.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33455 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96152 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96025 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26585 "Found 1 new test failure: fast/events/mouse-events-on-textarea-resize.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77220 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26455 "Found 1 new test failure: fast/events/mouse-events-on-textarea-resize.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69461 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34551 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15224 "Found 1 new test failure: fast/events/mouse-events-on-textarea-resize.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32375 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16184 "Found 1 new test failure: fast/events/mouse-events-on-textarea-resize.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36138 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39134 "Found 1 new test failure: fast/events/mouse-events-on-textarea-resize.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38052 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35273 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->