### PR TITLE
Use destroying delete for CSSValue

### DIFF
--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  * Copyright (C) 2022 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,6 +35,7 @@
 #include "VMTrapsInlines.h"
 
 namespace JSC {
+
 namespace TemporalPlainDateInternal {
 static constexpr bool verbose = false;
 }

--- a/Source/WebCore/css/CSSCrossfadeValue.cpp
+++ b/Source/WebCore/css/CSSCrossfadeValue.cpp
@@ -193,13 +193,9 @@ inline void CSSCrossfadeValue::crossfadeChanged()
         client.key->imageChanged(this);
 }
 
-bool CSSCrossfadeValue::traverseSubresources(const Function<bool(const CachedResource&)>& handler) const
+bool CSSCrossfadeValue::customTraverseSubresources(const Function<bool(const CachedResource&)>& handler) const
 {
-    if (m_cachedFromImage && handler(*m_cachedFromImage))
-        return true;
-    if (m_cachedToImage && handler(*m_cachedToImage))
-        return true;
-    return false;
+    return (m_cachedFromImage && handler(*m_cachedFromImage)) || (m_cachedToImage && handler(*m_cachedToImage));
 }
 
 RefPtr<CSSCrossfadeValue> CSSCrossfadeValue::blend(const CSSCrossfadeValue& from, const BlendingContext& context) const

--- a/Source/WebCore/css/CSSCrossfadeValue.h
+++ b/Source/WebCore/css/CSSCrossfadeValue.h
@@ -61,7 +61,7 @@ public:
 
     void loadSubimages(CachedResourceLoader&, const ResourceLoaderOptions&);
 
-    bool traverseSubresources(const Function<bool(const CachedResource&)>& handler) const;
+    bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
 
     RefPtr<CSSCrossfadeValue> blend(const CSSCrossfadeValue&, const BlendingContext&) const;
 

--- a/Source/WebCore/css/CSSFilterImageValue.cpp
+++ b/Source/WebCore/css/CSSFilterImageValue.cpp
@@ -152,11 +152,9 @@ void CSSFilterImageValue::FilterSubimageObserverProxy::imageChanged(CachedImage*
         m_ownerValue->filterImageChanged(*rect);
 }
 
-bool CSSFilterImageValue::traverseSubresources(const Function<bool(const CachedResource&)>& handler) const
+bool CSSFilterImageValue::customTraverseSubresources(const Function<bool(const CachedResource&)>& handler) const
 {
-    if (!m_cachedImage)
-        return false;
-    return handler(*m_cachedImage);
+    return m_cachedImage && handler(*m_cachedImage);
 }
 
 bool CSSFilterImageValue::equals(const CSSFilterImageValue& other) const

--- a/Source/WebCore/css/CSSFilterImageValue.h
+++ b/Source/WebCore/css/CSSFilterImageValue.h
@@ -64,7 +64,7 @@ public:
 
     void loadSubimages(CachedResourceLoader&, const ResourceLoaderOptions&);
 
-    bool traverseSubresources(const Function<bool(const CachedResource&)>& handler) const;
+    bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
 
     bool equals(const CSSFilterImageValue&) const;
 

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -85,11 +85,9 @@ String CSSFontFaceSrcValue::customCSSText() const
     return makeString(prefix, serializeString(m_resource), ")", " format(", serializeString(m_format), ")");
 }
 
-bool CSSFontFaceSrcValue::traverseSubresources(const Function<bool(const CachedResource&)>& handler) const
+bool CSSFontFaceSrcValue::customTraverseSubresources(const Function<bool(const CachedResource&)>& handler) const
 {
-    if (!m_cachedFont)
-        return false;
-    return handler(*m_cachedFont);
+    return m_cachedFont && handler(*m_cachedFont);
 }
 
 std::unique_ptr<FontLoadRequest> CSSFontFaceSrcValue::fontLoadRequest(ScriptExecutionContext* context, bool isSVG, bool isInitiatingElementInUserAgentShadowTree)

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -68,7 +68,7 @@ public:
 
     String customCSSText() const;
 
-    bool traverseSubresources(const Function<bool(const CachedResource&)>& handler) const;
+    bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
 
     std::unique_ptr<FontLoadRequest> fontLoadRequest(ScriptExecutionContext*, bool isSVG, bool isInitiatingElementInUserAgentShadowTree);
 

--- a/Source/WebCore/css/CSSFunctionValue.cpp
+++ b/Source/WebCore/css/CSSFunctionValue.cpp
@@ -26,18 +26,11 @@
 #include "config.h"
 #include "CSSFunctionValue.h"
 
-#include <wtf/text/StringBuilder.h>
-
 namespace WebCore {
     
-String CSSFunctionValue::customCSSText(Document* document) const
+String CSSFunctionValue::customCSSText() const
 {
-    StringBuilder result;
-    result.append(getValueName(m_name));
-    result.append('(');
-    result.append(CSSValueList::customCSSText(document));
-    result.append(')');
-    return result.toString();
+    return makeString(getValueName(m_name), '(', CSSValueList::customCSSText(), ')');
 }
 
 }

--- a/Source/WebCore/css/CSSFunctionValue.h
+++ b/Source/WebCore/css/CSSFunctionValue.h
@@ -37,7 +37,7 @@ public:
         return adoptRef(*new CSSFunctionValue(name));
     }
     
-    String customCSSText(Document* = nullptr) const;
+    String customCSSText() const;
 
     CSSValueID name() const { return m_name; }
 

--- a/Source/WebCore/css/CSSGridAutoRepeatValue.cpp
+++ b/Source/WebCore/css/CSSGridAutoRepeatValue.cpp
@@ -31,19 +31,13 @@
 #include "config.h"
 #include "CSSGridAutoRepeatValue.h"
 
