### PR TITLE
[web-animations] additive/accumulative color blending fails to yield intermediary out-of-bounds values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
@@ -16,7 +16,7 @@ PASS background-attachment (type: discrete) has testAccumulation function
 PASS background-attachment: "local" onto "fixed"
 PASS background-attachment: "fixed" onto "local"
 PASS background-color (type: color) has testAccumulation function
-FAIL background-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS background-color supports animating as color of rgb() with overflowed  from and to values
 PASS background-color supports animating as color of #RGB
 PASS background-color supports animating as color of hsl()
 PASS background-color supports animating as color of #RGBa
@@ -38,7 +38,7 @@ PASS background-repeat (type: discrete) has testAccumulation function
 PASS background-repeat: "round" onto "space"
 PASS background-repeat: "space" onto "round"
 PASS border-bottom-color (type: color) has testAccumulation function
-FAIL border-bottom-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS border-bottom-color supports animating as color of rgb() with overflowed  from and to values
 PASS border-bottom-color supports animating as color of #RGB
 PASS border-bottom-color supports animating as color of hsl()
 PASS border-bottom-color supports animating as color of #RGBa
@@ -60,7 +60,7 @@ PASS border-image-source (type: discrete) has testAccumulation function
 PASS border-image-source: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS border-image-source: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"
 PASS border-left-color (type: color) has testAccumulation function
-FAIL border-left-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS border-left-color supports animating as color of rgb() with overflowed  from and to values
 PASS border-left-color supports animating as color of #RGB
 PASS border-left-color supports animating as color of hsl()
 PASS border-left-color supports animating as color of #RGBa
@@ -73,7 +73,7 @@ PASS border-left-width (type: length) has testAccumulation function
 PASS border-left-width: length
 PASS border-left-width: length of rem
 PASS border-right-color (type: color) has testAccumulation function
-FAIL border-right-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS border-right-color supports animating as color of rgb() with overflowed  from and to values
 PASS border-right-color supports animating as color of #RGB
 PASS border-right-color supports animating as color of hsl()
 PASS border-right-color supports animating as color of #RGBa
@@ -89,7 +89,7 @@ PASS border-spacing (type: lengthPair) has testAccumulation function
 PASS border-spacing: length pair
 PASS border-spacing: length pair of rem
 PASS border-top-color (type: color) has testAccumulation function
-FAIL border-top-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS border-top-color supports animating as color of rgb() with overflowed  from and to values
 PASS border-top-color supports animating as color of #RGB
 PASS border-top-color supports animating as color of hsl()
 PASS border-top-color supports animating as color of #RGBa
@@ -110,7 +110,7 @@ PASS caption-side (type: discrete) has testAccumulation function
 PASS caption-side: "bottom" onto "top"
 PASS caption-side: "top" onto "bottom"
 PASS caret-color (type: color) has testAccumulation function
-FAIL caret-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS caret-color supports animating as color of rgb() with overflowed  from and to values
 PASS caret-color supports animating as color of #RGB
 PASS caret-color supports animating as color of hsl()
 PASS caret-color supports animating as color of #RGBa
@@ -130,7 +130,7 @@ PASS clip-rule (type: discrete) has testAccumulation function
 PASS clip-rule: "nonzero" onto "evenodd"
 PASS clip-rule: "evenodd" onto "nonzero"
 PASS color (type: color) has testAccumulation function
-FAIL color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS color supports animating as color of rgb() with overflowed  from and to values
 PASS color supports animating as color of #RGB
 PASS color supports animating as color of hsl()
 PASS color supports animating as color of #RGBa
@@ -154,7 +154,7 @@ PASS column-gap (type: discrete) has testAccumulation function
 PASS column-gap: "200px" onto "normal"
 PASS column-gap: "normal" onto "200px"
 PASS column-rule-color (type: color) has testAccumulation function
-FAIL column-rule-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS column-rule-color supports animating as color of rgb() with overflowed  from and to values
 PASS column-rule-color supports animating as color of #RGB
 PASS column-rule-color supports animating as color of hsl()
 PASS column-rule-color supports animating as color of #RGBa
