### PR TITLE
Remove `text` value for <color>

### DIFF
--- a/LayoutTests/css-dark-mode/color-scheme-css.html
+++ b/LayoutTests/css-dark-mode/color-scheme-css.html
@@ -5,7 +5,7 @@
 
 <style>
 #test1 {
-    color: text;
+    color: CanvasText;
 }
 </style>
 

--- a/LayoutTests/css-dark-mode/color-scheme-meta.html
+++ b/LayoutTests/css-dark-mode/color-scheme-meta.html
@@ -5,7 +5,7 @@
 
 <style>
 #test1 {
-    color: text;
+    color: CanvasText;
 }
 </style>
 

--- a/LayoutTests/css-dark-mode/color-scheme-priority.html
+++ b/LayoutTests/css-dark-mode/color-scheme-priority.html
@@ -6,7 +6,7 @@
 <style>
 #test1 {
     color-scheme: light dark;
-    color: text;
+    color: CanvasText;
 }
 </style>
 

--- a/LayoutTests/css-dark-mode/older-syntax/supported-color-schemes-css.html
+++ b/LayoutTests/css-dark-mode/older-syntax/supported-color-schemes-css.html
@@ -5,7 +5,7 @@
 
 <style>
 #test1 {
-    color: text;
+    color: CanvasText;
 }
 </style>
 

--- a/LayoutTests/css-dark-mode/older-syntax/supported-color-schemes-meta.html
+++ b/LayoutTests/css-dark-mode/older-syntax/supported-color-schemes-meta.html
@@ -5,7 +5,7 @@
 
 <style>
 #test1 {
-    color: text;
+    color: CanvasText;
 }
 </style>
 

--- a/LayoutTests/css-dark-mode/older-systems/color-scheme-css.html
+++ b/LayoutTests/css-dark-mode/older-systems/color-scheme-css.html
@@ -5,7 +5,7 @@
 
 <style>
 #test1 {
-    color: text;
+    color: CanvasText;
 }
 </style>
 

--- a/LayoutTests/css-dark-mode/older-systems/color-scheme-meta.html
+++ b/LayoutTests/css-dark-mode/older-systems/color-scheme-meta.html
@@ -5,7 +5,7 @@
 
 <style>
 #test1 {
-    color: text;
+    color: CanvasText;
 }
 </style>
 