-#include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringConcatenate.h>
 
 namespace WebCore {
 
 String CSSGridAutoRepeatValue::customCSSText() const
 {
-    StringBuilder result;
-    result.append("repeat(");
-    result.append(getValueName(autoRepeatID()));
-    result.append(", ");
-    result.append(CSSValueList::customCSSText());
-    result.append(')');
-    return result.toString();
+    return makeString("repeat("_s, getValueName(autoRepeatID()), ", "_s, CSSValueList::customCSSText(), ')');
 }
 
 bool CSSGridAutoRepeatValue::equals(const CSSGridAutoRepeatValue& other) const

--- a/Source/WebCore/css/CSSGridIntegerRepeatValue.cpp
+++ b/Source/WebCore/css/CSSGridIntegerRepeatValue.cpp
@@ -30,13 +30,14 @@
 
 #include "config.h"
 #include "CSSGridIntegerRepeatValue.h"
+
 #include <wtf/text/StringConcatenateNumbers.h>
 
 namespace WebCore {
 
 String CSSGridIntegerRepeatValue::customCSSText() const
 {
-    return makeString("repeat(", repetitions(), ", ", CSSValueList::customCSSText(), ')');
+    return makeString("repeat("_s, repetitions(), ", "_s, CSSValueList::customCSSText(), ')');
 }
 
 bool CSSGridIntegerRepeatValue::equals(const CSSGridIntegerRepeatValue& other) const

--- a/Source/WebCore/css/CSSGridLineNamesValue.cpp
+++ b/Source/WebCore/css/CSSGridLineNamesValue.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 
 String CSSGridLineNamesValue::customCSSText() const
 {
-    return "[" + CSSValueList::customCSSText() + "]";
+    return makeString('[', CSSValueList::customCSSText(), ']');
 }
 
 CSSGridLineNamesValue::CSSGridLineNamesValue()

--- a/Source/WebCore/css/CSSImageSetValue.cpp
+++ b/Source/WebCore/css/CSSImageSetValue.cpp
@@ -137,9 +137,9 @@ String CSSImageSetValue::customCSSText() const
     return result.toString();
 }
 
-bool CSSImageSetValue::traverseSubresources(const Function<bool(const CachedResource&)>& handler) const
+bool CSSImageSetValue::customTraverseSubresources(const Function<bool(const CachedResource&)>& handler) const
 {
-    return m_selectedImageValue && m_selectedImageValue->traverseSubresources(handler);
+    return CSSValueList::customTraverseSubresources(handler) || (m_selectedImageValue && m_selectedImageValue->traverseSubresources(handler));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImageSetValue.h
+++ b/Source/WebCore/css/CSSImageSetValue.h
@@ -57,7 +57,7 @@ public:
 
     String customCSSText() const;
 
-    bool traverseSubresources(const Function<bool(const CachedResource&)>& handler) const;
+    bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
 
     void updateDeviceScaleFactor(const Document&);
 

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -134,9 +134,9 @@ CachedImage* CSSImageValue::loadImage(CachedResourceLoader& loader, const Resour
     return m_cachedImage.value().get();
 }
 
-bool CSSImageValue::traverseSubresources(const Function<bool(const CachedResource&)>& handler) const
+bool CSSImageValue::customTraverseSubresources(const Function<bool(const CachedResource&)>& handler) const
 {
-    return m_cachedImage.value_or(nullptr) && handler(**m_cachedImage);
+    return m_cachedImage && *m_cachedImage && handler(**m_cachedImage);
 }
 
 bool CSSImageValue::equals(const CSSImageValue& other) const

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -64,7 +64,7 @@ public:
 
     Ref<DeprecatedCSSOMValue> createDeprecatedCSSOMWrapper(CSSStyleDeclaration&) const;
 
-    bool traverseSubresources(const Function<bool(const CachedResource&)>& handler) const;
+    bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
 
     bool equals(const CSSImageValue&) const;
 

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -42,7 +42,6 @@
 #include "Length.h"
 #include "NodeRenderStyle.h"
 #include "Pair.h"
-#include "Quirks.h"
 #include "Rect.h"
 #include "RenderStyle.h"
 #include "RenderView.h"
@@ -52,6 +51,8 @@
 #include <wtf/text/StringConcatenateNumbers.h>
 
 namespace WebCore {
+
+bool CSSPrimitiveValue::s_useLegacyPrecision;
 
 static inline bool isValidCSSUnitTypeForDoubleConversion(CSSUnitType unitType)
 {
@@ -1515,20 +1516,18 @@ ALWAYS_INLINE String CSSPrimitiveValue::formatNumberForCustomCSSText() const
     return String();
 }
 
-String CSSPrimitiveValue::customCSSText(Document* document) const
+String CSSPrimitiveValue::customCSSText() const
 {
     // FIXME: return the original value instead of a generated one (e.g. color
     // name if it was specified) - check what spec says about this
 
     CSSTextCache& cssTextCache = WebCore::cssTextCache();
 
-    bool needsQuirk = document && document->quirks().needsFlightAwareSerializationQuirk();
-
-    if (m_hasCachedCSSText && m_cachedCSSTextUsesLegacyPrecision == needsQuirk) {
+    if (m_hasCachedCSSText && m_cachedCSSTextUsesLegacyPrecision == s_useLegacyPrecision) {
         ASSERT(cssTextCache.contains(this));
         return cssTextCache.get(this);
     }
-    m_cachedCSSTextUsesLegacyPrecision = needsQuirk;
+    m_cachedCSSTextUsesLegacyPrecision = s_useLegacyPrecision;
 
     String text = formatNumberForCustomCSSText();
 

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -190,7 +190,7 @@ public:
 
     template<typename T> inline operator T() const; // Defined in CSSPrimitiveValueMappings.h
 
-    String customCSSText(Document* = nullptr) const;
+    String customCSSText() const;
 
     bool equals(const CSSPrimitiveValue&) const;
 
@@ -206,6 +206,8 @@ public:
 
     void collectDirectComputationalDependencies(HashSet<CSSPropertyID>&) const;
     void collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>&) const;
+
+    static void setUseLegacyPrecision(bool useLegacyPrecision) { s_useLegacyPrecision = useLegacyPrecision; }
 
 private:
     friend class CSSValuePool;
@@ -260,6 +262,8 @@ private:
     static constexpr bool isFontRelativeLength(CSSUnitType);
     static constexpr bool isResolution(CSSUnitType);
     static constexpr bool isViewportPercentageLength(CSSUnitType);
+
+    static bool s_useLegacyPrecision;
 
     union {
         CSSPropertyID propertyID;

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2011 Andreas Kling (kling@webkit.org)
  * Copyright (C) 2013 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,10 @@
 #include "CSSFontVariationValue.h"
 #include "CSSFunctionValue.h"
 #include "CSSGradientValue.h"
+#include "CSSGridAutoRepeatValue.h"
+#include "CSSGridIntegerRepeatValue.h"
+#include "CSSGridLineNamesValue.h"
+#include "CSSGridTemplateAreasValue.h"
 #include "CSSImageSetValue.h"
 #include "CSSImageValue.h"
 #include "CSSLineBoxContainValue.h"
@@ -61,18 +65,12 @@
 #include "CSSRayValue.h"
 #include "CSSReflectValue.h"
 #include "CSSShadowValue.h"
+#include "CSSSubgridValue.h"
 #include "CSSTimingFunctionValue.h"
 #include "CSSUnicodeRangeValue.h"
 #include "CSSValueList.h"
 #include "CSSValuePair.h"
 #include "CSSVariableReferenceValue.h"
-
-#include "CSSGridAutoRepeatValue.h"
-#include "CSSGridIntegerRepeatValue.h"
-#include "CSSGridLineNamesValue.h"
-#include "CSSGridTemplateAreasValue.h"
-#include "CSSSubgridValue.h"
-
 #include "DeprecatedCSSOMPrimitiveValue.h"
 #include "DeprecatedCSSOMValueList.h"
 
@@ -87,38 +85,122 @@ static_assert(sizeof(CSSValue) == sizeof(SameSizeAsCSSValue), "CSS value should 
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSValue);
 
-CSSValue::Type CSSValue::cssValueType() const
+template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visitor&& visitor)
 {
-    if (isInheritValue())
-        return CSS_INHERIT;
-    if (isPrimitiveValue())
-        return CSS_PRIMITIVE_VALUE;
-    if (isValueList())
-        return CSS_VALUE_LIST;
-    if (isInitialValue())
-        return CSS_INITIAL;
-    if (isUnsetValue())
-        return CSS_UNSET;
-    if (isRevertValue())
-        return CSS_REVERT;
-    return CSS_CUSTOM;
+    switch (classType()) {
+    case AspectRatioClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSAspectRatioValue>(*this));
+    case BackgroundRepeatClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSBackgroundRepeatValue>(*this));
+    case BorderImageSliceClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSBorderImageSliceValue>(*this));
+    case BorderImageWidthClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSBorderImageWidthValue>(*this));
+    case CSSContentDistributionClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSContentDistributionValue>(*this));
+    case CalculationClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCalcValue>(*this));
+    case CanvasClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCanvasValue>(*this));
+    case ConicGradientClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSConicGradientValue>(*this));
+    case CrossfadeClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCrossfadeValue>(*this));
+    case CubicBezierTimingFunctionClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCubicBezierTimingFunctionValue>(*this));
+    case CursorImageClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCursorImageValue>(*this));
+    case CustomPropertyClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCustomPropertyValue>(*this));
+    case FilterImageClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFilterImageValue>(*this));
+    case FontClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontValue>(*this));
+    case FontFaceSrcClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontFaceSrcValue>(*this));
+    case FontFeatureClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontFeatureValue>(*this));
+    case FontPaletteValuesOverrideColorsClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontPaletteValuesOverrideColorsValue>(*this));
+    case FontStyleClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontStyleValue>(*this));
+    case FontStyleRangeClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontStyleRangeValue>(*this));
+    case FontVariationClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontVariationValue>(*this));
+    case FunctionClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFunctionValue>(*this));
+    case GridAutoRepeatClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSGridAutoRepeatValue>(*this));
+    case GridIntegerRepeatClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSGridIntegerRepeatValue>(*this));
+    case GridLineNamesClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSGridLineNamesValue>(*this));
+    case GridTemplateAreasClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSGridTemplateAreasValue>(*this));
+    case ImageClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSImageValue>(*this));
+    case ImageSetClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSImageSetValue>(*this));
+    case LineBoxContainClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSLineBoxContainValue>(*this));
+    case LinearGradientClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSLinearGradientValue>(*this));
+    case NamedImageClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSNamedImageValue>(*this));
+    case RadialGradientClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSRadialGradientValue>(*this));
+    case OffsetRotateClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSOffsetRotateValue>(*this));
+    case PendingSubstitutionValueClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSPendingSubstitutionValue>(*this));
+    case PrimitiveClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSPrimitiveValue>(*this));
+    case RayClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSRayValue>(*this));
+    case ReflectClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSReflectValue>(*this));
+    case ShadowClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSShadowValue>(*this));
+    case SubgridClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSSubgridValue>(*this));
+    case StepsTimingFunctionClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSStepsTimingFunctionValue>(*this));
+    case SpringTimingFunctionClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSSpringTimingFunctionValue>(*this));
+    case UnicodeRangeClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSUnicodeRangeValue>(*this));
+    case ValueListClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSValueList>(*this));
+    case ValuePairClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSValuePair>(*this));
+    case VariableReferenceClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSVariableReferenceValue>(*this));
+#if ENABLE(CSS_PAINTING_API)
+    case PaintImageClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSPaintImageValue>(*this));
+#endif
+    }
+    ASSERT_NOT_REACHED();
+}
+
+template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visitor&& visitor) const
+{
+    return const_cast<CSSValue&>(*this).visitDerived([&](auto& value) {
+        return std::invoke(std::forward<Visitor>(visitor), std::as_const(value));
+    });
+}
+
+inline bool CSSValue::customTraverseSubresources(const Function<bool(const CachedResource&)>&)
+{
+    return false;
 }
 
 bool CSSValue::traverseSubresources(const Function<bool(const CachedResource&)>& handler) const
 {
-    if (is<CSSValueList>(*this))
-        return downcast<CSSValueList>(*this).traverseSubresources(handler);
-    if (is<CSSFontFaceSrcValue>(*this))
-        return downcast<CSSFontFaceSrcValue>(*this).traverseSubresources(handler);
-    if (is<CSSImageValue>(*this))
-        return downcast<CSSImageValue>(*this).traverseSubresources(handler);
-    if (is<CSSCrossfadeValue>(*this))
-        return downcast<CSSCrossfadeValue>(*this).traverseSubresources(handler);
-    if (is<CSSFilterImageValue>(*this))
-        return downcast<CSSFilterImageValue>(*this).traverseSubresources(handler);
-    if (is<CSSImageSetValue>(*this))
-        return downcast<CSSImageSetValue>(*this).traverseSubresources(handler);
-    return false;
+    return visitDerived([&](auto& value) {
+        return value.customTraverseSubresources(handler);
+    });
 }
 
 void CSSValue::collectDirectComputationalDependencies(HashSet<CSSPropertyID>& values) const
