### PR TITLE
[GLib] Modernize Tools/glib/apply-build-revision-to-files.py

### DIFF
--- a/Tools/glib/apply-build-revision-to-files.py
+++ b/Tools/glib/apply-build-revision-to-files.py
@@ -16,29 +16,52 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+import os
 import sys
 from pathlib import Path
+import subprocess
+try:
+    from urllib.parse import urlparse  # pylint: disable=E0611
+except ImportError:
+    from urlparse import urlparse
 
 WEBKIT_TOP_LEVEL = Path(__file__).parent.parent.parent.resolve()
-sys.path.insert(0, str(Path(WEBKIT_TOP_LEVEL.joinpath("Tools", "Scripts"))))
 
-import webkitpy  # noqa
-from webkitscmpy import local  # noqa
 
+def get_revision_from_most_recent_git_commit():
+    with open(os.devnull, 'w') as devnull:
+        try:
+            commit_message = subprocess.check_output(("git", "log", "-1", "--pretty=%B", "origin/HEAD"), stderr=devnull)
+        except subprocess.CalledProcessError:
+            # This may happen with shallow checkouts whose HEAD has been
+            # modified; there is no origin reference anymore, and git
+            # will fail - let's pretend that this is not a repo at all
+            return None
+
+        # Commit messages tend to be huge and the metadata we're looking
+        # for is at the very end. Also a spoofed 'Canonical link' mention
+        # could appear early on. So make sure we get the right metadata by
+        # reversing the contents. And this is a micro-optimization as well.
+        for line in reversed(commit_message.splitlines()):
+            parsed = line.split(b':')
+            key = parsed[0]
+            contents = b':'.join(parsed[1:])
+            if key == b'Canonical link':
+                url = contents.decode('utf-8').strip()
+                revision = urlparse(url).path[1:]  # strip leading /
+                return revision
+    return None
 
 def get_build_revision():
-    try:
-        repository = local.Scm.from_path(str(WEBKIT_TOP_LEVEL), contributors=None)
-        return str(repository.find("HEAD", include_log=False))
-    except (local.Scm.Exception, TypeError, OSError, KeyError):
-        # This may happen with shallow checkouts whose HEAD has been
-        # modified; there is no origin reference anymore, and git
-        # will fail - let's pretend that this is not a repo at all
-        return "unknown"
+    git_path = str(WEBKIT_TOP_LEVEL.joinpath('.git'))
+    # In case of git worktrees the .git is a file.
+    if os.path.isdir(git_path) or os.path.isfile(git_path):
+        return get_revision_from_most_recent_git_commit()
 
+    return None
 
 def main(args):
-    build_revision = get_build_revision()
+    build_revision = get_build_revision() or "unknown"
 
     for in_file in args:
         file = Path(in_file)


### PR DESCRIPTION
#### 792d6325aedb3d164f2f4a2d139523b0f7ffab02
<pre>
[GLib] Modernize Tools/glib/apply-build-revision-to-files.py
<a href="https://bugs.webkit.org/show_bug.cgi?id=242191">https://bugs.webkit.org/show_bug.cgi?id=242191</a>
&lt;rdar://problem/96245384&gt;

Reviewed by Michael Catanzaro.

Switch back to git log parsing, as before 252012@main. Using webkitpy was not a great idea for two
reasons:

- autoinstall kicking off during offline builds and failing
- SSL issues in buildroot setups.

* Tools/glib/apply-build-revision-to-files.py:
(get_revision_from_most_recent_git_commit):
(get_build_revision):
(main):

Canonical link: <a href="https://commits.webkit.org/254851@main">https://commits.webkit.org/254851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf4b605381c8bcc3660646df8271a110aff39c12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99779 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157248 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33530 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28728 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82809 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96223 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26660 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77298 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26527 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69539 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34624 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15299 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32447 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16268 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3396 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39200 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35357 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->