--- a/LayoutTests/css-dark-mode/older-systems/prefers-color-scheme.html
+++ b/LayoutTests/css-dark-mode/older-systems/prefers-color-scheme.html
@@ -6,7 +6,7 @@
 <style>
 div {
     background-color: red;
-    color: text;
+    color: CanvasText;
 }
 
 @media (prefers-color-scheme: light) {

--- a/LayoutTests/css-dark-mode/prefers-color-scheme.html
+++ b/LayoutTests/css-dark-mode/prefers-color-scheme.html
@@ -6,7 +6,7 @@
 <style>
 div {
     background-color: red;
-    color: text;
+    color: CanvasText;
 }
 
 @media (prefers-color-scheme: light) {

--- a/LayoutTests/css3/color-filters/color-filter-ignore-semantic-expected.html
+++ b/LayoutTests/css3/color-filters/color-filter-ignore-semantic-expected.html
@@ -18,7 +18,7 @@
     <body>
         <div class="test" style="background-color: rgb(0, 255, 255);"></div>
         <div class="test" style="background-color: rgb(0, 255, 255);"></div>
-        <div class="test" style="background-color: text"></div>
+        <div class="test" style="background-color: CanvasText"></div>
         <div class="test" style="background-color: highlight"></div>
         <div class="test" style="background-color: window"></div>
         <div class="test" style="background-color: -apple-system-text-background"></div>

--- a/LayoutTests/css3/color-filters/color-filter-ignore-semantic.html
+++ b/LayoutTests/css3/color-filters/color-filter-ignore-semantic.html
@@ -21,7 +21,7 @@
         <div class="test" style="background-color: rgb(255, 0, 0)"></div>
         <div class="test" style="background-color: red"></div>
         <!--Not filtered-->
-        <div class="test" style="background-color: text"></div>
+        <div class="test" style="background-color: CanvasText"></div>
         <div class="test" style="background-color: highlight"></div>
         <div class="test" style="background-color: window"></div>
         <div class="test" style="background-color: -apple-system-text-background"></div>

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -70,6 +70,7 @@ enum class SDKAlignedBehavior {
     NoMoviStarPlusCORSPreflightQuirk,
     NoPokerBrosBuiltInTagQuirk,
     NoShowModalDialog,
+    NoTextValueForCSSColor,
     NoTheSecretSocietyHiddenMysteryWindowOpenQuirk,
     NoTypedArrayAPIQuirk,
     NoUnconditionalUniversalSandboxExtension,

--- a/Source/WebCore/css/StyleColor.cpp
+++ b/Source/WebCore/css/StyleColor.cpp
@@ -35,6 +35,10 @@
 #include "HashTools.h"
 #include "RenderTheme.h"
 
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
+
 namespace WebCore {
 
 Color StyleColor::colorFromKeyword(CSSValueID keyword, OptionSet<StyleColorOptions> options)
@@ -70,11 +74,17 @@ bool StyleColor::isAbsoluteColorKeyword(CSSValueID id)
 bool StyleColor::isSystemColorKeyword(CSSValueID id)
 {
     // https://drafts.csswg.org/css-color-4/#css-system-colors
-    return (id >= CSSValueCanvas && id <= CSSValueInternalDocumentTextColor) || id == CSSValueText || isDeprecatedSystemColorKeyword(id);
+    return (id >= CSSValueCanvas && id <= CSSValueInternalDocumentTextColor) || isDeprecatedSystemColorKeyword(id);
 }
 
 bool StyleColor::isDeprecatedSystemColorKeyword(CSSValueID id)
 {
+    if (id == CSSValueText)
+#if PLATFORM(COCOA)
+        return !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoTextValueForCSSColor);
+#else
+        return false;
+#endif
     // https://drafts.csswg.org/css-color-4/#deprecated-system-colors
     return (id >= CSSValueActiveborder && id <= CSSValueWindowtext) || id == CSSValueMenu;
 }

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1422,10 +1422,6 @@ Color RenderTheme::systemColor(CSSValueID cssValueId, OptionSet<StyleColorOption
         return Color::black;
 
     // Non-standard addition.
-    case CSSValueText:
-        return Color::black;
-
-    // Non-standard addition.
     case CSSValueWebkitLink:
         return options.contains(StyleColorOptions::ForVisitedLink) ? SRGBA<uint8_t> { 85, 26, 139 } : SRGBA<uint8_t> { 0, 0, 238 };
 

--- a/Source/WebCore/rendering/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/RenderThemeAdwaita.cpp
@@ -269,7 +269,6 @@ Color RenderThemeAdwaita::systemColor(CSSValueID cssValueID, OptionSet<StyleColo
     case CSSValueFieldtext:
     case CSSValueInactivecaptiontext:
     case CSSValueInfotext:
-    case CSSValueText:
     case CSSValueWindowtext:
         return useDarkAppearance ? Color::white : Color::black;
 

--- a/Websites/bugs.webkit.org/PrettyPatch/PrettyPatch.rb
+++ b/Websites/bugs.webkit.org/PrettyPatch/PrettyPatch.rb
@@ -522,7 +522,7 @@ pre, .text {
 .LinkContainer label:after,
 .LinkContainer a:after {
   content: " | ";
-  color: text;
+  color: CanvasText;
 }
 
 .LinkContainer a:last-of-type:after {


### PR DESCRIPTION
#### 652bbee5458347ee036dee2f951cead08b527adf
<pre>
Remove `text` value for &lt;color&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=245626">https://bugs.webkit.org/show_bug.cgi?id=245626</a>
&lt;rdar://100364547&gt;

Reviewed by NOBODY (OOPS!).

`color: text` is non standard, and is equivalent to CanvasText. WebKit is the only browser engine that supports it.

Reject it at parse-time behind a linked on or after check for Cocoa platforms for backwards compat with apps, remove entire support for other platforms.

* LayoutTests/css-dark-mode/color-scheme-css.html:
* LayoutTests/css-dark-mode/color-scheme-meta.html:
* LayoutTests/css-dark-mode/color-scheme-priority.html:
* LayoutTests/css-dark-mode/older-syntax/supported-color-schemes-css.html:
* LayoutTests/css-dark-mode/older-syntax/supported-color-schemes-meta.html:
* LayoutTests/css-dark-mode/older-systems/color-scheme-css.html:
* LayoutTests/css-dark-mode/older-systems/color-scheme-meta.html:
* LayoutTests/css-dark-mode/older-systems/prefers-color-scheme.html:
* LayoutTests/css-dark-mode/prefers-color-scheme.html:
* LayoutTests/css3/color-filters/color-filter-ignore-semantic-expected.html:
* LayoutTests/css3/color-filters/color-filter-ignore-semantic.html:
* Source/WebCore/css/StyleColor.cpp:
(WebCore::StyleColor::isDeprecatedSystemColorKeyword):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::systemColor const):
* Source/WebCore/rendering/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::systemColor const):
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Websites/bugs.webkit.org/PrettyPatch/PrettyPatch.rb:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/652bbee5458347ee036dee2f951cead08b527adf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100239 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158755 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33997 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29034 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83268 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97073 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/27090 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77716 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26887 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69923 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82432 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35077 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15599 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77431 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32878 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16582 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26684 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39535 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80026 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35671 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17530 "Passed tests") | 
<!--EWS-Status-Bubble-End-->