@@ -133,114 +215,17 @@ void CSSValue::collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>
         downcast<CSSPrimitiveValue>(*this).collectDirectRootComputationalDependencies(values);
 }
 
-template<class ChildClassType>
-inline static bool compareCSSValues(const CSSValue& first, const CSSValue& second)
-{
-    return static_cast<const ChildClassType&>(first).equals(static_cast<const ChildClassType&>(second));
-}
-
 bool CSSValue::equals(const CSSValue& other) const
 {
-    if (m_classType == other.m_classType) {
-        switch (m_classType) {
-        case AspectRatioClass:
-            return compareCSSValues<CSSAspectRatioValue>(*this, other);
-        case BackgroundRepeatClass:
-            return compareCSSValues<CSSBackgroundRepeatValue>(*this, other);
-        case BorderImageSliceClass:
-            return compareCSSValues<CSSBorderImageSliceValue>(*this, other);
-        case BorderImageWidthClass:
-            return compareCSSValues<CSSBorderImageWidthValue>(*this, other);
-        case CanvasClass:
-            return compareCSSValues<CSSCanvasValue>(*this, other);
-        case NamedImageClass:
-            return compareCSSValues<CSSNamedImageValue>(*this, other);
-        case CursorImageClass:
-            return compareCSSValues<CSSCursorImageValue>(*this, other);
-        case FilterImageClass:
-            return compareCSSValues<CSSFilterImageValue>(*this, other);
-#if ENABLE(CSS_PAINTING_API)
-        case PaintImageClass:
-            return compareCSSValues<CSSPaintImageValue>(*this, other);
-#endif
-        case FontClass:
-            return compareCSSValues<CSSFontValue>(*this, other);
-        case FontFaceSrcClass:
-            return compareCSSValues<CSSFontFaceSrcValue>(*this, other);
-        case FontPaletteValuesOverrideColorsClass:
-            return compareCSSValues<CSSFontPaletteValuesOverrideColorsValue>(*this, other);
-        case FontFeatureClass:
-            return compareCSSValues<CSSFontFeatureValue>(*this, other);
-        case FontVariationClass:
-            return compareCSSValues<CSSFontVariationValue>(*this, other);
-        case FunctionClass:
-            return compareCSSValues<CSSFunctionValue>(*this, other);
-        case LinearGradientClass:
-            return compareCSSValues<CSSLinearGradientValue>(*this, other);
-        case RadialGradientClass:
-            return compareCSSValues<CSSRadialGradientValue>(*this, other);
-        case ConicGradientClass:
-            return compareCSSValues<CSSConicGradientValue>(*this, other);
-        case CrossfadeClass:
-            return compareCSSValues<CSSCrossfadeValue>(*this, other);
-        case ImageClass:
-            return compareCSSValues<CSSImageValue>(*this, other);
-        case GridAutoRepeatClass:
-            return compareCSSValues<CSSGridAutoRepeatValue>(*this, other);
-        case GridIntegerRepeatClass:
-            return compareCSSValues<CSSGridIntegerRepeatValue>(*this, other);
-        case GridLineNamesClass:
-            return compareCSSValues<CSSGridLineNamesValue>(*this, other);
-        case SubgridClass:
-            return compareCSSValues<CSSSubgridValue>(*this, other);
-        case GridTemplateAreasClass:
-            return compareCSSValues<CSSGridTemplateAreasValue>(*this, other);
-        case PrimitiveClass:
-            return compareCSSValues<CSSPrimitiveValue>(*this, other);
-        case ReflectClass:
-            return compareCSSValues<CSSReflectValue>(*this, other);
-        case ShadowClass:
-            return compareCSSValues<CSSShadowValue>(*this, other);
-        case CubicBezierTimingFunctionClass:
-            return compareCSSValues<CSSCubicBezierTimingFunctionValue>(*this, other);
-        case StepsTimingFunctionClass:
-            return compareCSSValues<CSSStepsTimingFunctionValue>(*this, other);
-        case SpringTimingFunctionClass:
-            return compareCSSValues<CSSSpringTimingFunctionValue>(*this, other);
-        case UnicodeRangeClass:
-            return compareCSSValues<CSSUnicodeRangeValue>(*this, other);
-        case ValueListClass:
-            return compareCSSValues<CSSValueList>(*this, other);
-        case LineBoxContainClass:
-            return compareCSSValues<CSSLineBoxContainValue>(*this, other);
-        case CalculationClass:
-            return compareCSSValues<CSSCalcValue>(*this, other);
-        case ImageSetClass:
-            return compareCSSValues<CSSImageSetValue>(*this, other);
-        case CSSContentDistributionClass:
-            return compareCSSValues<CSSContentDistributionValue>(*this, other);
-        case CustomPropertyClass:
-            return compareCSSValues<CSSCustomPropertyValue>(*this, other);
-        case VariableReferenceClass:
-            return compareCSSValues<CSSVariableReferenceValue>(*this, other);
-        case PendingSubstitutionValueClass:
-            return compareCSSValues<CSSPendingSubstitutionValue>(*this, other);
-        case OffsetRotateClass:
-            return compareCSSValues<CSSOffsetRotateValue>(*this, other);
-        case RayClass:
-            return compareCSSValues<CSSRayValue>(*this, other);
-        case FontStyleClass:
-            return compareCSSValues<CSSFontStyleValue>(*this, other);
-        case FontStyleRangeClass:
-            return compareCSSValues<CSSFontStyleRangeValue>(*this, other);
-        default:
-            ASSERT_NOT_REACHED();
-            return false;
-        }
-    } else if (is<CSSValueList>(*this) && !is<CSSValueList>(other))
+    if (classType() == other.classType()) {
+        return visitDerived([&](auto& typedThis) {
+            return typedThis.equals(downcast<std::remove_reference_t<decltype(typedThis)>>(other));
+        });
+    }
+    if (is<CSSValueList>(*this) && !is<CSSValueList>(other))
         return downcast<CSSValueList>(*this).equals(other);
-    else if (!is<CSSValueList>(*this) && is<CSSValueList>(other))
-        return static_cast<const CSSValueList&>(other).equals(*this);
+    if (!is<CSSValueList>(*this) && is<CSSValueList>(other))
+        return downcast<CSSValueList>(other).equals(*this);
     return false;
 }
 
