### PR TITLE
Implement importmaps

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -651,7 +651,6 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/mo
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-origin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-same-origin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-unsafe-url.sub.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-importmap.html [ Skip ]
 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-keyboard-enter.html [ Skip ]
 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-keyboard-escape.html [ Skip ]
 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-mouse-left.html [ Skip ]
@@ -6057,3 +6056,9 @@ js/ShadowRealm-worker.html [ Pass Failure ]
 imported/w3c/web-platform-tests/svg/import/color-prop-05-t-manual.svg [ Skip ]
 svg/W3C-SVG-1.1-SE/color-prop-05-t.svg [ Skip ]
 
+# modulepreload is not supported
+imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html [ Skip ]
+imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html [ Skip ]
+
+# WPT meta name="variant" is not supported. And iframe 'load' event has a bug.
+imported/w3c/web-platform-tests/import-maps/data-driven/resolving.html [ Skip ]

--- a/LayoutTests/http/wpt/import-maps/data-driven/README.md
+++ b/LayoutTests/http/wpt/import-maps/data-driven/README.md
@@ -1,0 +1,87 @@
+# Data-driven import maps tests
+
+In this directory, test inputs and expectations are expressed as JSON files.
+This is in order to share the same JSON files between WPT tests and other
+implementations that might not run the full WPT suite, e.g. server-side
+JavaScript runtimes or the [JavaScript reference implementation](https://github.com/WICG/import-maps/tree/master/reference-implementation).
+
+## Basics
+
+A **test object** describes a set of parameters (import maps and base URLs) and test expectations.
+Test expectations consist of the expected resulting URLs for specifiers.
+
+Each JSON file under [resources/](resources/) directory consists of a test object.
+A minimum test object would be:
+
+```json
+{
+  "name": "Main test name",
+  "importMapBaseURL": "https://example.com/import-map-base-url/index.html",
+  "importMap": {
+    "imports": {
+      "a": "/mapped-a.mjs"
+    }
+  },
+  "baseURL": "https://example.com/base-url/app.mjs",
+  "expectedResults": {
+    "a": "https://example.com/mapped-a.mjs",
+    "b": null
+  }
+}
+```
+
+Required fields:
+
+- `name`: Test name.
+    - In WPT tests, this is used for the test name of `promise_test()` together with specifier to be resolved, like `"Main test name: a"`.
+- `importMap` (object or string): the import map to be attached.
+- `importMapBaseURL` (string): the base URL used for [parsing the import map](https://wicg.github.io/import-maps/#parse-an-import-map-string).
+- `expectedResults` (object; string to (string or null)): resolution test cases.
+    - The keys are specifiers to be resolved.
+    - The values are expected resolved URLs. If `null`, resolution should fail.
+- `baseURL` (string): the base URL used in [resolving a specifier](https://wicg.github.io/import-maps/#resolve-a-module-specifier) for each specifiers.
+
+Optional fields:
+
+- `link` and `details` can be used for e.g. linking to specs or adding more detailed descriptions.
+    - Currently they are simply ignored by the WPT test helper.
+
+## Nesting and inheritance
+
+We can organize tests by nesting test objects.
+A test object can contain child test objects (*subtests*) using `tests` field.
+The Keys of the `tests` value are the names of subtests, and values are test objects.
+
+For example:
+
+```json
+{
+  "name": "Main test name",
+  "importMapBaseURL": "https://example.com/import-map-base-url/index.html",
+  "importMap": {
+    "imports": {
+      "a": "/mapped-a.mjs"
+    }
+  },
+  "tests": {
+    "Subtest1": {
+      "baseURL": "https://example.com/base-url1/app.mjs",
+      "expectedResults": { "a": "https://example.com/mapped-a.mjs" }
+    },
+    "Subtest2": {
+      "baseURL": "https://example.com/base-url2/app.mjs",
+      "expectedResults": { "b": null }
+    }
+  }
+}
+```
+
+The top-level test object contains two sub test objects, named as `Subtest1` and `Subtest2`, respectively.
+
+Child test objects inherit fields from their parent test object.
+In the example above, the child test objects specifies `baseURL` fields, while they inherits other fields (e.g. `importMapBaseURL`) from the top-level test object.
+
+## TODO
+
+The `parsing-*.json` files are not currently used by the WPT harness. We should
+convert them to resolution tests.

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-data-url-prefix-expected.txt
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-data-url-prefix-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Test helper: fetching and sanity checking test JSON: data-url-prefix.json
+PASS data: URL prefix: should not resolve since you can't resolve relative to a data: URL: foo/bar
+

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-data-url-prefix.html
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-data-url-prefix.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script type="module">
+import { runTestsFromJSON } from "./resources/test-helper.js";
+
+const filename = "data-url-prefix.json";
+promise_test(
+  () => runTestsFromJSON('resources/' + filename),
+  "Test helper: fetching and sanity checking test JSON: " + filename);
+</script>

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-empty-import-map-expected.txt
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-empty-import-map-expected.txt
@@ -1,0 +1,34 @@
+
+
+PASS Test helper: fetching and sanity checking test JSON: empty-import-map.json
+PASS valid relative specifiers: ./foo
+PASS valid relative specifiers: ./foo/bar
+PASS valid relative specifiers: ./foo/../bar
+PASS valid relative specifiers: ./foo/../../bar
+PASS valid relative specifiers: ../foo
+PASS valid relative specifiers: ../foo/bar
+PASS valid relative specifiers: ../../../foo/bar
+PASS valid relative specifiers: /foo
+PASS valid relative specifiers: /foo/bar
+PASS valid relative specifiers: /../../foo/bar
+PASS valid relative specifiers: /../foo/../bar
+PASS HTTPS scheme absolute URLs: https://fetch-scheme.net
+PASS HTTPS scheme absolute URLs: https:fetch-scheme.org
+PASS HTTPS scheme absolute URLs: https://fetch%2Dscheme.com/
+PASS HTTPS scheme absolute URLs: https://///fetch-scheme.com///
+PASS valid relative URLs that are invalid as specifiers should fail: invalid-specifier
+PASS valid relative URLs that are invalid as specifiers should fail: \invalid-specifier
+PASS valid relative URLs that are invalid as specifiers should fail: :invalid-specifier
+PASS valid relative URLs that are invalid as specifiers should fail: @invalid-specifier
+PASS valid relative URLs that are invalid as specifiers should fail: %2E/invalid-specifier
+PASS valid relative URLs that are invalid as specifiers should fail: %2E%2E/invalid-specifier
+PASS valid relative URLs that are invalid as specifiers should fail: .%2Finvalid-specifier
+PASS invalid absolute URLs should fail: https://invalid-url.com:demo
+PASS invalid absolute URLs should fail: http://[invalid-url.com]/
+PASS non-HTTPS fetch scheme absolute URLs: about:fetch-scheme
+PASS non-fetch scheme absolute URLs: about:fetch-scheme
+PASS non-fetch scheme absolute URLs: mailto:non-fetch-scheme
+PASS non-fetch scheme absolute URLs: import:non-fetch-scheme
+PASS non-fetch scheme absolute URLs: javascript:non-fetch-scheme
+PASS non-fetch scheme absolute URLs: wss:non-fetch-scheme
+

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-empty-import-map.html
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-empty-import-map.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script type="module">
+import { runTestsFromJSON } from "./resources/test-helper.js";
+
+const filename = "empty-import-map.json";
+promise_test(
+  () => runTestsFromJSON('resources/' + filename),
+  "Test helper: fetching and sanity checking test JSON: " + filename);
+</script>

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-overlapping-entries-expected.txt
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-overlapping-entries-expected.txt
@@ -1,0 +1,10 @@
+
+
+PASS Test helper: fetching and sanity checking test JSON: overlapping-entries.json
+PASS should favor the most-specific key: Overlapping entries with trailing slashes: a
+PASS should favor the most-specific key: Overlapping entries with trailing slashes: a/
+PASS should favor the most-specific key: Overlapping entries with trailing slashes: a/x
+PASS should favor the most-specific key: Overlapping entries with trailing slashes: a/b
+PASS should favor the most-specific key: Overlapping entries with trailing slashes: a/b/
+PASS should favor the most-specific key: Overlapping entries with trailing slashes: a/b/c
+

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-overlapping-entries.html
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-overlapping-entries.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script type="module">
+import { runTestsFromJSON } from "./resources/test-helper.js";
+
+const filename = "overlapping-entries.json";
+promise_test(
+  () => runTestsFromJSON('resources/' + filename),
+  "Test helper: fetching and sanity checking test JSON: " + filename);
+</script>

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-packages-via-trailing-slashes-expected.txt
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-packages-via-trailing-slashes-expected.txt
@@ -1,0 +1,36 @@
+
+
+PASS Test helper: fetching and sanity checking test JSON: packages-via-trailing-slashes.json
+PASS Package-like scenarios: package main modules: moment
+PASS Package-like scenarios: package main modules: lodash-dot
+PASS Package-like scenarios: package main modules: lodash-dotdot
+PASS Package-like scenarios: package submodules: moment/foo
+PASS Package-like scenarios: package submodules: moment/foo?query
+PASS Package-like scenarios: package submodules: moment/foo#fragment
+PASS Package-like scenarios: package submodules: moment/foo?query#fragment
+PASS Package-like scenarios: package submodules: lodash-dot/foo
+PASS Package-like scenarios: package submodules: lodash-dotdot/foo
+PASS Package-like scenarios: package names that end in a slash should just pass through: moment/
+PASS Package-like scenarios: package modules that are not declared should fail: underscore/
+PASS Package-like scenarios: package modules that are not declared should fail: underscore/foo
+PASS Package-like scenarios: backtracking via ..: mapped/path
+PASS Package-like scenarios: backtracking via ..: mapped/path/
+PASS Package-like scenarios: backtracking via ..: mapped/path/..
+PASS Package-like scenarios: backtracking via ..: mapped/path/../path/
+PASS Package-like scenarios: backtracking via ..: mapped/path/../207
+PASS Package-like scenarios: backtracking via ..: mapped/path/../207/
+PASS Package-like scenarios: backtracking via ..: mapped/path//
+PASS Package-like scenarios: backtracking via ..: mapped/path/WICG/import-maps/issues/207/
+PASS Package-like scenarios: backtracking via ..: mapped/path//WICG/import-maps/issues/207/
+PASS Package-like scenarios: backtracking via ..: mapped/path/../backtrack
+PASS Package-like scenarios: backtracking via ..: mapped/path/../../backtrack
+PASS Package-like scenarios: backtracking via ..: mapped/path/../../../backtrack
+PASS Package-like scenarios: backtracking via ..: moment/../backtrack
+PASS Package-like scenarios: backtracking via ..: moment/..
+PASS Package-like scenarios: backtracking via ..: mapped/non-ascii-1/
+PASS Package-like scenarios: backtracking via ..: mapped/non-ascii-1/../%E3%81%8D%E3%81%A4%E3%81%AD/
+PASS Package-like scenarios: backtracking via ..: mapped/non-ascii-1/../きつね/
+PASS Package-like scenarios: backtracking via ..: mapped/non-ascii-2/
+PASS Package-like scenarios: backtracking via ..: mapped/non-ascii-2/../%E3%81%8D%E3%81%A4%E3%81%AD/
+PASS Package-like scenarios: backtracking via ..: mapped/non-ascii-2/../きつね/
+

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-packages-via-trailing-slashes.html
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-packages-via-trailing-slashes.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script type="module">
+import { runTestsFromJSON } from "./resources/test-helper.js";
+
+const filename = "packages-via-trailing-slashes.json";
+promise_test(
+  () => runTestsFromJSON('resources/' + filename),
+  "Test helper: fetching and sanity checking test JSON: " + filename);
+</script>

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-resolving-null-expected.txt
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-resolving-null-expected.txt
@@ -1,0 +1,33 @@
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL https://:invalid-url:/
+CONSOLE MESSAGE: value in specifier map needs to be a string
+CONSOLE MESSAGE: address https://example.com/x does not end with '/' while key without-trailing-slashes/b/ ends with '/'
+CONSOLE MESSAGE: value in specifier map needs to be a string
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL https://:invalid-url:/
+CONSOLE MESSAGE: address https://example.com/x does not end with '/' while key without-trailing-slashes/ ends with '/'
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL https://:invalid-url:/
+CONSOLE MESSAGE: address https://example.com/x does not end with '/' while key https://example.com/without-trailing-slashes/ ends with '/'
+CONSOLE MESSAGE: value in specifier map needs to be a string
+
+
+PASS Test helper: fetching and sanity checking test JSON: resolving-null.json
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: null/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: null/b/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: null/b/c/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: invalid-url/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: invalid-url/b/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: invalid-url/b/c/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: without-trailing-slashes/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: without-trailing-slashes/b/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: without-trailing-slashes/b/c/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: prefix-resolution-error/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: prefix-resolution-error/b/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific prefixes: prefix-resolution-error/b/c/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific scopes: null
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific scopes: invalid-url
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific scopes: without-trailing-slashes/x
+PASS Entries with errors shouldn't allow fallback: No fallback to less-specific scopes: prefix-resolution-error/x
+PASS Entries with errors shouldn't allow fallback: No fallback to absolute URL parsing: https://example.com/null
+PASS Entries with errors shouldn't allow fallback: No fallback to absolute URL parsing: https://example.com/invalid-url
+PASS Entries with errors shouldn't allow fallback: No fallback to absolute URL parsing: https://example.com/without-trailing-slashes/x
+PASS Entries with errors shouldn't allow fallback: No fallback to absolute URL parsing: https://example.com/prefix-resolution-error/x
+

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-resolving-null.html
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-resolving-null.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script type="module">
+import { runTestsFromJSON } from "./resources/test-helper.js";
+
+const filename = "resolving-null.json";
+promise_test(
+  () => runTestsFromJSON('resources/' + filename),
+  "Test helper: fetching and sanity checking test JSON: " + filename);
+</script>

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-scopes-exact-vs-prefix-expected.txt
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-scopes-exact-vs-prefix-expected.txt
@@ -1,0 +1,28 @@
+
+
+PASS Test helper: fetching and sanity checking test JSON: scopes-exact-vs-prefix.json
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Non-trailing-slash base URL (exact match): moment
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Non-trailing-slash base URL (exact match): moment/foo
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Trailing-slash base URL (fail): moment
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Trailing-slash base URL (fail): moment/foo
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Subpath base URL (fail): moment
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Subpath base URL (fail): moment/foo
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Non-subpath base URL (fail): moment
+PASS Exact vs. prefix based matching: Scope without trailing slash only: Non-subpath base URL (fail): moment/foo
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Non-trailing-slash base URL (fail): moment
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Non-trailing-slash base URL (fail): moment/foo
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Trailing-slash base URL (exact match): moment
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Trailing-slash base URL (exact match): moment/foo
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Subpath base URL (prefix match): moment
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Subpath base URL (prefix match): moment/foo
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Non-subpath base URL (fail): moment
+PASS Exact vs. prefix based matching: Scope with trailing slash only: Non-subpath base URL (fail): moment/foo
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Non-trailing-slash base URL (exact match): moment
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Non-trailing-slash base URL (exact match): moment/foo
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Trailing-slash base URL (exact match): moment
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Trailing-slash base URL (exact match): moment/foo
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Subpath base URL (prefix match): moment
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Subpath base URL (prefix match): moment/foo
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Non-subpath base URL (fail): moment
+PASS Exact vs. prefix based matching: Scopes with and without trailing slash: Non-subpath base URL (fail): moment/foo
+

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-scopes-exact-vs-prefix.html
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-scopes-exact-vs-prefix.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script type="module">
+import { runTestsFromJSON } from "./resources/test-helper.js";
+
+const filename = "scopes-exact-vs-prefix.json";
+promise_test(
+  () => runTestsFromJSON('resources/' + filename),
+  "Test helper: fetching and sanity checking test JSON: " + filename);
+</script>

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-scopes-expected.txt
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-scopes-expected.txt
@@ -1,0 +1,40 @@
+
+
+PASS Test helper: fetching and sanity checking test JSON: scopes.json
+PASS Fallback to toplevel and between scopes: should fall back to `imports` when no scopes match: a
+PASS Fallback to toplevel and between scopes: should fall back to `imports` when no scopes match: b
+PASS Fallback to toplevel and between scopes: should fall back to `imports` when no scopes match: c
+PASS Fallback to toplevel and between scopes: should fall back to `imports` when no scopes match: d
+PASS Fallback to toplevel and between scopes: should use a direct scope override: a
+PASS Fallback to toplevel and between scopes: should use a direct scope override: b
+PASS Fallback to toplevel and between scopes: should use a direct scope override: c
+PASS Fallback to toplevel and between scopes: should use a direct scope override: d
+PASS Fallback to toplevel and between scopes: should use an indirect scope override: a
+PASS Fallback to toplevel and between scopes: should use an indirect scope override: b
+PASS Fallback to toplevel and between scopes: should use an indirect scope override: c
+PASS Fallback to toplevel and between scopes: should use an indirect scope override: d
+PASS Relative URL scope keys: An empty string scope is a scope with import map base URL: a
+PASS Relative URL scope keys: An empty string scope is a scope with import map base URL: b
+PASS Relative URL scope keys: An empty string scope is a scope with import map base URL: c
+PASS Relative URL scope keys: './' scope is a scope with import map base URL's directory: a
+PASS Relative URL scope keys: './' scope is a scope with import map base URL's directory: b
+PASS Relative URL scope keys: './' scope is a scope with import map base URL's directory: c
+PASS Relative URL scope keys: '../' scope is a scope with import map base URL's parent directory: a
+PASS Relative URL scope keys: '../' scope is a scope with import map base URL's parent directory: b
+PASS Relative URL scope keys: '../' scope is a scope with import map base URL's parent directory: c
+PASS Package-like scenarios: Base URLs inside the scope should use the scope if the scope has matching keys: lodash-dot
+PASS Package-like scenarios: Base URLs inside the scope should use the scope if the scope has matching keys: lodash-dot/foo
+PASS Package-like scenarios: Base URLs inside the scope should use the scope if the scope has matching keys: lodash-dotdot
+PASS Package-like scenarios: Base URLs inside the scope should use the scope if the scope has matching keys: lodash-dotdot/foo
+PASS Package-like scenarios: Base URLs inside the scope fallback to less specific scope: moment
+PASS Package-like scenarios: Base URLs inside the scope fallback to less specific scope: vue
+PASS Package-like scenarios: Base URLs inside the scope fallback to toplevel: moment/foo
+PASS Package-like scenarios: Base URLs outside a scope shouldn't use the scope even if the scope has matching keys: lodash-dot
+PASS Package-like scenarios: Base URLs outside a scope shouldn't use the scope even if the scope has matching keys: lodash-dotdot
+PASS Package-like scenarios: Base URLs outside a scope shouldn't use the scope even if the scope has matching keys: lodash-dot/foo
+PASS Package-like scenarios: Base URLs outside a scope shouldn't use the scope even if the scope has matching keys: lodash-dotdot/foo
+PASS Package-like scenarios: Fallback to toplevel or not, depending on trailing slash match: moment
+PASS Package-like scenarios: Fallback to toplevel or not, depending on trailing slash match: moment/foo
+PASS Package-like scenarios: should still fail for package-like specifiers that are not declared: underscore/
+PASS Package-like scenarios: should still fail for package-like specifiers that are not declared: underscore/foo
+

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-scopes.html
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-scopes.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script type="module">
+import { runTestsFromJSON } from "./resources/test-helper.js";
+
+const filename = "scopes.json";
+promise_test(
+  () => runTestsFromJSON('resources/' + filename),
+  "Test helper: fetching and sanity checking test JSON: " + filename);
+</script>

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-tricky-specifiers-expected.txt
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-tricky-specifiers-expected.txt
@@ -1,0 +1,28 @@
+
+
+PASS Test helper: fetching and sanity checking test JSON: tricky-specifiers.json
+PASS Tricky specifiers: explicitly-mapped specifiers that happen to have a slash: package/withslash
+PASS Tricky specifiers: specifier with punctuation: .
+PASS Tricky specifiers: specifier with punctuation: ..
+PASS Tricky specifiers: specifier with punctuation: ..\
+PASS Tricky specifiers: specifier with punctuation: %2E
+PASS Tricky specifiers: specifier with punctuation: %2F
+PASS Tricky specifiers: submodule of something not declared with a trailing slash should fail: not-a-package/foo
+PASS Tricky specifiers: module for which only a trailing-slash version is present should fail: only-slash
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/bar
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/fox/
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/fox/bar
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/きつね/
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/きつね/bar
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/きつね/fox/
+PASS Tricky specifiers: URL-like specifiers are normalized: https://map.example/きつね/fox/bar
+PASS Tricky specifiers: Bare specifiers are not normalized: %E3%81%8D%E3%81%A4%E3%81%AD/
+PASS Tricky specifiers: Bare specifiers are not normalized: %E3%81%8D%E3%81%A4%E3%81%AD/bar
+PASS Tricky specifiers: Bare specifiers are not normalized: %E3%81%8D%E3%81%A4%E3%81%AD/fox/
+PASS Tricky specifiers: Bare specifiers are not normalized: %E3%81%8D%E3%81%A4%E3%81%AD/fox/bar
+PASS Tricky specifiers: Bare specifiers are not normalized: きつね/
+PASS Tricky specifiers: Bare specifiers are not normalized: きつね/bar
+PASS Tricky specifiers: Bare specifiers are not normalized: きつね/fox/
+PASS Tricky specifiers: Bare specifiers are not normalized: きつね/fox/bar
+

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-tricky-specifiers.html
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-tricky-specifiers.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script type="module">
+import { runTestsFromJSON } from "./resources/test-helper.js";
+
+const filename = "tricky-specifiers.json";
+promise_test(
+  () => runTestsFromJSON('resources/' + filename),
+  "Test helper: fetching and sanity checking test JSON: " + filename);
+</script>

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-url-specifiers-expected.txt
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-url-specifiers-expected.txt
@@ -1,0 +1,28 @@
+
+
+PASS Test helper: fetching and sanity checking test JSON: url-specifiers.json
+PASS URL-like specifiers: Ordinary URL-like specifiers: https://example.com/lib/foo.mjs
+PASS URL-like specifiers: Ordinary URL-like specifiers: https://///example.com/lib/foo.mjs
+PASS URL-like specifiers: Ordinary URL-like specifiers: /lib/foo.mjs
+PASS URL-like specifiers: Ordinary URL-like specifiers: https://example.com/app/dotrelative/foo.mjs
+PASS URL-like specifiers: Ordinary URL-like specifiers: ../app/dotrelative/foo.mjs
+PASS URL-like specifiers: Ordinary URL-like specifiers: https://example.com/dotdotrelative/foo.mjs
+PASS URL-like specifiers: Ordinary URL-like specifiers: ../dotdotrelative/foo.mjs
+PASS URL-like specifiers: Import map entries just composed from / and .: https://example.com/
+PASS URL-like specifiers: Import map entries just composed from / and .: /
+PASS URL-like specifiers: Import map entries just composed from / and .: ../
+PASS URL-like specifiers: Import map entries just composed from / and .: https://example.com/app/
+PASS URL-like specifiers: Import map entries just composed from / and .: /app/
+PASS URL-like specifiers: Import map entries just composed from / and .: ../app/
+PASS URL-like specifiers: prefix-matched by keys with trailing slashes: /test/foo.mjs
+PASS URL-like specifiers: prefix-matched by keys with trailing slashes: https://example.com/app/test/foo.mjs
+PASS URL-like specifiers: should use the last entry's address when URL-like specifiers parse to the same absolute URL: /test
+PASS URL-like specifiers: backtracking (relative URLs): /test/..
+PASS URL-like specifiers: backtracking (relative URLs): /test/../backtrack
+PASS URL-like specifiers: backtracking (relative URLs): /test/../../backtrack
+PASS URL-like specifiers: backtracking (relative URLs): /test/../../../backtrack
+PASS URL-like specifiers: backtracking (absolute URLs): https://example.com/test/..
+PASS URL-like specifiers: backtracking (absolute URLs): https://example.com/test/../backtrack
+PASS URL-like specifiers: backtracking (absolute URLs): https://example.com/test/../../backtrack
+PASS URL-like specifiers: backtracking (absolute URLs): https://example.com/test/../../../backtrack
+

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-url-specifiers-schemes-expected.txt
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-url-specifiers-schemes-expected.txt
@@ -1,0 +1,24 @@
+
+
+PASS Test helper: fetching and sanity checking test JSON: url-specifiers-schemes.json
+PASS URL-like specifiers: Non-special vs. special schemes: data:text/javascript,console.log('foo')
+PASS URL-like specifiers: Non-special vs. special schemes: data:text/
+PASS URL-like specifiers: Non-special vs. special schemes: about:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: about:text/
+PASS URL-like specifiers: Non-special vs. special schemes: blob:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: blob:text/
+PASS URL-like specifiers: Non-special vs. special schemes: blah:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: blah:text/
+PASS URL-like specifiers: Non-special vs. special schemes: http:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: http:text/
+PASS URL-like specifiers: Non-special vs. special schemes: https:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: https:text/
+PASS URL-like specifiers: Non-special vs. special schemes: ftp:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: ftp:text/
+PASS URL-like specifiers: Non-special vs. special schemes: file:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: file:text/
+PASS URL-like specifiers: Non-special vs. special schemes: ws:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: ws:text/
+PASS URL-like specifiers: Non-special vs. special schemes: wss:text/foo
+PASS URL-like specifiers: Non-special vs. special schemes: wss:text/
+

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-url-specifiers-schemes.html
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-url-specifiers-schemes.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script type="module">
+import { runTestsFromJSON } from "./resources/test-helper.js";
+
+const filename = "url-specifiers-schemes.json";
+promise_test(
+  () => runTestsFromJSON('resources/' + filename),
+  "Test helper: fetching and sanity checking test JSON: " + filename);
+</script>

--- a/LayoutTests/http/wpt/import-maps/data-driven/resolving-url-specifiers.html
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resolving-url-specifiers.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script type="module">
+import { runTestsFromJSON } from "./resources/test-helper.js";
+
+const filename = "url-specifiers.json";
+promise_test(
+  () => runTestsFromJSON('resources/' + filename),
+  "Test helper: fetching and sanity checking test JSON: " + filename);
+</script>

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/data-url-prefix.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/data-url-prefix.json
@@ -1,0 +1,17 @@
+{
+  "importMap": {
+    "imports": {
+      "foo/": "data:text/javascript,foo/"
+    }
+  },
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "data: URL prefix",
+  "tests": {
+    "should not resolve since you can't resolve relative to a data: URL": {
+      "expectedResults": {
+        "foo/bar": null
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/empty-import-map.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/empty-import-map.json
@@ -1,0 +1,61 @@
+{
+  "importMap": {},
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "tests": {
+    "valid relative specifiers": {
+      "expectedResults": {
+        "./foo": "https://example.com/js/foo",
+        "./foo/bar": "https://example.com/js/foo/bar",
+        "./foo/../bar": "https://example.com/js/bar",
+        "./foo/../../bar": "https://example.com/bar",
+        "../foo": "https://example.com/foo",
+        "../foo/bar": "https://example.com/foo/bar",
+        "../../../foo/bar": "https://example.com/foo/bar",
+        "/foo": "https://example.com/foo",
+        "/foo/bar": "https://example.com/foo/bar",
+        "/../../foo/bar": "https://example.com/foo/bar",
+        "/../foo/../bar": "https://example.com/bar"
+      }
+    },
+    "HTTPS scheme absolute URLs": {
+      "expectedResults": {
+        "https://fetch-scheme.net": "https://fetch-scheme.net/",
+        "https:fetch-scheme.org": "https://fetch-scheme.org/",
+        "https://fetch%2Dscheme.com/": "https://fetch-scheme.com/",
+        "https://///fetch-scheme.com///": "https://fetch-scheme.com///"
+      }
+    },
+    "valid relative URLs that are invalid as specifiers should fail": {
+      "expectedResults": {
+        "invalid-specifier": null,
+        "\\invalid-specifier": null,
+        ":invalid-specifier": null,
+        "@invalid-specifier": null,
+        "%2E/invalid-specifier": null,
+        "%2E%2E/invalid-specifier": null,
+        ".%2Finvalid-specifier": null
+      }
+    },
+    "invalid absolute URLs should fail": {
+      "expectedResults": {
+        "https://invalid-url.com:demo": null,
+        "http://[invalid-url.com]/": null
+      }
+    },
+    "non-HTTPS fetch scheme absolute URLs": {
+      "expectedResults": {
+        "about:fetch-scheme": "about:fetch-scheme"
+      }
+    },
+    "non-fetch scheme absolute URLs": {
+      "expectedResults": {
+        "about:fetch-scheme": "about:fetch-scheme",
+        "mailto:non-fetch-scheme": "mailto:non-fetch-scheme",
+        "import:non-fetch-scheme": "import:non-fetch-scheme",
+        "javascript:non-fetch-scheme": "javascript:non-fetch-scheme",
+        "wss:non-fetch-scheme": "wss://non-fetch-scheme/"
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/overlapping-entries.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/overlapping-entries.json
@@ -1,0 +1,25 @@
+{
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "should favor the most-specific key",
+  "tests": {
+    "Overlapping entries with trailing slashes": {
+      "importMap": {
+        "imports": {
+          "a": "/1",
+          "a/": "/2/",
+          "a/b": "/3",
+          "a/b/": "/4/"
+        }
+      },
+      "expectedResults": {
+        "a": "https://example.com/1",
+        "a/": "https://example.com/2/",
+        "a/x": "https://example.com/2/x",
+        "a/b": "https://example.com/3",
+        "a/b/": "https://example.com/4/",
+        "a/b/c": "https://example.com/4/c"
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/packages-via-trailing-slashes.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/packages-via-trailing-slashes.json
@@ -1,0 +1,74 @@
+{
+  "importMap": {
+    "imports": {
+      "moment": "/node_modules/moment/src/moment.js",
+      "moment/": "/node_modules/moment/src/",
+      "lodash-dot": "./node_modules/lodash-es/lodash.js",
+      "lodash-dot/": "./node_modules/lodash-es/",
+      "lodash-dotdot": "../node_modules/lodash-es/lodash.js",
+      "lodash-dotdot/": "../node_modules/lodash-es/",
+      "mapped/": "https://example.com/",
+      "mapped/path/": "https://github.com/WICG/import-maps/issues/207/",
+      "mapped/non-ascii-1/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/",
+      "mapped/non-ascii-2/": "https://example.com/きつね/"
+    }
+  },
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "Package-like scenarios",
+  "link": "https://github.com/WICG/import-maps#packages-via-trailing-slashes",
+  "tests": {
+    "package main modules": {
+      "expectedResults": {
+        "moment": "https://example.com/node_modules/moment/src/moment.js",
+        "lodash-dot": "https://example.com/app/node_modules/lodash-es/lodash.js",
+        "lodash-dotdot": "https://example.com/node_modules/lodash-es/lodash.js"
+      }
+    },
+    "package submodules": {
+      "expectedResults": {
+        "moment/foo": "https://example.com/node_modules/moment/src/foo",
+        "moment/foo?query": "https://example.com/node_modules/moment/src/foo?query",
+        "moment/foo#fragment": "https://example.com/node_modules/moment/src/foo#fragment",
+        "moment/foo?query#fragment": "https://example.com/node_modules/moment/src/foo?query#fragment",
+        "lodash-dot/foo": "https://example.com/app/node_modules/lodash-es/foo",
+        "lodash-dotdot/foo": "https://example.com/node_modules/lodash-es/foo"
+      }
+    },
+    "package names that end in a slash should just pass through": {
+      "expectedResults": {
+        "moment/": "https://example.com/node_modules/moment/src/"
+      }
+    },
+    "package modules that are not declared should fail": {
+      "expectedResults": {
+        "underscore/": null,
+        "underscore/foo": null
+      }
+    },
+    "backtracking via ..": {
+      "expectedResults": {
+        "mapped/path": "https://example.com/path",
+        "mapped/path/": "https://github.com/WICG/import-maps/issues/207/",
+        "mapped/path/..": null,
+        "mapped/path/../path/": null,
+        "mapped/path/../207": null,
+        "mapped/path/../207/": "https://github.com/WICG/import-maps/issues/207/",
+        "mapped/path//": null,
+        "mapped/path/WICG/import-maps/issues/207/": "https://github.com/WICG/import-maps/issues/207/WICG/import-maps/issues/207/",
+        "mapped/path//WICG/import-maps/issues/207/": "https://github.com/WICG/import-maps/issues/207/",
+        "mapped/path/../backtrack": null,
+        "mapped/path/../../backtrack": null,
+        "mapped/path/../../../backtrack": null,
+        "moment/../backtrack": null,
+        "moment/..": null,
+        "mapped/non-ascii-1/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/",
+        "mapped/non-ascii-1/../%E3%81%8D%E3%81%A4%E3%81%AD/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/",
+        "mapped/non-ascii-1/../きつね/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/",
+        "mapped/non-ascii-2/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/",
+        "mapped/non-ascii-2/../%E3%81%8D%E3%81%A4%E3%81%AD/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/",
+        "mapped/non-ascii-2/../きつね/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/"
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-addresses-absolute.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-addresses-absolute.json
@@ -1,0 +1,65 @@
+{
+  "name": "Absolute URL addresses",
+  "tests": {
+    "should only accept absolute URL addresses with fetch schemes": {
+      "importMap": {
+        "imports": {
+          "about": "about:good",
+          "blob": "blob:good",
+          "data": "data:good",
+          "file": "file:///good",
+          "filesystem": "filesystem:http://example.com/good/",
+          "http": "http://good/",
+          "https": "https://good/",
+          "ftp": "ftp://good/",
+          "import": "import:bad",
+          "mailto": "mailto:bad",
+          "javascript": "javascript:bad",
+          "wss": "wss:bad"
+        }
+      },
+      "importMapBaseURL": "https://base.example/path1/path2/path3",
+      "expectedParsedImportMap": {
+        "imports": {
+          "about": "about:good",
+          "blob": "blob:good",
+          "data": "data:good",
+          "file": "file:///good",
+          "filesystem": "filesystem:http://example.com/good/",
+          "http": "http://good/",
+          "https": "https://good/",
+          "ftp": "ftp://good/",
+          "import": "import:bad",
+          "javascript": "javascript:bad",
+          "mailto": "mailto:bad",
+          "wss": "wss://bad/"
+        },
+        "scopes": {}
+      }
+    },
+    "should parse absolute URLs, ignoring unparseable ones": {
+      "importMap": {
+        "imports": {
+          "unparseable2": "https://example.com:demo",
+          "unparseable3": "http://[www.example.com]/",
+          "invalidButParseable1": "https:example.org",
+          "invalidButParseable2": "https://///example.com///",
+          "prettyNormal": "https://example.net",
+          "percentDecoding": "https://ex%41mple.com/"
+        }
+      },
+      "importMapBaseURL": "https://base.example/path1/path2/path3",
+      "expectedParsedImportMap": {
+        "imports": {
+          "unparseable2": null,
+          "unparseable3": null,
+          "invalidButParseable1": "https://example.org/",
+          "invalidButParseable2": "https://example.com///",
+          "prettyNormal": "https://example.net/",
+          "percentDecoding": "https://example.com/"
+        },
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-addresses-invalid.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-addresses-invalid.json
@@ -1,0 +1,27 @@
+{
+  "name": "Other invalid addresses",
+  "tests": {
+    "should ignore unprefixed strings that are not absolute URLs": {
+      "importMap": {
+        "imports": {
+          "foo1": "bar",
+          "foo2": "\\bar",
+          "foo3": "~bar",
+          "foo4": "#bar",
+          "foo5": "?bar"
+        }
+      },
+      "importMapBaseURL": "https://base.example/path1/path2/path3",
+      "expectedParsedImportMap": {
+        "imports": {
+          "foo1": null,
+          "foo2": null,
+          "foo3": null,
+          "foo4": null,
+          "foo5": null
+        },
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-addresses.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-addresses.json
@@ -1,0 +1,85 @@
+{
+  "name": "Relative URL-like addresses",
+  "tests": {
+    "should accept strings prefixed with ./, ../, or /": {
+      "importMap": {
+        "imports": {
+          "dotSlash": "./foo",
+          "dotDotSlash": "../foo",
+          "slash": "/foo"
+        }
+      },
+      "importMapBaseURL": "https://base.example/path1/path2/path3",
+      "expectedParsedImportMap": {
+        "imports": {
+          "dotSlash": "https://base.example/path1/path2/foo",
+          "dotDotSlash": "https://base.example/path1/foo",
+          "slash": "https://base.example/foo"
+        },
+        "scopes": {}
+      }
+    },
+    "should not accept strings prefixed with ./, ../, or / for data: base URLs": {
+      "importMap": {
+        "imports": {
+          "dotSlash": "./foo",
+          "dotDotSlash": "../foo",
+          "slash": "/foo"
+        }
+      },
+      "importMapBaseURL": "data:text/html,test",
+      "expectedParsedImportMap": {
+        "imports": {
+          "dotSlash": null,
+          "dotDotSlash": null,
+          "slash": null
+        },
+        "scopes": {}
+      }
+    },
+    "should accept the literal strings ./, ../, or / with no suffix": {
+      "importMap": {
+        "imports": {
+          "dotSlash": "./",
+          "dotDotSlash": "../",
+          "slash": "/"
+        }
+      },
+      "importMapBaseURL": "https://base.example/path1/path2/path3",
+      "expectedParsedImportMap": {
+        "imports": {
+          "dotSlash": "https://base.example/path1/path2/",
+          "dotDotSlash": "https://base.example/path1/",
+          "slash": "https://base.example/"
+        },
+        "scopes": {}
+      }
+    },
+    "should ignore percent-encoded variants of ./, ../, or /": {
+      "importMap": {
+        "imports": {
+          "dotSlash1": "%2E/",
+          "dotDotSlash1": "%2E%2E/",
+          "dotSlash2": ".%2F",
+          "dotDotSlash2": "..%2F",
+          "slash2": "%2F",
+          "dotSlash3": "%2E%2F",
+          "dotDotSlash3": "%2E%2E%2F"
+        }
+      },
+      "importMapBaseURL": "https://base.example/path1/path2/path3",
+      "expectedParsedImportMap": {
+        "imports": {
+          "dotSlash1": null,
+          "dotDotSlash1": null,
+          "dotSlash2": null,
+          "dotDotSlash2": null,
+          "slash2": null,
+          "dotSlash3": null,
+          "dotDotSlash3": null
+        },
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-invalid-json.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-invalid-json.json
@@ -1,0 +1,6 @@
+{
+  "name": "Invalid JSON",
+  "importMapBaseURL": "https://base.example/",
+  "importMap": "{imports: {}}",
+  "expectedParsedImportMap": null
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-schema-normalization.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-schema-normalization.json
@@ -1,0 +1,31 @@
+{
+  "name": "Normalization",
+  "importMapBaseURL": "https://base.example/",
+  "tests": {
+    "should normalize empty import maps to have imports and scopes keys": {
+      "importMap": {},
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    },
+    "should normalize an import map without imports to have imports": {
+      "importMap": {
+        "scopes": {}
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    },
+    "should normalize an import map without scopes to have scopes": {
+      "importMap": {
+        "imports": {}
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-schema-scope.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-schema-scope.json
@@ -1,0 +1,46 @@
+{
+  "name": "Mismatching scopes schema",
+  "importMapBaseURL": "https://base.example/",
+  "tests": {
+    "should throw if a scope's value is not an object": {
+      "expectedParsedImportMap": null,
+      "tests": {
+        "null": {
+          "importMap": {
+            "scopes": {
+              "https://example.com/": null
+            }
+          }
+        },
+        "boolean": {
+          "importMap": {
+            "scopes": {
+              "https://example.com/": true
+            }
+          }
+        },
+        "number": {
+          "importMap": {
+            "scopes": {
+              "https://example.com/": 1
+            }
+          }
+        },
+        "string": {
+          "importMap": {
+            "scopes": {
+              "https://example.com/": "foo"
+            }
+          }
+        },
+        "array": {
+          "importMap": {
+            "scopes": {
+              "https://example.com/": []
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-schema-specifier-map.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-schema-specifier-map.json
@@ -1,0 +1,44 @@
+{
+  "name": "Mismatching the specifier map schema",
+  "importMapBaseURL": "https://base.example/",
+  "tests": {
+    "should ignore entries where the address is not a string": {
+      "importMap": {
+        "imports": {
+          "null": null,
+          "boolean": true,
+          "number": 1,
+          "object": {},
+          "array": [],
+          "array2": [
+            "https://example.com/"
+          ],
+          "string": "https://example.com/"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "null": null,
+          "boolean": null,
+          "number": null,
+          "object": null,
+          "array": null,
+          "array2": null,
+          "string": "https://example.com/"
+        },
+        "scopes": {}
+      }
+    },
+    "should ignore entries where the specifier key is an empty string": {
+      "importMap": {
+        "imports": {
+          "": "https://example.com/"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-schema-toplevel.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-schema-toplevel.json
@@ -1,0 +1,97 @@
+{
+  "name": "Mismatching the top-level schema",
+  "importMapBaseURL": "https://base.example/",
+  "tests": {
+    "should throw for top-level non-objects": {
+      "expectedParsedImportMap": null,
+      "tests": {
+        "null": {
+          "importMap": null
+        },
+        "boolean": {
+          "importMap": true
+        },
+        "number": {
+          "importMap": 1
+        },
+        "string": {
+          "importMap": "foo"
+        },
+        "array": {
+          "importMap": []
+        }
+      }
+    },
+    "should throw if imports is a non-object": {
+      "expectedParsedImportMap": null,
+      "tests": {
+        "null": {
+          "importMap": {
+            "imports": null
+          }
+        },
+        "boolean": {
+          "importMap": {
+            "imports": true
+          }
+        },
+        "number": {
+          "importMap": {
+            "imports": 1
+          }
+        },
+        "string": {
+          "importMap": {
+            "imports": "foo"
+          }
+        },
+        "array": {
+          "importMap": {
+            "imports": []
+          }
+        }
+      }
+    },
+    "should throw if scopes is a non-object": {
+      "expectedParsedImportMap": null,
+      "tests": {
+        "null": {
+          "importMap": {
+            "scopes": null
+          }
+        },
+        "boolean": {
+          "importMap": {
+            "scopes": true
+          }
+        },
+        "number": {
+          "importMap": {
+            "scopes": 1
+          }
+        },
+        "string": {
+          "importMap": {
+            "scopes": "foo"
+          }
+        },
+        "array": {
+          "importMap": {
+            "scopes": []
+          }
+        }
+      }
+    },
+    "should ignore unspecified top-level entries": {
+      "importMap": {
+        "imports": {},
+        "new-feature": {},
+        "scops": {}
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-scope-keys.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-scope-keys.json
@@ -1,0 +1,191 @@
+{
+  "importMapBaseURL": "https://base.example/path1/path2/path3",
+  "tests": {
+    "Relative URL scope keys should work with no prefix": {
+      "importMap": {
+        "scopes": {
+          "foo": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/foo": {}
+        }
+      }
+    },
+    "Relative URL scope keys should work with ./, ../, and / prefixes": {
+      "importMap": {
+        "scopes": {
+          "./foo": {},
+          "../foo": {},
+          "/foo": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/foo": {},
+          "https://base.example/path1/foo": {},
+          "https://base.example/foo": {}
+        }
+      }
+    },
+    "Absolute URL scope keys should ignore relative URL scope keys when the base URL is a data: URL": {
+      "importMap": {
+        "scopes": {
+          "./foo": {},
+          "../foo": {},
+          "/foo": {}
+        }
+      },
+      "importMapBaseURL": "data:text/html,test",
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    },
+    "Relative URL scope keys should work with ./, ../, or / with no suffix": {
+      "importMap": {
+        "scopes": {
+          "./": {},
+          "../": {},
+          "/": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/": {},
+          "https://base.example/path1/": {},
+          "https://base.example/": {}
+        }
+      }
+    },
+    "Relative URL scope keys should work with /s, ?s, and #s": {
+      "importMap": {
+        "scopes": {
+          "foo/bar?baz#qux": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/foo/bar?baz#qux": {}
+        }
+      }
+    },
+    "Relative URL scope keys should work with an empty string scope key": {
+      "importMap": {
+        "scopes": {
+          "": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/path3": {}
+        }
+      }
+    },
+    "Relative URL scope keys should work with / suffixes": {
+      "importMap": {
+        "scopes": {
+          "foo/": {},
+          "./foo/": {},
+          "../foo/": {},
+          "/foo/": {},
+          "/foo//": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/foo/": {},
+          "https://base.example/path1/foo/": {},
+          "https://base.example/foo/": {},
+          "https://base.example/foo//": {}
+        }
+      }
+    },
+    "Relative URL scope keys should deduplicate based on URL parsing rules": {
+      "importMap": {
+        "scopes": {
+          "foo/\\": {
+            "1": "./a"
+          },
+          "foo//": {
+            "2": "./b"
+          },
+          "foo\\\\": {
+            "3": "./c"
+          }
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/foo//": {
+            "3": "https://base.example/path1/path2/c"
+          }
+        }
+      }
+    },
+    "Absolute URL scope keys should accept all absolute URL scope keys, with or without fetch schemes": {
+      "importMap": {
+        "scopes": {
+          "about:good": {},
+          "blob:good": {},
+          "data:good": {},
+          "file:///good": {},
+          "filesystem:http://example.com/good/": {},
+          "http://good/": {},
+          "https://good/": {},
+          "ftp://good/": {},
+          "import:bad": {},
+          "mailto:bad": {},
+          "javascript:bad": {},
+          "wss:ba": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "about:good": {},
+          "blob:good": {},
+          "data:good": {},
+          "file:///good": {},
+          "filesystem:http://example.com/good/": {},
+          "http://good/": {},
+          "https://good/": {},
+          "ftp://good/": {},
+          "import:bad": {},
+          "mailto:bad": {},
+          "javascript:bad": {},
+          "wss://ba/": {}
+        }
+      }
+    },
+    "Absolute URL scope keys should parse absolute URL scope keys, ignoring unparseable ones": {
+      "importMap": {
+        "scopes": {
+          "https://example.com:demo": {},
+          "http://[www.example.com]/": {},
+          "https:example.org": {},
+          "https://///example.com///": {},
+          "https://example.net": {},
+          "https://ex%41mple.com/foo/": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/example.org": {},
+          "https://example.com///": {},
+          "https://example.net/": {},
+          "https://example.com/foo/": {}
+        }
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-specifier-keys.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-specifier-keys.json
@@ -1,0 +1,209 @@
+{
+  "importMapBaseURL": "https://base.example/path1/path2/path3",
+  "tests": {
+    "Relative URL specifier keys should absolutize strings prefixed with ./, ../, or / into the corresponding URLs": {
+      "importMap": {
+        "imports": {
+          "./foo": "/dotslash",
+          "../foo": "/dotdotslash",
+          "/foo": "/slash"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://base.example/path1/path2/foo": "https://base.example/dotslash",
+          "https://base.example/path1/foo": "https://base.example/dotdotslash",
+          "https://base.example/foo": "https://base.example/slash"
+        },
+        "scopes": {}
+      }
+    },
+    "Relative URL specifier keys should not absolutize strings prefixed with ./, ../, or / with a data: URL base": {
+      "importMap": {
+        "imports": {
+          "./foo": "https://example.com/dotslash",
+          "../foo": "https://example.com/dotdotslash",
+          "/foo": "https://example.com/slash"
+        }
+      },
+      "importMapBaseURL": "data:text/html,",
+      "expectedParsedImportMap": {
+        "imports": {
+          "./foo": "https://example.com/dotslash",
+          "../foo": "https://example.com/dotdotslash",
+          "/foo": "https://example.com/slash"
+        },
+        "scopes": {}
+      }
+    },
+    "Relative URL specifier keys should absolutize the literal strings ./, ../, or / with no suffix": {
+      "importMap": {
+        "imports": {
+          "./": "/dotslash/",
+          "../": "/dotdotslash/",
+          "/": "/slash/"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://base.example/path1/path2/": "https://base.example/dotslash/",
+          "https://base.example/path1/": "https://base.example/dotdotslash/",
+          "https://base.example/": "https://base.example/slash/"
+        },
+        "scopes": {}
+      }
+    },
+    "Relative URL specifier keys should work with /s, ?s, and #s": {
+      "importMap": {
+        "imports": {
+          "./foo/bar?baz#qux": "/foo"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://base.example/path1/path2/foo/bar?baz#qux": "https://base.example/foo"
+        },
+        "scopes": {}
+      }
+    },
+    "Relative URL specifier keys should ignore an empty string key": {
+      "importMap": {
+        "imports": {
+          "": "/foo"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    },
+    "Relative URL specifier keys should treat percent-encoded variants of ./, ../, or / as bare specifiers": {
+      "importMap": {
+        "imports": {
+          "%2E/": "/dotSlash1/",
+          "%2E%2E/": "/dotDotSlash1/",
+          ".%2F": "/dotSlash2",
+          "..%2F": "/dotDotSlash2",
+          "%2F": "/slash2",
+          "%2E%2F": "/dotSlash3",
+          "%2E%2E%2F": "/dotDotSlash3"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "%2E/": "https://base.example/dotSlash1/",
+          "%2E%2E/": "https://base.example/dotDotSlash1/",
+          ".%2F": "https://base.example/dotSlash2",
+          "..%2F": "https://base.example/dotDotSlash2",
+          "%2F": "https://base.example/slash2",
+          "%2E%2F": "https://base.example/dotSlash3",
+          "%2E%2E%2F": "https://base.example/dotDotSlash3"
+        },
+        "scopes": {}
+      }
+    },
+    "Relative URL specifier keys should deduplicate based on URL parsing rules": {
+      "importMap": {
+        "imports": {
+          "./foo/\\": "/foo1",
+          "./foo//": "/foo2",
+          "./foo\\\\": "/foo3"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://base.example/path1/path2/foo//": "https://base.example/foo3"
+        },
+        "scopes": {}
+      }
+    },
+    "Absolute URL specifier keys should accept all absolute URL specifier keys, with or without fetch schemes": {
+      "importMap": {
+        "imports": {
+          "about:good": "/about",
+          "blob:good": "/blob",
+          "data:good": "/data",
+          "file:///good": "/file",
+          "filesystem:http://example.com/good/": "/filesystem/",
+          "http://good/": "/http/",
+          "https://good/": "/https/",
+          "ftp://good/": "/ftp/",
+          "import:bad": "/import",
+          "mailto:bad": "/mailto",
+          "javascript:bad": "/javascript",
+          "wss:bad": "/wss"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "about:good": "https://base.example/about",
+          "blob:good": "https://base.example/blob",
+          "data:good": "https://base.example/data",
+          "file:///good": "https://base.example/file",
+          "filesystem:http://example.com/good/": "https://base.example/filesystem/",
+          "http://good/": "https://base.example/http/",
+          "https://good/": "https://base.example/https/",
+          "ftp://good/": "https://base.example/ftp/",
+          "import:bad": "https://base.example/import",
+          "mailto:bad": "https://base.example/mailto",
+          "javascript:bad": "https://base.example/javascript",
+          "wss://bad/": "https://base.example/wss"
+        },
+        "scopes": {}
+      }
+    },
+    "Absolute URL specifier keys should parse absolute URLs, treating unparseable ones as bare specifiers": {
+      "importMap": {
+        "imports": {
+          "https://example.com:demo": "/unparseable2",
+          "http://[www.example.com]/": "/unparseable3/",
+          "https:example.org": "/invalidButParseable1/",
+          "https://///example.com///": "/invalidButParseable2/",
+          "https://example.net": "/prettyNormal/",
+          "https://ex%41mple.com/": "/percentDecoding/"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://example.com:demo": "https://base.example/unparseable2",
+          "http://[www.example.com]/": "https://base.example/unparseable3/",
+          "https://example.org/": "https://base.example/invalidButParseable1/",
+          "https://example.com///": "https://base.example/invalidButParseable2/",
+          "https://example.net/": "https://base.example/prettyNormal/",
+          "https://example.com/": "https://base.example/percentDecoding/"
+        },
+        "scopes": {}
+      }
+    },
+    "Specifier keys should be sort correctly (issue #181) - Test #1": {
+      "importMap": {
+        "imports": {
+          "https://example.com/aaa": "https://example.com/aaa",
+          "https://example.com/a": "https://example.com/a"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://example.com/aaa": "https://example.com/aaa",
+          "https://example.com/a": "https://example.com/a"
+        },
+        "scopes": {}
+      }
+    },
+    "Specifier keys should be sort correctly (issue #181) - Test #2": {
+      "importMap": {
+        "imports": {
+          "https://example.com/a": "https://example.com/a",
+          "https://example.com/aaa": "https://example.com/aaa"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://example.com/aaa": "https://example.com/aaa",
+          "https://example.com/a": "https://example.com/a"
+        },
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-trailing-slashes.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/parsing-trailing-slashes.json
@@ -1,0 +1,15 @@
+{
+  "name": "Failing addresses: mismatched trailing slashes",
+  "importMap": {
+    "imports": {
+      "trailer/": "/notrailer"
+    }
+  },
+  "importMapBaseURL": "https://base.example/path1/path2/path3",
+  "expectedParsedImportMap": {
+    "imports": {
+      "trailer/": null
+    },
+    "scopes": {}
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/resolving-null.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/resolving-null.json
@@ -1,0 +1,82 @@
+{
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "Entries with errors shouldn't allow fallback",
+  "tests": {
+    "No fallback to less-specific prefixes": {
+      "importMap": {
+        "imports": {
+          "null/": "/1/",
+          "null/b/": null,
+          "null/b/c/": "/1/2/",
+          "invalid-url/": "/1/",
+          "invalid-url/b/": "https://:invalid-url:/",
+          "invalid-url/b/c/": "/1/2/",
+          "without-trailing-slashes/": "/1/",
+          "without-trailing-slashes/b/": "/x",
+          "without-trailing-slashes/b/c/": "/1/2/",
+          "prefix-resolution-error/": "/1/",
+          "prefix-resolution-error/b/": "data:text/javascript,/",
+          "prefix-resolution-error/b/c/": "/1/2/"
+        }
+      },
+      "expectedResults": {
+        "null/x": "https://example.com/1/x",
+        "null/b/x": null,
+        "null/b/c/x": "https://example.com/1/2/x",
+        "invalid-url/x": "https://example.com/1/x",
+        "invalid-url/b/x": null,
+        "invalid-url/b/c/x": "https://example.com/1/2/x",
+        "without-trailing-slashes/x": "https://example.com/1/x",
+        "without-trailing-slashes/b/x": null,
+        "without-trailing-slashes/b/c/x": "https://example.com/1/2/x",
+        "prefix-resolution-error/x": "https://example.com/1/x",
+        "prefix-resolution-error/b/x": null,
+        "prefix-resolution-error/b/c/x": "https://example.com/1/2/x"
+      }
+    },
+    "No fallback to less-specific scopes": {
+      "importMap": {
+        "imports": {
+          "null": "https://example.com/a",
+          "invalid-url": "https://example.com/b",
+          "without-trailing-slashes/": "https://example.com/c/",
+          "prefix-resolution-error/": "https://example.com/d/"
+        },
+        "scopes": {
+          "/js/": {
+            "null": null,
+            "invalid-url": "https://:invalid-url:/",
+            "without-trailing-slashes/": "/x",
+            "prefix-resolution-error/": "data:text/javascript,/"
+          }
+        }
+      },
+      "expectedResults": {
+        "null": null,
+        "invalid-url": null,
+        "without-trailing-slashes/x": null,
+        "prefix-resolution-error/x": null
+      }
+    },
+    "No fallback to absolute URL parsing": {
+      "importMap": {
+        "imports": {},
+        "scopes": {
+          "/js/": {
+            "https://example.com/null": null,
+            "https://example.com/invalid-url": "https://:invalid-url:/",
+            "https://example.com/without-trailing-slashes/": "/x",
+            "https://example.com/prefix-resolution-error/": "data:text/javascript,/"
+          }
+        }
+      },
+      "expectedResults": {
+        "https://example.com/null": null,
+        "https://example.com/invalid-url": null,
+        "https://example.com/without-trailing-slashes/x": null,
+        "https://example.com/prefix-resolution-error/x": null
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/scopes-exact-vs-prefix.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/scopes-exact-vs-prefix.json
@@ -1,0 +1,134 @@
+{
+  "name": "Exact vs. prefix based matching",
+  "details": "Scopes are matched with base URLs that are exactly the same or subpaths under the scopes with trailing shashes",
+  "link": "https://wicg.github.io/import-maps/#resolve-a-module-specifier Step 8.1",
+  "tests": {
+    "Scope without trailing slash only": {
+      "importMap": {
+        "scopes": {
+          "/js": {
+            "moment": "/only-triggered-by-exact/moment",
+            "moment/": "/only-triggered-by-exact/moment/"
+          }
+        }
+      },
+      "importMapBaseURL": "https://example.com/app/index.html",
+      "tests": {
+        "Non-trailing-slash base URL (exact match)": {
+          "baseURL": "https://example.com/js",
+          "expectedResults": {
+            "moment": "https://example.com/only-triggered-by-exact/moment",
+            "moment/foo": "https://example.com/only-triggered-by-exact/moment/foo"
+          }
+        },
+        "Trailing-slash base URL (fail)": {
+          "baseURL": "https://example.com/js/",
+          "expectedResults": {
+            "moment": null,
+            "moment/foo": null
+          }
+        },
+        "Subpath base URL (fail)": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "moment": null,
+            "moment/foo": null
+          }
+        },
+        "Non-subpath base URL (fail)": {
+          "baseURL": "https://example.com/jsiscool",
+          "expectedResults": {
+            "moment": null,
+            "moment/foo": null
+          }
+        }
+      }
+    },
+    "Scope with trailing slash only": {
+      "importMap": {
+        "scopes": {
+          "/js/": {
+            "moment": "/triggered-by-any-subpath/moment",
+            "moment/": "/triggered-by-any-subpath/moment/"
+          }
+        }
+      },
+      "importMapBaseURL": "https://example.com/app/index.html",
+      "tests": {
+        "Non-trailing-slash base URL (fail)": {
+          "baseURL": "https://example.com/js",
+          "expectedResults": {
+            "moment": null,
+            "moment/foo": null
+          }
+        },
+        "Trailing-slash base URL (exact match)": {
+          "baseURL": "https://example.com/js/",
+          "expectedResults": {
+            "moment": "https://example.com/triggered-by-any-subpath/moment",
+            "moment/foo": "https://example.com/triggered-by-any-subpath/moment/foo"
+          }
+        },
+        "Subpath base URL (prefix match)": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "moment": "https://example.com/triggered-by-any-subpath/moment",
+            "moment/foo": "https://example.com/triggered-by-any-subpath/moment/foo"
+          }
+        },
+        "Non-subpath base URL (fail)": {
+          "baseURL": "https://example.com/jsiscool",
+          "expectedResults": {
+            "moment": null,
+            "moment/foo": null
+          }
+        }
+      }
+    },
+    "Scopes with and without trailing slash": {
+      "importMap": {
+        "scopes": {
+          "/js": {
+            "moment": "/only-triggered-by-exact/moment",
+            "moment/": "/only-triggered-by-exact/moment/"
+          },
+          "/js/": {
+            "moment": "/triggered-by-any-subpath/moment",
+            "moment/": "/triggered-by-any-subpath/moment/"
+          }
+        }
+      },
+      "importMapBaseURL": "https://example.com/app/index.html",
+      "tests": {
+        "Non-trailing-slash base URL (exact match)": {
+          "baseURL": "https://example.com/js",
+          "expectedResults": {
+            "moment": "https://example.com/only-triggered-by-exact/moment",
+            "moment/foo": "https://example.com/only-triggered-by-exact/moment/foo"
+          }
+        },
+        "Trailing-slash base URL (exact match)": {
+          "baseURL": "https://example.com/js/",
+          "expectedResults": {
+            "moment": "https://example.com/triggered-by-any-subpath/moment",
+            "moment/foo": "https://example.com/triggered-by-any-subpath/moment/foo"
+          }
+        },
+        "Subpath base URL (prefix match)": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "moment": "https://example.com/triggered-by-any-subpath/moment",
+            "moment/foo": "https://example.com/triggered-by-any-subpath/moment/foo"
+          }
+        },
+        "Non-subpath base URL (fail)": {
+          "baseURL": "https://example.com/jsiscool",
+          "expectedResults": {
+            "moment": null,
+            "moment/foo": null
+          }
+        }
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/scopes.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/scopes.json
@@ -1,0 +1,171 @@
+{
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "tests": {
+    "Fallback to toplevel and between scopes": {
+      "importMap": {
+        "imports": {
+          "a": "/a-1.mjs",
+          "b": "/b-1.mjs",
+          "c": "/c-1.mjs",
+          "d": "/d-1.mjs"
+        },
+        "scopes": {
+          "/scope2/": {
+            "a": "/a-2.mjs",
+            "d": "/d-2.mjs"
+          },
+          "/scope2/scope3/": {
+            "b": "/b-3.mjs",
+            "d": "/d-3.mjs"
+          }
+        }
+      },
+      "tests": {
+        "should fall back to `imports` when no scopes match": {
+          "baseURL": "https://example.com/scope1/foo.mjs",
+          "expectedResults": {
+            "a": "https://example.com/a-1.mjs",
+            "b": "https://example.com/b-1.mjs",
+            "c": "https://example.com/c-1.mjs",
+            "d": "https://example.com/d-1.mjs"
+          }
+        },
+        "should use a direct scope override": {
+          "baseURL": "https://example.com/scope2/foo.mjs",
+          "expectedResults": {
+            "a": "https://example.com/a-2.mjs",
+            "b": "https://example.com/b-1.mjs",
+            "c": "https://example.com/c-1.mjs",
+            "d": "https://example.com/d-2.mjs"
+          }
+        },
+        "should use an indirect scope override": {
+          "baseURL": "https://example.com/scope2/scope3/foo.mjs",
+          "expectedResults": {
+            "a": "https://example.com/a-2.mjs",
+            "b": "https://example.com/b-3.mjs",
+            "c": "https://example.com/c-1.mjs",
+            "d": "https://example.com/d-3.mjs"
+          }
+        }
+      }
+    },
+    "Relative URL scope keys": {
+      "importMap": {
+        "imports": {
+          "a": "/a-1.mjs",
+          "b": "/b-1.mjs",
+          "c": "/c-1.mjs"
+        },
+        "scopes": {
+          "": {
+            "a": "/a-empty-string.mjs"
+          },
+          "./": {
+            "b": "/b-dot-slash.mjs"
+          },
+          "../": {
+            "c": "/c-dot-dot-slash.mjs"
+          }
+        }
+      },
+      "tests": {
+        "An empty string scope is a scope with import map base URL": {
+          "baseURL": "https://example.com/app/index.html",
+          "expectedResults": {
+            "a": "https://example.com/a-empty-string.mjs",
+            "b": "https://example.com/b-dot-slash.mjs",
+            "c": "https://example.com/c-dot-dot-slash.mjs"
+          }
+        },
+        "'./' scope is a scope with import map base URL's directory": {
+          "baseURL": "https://example.com/app/foo.mjs",
+          "expectedResults": {
+            "a": "https://example.com/a-1.mjs",
+            "b": "https://example.com/b-dot-slash.mjs",
+            "c": "https://example.com/c-dot-dot-slash.mjs"
+          }
+        },
+        "'../' scope is a scope with import map base URL's parent directory": {
+          "baseURL": "https://example.com/foo.mjs",
+          "expectedResults": {
+            "a": "https://example.com/a-1.mjs",
+            "b": "https://example.com/b-1.mjs",
+            "c": "https://example.com/c-dot-dot-slash.mjs"
+          }
+        }
+      }
+    },
+    "Package-like scenarios": {
+      "importMap": {
+        "imports": {
+          "moment": "/node_modules/moment/src/moment.js",
+          "moment/": "/node_modules/moment/src/",
+          "lodash-dot": "./node_modules/lodash-es/lodash.js",
+          "lodash-dot/": "./node_modules/lodash-es/",
+          "lodash-dotdot": "../node_modules/lodash-es/lodash.js",
+          "lodash-dotdot/": "../node_modules/lodash-es/"
+        },
+        "scopes": {
+          "/": {
+            "moment": "/node_modules_3/moment/src/moment.js",
+            "vue": "/node_modules_3/vue/dist/vue.runtime.esm.js"
+          },
+          "/js/": {
+            "lodash-dot": "./node_modules_2/lodash-es/lodash.js",
+            "lodash-dot/": "./node_modules_2/lodash-es/",
+            "lodash-dotdot": "../node_modules_2/lodash-es/lodash.js",
+            "lodash-dotdot/": "../node_modules_2/lodash-es/"
+          }
+        }
+      },
+      "tests": {
+        "Base URLs inside the scope should use the scope if the scope has matching keys": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "lodash-dot": "https://example.com/app/node_modules_2/lodash-es/lodash.js",
+            "lodash-dot/foo": "https://example.com/app/node_modules_2/lodash-es/foo",
+            "lodash-dotdot": "https://example.com/node_modules_2/lodash-es/lodash.js",
+            "lodash-dotdot/foo": "https://example.com/node_modules_2/lodash-es/foo"
+          }
+        },
+        "Base URLs inside the scope fallback to less specific scope": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "moment": "https://example.com/node_modules_3/moment/src/moment.js",
+            "vue": "https://example.com/node_modules_3/vue/dist/vue.runtime.esm.js"
+          }
+        },
+        "Base URLs inside the scope fallback to toplevel": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "moment/foo": "https://example.com/node_modules/moment/src/foo"
+          }
+        },
+        "Base URLs outside a scope shouldn't use the scope even if the scope has matching keys": {
+          "baseURL": "https://example.com/app.mjs",
+          "expectedResults": {
+            "lodash-dot": "https://example.com/app/node_modules/lodash-es/lodash.js",
+            "lodash-dotdot": "https://example.com/node_modules/lodash-es/lodash.js",
+            "lodash-dot/foo": "https://example.com/app/node_modules/lodash-es/foo",
+            "lodash-dotdot/foo": "https://example.com/node_modules/lodash-es/foo"
+          }
+        },
+        "Fallback to toplevel or not, depending on trailing slash match": {
+          "baseURL": "https://example.com/app.mjs",
+          "expectedResults": {
+            "moment": "https://example.com/node_modules_3/moment/src/moment.js",
+            "moment/foo": "https://example.com/node_modules/moment/src/foo"
+          }
+        },
+        "should still fail for package-like specifiers that are not declared": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "underscore/": null,
+            "underscore/foo": null
+          }
+        }
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/test-helper-iframe.js
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/test-helper-iframe.js
@@ -1,0 +1,46 @@
+// Handle errors around fetching, parsing and registering import maps.
+window.onScriptError = event => {
+  window.registrationResult = {type: 'FetchError', error: event.error};
+  return false;
+};
+window.windowErrorHandler = event => {
+  window.registrationResult = {type: 'ParseError', error: event.error};
+  return false;
+};
+window.addEventListener('error', window.windowErrorHandler);
+
+// Handle specifier resolution requests from the parent frame.
+// For failures, we post error names and messages instead of error
+// objects themselves and re-create error objects later, to avoid
+// issues around serializing error objects which is a quite new feature.
+window.addEventListener('message', event => {
+  if (event.data.action !== 'resolve') {
+    parent.postMessage({
+        type: 'Failure',
+        result: 'Error',
+        message: 'Invalid Action: ' + event.data.action}, '*');
+    return;
+  }
+
+  // To respond to a resolution request, we:
+  // 1. Save the specifier to resolve into a global.
+  // 2. Update the document's base URL to the requested base URL.
+  // 3. Create a new inline script, parsed with that base URL, which
+  //    resolves the saved specifier using import.meta.resolve(), and
+  //    sents the result to the parent window.
+  window.specifierToResolve = event.data.specifier;
+  document.querySelector('base').href = event.data.baseURL;
+
+  const inlineScript = document.createElement('script');
+  inlineScript.type = 'module';
+  inlineScript.textContent = `
+    try {
+      const result = import.meta.resolve(window.specifierToResolve);
+      parent.postMessage({type: 'ResolutionSuccess', result}, '*');
+    } catch (e) {
+      parent.postMessage(
+          {type: 'Failure', result: e.name, message: e.message}, '*');
+    }
+  `;
+  document.body.append(inlineScript);
+});

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/test-helper.js
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/test-helper.js
@@ -1,0 +1,142 @@
+setup({allow_uncaught_exception : true});
+
+// Creates a new Document (via <iframe>) and add an inline import map.
+function createTestIframe(importMap, importMapBaseURL) {
+  return new Promise(resolve => {
+    const iframe = document.createElement('iframe');
+
+    window.addEventListener('message', event => {
+        // Parsing result is saved here and checked later, rather than
+        // rejecting the promise on errors.
+        iframe.parseImportMapResult = event.data.type;
+        resolve(iframe);
+      },
+      {once: true});
+
+    const testHTML = createTestHTML(importMap, importMapBaseURL);
+
+    if (new URL(importMapBaseURL).protocol === 'data:') {
+      iframe.src = 'data:text/html;base64,' + btoa(testHTML);
+    } else {
+      iframe.src = '/common/blank.html';
+      iframe.addEventListener('load', () => {
+        iframe.contentDocument.write(testHTML);
+        iframe.contentDocument.close();
+      }, {once: true})
+    }
+    document.body.appendChild(iframe);
+  });
+}
+
+function createTestHTML(importMap, importMapBaseURL) {
+  return `
+    <!DOCTYPE html>
+    <script src="${location.origin}/import-maps/data-driven/resources/test-helper-iframe.js"></script>
+
+    <base href="${importMapBaseURL}">
+    <script type="importmap" onerror="onScriptError(event)">
+    ${JSON.stringify(importMap)}
+    </script>
+
+    <script type="module">
+      if (!window.registrationResult) {
+        window.registrationResult = {type: 'Success'};
+      }
+      window.removeEventListener('error', window.windowErrorHandler);
+      parent.postMessage(window.registrationResult, '*');
+    </script>
+  `;
+}
+
+// Returns a promise that is resolved with the resulting URL, or rejected if
+// the resolution fails.
+function resolve(specifier, baseURL, iframe) {
+  return new Promise((resolve, reject) => {
+    window.addEventListener('message', event => {
+        if (event.data.type === 'ResolutionSuccess') {
+          resolve(event.data.result);
+        } else if (event.data.type === 'Failure') {
+          if (event.data.result === 'TypeError') {
+            reject(new TypeError(event.data.message));
+          } else {
+            reject(new Error(event.data.message));
+          }
+        } else {
+          assert_unreached('Invalid message: ' + event.data.type);
+        }
+      },
+      {once: true});
+
+    iframe.contentWindow.postMessage(
+      {action: 'resolve', specifier, baseURL},
+      '*'
+    );
+  });
+}
+
+function assert_no_extra_properties(object, expectedProperties, description) {
+  for (const actualProperty in object) {
+    assert_true(expectedProperties.indexOf(actualProperty) !== -1,
+        description + ': unexpected property ' + actualProperty);
+  }
+}
+
+async function runTests(j) {
+  const tests = j.tests;
+  delete j.tests;
+
+  if (j.hasOwnProperty('importMap')) {
+    assert_own_property(j, 'importMap');
+    assert_own_property(j, 'importMapBaseURL');
+    j.iframe = await createTestIframe(j.importMap, j.importMapBaseURL);
+    delete j.importMap;
+    delete j.importMapBaseURL;
+  }
+
+  assert_no_extra_properties(
+      j,
+      ['expectedResults', 'expectedParsedImportMap',
+      'baseURL', 'name', 'iframe',
+      'importMap', 'importMapBaseURL',
+      'link', 'details'],
+      j.name);
+
+  if (tests) {
+    // Nested node.
+    for (const testName in tests) {
+      let fullTestName = testName;
+      if (j.name) {
+        fullTestName = j.name + ': ' + testName;
+      }
+      tests[testName].name = fullTestName;
+      const k = Object.assign({}, j, tests[testName]);
+      await runTests(k);
+    }
+  } else {
+    // Leaf node.
+    for (const key of ['iframe', 'name', 'expectedResults']) {
+      assert_own_property(j, key, j.name);
+    }
+
+    assert_equals(
+        j.iframe.parseImportMapResult,
+        'Success',
+        'Import map registration should be successful for resolution tests');
+    for (const [specifier, expected] of Object.entries(j.expectedResults)) {
+      promise_test(async t => {
+        if (expected === null) {
+          return promise_rejects_js(t, TypeError, resolve(specifier, j.baseURL, j.iframe));
+        } else {
+          assert_equals(await resolve(specifier, j.baseURL, j.iframe), expected);
+        }
+      },
+      j.name + ': ' + specifier);
+    }
+  }
+}
+
+export async function runTestsFromJSON(jsonURL) {
+  const response = await fetch(jsonURL);
+  const json = await response.json();
+  await runTests(json);
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/tricky-specifiers.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/tricky-specifiers.json
@@ -1,0 +1,71 @@
+{
+  "importMap": {
+    "imports": {
+      "package/withslash": "/node_modules/package-with-slash/index.mjs",
+      "not-a-package": "/lib/not-a-package.mjs",
+      "only-slash/": "/lib/only-slash/",
+      ".": "/lib/dot.mjs",
+      "..": "/lib/dotdot.mjs",
+      "..\\": "/lib/dotdotbackslash.mjs",
+      "%2E": "/lib/percent2e.mjs",
+      "%2F": "/lib/percent2f.mjs",
+      "https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/": "/a/",
+      "https://map.example/きつね/fox/": "/b/",
+      "%E3%81%8D%E3%81%A4%E3%81%AD/": "/c/",
+      "きつね/fox/": "/d/"
+    }
+  },
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "Tricky specifiers",
+  "tests": {
+    "explicitly-mapped specifiers that happen to have a slash": {
+      "expectedResults": {
+        "package/withslash": "https://example.com/node_modules/package-with-slash/index.mjs"
+      }
+    },
+    "specifier with punctuation": {
+      "expectedResults": {
+        ".": "https://example.com/lib/dot.mjs",
+        "..": "https://example.com/lib/dotdot.mjs",
+        "..\\": "https://example.com/lib/dotdotbackslash.mjs",
+        "%2E": "https://example.com/lib/percent2e.mjs",
+        "%2F": "https://example.com/lib/percent2f.mjs"
+      }
+    },
+    "submodule of something not declared with a trailing slash should fail": {
+      "expectedResults": {
+        "not-a-package/foo": null
+      }
+    },
+    "module for which only a trailing-slash version is present should fail": {
+      "expectedResults": {
+        "only-slash": null
+      }
+    },
+    "URL-like specifiers are normalized": {
+      "expectedResults": {
+        "https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/": "https://example.com/a/",
+        "https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/bar": "https://example.com/a/bar",
+        "https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/fox/": "https://example.com/b/",
+        "https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/fox/bar": "https://example.com/b/bar",
+        "https://map.example/きつね/": "https://example.com/a/",
+        "https://map.example/きつね/bar": "https://example.com/a/bar",
+        "https://map.example/きつね/fox/": "https://example.com/b/",
+        "https://map.example/きつね/fox/bar": "https://example.com/b/bar"
+      }
+    },
+    "Bare specifiers are not normalized": {
+      "expectedResults": {
+        "%E3%81%8D%E3%81%A4%E3%81%AD/": "https://example.com/c/",
+        "%E3%81%8D%E3%81%A4%E3%81%AD/bar": "https://example.com/c/bar",
+        "%E3%81%8D%E3%81%A4%E3%81%AD/fox/": "https://example.com/c/fox/",
+        "%E3%81%8D%E3%81%A4%E3%81%AD/fox/bar": "https://example.com/c/fox/bar",
+        "きつね/": null,
+        "きつね/bar": null,
+        "きつね/fox/": "https://example.com/d/",
+        "きつね/fox/bar": "https://example.com/d/bar"
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/url-specifiers-schemes.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/url-specifiers-schemes.json
@@ -1,0 +1,45 @@
+{
+  "importMap": {
+    "imports": {
+      "data:text/": "/lib/test-data/",
+      "about:text/": "/lib/test-about/",
+      "blob:text/": "/lib/test-blob/",
+      "blah:text/": "/lib/test-blah/",
+      "http:text/": "/lib/test-http/",
+      "https:text/": "/lib/test-https/",
+      "file:text/": "/lib/test-file/",
+      "ftp:text/": "/lib/test-ftp/",
+      "ws:text/": "/lib/test-ws/",
+      "wss:text/": "/lib/test-wss/"
+    }
+  },
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "URL-like specifiers",
+  "tests": {
+    "Non-special vs. special schemes": {
+      "expectedResults": {
+        "data:text/javascript,console.log('foo')": "data:text/javascript,console.log('foo')",
+        "data:text/": "https://example.com/lib/test-data/",
+        "about:text/foo": "about:text/foo",
+        "about:text/": "https://example.com/lib/test-about/",
+        "blob:text/foo": "blob:text/foo",
+        "blob:text/": "https://example.com/lib/test-blob/",
+        "blah:text/foo": "blah:text/foo",
+        "blah:text/": "https://example.com/lib/test-blah/",
+        "http:text/foo": "https://example.com/lib/test-http/foo",
+        "http:text/": "https://example.com/lib/test-http/",
+        "https:text/foo": "https://example.com/lib/test-https/foo",
+        "https:text/": "https://example.com/lib/test-https/",
+        "ftp:text/foo": "https://example.com/lib/test-ftp/foo",
+        "ftp:text/": "https://example.com/lib/test-ftp/",
+        "file:text/foo": "https://example.com/lib/test-file/foo",
+        "file:text/": "https://example.com/lib/test-file/",
+        "ws:text/foo": "https://example.com/lib/test-ws/foo",
+        "ws:text/": "https://example.com/lib/test-ws/",
+        "wss:text/foo": "https://example.com/lib/test-wss/foo",
+        "wss:text/": "https://example.com/lib/test-wss/"
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/url-specifiers.json
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/url-specifiers.json
@@ -1,0 +1,68 @@
+{
+  "importMap": {
+    "imports": {
+      "/lib/foo.mjs": "./more/bar.mjs",
+      "./dotrelative/foo.mjs": "/lib/dot.mjs",
+      "../dotdotrelative/foo.mjs": "/lib/dotdot.mjs",
+      "/": "/lib/slash-only/",
+      "./": "/lib/dotslash-only/",
+      "/test/": "/lib/url-trailing-slash/",
+      "./test/": "/lib/url-trailing-slash-dot/",
+      "/test": "/lib/test1.mjs",
+      "../test": "/lib/test2.mjs"
+    }
+  },
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "URL-like specifiers",
+  "tests": {
+    "Ordinary URL-like specifiers": {
+      "expectedResults": {
+        "https://example.com/lib/foo.mjs": "https://example.com/app/more/bar.mjs",
+        "https://///example.com/lib/foo.mjs": "https://example.com/app/more/bar.mjs",
+        "/lib/foo.mjs": "https://example.com/app/more/bar.mjs",
+        "https://example.com/app/dotrelative/foo.mjs": "https://example.com/lib/dot.mjs",
+        "../app/dotrelative/foo.mjs": "https://example.com/lib/dot.mjs",
+        "https://example.com/dotdotrelative/foo.mjs": "https://example.com/lib/dotdot.mjs",
+        "../dotdotrelative/foo.mjs": "https://example.com/lib/dotdot.mjs"
+      }
+    },
+    "Import map entries just composed from / and .": {
+      "expectedResults": {
+        "https://example.com/": "https://example.com/lib/slash-only/",
+        "/": "https://example.com/lib/slash-only/",
+        "../": "https://example.com/lib/slash-only/",
+        "https://example.com/app/": "https://example.com/lib/dotslash-only/",
+        "/app/": "https://example.com/lib/dotslash-only/",
+        "../app/": "https://example.com/lib/dotslash-only/"
+      }
+    },
+    "prefix-matched by keys with trailing slashes": {
+      "expectedResults": {
+        "/test/foo.mjs": "https://example.com/lib/url-trailing-slash/foo.mjs",
+        "https://example.com/app/test/foo.mjs": "https://example.com/lib/url-trailing-slash-dot/foo.mjs"
+      }
+    },
+    "should use the last entry's address when URL-like specifiers parse to the same absolute URL": {
+      "expectedResults": {
+        "/test": "https://example.com/lib/test2.mjs"
+      }
+    },
+    "backtracking (relative URLs)": {
+      "expectedResults": {
+        "/test/..": "https://example.com/lib/slash-only/",
+        "/test/../backtrack": "https://example.com/lib/slash-only/backtrack",
+        "/test/../../backtrack": "https://example.com/lib/slash-only/backtrack",
+        "/test/../../../backtrack": "https://example.com/lib/slash-only/backtrack"
+      }
+    },
+    "backtracking (absolute URLs)": {
+      "expectedResults": {
+        "https://example.com/test/..": "https://example.com/lib/slash-only/",
+        "https://example.com/test/../backtrack": "https://example.com/lib/slash-only/backtrack",
+        "https://example.com/test/../../backtrack": "https://example.com/lib/slash-only/backtrack",
+        "https://example.com/test/../../../backtrack": "https://example.com/lib/slash-only/backtrack"
+      }
+    }
+  }
+}

--- a/LayoutTests/http/wpt/import-maps/data-driven/resources/w3c-import.log
+++ b/LayoutTests/http/wpt/import-maps/data-driven/resources/w3c-import.log
@@ -1,0 +1,39 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/data-url-prefix.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/empty-import-map.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/overlapping-entries.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/packages-via-trailing-slashes.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-addresses-absolute.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-addresses-invalid.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-addresses.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-invalid-json.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-normalization.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-scope.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-specifier-map.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-toplevel.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-scope-keys.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-specifier-keys.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-trailing-slashes.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/resolving-null.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/scopes-exact-vs-prefix.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/scopes.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/test-helper-iframe.js
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/test-helper.js
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/tricky-specifiers.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/url-specifiers-schemes.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/url-specifiers.json

--- a/LayoutTests/http/wpt/import-maps/data-driven/tools/format_json.py
+++ b/LayoutTests/http/wpt/import-maps/data-driven/tools/format_json.py
@@ -1,0 +1,27 @@
+import collections
+import json
+import sys
+import traceback
+"""
+Simple JSON formatter, to be used for JSON files under resources/.
+
+Usage:
+$ python tools/format_json.py resources/*.json
+"""
+
+
+def main():
+    for filename in sys.argv[1:]:
+        print(filename)
+        try:
+            spec = json.load(
+                open(filename, u'r'), object_pairs_hook=collections.OrderedDict)
+            with open(filename, u'w') as f:
+                f.write(json.dumps(spec, indent=2, separators=(u',', u': ')))
+                f.write(u'\n')
+        except:
+            traceback.print_exc()
+
+
+if __name__ == '__main__':
+    main()

--- a/LayoutTests/http/wpt/import-maps/data-driven/tools/w3c-import.log
+++ b/LayoutTests/http/wpt/import-maps/data-driven/tools/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/tools/format_json.py

--- a/LayoutTests/http/wpt/import-maps/data-driven/w3c-import.log
+++ b/LayoutTests/http/wpt/import-maps/data-driven/w3c-import.log
@@ -1,0 +1,18 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/README.md
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving.html

--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -355,6 +355,7 @@
     "web-platform-tests/image-decodes": "skip", 
     "web-platform-tests/imagebitmap-renderingcontext": "import", 
     "web-platform-tests/images": "import", 
+    "web-platform-tests/import-maps": "import", 
     "web-platform-tests/inert": "import", 
     "web-platform-tests/infrastructure": "import", 
     "web-platform-tests/innerText": "import", 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-importmap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-importmap-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL import.meta.resolve() given an import mapped bare specifier Module specifier, 'bare' does not start with "/", "./", or "../". Referenced from http://localhost:8800/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-importmap.html
-FAIL import.meta.resolve() given an import mapped  URL-like specifier assert_equals: expected "https://example.com/rewritten" but got "https://example.com/rewrite"
-FAIL Testing the ToString() step of import.meta.resolve() via import maps Module specifier, 'undefined' does not start with "/", "./", or "../". Referenced from http://localhost:8800/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-importmap.html
-FAIL import(import.meta.resolve(x)) can be different from import(x) promise_test: Unhandled rejection with value: object "TypeError: Importing a module script failed."
+PASS import.meta.resolve() given an import mapped bare specifier
+PASS import.meta.resolve() given an import mapped  URL-like specifier
+PASS Testing the ToString() step of import.meta.resolve() via import maps
+PASS import(import.meta.resolve(x)) can be different from import(x)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/specifier-error-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/specifier-error-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: TypeError: Module specifier, 'string-without-dot-slash-prefix' does not start with "/", "./", or "../". Referenced from http://localhost:8800/html/semantics/scripting-1/the-script-element/module/bad-module-specifier.js
+CONSOLE MESSAGE: TypeError: Module name, 'string-without-dot-slash-prefix' does not resolve to a valid URL.
 
 PASS Test that invalid module specifier leads to TypeError on window.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/META.yml
@@ -1,0 +1,4 @@
+spec: https://wicg.github.io/import-maps/
+suggested_reviewers:
+  - domenic
+  - hiroshige-g

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/README.md
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/README.md
@@ -1,0 +1,1 @@
+These tests are about the impact of the [acquiring import maps](https://wicg.github.io/import-maps/#document-acquiring-import-maps) boolean, which prevents import maps from taking effect after a module import has started.

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import-expected.txt
@@ -1,0 +1,5 @@
+
+PASS After dynamic imports, import maps should fire error events
+PASS A dynamic import succeeds
+PASS After a dynamic import(), import maps are not effective
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const t = async_test(
+  'After dynamic imports, import maps should fire error events');
+const log = [];
+// To ensure we are testing that the flag is cleared at the beginning of module
+// script loading unconditionally, not at the end of loading or not at the
+// first attempt to resolve a module specifier, trickle(d1) is used to ensure
+// the following import map is added after module loading is triggered but
+// before the first module script is parsed.
+promise_test(() => import('../resources/empty.js?pipe=trickle(d1)'),
+             "A dynamic import succeeds");
+</script>
+<script type="importmap" onload="t.assert_unreached('onload')" onerror="t.done()">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+<script>
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => assert_array_equals(log, ["log:A"]))
+  },
+  'After a dynamic import(), import maps are not effective');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-expected.txt
@@ -1,0 +1,6 @@
+
+Harness Error (TIMEOUT), message = null
+
+NOTRUN After <link rel=modulepreload> import maps should fire error events
+FAIL After <link rel=modulepreload> import maps are not effective assert_array_equals: expected property 0 to be "log:A" but got "log:B" (expected array ["log:A"] got ["log:B"])
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header-expected.txt
@@ -1,0 +1,6 @@
+
+Harness Error (TIMEOUT), message = null
+
+NOTRUN With modulepreload link header, import maps should fire error events
+FAIL With modulepreload link header, import maps are not effective assert_array_equals: expected property 0 to be "log:A" but got "log:B" (expected array ["log:A"] got ["log:B"])
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const t = async_test(
+  'With modulepreload link header, import maps should fire error events');
+const log = [];
+</script>
+<script type="importmap" onerror="t.done()">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+<script>
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => assert_array_equals(log, ["log:A"]))
+  },
+  'With modulepreload link header, import maps are not effective');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html.headers
@@ -1,0 +1,1 @@
+Link: <../resources/empty.js?pipe=trickle(d1)>;rel=modulepreload

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const t = async_test(
+  'After <link rel=modulepreload> import maps should fire error events');
+const log = [];
+</script>
+<link rel="modulepreload" href="../resources/empty.js?pipe=trickle(d1)"></link>
+<script type="importmap" onerror="t.done()">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+<script>
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => assert_array_equals(log, ["log:A"]))
+  },
+  'After <link rel=modulepreload> import maps are not effective');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-expected.txt
@@ -1,0 +1,4 @@
+
+PASS After <script type="module"> import maps should fire error events
+PASS After <script type="module"> import maps are not effective
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline-expected.txt
@@ -1,0 +1,4 @@
+
+PASS After inline <script type="module"> import maps should fire error events
+PASS After inline <script type="module"> import maps are not effective
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const t = async_test(
+  'After inline <script type="module"> import maps should fire error events');
+const log = [];
+</script>
+<script type="module">
+// While this inline module script doesn't have any specifiers and doesn't fetch
+// anything, this still disables subsequent import maps, because
+// https://wicg.github.io/import-maps/#wait-for-import-maps
+// is anyway called at the beginning of
+// https://html.spec.whatwg.org/multipage/webappapis.html#fetch-an-inline-module-script-graph
+</script>
+<script type="importmap" onerror="t.done()">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+<script>
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => assert_array_equals(log, ["log:A"]))
+  },
+  'After inline <script type="module"> import maps are not effective');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const t = async_test(
+  'After <script type="module"> import maps should fire error events');
+const log = [];
+</script>
+<script type="module" src="../resources/empty.js?pipe=trickle(d1)"></script>
+<script type="importmap" onerror="t.done()">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+<script>
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => assert_array_equals(log, ["log:A"]))
+  },
+  'After <script type="module"> import maps are not effective');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/w3c-import.log
@@ -1,0 +1,24 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/README.md
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html.headers
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/worker-request.html

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/worker-request-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/worker-request-expected.txt
@@ -1,0 +1,3 @@
+
+PASS After module worker creation import maps are still effective
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/worker-request.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/worker-request.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const log = [];
+new Worker('../resources/empty.js?pipe=trickle(d1)', {type: "module"});
+</script>
+<script type="importmap">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+<script>
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => assert_array_equals(log, ["log:B"]))
+  },
+  'After module worker creation import maps are still effective');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt
@@ -1,0 +1,47 @@
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: TypeError: Module name, 'bare/to-bare' does not resolve to a valid URL.
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+
+
+PASS bare/bare: <script src type=module>
+PASS bare/bare: <script src type=text/javascript>
+PASS bare/bare: static import
+PASS bare/bare: dynamic import (from module)
+PASS bare/bare: dynamic import (from text/javascript)
+PASS bare/cross-origin-bare: <script src type=module>
+PASS bare/cross-origin-bare: <script src type=text/javascript>
+FAIL bare/cross-origin-bare: static import assert_unreached: script's error event shouldn't be fired Reached unreachable code
+FAIL bare/cross-origin-bare: dynamic import (from module) assert_unreached: dynamic import promise shouldn't be rejected Reached unreachable code
+FAIL bare/cross-origin-bare: dynamic import (from text/javascript) assert_unreached: dynamic import promise shouldn't be rejected Reached unreachable code
+PASS bare/to-data: <script src type=module>
+PASS bare/to-data: <script src type=text/javascript>
+PASS bare/to-data: static import
+PASS bare/to-data: dynamic import (from module)
+PASS bare/to-data: dynamic import (from text/javascript)
+PASS bare/to-bare: <script src type=module>
+PASS bare/to-bare: <script src type=text/javascript>
+PASS bare/to-bare: static import
+PASS bare/to-bare: dynamic import (from module)
+PASS bare/to-bare: dynamic import (from text/javascript)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/test-helper.js"></script>
+
+<script>
+// "bare/..." (i.e. without leading "./") are bare specifiers
+// (not relative paths).
+const importMap = `
+{
+  "imports": {
+    "bare/bare": "./resources/log.js?pipe=sub&name=bare",
+    "bare/cross-origin-bare": "https://{{domains[www1]}}:{{ports[https][0]}}/import-maps/resources/log.js?pipe=sub&name=cross-origin-bare",
+    "bare/to-data": "data:text/javascript,log.push('dataURL')",
+
+    "bare/to-bare": "bare/bare"
+  }
+}
+`;
+
+const tests = {
+  // Arrays of expected results for:
+  // - <script src type="module">,
+  // - <script src> (classic script),
+  // - static import, and
+  // - dynamic import.
+
+  // Bare to HTTP(S).
+  "bare/bare":
+    [Result.URL, Result.URL, "log:bare", "log:bare"],
+  "bare/cross-origin-bare":
+    [Result.URL, Result.URL, "log:cross-origin-bare", "log:cross-origin-bare"],
+
+  // Bare to data:
+  "bare/to-data":
+    [Result.URL, Result.URL, "dataURL", "dataURL"],
+
+  // Bare to bare mapping is disabled.
+  "bare/to-bare":
+    [Result.URL, Result.URL, Result.PARSE_ERROR, Result.PARSE_ERROR],
+};
+
+doTests(importMap, null, tests);
+</script>
+<body>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/README.md
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/README.md
@@ -1,0 +1,1 @@
+This directory contains resources which might get imported, post-mapping. The exact URLs are important, which is why we don't place it under resources/ or similar.

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/__dir__.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/__dir__.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/bare
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/bare
@@ -1,0 +1,1 @@
+log.push("relative:bare/bare");

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/cross-origin-bare
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/cross-origin-bare
@@ -1,0 +1,1 @@
+log.push("relative:bare/cross-origin-bare");

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/to-bare
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/to-bare
@@ -1,0 +1,1 @@
+log.push("relative:bare/to-bare");

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/to-data
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/to-data
@@ -1,0 +1,1 @@
+log.push("relative:bare/to-data");

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/w3c-import.log
@@ -1,0 +1,22 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/README.md
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/__dir__.headers
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/bare
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/cross-origin-bare
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/to-bare
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/to-data

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Refused to load https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=B because it does not appear in the script-src directive of the Content Security Policy.
+
+PASS The URL after mapping violates CSP (but not the URL before mapping)
+PASS The URL before mapping violates CSP (but not the URL after mapping)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/test-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';">
+<script type="importmap">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "https://{{domains[www1]}}:{{ports[https][0]}}/import-maps/resources/log.js?pipe=sub&name=B",
+    "https://{{domains[www1]}}:{{ports[https][0]}}/import-maps/resources/log.js?pipe=sub&name=C": "../resources/log.js?pipe=sub&name=D"
+  }
+}
+</script>
+<script>
+promise_test(t => {
+    return promise_rejects_js(t, TypeError,
+                           import('../resources/log.js?pipe=sub&name=A'),
+                           'Dynamic import should fail');
+  }, 'The URL after mapping violates CSP (but not the URL before mapping)');
+
+promise_test(t => {
+    return import('https://{{domains[www1]}}:{{ports[https][0]}}/import-maps/resources/log.js?pipe=sub&name=C')
+      .then(() => assert_array_equals(log, ["log:D"]));
+  }, 'The URL before mapping violates CSP (but not the URL after mapping)');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Refused to load https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=B because it does not appear in the script-src directive of the Content Security Policy.
+
+PASS The URL after mapping violates CSP (but not the URL before mapping)
+PASS The URL before mapping violates CSP (but not the URL after mapping)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/test-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';">
+<script type="importmap">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "https://{{domains[www1]}}:{{ports[https][0]}}/import-maps/resources/log.js?pipe=sub&name=B",
+    "https://{{domains[www1]}}:{{ports[https][0]}}/import-maps/resources/log.js?pipe=sub&name=C": "../resources/log.js?pipe=sub&name=D"
+  }
+}
+</script>
+<script type="module">
+import '../resources/log.js?pipe=sub&name=A';
+</script>
+<script type="module">
+test(t => {
+    assert_array_equals(log, []);
+  }, 'The URL after mapping violates CSP (but not the URL before mapping)');
+</script>
+
+<script type="module">
+import 'https://{{domains[www1]}}:{{ports[https][0]}}/import-maps/resources/log.js?pipe=sub&name=C';
+</script>
+<script type="module">
+test(t => {
+    assert_array_equals(log, ["log:D"]);
+  }, 'The URL before mapping violates CSP (but not the URL after mapping)');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Importmap should be accepted due to hash
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash-failure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash-failure-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Refused to execute a script because its hash, its nonce, or 'unsafe-inline' does not appear in the script-src directive of the Content Security Policy.
+
+PASS Importmap should not be accepted due to wrong hash
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash-failure.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash-failure.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'sha256-wrong9e+pZbSYIkpB8BIE0Hs7yHajJDiX5mnT/wrong=' 'sha256-RAsyam34o4peVe9sCebtaZWRVhqAhudem+NlcnP2Kp8=';">
+
+<!-- 'sha256-P5xqp9e+pZbSYIkpB8BIE0Hs7yHajJDiX5mnT/1PO1I=' -->
+<script type="importmap">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+
+<!-- 'sha256-RAsyam34o4peVe9sCebtaZWRVhqAhudem+NlcnP2Kp8=' -->
+<script>
+const log = [];
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => assert_array_equals(log, ["log:A"]))
+  },
+  'Importmap should not be accepted due to wrong hash');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'sha256-P5xqp9e+pZbSYIkpB8BIE0Hs7yHajJDiX5mnT/1PO1I=' 'sha256-Ciqph+wQDoB2suzqZVHOD0iw99WqaTUwZXRl7ATzBxc=';">
+
+<!-- 'sha256-P5xqp9e+pZbSYIkpB8BIE0Hs7yHajJDiX5mnT/1PO1I=' -->
+<script type="importmap">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+
+<!-- 'sha256-Ciqph+wQDoB2suzqZVHOD0iw99WqaTUwZXRl7ATzBxc=' -->
+<script>
+const log = [];
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => assert_array_equals(log, ["log:B"]))
+  },
+  'Importmap should be accepted due to hash');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Importmap should be accepted according to its correct nonce
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce-failure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce-failure-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Refused to execute a script because its hash, its nonce, or 'unsafe-inline' does not appear in the script-src directive of the Content Security Policy.
+
+PASS Importmap should be rejected due to nonce
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce-failure.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce-failure.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta http-equiv="Content-Security-Policy" content="script-src 'nonce-abc';">
+<script type="importmap">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+<script type="importmap" nonce="wrong">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+<script nonce="abc">
+const log = [];
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => assert_array_equals(log, ["log:A"]))
+  },
+  'Importmap should be rejected due to nonce');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta http-equiv="Content-Security-Policy" content="script-src 'nonce-abc';">
+<script type="importmap" nonce="abc">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+<script nonce="abc">
+const log = [];
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => assert_array_equals(log, ["log:B"]))
+  },
+  'Importmap should be accepted according to its correct nonce');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/unsafe-inline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/unsafe-inline-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Importmap should be accepted due to unsafe-inline
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/unsafe-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/unsafe-inline.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';">
+<script type="importmap">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+<script>
+const log = [];
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => assert_array_equals(log, ["log:B"]))
+  },
+  'Importmap should be accepted due to unsafe-inline');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/w3c-import.log
@@ -1,0 +1,23 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash-failure.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce-failure.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/unsafe-inline.html

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/README.md
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/README.md
@@ -1,0 +1,87 @@
+# Data-driven import maps tests
+
+In this directory, test inputs and expectations are expressed as JSON files.
+This is in order to share the same JSON files between WPT tests and other
+implementations that might not run the full WPT suite, e.g. server-side
+JavaScript runtimes or the [JavaScript reference implementation](https://github.com/WICG/import-maps/tree/master/reference-implementation).
+
+## Basics
+
+A **test object** describes a set of parameters (import maps and base URLs) and test expectations.
+Test expectations consist of the expected resulting URLs for specifiers.
+
+Each JSON file under [resources/](resources/) directory consists of a test object.
+A minimum test object would be:
+
+```json
+{
+  "name": "Main test name",
+  "importMapBaseURL": "https://example.com/import-map-base-url/index.html",
+  "importMap": {
+    "imports": {
+      "a": "/mapped-a.mjs"
+    }
+  },
+  "baseURL": "https://example.com/base-url/app.mjs",
+  "expectedResults": {
+    "a": "https://example.com/mapped-a.mjs",
+    "b": null
+  }
+}
+```
+
+Required fields:
+
+- `name`: Test name.
+    - In WPT tests, this is used for the test name of `promise_test()` together with specifier to be resolved, like `"Main test name: a"`.
+- `importMap` (object or string): the import map to be attached.
+- `importMapBaseURL` (string): the base URL used for [parsing the import map](https://wicg.github.io/import-maps/#parse-an-import-map-string).
+- `expectedResults` (object; string to (string or null)): resolution test cases.
+    - The keys are specifiers to be resolved.
+    - The values are expected resolved URLs. If `null`, resolution should fail.
+- `baseURL` (string): the base URL used in [resolving a specifier](https://wicg.github.io/import-maps/#resolve-a-module-specifier) for each specifiers.
+
+Optional fields:
+
+- `link` and `details` can be used for e.g. linking to specs or adding more detailed descriptions.
+    - Currently they are simply ignored by the WPT test helper.
+
+## Nesting and inheritance
+
+We can organize tests by nesting test objects.
+A test object can contain child test objects (*subtests*) using `tests` field.
+The Keys of the `tests` value are the names of subtests, and values are test objects.
+
+For example:
+
+```json
+{
+  "name": "Main test name",
+  "importMapBaseURL": "https://example.com/import-map-base-url/index.html",
+  "importMap": {
+    "imports": {
+      "a": "/mapped-a.mjs"
+    }
+  },
+  "tests": {
+    "Subtest1": {
+      "baseURL": "https://example.com/base-url1/app.mjs",
+      "expectedResults": { "a": "https://example.com/mapped-a.mjs" }
+    },
+    "Subtest2": {
+      "baseURL": "https://example.com/base-url2/app.mjs",
+      "expectedResults": { "b": null }
+    }
+  }
+}
+```
+
+The top-level test object contains two sub test objects, named as `Subtest1` and `Subtest2`, respectively.
+
+Child test objects inherit fields from their parent test object.
+In the example above, the child test objects specifies `baseURL` fields, while they inherits other fields (e.g. `importMapBaseURL`) from the top-level test object.
+
+## TODO
+
+The `parsing-*.json` files are not currently used by the WPT harness. We should
+convert them to resolution tests.

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta name="variant" content="?data-url-prefix.json">
+<meta name="variant" content="?empty-import-map.json">
+<meta name="variant" content="?overlapping-entries.json">
+<meta name="variant" content="?packages-via-trailing-slashes.json">
+<meta name="variant" content="?resolving-null.json">
+<meta name="variant" content="?scopes-exact-vs-prefix.json">
+<meta name="variant" content="?scopes.json">
+<meta name="variant" content="?tricky-specifiers.json">
+<meta name="variant" content="?url-specifiers-schemes.json">
+<meta name="variant" content="?url-specifiers.json">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script type="module">
+import { runTestsFromJSON } from "./resources/test-helper.js";
+
+const filename = location.search.substring(1);
+promise_test(
+  () => runTestsFromJSON('resources/' + filename),
+  "Test helper: fetching and sanity checking test JSON: " + filename);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/data-url-prefix.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/data-url-prefix.json
@@ -1,0 +1,17 @@
+{
+  "importMap": {
+    "imports": {
+      "foo/": "data:text/javascript,foo/"
+    }
+  },
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "data: URL prefix",
+  "tests": {
+    "should not resolve since you can't resolve relative to a data: URL": {
+      "expectedResults": {
+        "foo/bar": null
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/empty-import-map.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/empty-import-map.json
@@ -1,0 +1,61 @@
+{
+  "importMap": {},
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "tests": {
+    "valid relative specifiers": {
+      "expectedResults": {
+        "./foo": "https://example.com/js/foo",
+        "./foo/bar": "https://example.com/js/foo/bar",
+        "./foo/../bar": "https://example.com/js/bar",
+        "./foo/../../bar": "https://example.com/bar",
+        "../foo": "https://example.com/foo",
+        "../foo/bar": "https://example.com/foo/bar",
+        "../../../foo/bar": "https://example.com/foo/bar",
+        "/foo": "https://example.com/foo",
+        "/foo/bar": "https://example.com/foo/bar",
+        "/../../foo/bar": "https://example.com/foo/bar",
+        "/../foo/../bar": "https://example.com/bar"
+      }
+    },
+    "HTTPS scheme absolute URLs": {
+      "expectedResults": {
+        "https://fetch-scheme.net": "https://fetch-scheme.net/",
+        "https:fetch-scheme.org": "https://fetch-scheme.org/",
+        "https://fetch%2Dscheme.com/": "https://fetch-scheme.com/",
+        "https://///fetch-scheme.com///": "https://fetch-scheme.com///"
+      }
+    },
+    "valid relative URLs that are invalid as specifiers should fail": {
+      "expectedResults": {
+        "invalid-specifier": null,
+        "\\invalid-specifier": null,
+        ":invalid-specifier": null,
+        "@invalid-specifier": null,
+        "%2E/invalid-specifier": null,
+        "%2E%2E/invalid-specifier": null,
+        ".%2Finvalid-specifier": null
+      }
+    },
+    "invalid absolute URLs should fail": {
+      "expectedResults": {
+        "https://invalid-url.com:demo": null,
+        "http://[invalid-url.com]/": null
+      }
+    },
+    "non-HTTPS fetch scheme absolute URLs": {
+      "expectedResults": {
+        "about:fetch-scheme": "about:fetch-scheme"
+      }
+    },
+    "non-fetch scheme absolute URLs": {
+      "expectedResults": {
+        "about:fetch-scheme": "about:fetch-scheme",
+        "mailto:non-fetch-scheme": "mailto:non-fetch-scheme",
+        "import:non-fetch-scheme": "import:non-fetch-scheme",
+        "javascript:non-fetch-scheme": "javascript:non-fetch-scheme",
+        "wss:non-fetch-scheme": "wss://non-fetch-scheme/"
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/overlapping-entries.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/overlapping-entries.json
@@ -1,0 +1,25 @@
+{
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "should favor the most-specific key",
+  "tests": {
+    "Overlapping entries with trailing slashes": {
+      "importMap": {
+        "imports": {
+          "a": "/1",
+          "a/": "/2/",
+          "a/b": "/3",
+          "a/b/": "/4/"
+        }
+      },
+      "expectedResults": {
+        "a": "https://example.com/1",
+        "a/": "https://example.com/2/",
+        "a/x": "https://example.com/2/x",
+        "a/b": "https://example.com/3",
+        "a/b/": "https://example.com/4/",
+        "a/b/c": "https://example.com/4/c"
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/packages-via-trailing-slashes.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/packages-via-trailing-slashes.json
@@ -1,0 +1,74 @@
+{
+  "importMap": {
+    "imports": {
+      "moment": "/node_modules/moment/src/moment.js",
+      "moment/": "/node_modules/moment/src/",
+      "lodash-dot": "./node_modules/lodash-es/lodash.js",
+      "lodash-dot/": "./node_modules/lodash-es/",
+      "lodash-dotdot": "../node_modules/lodash-es/lodash.js",
+      "lodash-dotdot/": "../node_modules/lodash-es/",
+      "mapped/": "https://example.com/",
+      "mapped/path/": "https://github.com/WICG/import-maps/issues/207/",
+      "mapped/non-ascii-1/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/",
+      "mapped/non-ascii-2/": "https://example.com/きつね/"
+    }
+  },
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "Package-like scenarios",
+  "link": "https://github.com/WICG/import-maps#packages-via-trailing-slashes",
+  "tests": {
+    "package main modules": {
+      "expectedResults": {
+        "moment": "https://example.com/node_modules/moment/src/moment.js",
+        "lodash-dot": "https://example.com/app/node_modules/lodash-es/lodash.js",
+        "lodash-dotdot": "https://example.com/node_modules/lodash-es/lodash.js"
+      }
+    },
+    "package submodules": {
+      "expectedResults": {
+        "moment/foo": "https://example.com/node_modules/moment/src/foo",
+        "moment/foo?query": "https://example.com/node_modules/moment/src/foo?query",
+        "moment/foo#fragment": "https://example.com/node_modules/moment/src/foo#fragment",
+        "moment/foo?query#fragment": "https://example.com/node_modules/moment/src/foo?query#fragment",
+        "lodash-dot/foo": "https://example.com/app/node_modules/lodash-es/foo",
+        "lodash-dotdot/foo": "https://example.com/node_modules/lodash-es/foo"
+      }
+    },
+    "package names that end in a slash should just pass through": {
+      "expectedResults": {
+        "moment/": "https://example.com/node_modules/moment/src/"
+      }
+    },
+    "package modules that are not declared should fail": {
+      "expectedResults": {
+        "underscore/": null,
+        "underscore/foo": null
+      }
+    },
+    "backtracking via ..": {
+      "expectedResults": {
+        "mapped/path": "https://example.com/path",
+        "mapped/path/": "https://github.com/WICG/import-maps/issues/207/",
+        "mapped/path/..": null,
+        "mapped/path/../path/": null,
+        "mapped/path/../207": null,
+        "mapped/path/../207/": "https://github.com/WICG/import-maps/issues/207/",
+        "mapped/path//": null,
+        "mapped/path/WICG/import-maps/issues/207/": "https://github.com/WICG/import-maps/issues/207/WICG/import-maps/issues/207/",
+        "mapped/path//WICG/import-maps/issues/207/": "https://github.com/WICG/import-maps/issues/207/",
+        "mapped/path/../backtrack": null,
+        "mapped/path/../../backtrack": null,
+        "mapped/path/../../../backtrack": null,
+        "moment/../backtrack": null,
+        "moment/..": null,
+        "mapped/non-ascii-1/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/",
+        "mapped/non-ascii-1/../%E3%81%8D%E3%81%A4%E3%81%AD/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/",
+        "mapped/non-ascii-1/../きつね/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/",
+        "mapped/non-ascii-2/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/",
+        "mapped/non-ascii-2/../%E3%81%8D%E3%81%A4%E3%81%AD/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/",
+        "mapped/non-ascii-2/../きつね/": "https://example.com/%E3%81%8D%E3%81%A4%E3%81%AD/"
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-addresses-absolute.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-addresses-absolute.json
@@ -1,0 +1,65 @@
+{
+  "name": "Absolute URL addresses",
+  "tests": {
+    "should only accept absolute URL addresses with fetch schemes": {
+      "importMap": {
+        "imports": {
+          "about": "about:good",
+          "blob": "blob:good",
+          "data": "data:good",
+          "file": "file:///good",
+          "filesystem": "filesystem:http://example.com/good/",
+          "http": "http://good/",
+          "https": "https://good/",
+          "ftp": "ftp://good/",
+          "import": "import:bad",
+          "mailto": "mailto:bad",
+          "javascript": "javascript:bad",
+          "wss": "wss:bad"
+        }
+      },
+      "importMapBaseURL": "https://base.example/path1/path2/path3",
+      "expectedParsedImportMap": {
+        "imports": {
+          "about": "about:good",
+          "blob": "blob:good",
+          "data": "data:good",
+          "file": "file:///good",
+          "filesystem": "filesystem:http://example.com/good/",
+          "http": "http://good/",
+          "https": "https://good/",
+          "ftp": "ftp://good/",
+          "import": "import:bad",
+          "javascript": "javascript:bad",
+          "mailto": "mailto:bad",
+          "wss": "wss://bad/"
+        },
+        "scopes": {}
+      }
+    },
+    "should parse absolute URLs, ignoring unparseable ones": {
+      "importMap": {
+        "imports": {
+          "unparseable2": "https://example.com:demo",
+          "unparseable3": "http://[www.example.com]/",
+          "invalidButParseable1": "https:example.org",
+          "invalidButParseable2": "https://///example.com///",
+          "prettyNormal": "https://example.net",
+          "percentDecoding": "https://ex%41mple.com/"
+        }
+      },
+      "importMapBaseURL": "https://base.example/path1/path2/path3",
+      "expectedParsedImportMap": {
+        "imports": {
+          "unparseable2": null,
+          "unparseable3": null,
+          "invalidButParseable1": "https://example.org/",
+          "invalidButParseable2": "https://example.com///",
+          "prettyNormal": "https://example.net/",
+          "percentDecoding": "https://example.com/"
+        },
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-addresses-invalid.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-addresses-invalid.json
@@ -1,0 +1,27 @@
+{
+  "name": "Other invalid addresses",
+  "tests": {
+    "should ignore unprefixed strings that are not absolute URLs": {
+      "importMap": {
+        "imports": {
+          "foo1": "bar",
+          "foo2": "\\bar",
+          "foo3": "~bar",
+          "foo4": "#bar",
+          "foo5": "?bar"
+        }
+      },
+      "importMapBaseURL": "https://base.example/path1/path2/path3",
+      "expectedParsedImportMap": {
+        "imports": {
+          "foo1": null,
+          "foo2": null,
+          "foo3": null,
+          "foo4": null,
+          "foo5": null
+        },
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-addresses.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-addresses.json
@@ -1,0 +1,85 @@
+{
+  "name": "Relative URL-like addresses",
+  "tests": {
+    "should accept strings prefixed with ./, ../, or /": {
+      "importMap": {
+        "imports": {
+          "dotSlash": "./foo",
+          "dotDotSlash": "../foo",
+          "slash": "/foo"
+        }
+      },
+      "importMapBaseURL": "https://base.example/path1/path2/path3",
+      "expectedParsedImportMap": {
+        "imports": {
+          "dotSlash": "https://base.example/path1/path2/foo",
+          "dotDotSlash": "https://base.example/path1/foo",
+          "slash": "https://base.example/foo"
+        },
+        "scopes": {}
+      }
+    },
+    "should not accept strings prefixed with ./, ../, or / for data: base URLs": {
+      "importMap": {
+        "imports": {
+          "dotSlash": "./foo",
+          "dotDotSlash": "../foo",
+          "slash": "/foo"
+        }
+      },
+      "importMapBaseURL": "data:text/html,test",
+      "expectedParsedImportMap": {
+        "imports": {
+          "dotSlash": null,
+          "dotDotSlash": null,
+          "slash": null
+        },
+        "scopes": {}
+      }
+    },
+    "should accept the literal strings ./, ../, or / with no suffix": {
+      "importMap": {
+        "imports": {
+          "dotSlash": "./",
+          "dotDotSlash": "../",
+          "slash": "/"
+        }
+      },
+      "importMapBaseURL": "https://base.example/path1/path2/path3",
+      "expectedParsedImportMap": {
+        "imports": {
+          "dotSlash": "https://base.example/path1/path2/",
+          "dotDotSlash": "https://base.example/path1/",
+          "slash": "https://base.example/"
+        },
+        "scopes": {}
+      }
+    },
+    "should ignore percent-encoded variants of ./, ../, or /": {
+      "importMap": {
+        "imports": {
+          "dotSlash1": "%2E/",
+          "dotDotSlash1": "%2E%2E/",
+          "dotSlash2": ".%2F",
+          "dotDotSlash2": "..%2F",
+          "slash2": "%2F",
+          "dotSlash3": "%2E%2F",
+          "dotDotSlash3": "%2E%2E%2F"
+        }
+      },
+      "importMapBaseURL": "https://base.example/path1/path2/path3",
+      "expectedParsedImportMap": {
+        "imports": {
+          "dotSlash1": null,
+          "dotDotSlash1": null,
+          "dotSlash2": null,
+          "dotDotSlash2": null,
+          "slash2": null,
+          "dotSlash3": null,
+          "dotDotSlash3": null
+        },
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-invalid-json.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-invalid-json.json
@@ -1,0 +1,6 @@
+{
+  "name": "Invalid JSON",
+  "importMapBaseURL": "https://base.example/",
+  "importMap": "{imports: {}}",
+  "expectedParsedImportMap": null
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-normalization.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-normalization.json
@@ -1,0 +1,31 @@
+{
+  "name": "Normalization",
+  "importMapBaseURL": "https://base.example/",
+  "tests": {
+    "should normalize empty import maps to have imports and scopes keys": {
+      "importMap": {},
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    },
+    "should normalize an import map without imports to have imports": {
+      "importMap": {
+        "scopes": {}
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    },
+    "should normalize an import map without scopes to have scopes": {
+      "importMap": {
+        "imports": {}
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-scope.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-scope.json
@@ -1,0 +1,46 @@
+{
+  "name": "Mismatching scopes schema",
+  "importMapBaseURL": "https://base.example/",
+  "tests": {
+    "should throw if a scope's value is not an object": {
+      "expectedParsedImportMap": null,
+      "tests": {
+        "null": {
+          "importMap": {
+            "scopes": {
+              "https://example.com/": null
+            }
+          }
+        },
+        "boolean": {
+          "importMap": {
+            "scopes": {
+              "https://example.com/": true
+            }
+          }
+        },
+        "number": {
+          "importMap": {
+            "scopes": {
+              "https://example.com/": 1
+            }
+          }
+        },
+        "string": {
+          "importMap": {
+            "scopes": {
+              "https://example.com/": "foo"
+            }
+          }
+        },
+        "array": {
+          "importMap": {
+            "scopes": {
+              "https://example.com/": []
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-specifier-map.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-specifier-map.json
@@ -1,0 +1,44 @@
+{
+  "name": "Mismatching the specifier map schema",
+  "importMapBaseURL": "https://base.example/",
+  "tests": {
+    "should ignore entries where the address is not a string": {
+      "importMap": {
+        "imports": {
+          "null": null,
+          "boolean": true,
+          "number": 1,
+          "object": {},
+          "array": [],
+          "array2": [
+            "https://example.com/"
+          ],
+          "string": "https://example.com/"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "null": null,
+          "boolean": null,
+          "number": null,
+          "object": null,
+          "array": null,
+          "array2": null,
+          "string": "https://example.com/"
+        },
+        "scopes": {}
+      }
+    },
+    "should ignore entries where the specifier key is an empty string": {
+      "importMap": {
+        "imports": {
+          "": "https://example.com/"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-toplevel.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-toplevel.json
@@ -1,0 +1,97 @@
+{
+  "name": "Mismatching the top-level schema",
+  "importMapBaseURL": "https://base.example/",
+  "tests": {
+    "should throw for top-level non-objects": {
+      "expectedParsedImportMap": null,
+      "tests": {
+        "null": {
+          "importMap": null
+        },
+        "boolean": {
+          "importMap": true
+        },
+        "number": {
+          "importMap": 1
+        },
+        "string": {
+          "importMap": "foo"
+        },
+        "array": {
+          "importMap": []
+        }
+      }
+    },
+    "should throw if imports is a non-object": {
+      "expectedParsedImportMap": null,
+      "tests": {
+        "null": {
+          "importMap": {
+            "imports": null
+          }
+        },
+        "boolean": {
+          "importMap": {
+            "imports": true
+          }
+        },
+        "number": {
+          "importMap": {
+            "imports": 1
+          }
+        },
+        "string": {
+          "importMap": {
+            "imports": "foo"
+          }
+        },
+        "array": {
+          "importMap": {
+            "imports": []
+          }
+        }
+      }
+    },
+    "should throw if scopes is a non-object": {
+      "expectedParsedImportMap": null,
+      "tests": {
+        "null": {
+          "importMap": {
+            "scopes": null
+          }
+        },
+        "boolean": {
+          "importMap": {
+            "scopes": true
+          }
+        },
+        "number": {
+          "importMap": {
+            "scopes": 1
+          }
+        },
+        "string": {
+          "importMap": {
+            "scopes": "foo"
+          }
+        },
+        "array": {
+          "importMap": {
+            "scopes": []
+          }
+        }
+      }
+    },
+    "should ignore unspecified top-level entries": {
+      "importMap": {
+        "imports": {},
+        "new-feature": {},
+        "scops": {}
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-scope-keys.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-scope-keys.json
@@ -1,0 +1,191 @@
+{
+  "importMapBaseURL": "https://base.example/path1/path2/path3",
+  "tests": {
+    "Relative URL scope keys should work with no prefix": {
+      "importMap": {
+        "scopes": {
+          "foo": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/foo": {}
+        }
+      }
+    },
+    "Relative URL scope keys should work with ./, ../, and / prefixes": {
+      "importMap": {
+        "scopes": {
+          "./foo": {},
+          "../foo": {},
+          "/foo": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/foo": {},
+          "https://base.example/path1/foo": {},
+          "https://base.example/foo": {}
+        }
+      }
+    },
+    "Absolute URL scope keys should ignore relative URL scope keys when the base URL is a data: URL": {
+      "importMap": {
+        "scopes": {
+          "./foo": {},
+          "../foo": {},
+          "/foo": {}
+        }
+      },
+      "importMapBaseURL": "data:text/html,test",
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    },
+    "Relative URL scope keys should work with ./, ../, or / with no suffix": {
+      "importMap": {
+        "scopes": {
+          "./": {},
+          "../": {},
+          "/": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/": {},
+          "https://base.example/path1/": {},
+          "https://base.example/": {}
+        }
+      }
+    },
+    "Relative URL scope keys should work with /s, ?s, and #s": {
+      "importMap": {
+        "scopes": {
+          "foo/bar?baz#qux": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/foo/bar?baz#qux": {}
+        }
+      }
+    },
+    "Relative URL scope keys should work with an empty string scope key": {
+      "importMap": {
+        "scopes": {
+          "": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/path3": {}
+        }
+      }
+    },
+    "Relative URL scope keys should work with / suffixes": {
+      "importMap": {
+        "scopes": {
+          "foo/": {},
+          "./foo/": {},
+          "../foo/": {},
+          "/foo/": {},
+          "/foo//": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/foo/": {},
+          "https://base.example/path1/foo/": {},
+          "https://base.example/foo/": {},
+          "https://base.example/foo//": {}
+        }
+      }
+    },
+    "Relative URL scope keys should deduplicate based on URL parsing rules": {
+      "importMap": {
+        "scopes": {
+          "foo/\\": {
+            "1": "./a"
+          },
+          "foo//": {
+            "2": "./b"
+          },
+          "foo\\\\": {
+            "3": "./c"
+          }
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/foo//": {
+            "3": "https://base.example/path1/path2/c"
+          }
+        }
+      }
+    },
+    "Absolute URL scope keys should accept all absolute URL scope keys, with or without fetch schemes": {
+      "importMap": {
+        "scopes": {
+          "about:good": {},
+          "blob:good": {},
+          "data:good": {},
+          "file:///good": {},
+          "filesystem:http://example.com/good/": {},
+          "http://good/": {},
+          "https://good/": {},
+          "ftp://good/": {},
+          "import:bad": {},
+          "mailto:bad": {},
+          "javascript:bad": {},
+          "wss:ba": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "about:good": {},
+          "blob:good": {},
+          "data:good": {},
+          "file:///good": {},
+          "filesystem:http://example.com/good/": {},
+          "http://good/": {},
+          "https://good/": {},
+          "ftp://good/": {},
+          "import:bad": {},
+          "mailto:bad": {},
+          "javascript:bad": {},
+          "wss://ba/": {}
+        }
+      }
+    },
+    "Absolute URL scope keys should parse absolute URL scope keys, ignoring unparseable ones": {
+      "importMap": {
+        "scopes": {
+          "https://example.com:demo": {},
+          "http://[www.example.com]/": {},
+          "https:example.org": {},
+          "https://///example.com///": {},
+          "https://example.net": {},
+          "https://ex%41mple.com/foo/": {}
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {
+          "https://base.example/path1/path2/example.org": {},
+          "https://example.com///": {},
+          "https://example.net/": {},
+          "https://example.com/foo/": {}
+        }
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-specifier-keys.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-specifier-keys.json
@@ -1,0 +1,209 @@
+{
+  "importMapBaseURL": "https://base.example/path1/path2/path3",
+  "tests": {
+    "Relative URL specifier keys should absolutize strings prefixed with ./, ../, or / into the corresponding URLs": {
+      "importMap": {
+        "imports": {
+          "./foo": "/dotslash",
+          "../foo": "/dotdotslash",
+          "/foo": "/slash"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://base.example/path1/path2/foo": "https://base.example/dotslash",
+          "https://base.example/path1/foo": "https://base.example/dotdotslash",
+          "https://base.example/foo": "https://base.example/slash"
+        },
+        "scopes": {}
+      }
+    },
+    "Relative URL specifier keys should not absolutize strings prefixed with ./, ../, or / with a data: URL base": {
+      "importMap": {
+        "imports": {
+          "./foo": "https://example.com/dotslash",
+          "../foo": "https://example.com/dotdotslash",
+          "/foo": "https://example.com/slash"
+        }
+      },
+      "importMapBaseURL": "data:text/html,",
+      "expectedParsedImportMap": {
+        "imports": {
+          "./foo": "https://example.com/dotslash",
+          "../foo": "https://example.com/dotdotslash",
+          "/foo": "https://example.com/slash"
+        },
+        "scopes": {}
+      }
+    },
+    "Relative URL specifier keys should absolutize the literal strings ./, ../, or / with no suffix": {
+      "importMap": {
+        "imports": {
+          "./": "/dotslash/",
+          "../": "/dotdotslash/",
+          "/": "/slash/"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://base.example/path1/path2/": "https://base.example/dotslash/",
+          "https://base.example/path1/": "https://base.example/dotdotslash/",
+          "https://base.example/": "https://base.example/slash/"
+        },
+        "scopes": {}
+      }
+    },
+    "Relative URL specifier keys should work with /s, ?s, and #s": {
+      "importMap": {
+        "imports": {
+          "./foo/bar?baz#qux": "/foo"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://base.example/path1/path2/foo/bar?baz#qux": "https://base.example/foo"
+        },
+        "scopes": {}
+      }
+    },
+    "Relative URL specifier keys should ignore an empty string key": {
+      "importMap": {
+        "imports": {
+          "": "/foo"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {},
+        "scopes": {}
+      }
+    },
+    "Relative URL specifier keys should treat percent-encoded variants of ./, ../, or / as bare specifiers": {
+      "importMap": {
+        "imports": {
+          "%2E/": "/dotSlash1/",
+          "%2E%2E/": "/dotDotSlash1/",
+          ".%2F": "/dotSlash2",
+          "..%2F": "/dotDotSlash2",
+          "%2F": "/slash2",
+          "%2E%2F": "/dotSlash3",
+          "%2E%2E%2F": "/dotDotSlash3"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "%2E/": "https://base.example/dotSlash1/",
+          "%2E%2E/": "https://base.example/dotDotSlash1/",
+          ".%2F": "https://base.example/dotSlash2",
+          "..%2F": "https://base.example/dotDotSlash2",
+          "%2F": "https://base.example/slash2",
+          "%2E%2F": "https://base.example/dotSlash3",
+          "%2E%2E%2F": "https://base.example/dotDotSlash3"
+        },
+        "scopes": {}
+      }
+    },
+    "Relative URL specifier keys should deduplicate based on URL parsing rules": {
+      "importMap": {
+        "imports": {
+          "./foo/\\": "/foo1",
+          "./foo//": "/foo2",
+          "./foo\\\\": "/foo3"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://base.example/path1/path2/foo//": "https://base.example/foo3"
+        },
+        "scopes": {}
+      }
+    },
+    "Absolute URL specifier keys should accept all absolute URL specifier keys, with or without fetch schemes": {
+      "importMap": {
+        "imports": {
+          "about:good": "/about",
+          "blob:good": "/blob",
+          "data:good": "/data",
+          "file:///good": "/file",
+          "filesystem:http://example.com/good/": "/filesystem/",
+          "http://good/": "/http/",
+          "https://good/": "/https/",
+          "ftp://good/": "/ftp/",
+          "import:bad": "/import",
+          "mailto:bad": "/mailto",
+          "javascript:bad": "/javascript",
+          "wss:bad": "/wss"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "about:good": "https://base.example/about",
+          "blob:good": "https://base.example/blob",
+          "data:good": "https://base.example/data",
+          "file:///good": "https://base.example/file",
+          "filesystem:http://example.com/good/": "https://base.example/filesystem/",
+          "http://good/": "https://base.example/http/",
+          "https://good/": "https://base.example/https/",
+          "ftp://good/": "https://base.example/ftp/",
+          "import:bad": "https://base.example/import",
+          "mailto:bad": "https://base.example/mailto",
+          "javascript:bad": "https://base.example/javascript",
+          "wss://bad/": "https://base.example/wss"
+        },
+        "scopes": {}
+      }
+    },
+    "Absolute URL specifier keys should parse absolute URLs, treating unparseable ones as bare specifiers": {
+      "importMap": {
+        "imports": {
+          "https://example.com:demo": "/unparseable2",
+          "http://[www.example.com]/": "/unparseable3/",
+          "https:example.org": "/invalidButParseable1/",
+          "https://///example.com///": "/invalidButParseable2/",
+          "https://example.net": "/prettyNormal/",
+          "https://ex%41mple.com/": "/percentDecoding/"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://example.com:demo": "https://base.example/unparseable2",
+          "http://[www.example.com]/": "https://base.example/unparseable3/",
+          "https://example.org/": "https://base.example/invalidButParseable1/",
+          "https://example.com///": "https://base.example/invalidButParseable2/",
+          "https://example.net/": "https://base.example/prettyNormal/",
+          "https://example.com/": "https://base.example/percentDecoding/"
+        },
+        "scopes": {}
+      }
+    },
+    "Specifier keys should be sort correctly (issue #181) - Test #1": {
+      "importMap": {
+        "imports": {
+          "https://example.com/aaa": "https://example.com/aaa",
+          "https://example.com/a": "https://example.com/a"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://example.com/aaa": "https://example.com/aaa",
+          "https://example.com/a": "https://example.com/a"
+        },
+        "scopes": {}
+      }
+    },
+    "Specifier keys should be sort correctly (issue #181) - Test #2": {
+      "importMap": {
+        "imports": {
+          "https://example.com/a": "https://example.com/a",
+          "https://example.com/aaa": "https://example.com/aaa"
+        }
+      },
+      "expectedParsedImportMap": {
+        "imports": {
+          "https://example.com/aaa": "https://example.com/aaa",
+          "https://example.com/a": "https://example.com/a"
+        },
+        "scopes": {}
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-trailing-slashes.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-trailing-slashes.json
@@ -1,0 +1,15 @@
+{
+  "name": "Failing addresses: mismatched trailing slashes",
+  "importMap": {
+    "imports": {
+      "trailer/": "/notrailer"
+    }
+  },
+  "importMapBaseURL": "https://base.example/path1/path2/path3",
+  "expectedParsedImportMap": {
+    "imports": {
+      "trailer/": null
+    },
+    "scopes": {}
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/resolving-null.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/resolving-null.json
@@ -1,0 +1,82 @@
+{
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "Entries with errors shouldn't allow fallback",
+  "tests": {
+    "No fallback to less-specific prefixes": {
+      "importMap": {
+        "imports": {
+          "null/": "/1/",
+          "null/b/": null,
+          "null/b/c/": "/1/2/",
+          "invalid-url/": "/1/",
+          "invalid-url/b/": "https://:invalid-url:/",
+          "invalid-url/b/c/": "/1/2/",
+          "without-trailing-slashes/": "/1/",
+          "without-trailing-slashes/b/": "/x",
+          "without-trailing-slashes/b/c/": "/1/2/",
+          "prefix-resolution-error/": "/1/",
+          "prefix-resolution-error/b/": "data:text/javascript,/",
+          "prefix-resolution-error/b/c/": "/1/2/"
+        }
+      },
+      "expectedResults": {
+        "null/x": "https://example.com/1/x",
+        "null/b/x": null,
+        "null/b/c/x": "https://example.com/1/2/x",
+        "invalid-url/x": "https://example.com/1/x",
+        "invalid-url/b/x": null,
+        "invalid-url/b/c/x": "https://example.com/1/2/x",
+        "without-trailing-slashes/x": "https://example.com/1/x",
+        "without-trailing-slashes/b/x": null,
+        "without-trailing-slashes/b/c/x": "https://example.com/1/2/x",
+        "prefix-resolution-error/x": "https://example.com/1/x",
+        "prefix-resolution-error/b/x": null,
+        "prefix-resolution-error/b/c/x": "https://example.com/1/2/x"
+      }
+    },
+    "No fallback to less-specific scopes": {
+      "importMap": {
+        "imports": {
+          "null": "https://example.com/a",
+          "invalid-url": "https://example.com/b",
+          "without-trailing-slashes/": "https://example.com/c/",
+          "prefix-resolution-error/": "https://example.com/d/"
+        },
+        "scopes": {
+          "/js/": {
+            "null": null,
+            "invalid-url": "https://:invalid-url:/",
+            "without-trailing-slashes/": "/x",
+            "prefix-resolution-error/": "data:text/javascript,/"
+          }
+        }
+      },
+      "expectedResults": {
+        "null": null,
+        "invalid-url": null,
+        "without-trailing-slashes/x": null,
+        "prefix-resolution-error/x": null
+      }
+    },
+    "No fallback to absolute URL parsing": {
+      "importMap": {
+        "imports": {},
+        "scopes": {
+          "/js/": {
+            "https://example.com/null": null,
+            "https://example.com/invalid-url": "https://:invalid-url:/",
+            "https://example.com/without-trailing-slashes/": "/x",
+            "https://example.com/prefix-resolution-error/": "data:text/javascript,/"
+          }
+        }
+      },
+      "expectedResults": {
+        "https://example.com/null": null,
+        "https://example.com/invalid-url": null,
+        "https://example.com/without-trailing-slashes/x": null,
+        "https://example.com/prefix-resolution-error/x": null
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/scopes-exact-vs-prefix.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/scopes-exact-vs-prefix.json
@@ -1,0 +1,134 @@
+{
+  "name": "Exact vs. prefix based matching",
+  "details": "Scopes are matched with base URLs that are exactly the same or subpaths under the scopes with trailing shashes",
+  "link": "https://wicg.github.io/import-maps/#resolve-a-module-specifier Step 8.1",
+  "tests": {
+    "Scope without trailing slash only": {
+      "importMap": {
+        "scopes": {
+          "/js": {
+            "moment": "/only-triggered-by-exact/moment",
+            "moment/": "/only-triggered-by-exact/moment/"
+          }
+        }
+      },
+      "importMapBaseURL": "https://example.com/app/index.html",
+      "tests": {
+        "Non-trailing-slash base URL (exact match)": {
+          "baseURL": "https://example.com/js",
+          "expectedResults": {
+            "moment": "https://example.com/only-triggered-by-exact/moment",
+            "moment/foo": "https://example.com/only-triggered-by-exact/moment/foo"
+          }
+        },
+        "Trailing-slash base URL (fail)": {
+          "baseURL": "https://example.com/js/",
+          "expectedResults": {
+            "moment": null,
+            "moment/foo": null
+          }
+        },
+        "Subpath base URL (fail)": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "moment": null,
+            "moment/foo": null
+          }
+        },
+        "Non-subpath base URL (fail)": {
+          "baseURL": "https://example.com/jsiscool",
+          "expectedResults": {
+            "moment": null,
+            "moment/foo": null
+          }
+        }
+      }
+    },
+    "Scope with trailing slash only": {
+      "importMap": {
+        "scopes": {
+          "/js/": {
+            "moment": "/triggered-by-any-subpath/moment",
+            "moment/": "/triggered-by-any-subpath/moment/"
+          }
+        }
+      },
+      "importMapBaseURL": "https://example.com/app/index.html",
+      "tests": {
+        "Non-trailing-slash base URL (fail)": {
+          "baseURL": "https://example.com/js",
+          "expectedResults": {
+            "moment": null,
+            "moment/foo": null
+          }
+        },
+        "Trailing-slash base URL (exact match)": {
+          "baseURL": "https://example.com/js/",
+          "expectedResults": {
+            "moment": "https://example.com/triggered-by-any-subpath/moment",
+            "moment/foo": "https://example.com/triggered-by-any-subpath/moment/foo"
+          }
+        },
+        "Subpath base URL (prefix match)": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "moment": "https://example.com/triggered-by-any-subpath/moment",
+            "moment/foo": "https://example.com/triggered-by-any-subpath/moment/foo"
+          }
+        },
+        "Non-subpath base URL (fail)": {
+          "baseURL": "https://example.com/jsiscool",
+          "expectedResults": {
+            "moment": null,
+            "moment/foo": null
+          }
+        }
+      }
+    },
+    "Scopes with and without trailing slash": {
+      "importMap": {
+        "scopes": {
+          "/js": {
+            "moment": "/only-triggered-by-exact/moment",
+            "moment/": "/only-triggered-by-exact/moment/"
+          },
+          "/js/": {
+            "moment": "/triggered-by-any-subpath/moment",
+            "moment/": "/triggered-by-any-subpath/moment/"
+          }
+        }
+      },
+      "importMapBaseURL": "https://example.com/app/index.html",
+      "tests": {
+        "Non-trailing-slash base URL (exact match)": {
+          "baseURL": "https://example.com/js",
+          "expectedResults": {
+            "moment": "https://example.com/only-triggered-by-exact/moment",
+            "moment/foo": "https://example.com/only-triggered-by-exact/moment/foo"
+          }
+        },
+        "Trailing-slash base URL (exact match)": {
+          "baseURL": "https://example.com/js/",
+          "expectedResults": {
+            "moment": "https://example.com/triggered-by-any-subpath/moment",
+            "moment/foo": "https://example.com/triggered-by-any-subpath/moment/foo"
+          }
+        },
+        "Subpath base URL (prefix match)": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "moment": "https://example.com/triggered-by-any-subpath/moment",
+            "moment/foo": "https://example.com/triggered-by-any-subpath/moment/foo"
+          }
+        },
+        "Non-subpath base URL (fail)": {
+          "baseURL": "https://example.com/jsiscool",
+          "expectedResults": {
+            "moment": null,
+            "moment/foo": null
+          }
+        }
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/scopes.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/scopes.json
@@ -1,0 +1,171 @@
+{
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "tests": {
+    "Fallback to toplevel and between scopes": {
+      "importMap": {
+        "imports": {
+          "a": "/a-1.mjs",
+          "b": "/b-1.mjs",
+          "c": "/c-1.mjs",
+          "d": "/d-1.mjs"
+        },
+        "scopes": {
+          "/scope2/": {
+            "a": "/a-2.mjs",
+            "d": "/d-2.mjs"
+          },
+          "/scope2/scope3/": {
+            "b": "/b-3.mjs",
+            "d": "/d-3.mjs"
+          }
+        }
+      },
+      "tests": {
+        "should fall back to `imports` when no scopes match": {
+          "baseURL": "https://example.com/scope1/foo.mjs",
+          "expectedResults": {
+            "a": "https://example.com/a-1.mjs",
+            "b": "https://example.com/b-1.mjs",
+            "c": "https://example.com/c-1.mjs",
+            "d": "https://example.com/d-1.mjs"
+          }
+        },
+        "should use a direct scope override": {
+          "baseURL": "https://example.com/scope2/foo.mjs",
+          "expectedResults": {
+            "a": "https://example.com/a-2.mjs",
+            "b": "https://example.com/b-1.mjs",
+            "c": "https://example.com/c-1.mjs",
+            "d": "https://example.com/d-2.mjs"
+          }
+        },
+        "should use an indirect scope override": {
+          "baseURL": "https://example.com/scope2/scope3/foo.mjs",
+          "expectedResults": {
+            "a": "https://example.com/a-2.mjs",
+            "b": "https://example.com/b-3.mjs",
+            "c": "https://example.com/c-1.mjs",
+            "d": "https://example.com/d-3.mjs"
+          }
+        }
+      }
+    },
+    "Relative URL scope keys": {
+      "importMap": {
+        "imports": {
+          "a": "/a-1.mjs",
+          "b": "/b-1.mjs",
+          "c": "/c-1.mjs"
+        },
+        "scopes": {
+          "": {
+            "a": "/a-empty-string.mjs"
+          },
+          "./": {
+            "b": "/b-dot-slash.mjs"
+          },
+          "../": {
+            "c": "/c-dot-dot-slash.mjs"
+          }
+        }
+      },
+      "tests": {
+        "An empty string scope is a scope with import map base URL": {
+          "baseURL": "https://example.com/app/index.html",
+          "expectedResults": {
+            "a": "https://example.com/a-empty-string.mjs",
+            "b": "https://example.com/b-dot-slash.mjs",
+            "c": "https://example.com/c-dot-dot-slash.mjs"
+          }
+        },
+        "'./' scope is a scope with import map base URL's directory": {
+          "baseURL": "https://example.com/app/foo.mjs",
+          "expectedResults": {
+            "a": "https://example.com/a-1.mjs",
+            "b": "https://example.com/b-dot-slash.mjs",
+            "c": "https://example.com/c-dot-dot-slash.mjs"
+          }
+        },
+        "'../' scope is a scope with import map base URL's parent directory": {
+          "baseURL": "https://example.com/foo.mjs",
+          "expectedResults": {
+            "a": "https://example.com/a-1.mjs",
+            "b": "https://example.com/b-1.mjs",
+            "c": "https://example.com/c-dot-dot-slash.mjs"
+          }
+        }
+      }
+    },
+    "Package-like scenarios": {
+      "importMap": {
+        "imports": {
+          "moment": "/node_modules/moment/src/moment.js",
+          "moment/": "/node_modules/moment/src/",
+          "lodash-dot": "./node_modules/lodash-es/lodash.js",
+          "lodash-dot/": "./node_modules/lodash-es/",
+          "lodash-dotdot": "../node_modules/lodash-es/lodash.js",
+          "lodash-dotdot/": "../node_modules/lodash-es/"
+        },
+        "scopes": {
+          "/": {
+            "moment": "/node_modules_3/moment/src/moment.js",
+            "vue": "/node_modules_3/vue/dist/vue.runtime.esm.js"
+          },
+          "/js/": {
+            "lodash-dot": "./node_modules_2/lodash-es/lodash.js",
+            "lodash-dot/": "./node_modules_2/lodash-es/",
+            "lodash-dotdot": "../node_modules_2/lodash-es/lodash.js",
+            "lodash-dotdot/": "../node_modules_2/lodash-es/"
+          }
+        }
+      },
+      "tests": {
+        "Base URLs inside the scope should use the scope if the scope has matching keys": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "lodash-dot": "https://example.com/app/node_modules_2/lodash-es/lodash.js",
+            "lodash-dot/foo": "https://example.com/app/node_modules_2/lodash-es/foo",
+            "lodash-dotdot": "https://example.com/node_modules_2/lodash-es/lodash.js",
+            "lodash-dotdot/foo": "https://example.com/node_modules_2/lodash-es/foo"
+          }
+        },
+        "Base URLs inside the scope fallback to less specific scope": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "moment": "https://example.com/node_modules_3/moment/src/moment.js",
+            "vue": "https://example.com/node_modules_3/vue/dist/vue.runtime.esm.js"
+          }
+        },
+        "Base URLs inside the scope fallback to toplevel": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "moment/foo": "https://example.com/node_modules/moment/src/foo"
+          }
+        },
+        "Base URLs outside a scope shouldn't use the scope even if the scope has matching keys": {
+          "baseURL": "https://example.com/app.mjs",
+          "expectedResults": {
+            "lodash-dot": "https://example.com/app/node_modules/lodash-es/lodash.js",
+            "lodash-dotdot": "https://example.com/node_modules/lodash-es/lodash.js",
+            "lodash-dot/foo": "https://example.com/app/node_modules/lodash-es/foo",
+            "lodash-dotdot/foo": "https://example.com/node_modules/lodash-es/foo"
+          }
+        },
+        "Fallback to toplevel or not, depending on trailing slash match": {
+          "baseURL": "https://example.com/app.mjs",
+          "expectedResults": {
+            "moment": "https://example.com/node_modules_3/moment/src/moment.js",
+            "moment/foo": "https://example.com/node_modules/moment/src/foo"
+          }
+        },
+        "should still fail for package-like specifiers that are not declared": {
+          "baseURL": "https://example.com/js/app.mjs",
+          "expectedResults": {
+            "underscore/": null,
+            "underscore/foo": null
+          }
+        }
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/test-helper-iframe.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/test-helper-iframe.js
@@ -1,0 +1,46 @@
+// Handle errors around fetching, parsing and registering import maps.
+window.onScriptError = event => {
+  window.registrationResult = {type: 'FetchError', error: event.error};
+  return false;
+};
+window.windowErrorHandler = event => {
+  window.registrationResult = {type: 'ParseError', error: event.error};
+  return false;
+};
+window.addEventListener('error', window.windowErrorHandler);
+
+// Handle specifier resolution requests from the parent frame.
+// For failures, we post error names and messages instead of error
+// objects themselves and re-create error objects later, to avoid
+// issues around serializing error objects which is a quite new feature.
+window.addEventListener('message', event => {
+  if (event.data.action !== 'resolve') {
+    parent.postMessage({
+        type: 'Failure',
+        result: 'Error',
+        message: 'Invalid Action: ' + event.data.action}, '*');
+    return;
+  }
+
+  // To respond to a resolution request, we:
+  // 1. Save the specifier to resolve into a global.
+  // 2. Update the document's base URL to the requested base URL.
+  // 3. Create a new inline script, parsed with that base URL, which
+  //    resolves the saved specifier using import.meta.resolve(), and
+  //    sents the result to the parent window.
+  window.specifierToResolve = event.data.specifier;
+  document.querySelector('base').href = event.data.baseURL;
+
+  const inlineScript = document.createElement('script');
+  inlineScript.type = 'module';
+  inlineScript.textContent = `
+    try {
+      const result = import.meta.resolve(window.specifierToResolve);
+      parent.postMessage({type: 'ResolutionSuccess', result}, '*');
+    } catch (e) {
+      parent.postMessage(
+          {type: 'Failure', result: e.name, message: e.message}, '*');
+    }
+  `;
+  document.body.append(inlineScript);
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/test-helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/test-helper.js
@@ -1,0 +1,142 @@
+setup({allow_uncaught_exception : true});
+
+// Creates a new Document (via <iframe>) and add an inline import map.
+function createTestIframe(importMap, importMapBaseURL) {
+  return new Promise(resolve => {
+    const iframe = document.createElement('iframe');
+
+    window.addEventListener('message', event => {
+        // Parsing result is saved here and checked later, rather than
+        // rejecting the promise on errors.
+        iframe.parseImportMapResult = event.data.type;
+        resolve(iframe);
+      },
+      {once: true});
+
+    const testHTML = createTestHTML(importMap, importMapBaseURL);
+
+    if (new URL(importMapBaseURL).protocol === 'data:') {
+      iframe.src = 'data:text/html;base64,' + btoa(testHTML);
+    } else {
+      iframe.src = '/common/blank.html';
+      iframe.onload = () => {
+        iframe.contentDocument.write(testHTML);
+        iframe.contentDocument.close();
+      };
+    }
+    document.body.appendChild(iframe);
+  });
+}
+
+function createTestHTML(importMap, importMapBaseURL) {
+  return `
+    <!DOCTYPE html>
+    <script src="${location.origin}/import-maps/data-driven/resources/test-helper-iframe.js"></script>
+
+    <base href="${importMapBaseURL}">
+    <script type="importmap" onerror="onScriptError(event)">
+    ${JSON.stringify(importMap)}
+    </script>
+
+    <script type="module">
+      if (!window.registrationResult) {
+        window.registrationResult = {type: 'Success'};
+      }
+      window.removeEventListener('error', window.windowErrorHandler);
+      parent.postMessage(window.registrationResult, '*');
+    </script>
+  `;
+}
+
+// Returns a promise that is resolved with the resulting URL, or rejected if
+// the resolution fails.
+function resolve(specifier, baseURL, iframe) {
+  return new Promise((resolve, reject) => {
+    window.addEventListener('message', event => {
+        if (event.data.type === 'ResolutionSuccess') {
+          resolve(event.data.result);
+        } else if (event.data.type === 'Failure') {
+          if (event.data.result === 'TypeError') {
+            reject(new TypeError(event.data.message));
+          } else {
+            reject(new Error(event.data.message));
+          }
+        } else {
+          assert_unreached('Invalid message: ' + event.data.type);
+        }
+      },
+      {once: true});
+
+    iframe.contentWindow.postMessage(
+      {action: 'resolve', specifier, baseURL},
+      '*'
+    );
+  });
+}
+
+function assert_no_extra_properties(object, expectedProperties, description) {
+  for (const actualProperty in object) {
+    assert_true(expectedProperties.indexOf(actualProperty) !== -1,
+        description + ': unexpected property ' + actualProperty);
+  }
+}
+
+async function runTests(j) {
+  const tests = j.tests;
+  delete j.tests;
+
+  if (j.hasOwnProperty('importMap')) {
+    assert_own_property(j, 'importMap');
+    assert_own_property(j, 'importMapBaseURL');
+    j.iframe = await createTestIframe(j.importMap, j.importMapBaseURL);
+    delete j.importMap;
+    delete j.importMapBaseURL;
+  }
+
+  assert_no_extra_properties(
+      j,
+      ['expectedResults', 'expectedParsedImportMap',
+      'baseURL', 'name', 'iframe',
+      'importMap', 'importMapBaseURL',
+      'link', 'details'],
+      j.name);
+
+  if (tests) {
+    // Nested node.
+    for (const testName in tests) {
+      let fullTestName = testName;
+      if (j.name) {
+        fullTestName = j.name + ': ' + testName;
+      }
+      tests[testName].name = fullTestName;
+      const k = Object.assign({}, j, tests[testName]);
+      await runTests(k);
+    }
+  } else {
+    // Leaf node.
+    for (const key of ['iframe', 'name', 'expectedResults']) {
+      assert_own_property(j, key, j.name);
+    }
+
+    assert_equals(
+        j.iframe.parseImportMapResult,
+        'Success',
+        'Import map registration should be successful for resolution tests');
+    for (const [specifier, expected] of Object.entries(j.expectedResults)) {
+      promise_test(async t => {
+        if (expected === null) {
+          return promise_rejects_js(t, TypeError, resolve(specifier, j.baseURL, j.iframe));
+        } else {
+          assert_equals(await resolve(specifier, j.baseURL, j.iframe), expected);
+        }
+      },
+      j.name + ': ' + specifier);
+    }
+  }
+}
+
+export async function runTestsFromJSON(jsonURL) {
+  const response = await fetch(jsonURL);
+  const json = await response.json();
+  await runTests(json);
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/tricky-specifiers.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/tricky-specifiers.json
@@ -1,0 +1,71 @@
+{
+  "importMap": {
+    "imports": {
+      "package/withslash": "/node_modules/package-with-slash/index.mjs",
+      "not-a-package": "/lib/not-a-package.mjs",
+      "only-slash/": "/lib/only-slash/",
+      ".": "/lib/dot.mjs",
+      "..": "/lib/dotdot.mjs",
+      "..\\": "/lib/dotdotbackslash.mjs",
+      "%2E": "/lib/percent2e.mjs",
+      "%2F": "/lib/percent2f.mjs",
+      "https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/": "/a/",
+      "https://map.example/きつね/fox/": "/b/",
+      "%E3%81%8D%E3%81%A4%E3%81%AD/": "/c/",
+      "きつね/fox/": "/d/"
+    }
+  },
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "Tricky specifiers",
+  "tests": {
+    "explicitly-mapped specifiers that happen to have a slash": {
+      "expectedResults": {
+        "package/withslash": "https://example.com/node_modules/package-with-slash/index.mjs"
+      }
+    },
+    "specifier with punctuation": {
+      "expectedResults": {
+        ".": "https://example.com/lib/dot.mjs",
+        "..": "https://example.com/lib/dotdot.mjs",
+        "..\\": "https://example.com/lib/dotdotbackslash.mjs",
+        "%2E": "https://example.com/lib/percent2e.mjs",
+        "%2F": "https://example.com/lib/percent2f.mjs"
+      }
+    },
+    "submodule of something not declared with a trailing slash should fail": {
+      "expectedResults": {
+        "not-a-package/foo": null
+      }
+    },
+    "module for which only a trailing-slash version is present should fail": {
+      "expectedResults": {
+        "only-slash": null
+      }
+    },
+    "URL-like specifiers are normalized": {
+      "expectedResults": {
+        "https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/": "https://example.com/a/",
+        "https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/bar": "https://example.com/a/bar",
+        "https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/fox/": "https://example.com/b/",
+        "https://map.example/%E3%81%8D%E3%81%A4%E3%81%AD/fox/bar": "https://example.com/b/bar",
+        "https://map.example/きつね/": "https://example.com/a/",
+        "https://map.example/きつね/bar": "https://example.com/a/bar",
+        "https://map.example/きつね/fox/": "https://example.com/b/",
+        "https://map.example/きつね/fox/bar": "https://example.com/b/bar"
+      }
+    },
+    "Bare specifiers are not normalized": {
+      "expectedResults": {
+        "%E3%81%8D%E3%81%A4%E3%81%AD/": "https://example.com/c/",
+        "%E3%81%8D%E3%81%A4%E3%81%AD/bar": "https://example.com/c/bar",
+        "%E3%81%8D%E3%81%A4%E3%81%AD/fox/": "https://example.com/c/fox/",
+        "%E3%81%8D%E3%81%A4%E3%81%AD/fox/bar": "https://example.com/c/fox/bar",
+        "きつね/": null,
+        "きつね/bar": null,
+        "きつね/fox/": "https://example.com/d/",
+        "きつね/fox/bar": "https://example.com/d/bar"
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/url-specifiers-schemes.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/url-specifiers-schemes.json
@@ -1,0 +1,45 @@
+{
+  "importMap": {
+    "imports": {
+      "data:text/": "/lib/test-data/",
+      "about:text/": "/lib/test-about/",
+      "blob:text/": "/lib/test-blob/",
+      "blah:text/": "/lib/test-blah/",
+      "http:text/": "/lib/test-http/",
+      "https:text/": "/lib/test-https/",
+      "file:text/": "/lib/test-file/",
+      "ftp:text/": "/lib/test-ftp/",
+      "ws:text/": "/lib/test-ws/",
+      "wss:text/": "/lib/test-wss/"
+    }
+  },
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "URL-like specifiers",
+  "tests": {
+    "Non-special vs. special schemes": {
+      "expectedResults": {
+        "data:text/javascript,console.log('foo')": "data:text/javascript,console.log('foo')",
+        "data:text/": "https://example.com/lib/test-data/",
+        "about:text/foo": "about:text/foo",
+        "about:text/": "https://example.com/lib/test-about/",
+        "blob:text/foo": "blob:text/foo",
+        "blob:text/": "https://example.com/lib/test-blob/",
+        "blah:text/foo": "blah:text/foo",
+        "blah:text/": "https://example.com/lib/test-blah/",
+        "http:text/foo": "https://example.com/lib/test-http/foo",
+        "http:text/": "https://example.com/lib/test-http/",
+        "https:text/foo": "https://example.com/lib/test-https/foo",
+        "https:text/": "https://example.com/lib/test-https/",
+        "ftp:text/foo": "https://example.com/lib/test-ftp/foo",
+        "ftp:text/": "https://example.com/lib/test-ftp/",
+        "file:text/foo": "https://example.com/lib/test-file/foo",
+        "file:text/": "https://example.com/lib/test-file/",
+        "ws:text/foo": "https://example.com/lib/test-ws/foo",
+        "ws:text/": "https://example.com/lib/test-ws/",
+        "wss:text/foo": "https://example.com/lib/test-wss/foo",
+        "wss:text/": "https://example.com/lib/test-wss/"
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/url-specifiers.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/url-specifiers.json
@@ -1,0 +1,68 @@
+{
+  "importMap": {
+    "imports": {
+      "/lib/foo.mjs": "./more/bar.mjs",
+      "./dotrelative/foo.mjs": "/lib/dot.mjs",
+      "../dotdotrelative/foo.mjs": "/lib/dotdot.mjs",
+      "/": "/lib/slash-only/",
+      "./": "/lib/dotslash-only/",
+      "/test/": "/lib/url-trailing-slash/",
+      "./test/": "/lib/url-trailing-slash-dot/",
+      "/test": "/lib/test1.mjs",
+      "../test": "/lib/test2.mjs"
+    }
+  },
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "URL-like specifiers",
+  "tests": {
+    "Ordinary URL-like specifiers": {
+      "expectedResults": {
+        "https://example.com/lib/foo.mjs": "https://example.com/app/more/bar.mjs",
+        "https://///example.com/lib/foo.mjs": "https://example.com/app/more/bar.mjs",
+        "/lib/foo.mjs": "https://example.com/app/more/bar.mjs",
+        "https://example.com/app/dotrelative/foo.mjs": "https://example.com/lib/dot.mjs",
+        "../app/dotrelative/foo.mjs": "https://example.com/lib/dot.mjs",
+        "https://example.com/dotdotrelative/foo.mjs": "https://example.com/lib/dotdot.mjs",
+        "../dotdotrelative/foo.mjs": "https://example.com/lib/dotdot.mjs"
+      }
+    },
+    "Import map entries just composed from / and .": {
+      "expectedResults": {
+        "https://example.com/": "https://example.com/lib/slash-only/",
+        "/": "https://example.com/lib/slash-only/",
+        "../": "https://example.com/lib/slash-only/",
+        "https://example.com/app/": "https://example.com/lib/dotslash-only/",
+        "/app/": "https://example.com/lib/dotslash-only/",
+        "../app/": "https://example.com/lib/dotslash-only/"
+      }
+    },
+    "prefix-matched by keys with trailing slashes": {
+      "expectedResults": {
+        "/test/foo.mjs": "https://example.com/lib/url-trailing-slash/foo.mjs",
+        "https://example.com/app/test/foo.mjs": "https://example.com/lib/url-trailing-slash-dot/foo.mjs"
+      }
+    },
+    "should use the last entry's address when URL-like specifiers parse to the same absolute URL": {
+      "expectedResults": {
+        "/test": "https://example.com/lib/test2.mjs"
+      }
+    },
+    "backtracking (relative URLs)": {
+      "expectedResults": {
+        "/test/..": "https://example.com/lib/slash-only/",
+        "/test/../backtrack": "https://example.com/lib/slash-only/backtrack",
+        "/test/../../backtrack": "https://example.com/lib/slash-only/backtrack",
+        "/test/../../../backtrack": "https://example.com/lib/slash-only/backtrack"
+      }
+    },
+    "backtracking (absolute URLs)": {
+      "expectedResults": {
+        "https://example.com/test/..": "https://example.com/lib/slash-only/",
+        "https://example.com/test/../backtrack": "https://example.com/lib/slash-only/backtrack",
+        "https://example.com/test/../../backtrack": "https://example.com/lib/slash-only/backtrack",
+        "https://example.com/test/../../../backtrack": "https://example.com/lib/slash-only/backtrack"
+      }
+    }
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/w3c-import.log
@@ -1,0 +1,39 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/data-url-prefix.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/empty-import-map.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/overlapping-entries.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/packages-via-trailing-slashes.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-addresses-absolute.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-addresses-invalid.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-addresses.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-invalid-json.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-normalization.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-scope.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-specifier-map.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-schema-toplevel.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-scope-keys.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-specifier-keys.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/parsing-trailing-slashes.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/resolving-null.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/scopes-exact-vs-prefix.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/scopes.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/test-helper-iframe.js
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/test-helper.js
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/tricky-specifiers.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/url-specifiers-schemes.json
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/url-specifiers.json

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/tools/format_json.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/tools/format_json.py
@@ -1,0 +1,27 @@
+import collections
+import json
+import sys
+import traceback
+"""
+Simple JSON formatter, to be used for JSON files under resources/.
+
+Usage:
+$ python tools/format_json.py resources/*.json
+"""
+
+
+def main():
+    for filename in sys.argv[1:]:
+        print(filename)
+        try:
+            spec = json.load(
+                open(filename, u'r'), object_pairs_hook=collections.OrderedDict)
+            with open(filename, u'w') as f:
+                f.write(json.dumps(spec, indent=2, separators=(u',', u': ')))
+                f.write(u'\n')
+        except:
+            traceback.print_exc()
+
+
+if __name__ == '__main__':
+    main()

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/tools/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/tools/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/tools/format_json.py

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/w3c-import.log
@@ -1,0 +1,18 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/README.md
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving.html

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt
@@ -1,0 +1,47 @@
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: TypeError: Module name, 'data:text/javascript,log.push('data:to-bare')' does not resolve to a valid URL.
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+
+
+PASS data:text/javascript,log.push('data:foo'): <script src type=module>
+PASS data:text/javascript,log.push('data:foo'): <script src type=text/javascript>
+PASS data:text/javascript,log.push('data:foo'): static import
+PASS data:text/javascript,log.push('data:foo'): dynamic import (from module)
+PASS data:text/javascript,log.push('data:foo'): dynamic import (from text/javascript)
+PASS data:text/javascript,log.push('data:cross-origin-foo'): <script src type=module>
+PASS data:text/javascript,log.push('data:cross-origin-foo'): <script src type=text/javascript>
+FAIL data:text/javascript,log.push('data:cross-origin-foo'): static import assert_unreached: script's error event shouldn't be fired Reached unreachable code
+FAIL data:text/javascript,log.push('data:cross-origin-foo'): dynamic import (from module) assert_unreached: dynamic import promise shouldn't be rejected Reached unreachable code
+FAIL data:text/javascript,log.push('data:cross-origin-foo'): dynamic import (from text/javascript) assert_unreached: dynamic import promise shouldn't be rejected Reached unreachable code
+PASS data:text/javascript,log.push('data:to-data'): <script src type=module>
+PASS data:text/javascript,log.push('data:to-data'): <script src type=text/javascript>
+PASS data:text/javascript,log.push('data:to-data'): static import
+PASS data:text/javascript,log.push('data:to-data'): dynamic import (from module)
+PASS data:text/javascript,log.push('data:to-data'): dynamic import (from text/javascript)
+PASS data:text/javascript,log.push('data:to-bare'): <script src type=module>
+PASS data:text/javascript,log.push('data:to-bare'): <script src type=text/javascript>
+PASS data:text/javascript,log.push('data:to-bare'): static import
+PASS data:text/javascript,log.push('data:to-bare'): dynamic import (from module)
+PASS data:text/javascript,log.push('data:to-bare'): dynamic import (from text/javascript)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/test-helper.js"></script>
+
+<script>
+// "bare/..." (i.e. without leading "./") are bare specifiers
+// (not relative paths).
+const importMap = `
+{
+  "imports": {
+    "bare": "./resources/log.js?pipe=sub&name=bare",
+
+    "data:text/javascript,log.push('data:foo')": "./resources/log.js?pipe=sub&name=foo",
+    "data:text/javascript,log.push('data:cross-origin-foo')": "https://{{domains[www1]}}:{{ports[https][0]}}/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo",
+    "data:text/javascript,log.push('data:to-data')": "data:text/javascript,log.push('dataURL')",
+
+    "data:text/javascript,log.push('data:to-bare')": "bare"
+  }
+}
+`;
+
+const tests = {
+  // Arrays of expected results for:
+  // - <script src type="module">,
+  // - <script src> (classic script),
+  // - static import, and
+  // - dynamic import.
+
+  // data: to HTTP(S).
+  "data:text/javascript,log.push('data:foo')":
+    [Result.URL, Result.URL, "log:foo", "log:foo"],
+  "data:text/javascript,log.push('data:cross-origin-foo')":
+    [Result.URL, Result.URL, "log:cross-origin-foo", "log:cross-origin-foo"],
+
+  // data: to data:
+  "data:text/javascript,log.push('data:to-data')":
+    [Result.URL, Result.URL, "dataURL", "dataURL"],
+
+  // data: to bare mapping is disabled.
+  "data:text/javascript,log.push('data:to-bare')":
+    [Result.URL, Result.URL, Result.PARSE_ERROR, Result.PARSE_ERROR],
+};
+
+doTests(importMap, null, tests);
+</script>
+<body>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt
@@ -1,0 +1,47 @@
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-bar
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-bar
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+Blocked access to external URL https://www1.localhost:9443/import-maps/resources/log.js?pipe=sub&name=cross-origin-bar
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: TypeError: Module name, 'http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=to-bare' does not resolve to a valid URL.
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+
+
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=foo: <script src type=module>
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=foo: <script src type=text/javascript>
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=foo: static import
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=foo: dynamic import (from module)
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=foo: dynamic import (from text/javascript)
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: <script src type=module>
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: <script src type=text/javascript>
+FAIL http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: static import assert_unreached: script's error event shouldn't be fired Reached unreachable code
+FAIL http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: dynamic import (from module) assert_unreached: dynamic import promise shouldn't be rejected Reached unreachable code
+FAIL http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: dynamic import (from text/javascript) assert_unreached: dynamic import promise shouldn't be rejected Reached unreachable code
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=to-data: <script src type=module>
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=to-data: <script src type=text/javascript>
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=to-data: static import
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=to-data: dynamic import (from module)
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=to-data: dynamic import (from text/javascript)
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: <script src type=module>
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: <script src type=text/javascript>
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: static import
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: dynamic import (from module)
+PASS http://localhost:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: dynamic import (from text/javascript)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/test-helper.js"></script>
+
+<script>
+// "bare/..." (i.e. without leading "./") are bare specifiers
+// (not relative paths).
+const importMap = `
+{
+  "imports": {
+    "bare": "./resources/log.js?pipe=sub&name=bare",
+
+    "./resources/log.js?pipe=sub&name=foo": "./resources/log.js?pipe=sub&name=bar",
+    "./resources/log.js?pipe=sub&name=cross-origin-foo": "https://{{domains[www1]}}:{{ports[https][0]}}/import-maps/resources/log.js?pipe=sub&name=cross-origin-bar",
+    "./resources/log.js?pipe=sub&name=to-data": "data:text/javascript,log.push('dataURL')",
+
+    "./resources/log.js?pipe=sub&name=to-bare": "bare"
+  }
+}
+`;
+
+const tests = {
+  // Arrays of expected results for:
+  // - <script src type="module">,
+  // - <script src> (classic script),
+  // - static import, and
+  // - dynamic import.
+
+  // HTTP(S) to HTTP(S).
+  "{{location[server]}}/import-maps/resources/log.js?pipe=sub&name=foo":
+    [Result.URL, Result.URL, "log:bar", "log:bar"],
+  "{{location[server]}}/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo":
+    [Result.URL, Result.URL, "log:cross-origin-bar", "log:cross-origin-bar"],
+
+  // HTTP(S) to data:
+  "{{location[server]}}/import-maps/resources/log.js?pipe=sub&name=to-data":
+    [Result.URL, Result.URL, "dataURL", "dataURL"],
+
+  // HTTP(S) to bare mapping is disabled.
+  "{{location[server]}}/import-maps/resources/log.js?pipe=sub&name=to-bare":
+    [Result.URL, Result.URL, Result.PARSE_ERROR, Result.PARSE_ERROR],
+};
+
+doTests(importMap, null, tests);
+</script>
+<body>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/import-maps-base-url.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/import-maps-base-url.sub-expected.txt
@@ -1,0 +1,9 @@
+
+
+PASS bare/bare: static import
+PASS bare/bare: dynamic import (from module)
+PASS bare/bare: dynamic import (from text/javascript)
+PASS bare/bare: static import with inject <base>
+PASS bare/bare: dynamic import (from module) with inject <base>
+PASS bare/bare: dynamic import (from text/javascript) with inject <base>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/import-maps-base-url.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/import-maps-base-url.sub.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/test-helper.js"></script>
+
+<script>
+
+// baseURL will be used to create a <base> element, which will change the
+// baseURL of the import map.
+const baseURL = "http://{{host}}:{{ports[http][0]}}/import-maps/resources/";
+const importMap = `
+{
+  "imports": {
+    "bare/bare": "./log.js?pipe=sub&name=bare"
+  }
+}
+`;
+
+promise_setup(function () {
+  return new Promise((resolve) => {
+    window.addEventListener("load", async () => {
+      await testStaticImport(importMap, baseURL, "bare/bare", "log:bare");
+      await testDynamicImport(importMap, baseURL, "bare/bare", "log:bare", "module");
+      await testDynamicImport(importMap, baseURL, "bare/bare", "log:bare", "text/javascript");
+
+      await testStaticImportInjectBase(importMap, baseURL, "bare/bare", "log:bare");
+      await testDynamicImportInjectBase(importMap, baseURL, "bare/bare", "log:bare", "module");
+      await testDynamicImportInjectBase(importMap, baseURL, "bare/bare", "log:bare", "text/javascript");
+      done();
+      resolve();
+    });
+  });
+}, { explicit_done: true });
+
+
+</script>
+<body>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/module-map-key-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/module-map-key-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Module map's key is the URL after import map resolution
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/module-map-key.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/module-map-key.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "./resources/log.js?pipe=sub&name=A": "./resources/log.js?pipe=sub&name=B"
+  }
+}
+</script>
+<script>
+const log = [];
+
+promise_test(() => {
+  return import("./resources/log.js?pipe=sub&name=A")
+    .then(() => import("./resources/log.js?pipe=sub&name=B"))
+    .then(() => assert_array_equals(log, ["log:B"]))
+  },
+  "Module map's key is the URL after import map resolution");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Second import map should be rejected
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const log = [];
+</script>
+<script type="importmap" onerror="log.push('onerror 1')">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A1": "../resources/log.js?pipe=sub&name=B1",
+    "../resources/log.js?pipe=sub&name=A2": "../resources/log.js?pipe=sub&name=B2"
+  }
+}
+</script>
+<script type="importmap" onerror="log.push('onerror 2')">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A1": "../resources/log.js?pipe=sub&name=C1",
+    "../resources/log.js?pipe=sub&name=A3": "../resources/log.js?pipe=sub&name=C3"
+  }
+}
+</script>
+<script>
+// Currently the spec doesn't allow multiple import maps, by setting acquiring
+// import maps to false on preparing the first import map.
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A1")
+    .then(() => import("../resources/log.js?pipe=sub&name=A2"))
+    .then(() => import("../resources/log.js?pipe=sub&name=A3"))
+    .then(() => assert_array_equals(
+                    log,
+                    ["onerror 2", "log:B1", "log:B2", "log:A3"]))
+  },
+  "Second import map should be rejected");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/w3c-import.log
@@ -1,0 +1,18 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors.html

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: ImportMap has invalid JSON
+
+PASS Second import map should be rejected after an import map with errors
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({allow_uncaught_exception : true});
+
+const log = [];
+</script>
+<script type="importmap" onerror="log.push('onerror 1')">
+Parse Error
+</script>
+<script type="importmap" onerror="log.push('onerror 2')">
+{
+  "imports": {
+    "../resources/log.js?pipe=sub&name=A": "../resources/log.js?pipe=sub&name=C"
+  }
+}
+</script>
+<script>
+// Currently the spec doesn't allow multiple import maps, by setting acquiring
+// import maps to false on preparing the first import map.
+// Even the first import map has errors and thus Document's import map is not
+// updated, the second import map is still rejected at preparationg.
+promise_test(() => {
+  return import("../resources/log.js?pipe=sub&name=A")
+    .then(() => assert_array_equals(
+                    log,
+                    ["onerror 2", "log:A"]))
+  },
+  "Second import map should be rejected after an import map with errors");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-as-classic-script-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-as-classic-script-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Import maps shouldn't be parsed as scripts
+PASS Import maps shouldn't be executed as scripts
+PASS External import maps shouldn't be executed as scripts
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-as-classic-script.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-as-classic-script.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+setup({allow_uncaught_exception : true});
+
+const t_parse = async_test("Import maps shouldn't be parsed as scripts");
+const t_evaluate = async_test("Import maps shouldn't be executed as scripts");
+const t_external = async_test(
+   "External import maps shouldn't be executed as scripts");
+
+const errorHandler = event => {
+  event.preventDefault();
+  t_parse.unreached_func("An import map is parsed as a classic script")();
+};
+
+window.addEventListener("error", errorHandler, {once: true});
+</script>
+
+<!-- This import map causes a parse error when parsed as a classic script. -->
+<script type="importmap">
+{
+  "imports": {
+  }
+}
+</script>
+
+<script>
+// Remove error handler, because the following import map can causes parse
+// error.
+window.removeEventListener("error", errorHandler);
+</script>
+
+<script type="importmap">
+t_evaluate.unreached_func("An import map is evaluated")();
+</script>
+
+<script type="importmap" src="data:text/javascript,t_external.unreached_func('An external import map is evaluated')();"></script>
+
+<script>
+t_parse.done();
+t_evaluate.done();
+t_external.done();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/inject-base.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/inject-base.js
@@ -1,0 +1,3 @@
+const el = document.createElement("base");
+el.href = "{{GET[baseurl]}}";
+document.currentScript.after(el);

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.js
@@ -1,0 +1,1 @@
+log.push("log:{{GET[name]}}");

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.js.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.js.headers
@@ -1,0 +1,1 @@
+Access-Control-Allow-Origin: *

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/test-helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/test-helper.js
@@ -1,0 +1,246 @@
+let log = [];
+
+function expect_log(test, expected_log) {
+  test.step_func_done(() => {
+    const actual_log = log;
+    log = [];
+    assert_array_equals(actual_log, expected_log, 'fallback log');
+  })();
+}
+
+// Results of resolving a specifier using import maps.
+const Result = {
+  // A failure considered as a fetch error in a module script tree.
+  // <script>'s error event is fired.
+  FETCH_ERROR: "fetch_error",
+
+  // A failure considered as a parse error in a module script tree.
+  // Window's error event is fired.
+  PARSE_ERROR: "parse_error",
+
+  // The specifier is considered as a relative or absolute URL.
+  // Specifier                 Expected log
+  // ------------------------- ----------------------
+  // ...?name=foo              log:foo
+  // data:...log('foo')        foo
+  // Others, e.g. bare/bare    relative:bare/bare
+  // ------------------------- ----------------------
+  // (The last case assumes a file `bare/bare` that logs `relative:bare/bare`
+  // exists)
+  URL: "URL",
+};
+
+const Handler = {
+  // Handlers for <script> element cases.
+  // Note that on a parse error both WindowErrorEvent and ScriptLoadEvent are
+  // called.
+  ScriptLoadEvent: "<script> element's load event handler",
+  ScriptErrorEvent: "<script> element's error event handler",
+  WindowErrorEvent: "window's error event handler",
+
+  // Handlers for dynamic imports.
+  DynamicImportResolve: "dynamic import resolve",
+  DynamicImportReject: "dynamic import reject",
+};
+
+// Returns a map with Handler.* as the keys.
+function getHandlers(t, specifier, expected) {
+  let handlers = {};
+  handlers[Handler.ScriptLoadEvent] = t.unreached_func("Shouldn't load");
+  handlers[Handler.ScriptErrorEvent] =
+      t.unreached_func("script's error event shouldn't be fired");
+  handlers[Handler.WindowErrorEvent] =
+      t.unreached_func("window's error event shouldn't be fired");
+  handlers[Handler.DynamicImportResolve] =
+    t.unreached_func("dynamic import promise shouldn't be resolved");
+  handlers[Handler.DynamicImportReject] =
+    t.unreached_func("dynamic import promise shouldn't be rejected");
+
+  if (expected === Result.FETCH_ERROR) {
+    handlers[Handler.ScriptErrorEvent] = () => expect_log(t, []);
+    handlers[Handler.DynamicImportReject] = () => expect_log(t, []);
+  } else if (expected === Result.PARSE_ERROR) {
+    let error_occurred = false;
+    handlers[Handler.WindowErrorEvent] = () => { error_occurred = true; };
+    handlers[Handler.ScriptLoadEvent] = t.step_func(() => {
+      // Even if a parse error occurs, load event is fired (after
+      // window.onerror is called), so trigger the load handler only if
+      // there was no previous window.onerror call.
+      assert_true(error_occurred, "window.onerror should be fired");
+      expect_log(t, []);
+    });
+    handlers[Handler.DynamicImportReject] = t.step_func(() => {
+      assert_false(error_occurred,
+        "window.onerror shouldn't be fired for dynamic imports");
+      expect_log(t, []);
+    });
+  } else {
+    let expected_log;
+    if (expected === Result.URL) {
+      const match_data_url = specifier.match(/data:.*log\.push\('(.*)'\)/);
+      const match_log_js = specifier.match(/name=(.*)/);
+      if (match_data_url) {
+        expected_log = [match_data_url[1]];
+      } else if (match_log_js) {
+        expected_log = ["log:" + match_log_js[1]];
+      } else {
+        expected_log = ["relative:" + specifier];
+      }
+    } else {
+      expected_log = [expected];
+    }
+    handlers[Handler.ScriptLoadEvent] = () => expect_log(t, expected_log);
+    handlers[Handler.DynamicImportResolve] = () => expect_log(t, expected_log);
+  }
+  return handlers;
+}
+
+// Creates an <iframe> and run a test inside the <iframe>
+// to separate the module maps and import maps in each test.
+function testInIframe(importMapString, importMapBaseURL, testScript) {
+  const iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+  if (!importMapBaseURL) {
+    importMapBaseURL = document.baseURI;
+  }
+  let content = `
+    <script src="/resources/testharness.js"></script>
+    <script src="/import-maps/resources/test-helper.js"></script>
+    <base href="${importMapBaseURL}">
+    <script type="importmap">${importMapString}</script>
+    <body>
+    <script>
+    setup({ allow_uncaught_exception: true });
+    ${testScript}
+    </sc` + `ript>
+  `;
+  iframe.contentDocument.write(content);
+  iframe.contentDocument.close();
+  return fetch_tests_from_window(iframe.contentWindow);
+}
+
+function testScriptElement(importMapString, importMapBaseURL, specifier, expected, type) {
+  return testInIframe(importMapString, importMapBaseURL, `
+    const t = async_test("${specifier}: <script src type=${type}>");
+    const handlers = getHandlers(t, "${specifier}", "${expected}");
+    const script = document.createElement("script");
+    script.setAttribute("type", "${type}");
+    script.setAttribute("src", "${specifier}");
+    script.addEventListener("load", handlers[Handler.ScriptLoadEvent]);
+    script.addEventListener("error", handlers[Handler.ScriptErrorEvent]);
+    window.addEventListener("error", handlers[Handler.WindowErrorEvent]);
+    document.body.appendChild(script);
+  `);
+}
+
+function testStaticImport(importMapString, importMapBaseURL, specifier, expected) {
+  return testInIframe(importMapString, importMapBaseURL, `
+    const t = async_test("${specifier}: static import");
+    const handlers = getHandlers(t, "${specifier}", "${expected}");
+    const script = document.createElement("script");
+    script.setAttribute("type", "module");
+    script.setAttribute("src",
+        "/import-maps/static-import.py?url=" +
+        encodeURIComponent("${specifier}"));
+    script.addEventListener("load", handlers[Handler.ScriptLoadEvent]);
+    script.addEventListener("error", handlers[Handler.ScriptErrorEvent]);
+    window.addEventListener("error", handlers[Handler.WindowErrorEvent]);
+    document.body.appendChild(script);
+  `);
+}
+
+function testDynamicImport(importMapString, importMapBaseURL, specifier, expected, type) {
+  return testInIframe(importMapString, importMapBaseURL, `
+    const t = async_test("${specifier}: dynamic import (from ${type})");
+    const handlers = getHandlers(t, "${specifier}", "${expected}");
+    const script = document.createElement("script");
+    script.setAttribute("type", "${type}");
+    script.innerText =
+        "import(\\"${specifier}\\")" +
+        ".then(handlers[Handler.DynamicImportResolve], " +
+        "handlers[Handler.DynamicImportReject]);";
+    script.addEventListener("error",
+        t.unreached_func("top-level inline script shouldn't error"));
+    document.body.appendChild(script);
+  `);
+}
+
+function testInIframeInjectBase(importMapString, importMapBaseURL, testScript) {
+  const iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+  let content = `
+    <script src="/resources/testharness.js"></script>
+    <script src="/import-maps/resources/test-helper.js"></script>
+    <script src="/import-maps/resources/inject-base.js?pipe=sub&baseurl=${importMapBaseURL}"></script>
+    <script type="importmap">
+      ${importMapString}
+    </script>
+    <body>
+    <script>
+    setup({ allow_uncaught_exception: true });
+    ${testScript}
+    </sc` + `ript>
+  `;
+  iframe.contentDocument.write(content);
+  iframe.contentDocument.close();
+  return fetch_tests_from_window(iframe.contentWindow);
+}
+
+function testStaticImportInjectBase(importMapString, importMapBaseURL, specifier, expected) {
+  return testInIframeInjectBase(importMapString, importMapBaseURL, `
+    const t = async_test("${specifier}: static import with inject <base>");
+    const handlers = getHandlers(t, "${specifier}", "${expected}");
+    const script = document.createElement("script");
+    script.setAttribute("type", "module");
+    script.setAttribute("src",
+        "/import-maps/static-import.py?url=" +
+        encodeURIComponent("${specifier}"));
+    script.addEventListener("load", handlers[Handler.ScriptLoadEvent]);
+    script.addEventListener("error", handlers[Handler.ScriptErrorEvent]);
+    window.addEventListener("error", handlers[Handler.WindowErrorEvent]);
+    document.body.appendChild(script);
+  `);
+}
+
+function testDynamicImportInjectBase(importMapString, importMapBaseURL, specifier, expected, type) {
+  return testInIframeInjectBase(importMapString, importMapBaseURL, `
+    const t = async_test("${specifier}: dynamic import (from ${type}) with inject <base>");
+    const handlers = getHandlers(t, "${specifier}", "${expected}");
+    const script = document.createElement("script");
+    script.setAttribute("type", "${type}");
+    script.innerText =
+        "import(\\"${specifier}\\")" +
+        ".then(handlers[Handler.DynamicImportResolve], " +
+        "handlers[Handler.DynamicImportReject]);";
+    script.addEventListener("error",
+        t.unreached_func("top-level inline script shouldn't error"));
+    document.body.appendChild(script);
+  `);
+}
+
+function doTests(importMapString, importMapBaseURL, tests) {
+  promise_setup(function () {
+    return new Promise((resolve) => {
+      window.addEventListener("load", async () => {
+        for (const specifier in tests) {
+          // <script src> (module scripts)
+          await testScriptElement(importMapString, importMapBaseURL, specifier, tests[specifier][0], "module");
+
+          // <script src> (classic scripts)
+          await testScriptElement(importMapString, importMapBaseURL, specifier, tests[specifier][1], "text/javascript");
+
+          // static imports.
+          await testStaticImport(importMapString, importMapBaseURL, specifier, tests[specifier][2]);
+
+          // dynamic imports from a module script.
+          await testDynamicImport(importMapString, importMapBaseURL, specifier, tests[specifier][3], "module");
+
+          // dynamic imports from a classic script.
+          await testDynamicImport(importMapString, importMapBaseURL, specifier, tests[specifier][3], "text/javascript");
+        }
+        done();
+        resolve();
+      });
+    });
+  }, { explicit_done: true });
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/w3c-import.log
@@ -1,0 +1,21 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/empty.js
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/inject-base.js
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.js
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.js.headers
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/test-helper.js

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/script-supports-importmap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/script-supports-importmap-expected.txt
@@ -1,0 +1,4 @@
+
+PASS HTMLScriptElement.supports returns true for 'importmap'
+PASS HTMLScriptElement.supports returns false for unsupported types
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/script-supports-importmap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/script-supports-importmap.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<title>HTMLScriptElement.supports importmap</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  assert_true(HTMLScriptElement.supports('importmap'));
+}, 'HTMLScriptElement.supports returns true for \'importmap\'');
+
+test(function() {
+  assert_false(HTMLScriptElement.supports(' importmap'));
+  assert_false(HTMLScriptElement.supports('importmap '));
+  assert_false(HTMLScriptElement.supports('Importmap'));
+  assert_false(HTMLScriptElement.supports('ImportMap'));
+  assert_false(HTMLScriptElement.supports('importMap'));
+  assert_false(HTMLScriptElement.supports('import-map'));
+  assert_false(HTMLScriptElement.supports('importmaps'));
+  assert_false(HTMLScriptElement.supports('import-maps'));
+}, 'HTMLScriptElement.supports returns false for unsupported types');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/static-import.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/static-import.py
@@ -1,0 +1,11 @@
+# This file needs to be a sibling of the test files (and not under resources/)
+# so that base URL resolution is the same between those test files and <script>s
+# pointing to this file.
+
+from wptserve.utils import isomorphic_decode
+
+def main(request, response):
+    return (
+        ((b'Content-Type', b'text/javascript'),),
+        u'import "{}";\n'.format(isomorphic_decode(request.GET.first(b'url')))
+    )

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/w3c-import.log
@@ -1,0 +1,25 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/import-maps-base-url.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/module-map-key.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/not-as-classic-script.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/script-supports-importmap.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/static-import.py

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js
@@ -3822,7 +3822,9 @@
             return;
         }
 
-        this.pending_remotes.push(this.create_remote_window(remote));
+        var remoteContext = this.create_remote_window(remote);
+        this.pending_remotes.push(remoteContext);
+        return remoteContext.done;
     };
 
     /**
@@ -3837,7 +3839,7 @@
      * @param {Window} window - The window to fetch tests from.
      */
     function fetch_tests_from_window(window) {
-        tests.fetch_tests_from_window(window);
+        return tests.fetch_tests_from_window(window);
     }
     expose(fetch_tests_from_window, 'fetch_tests_from_window');
 

--- a/LayoutTests/inspector/controller/runtime-controller-import-expected.txt
+++ b/LayoutTests/inspector/controller/runtime-controller-import-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: TypeError: Module specifier, '' does not start with "/", "./", or "../". Referenced from runtime-controller-import.html
+CONSOLE MESSAGE: TypeError: Module name, '' does not resolve to a valid URL.
 CONSOLE MESSAGE: TypeError: Importing a module script failed.
 CONSOLE MESSAGE: Cocoa is Sweet.
 CONSOLE MESSAGE: %o

--- a/LayoutTests/inspector/controller/runtime-controller-import.html
+++ b/LayoutTests/inspector/controller/runtime-controller-import.html
@@ -13,14 +13,11 @@ function test()
         description: "Test evaluating an import expression from console.",
         test(resolve, reject) {
             function testSource(expression, count) {
-                let promise = WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded);
                 return new Promise((resolve, reject) => {
                     WI.runtimeManager.evaluateInInspectedWindow(expression, {objectGroup: "test"}, (result, wasThrown) => {
-                        promise.then(() => {
-                            InspectorTest.log("Source: " + expression);
-                            InspectorTest.expectThat(result.isUndefined(), "Transformed. Should log the value or an exception.");
-                            resolve();
-                        });
+                        InspectorTest.log("Source: " + expression);
+                        InspectorTest.expectThat(result.isUndefined(), "Transformed. Should log the value or an exception.");
+                        resolve();
                     });
                 })
             }

--- a/LayoutTests/js/dom/modules/import-incorrect-relative-specifier-expected.txt
+++ b/LayoutTests/js/dom/modules/import-incorrect-relative-specifier-expected.txt
@@ -3,9 +3,9 @@ Test import rejects the incorrect relative specifiers.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS import("incorrect") rejected promise  with TypeError: Module specifier, 'incorrect' does not start with "/", "./", or "../". Referenced from file:///LayoutTests/resources/js-test-pre.js.
-PASS import("$hello") rejected promise  with TypeError: Module specifier, '$hello' does not start with "/", "./", or "../". Referenced from file:///LayoutTests/resources/js-test-pre.js.
-PASS import(".../test") rejected promise  with TypeError: Module specifier, '.../test' does not start with "/", "./", or "../". Referenced from file:///LayoutTests/resources/js-test-pre.js.
+PASS import("incorrect") rejected promise  with TypeError: Module name, 'incorrect' does not resolve to a valid URL..
+PASS import("$hello") rejected promise  with TypeError: Module name, '$hello' does not resolve to a valid URL..
+PASS import(".../test") rejected promise  with TypeError: Module name, '.../test' does not resolve to a valid URL..
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/js/dom/modules/module-incorrect-relative-specifier-expected.txt
+++ b/LayoutTests/js/dom/modules/module-incorrect-relative-specifier-expected.txt
@@ -1,6 +1,6 @@
-CONSOLE MESSAGE: TypeError: Module specifier, 'incorrect' does not start with "/", "./", or "../". Referenced from module-incorrect-relative-specifier.html
-CONSOLE MESSAGE: TypeError: Module specifier, '$hello' does not start with "/", "./", or "../". Referenced from module-incorrect-relative-specifier.html
-CONSOLE MESSAGE: TypeError: Module specifier, '.../test' does not start with "/", "./", or "../". Referenced from module-incorrect-relative-specifier.html
+CONSOLE MESSAGE: TypeError: Module name, 'incorrect' does not resolve to a valid URL.
+CONSOLE MESSAGE: TypeError: Module name, '$hello' does not resolve to a valid URL.
+CONSOLE MESSAGE: TypeError: Module name, '.../test' does not resolve to a valid URL.
 Test script.onerror will be fired when the incorrect relative specifier is specified.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/specifier-error-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/specifier-error-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: TypeError: Module specifier, 'string-without-dot-slash-prefix' does not start with "/", "./", or "../". Referenced from http://web-platform.test:8800/html/semantics/scripting-1/the-script-element/module/bad-module-specifier.js
+CONSOLE MESSAGE: TypeError: Module name, 'string-without-dot-slash-prefix' does not resolve to a valid URL.
 
 PASS Test that invalid module specifier leads to TypeError on window.
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt
@@ -1,0 +1,44 @@
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: TypeError: Module name, 'bare/to-bare' does not resolve to a valid URL.
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+
+
+PASS bare/bare: <script src type=module>
+PASS bare/bare: <script src type=text/javascript>
+PASS bare/bare: static import
+PASS bare/bare: dynamic import (from module)
+PASS bare/bare: dynamic import (from text/javascript)
+PASS bare/cross-origin-bare: <script src type=module>
+PASS bare/cross-origin-bare: <script src type=text/javascript>
+PASS bare/cross-origin-bare: static import
+PASS bare/cross-origin-bare: dynamic import (from module)
+PASS bare/cross-origin-bare: dynamic import (from text/javascript)
+PASS bare/to-data: <script src type=module>
+PASS bare/to-data: <script src type=text/javascript>
+PASS bare/to-data: static import
+PASS bare/to-data: dynamic import (from module)
+PASS bare/to-data: dynamic import (from text/javascript)
+PASS bare/to-bare: <script src type=module>
+PASS bare/to-bare: <script src type=text/javascript>
+PASS bare/to-bare: static import
+PASS bare/to-bare: dynamic import (from module)
+PASS bare/to-bare: dynamic import (from text/javascript)
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Refused to load https://www1.web-platform.test:9443/import-maps/resources/log.js?pipe=sub&name=B because it does not appear in the script-src directive of the Content Security Policy.
+
+PASS The URL after mapping violates CSP (but not the URL before mapping)
+PASS The URL before mapping violates CSP (but not the URL after mapping)
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Refused to load https://www1.web-platform.test:9443/import-maps/resources/log.js?pipe=sub&name=B because it does not appear in the script-src directive of the Content Security Policy.
+
+PASS The URL after mapping violates CSP (but not the URL before mapping)
+PASS The URL before mapping violates CSP (but not the URL after mapping)
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt
@@ -1,0 +1,44 @@
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: TypeError: Module name, 'data:text/javascript,log.push('data:to-bare')' does not resolve to a valid URL.
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+
+
+PASS data:text/javascript,log.push('data:foo'): <script src type=module>
+PASS data:text/javascript,log.push('data:foo'): <script src type=text/javascript>
+PASS data:text/javascript,log.push('data:foo'): static import
+PASS data:text/javascript,log.push('data:foo'): dynamic import (from module)
+PASS data:text/javascript,log.push('data:foo'): dynamic import (from text/javascript)
+PASS data:text/javascript,log.push('data:cross-origin-foo'): <script src type=module>
+PASS data:text/javascript,log.push('data:cross-origin-foo'): <script src type=text/javascript>
+PASS data:text/javascript,log.push('data:cross-origin-foo'): static import
+PASS data:text/javascript,log.push('data:cross-origin-foo'): dynamic import (from module)
+PASS data:text/javascript,log.push('data:cross-origin-foo'): dynamic import (from text/javascript)
+PASS data:text/javascript,log.push('data:to-data'): <script src type=module>
+PASS data:text/javascript,log.push('data:to-data'): <script src type=text/javascript>
+PASS data:text/javascript,log.push('data:to-data'): static import
+PASS data:text/javascript,log.push('data:to-data'): dynamic import (from module)
+PASS data:text/javascript,log.push('data:to-data'): dynamic import (from text/javascript)
+PASS data:text/javascript,log.push('data:to-bare'): <script src type=module>
+PASS data:text/javascript,log.push('data:to-bare'): <script src type=text/javascript>
+PASS data:text/javascript,log.push('data:to-bare'): static import
+PASS data:text/javascript,log.push('data:to-bare'): dynamic import (from module)
+PASS data:text/javascript,log.push('data:to-bare'): dynamic import (from text/javascript)
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt
@@ -1,0 +1,44 @@
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: TypeError: Module name, 'http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare' does not resolve to a valid URL.
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+
+
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=foo: <script src type=module>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=foo: <script src type=text/javascript>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=foo: static import
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=foo: dynamic import (from module)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=foo: dynamic import (from text/javascript)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: <script src type=module>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: <script src type=text/javascript>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: static import
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: dynamic import (from module)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: dynamic import (from text/javascript)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-data: <script src type=module>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-data: <script src type=text/javascript>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-data: static import
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-data: dynamic import (from module)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-data: dynamic import (from text/javascript)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: <script src type=module>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: <script src type=text/javascript>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: static import
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: dynamic import (from module)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: dynamic import (from text/javascript)
+

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -4118,6 +4118,15 @@
     "imported/w3c/web-platform-tests/image-decodes/image-decode.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/import-maps/import-maps-base-url.sub.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-001.html": [
         "slow"
     ],

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1031,6 +1031,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/Identifier.h
     runtime/IdentifierInlines.h
     runtime/ImplementationVisibility.h
+    runtime/ImportMap.h
     runtime/IndexingHeader.h
     runtime/IndexingHeaderInlines.h
     runtime/IndexingType.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2031,6 +2031,7 @@
 		E3C79CAB1DB9A4DC00D1ECA4 /* DOMJITEffect.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C79CAA1DB9A4D600D1ECA4 /* DOMJITEffect.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3C8ED4323A1DBCB00131958 /* IsoInlinedHeapCellType.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C8ED4223A1DBC500131958 /* IsoInlinedHeapCellType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3CA3A4E2527AB2F004802BF /* JITOperationList.h in Headers */ = {isa = PBXBuildFile; fileRef = E3CA3A4C2527AB2F004802BF /* JITOperationList.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3CDCFAF28DD065A00215350 /* ImportMap.h in Headers */ = {isa = PBXBuildFile; fileRef = E3CDCFAE28DD065A00215350 /* ImportMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3D239C91B829C1C00BBEF67 /* JSModuleEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D239C71B829C1C00BBEF67 /* JSModuleEnvironment.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3D3515F241B89D7008DC16E /* MarkedJSValueRefArray.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D3515D241B89CE008DC16E /* MarkedJSValueRefArray.h */; };
 		E3D877741E65C0A000BE945A /* BytecodeDumper.h in Headers */ = {isa = PBXBuildFile; fileRef = E3D877721E65C08900BE945A /* BytecodeDumper.h */; };
@@ -5340,6 +5341,7 @@
 		E326C4961ECBEF5700A9A905 /* ClassInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ClassInfo.cpp; sourceTree = "<group>"; };
 		E3282BB91FE930A300EDAF71 /* YarrErrorCode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = YarrErrorCode.cpp; path = yarr/YarrErrorCode.cpp; sourceTree = "<group>"; };
 		E3282BBA1FE930A400EDAF71 /* YarrErrorCode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = YarrErrorCode.h; path = yarr/YarrErrorCode.h; sourceTree = "<group>"; };
+		E3285D8E28DD8317008E0090 /* ImportMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImportMap.cpp; sourceTree = "<group>"; };
 		E32C3C6823E94C1E00BC97C0 /* UnlinkedCodeBlockGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UnlinkedCodeBlockGenerator.h; sourceTree = "<group>"; };
 		E32D4DE026DAFD4200D4533A /* TemporalCalendar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TemporalCalendar.cpp; sourceTree = "<group>"; };
 		E32D4DE126DAFD4200D4533A /* TemporalCalendarPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemporalCalendarPrototype.h; sourceTree = "<group>"; };
@@ -5562,6 +5564,7 @@
 		E3C8ED4223A1DBC500131958 /* IsoInlinedHeapCellType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IsoInlinedHeapCellType.h; sourceTree = "<group>"; };
 		E3CA3A4B2527AB2E004802BF /* JITOperationList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JITOperationList.cpp; sourceTree = "<group>"; };
 		E3CA3A4C2527AB2F004802BF /* JITOperationList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JITOperationList.h; sourceTree = "<group>"; };
+		E3CDCFAE28DD065A00215350 /* ImportMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImportMap.h; sourceTree = "<group>"; };
 		E3D239C61B829C1C00BBEF67 /* JSModuleEnvironment.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSModuleEnvironment.cpp; sourceTree = "<group>"; };
 		E3D239C71B829C1C00BBEF67 /* JSModuleEnvironment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSModuleEnvironment.h; sourceTree = "<group>"; };
 		E3D264261D38C042000BE174 /* BytecodeGeneratorification.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BytecodeGeneratorification.cpp; sourceTree = "<group>"; };
@@ -7837,6 +7840,8 @@
 				933A349A038AE7C6008635CE /* Identifier.h */,
 				8606DDE918DA44AB00A383D0 /* IdentifierInlines.h */,
 				95CA6AD228809E010062D5EC /* ImplementationVisibility.h */,
+				E3285D8E28DD8317008E0090 /* ImportMap.cpp */,
+				E3CDCFAE28DD065A00215350 /* ImportMap.h */,
 				0FB7F38D15ED8E3800F167B2 /* IndexingHeader.h */,
 				0FB7F38E15ED8E3800F167B2 /* IndexingHeaderInlines.h */,
 				0F13E04C16164A1B00DC8DE7 /* IndexingType.cpp */,
@@ -10512,6 +10517,7 @@
 				8606DDEA18DA44AB00A383D0 /* IdentifierInlines.h in Headers */,
 				A5FD0076189B038C00633231 /* IdentifiersFactory.h in Headers */,
 				95CA6AD328809E010062D5EC /* ImplementationVisibility.h in Headers */,
+				E3CDCFAF28DD065A00215350 /* ImportMap.h in Headers */,
 				A38D5BFC2666D3DA00A109A6 /* InByStatus.h in Headers */,
 				A382C5312667111D0042CD99 /* InByVariant.h in Headers */,
 				C25F8BCE157544A900245B71 /* IncrementalSweeper.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -832,6 +832,7 @@ runtime/GetterSetter.cpp
 runtime/GlobalExecutable.cpp
 runtime/HashMapImpl.cpp
 runtime/Identifier.cpp
+runtime/ImportMap.cpp
 runtime/IndexingType.cpp
 runtime/IndirectEvalExecutable.cpp
 runtime/InitializeThreading.cpp

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -121,6 +121,7 @@ namespace JSC {
     macro(asyncGeneratorQueueItemNext) \
     macro(dateTimeFormat) \
     macro(this) \
+    macro(importMapStatus) \
     macro(importInRealm) \
     macro(evalInRealm) \
     macro(moveFunctionToRealm) \

--- a/Source/JavaScriptCore/builtins/ModuleLoader.js
+++ b/Source/JavaScriptCore/builtins/ModuleLoader.js
@@ -378,15 +378,13 @@ function provideFetch(key, value)
 }
 
 @visibility=PrivateRecursive
-async function loadModule(moduleName, parameters, fetcher)
+async function loadModule(key, parameters, fetcher)
 {
     "use strict";
 
-    // Loader.resolve hook point.
-    // resolve: moduleName => Promise(moduleKey)
-    // Take the name and resolve it to the unique identifier for the resource location.
-    // For example, take the "jquery" and return the URL for the resource.
-    var key = this.resolve(moduleName, @undefined, fetcher);
+    var importMap = @importMapStatus();
+    if (importMap)
+        await importMap;
     var entry = await this.requestSatisfy(this.ensureRegistered(key), parameters, fetcher, new @Set);
     return entry.key;
 }
@@ -409,15 +407,23 @@ async function loadAndEvaluateModule(moduleName, parameters, fetcher)
 {
     "use strict";
 
-    var key = await this.loadModule(moduleName, parameters, fetcher);
+    var importMap = @importMapStatus();
+    if (importMap)
+        await importMap;
+    var key = this.resolve(moduleName, @undefined, fetcher);
+    key = await this.loadModule(key, parameters, fetcher);
     return await this.linkAndEvaluateModule(key, fetcher);
 }
 
 @visibility=PrivateRecursive
-async function requestImportModule(key, parameters, fetcher)
+async function requestImportModule(moduleName, referrer, parameters, fetcher)
 {
     "use strict";
 
+    var importMap = @importMapStatus();
+    if (importMap)
+        await importMap;
+    var key = this.resolve(moduleName, referrer, fetcher);
     var entry = await this.requestSatisfy(this.ensureRegistered(key), parameters, fetcher, new @Set);
     await this.linkAndEvaluateModule(entry.key, fetcher);
     return this.getModuleNamespaceObject(entry.module);

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -80,6 +80,7 @@ class JSGlobalObject;
     v(Set, nullptr) \
     v(Map, nullptr) \
     v(thisTimeValue, nullptr) \
+    v(importMapStatus, nullptr) \
     v(importInRealm, nullptr) \
     v(evalInRealm, nullptr) \
     v(moveFunctionToRealm, nullptr) \

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -909,14 +909,6 @@ JSInternalPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* global
     if (!referrer.isLocalFile())
         RELEASE_AND_RETURN(scope, rejectWithError(createError(globalObject, makeString("Could not resolve the referrer's path '", referrer.string(), "', while trying to resolve module '", specifier, "'."))));
 
-    bool specifierIsAbsolute = isAbsolutePath(specifier);
-    if (!specifierIsAbsolute && !isDottedRelativePath(specifier))
-        RELEASE_AND_RETURN(scope, rejectWithError(createTypeError(globalObject, makeString("Module specifier, '"_s, specifier, "' is not absolute and does not start with \"./\" or \"../\". Referenced from: "_s, referrer.fileSystemPath()))));
-
-    auto moduleURL = specifierIsAbsolute ? URL::fileURLWithFileSystemPath(specifier) : URL(referrer, specifier);
-    if (!moduleURL.isLocalFile())
-        RELEASE_AND_RETURN(scope, rejectWithError(createError(globalObject, makeString("Module url, '", moduleURL.string(), "' does not map to a local file."))));
-
     auto assertions = JSC::retrieveAssertionsFromDynamicImportOptions(globalObject, parameters, { vm.propertyNames->type.impl() });
     RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
 
@@ -926,7 +918,7 @@ JSInternalPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* global
             parameters = JSScriptFetchParameters::create(vm, ScriptFetchParameters::create(type.value()));
     }
 
-    auto result = JSC::importModule(globalObject, Identifier::fromString(vm, moduleURL.string()), parameters, jsUndefined());
+    auto result = JSC::importModule(globalObject, Identifier::fromString(vm, specifier), jsString(vm, referrer.string()), parameters, jsUndefined());
     RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
 
     return result;

--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -46,6 +46,7 @@ class UnlinkedFunctionCodeBlock;
         Module,
         WebAssembly,
         JSON,
+        ImportMap,
     };
 
     using BytecodeCacheGenerator = Function<RefPtr<CachedBytecode>()>;

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -220,14 +220,14 @@ JSInternalPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, const Sou
     RELEASE_AND_RETURN(scope, globalObject->moduleLoader()->loadAndEvaluateModule(globalObject, key, jsUndefined(), scriptFetcher));
 }
 
-JSInternalPromise* loadModule(JSGlobalObject* globalObject, const String& moduleName, JSValue parameters, JSValue scriptFetcher)
+JSInternalPromise* loadModule(JSGlobalObject* globalObject, const Identifier& moduleKey, JSValue parameters, JSValue scriptFetcher)
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
-    return globalObject->moduleLoader()->loadModule(globalObject, identifierToJSValue(vm, Identifier::fromString(vm, moduleName)), parameters, scriptFetcher);
+    return globalObject->moduleLoader()->loadModule(globalObject, identifierToJSValue(vm, moduleKey), parameters, scriptFetcher);
 }
 
 JSInternalPromise* loadModule(JSGlobalObject* globalObject, const SourceCode& source, JSValue scriptFetcher)
@@ -257,14 +257,14 @@ JSValue linkAndEvaluateModule(JSGlobalObject* globalObject, const Identifier& mo
     return globalObject->moduleLoader()->linkAndEvaluateModule(globalObject, identifierToJSValue(vm, moduleKey), scriptFetcher);
 }
 
-JSInternalPromise* importModule(JSGlobalObject* globalObject, const Identifier& moduleKey, JSValue parameters, JSValue scriptFetcher)
+JSInternalPromise* importModule(JSGlobalObject* globalObject, const Identifier& moduleName, JSValue referrer, JSValue parameters, JSValue scriptFetcher)
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
-    return globalObject->moduleLoader()->requestImportModule(globalObject, moduleKey, parameters, scriptFetcher);
+    return globalObject->moduleLoader()->requestImportModule(globalObject, moduleName, referrer, parameters, scriptFetcher);
 }
 
 HashMap<RefPtr<UniquedStringImpl>, String> retrieveAssertionsFromDynamicImportOptions(JSGlobalObject* globalObject, JSValue options, const Vector<RefPtr<UniquedStringImpl>>& supportedAssertions)

--- a/Source/JavaScriptCore/runtime/Completion.h
+++ b/Source/JavaScriptCore/runtime/Completion.h
@@ -70,13 +70,13 @@ JS_EXPORT_PRIVATE JSInternalPromise* loadAndEvaluateModule(JSGlobalObject*, cons
 JS_EXPORT_PRIVATE JSInternalPromise* loadAndEvaluateModule(JSGlobalObject*, const SourceCode&, JSValue scriptFetcher);
 
 // Fetch the module source, and instantiate the module record.
-JS_EXPORT_PRIVATE JSInternalPromise* loadModule(JSGlobalObject*, const String& moduleName, JSValue parameters, JSValue scriptFetcher);
+JS_EXPORT_PRIVATE JSInternalPromise* loadModule(JSGlobalObject*, const Identifier& moduleKey, JSValue parameters, JSValue scriptFetcher);
 JS_EXPORT_PRIVATE JSInternalPromise* loadModule(JSGlobalObject*, const SourceCode&, JSValue scriptFetcher);
 
 // Link and evaluate the already linked module. This function is called in a sync manner.
 JS_EXPORT_PRIVATE JSValue linkAndEvaluateModule(JSGlobalObject*, const Identifier& moduleKey, JSValue scriptFetcher);
 
-JS_EXPORT_PRIVATE JSInternalPromise* importModule(JSGlobalObject*, const Identifier& moduleKey, JSValue parameters, JSValue scriptFetcher);
+JS_EXPORT_PRIVATE JSInternalPromise* importModule(JSGlobalObject*, const Identifier& moduleName, JSValue referrer, JSValue parameters, JSValue scriptFetcher);
 
 JS_EXPORT_PRIVATE HashMap<RefPtr<UniquedStringImpl>, String> retrieveAssertionsFromDynamicImportOptions(JSGlobalObject*, JSValue, const Vector<RefPtr<UniquedStringImpl>>& supportedAssertions);
 

--- a/Source/JavaScriptCore/runtime/ImportMap.cpp
+++ b/Source/JavaScriptCore/runtime/ImportMap.cpp
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ImportMap.h"
+
+#include "SourceCode.h"
+#include <algorithm>
+#include <wtf/JSONValues.h>
+
+namespace JSC {
+namespace ImportMapInternal {
+static constexpr bool verbose = false;
+}
+
+Expected<URL, String> ImportMap::resolveImportMatch(const String& normalizedSpecifier, const URL& asURL, const SpecifierMap& specifierMap)
+{
+    // https://wicg.github.io/import-maps/#resolve-an-imports-match
+
+    auto result = specifierMap.find(normalizedSpecifier);
+
+    // 1.1.1. If resolutionResult is null, then throw a TypeError indicating that resolution of specifierKey was blocked by a null entry.
+    if (result != specifierMap.end()) {
+        if (result->value.isNull())
+            return makeUnexpected("speficier is blocked"_s);
+        return result->value;
+    }
+
+    if (!asURL.isValid() || asURL.hasSpecialScheme()) {
+        int64_t length = -1;
+        std::optional<URL> matched;
+        for (auto& [key, value] : specifierMap) {
+            if (key.endsWith('/')) {
+                auto position = normalizedSpecifier.find(key);
+                if (position == 0) {
+                    if (key.length() > length) {
+                        matched = value;
+                        length = key.length();
+                    }
+                }
+            }
+        }
+
+        if (matched) {
+            if (matched->isNull())
+                return makeUnexpected("speficier is blocked"_s);
+            auto afterPrefix = normalizedSpecifier.substring(length);
+            ASSERT(matched->string().endsWith('/'));
+            URL url { matched.value(), afterPrefix };
+            if (!url.isValid())
+                return makeUnexpected("speficier is blocked"_s);
+            if (!url.string().startsWith(matched->string()))
+                return makeUnexpected("speficier is blocked"_s);
+            return url;
+        }
+    }
+
+    return { };
+}
+
+static URL parseURLLikeModuleSpecifier(const String& specifier, const URL& baseURL)
+{
+    // https://wicg.github.io/import-maps/#parse-a-url-like-import-specifier
+
+    if (specifier.startsWith('/') || specifier.startsWith("./"_s) || specifier.startsWith("../"_s))
+        return URL(baseURL, specifier);
+
+    return URL { specifier };
+}
+
+URL ImportMap::resolve(const String& specifier, const URL& baseURL) const
+{
+    // https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier
+    // https://wicg.github.io/import-maps/#new-resolve-algorithm
+
+    URL asURL = parseURLLikeModuleSpecifier(specifier, baseURL);
+    String normalizedSpecifier = asURL.isValid() ? asURL.string() : specifier;
+
+    dataLogLnIf(ImportMapInternal::verbose, "Resolve ", specifier, " with ", baseURL);
+    for (auto& entry : m_scopes) {
+        dataLogLnIf(ImportMapInternal::verbose, "    Scope ", entry.m_scope);
+        if (entry.m_scope == baseURL || (entry.m_scope.string().endsWith('/') && baseURL.string().startsWith(entry.m_scope.string()))) {
+            dataLogLnIf(ImportMapInternal::verbose, "        Matching");
+            auto result = resolveImportMatch(normalizedSpecifier, asURL, entry.m_map);
+            if (!result)
+                return { };
+            URL scopeImportsMatch = WTFMove(result.value());
+            if (!scopeImportsMatch.isNull())
+                return scopeImportsMatch;
+        }
+    }
+
+    dataLogLnIf(ImportMapInternal::verbose, "    Matching with imports");
+    auto result = resolveImportMatch(normalizedSpecifier, asURL, m_imports);
+    if (!result)
+        return { };
+    URL topLevelImportsMatch = WTFMove(result.value());
+    if (!topLevelImportsMatch.isNull())
+        return topLevelImportsMatch;
+
+    if (asURL.isValid())
+        return asURL;
+
+    return { };
+}
+
+static String normalizeSpecifierKey(const String& specifierKey, const URL& baseURL, ImportMap::Reporter* reporter)
+{
+    // https://wicg.github.io/import-maps/#normalize-a-specifier-key
+
+    if (UNLIKELY(specifierKey.isEmpty())) {
+        if (reporter)
+            reporter->reportWarning("specifier key is empty"_s);
+        return nullString();
+    }
+    URL url = parseURLLikeModuleSpecifier(specifierKey, baseURL);
+    if (url.isValid())
+        return url.string();
+    return specifierKey;
+}
+
+static ImportMap::SpecifierMap sortAndNormalizeSpecifierMap(Ref<JSON::Object> importsMap, const URL& baseURL, ImportMap::Reporter* reporter)
+{
+    // https://wicg.github.io/import-maps/#sort-and-normalize-a-specifier-map
+
+    ImportMap::SpecifierMap normalized;
+    for (auto& [key, value] : importsMap.get()) {
+        String normalizedSpecifierKey = normalizeSpecifierKey(key, baseURL, reporter);
+        if (normalizedSpecifierKey.isNull())
+            continue;
+        if (auto valueAsString = value->asString(); LIKELY(!valueAsString.isNull())) {
+            URL addressURL = parseURLLikeModuleSpecifier(valueAsString, baseURL);
+            if (UNLIKELY(!addressURL.isValid())) {
+                if (reporter)
+                    reporter->reportWarning(makeString("value in specifier map cannot be parsed as URL "_s, valueAsString));
+                normalized.add(normalizedSpecifierKey, URL { });
+                continue;
+            }
+            if (UNLIKELY(key.endsWith('/') && !addressURL.string().endsWith('/'))) {
+                if (reporter)
+                    reporter->reportWarning(makeString("address "_s, addressURL.string(), " does not end with '/' while key "_s, key, " ends with '/'"_s));
+                normalized.add(normalizedSpecifierKey, URL { });
+                continue;
+            }
+            normalized.add(normalizedSpecifierKey, WTFMove(addressURL));
+        } else {
+            if (reporter)
+                reporter->reportWarning("value in specifier map needs to be a string"_s);
+            normalized.add(normalizedSpecifierKey, URL { });
+            continue;
+        }
+    }
+    return normalized;
+}
+
+Expected<void, String> ImportMap::registerImportMap(const SourceCode& sourceCode, const URL& baseURL, ImportMap::Reporter* reporter)
+{
+    // https://wicg.github.io/import-maps/#integration-register-an-import-map
+    // https://wicg.github.io/import-maps/#parsing
+
+    auto result = JSON::Value::parseJSON(sourceCode.view());
+    if (!result)
+        return makeUnexpected("ImportMap has invalid JSON"_s);
+
+    auto rootMap = result->asObject();
+    if (!rootMap)
+        return makeUnexpected("ImportMap is not a map"_s);
+
+    SpecifierMap normalizedImports;
+    if (auto importsMapValue = rootMap->getValue("imports"_s)) {
+        auto importsMap = importsMapValue->asObject();
+        if (!importsMap)
+            return makeUnexpected("imports is not a map"_s);
+
+        normalizedImports = sortAndNormalizeSpecifierMap(importsMap.releaseNonNull(), baseURL, reporter);
+    }
+
+    Scopes scopes;
+    if (auto scopesMapValue = rootMap->getValue("scopes"_s)) {
+        auto scopesMap = scopesMapValue->asObject();
+        if (!scopesMap)
+            return makeUnexpected("scopes is not a map"_s);
+
+        // https://wicg.github.io/import-maps/#sort-and-normalize-scopes
+        for (auto& [key, value] : *scopesMap) {
+            auto potentialSpecifierMap = value->asObject();
+            if (!potentialSpecifierMap)
+                return makeUnexpected("scopes' value is not a map"_s);
+            URL scopePrefixURL { baseURL, key }; // Do not use parseURLLikeModuleSpecifier since we should accept non relative path.
+            dataLogLnIf(ImportMapInternal::verbose, "scope key ", key, " and URL ", scopePrefixURL);
+            if (UNLIKELY(!scopePrefixURL.isValid())) {
+                if (reporter)
+                    reporter->reportWarning(makeString("scope key"_s, key, " was not parsable"_s));
+                continue;
+            }
+
+            scopes.append({ scopePrefixURL, sortAndNormalizeSpecifierMap(potentialSpecifierMap.releaseNonNull(), baseURL, reporter) });
+        }
+    }
+
+    // Sort to accending order. So, more specific scope will come first.
+    std::sort(scopes.begin(), scopes.end(), [&](const auto& lhs, const auto& rhs) -> bool {
+        return codePointCompareLessThan(rhs.m_scope.string(), lhs.m_scope.string());
+    });
+
+    m_imports = WTFMove(normalizedImports);
+    m_scopes = WTFMove(scopes);
+    return { };
+}
+
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/ImportMap.h
+++ b/Source/JavaScriptCore/runtime/ImportMap.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Expected.h>
+#include <wtf/HashMap.h>
+#include <wtf/URL.h>
+#include <wtf/URLHash.h>
+#include <wtf/Vector.h>
+
+namespace JSC {
+
+class ImportMap final : public RefCounted<ImportMap> {
+public:
+    using SpecifierMap = HashMap<String, URL>;
+    struct ScopeEntry {
+        URL m_scope;
+        SpecifierMap m_map;
+    };
+    using Scopes = Vector<ScopeEntry>;
+
+    class Reporter {
+    public:
+        virtual ~Reporter() = default;
+        virtual void reportWarning(const String&) { };
+    };
+
+    static Ref<ImportMap> create() { return adoptRef(*new ImportMap()); }
+
+    JS_EXPORT_PRIVATE URL resolve(const String& specifier, const URL& baseURL) const;
+    JS_EXPORT_PRIVATE Expected<void, String> registerImportMap(const SourceCode&, const URL& baseURL, ImportMap::Reporter*);
+
+    bool isAcquiringImportMaps() const { return m_isAcquiringImportMaps; }
+    void setAcquiringImportMaps() { m_isAcquiringImportMaps = false; }
+
+private:
+    ImportMap() = default;
+
+    static Expected<URL, String> resolveImportMatch(const String&, const URL&, const SpecifierMap&);
+
+    SpecifierMap m_imports;
+    Scopes m_scopes;
+    bool m_isAcquiringImportMaps : 1 { true };
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -83,6 +83,7 @@ class GeneratorPrototype;
 class GeneratorFunctionPrototype;
 class GetterSetter;
 class GlobalCodeBlock;
+class ImportMap;
 class IndirectEvalExecutable;
 class InputCursor;
 class IntlObject;
@@ -491,6 +492,8 @@ public:
     FOR_EACH_TYPED_ARRAY_TYPE(DECLARE_TYPED_ARRAY_TYPE_STRUCTURE)
 #undef DECLARE_TYPED_ARRAY_TYPE_STRUCTURE
 
+    LazyProperty<JSGlobalObject, JSInternalPromise> m_importMapStatusPromise;
+
     FixedVector<LazyProperty<JSGlobalObject, JSCell>> m_linkTimeConstants;
 
     StructureCache m_structureCache;
@@ -713,6 +716,8 @@ public:
 
     WeakGCSet<JSCustomGetterFunction, WeakCustomGetterOrSetterHash<JSCustomGetterFunction>>& customGetterFunctionSet() { return m_customGetterFunctionSet; }
     WeakGCSet<JSCustomSetterFunction, WeakCustomGetterOrSetterHash<JSCustomSetterFunction>>& customSetterFunctionSet() { return m_customSetterFunctionSet; }
+
+    Ref<ImportMap> m_importMap;
 
 #if ASSERT_ENABLED
     const JSGlobalObject* m_globalObjectAtDebuggerEntry { nullptr };
@@ -1307,6 +1312,20 @@ public:
     void installTypedArrayIteratorProtocolWatchpoint(JSObject* prototype, TypedArrayType);
     void installTypedArrayConstructorSpeciesWatchpoint(JSTypedArrayViewConstructor*);
     void installTypedArrayPrototypeIteratorProtocolWatchpoint(JSTypedArrayViewPrototype*);
+
+    const ImportMap& importMap() const { return m_importMap.get(); }
+    ImportMap& importMap() { return m_importMap.get(); }
+    JSInternalPromise* importMapStatusPromise() const
+    {
+        if (m_importMapStatusPromise.isInitialized())
+            return m_importMapStatusPromise.get(this);
+        return nullptr;
+    }
+    JS_EXPORT_PRIVATE void registerImportMap() const;
+    JS_EXPORT_PRIVATE bool isAcquiringImportMaps() const;
+    JS_EXPORT_PRIVATE void setAcquiringImportMaps();
+    JS_EXPORT_PRIVATE void setPendingImportMaps();
+    JS_EXPORT_PRIVATE void clearPendingImportMaps();
 
 protected:
     enum class HasSpeciesProperty : bool { Yes, No };

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -26,6 +26,7 @@
 #include "JSGlobalObjectFunctions.h"
 
 #include "CallFrame.h"
+#include "ImportMap.h"
 #include "IndirectEvalExecutable.h"
 #include "InlineCallFrame.h"
 #include "Interpreter.h"
@@ -811,6 +812,15 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncBuiltinLog, (JSGlobalObject* globalObject, Ca
 JSC_DEFINE_HOST_FUNCTION(globalFuncBuiltinDescribe, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     return JSValue::encode(jsString(globalObject->vm(), toString(callFrame->argument(0))));
+}
+
+JSC_DEFINE_HOST_FUNCTION(globalFuncImportMapStatus, (JSGlobalObject* globalObject, CallFrame*))
+{
+    // https://wicg.github.io/import-maps/#integration-wait-for-import-maps
+    globalObject->importMap().setAcquiringImportMaps();
+    if (auto* promise = globalObject->importMapStatusPromise())
+        return JSValue::encode(promise);
+    return JSValue::encode(jsUndefined());
 }
 
 JSC_DEFINE_HOST_FUNCTION(globalFuncImportModule, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.h
@@ -57,6 +57,7 @@ JSC_DECLARE_HOST_FUNCTION(globalFuncSetPrototypeDirectOrThrow);
 JSC_DECLARE_HOST_FUNCTION(globalFuncHostPromiseRejectionTracker);
 JSC_DECLARE_HOST_FUNCTION(globalFuncBuiltinLog);
 JSC_DECLARE_HOST_FUNCTION(globalFuncBuiltinDescribe);
+JSC_DECLARE_HOST_FUNCTION(globalFuncImportMapStatus);
 JSC_DECLARE_HOST_FUNCTION(globalFuncImportModule);
 JSC_DECLARE_HOST_FUNCTION(globalFuncCopyDataProperties);
 JSC_DECLARE_HOST_FUNCTION(globalFuncDateTimeFormat);

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -174,7 +174,7 @@ JSInternalPromise* JSModuleLoader::loadAndEvaluateModule(JSGlobalObject* globalO
     return jsCast<JSInternalPromise*>(promise);
 }
 
-JSInternalPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, JSValue moduleName, JSValue parameters, JSValue scriptFetcher)
+JSInternalPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, JSValue moduleKey, JSValue parameters, JSValue scriptFetcher)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -185,7 +185,7 @@ JSInternalPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, JSVa
     ASSERT(callData.type != CallData::Type::None);
 
     MarkedArgumentBuffer arguments;
-    arguments.append(moduleName);
+    arguments.append(moduleKey);
     arguments.append(parameters);
     arguments.append(scriptFetcher);
     ASSERT(!arguments.hasOverflowed());
@@ -213,7 +213,7 @@ JSValue JSModuleLoader::linkAndEvaluateModule(JSGlobalObject* globalObject, JSVa
     RELEASE_AND_RETURN(scope, call(globalObject, function, callData, this, arguments));
 }
 
-JSInternalPromise* JSModuleLoader::requestImportModule(JSGlobalObject* globalObject, const Identifier& moduleKey, JSValue parameters, JSValue scriptFetcher)
+JSInternalPromise* JSModuleLoader::requestImportModule(JSGlobalObject* globalObject, const Identifier& moduleName, JSValue referrer, JSValue parameters, JSValue scriptFetcher)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -224,7 +224,8 @@ JSInternalPromise* JSModuleLoader::requestImportModule(JSGlobalObject* globalObj
     ASSERT(callData.type != CallData::Type::None);
 
     MarkedArgumentBuffer arguments;
-    arguments.append(jsString(vm, moduleKey.string()));
+    arguments.append(jsString(vm, moduleName.string()));
+    arguments.append(referrer);
     arguments.append(parameters);
     arguments.append(scriptFetcher);
     ASSERT(!arguments.hasOverflowed());

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.h
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.h
@@ -74,7 +74,7 @@ public:
     JSInternalPromise* loadAndEvaluateModule(JSGlobalObject*, JSValue moduleName, JSValue parameters, JSValue scriptFetcher);
     JSInternalPromise* loadModule(JSGlobalObject*, JSValue moduleName, JSValue parameters, JSValue scriptFetcher);
     JSValue linkAndEvaluateModule(JSGlobalObject*, JSValue moduleKey, JSValue scriptFetcher);
-    JSInternalPromise* requestImportModule(JSGlobalObject*, const Identifier&, JSValue parameters, JSValue scriptFetcher);
+    JSInternalPromise* requestImportModule(JSGlobalObject*, const Identifier&, JSValue referrer, JSValue parameters, JSValue scriptFetcher);
 
     // Platform dependent hooked APIs.
     JSInternalPromise* importModule(JSGlobalObject*, JSString* moduleName, JSValue parameters, const SourceOrigin& referrer);

--- a/Source/JavaScriptCore/runtime/LazyProperty.h
+++ b/Source/JavaScriptCore/runtime/LazyProperty.h
@@ -88,6 +88,8 @@ public:
         return bitwise_cast<ElementType*>(pointer);
     }
 
+    bool isInitialized() const { return !(m_pointer & lazyTag); }
+
     ElementType* getInitializedOnMainThread(const OwnerType* owner) const
     {
         if (UNLIKELY(m_pointer & lazyTag)) {

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -513,7 +513,7 @@ RefPtr<Array> Value::asArray()
     return nullptr;
 }
 
-RefPtr<Value> Value::parseJSON(const String& json)
+RefPtr<Value> Value::parseJSON(StringView json)
 {
     auto containsNonSpace = [] (const auto* begin, const auto* end) {
         if (!begin)

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -102,7 +102,7 @@ public:
     virtual RefPtr<const Object> asObject() const;
     virtual RefPtr<Array> asArray();
 
-    static RefPtr<Value> parseJSON(const String&);
+    static RefPtr<Value> parseJSON(StringView);
     static void escapeString(StringBuilder&, StringView);
 
     String toJSONString() const;

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -752,6 +752,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/ScriptElement.h
     dom/ScriptElementCachedScriptFetcher.h
     dom/ScriptExecutionContext.h
+    dom/ScriptType.h
     dom/SecurityContext.h
     dom/SecurityPolicyViolationEvent.h
     dom/SecurityPolicyViolationEventDisposition.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1025,6 +1025,7 @@ dom/InputEvent.cpp
 dom/KeyboardEvent.cpp
 dom/LiveNodeList.cpp
 dom/LoadableClassicScript.cpp
+dom/LoadableImportMap.cpp
 dom/LoadableModuleScript.cpp
 dom/LoadableScript.cpp
 dom/MessageChannel.cpp

--- a/Source/WebCore/bindings/js/JSExecState.h
+++ b/Source/WebCore/bindings/js/JSExecState.h
@@ -119,10 +119,10 @@ public:
         task.run(lexicalGlobalObject);
     }
 
-    static JSC::JSInternalPromise& loadModule(JSC::JSGlobalObject& lexicalGlobalObject, const String& moduleName, JSC::JSValue parameters, JSC::JSValue scriptFetcher)
+    static JSC::JSInternalPromise& loadModule(JSC::JSGlobalObject& lexicalGlobalObject, const URL& topLevelModuleURL, JSC::JSValue parameters, JSC::JSValue scriptFetcher)
     {
         JSExecState currentState(&lexicalGlobalObject);
-        return *JSC::loadModule(&lexicalGlobalObject, moduleName, parameters, scriptFetcher);
+        return *JSC::loadModule(&lexicalGlobalObject, JSC::Identifier::fromString(lexicalGlobalObject.vm(), topLevelModuleURL.string()), parameters, scriptFetcher);
     }
 
     static JSC::JSInternalPromise& loadModule(JSC::JSGlobalObject& lexicalGlobalObject, const JSC::SourceCode& sourceCode, JSC::JSValue scriptFetcher)

--- a/Source/WebCore/bindings/js/ModuleFetchFailureKind.h
+++ b/Source/WebCore/bindings/js/ModuleFetchFailureKind.h
@@ -31,6 +31,7 @@ enum class ModuleFetchFailureKind {
     WasPropagatedError,
     WasCanceled,
     WasFetchError,
+    WasResolveError,
 };
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -117,8 +117,8 @@ public:
 
     static void initializeMainThread();
 
-    void loadModuleScriptInWorld(LoadableModuleScript&, const String& moduleName, Ref<JSC::ScriptFetchParameters>&&, DOMWrapperWorld&);
-    void loadModuleScript(LoadableModuleScript&, const String& moduleName, Ref<JSC::ScriptFetchParameters>&&);
+    void loadModuleScriptInWorld(LoadableModuleScript&, const URL& topLevelModuleURL, Ref<JSC::ScriptFetchParameters>&&, DOMWrapperWorld&);
+    void loadModuleScript(LoadableModuleScript&, const URL&, Ref<JSC::ScriptFetchParameters>&&);
     void loadModuleScriptInWorld(LoadableModuleScript&, const ScriptSourceCode&, DOMWrapperWorld&);
     void loadModuleScript(LoadableModuleScript&, const ScriptSourceCode&);
 
@@ -172,6 +172,12 @@ public:
     bool willReplaceWithResultOfExecutingJavascriptURL() const { return m_willReplaceWithResultOfExecutingJavascriptURL; }
 
     void reportExceptionFromScriptError(LoadableScript::Error, bool);
+
+    void registerImportMap(const ScriptSourceCode&, const URL& baseURL);
+    bool isAcquiringImportMaps();
+    void setAcquiringImportMaps();
+    void setPendingImportMaps();
+    void clearPendingImportMaps();
 
 private:
     ValueOrException executeScriptInWorld(DOMWrapperWorld&, RunJavaScriptParameters&&);

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -51,6 +51,7 @@
 #include "WorkletGlobalScope.h"
 #include <JavaScriptCore/AbstractModuleRecord.h>
 #include <JavaScriptCore/Completion.h>
+#include <JavaScriptCore/ImportMap.h>
 #include <JavaScriptCore/JSInternalPromise.h>
 #include <JavaScriptCore/JSNativeStdFunction.h>
 #include <JavaScriptCore/JSScriptFetchParameters.h>
@@ -90,25 +91,13 @@ static bool isRootModule(JSC::JSValue importerModuleKey)
     return importerModuleKey.isSymbol() || importerModuleKey.isUndefined();
 }
 
-static Expected<URL, String> resolveModuleSpecifier(ScriptExecutionContext& context, ScriptModuleLoader::OwnerType ownerType, const String& specifier, const URL& baseURL)
+static Expected<URL, String> resolveModuleSpecifier(ScriptExecutionContext& context, ScriptModuleLoader::OwnerType ownerType, JSC::ImportMap& importMap, const String& specifier, const URL& originalBaseURL)
 {
     // https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier
 
-    URL absoluteURL { specifier };
-    if (absoluteURL.isValid())
-        return absoluteURL;
-
-    if (!specifier.startsWith('/') && !specifier.startsWith("./"_s) && !specifier.startsWith("../"_s))
-        return makeUnexpected(makeString("Module specifier, '"_s, specifier, "' does not start with \"/\", \"./\", or \"../\". Referenced from "_s, baseURL.string()));
-
-    URL result;
-    if (ownerType == ScriptModuleLoader::OwnerType::Document)
-        result = downcast<Document>(context).completeURL(specifier, baseURL);
-    else
-        result = URL(baseURL, specifier);
-
-    if (!result.isValid())
-        return makeUnexpected(makeString("Module name, '"_s, result.string(), "' does not resolve to a valid URL."_s));
+    URL result = importMap.resolve(specifier, ownerType == ScriptModuleLoader::OwnerType::Document ? downcast<Document>(context).baseURLForComplete(originalBaseURL) : originalBaseURL);
+    if (result.isNull())
+        return makeUnexpected(makeString("Module name, '"_s, specifier, "' does not resolve to a valid URL."_s));
     return result;
 }
 
@@ -134,9 +123,12 @@ JSC::Identifier ScriptModuleLoader::resolve(JSC::JSGlobalObject* jsGlobalObject,
     URL baseURL = responseURLFromRequestURL(*jsGlobalObject, importerModuleKey);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto result = resolveModuleSpecifier(m_context, m_ownerType, specifier, baseURL);
+    auto result = resolveModuleSpecifier(m_context, m_ownerType, jsGlobalObject->importMap(), specifier, baseURL);
     if (!result) {
-        JSC::throwTypeError(jsGlobalObject, scope, result.error());
+        auto* error = JSC::createTypeError(jsGlobalObject, result.error());
+        ASSERT(error);
+        error->putDirect(vm, builtinNames(vm).failureKindPrivateName(), JSC::jsNumber(static_cast<int32_t>(ModuleFetchFailureKind::WasResolveError)));
+        JSC::throwException(jsGlobalObject, scope, error);
         return { };
     }
 
@@ -245,7 +237,8 @@ URL ScriptModuleLoader::responseURLFromRequestURL(JSC::JSGlobalObject& jsGlobalO
     ASSERT_WITH_MESSAGE(URL(requestURL).isValid(), "Invalid module referrer never starts importing dependent modules.");
 
     auto iterator = m_requestURLToResponseURLMap.find(requestURL);
-    ASSERT_WITH_MESSAGE(iterator != m_requestURLToResponseURLMap.end(), "Module referrer must register itself to the map before starting importing dependent modules.");
+    if (iterator == m_requestURLToResponseURLMap.end())
+        return URL { requestURL }; // dynamic-import().
     URL result = iterator->value;
     ASSERT(result.isValid());
     return result;
@@ -385,13 +378,7 @@ JSC::JSInternalPromise* ScriptModuleLoader::importModule(JSC::JSGlobalObject* js
 
     auto specifier = moduleName->value(jsGlobalObject);
     RETURN_IF_EXCEPTION(scope, reject(scope));
-    auto result = resolveModuleSpecifier(m_context, m_ownerType, specifier, baseURL);
-    if (!result) {
-        scope.release();
-        return rejectPromise(globalObject, TypeError, result.error());
-    }
-
-    RELEASE_AND_RETURN(scope, JSC::importModule(jsGlobalObject, JSC::Identifier::fromString(vm, result->string()), JSC::JSScriptFetchParameters::create(vm, parameters.releaseNonNull()), JSC::JSScriptFetcher::create(vm, WTFMove(scriptFetcher))));
+    RELEASE_AND_RETURN(scope, JSC::importModule(jsGlobalObject, JSC::Identifier::fromString(vm, specifier), JSC::jsString(vm, baseURL.string()), JSC::JSScriptFetchParameters::create(vm, parameters.releaseNonNull()), JSC::JSScriptFetcher::create(vm, WTFMove(scriptFetcher))));
 }
 
 JSC::JSObject* ScriptModuleLoader::createImportMetaProperties(JSC::JSGlobalObject* jsGlobalObject, JSC::JSModuleLoader*, JSC::JSValue moduleKeyValue, JSC::JSModuleRecord*, JSC::JSValue)
@@ -419,11 +406,15 @@ JSC::JSObject* ScriptModuleLoader::createImportMetaProperties(JSC::JSGlobalObjec
         auto specifier = callFrame->argument(0).toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
 
-        auto* context = jsCast<JSDOMGlobalObject*>(globalObject)->scriptExecutionContext();
+        auto* domGlobalObject = jsDynamicCast<JSDOMGlobalObject*>(globalObject);
+        if (UNLIKELY(!domGlobalObject))
+            return JSC::throwVMTypeError(globalObject, scope);
+
+        auto* context = domGlobalObject->scriptExecutionContext();
         if (UNLIKELY(!context))
             return JSC::throwVMTypeError(globalObject, scope);
 
-        auto result = resolveModuleSpecifier(*context, ownerType, specifier, responseURL);
+        auto result = resolveModuleSpecifier(*context, ownerType, domGlobalObject->importMap(), specifier, responseURL);
         if (UNLIKELY(!result))
             return JSC::throwVMTypeError(globalObject, scope, result.error());
 

--- a/Source/WebCore/dom/CurrentScriptIncrementer.h
+++ b/Source/WebCore/dom/CurrentScriptIncrementer.h
@@ -39,7 +39,7 @@ public:
     CurrentScriptIncrementer(Document& document, ScriptElement& scriptElement)
         : m_document(document)
     {
-        bool shouldPushNullForCurrentScript = scriptElement.element().isInShadowTree() || scriptElement.scriptType() != ScriptElement::ScriptType::Classic;
+        bool shouldPushNullForCurrentScript = scriptElement.element().isInShadowTree() || scriptElement.scriptType() != ScriptType::Classic;
         m_document.pushCurrentScript(shouldPushNullForCurrentScript ? nullptr : &scriptElement.element());
     }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5616,6 +5616,11 @@ void Document::setDecoder(RefPtr<TextResourceDecoder>&& decoder)
     m_decoder = WTFMove(decoder);
 }
 
+URL Document::baseURLForComplete(const URL& baseURLOverride) const
+{
+    return ((baseURLOverride.isEmpty() || baseURLOverride == aboutBlankURL()) && parentDocument()) ? parentDocument()->baseURL() : baseURLOverride;
+}
+
 URL Document::completeURL(const String& url, const URL& baseURLOverride, ForceUTF8 forceUTF8) const
 {
     // See also CSSParserContext::completeURL(const String&)
@@ -5625,7 +5630,7 @@ URL Document::completeURL(const String& url, const URL& baseURLOverride, ForceUT
     if (url.isNull())
         return URL();
 
-    const URL& baseURL = ((baseURLOverride.isEmpty() || baseURLOverride == aboutBlankURL()) && parentDocument()) ? parentDocument()->baseURL() : baseURLOverride;
+    URL baseURL = baseURLForComplete(baseURLOverride);
     if (!m_decoder || forceUTF8 == ForceUTF8::Yes)
         return URL(baseURL, url);
     return URL(baseURL, url, m_decoder->encodingForURLParsing());

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -724,6 +724,7 @@ public:
     const AtomString& baseTarget() const { return m_baseTarget; }
     void processBaseElement();
 
+    URL baseURLForComplete(const URL& baseURLOverride) const;
     WEBCORE_EXPORT URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final;
     URL completeURL(const String&, const URL& baseURLOverride, ForceUTF8 = ForceUTF8::No) const;
 

--- a/Source/WebCore/dom/InlineClassicScript.h
+++ b/Source/WebCore/dom/InlineClassicScript.h
@@ -35,8 +35,7 @@ class InlineClassicScript final : public ScriptElementCachedScriptFetcher {
 public:
     static Ref<InlineClassicScript> create(ScriptElement&);
 
-    bool isClassicScript() const final { return true; }
-    bool isModuleScript() const final { return false; }
+    ScriptType scriptType() const final { return ScriptType::Classic; }
 
 private:
     InlineClassicScript(const AtomString& nonce, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree);

--- a/Source/WebCore/dom/LoadableImportMap.cpp
+++ b/Source/WebCore/dom/LoadableImportMap.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Apple, Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LoadableImportMap.h"
+
+#include "DefaultResourceLoadPriority.h"
+#include "FetchIdioms.h"
+#include "ScriptElement.h"
+#include "ScriptSourceCode.h"
+#include "SubresourceIntegrity.h"
+#include <wtf/NeverDestroyed.h>
+#include <wtf/text/StringImpl.h>
+
+namespace WebCore {
+
+Ref<LoadableImportMap> LoadableImportMap::create(const AtomString& nonce, const AtomString& integrityMetadata, ReferrerPolicy policy, const AtomString& crossOriginMode, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync)
+{
+    return adoptRef(*new LoadableImportMap(nonce, integrityMetadata, policy, crossOriginMode, initiatorName, isInUserAgentShadowTree, isAsync));
+}
+
+LoadableImportMap::LoadableImportMap(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync)
+    : LoadableNonModuleScriptBase(nonce, integrity, policy, crossOriginMode, "utf-8"_s, initiatorName, isInUserAgentShadowTree, isAsync)
+{
+}
+
+void LoadableImportMap::execute(ScriptElement& scriptElement)
+{
+    ASSERT(!m_error);
+    scriptElement.registerImportMap(ScriptSourceCode(m_cachedScript.get(), JSC::SourceProviderSourceType::ImportMap, *this));
+}
+
+}

--- a/Source/WebCore/dom/LoadableImportMap.h
+++ b/Source/WebCore/dom/LoadableImportMap.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Apple, Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CachedResourceClient.h"
+#include "CachedResourceHandle.h"
+#include "CachedScript.h"
+#include "Document.h"
+#include "LoadableClassicScript.h"
+#include "ReferrerPolicy.h"
+#include <wtf/TypeCasts.h>
+
+namespace WebCore {
+
+// A CachedResourceHandle alone does not prevent the underlying CachedResource
+// from purging its data buffer. This class holds a client until this class is
+// destroyed in order to guarantee that the data buffer will not be purged.
+class LoadableImportMap final : public LoadableNonModuleScriptBase {
+public:
+    static Ref<LoadableImportMap> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync);
+
+    ScriptType scriptType() const final { return ScriptType::ImportMap; }
+
+    void execute(ScriptElement&) final;
+
+private:
+    LoadableImportMap(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync);
+};
+
+}
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LoadableImportMap)
+    static bool isType(const WebCore::LoadableScript& script) { return script.isImportMap(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/dom/LoadableModuleScript.cpp
+++ b/Source/WebCore/dom/LoadableModuleScript.cpp
@@ -52,9 +52,14 @@ bool LoadableModuleScript::isLoaded() const
     return m_isLoaded;
 }
 
-std::optional<LoadableScript::Error> LoadableModuleScript::error() const
+bool LoadableModuleScript::hasError() const
 {
-    return m_error;
+    return !!m_error;
+}
+
+std::optional<LoadableScript::Error> LoadableModuleScript::takeError()
+{
+    return std::exchange(m_error, std::nullopt);
 }
 
 bool LoadableModuleScript::wasCanceled() const

--- a/Source/WebCore/dom/LoadableModuleScript.h
+++ b/Source/WebCore/dom/LoadableModuleScript.h
@@ -40,15 +40,13 @@ public:
     static Ref<LoadableModuleScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree);
 
     bool isLoaded() const final;
-    std::optional<Error> error() const final;
+    bool hasError() const final;
+    std::optional<Error> takeError() final;
     bool wasCanceled() const final;
 
-    bool isClassicScript() const final { return false; }
-    bool isModuleScript() const final { return true; }
+    ScriptType scriptType() const final { return ScriptType::Module; }
 
     void execute(ScriptElement&) final;
-
-    void setError(Error&&);
 
     void notifyLoadCompleted(UniquedStringImpl&);
     void notifyLoadFailed(LoadableScript::Error&&);

--- a/Source/WebCore/dom/LoadableScript.h
+++ b/Source/WebCore/dom/LoadableScript.h
@@ -28,6 +28,7 @@
 #include "ScriptElementCachedScriptFetcher.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/Strong.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/text/WTFString.h>
 
@@ -38,12 +39,14 @@ class ScriptElement;
 
 class LoadableScript : public ScriptElementCachedScriptFetcher {
 public:
-    enum class ErrorType {
-        CachedScript,
+    enum class ErrorType : uint8_t {
+        Fetch,
         CrossOriginLoad,
         MIMEType,
         Nosniff,
         FailedIntegrityCheck,
+        Resolve,
+        Script,
     };
 
     struct ConsoleMessage {
@@ -55,13 +58,14 @@ public:
     struct Error {
         ErrorType type;
         std::optional<ConsoleMessage> consoleMessage;
-        std::optional<JSC::JSValue> errorValue;
+        JSC::Strong<JSC::Unknown> errorValue;
     };
 
     virtual ~LoadableScript() = default;
 
     virtual bool isLoaded() const = 0;
-    virtual std::optional<Error> error() const = 0;
+    virtual bool hasError() const = 0;
+    virtual std::optional<Error> takeError() = 0;
     virtual bool wasCanceled() const = 0;
 
     virtual void execute(ScriptElement&) = 0;

--- a/Source/WebCore/dom/PendingScript.cpp
+++ b/Source/WebCore/dom/PendingScript.cpp
@@ -79,9 +79,9 @@ bool PendingScript::isLoaded() const
     return m_loadableScript && m_loadableScript->isLoaded();
 }
 
-bool PendingScript::error() const
+bool PendingScript::hasError() const
 {
-    return m_loadableScript && m_loadableScript->error();
+    return m_loadableScript && m_loadableScript->hasError();
 }
 
 void PendingScript::setClient(PendingScriptClient& client)

--- a/Source/WebCore/dom/PendingScript.h
+++ b/Source/WebCore/dom/PendingScript.h
@@ -58,7 +58,7 @@ public:
     bool needsLoading() const { return loadableScript(); }
 
     bool isLoaded() const;
-    bool error() const;
+    bool hasError() const;
 
     void notifyFinished(LoadableScript&) override;
 

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CachedScriptFetcher.h"
+#include "ScriptType.h"
 
 namespace WebCore {
 
@@ -35,8 +36,10 @@ public:
 
     virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, String&& integrity) const;
 
-    virtual bool isClassicScript() const = 0;
-    virtual bool isModuleScript() const = 0;
+    virtual ScriptType scriptType() const = 0;
+    bool isClassicScript() const { return scriptType() == ScriptType::Classic; }
+    bool isModuleScript() const { return scriptType() == ScriptType::Module; }
+    bool isImportMap() const { return scriptType() == ScriptType::ImportMap; }
 
     const String& crossOriginMode() const { return m_crossOriginMode; }
 

--- a/Source/WebCore/dom/ScriptType.h
+++ b/Source/WebCore/dom/ScriptType.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+// https://html.spec.whatwg.org/multipage/scripting.html#concept-script-type
+// https://wicg.github.io/import-maps/#integration-prepare-a-script
+enum class ScriptType : uint8_t { Classic, Module, ImportMap };
+static constexpr unsigned bitWidthOfScriptType = 2;
+static_assert(static_cast<unsigned>(ScriptType::ImportMap) <= ((1U << bitWidthOfScriptType) - 1));
+
+}

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -51,7 +51,7 @@ public:
     using HTMLElement::ref;
     using HTMLElement::deref;
 
-    static bool supports(StringView type) { return type == "classic"_s || type == "module"_s; }
+    static bool supports(StringView type) { return type == "classic"_s || type == "module"_s || type == "importmap"_s; }
 
 private:
     HTMLScriptElement(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted);

--- a/Source/WebCore/html/parser/CSSPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.cpp
@@ -229,7 +229,7 @@ void CSSPreloadScanner::emitRule()
         if (!url.isEmpty() && hasValidImportConditions(conditions)) {
             URL baseElementURL; // FIXME: This should be passed in from the HTMLPreloadScanner via scan(): without it we will get relative URLs wrong.
             // FIXME: Should this be including the charset in the preload request?
-            m_requests->append(makeUnique<PreloadRequest>("css"_s, url, baseElementURL, CachedResource::Type::CSSStyleSheet, String(), PreloadRequest::ModuleScript::No, ReferrerPolicy::EmptyString));
+            m_requests->append(makeUnique<PreloadRequest>("css"_s, url, baseElementURL, CachedResource::Type::CSSStyleSheet, String(), ScriptType::Classic, ReferrerPolicy::EmptyString));
         }
         m_state = Initial;
     } else if (equalLettersIgnoringASCIICase(rule, "charset"_s))

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -57,7 +57,7 @@ CachedResourceRequest PreloadRequest::resourceRequest(Document& document)
         options.contentSecurityPolicyImposition = ContentSecurityPolicyImposition::SkipPolicyCheck;
 
     String crossOriginMode = m_crossOriginMode;
-    if (m_moduleScript == ModuleScript::Yes) {
+    if (m_scriptType == ScriptType::Module) {
         if (crossOriginMode.isNull())
             crossOriginMode = ScriptElementCachedScriptFetcher::defaultCrossOriginModeForModule;
     }
@@ -66,7 +66,7 @@ CachedResourceRequest PreloadRequest::resourceRequest(Document& document)
     auto request = createPotentialAccessControlRequest(completeURL(document), WTFMove(options), document, crossOriginMode);
     request.setInitiator(m_initiator);
 
-    if (m_scriptIsAsync && m_resourceType == CachedResource::Type::Script && m_moduleScript == ModuleScript::No)
+    if (m_scriptIsAsync && m_resourceType == CachedResource::Type::Script && m_scriptType == ScriptType::Classic)
         request.setPriority(DefaultResourceLoadPriority::asyncScript);
 
     return request;

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.h
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.h
@@ -27,23 +27,20 @@
 
 #include "CachedResource.h"
 #include "CachedResourceRequest.h"
+#include "ScriptType.h"
 
 namespace WebCore {
 
 class PreloadRequest {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    enum class ModuleScript {
-        Yes,
-        No,
-    };
-    PreloadRequest(ASCIILiteral initiator, const String& resourceURL, const URL& baseURL, CachedResource::Type resourceType, const String& mediaAttribute, ModuleScript moduleScript, const ReferrerPolicy& referrerPolicy)
+    PreloadRequest(ASCIILiteral initiator, const String& resourceURL, const URL& baseURL, CachedResource::Type resourceType, const String& mediaAttribute, ScriptType scriptType, const ReferrerPolicy& referrerPolicy)
         : m_initiator(initiator)
         , m_resourceURL(resourceURL)
         , m_baseURL(baseURL.isolatedCopy())
         , m_resourceType(resourceType)
         , m_mediaAttribute(mediaAttribute)
-        , m_moduleScript(moduleScript)
+        , m_scriptType(scriptType)
         , m_referrerPolicy(referrerPolicy)
     {
     }
@@ -70,7 +67,7 @@ private:
     String m_crossOriginMode;
     String m_nonceAttribute;
     bool m_scriptIsAsync { false };
-    ModuleScript m_moduleScript;
+    ScriptType m_scriptType;
     ReferrerPolicy m_referrerPolicy;
 };
 

--- a/Source/WebCore/html/parser/HTMLScriptRunner.cpp
+++ b/Source/WebCore/html/parser/HTMLScriptRunner.cpp
@@ -258,8 +258,12 @@ void HTMLScriptRunner::runScript(ScriptElement& scriptElement, const TextPositio
     else if (scriptElement.readyToBeParserExecuted()) {
         if (m_scriptNestingLevel == 1)
             m_parserBlockingScript = PendingScript::create(scriptElement, scriptStartPosition);
-        else
-            scriptElement.executeClassicScript(ScriptSourceCode(scriptElement.element().textContent(), documentURLForScriptExecution(m_document.get()), scriptStartPosition, JSC::SourceProviderSourceType::Program, InlineClassicScript::create(scriptElement)));
+        else {
+            if (scriptElement.scriptType() == ScriptType::Classic)
+                scriptElement.executeClassicScript(ScriptSourceCode(scriptElement.element().textContent(), documentURLForScriptExecution(m_document.get()), scriptStartPosition, JSC::SourceProviderSourceType::Program, InlineClassicScript::create(scriptElement)));
+            else
+                scriptElement.registerImportMap(ScriptSourceCode(scriptElement.element().textContent(), documentURLForScriptExecution(m_document.get()), scriptStartPosition, JSC::SourceProviderSourceType::ImportMap));
+        }
     } else
         requestParsingBlockingScript(scriptElement);
 }

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -66,6 +66,9 @@ struct ContentSecurityPolicyClient;
 struct ReportingClient;
 
 enum class ParserInserted : bool { No, Yes };
+static constexpr unsigned bitWidthOfParserInserted = 1;
+static_assert(static_cast<unsigned>(ParserInserted::Yes) <= ((1U << bitWidthOfParserInserted) - 1));
+
 enum class LogToConsole : bool { No, Yes };
 enum class CheckUnsafeHashes : bool { No, Yes };
 

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -310,9 +310,9 @@ bool WorkerOrWorkletScriptController::loadModuleSynchronously(WorkerScriptFetche
                     switch (static_cast<ModuleFetchFailureKind>(failureKindValue.asInt32())) {
                     case ModuleFetchFailureKind::WasPropagatedError:
                         protector->notifyLoadFailed(LoadableScript::Error {
-                            LoadableScript::ErrorType::CachedScript,
-                            std::nullopt,
-                            std::nullopt
+                            LoadableScript::ErrorType::Fetch,
+                            { },
+                            { }
                         });
                         break;
                     // For a fetch error that was not propagated from further in the
@@ -320,13 +320,26 @@ bool WorkerOrWorkletScriptController::loadModuleSynchronously(WorkerScriptFetche
                     // include an error value as it should not be reported.
                     case ModuleFetchFailureKind::WasFetchError:
                         protector->notifyLoadFailed(LoadableScript::Error {
-                            LoadableScript::ErrorType::CachedScript,
+                            LoadableScript::ErrorType::Fetch,
                             LoadableScript::ConsoleMessage {
                                 MessageSource::JS,
                                 MessageLevel::Error,
                                 retrieveErrorMessage(*globalObject, vm, errorValue, scope),
                             },
-                            std::nullopt
+                            { }
+                        });
+                        break;
+                    case ModuleFetchFailureKind::WasResolveError:
+                        protector->notifyLoadFailed(LoadableScript::Error {
+                            LoadableScript::ErrorType::Resolve,
+                            LoadableScript::ConsoleMessage {
+                                MessageSource::JS,
+                                MessageLevel::Error,
+                                retrieveErrorMessage(*globalObject, vm, errorValue, scope),
+                            },
+                            // The error value may need to be propagated here as it is in
+                            // ScriptController in the future.
+                            { }
                         });
                         break;
                     case ModuleFetchFailureKind::WasCanceled:
@@ -338,7 +351,7 @@ bool WorkerOrWorkletScriptController::loadModuleSynchronously(WorkerScriptFetche
             }
 
             protector->notifyLoadFailed(LoadableScript::Error {
-                LoadableScript::ErrorType::CachedScript,
+                LoadableScript::ErrorType::Script,
                 LoadableScript::ConsoleMessage {
                     MessageSource::JS,
                     MessageLevel::Error,
@@ -346,7 +359,7 @@ bool WorkerOrWorkletScriptController::loadModuleSynchronously(WorkerScriptFetche
                 },
                 // The error value may need to be propagated here as it is in
                 // ScriptController in the future.
-                std::nullopt
+                { }
             });
             return JSValue::encode(jsUndefined());
         });
@@ -429,7 +442,7 @@ void WorkerOrWorkletScriptController::loadAndEvaluateModule(const URL& moduleURL
     auto parameters = ModuleFetchParameters::create(JSC::ScriptFetchParameters::Type::JavaScript, emptyString(), /* isTopLevelModule */ true);
     auto scriptFetcher = WorkerScriptFetcher::create(WTFMove(parameters), credentials, globalScope()->destination(), globalScope()->referrerPolicy());
     {
-        auto& promise = JSExecState::loadModule(globalObject, moduleURL.string(), JSC::JSScriptFetchParameters::create(vm, scriptFetcher->parameters()), JSC::JSScriptFetcher::create(vm, { scriptFetcher.ptr() }));
+        auto& promise = JSExecState::loadModule(globalObject, moduleURL, JSC::JSScriptFetchParameters::create(vm, scriptFetcher->parameters()), JSC::JSScriptFetcher::create(vm, { scriptFetcher.ptr() }));
 
         auto task = createSharedTask<void(std::optional<Exception>&&)>([completionHandler = WTFMove(completionHandler)](std::optional<Exception>&& exception) mutable {
             completionHandler(WTFMove(exception));
@@ -486,6 +499,7 @@ void WorkerOrWorkletScriptController::loadAndEvaluateModule(const URL& moduleURL
                     String message = retrieveErrorMessageWithoutName(*globalObject, vm, object, catchScope);
                     switch (static_cast<ModuleFetchFailureKind>(failureKindValue.asInt32())) {
                     case ModuleFetchFailureKind::WasFetchError:
+                    case ModuleFetchFailureKind::WasResolveError:
                         task->run(Exception { TypeError, message });
                         break;
                     case ModuleFetchFailureKind::WasPropagatedError:

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -910,9 +910,12 @@ void XMLDocumentParser::endElementNs()
         // FIXME: Script execution should be shared between
         // the libxml2 and Qt XMLDocumentParser implementations.
 
-        if (scriptElement.readyToBeParserExecuted())
-            scriptElement.executeClassicScript(ScriptSourceCode(scriptElement.scriptContent(), URL(document()->url()), m_scriptStartPosition, JSC::SourceProviderSourceType::Program, InlineClassicScript::create(scriptElement)));
-        else if (scriptElement.willBeParserExecuted() && scriptElement.loadableScript()) {
+        if (scriptElement.readyToBeParserExecuted()) {
+            if (scriptElement.scriptType() == ScriptType::Classic)
+                scriptElement.executeClassicScript(ScriptSourceCode(scriptElement.scriptContent(), URL(document()->url()), m_scriptStartPosition, JSC::SourceProviderSourceType::Program, InlineClassicScript::create(scriptElement)));
+            else
+                scriptElement.registerImportMap(ScriptSourceCode(scriptElement.scriptContent(), URL(document()->url()), m_scriptStartPosition, JSC::SourceProviderSourceType::ImportMap));
+        } else if (scriptElement.willBeParserExecuted() && scriptElement.loadableScript()) {
             m_pendingScript = PendingScript::create(scriptElement, *scriptElement.loadableScript());
             m_pendingScript->setClient(*this);
 


### PR DESCRIPTION
#### 6c1996aea8b85babf563135acc2d05def8aca3cb
<pre>
Implement importmaps
<a href="https://bugs.webkit.org/show_bug.cgi?id=220823">https://bugs.webkit.org/show_bug.cgi?id=220823</a>
&lt;rdar://73478498&gt;

Reviewed by Youenn Fablet.

This patch implements import-maps[1], which integrates mapping between module specifier and actual URL so that we can import
modules with arbitrary module specifier. This helps integrating existing node.js / bun etc. modules into the web page without
bundlers.

1. JSC integrates importMapStatusPromise into its module loader pipeline. This makes us to wait for the importmap loading cleanly.
2. Fix a bug that &lt;script type=&quot;module&quot; src=&quot;URL&quot;&gt;&apos;s src is resolved. The spec does not resolve this URL and handle it as normal URL.
   The reason is that we would like to preload this resource so we need to have an URL here.
3. Fix WCIG import-mpas&apos; tests in WPT. These tests are indeterministic, so we modified WPT testharness.js and tests to make it deterministic.
4. For now, we workaround the iframe &apos;load&apos; event issue which blocks testing in WPT import-maps by modifying testharness.js. We should fix this
   issue in WebKit side later. They are located in LayoutTests/http/wpt/import-maps/data-driven.
   It should be removed once the issues are solved. <a href="https://bugs.webkit.org/show_bug.cgi?id=245772">https://bugs.webkit.org/show_bug.cgi?id=245772</a>
5. &quot;importmap&quot; &lt;script&gt; type and LoadableImportMap is integrated in WebCore. We share most of code with LoadableClassicScript by factoring out the
   common part as LoadableNonModuleScriptBase.
6. Core algorithm of ImportMap resolution is defined in JSC::ImportMap in runtime/ImportMap.h. This map is per JSGlobalObject, and implements the
   resolution algorithm. We would like to integrate this well in normal JSC framework in the future.
7. HTML script preloader is correctly configured to preload importmap as well.
8. Some of WPT tests are failing because of www1.localhost domain resolution issue.

[1]: <a href="https://github.com/WICG/import-maps">https://github.com/WICG/import-maps</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve-importmap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/specifier-error-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/import-maps/META.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/README.md: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/dynamic-import.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag-inline.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/script-tag.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/worker-request-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/acquiring/worker-request.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/README.md: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/__dir__.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/bare: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/cross-origin-bare: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/to-bare: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/to-data: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/bare/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash-failure-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash-failure.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/hash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce-failure-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce-failure.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/nonce.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/unsafe-inline-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/unsafe-inline.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/csp/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/README.md: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resolving.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/test-helper-iframe.js: Added.
(event.catch):
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/test-helper.js: Added.
(createTestIframe):
(resolve):
(async runTests):
(async export.async runTestsFromJSON):
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/tools/format_json.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/tools/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/import-maps-base-url.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/import-maps-base-url.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/module-map-key-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/module-map-key.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/basic.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/multiple-import-maps/with-errors.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-as-classic-script-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/not-as-classic-script.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/empty.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/inject-base.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/log.js.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/test-helper.js: Added.
(getHandlers):
(testInIframe):
(testScriptElement):
(testStaticImportInjectBase):
* LayoutTests/imported/w3c/web-platform-tests/import-maps/resources/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/script-supports-importmap-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/script-supports-importmap.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/static-import.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/import-maps/w3c-import.log: Added.
* LayoutTests/tests-options.json:
* Source/JavaScriptCore/API/JSAPIGlobalObject.mm:
(JSC::JSAPIGlobalObject::moduleLoaderImportModule):
(JSC::JSAPIGlobalObject::loadAndEvaluateJSScriptModule):
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/ModuleLoader.js:
(visibility.PrivateRecursive.async loadModule):
(visibility.PrivateRecursive.async loadAndEvaluateModule):
(visibility.PrivateRecursive.async requestImportModule):
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/jsc.cpp:
(GlobalObject::moduleLoaderImportModule):
* Source/JavaScriptCore/parser/SourceProvider.h:
* Source/JavaScriptCore/runtime/Completion.cpp:
(JSC::loadModule):
(JSC::importModule):
* Source/JavaScriptCore/runtime/Completion.h:
* Source/JavaScriptCore/runtime/ImportMap.cpp: Added.
(JSC::ImportMap::resolveImportMatch):
(JSC::parseURLLikeModuleSpecifier):
(JSC::ImportMap::resolve const):
(JSC::normalizeSpecifierKey):
(JSC::sortAndNormalizeSpecifierMap):
(JSC::ImportMap::registerImportMap):
* Source/JavaScriptCore/runtime/ImportMap.h: Copied from Source/WebCore/dom/ScriptElementCachedScriptFetcher.h.
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::JSGlobalObject):
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
(JSC::JSGlobalObject::isAcquiringImportMaps const):
(JSC::JSGlobalObject::setAcquiringImportMaps):
(JSC::JSGlobalObject::setPendingImportMaps):
(JSC::JSGlobalObject::clearPendingImportMaps):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::importMap const):
(JSC::JSGlobalObject::importMap):
(JSC::JSGlobalObject::importMapStatusPromise const):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.h:
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::loadModule):
(JSC::JSModuleLoader::requestImportModule):
* Source/JavaScriptCore/runtime/JSModuleLoader.h:
* Source/JavaScriptCore/runtime/LazyProperty.h:
(JSC::LazyProperty::isInitialized const):
* Source/WTF/wtf/JSONValues.cpp:
(WTF::JSONImpl::Value::parseJSON):
* Source/WTF/wtf/JSONValues.h:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSExecState.h:
(WebCore::JSExecState::loadModule):
* Source/WebCore/bindings/js/ModuleFetchFailureKind.h:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::loadModuleScriptInWorld):
(WebCore::ScriptController::loadModuleScript):
(WebCore::ScriptController::setupModuleScriptHandlers):
(WebCore::ScriptController::reportExceptionFromScriptError):
(WebCore::ScriptController::registerImportMap):
(WebCore::ScriptController::isAcquiringImportMaps):
(WebCore::ScriptController::setAcquiringImportMaps):
(WebCore::ScriptController::setPendingImportMaps):
(WebCore::ScriptController::clearPendingImportMaps):
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::resolveModuleSpecifier):
(WebCore::ScriptModuleLoader::resolve):
(WebCore::ScriptModuleLoader::responseURLFromRequestURL):
(WebCore::ScriptModuleLoader::importModule):
(WebCore::ScriptModuleLoader::createImportMetaProperties):
* Source/WebCore/dom/CurrentScriptIncrementer.h:
(WebCore::CurrentScriptIncrementer::CurrentScriptIncrementer):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::baseURLForComplete const):
(WebCore::Document::completeURL const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/InlineClassicScript.h:
* Source/WebCore/dom/LoadableClassicScript.cpp:
(WebCore::LoadableClassicScript::takeError):
(WebCore::LoadableClassicScript::notifyFinished):
(WebCore::LoadableClassicScript::error const): Deleted.
* Source/WebCore/dom/LoadableClassicScript.h:
* Source/WebCore/dom/LoadableImportMap.cpp: Copied from Source/WebCore/dom/LoadableClassicScript.cpp.
(WebCore::LoadableImportMap::create):
(WebCore::LoadableImportMap::LoadableImportMap):
(WebCore::LoadableImportMap::~LoadableImportMap):
(WebCore::LoadableImportMap::isLoaded const):
(WebCore::LoadableImportMap::takeError):
(WebCore::LoadableImportMap::wasCanceled const):
(WebCore::LoadableImportMap::notifyFinished):
(WebCore::LoadableImportMap::execute):
(WebCore::LoadableImportMap::load):
* Source/WebCore/dom/LoadableImportMap.h: Copied from Source/WebCore/dom/LoadableClassicScript.h.
(isType):
* Source/WebCore/dom/LoadableModuleScript.cpp:
(WebCore::LoadableModuleScript::takeError):
(WebCore::LoadableModuleScript::error const): Deleted.
* Source/WebCore/dom/LoadableModuleScript.h:
* Source/WebCore/dom/LoadableScript.h:
* Source/WebCore/dom/PendingScript.cpp:
(WebCore::PendingScript::takeError):
(WebCore::PendingScript::error const): Deleted.
* Source/WebCore/dom/PendingScript.h:
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::ScriptElement):
(WebCore::ScriptElement::determineScriptType const):
(WebCore::ScriptElement::prepareScript):
(WebCore::ScriptElement::requestModuleScript):
(WebCore::ScriptElement::requestImportMap):
(WebCore::ScriptElement::registerImportMap):
(WebCore::ScriptElement::executeModuleScript):
(WebCore::ScriptElement::executeScriptAndDispatchEvent):
(WebCore::ScriptElement::executePendingScript):
* Source/WebCore/dom/ScriptElement.h:
(WebCore::ScriptElement::scriptType const):
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.h:
(WebCore::ScriptElementCachedScriptFetcher::isClassicScript const):
(WebCore::ScriptElementCachedScriptFetcher::isModuleScript const):
(WebCore::ScriptElementCachedScriptFetcher::isImportMap const):
* Source/WebCore/dom/ScriptType.h: Copied from Source/WebCore/dom/InlineClassicScript.h.
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/html/parser/CSSPreloadScanner.cpp:
(WebCore::CSSPreloadScanner::emitRule):
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::createPreloadRequest):
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
(WebCore::TokenPreloadScanner::StartTagScanner::shouldPreload):
* Source/WebCore/html/parser/HTMLResourcePreloader.cpp:
(WebCore::PreloadRequest::resourceRequest):
* Source/WebCore/html/parser/HTMLResourcePreloader.h:
(WebCore::PreloadRequest::PreloadRequest):
* Source/WebCore/html/parser/HTMLScriptRunner.cpp:
(WebCore::HTMLScriptRunner::runScript):
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
(WebCore::WorkerOrWorkletScriptController::loadModuleSynchronously):
(WebCore::WorkerOrWorkletScriptController::loadAndEvaluateModule):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::endElementNs):

Canonical link: <a href="https://commits.webkit.org/254987@main">https://commits.webkit.org/254987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d46bf9ab930da9dd214fc19b30bd380864695c25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90857 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100144 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33933 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83201 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/96637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96512 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/27035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77657 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26842 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69873 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35016 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15558 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32818 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16541 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3474 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39492 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35630 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->