### PR TITLE
[WK2] Remove uses of SendSyncLegacyResult-based Connection::sendSync() under WebProcess/WebCoreSupport/

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp
@@ -68,7 +68,9 @@ void WebSearchPopupMenu::loadRecentSearches(const AtomString& name, Vector<Recen
     if (!page)
         return;
 
-    WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::LoadRecentSearches(name), Messages::WebPageProxy::LoadRecentSearches::Reply(resultItems), page->identifier());
+    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::LoadRecentSearches(name), page->identifier());
+    if (sendResult)
+        std::tie(resultItems) = sendResult.takeReply();
 }
 
 bool WebSearchPopupMenu::enabled()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
@@ -39,8 +39,8 @@ const Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>>& WebSpeechSynthesisC
     // FIXME: this message should not be sent synchronously. Instead, the UI process should
     // get the list of voices and pass it on to the WebContent processes, see
     // https://bugs.webkit.org/show_bug.cgi?id=195723
-    Vector<WebSpeechSynthesisVoice> voiceList;
-    m_page.sendSync(Messages::WebPageProxy::SpeechSynthesisVoiceList(), voiceList);
+    auto sendResult = m_page.sendSync(Messages::WebPageProxy::SpeechSynthesisVoiceList());
+    auto [voiceList] = sendResult.takeReplyOr(Vector<WebSpeechSynthesisVoice> { });
 
     m_voices = voiceList.map([](auto& voice) -> RefPtr<WebCore::PlatformSpeechSynthesisVoice> {
         return WebCore::PlatformSpeechSynthesisVoice::create(voice.voiceURI, voice.name, voice.lang, voice.localService, voice.defaultLang);

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebAlternativeTextClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebAlternativeTextClient.cpp
@@ -58,8 +58,8 @@ void WebAlternativeTextClient::dismissAlternative(ReasonForDismissingAlternative
 
 String WebAlternativeTextClient::dismissAlternativeSoon(ReasonForDismissingAlternativeText reason)
 {
-    String result;
-    m_page->sendSync(Messages::WebPageProxy::DismissCorrectionPanelSoon(reason), Messages::WebPageProxy::DismissCorrectionPanelSoon::Reply(result));
+    auto sendResult = m_page->sendSync(Messages::WebPageProxy::DismissCorrectionPanelSoon(reason));
+    auto [result] = sendResult.takeReplyOr(String { });
     return result;
 }
 
@@ -81,8 +81,8 @@ void WebAlternativeTextClient::showDictationAlternativeUI(const WebCore::FloatRe
 
 Vector<String> WebAlternativeTextClient::dictationAlternatives(WebCore::DictationContext dictationContext)
 {
-    Vector<String> result;
-    m_page->sendSync(Messages::WebPageProxy::DictationAlternatives(dictationContext), Messages::WebPageProxy::DictationAlternatives::Reply(result));
+    auto sendResult = m_page->sendSync(Messages::WebPageProxy::DictationAlternatives(dictationContext));
+    auto [result] = sendResult.takeReplyOr(Vector<String> { });
     return result;
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
@@ -105,8 +105,8 @@ void WebEditorClient::showSubstitutionsPanel(bool)
 
 bool WebEditorClient::substitutionsPanelIsShowing()
 {
-    bool isShowing { false };
-    m_page->sendSync(Messages::WebPageProxy::SubstitutionsPanelIsShowing(), Messages::WebPageProxy::SubstitutionsPanelIsShowing::Reply(isShowing));
+    auto sendResult = m_page->sendSync(Messages::WebPageProxy::SubstitutionsPanelIsShowing());
+    auto [isShowing] = sendResult.takeReplyOr(false);
     return isShowing;
 }
 


### PR DESCRIPTION
#### 99c97361f04cd5a5681e6ecb61518b5ecfa03d16
<pre>
[WK2] Remove uses of SendSyncLegacyResult-based Connection::sendSync() under WebProcess/WebCoreSupport/
<a href="https://bugs.webkit.org/show_bug.cgi?id=245635">https://bugs.webkit.org/show_bug.cgi?id=245635</a>

Reviewed by Kimmo Kinnunen.

Replace uses of SendSyncLegacyResult-returning Connection::sendSync() method with the
non-legacy variant, adjusting retrieval of reply values in each case. This patch does
so for uses under the WebProcess/WebCoreSupport/ directory.

* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::WebPlatformStrategies::getTypes):
(WebKit::WebPlatformStrategies::bufferForType):
(WebKit::WebPlatformStrategies::getPathnamesForType):
(WebKit::WebPlatformStrategies::stringForType):
(WebKit::WebPlatformStrategies::allStringsForType):
(WebKit::WebPlatformStrategies::changeCount):
(WebKit::WebPlatformStrategies::color):
(WebKit::WebPlatformStrategies::url):
(WebKit::WebPlatformStrategies::addTypes):
(WebKit::WebPlatformStrategies::setTypes):
(WebKit::WebPlatformStrategies::setBufferForType):
(WebKit::WebPlatformStrategies::setURL):
(WebKit::WebPlatformStrategies::setColor):
(WebKit::WebPlatformStrategies::setStringForType):
(WebKit::WebPlatformStrategies::getNumberOfFiles):
(WebKit::WebPlatformStrategies::containsURLStringSuitableForLoading):
(WebKit::WebPlatformStrategies::urlStringSuitableForLoading):
(WebKit::WebPlatformStrategies::types):
(WebKit::WebPlatformStrategies::readTextFromClipboard):
(WebKit::WebPlatformStrategies::readFilePathsFromClipboard):
(WebKit::WebPlatformStrategies::readBufferFromClipboard):
(WebKit::WebPlatformStrategies::typesSafeForDOMToReadAndWrite):
(WebKit::WebPlatformStrategies::writeCustomData):
(WebKit::WebPlatformStrategies::containsStringSafeForDOMToReadForType):
(WebKit::WebPlatformStrategies::getPasteboardItemsCount):
(WebKit::WebPlatformStrategies::allPasteboardItemInfo):
(WebKit::WebPlatformStrategies::informationForItemAtIndex):
(WebKit::WebPlatformStrategies::readBufferFromPasteboard):
(WebKit::WebPlatformStrategies::readURLFromPasteboard):
(WebKit::WebPlatformStrategies::readStringFromPasteboard):
* Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp:
(WebKit::WebSearchPopupMenu::loadRecentSearches):
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp:
(WebKit::WebSpeechSynthesisClient::voiceList):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebAlternativeTextClient.cpp:
(WebKit::WebAlternativeTextClient::dismissAlternativeSoon):
(WebKit::WebAlternativeTextClient::dictationAlternatives):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm:
(WebKit::WebEditorClient::substitutionsPanelIsShowing):

Canonical link: <a href="https://commits.webkit.org/254853@main">https://commits.webkit.org/254853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d0897f196a76e1df8a014293dbed15b3ffd7e3e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99766 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33517 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28716 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82796 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96210 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26645 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77282 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26516 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69528 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34611 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15279 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32434 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16244 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3398 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36198 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39186 "Found 1 new test failure: css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-relayouts.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38111 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35333 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->