@@ -249,264 +234,33 @@ bool CSSValue::isCSSLocalURL(StringView relativeURL)
     return relativeURL.isEmpty() || relativeURL.startsWith('#');
 }
 
-String CSSValue::cssText(Document* document) const
+String CSSValue::cssText() const
 {
-    switch (classType()) {
-    case AspectRatioClass:
-        return downcast<CSSAspectRatioValue>(*this).customCSSText();
-    case BackgroundRepeatClass:
-        return downcast<CSSBackgroundRepeatValue>(*this).customCSSText();
-    case BorderImageSliceClass:
-        return downcast<CSSBorderImageSliceValue>(*this).customCSSText();
-    case BorderImageWidthClass:
-        return downcast<CSSBorderImageWidthValue>(*this).customCSSText();
-    case CanvasClass:
-        return downcast<CSSCanvasValue>(*this).customCSSText();
-    case NamedImageClass:
-        return downcast<CSSNamedImageValue>(*this).customCSSText();
-    case CursorImageClass:
-        return downcast<CSSCursorImageValue>(*this).customCSSText();
-    case FilterImageClass:
-        return downcast<CSSFilterImageValue>(*this).customCSSText();
-#if ENABLE(CSS_PAINTING_API)
-    case PaintImageClass:
-        return downcast<CSSPaintImageValue>(*this).customCSSText();
-#endif
-    case FontClass:
-        return downcast<CSSFontValue>(*this).customCSSText();
-    case FontFaceSrcClass:
-        return downcast<CSSFontFaceSrcValue>(*this).customCSSText();
-    case FontPaletteValuesOverrideColorsClass:
-        return downcast<CSSFontPaletteValuesOverrideColorsValue>(*this).customCSSText();
-    case FontFeatureClass:
-        return downcast<CSSFontFeatureValue>(*this).customCSSText();
-    case FontVariationClass:
-        return downcast<CSSFontVariationValue>(*this).customCSSText();
-    case FunctionClass:
-        return downcast<CSSFunctionValue>(*this).customCSSText(document);
-    case LinearGradientClass:
-        return downcast<CSSLinearGradientValue>(*this).customCSSText();
-    case RadialGradientClass:
-        return downcast<CSSRadialGradientValue>(*this).customCSSText();
-    case ConicGradientClass:
-        return downcast<CSSConicGradientValue>(*this).customCSSText();
-    case CrossfadeClass:
-        return downcast<CSSCrossfadeValue>(*this).customCSSText();
-    case ImageClass:
-        return downcast<CSSImageValue>(*this).customCSSText();
-    case GridAutoRepeatClass:
-        return downcast<CSSGridAutoRepeatValue>(*this).customCSSText();
-    case GridIntegerRepeatClass:
-        return downcast<CSSGridIntegerRepeatValue>(*this).customCSSText();
-    case GridLineNamesClass:
-        return downcast<CSSGridLineNamesValue>(*this).customCSSText();
-    case SubgridClass:
-        return downcast<CSSSubgridValue>(*this).customCSSText();
-    case GridTemplateAreasClass:
-        return downcast<CSSGridTemplateAreasValue>(*this).customCSSText();
-    case PrimitiveClass:
-        return downcast<CSSPrimitiveValue>(*this).customCSSText(document);
-    case ReflectClass:
-        return downcast<CSSReflectValue>(*this).customCSSText();
-    case ShadowClass:
-        return downcast<CSSShadowValue>(*this).customCSSText();
-    case CubicBezierTimingFunctionClass:
-        return downcast<CSSCubicBezierTimingFunctionValue>(*this).customCSSText();
-    case StepsTimingFunctionClass:
-        return downcast<CSSStepsTimingFunctionValue>(*this).customCSSText();
-    case SpringTimingFunctionClass:
-        return downcast<CSSSpringTimingFunctionValue>(*this).customCSSText();
-    case UnicodeRangeClass:
-        return downcast<CSSUnicodeRangeValue>(*this).customCSSText();
-    case ValueListClass:
-        return downcast<CSSValueList>(*this).customCSSText(document);
-    case ValuePairClass:
-        return downcast<CSSValuePair>(*this).customCSSText();
-    case LineBoxContainClass:
-        return downcast<CSSLineBoxContainValue>(*this).customCSSText();
-    case CalculationClass:
-        return downcast<CSSCalcValue>(*this).customCSSText();
-    case ImageSetClass:
-        return downcast<CSSImageSetValue>(*this).customCSSText();
-    case CSSContentDistributionClass:
-        return downcast<CSSContentDistributionValue>(*this).customCSSText();
-    case CustomPropertyClass:
-        return downcast<CSSCustomPropertyValue>(*this).customCSSText();
-    case VariableReferenceClass:
-        return downcast<CSSVariableReferenceValue>(*this).customCSSText();
-    case PendingSubstitutionValueClass:
-        return downcast<CSSPendingSubstitutionValue>(*this).customCSSText();
-    case OffsetRotateClass:
-        return downcast<CSSOffsetRotateValue>(*this).customCSSText();
-    case RayClass:
-        return downcast<CSSRayValue>(*this).customCSSText();
-    case FontStyleClass:
-        return downcast<CSSFontStyleValue>(*this).customCSSText();
-    case FontStyleRangeClass:
-        return downcast<CSSFontStyleRangeValue>(*this).customCSSText();
-    }
-
-    ASSERT_NOT_REACHED();
-    return String();
+    return visitDerived([](auto& value) {
+        return value.customCSSText();
+    });
 }
 