@@ -225,7 +225,7 @@ PASS flex-wrap (type: discrete) has testAccumulation function
 PASS flex-wrap: "wrap" onto "nowrap"
 PASS flex-wrap: "nowrap" onto "wrap"
 PASS flood-color (type: color) has testAccumulation function
-FAIL flood-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS flood-color supports animating as color of rgb() with overflowed  from and to values
 PASS flood-color supports animating as color of #RGB
 PASS flood-color supports animating as color of hsl()
 PASS flood-color supports animating as color of #RGBa

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -16,7 +16,7 @@ PASS letter-spacing (type: length) has testAccumulation function
 PASS letter-spacing: length
 PASS letter-spacing: length of rem
 PASS lighting-color (type: color) has testAccumulation function
-FAIL lighting-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS lighting-color supports animating as color of rgb() with overflowed  from and to values
 PASS lighting-color supports animating as color of #RGB
 PASS lighting-color supports animating as color of hsl()
 PASS lighting-color supports animating as color of #RGBa
@@ -85,7 +85,7 @@ PASS offset-distance: calc
 PASS order (type: integer) has testAccumulation function
 PASS order: integer
 PASS outline-color (type: color) has testAccumulation function
-FAIL outline-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS outline-color supports animating as color of rgb() with overflowed  from and to values
 PASS outline-color supports animating as color of #RGB
 PASS outline-color supports animating as color of hsl()
 PASS outline-color supports animating as color of #RGBa
@@ -150,7 +150,7 @@ PASS shape-rendering (type: discrete) has testAccumulation function
 PASS shape-rendering: "crispEdges" onto "optimizeSpeed"
 PASS shape-rendering: "optimizeSpeed" onto "crispEdges"
 PASS stop-color (type: color) has testAccumulation function
-FAIL stop-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS stop-color supports animating as color of rgb() with overflowed  from and to values
 PASS stop-color supports animating as color of #RGB
 PASS stop-color supports animating as color of hsl()
 PASS stop-color supports animating as color of #RGBa
@@ -188,7 +188,7 @@ PASS text-anchor (type: discrete) has testAccumulation function
 PASS text-anchor: "end" onto "middle"
 PASS text-anchor: "middle" onto "end"
 PASS text-decoration-color (type: color) has testAccumulation function
-FAIL text-decoration-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS text-decoration-color supports animating as color of rgb() with overflowed  from and to values
 PASS text-decoration-color supports animating as color of #RGB
 PASS text-decoration-color supports animating as color of hsl()
 PASS text-decoration-color supports animating as color of #RGBa
@@ -201,7 +201,7 @@ PASS text-decoration-style (type: discrete) has testAccumulation function
 PASS text-decoration-style: "dotted" onto "solid"
 PASS text-decoration-style: "solid" onto "dotted"
 PASS text-emphasis-color (type: color) has testAccumulation function
-FAIL text-emphasis-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS text-emphasis-color supports animating as color of rgb() with overflowed  from and to values
 PASS text-emphasis-color supports animating as color of #RGB
 PASS text-emphasis-color supports animating as color of hsl()
 PASS text-emphasis-color supports animating as color of #RGBa

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
@@ -16,7 +16,7 @@ PASS background-attachment (type: discrete) has testAddition function
 PASS background-attachment: "local" onto "fixed"
 PASS background-attachment: "fixed" onto "local"
 PASS background-color (type: color) has testAddition function
-FAIL background-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS background-color supports animating as color of rgb() with overflowed  from and to values
 PASS background-color supports animating as color of #RGB
 PASS background-color supports animating as color of hsl()
 PASS background-color supports animating as color of #RGBa
@@ -38,7 +38,7 @@ PASS background-repeat (type: discrete) has testAddition function
 PASS background-repeat: "round" onto "space"
 PASS background-repeat: "space" onto "round"
 PASS border-bottom-color (type: color) has testAddition function
-FAIL border-bottom-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS border-bottom-color supports animating as color of rgb() with overflowed  from and to values
 PASS border-bottom-color supports animating as color of #RGB
 PASS border-bottom-color supports animating as color of hsl()
 PASS border-bottom-color supports animating as color of #RGBa
@@ -60,7 +60,7 @@ PASS border-image-source (type: discrete) has testAddition function
 PASS border-image-source: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS border-image-source: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"
 PASS border-left-color (type: color) has testAddition function
