### PR TITLE
Remove SDK issue workaround added in 243458

### DIFF
--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -39,10 +39,7 @@
 #include <wtf/spi/darwin/dyldSPI.h>
 
 #if HAVE(CHIRP_SPI)
-// Workaround for rdar://97945223
-#define dlsym (const canary_meta_t *)dlsym
 #include <chirp/chirp.h>
-#undef dlsym
 #endif
 
 #if HAVE(SHARED_REGION_SPI)


### PR DESCRIPTION
#### ae1f4b196b4ff149281d9c62a2b7ee0fa6da23e5
<pre>
Remove SDK issue workaround added in 243458
<a href="https://bugs.webkit.org/show_bug.cgi?id=245643">https://bugs.webkit.org/show_bug.cgi?id=245643</a>
rdar://100383268

Reviewed by Alexey Proskuryakov.

* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
    Remove a build fix workaround that is no longer needed since recent SDKs have fixed the underlying issue.

Canonical link: <a href="https://commits.webkit.org/254917@main">https://commits.webkit.org/254917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c41790180f07e6eb4dd9246bbcbd776a8c1beca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99778 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157247 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33529 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28727 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82808 "Updated gtk dependencies (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96222 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26659 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77296 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/82808 "Updated gtk dependencies (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81250 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/82808 "Updated gtk dependencies (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82028 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34623 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15298 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76965 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32446 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16267 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26593 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3434 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36210 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39199 "Found 1 new test failure: fast/events/blur-remove-parent-crash.html (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/79551 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35356 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17433 "Passed tests") | 
<!--EWS-Status-Bubble-End-->