-ASCIILiteral CSSValue::separatorCSSText() const
+ASCIILiteral CSSValue::separatorCSSText(ValueSeparator separator)
 {
-    switch (m_valueSeparator) {
+    switch (separator) {
     case SpaceSeparator:
         return " "_s;
     case CommaSeparator:
         return ", "_s;
     case SlashSeparator:
         return " / "_s;
-    default:
-        ASSERT_NOT_REACHED();
     }
+    ASSERT_NOT_REACHED();
     return " "_s;
 }
 
-void CSSValue::destroy()
+void CSSValue::operator delete(CSSValue* value, std::destroying_delete_t)
 {
-    switch (classType()) {
-    case AspectRatioClass:
-        delete downcast<CSSAspectRatioValue>(this);
-        return;
-    case BackgroundRepeatClass:
-        delete downcast<CSSBackgroundRepeatValue>(this);
-        return;
-    case BorderImageSliceClass:
-        delete downcast<CSSBorderImageSliceValue>(this);
-        return;
-    case BorderImageWidthClass:
-        delete downcast<CSSBorderImageWidthValue>(this);
-        return;
-    case CanvasClass:
-        delete downcast<CSSCanvasValue>(this);
-        return;
-    case NamedImageClass:
-        delete downcast<CSSNamedImageValue>(this);
-        return;
-    case CursorImageClass:
-        delete downcast<CSSCursorImageValue>(this);
-        return;
-    case FontClass:
-        delete downcast<CSSFontValue>(this);
-        return;
-    case FontFaceSrcClass:
-        delete downcast<CSSFontFaceSrcValue>(this);
-        return;
-    case FontPaletteValuesOverrideColorsClass:
-        delete downcast<CSSFontPaletteValuesOverrideColorsValue>(this);
-        return;
-    case FontFeatureClass:
-        delete downcast<CSSFontFeatureValue>(this);
-        return;
-    case FontVariationClass:
-        delete downcast<CSSFontVariationValue>(this);
-        return;
-    case FunctionClass:
-        delete downcast<CSSFunctionValue>(this);
-        return;
-    case LinearGradientClass:
-        delete downcast<CSSLinearGradientValue>(this);
-        return;
-    case RadialGradientClass:
-        delete downcast<CSSRadialGradientValue>(this);
-        return;
-    case ConicGradientClass:
-        delete downcast<CSSConicGradientValue>(this);
-        return;
-    case CrossfadeClass:
-        delete downcast<CSSCrossfadeValue>(this);
-        return;
-    case ImageClass:
-        delete downcast<CSSImageValue>(this);
-        return;
-    case GridAutoRepeatClass:
-        delete downcast<CSSGridAutoRepeatValue>(this);
-        return;
-    case GridIntegerRepeatClass:
-        delete downcast<CSSGridIntegerRepeatValue>(this);
-        return;
-    case GridLineNamesClass:
-        delete downcast<CSSGridLineNamesValue>(this);
-        return;
-    case SubgridClass:
-        delete downcast<CSSSubgridValue>(this);
-        return;
-    case GridTemplateAreasClass:
-        delete downcast<CSSGridTemplateAreasValue>(this);
-        return;
-    case PrimitiveClass:
-        delete downcast<CSSPrimitiveValue>(this);
-        return;
-    case ReflectClass:
-        delete downcast<CSSReflectValue>(this);
-        return;
-    case ShadowClass:
-        delete downcast<CSSShadowValue>(this);
-        return;
-    case CubicBezierTimingFunctionClass:
-        delete downcast<CSSCubicBezierTimingFunctionValue>(this);
-        return;
-    case StepsTimingFunctionClass:
-        delete downcast<CSSStepsTimingFunctionValue>(this);
-        return;
-    case SpringTimingFunctionClass:
-        delete downcast<CSSSpringTimingFunctionValue>(this);
-        return;
-    case UnicodeRangeClass:
-        delete downcast<CSSUnicodeRangeValue>(this);
-        return;
-    case ValueListClass:
-        delete downcast<CSSValueList>(this);
-        return;
-    case ValuePairClass:
-        delete downcast<CSSValuePair>(this);
-        return;
-    case LineBoxContainClass:
-        delete downcast<CSSLineBoxContainValue>(this);
-        return;
-    case CalculationClass:
-        delete downcast<CSSCalcValue>(this);
-        return;
-    case ImageSetClass:
-        delete downcast<CSSImageSetValue>(this);
-        return;
-    case FilterImageClass:
-        delete downcast<CSSFilterImageValue>(this);
-        return;
-#if ENABLE(CSS_PAINTING_API)
-    case PaintImageClass:
-        delete downcast<CSSPaintImageValue>(this);
-        return;
-#endif
-    case CSSContentDistributionClass:
-        delete downcast<CSSContentDistributionValue>(this);
-        return;
-    case CustomPropertyClass:
-        delete downcast<CSSCustomPropertyValue>(this);
-        return;
-    case VariableReferenceClass:
-        delete downcast<CSSVariableReferenceValue>(this);
-        return;
-    case PendingSubstitutionValueClass:
-        delete downcast<CSSPendingSubstitutionValue>(this);
-        return;
-    case OffsetRotateClass:
-        delete downcast<CSSOffsetRotateValue>(this);
-        return;
-    case RayClass:
-        delete downcast<CSSRayValue>(this);
-        return;
-    case FontStyleClass:
-        delete downcast<CSSFontStyleValue>(this);
-        return;
-    case FontStyleRangeClass:
-        delete downcast<CSSFontStyleRangeValue>(this);
-        return;
-    }
-    ASSERT_NOT_REACHED();
+    value->visitDerived([](auto& value) {
+        std::destroy_at(&value);
+    });
+    freeAfterDestruction(value);
 }
 
 Ref<DeprecatedCSSOMValue> CSSValue::createDeprecatedCSSOMWrapper(CSSStyleDeclaration& styleDeclaration) const

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -1,6 +1,6 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -25,10 +25,6 @@
 #include <wtf/Vector.h>
 
 namespace WebCore {
-
-class CSSCustomPropertyValue;
-struct CSSParserValue;
-class CSSParserValueList;
 
 class CSSValueList : public CSSValue {
 public:
@@ -66,13 +62,14 @@ public:
     bool hasValue(CSSValue*) const;
     Ref<CSSValueList> copy();
 
-    String customCSSText(Document* = nullptr) const;
+    String customCSSText() const;
     bool equals(const CSSValueList&) const;
     bool equals(const CSSValue&) const;
 
-    bool traverseSubresources(const Function<bool(const CachedResource&)>& handler) const;
+    bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
 
-    unsigned separator() const { return m_valueSeparator; }
+    using CSSValue::separator;
+    using CSSValue::separatorCSSText;
 
 protected:
     CSSValueList(ClassType, ValueSeparator);

--- a/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.h
+++ b/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.h
@@ -87,16 +87,16 @@ public:
 
     String stringValue() const { return m_value->stringValue(); }
     bool isCSSWideKeyword() const { return m_value->isCSSWideKeyword(); }
-    unsigned cssValueType() const { return m_value->cssValueType(); }
+    static unsigned short cssValueType() { return CSS_PRIMITIVE_VALUE; }
 
 private:
     DeprecatedCSSOMPrimitiveValue(const CSSPrimitiveValue& value, CSSStyleDeclaration& owner)
-        : DeprecatedCSSOMValue(DeprecatedPrimitiveValueClass, owner)
-        , m_value(const_cast<CSSPrimitiveValue&>(value))
+        : DeprecatedCSSOMValue(ClassType::Primitive, owner)
+        , m_value(value)
     {
     }
 
-    Ref<CSSPrimitiveValue> m_value;
+    Ref<const CSSPrimitiveValue> m_value;
 };
     
 } // namespace WebCore

--- a/Source/WebCore/css/DeprecatedCSSOMValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMValue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,34 +31,30 @@
 
 namespace WebCore {
 
-void DeprecatedCSSOMValue::destroy()
+void DeprecatedCSSOMValue::operator delete(DeprecatedCSSOMValue* value, std::destroying_delete_t)
 {
-    switch (classType()) {
-    case DeprecatedComplexValueClass: {
-        delete downcast<DeprecatedCSSOMComplexValue>(this);
-        return;
+    switch (value->classType()) {
+    case ClassType::Complex:
+        std::destroy_at(downcast<DeprecatedCSSOMComplexValue>(value));
+        break;
+    case ClassType::Primitive:
+        std::destroy_at(downcast<DeprecatedCSSOMPrimitiveValue>(value));
+        break;
+    case ClassType::List:
+        std::destroy_at(downcast<DeprecatedCSSOMValueList>(value));
+        break;
     }
-    case DeprecatedPrimitiveValueClass: {
-        delete downcast<DeprecatedCSSOMPrimitiveValue>(this);
-        return;
-    }
-    case DeprecatedValueListClass: {
-        delete downcast<DeprecatedCSSOMValueList>(this);
-        return;
-    }
-    }
-    ASSERT_NOT_REACHED();
-    delete this;
+    freeAfterDestruction(value);
 }
 
-unsigned DeprecatedCSSOMValue::cssValueType() const
+unsigned short DeprecatedCSSOMValue::cssValueType() const
 {
-    switch (m_classType) {
-    case DeprecatedComplexValueClass:
+    switch (classType()) {
+    case ClassType::Complex:
         return downcast<DeprecatedCSSOMComplexValue>(*this).cssValueType();
-    case DeprecatedPrimitiveValueClass:
+    case ClassType::Primitive:
         return downcast<DeprecatedCSSOMPrimitiveValue>(*this).cssValueType();
-    case DeprecatedValueListClass:
+    case ClassType::List:
         return CSS_VALUE_LIST;
     }
     ASSERT_NOT_REACHED();
@@ -67,16 +63,34 @@ unsigned DeprecatedCSSOMValue::cssValueType() const
 
 String DeprecatedCSSOMValue::cssText() const
 {
-    switch (m_classType) {
-    case DeprecatedComplexValueClass:
+    switch (classType()) {
+    case ClassType::Complex:
         return downcast<DeprecatedCSSOMComplexValue>(*this).cssText();
-    case DeprecatedPrimitiveValueClass:
+    case ClassType::Primitive:
         return downcast<DeprecatedCSSOMPrimitiveValue>(*this).cssText();
-    case DeprecatedValueListClass:
+    case ClassType::List:
         return downcast<DeprecatedCSSOMValueList>(*this).cssText();
     }
     ASSERT_NOT_REACHED();
     return emptyString();
+}
+
+unsigned short DeprecatedCSSOMComplexValue::cssValueType() const
+{
+    // These values are exposed in the DOM, but constants for them are not.
+    constexpr unsigned short CSS_INITIAL = 4;
+    constexpr unsigned short CSS_UNSET = 5;
+    constexpr unsigned short CSS_REVERT = 6;
+
+    if (m_value->isInheritValue())
+        return CSS_INHERIT;
+    if (m_value->isInitialValue())
+        return CSS_INITIAL;
+    if (m_value->isUnsetValue())
+        return CSS_UNSET;
+    if (m_value->isRevertValue())
+        return CSS_REVERT;
+    return CSS_CUSTOM;
 }
 
 }

--- a/Source/WebCore/css/DeprecatedCSSOMValueList.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMValueList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,25 +32,11 @@ namespace WebCore {
 
 String DeprecatedCSSOMValueList::cssText() const
 {
-    const char* separator;
-    switch (m_valueSeparator) {
-    case CSSValue::SpaceSeparator:
-        separator = " ";
-        break;
-    case CSSValue::CommaSeparator:
-        separator = ", ";
-        break;
-    case CSSValue::SlashSeparator:
-        separator = " / ";
-        break;
-    default:
-        ASSERT_NOT_REACHED();
-        separator = "";
-    }
-    
+    auto prefix = ""_s;
+    auto separator = CSSValueList::separatorCSSText(static_cast<CSSValueList::ValueSeparator>(m_valueSeparator));
     StringBuilder result;
     for (auto& value : m_values)
-        result.append(result.isEmpty() ? "" : separator, value.get().cssText());
+        result.append(std::exchange(prefix, separator), value.get().cssText());
     return result.toString();
 }
 

--- a/Source/WebCore/css/DeprecatedCSSOMValueList.h
+++ b/Source/WebCore/css/DeprecatedCSSOMValueList.h
@@ -32,26 +32,24 @@ namespace WebCore {
     
 class DeprecatedCSSOMValueList : public DeprecatedCSSOMValue {
 public:
-    static Ref<DeprecatedCSSOMValueList> create(const CSSValueList& value, CSSStyleDeclaration& owner)
+    static Ref<DeprecatedCSSOMValueList> create(const CSSValueList& values, CSSStyleDeclaration& owner)
     {
-        return adoptRef(*new DeprecatedCSSOMValueList(value, owner));
+        return adoptRef(*new DeprecatedCSSOMValueList(values, owner));
     }
-    
+
     String cssText() const;
-    
+
     size_t length() const { return m_values.size(); }
     DeprecatedCSSOMValue* item(size_t index) { return index < m_values.size() ? m_values[index].ptr() : nullptr; }
 
 private:
-    DeprecatedCSSOMValueList(const CSSValueList& value, CSSStyleDeclaration& owner)
-        : DeprecatedCSSOMValue(DeprecatedValueListClass, owner)
+    DeprecatedCSSOMValueList(const CSSValueList& values, CSSStyleDeclaration& owner)
+        : DeprecatedCSSOMValue(ClassType::List, owner)
+        , m_values(WTF::map(values, [&](auto& value) { return value->createDeprecatedCSSOMWrapper(owner); }))
     {
-        m_valueSeparator = value.separator();
-        m_values.reserveInitialCapacity(value.length());
-        for (unsigned i = 0, size = value.length(); i < size; ++i)
-            m_values.uncheckedAppend(value.itemWithoutBoundsCheck(i)->createDeprecatedCSSOMWrapper(owner));
+        m_valueSeparator = values.separator();
     }
-    
+
     Vector<Ref<DeprecatedCSSOMValue>, 4> m_values;
 };
 

--- a/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
+++ b/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
@@ -33,6 +33,7 @@
 #include "JSDOMWindowBase.h"
 #include "MutationObserverInterestGroup.h"
 #include "MutationRecord.h"
+#include "Quirks.h"
 #include "StyleProperties.h"
 #include "StyleSheetContents.h"
 #include "StyledElement.h"
@@ -317,16 +318,16 @@ String PropertySetCSSStyleDeclaration::getPropertyValueInternal(CSSPropertyID pr
     if (!propertyID || !isCSSPropertyExposed(propertyID))
         return { };
 
-    Document* doc = nullptr;
-    JSDOMObject* wrap = wrapper();
-    if (wrap) {
-        JSDOMGlobalObject* global = wrap->globalObject();
-        if (global) {
-            DOMWindow& window = activeDOMWindow(*global);
-            doc = window.document();
+    if (auto* wrapper = this->wrapper()) {
+        if (auto* globalObject = wrapper->globalObject()) {
+            if (auto* document = activeDOMWindow(*globalObject).document())
+                CSSPrimitiveValue::setUseLegacyPrecision(document->quirks().needsFlightAwareSerializationQuirk());
         }
     }
-    String value = m_propertySet->getPropertyValue(propertyID, doc);
+
+    auto value = m_propertySet->getPropertyValue(propertyID);
+
+    CSSPrimitiveValue::setUseLegacyPrecision(false);
 
     if (!value.isEmpty())
         return value;

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -179,7 +179,7 @@ bool StyleProperties::shorthandHasVariableReference(CSSPropertyID propertyID, St
     return false;
 }
 
-String StyleProperties::getPropertyValue(CSSPropertyID propertyID, Document* document) const
+String StyleProperties::getPropertyValue(CSSPropertyID propertyID) const
 {
     if (auto value = getPropertyCSSValue(propertyID)) {
         switch (propertyID) {
@@ -193,7 +193,7 @@ String StyleProperties::getPropertyValue(CSSPropertyID propertyID, Document* doc
                 return makeString(downcast<CSSPrimitiveValue>(*value).doubleValue() / 100);
             FALLTHROUGH;
         default:
-            return value->cssText(document);
+            return value->cssText();
         }
     }
 

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -90,7 +90,7 @@ public:
     PropertyReference propertyAt(unsigned) const;
 
     WEBCORE_EXPORT RefPtr<CSSValue> getPropertyCSSValue(CSSPropertyID) const;
-    WEBCORE_EXPORT String getPropertyValue(CSSPropertyID, Document* = nullptr) const;
+    WEBCORE_EXPORT String getPropertyValue(CSSPropertyID) const;
 
     WEBCORE_EXPORT std::optional<Color> propertyAsColor(CSSPropertyID) const;
     WEBCORE_EXPORT CSSValueID propertyAsValueID(CSSPropertyID) const;

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -34,6 +34,8 @@
 
 namespace WebCore {
 
+class StyleSheetContents;
+
 // A CSSParserTokenRange is an iterator over a subrange of a vector of CSSParserTokens.
 // Accessing outside of the range will return an endless stream of EOF tokens.
 // This class refers to half-open intervals [first, last).

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -30,11 +30,9 @@
 
 namespace WebCore {
 
+class CSSCustomPropertyValue;
 class CSSProperty;
-class CSSValue;
-class CSSValueList;
 class StylePropertyShorthand;
-class StyleSheetContents;
 
 namespace Style {
 class BuilderState;

--- a/Source/WebCore/css/typedom/CSSNumericValue.h
+++ b/Source/WebCore/css/typedom/CSSNumericValue.h
@@ -30,7 +30,7 @@
 #include "CSSNumericType.h"
 #include "CSSStyleValue.h"
 #include <variant>
-#include <wtf/FixedVector.h>
+#include <wtf/HashMap.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/typedom/numeric/CSSMathMax.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathMax.cpp
@@ -32,6 +32,7 @@
 
 #include "ExceptionOr.h"
 #include <wtf/Algorithms.h>
+#include <wtf/FixedVector.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/css/typedom/numeric/CSSMathProduct.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathProduct.cpp
@@ -31,6 +31,7 @@
 #include "CSSMathInvert.h"
 #include "CSSNumericArray.h"
 #include "ExceptionOr.h"
+#include <wtf/FixedVector.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/typedom/numeric/CSSMathSum.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathSum.cpp
@@ -32,6 +32,7 @@
 #include "CSSNumericArray.h"
 #include "ExceptionOr.h"
 #include <wtf/Algorithms.h>
+#include <wtf/FixedVector.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/style/StyleCustomPropertyData.h
+++ b/Source/WebCore/rendering/style/StyleCustomPropertyData.h
@@ -22,13 +22,14 @@
 #pragma once
 
 #include "CSSCustomPropertyValue.h"
-#include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {
+
+using CustomPropertyValueMap = HashMap<AtomString, RefPtr<CSSCustomPropertyValue>>;
 
 class StyleCustomPropertyData : public RefCounted<StyleCustomPropertyData> {
 public:


### PR DESCRIPTION
#### ca08a222c8067db9d4795eb81f714274df666485
<pre>
Use destroying delete for CSSValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=244997">https://bugs.webkit.org/show_bug.cgi?id=244997</a>
rdar://problem/99753615

Reviewed by Yusuke Suzuki and Sam Weinig.

* Source/JavaScriptCore/runtime/TemporalPlainDate.cpp: Fixed mistake in
copyright comment.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj: Added CSSValuePair.h/cpp to
project file. Without this, the build didn&apos;t properly handle dependencies.

* Source/WebCore/css/CSSCrossfadeValue.cpp:
(WebCore::CSSCrossfadeValue::customTraverseSubresources const): Renamed
from traverseSubresources, wrote with logical operators instead of if statements.
* Source/WebCore/css/CSSCrossfadeValue.h: Updated for above.
* Source/WebCore/css/CSSFilterImageValue.cpp:
(WebCore::CSSFilterImageValue::customTraverseSubresources const): Ditto.
* Source/WebCore/css/CSSFilterImageValue.h: Ditto.
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcValue::customTraverseSubresources const): Ditto.
* Source/WebCore/css/CSSFontFaceSrcValue.h: Ditto.

* Source/WebCore/css/CSSFunctionValue.cpp:
(WebCore::CSSFunctionValue::customCSSText const): Removed document argument
and moved to makeString instead of StringBuilder.
* Source/WebCore/css/CSSFunctionValue.h: Updated for above.
* Source/WebCore/css/CSSGridAutoRepeatValue.cpp:
(WebCore::CSSGridAutoRepeatValue::customCSSText const): Ditto.
* Source/WebCore/css/CSSGridIntegerRepeatValue.cpp:
(WebCore::CSSGridIntegerRepeatValue::customCSSText const): Ditto.
* Source/WebCore/css/CSSGridLineNamesValue.cpp:
(WebCore::CSSGridLineNamesValue::customCSSText const): Ditto.

* Source/WebCore/css/CSSImageSetValue.cpp:
(WebCore::CSSImageSetValue::customTraverseSubresources const): Renamed
from traverseSubresources, wrote with logical operators instead of if statements.
* Source/WebCore/css/CSSImageSetValue.h: Updated for above.
* Source/WebCore/css/CSSImageValue.cpp:
(WebCore::CSSImageValue::customTraverseSubresources const): Ditto.
* Source/WebCore/css/CSSImageValue.h: Ditto.

* Source/WebCore/css/CSSPrimitiveValue.cpp: Added global for the legacy
precision quirk. Since CSS serialization already depends on the CSS pool
global, this doesn&apos;t add any new problems, and side steps some complexity
where some customCSSText functions need document pointers and others do not.
(WebCore::CSSPrimitiveValue::customCSSText const): Removed document pointer
and use the global to figure out whether the legacy precison quirk is needed.
* Source/WebCore/css/CSSPrimitiveValue.h: Updated for above.

* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::visitDerived): Added a function template that lets us
use the visitor pattern to implement many functions below.
(WebCore::CSSValue::visitDerived const): Ditto.
(WebCore::CSSValue::cssValueType const): Deleted. This can be done entirely
in the deprecated CSS value classes and need not be here.
(WebCore::CSSValue::traverseSubresources const): Use visitDerived and
customTraverseSubresources. In passing, &quot;accidentally&quot; fixed a bug where
CSSImageSetValue::traverseSubresources would never have been called, since
CSSImageSetValue derives from CSSValueList.
(WebCore::compareCSSValues): Deleted.
(WebCore::CSSValue::equals const): Use visitDerived. No longer need the
compareCSSValues helper.
(WebCore::CSSValue::cssText const): Removed the document argument. Use
visitDerived.
(WebCore::CSSValue::separatorCSSText): Changed to take a separator argument
so this can be shared with DeprecatedCSSOMValueList.
(WebCore::CSSValue::operator delete): Added, replacing the
destroy function. Use visitDerived, std::destroy_at and freeAfterDestruction.
(WebCore::CSSValue::destroy): Deleted.

* Source/WebCore/css/CSSValue.h: Removed Type and cssValueType. Moved the
body of the deref function out of the class definition, and made it use
delete instead of a destroy function. Removed the document argument to
cssText and made separatorCSSText protected since it&apos;s only for CSSValueList
and CSSValuePair. Replaced the destroy function with a destroying delete
implementation. Added a base version of customTraverseSubresources that
just returns false, made it private since it&apos;s only intended to be called
by the implementation of traverseSubresources.

* Source/WebCore/css/CSSValueList.cpp:
(WebCore::CSSValueList::customCSSText const): Removed document argument
and tweaked the implementation to use std::exchange instead of checking
StringBuilder::isEmpty.
(WebCore::CSSValueList::customTraverseSubresources const): Renamed
from traverseSubresources, use a modern for loop.

* Source/WebCore/css/CSSValueList.h: Updated for above changes. Also
made separator and separatorCSSText public here, leaving them protected
in the base class.

* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.h: Changed cssValueType
to return unsigned short to match the IDL file. Updated for ClassType changes.
Use Ref&lt;const&gt; instead of a const_cast.

* Source/WebCore/css/DeprecatedCSSOMValue.cpp:
(WebCore::DeprecatedCSSOMValue::operator delete): Added, replacing the
destroy function. Use std::destroy_at and freeAfterDestruction.
(WebCore::DeprecatedCSSOMValue::cssValueType const): Updated for changes
to ClassType.
(WebCore::DeprecatedCSSOMValue::cssText const): Ditto.
(WebCore::DeprecatedCSSOMComplexValue::cssValueType const): Added.
This has the code that was previously in CSSValue::cssValueType, and
it&apos;s better to have it here, since it&apos;s specific to the deprecated CSSOM.

* Source/WebCore/css/DeprecatedCSSOMValue.h: Use unsigned short instead
of unsigned for cssValueType to match the IDL. Changed ClassType to
an enum class and gave the values short names. Use destroying delete
instead of a destroy function, which allows us to use the default deref
from RefCounted instead of having to write our own. Use Ref&lt;const&gt; instead
of a const_cast.

* Source/WebCore/css/DeprecatedCSSOMValueList.cpp:
(WebCore::DeprecatedCSSOMValueList::cssText const): Use the
CSSValueList::separatorCSSText function instead of repeating the code here
and tweaked the implementation to use std::exchange instead of checking
StringBuilder::isEmpty.

* Source/WebCore/css/DeprecatedCSSOMValueList.h: Use WTF::map
instead of CSSValueList::itemWithoutBoundsCheck.

* Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp:
(WebCore::PropertySetCSSStyleDeclaration::getPropertyValueInternal):
Call CSSPrimitiveValue::setUseLegacyPrecision here instead of passing
a document in.

* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::getPropertyValue const): Removed the document
argument that was used only for the legacy precision quirk.
* Source/WebCore/css/StyleProperties.h: Ditto.

Canonical link: <a href="https://commits.webkit.org/254846@main">https://commits.webkit.org/254846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77617640e3a3ab2ed88f12a89d19a55c2444d9d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99787 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157255 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33536 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28734 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82815 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96229 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96106 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26667 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77304 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26533 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69545 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82035 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34630 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15309 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76972 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32453 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16280 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26596 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3392 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39207 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/79558 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35369 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17435 "Passed tests") | 
<!--EWS-Status-Bubble-End-->