-FAIL border-left-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS border-left-color supports animating as color of rgb() with overflowed  from and to values
 PASS border-left-color supports animating as color of #RGB
 PASS border-left-color supports animating as color of hsl()
 PASS border-left-color supports animating as color of #RGBa
@@ -73,7 +73,7 @@ PASS border-left-width (type: length) has testAddition function
 PASS border-left-width: length
 PASS border-left-width: length of rem
 PASS border-right-color (type: color) has testAddition function
-FAIL border-right-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS border-right-color supports animating as color of rgb() with overflowed  from and to values
 PASS border-right-color supports animating as color of #RGB
 PASS border-right-color supports animating as color of hsl()
 PASS border-right-color supports animating as color of #RGBa
@@ -89,7 +89,7 @@ PASS border-spacing (type: lengthPair) has testAddition function
 PASS border-spacing: length pair
 PASS border-spacing: length pair of rem
 PASS border-top-color (type: color) has testAddition function
-FAIL border-top-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS border-top-color supports animating as color of rgb() with overflowed  from and to values
 PASS border-top-color supports animating as color of #RGB
 PASS border-top-color supports animating as color of hsl()
 PASS border-top-color supports animating as color of #RGBa
@@ -110,7 +110,7 @@ PASS caption-side (type: discrete) has testAddition function
 PASS caption-side: "bottom" onto "top"
 PASS caption-side: "top" onto "bottom"
 PASS caret-color (type: color) has testAddition function
-FAIL caret-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS caret-color supports animating as color of rgb() with overflowed  from and to values
 PASS caret-color supports animating as color of #RGB
 PASS caret-color supports animating as color of hsl()
 PASS caret-color supports animating as color of #RGBa
@@ -130,7 +130,7 @@ PASS clip-rule (type: discrete) has testAddition function
 PASS clip-rule: "nonzero" onto "evenodd"
 PASS clip-rule: "evenodd" onto "nonzero"
 PASS color (type: color) has testAddition function
-FAIL color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS color supports animating as color of rgb() with overflowed  from and to values
 PASS color supports animating as color of #RGB
 PASS color supports animating as color of hsl()
 PASS color supports animating as color of #RGBa
@@ -154,7 +154,7 @@ PASS column-gap (type: discrete) has testAddition function
 PASS column-gap: "200px" onto "normal"
 PASS column-gap: "normal" onto "200px"
 PASS column-rule-color (type: color) has testAddition function
-FAIL column-rule-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS column-rule-color supports animating as color of rgb() with overflowed  from and to values
 PASS column-rule-color supports animating as color of #RGB
 PASS column-rule-color supports animating as color of hsl()
 PASS column-rule-color supports animating as color of #RGBa
@@ -225,7 +225,7 @@ PASS flex-wrap (type: discrete) has testAddition function
 PASS flex-wrap: "wrap" onto "nowrap"
 PASS flex-wrap: "nowrap" onto "wrap"
 PASS flood-color (type: color) has testAddition function
-FAIL flood-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS flood-color supports animating as color of rgb() with overflowed  from and to values
 PASS flood-color supports animating as color of #RGB
 PASS flood-color supports animating as color of hsl()
 PASS flood-color supports animating as color of #RGBa

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -16,7 +16,7 @@ PASS letter-spacing (type: length) has testAddition function
 PASS letter-spacing: length
 PASS letter-spacing: length of rem
 PASS lighting-color (type: color) has testAddition function
-FAIL lighting-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS lighting-color supports animating as color of rgb() with overflowed  from and to values
 PASS lighting-color supports animating as color of #RGB
 PASS lighting-color supports animating as color of hsl()
 PASS lighting-color supports animating as color of #RGBa
@@ -85,7 +85,7 @@ PASS offset-distance: calc
 PASS order (type: integer) has testAddition function
 PASS order: integer
 PASS outline-color (type: color) has testAddition function
-FAIL outline-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS outline-color supports animating as color of rgb() with overflowed  from and to values
 PASS outline-color supports animating as color of #RGB
 PASS outline-color supports animating as color of hsl()
 PASS outline-color supports animating as color of #RGBa
