### PR TITLE
Don't suppress click event on textarea resize

### DIFF
--- a/LayoutTests/fast/events/mouse-events-on-textarea-resize-expected.txt
+++ b/LayoutTests/fast/events/mouse-events-on-textarea-resize-expected.txt
@@ -1,0 +1,26 @@
+
+Verifies that correct mouse events are fired and when resizing an element
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+--- test with preventDefault on 'mousedown' ---
+--- move mouse into target ---
+--- start resizing ---
+--- mouse released ---
+Received mouseup
+Received click
+
+--- test with preventDefault on '' ---
+--- move mouse into target ---
+--- start resizing ---
+Received mousedown
+Received focus
+--- mouse released ---
+Received mouseup
+Received click
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/mouse-events-on-textarea-resize.html
+++ b/LayoutTests/fast/events/mouse-events-on-textarea-resize.html
@@ -1,0 +1,50 @@
+<!DOCTYPE HTML>
+<script src="../../resources/js-test.js"></script>
+<style>
+textarea {
+  width: 100px;
+  height: 100px;
+  margin: 10px;
+}
+</style>
+<textarea id="target"></textarea>
+<div id="console"></div>
+<script>
+description("Verifies that correct mouse events are fired and when resizing an element");
+var testEventList = ['focus', 'mousedown', 'mouseup', 'click'];
+var preventDefaultList = ['mousedown', ''];
+var eventToPreventDefault = '';
+function init() {
+  var target = document.getElementById("target");
+  testEventList.forEach(function(eventName) {
+    target.addEventListener(eventName, function(event) {
+      if (event.type == eventToPreventDefault) {
+        event.preventDefault();
+      }
+      debug("Received " + event.type);
+    });
+  });
+}
+function runTests() {
+  var rect = document.getElementById("target").getBoundingClientRect();
+  var x = rect.right - 5;
+  var y = rect.bottom - 5;
+  preventDefaultList.forEach(function(eventName) {
+    eventToPreventDefault = eventName;
+    debug("--- test with preventDefault on '" + eventName + "' ---");
+    debug("--- move mouse into target ---");
+    eventSender.mouseMoveTo(x, y);
+    debug("--- start resizing ---");
+    eventSender.mouseDown();
+    eventSender.mouseMoveTo(x + 30, y + 30);
+    debug("--- mouse released ---");
+    eventSender.mouseUp();
+    debug("");
+  });
+}
+init();
+if (window.eventSender)
+  runTests();
+else
+  debug("This test requires eventSender");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-computed-value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-computed-value-expected.txt
@@ -78,7 +78,7 @@ PASS Interpolation between perspective(none) and perspective(none) gives the cor
 PASS Interpolation between matrix(2, 0, 0, 2, 10, 30) and matrix(4, 0, 0, 6, 14, 10) gives the correct computed value halfway according to computedStyleMap.
 PASS Interpolation between matrix(2, 0, 0, 2, 10, 30) and matrix(4, 0, 0, 6, 14, 10) gives the correct computed value halfway according to computedStyleMap with zoom active.
 PASS Interpolation between matrix3d(1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 1, 0, 5, 10, 4, 1) and matrix3d(3, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, -11, 2, 2, 1) gives the correct computed value halfway according to computedStyleMap.
-FAIL Interpolation between matrix3d(1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 1, 0, 5, 10, 4, 1) and matrix3d(3, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, -11, 2, 2, 1) gives the correct computed value halfway according to computedStyleMap with zoom active. assert_equals: The value at 50% progress is as expected expected "matrix3d(2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 2, 0, -3, 6, 3, 1)" but got "matrix3d(2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 2, 0, -3, 6, 2.4, 1)"
+PASS Interpolation between matrix3d(1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 1, 0, 5, 10, 4, 1) and matrix3d(3, 0, 0, 0, 0, 2, 0, 0, 0, 0, 3, 0, -11, 2, 2, 1) gives the correct computed value halfway according to computedStyleMap with zoom active.
 PASS Interpolation between matrix3d(1, 0, 0, 3, 0, 1, 0, 2, 0, 0, 1, 8, 0, 0, 0, 1) and matrix3d(1, 0, 0, 5, 0, 1, 0, 8, 0, 0, 1, 14, 0, 0, 0, 1) gives the correct computed value halfway according to computedStyleMap.
 PASS Interpolation between matrix3d(1, 0, 0, 3, 0, 1, 0, 2, 0, 0, 1, 8, 0, 0, 0, 1) and matrix3d(1, 0, 0, 5, 0, 1, 0, 8, 0, 0, 1, 14, 0, 0, 0, 1) gives the correct computed value halfway according to computedStyleMap with zoom active.
 

--- a/LayoutTests/platform/ios/fast/events/mouse-events-on-textarea-resize-expected.txt
+++ b/LayoutTests/platform/ios/fast/events/mouse-events-on-textarea-resize-expected.txt
@@ -1,0 +1,20 @@
+
+Verifies that correct mouse events are fired and when resizing an element
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+--- test with preventDefault on 'mousedown' ---
+--- move mouse into target ---
+--- start resizing ---
+--- mouse released ---
+
+--- test with preventDefault on '' ---
+--- move mouse into target ---
+--- start resizing ---
+--- mouse released ---
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/Source/WebCore/css/TransformFunctions.cpp
+++ b/Source/WebCore/css/TransformFunctions.cpp
@@ -317,7 +317,7 @@ bool transformsForValue(const CSSValue& value, const CSSToLengthConversionData& 
                 downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(11)).doubleValue(),
                 conversionData.zoom() * downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(12)).doubleValue(),
                 conversionData.zoom() * downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(13)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(14)).doubleValue(),
+                conversionData.zoom() * downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(14)).doubleValue(),
                 downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(15)).doubleValue());
             operations.append(Matrix3DTransformOperation::create(matrix));
             break;

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1790,7 +1790,6 @@ bool EventHandler::handleMousePressEvent(const PlatformMouseEvent& platformMouse
         layer->setInResizeMode(true);
         m_resizeLayer = WeakPtr { layer };
         m_offsetFromResizeCorner = layer->offsetFromResizeCorner(localPoint);
-        invalidateClick();
         return true;
     }
 


### PR DESCRIPTION
<pre>
Don't suppress click event on textarea resize

<a href="https://bugs.webkit.org/show_bug.cgi?id=245617">https://bugs.webkit.org/show_bug.cgi?id=245617</a>

Reviewed by NOBODY (OOPS!).

This is to align Webkit behavior with all other browser engines Gecko / Firefox and Blink / Chromium.

As Webkit does send both mousedown and mouseup for a textarea while resizing it might as well send the click event.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/add02c1e965eccadef4ee43d99d5dfc0083afa23">https://chromium.googlesource.com/chromium/src.git/+/add02c1e965eccadef4ee43d99d5dfc0083afa23</a>

* Source/WebCore/page/EventHandler.cpp:
(EventHandler::handlerMousePressEvent): Remove "invalidateClick" to enable "Click" events
* LayoutTests/fast/event/mouse-events-on-textarea-resize.html: Added Test Case
* LayoutTests/fast/event/mouse-events-on-textarea-resize-expected.txt: Added Test Case Expectations
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6626a1d70cf80f88a71efcf26493963d0e5c8ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34985 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99732 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157197 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33483 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82761 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96177 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96053 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77247 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/26486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/69494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34577 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32401 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36164 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38078 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->