@@ -150,7 +150,7 @@ PASS shape-rendering (type: discrete) has testAddition function
 PASS shape-rendering: "crispEdges" onto "optimizeSpeed"
 PASS shape-rendering: "optimizeSpeed" onto "crispEdges"
 PASS stop-color (type: color) has testAddition function
-FAIL stop-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS stop-color supports animating as color of rgb() with overflowed  from and to values
 PASS stop-color supports animating as color of #RGB
 PASS stop-color supports animating as color of hsl()
 PASS stop-color supports animating as color of #RGBa
@@ -188,7 +188,7 @@ PASS text-anchor (type: discrete) has testAddition function
 PASS text-anchor: "end" onto "middle"
 PASS text-anchor: "middle" onto "end"
 PASS text-decoration-color (type: color) has testAddition function
-FAIL text-decoration-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS text-decoration-color supports animating as color of rgb() with overflowed  from and to values
 PASS text-decoration-color supports animating as color of #RGB
 PASS text-decoration-color supports animating as color of hsl()
 PASS text-decoration-color supports animating as color of #RGBa
@@ -201,7 +201,7 @@ PASS text-decoration-style (type: discrete) has testAddition function
 PASS text-decoration-style: "dotted" onto "solid"
 PASS text-decoration-style: "solid" onto "dotted"
 PASS text-emphasis-color (type: color) has testAddition function
-FAIL text-emphasis-color supports animating as color of rgb() with overflowed  from and to values assert_equals: The value should be rgb(255, 128, 255) at 500ms expected "rgb(255, 128, 255)" but got "rgb(192, 128, 192)"
+PASS text-emphasis-color supports animating as color of rgb() with overflowed  from and to values
 PASS text-emphasis-color supports animating as color of #RGB
 PASS text-emphasis-color supports animating as color of hsl()
 PASS text-emphasis-color supports animating as color of #RGBa


### PR DESCRIPTION
#### 35a0ba08385cfdc1e374a1622a229ccbe618f0ed
<pre>
[web-animations] additive/accumulative color blending fails to yield intermediary out-of-bounds values
<a href="https://bugs.webkit.org/show_bug.cgi?id=242185">https://bugs.webkit.org/show_bug.cgi?id=242185</a>
&lt;rdar://96593559&gt;

Reviewed by Antoine Quint.

Additive (and Accumulative, which is identical for colors) blending in web animations is
implemented by calling the blend function two extra times:

1. First to add the &apos;base&apos; color to the &apos;from&apos; color, giving us &apos;additive-from&apos;.
    e.g. blend(base, from, add-operation)
2. Second to add the &apos;base&apos; color to the &apos;to&apos; color, giving us the &apos;additive-to&apos;.
    e.g. blend(base, to, add-operation)

It then interpolates &apos;additive-from&apos; to &apos;additive-to&apos;, using the normal, &apos;replace&apos;, blend
path. Further, it expects &apos;additive-from&apos; and &apos;additive-to&apos; to be unclamped color values.

To support this scheme, the blend function for Color was updated to implement support for
the add operation, using a new addColorComponents helper (which is just a wrapper around
interpolatColorComponents that specifies 100% of each color) which uses ExtendedSRGBA to
avoid clamping. The normal, replace, blend path was changed to use the now standard color
interpolation function, interpolateColorComponents, which supports all interpolation methods
not just SRGB, to make it match convention. To maintain compatability with existing animmation
interpolation, the result of the replace blend is clipped to the sRGB gamut. This clipping
is suspect, but the tests currently require this. Additional discussion with the WG is
needed to deterimine the best path forward.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* Source/WebCore/platform/graphics/ColorBlending.cpp:
(WebCore::blend):
* Source/WebCore/platform/graphics/ColorInterpolation.h:
(WebCore::interpolateAlphaPremulitplied): Add a clamp, needed for the additive blend, as alpha &gt; 1 doesn&apos;t really make sense.
(WebCore::addColorComponents):

Canonical link: <a href="https://commits.webkit.org/254850@main">https://commits.webkit.org/254850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f9ba622761cf0f520c4bae17da63e54a3846691

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99747 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157212 "Found 1 new test failure: fast/workers/worker-crash-with-invalid-location.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33498 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28705 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82776 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96192 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26629 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77263 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26500 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69512 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34592 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15262 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32416 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16225 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3395 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39173 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35314 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->