### PR TITLE
Add some Cocoa helper templates for getting objects of types and filtering containers.

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <wtf/RetainPtr.h>
+
+OBJC_CLASS NSDictionary;
+
+namespace WebKit {
+
+template<typename T> T *filterObjects(T *container, bool NS_NOESCAPE (^block)(__kindof id key, __kindof id value));
+template<> NSArray *filterObjects<NSArray>(NSArray *, bool NS_NOESCAPE (^block)(__kindof id key, __kindof id value));
+template<> NSDictionary *filterObjects<NSDictionary>(NSDictionary *, bool NS_NOESCAPE (^block)(__kindof id key, __kindof id value));
+template<> NSSet *filterObjects<NSSet>(NSSet *, bool NS_NOESCAPE (^block)(__kindof id key, __kindof id value));
+
+template<typename T>
+T *filterObjects(const RetainPtr<T>& container, bool NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
+{
+    return filterObjects<T>(container.get(), block);
+}
+
+template<typename T> T *mapObjects(T *container, __kindof id NS_NOESCAPE (^block)(__kindof id key, __kindof id value));
+template<> NSArray *mapObjects<NSArray>(NSArray *, __kindof id NS_NOESCAPE (^block)(__kindof id key, __kindof id value));
+template<> NSDictionary *mapObjects<NSDictionary>(NSDictionary *, __kindof id NS_NOESCAPE (^block)(__kindof id key, __kindof id value));
+template<> NSSet *mapObjects<NSSet>(NSSet *, __kindof id NS_NOESCAPE (^block)(__kindof id key, __kindof id value));
+
+template<typename T>
+T *mapObjects(const RetainPtr<T>& container, __kindof id NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
+{
+    return mapObjects<T>(container.get(), block);
+}
+
+template<typename T>
+T *objectForKey(NSDictionary *dictionary, id key, bool returningNilIfEmpty = true, Class containingObjectsOfClass = Nil)
+{
+    ASSERT(returningNilIfEmpty);
+    ASSERT(!containingObjectsOfClass);
+    // Specialized implementations in CocoaHelpers.mm handle returningNilIfEmpty and containingObjectsOfClass for different Foundation types.
+    return dynamic_objc_cast<T>(dictionary[key]);
+}
+
+template<typename T>
+T *objectForKey(const RetainPtr<NSDictionary>& dictionary, id key, bool returningNilIfEmpty = true, Class containingObjectsOfClass = Nil)
+{
+    return objectForKey<T>(dictionary.get(), key, returningNilIfEmpty, containingObjectsOfClass);
+}
+
+} // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "CocoaHelpers.h"
+
+namespace WebKit {
+
+template<>
+NSArray *filterObjects<NSArray>(NSArray *array, bool NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
+{
+    switch (array.count) {
+    case 0:
+        return @[ ];
+
+    case 1:
+        return block(@(0), array[0]) ? [array copy] : @[ ];
+
+    default:
+        return [array objectsAtIndexes:[array indexesOfObjectsPassingTest:^BOOL (id object, NSUInteger index, BOOL *stop) {
+            return block(@(index), object);
+        }]];
+    }
+}
+
+template<>
+NSDictionary *filterObjects<NSDictionary>(NSDictionary *dictionary, bool NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
+{
+    if (!dictionary.count)
+        return @{ };
+
+    NSMutableDictionary *filterResult = [NSMutableDictionary dictionaryWithCapacity:dictionary.count];
+
+    [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+        if (block(key, value))
+            filterResult[key] = value;
+    }];
+
+    return [filterResult copy];
+}
+
+template<>
+NSSet *filterObjects<NSSet>(NSSet *set, bool NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
+{
+    if (!set.count)
+        return [NSSet set];
+
+    return [set objectsPassingTest:^BOOL (id value, BOOL *stop) {
+        return block(nil, value);
+    }];
+}
+
+template<>
+NSArray *mapObjects<NSArray>(NSArray *array, __kindof id NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
+{
+    switch (array.count) {
+    case 0:
+        return @[ ];
+
+    case 1: {
+        id result = block(@(0), array[0]);
+        return result ? @[ result ] : @[ ];
+    }
+
+    default: {
+        NSMutableArray *mapResult = [NSMutableArray arrayWithCapacity:array.count];
+
+        [array enumerateObjectsUsingBlock:^(id value, NSUInteger index, BOOL *stop) {
+            if (id result = block(@(index), value))
+                [mapResult addObject:result];
+        }];
+
+        return [mapResult copy];
+    }
+    }
+}
+
+template<>
+NSDictionary *mapObjects<NSDictionary>(NSDictionary *dictionary, __kindof id NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
+{
+    if (!dictionary.count)
+        return @{ };
+
+    NSMutableDictionary *mapResult = [NSMutableDictionary dictionaryWithCapacity:dictionary.count];
+
+    [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+        if (id result = block(key, value))
+            mapResult[key] = result;
+    }];
+
+    return [mapResult copy];
+}
+
+template<>
+NSSet *mapObjects<NSSet>(NSSet *set, __kindof id NS_NOESCAPE (^block)(__kindof id key, __kindof id value))
+{
+    switch (set.count) {
+    case 0:
+        return [NSSet set];
+
+    case 1: {
+        id result = block(nil, set.anyObject);
+        return result ? [NSSet setWithObject:result] : [NSSet set];
+    }
+
+    default: {
+        NSMutableSet *mapResult = [NSMutableSet setWithCapacity:set.count];
+
+        [set enumerateObjectsUsingBlock:^(id value, BOOL *stop) {
+            if (id result = block(nil, value))
+                [mapResult addObject:result];
+        }];
+
+        return [mapResult copy];
+    }
+    }
+}
+
+template<>
+NSString *objectForKey<NSString>(NSDictionary *dictionary, id key, bool nilIfEmpty, Class requiredClass)
+{
+    ASSERT(!requiredClass);
+    NSString *result = dynamic_objc_cast<NSString>(dictionary[key]);
+    return !nilIfEmpty || result.length ? result : nil;
+}
+
+template<>
+NSArray *objectForKey<NSArray>(NSDictionary *dictionary, id key, bool nilIfEmpty, Class requiredClass)
+{
+    NSArray *result = dynamic_objc_cast<NSArray>(dictionary[key]);
+    result = !nilIfEmpty || result.count ? result : nil;
+    if (!result || !requiredClass)
+        return result;
+    return filterObjects(result, ^bool (id, id value) {
+        return [value isKindOfClass:requiredClass];
+    });
+}
+
+template<>
+NSDictionary *objectForKey<NSDictionary>(NSDictionary *dictionary, id key, bool nilIfEmpty, Class requiredClass)
+{
+    NSDictionary *result = dynamic_objc_cast<NSDictionary>(dictionary[key]);
+    result = !nilIfEmpty || result.count ? result : nil;
+    if (!result || !requiredClass)
+        return result;
+    return filterObjects(result, ^bool (id, id value) {
+        return [value isKindOfClass:requiredClass];
+    });
+}
+
+template<>
+NSSet *objectForKey<NSSet>(NSDictionary *dictionary, id key, bool nilIfEmpty, Class requiredClass)
+{
+    NSSet *result = dynamic_objc_cast<NSSet>(dictionary[key]);
+    result = !nilIfEmpty || result.count ? result : nil;
+    if (!result || !requiredClass)
+        return result;
+    return filterObjects(result, ^bool (id, id value) {
+        return [value isKindOfClass:requiredClass];
+    });
+}
+
+} // namespace WebKit

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -381,6 +381,8 @@
 		1C56557F2745C5A1006300AF /* UnifiedSource101.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C56557C2745C5A0006300AF /* UnifiedSource101.cpp */; };
 		1C5655802745C5A1006300AF /* UnifiedSource102.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C56557D2745C5A1006300AF /* UnifiedSource102.cpp */; };
 		1C5655812745C5A1006300AF /* UnifiedSource103.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C56557E2745C5A1006300AF /* UnifiedSource103.cpp */; };
+		1C62747D288B4C3E00CED3A2 /* CocoaHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C62747B288B4C3E00CED3A2 /* CocoaHelpers.h */; };
+		1C62747E288B4C3E00CED3A2 /* CocoaHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C62747C288B4C3E00CED3A2 /* CocoaHelpers.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C891D6619B124FF00BA79DD /* WebInspectorUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C891D6319B124FF00BA79DD /* WebInspectorUI.h */; };
 		1C8E28201275D15400BC7BD0 /* WebInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8E281E1275D15400BC7BD0 /* WebInspector.h */; };
 		1C8E28341275D73800BC7BD0 /* WebInspectorUIProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8E28321275D73800BC7BD0 /* WebInspectorUIProxy.h */; };
@@ -3466,6 +3468,8 @@
 		1C56557E2745C5A1006300AF /* UnifiedSource103.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource103.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource103.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1C5A104E287BB1E90034FDA4 /* OverrideLanguages.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = OverrideLanguages.cpp; sourceTree = "<group>"; };
 		1C5A104F287BB1E90034FDA4 /* OverrideLanguages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OverrideLanguages.h; sourceTree = "<group>"; };
+		1C62747B288B4C3E00CED3A2 /* CocoaHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocoaHelpers.h; sourceTree = "<group>"; };
+		1C62747C288B4C3E00CED3A2 /* CocoaHelpers.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaHelpers.mm; sourceTree = "<group>"; };
 		1C739E852347BCF600C621EC /* CoreTextHelpers.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreTextHelpers.mm; sourceTree = "<group>"; };
 		1C739E872347BD0F00C621EC /* CoreTextHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreTextHelpers.h; sourceTree = "<group>"; };
 		1C77C1951288A872006A742F /* WebInspectorUIProxy.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebInspectorUIProxy.messages.in; sourceTree = "<group>"; };
@@ -10125,6 +10129,8 @@
 		4450AEBE1DC3FAAC009943F2 /* cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				1C62747B288B4C3E00CED3A2 /* CocoaHelpers.h */,
+				1C62747C288B4C3E00CED3A2 /* CocoaHelpers.mm */,
 				4482734624528F6000A95493 /* CocoaImage.h */,
 				F4E47BB527B5AE5B00813B38 /* CocoaImage.mm */,
 				F4351B9D25EEC84C00D63892 /* ImageAnalysisUtilities.h */,
@@ -14108,6 +14114,7 @@
 				2D478B91288F33A600F3B73A /* CGDisplayList.h in Headers */,
 				BCE579A62634836700F5C5E9 /* CGDisplayListImageBufferBackend.h in Headers */,
 				57B4B46020B504AC00D4AD79 /* ClientCertificateAuthenticationXPCConstants.h in Headers */,
+				1C62747D288B4C3E00CED3A2 /* CocoaHelpers.h in Headers */,
 				4482734724528F6000A95493 /* CocoaImage.h in Headers */,
 				CE11AD521CBC482F00681EE5 /* CodeSigning.h in Headers */,
 				37BEC4E119491486008B4286 /* CompletionHandlerCallChecker.h in Headers */,
@@ -16979,6 +16986,7 @@
 				51FAEC3B1B0657680009C4E7 /* AuxiliaryProcessMessageReceiver.cpp in Sources */,
 				E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */,
 				517CF0E3163A486C00C2950F /* CacheStorageEngineConnectionMessageReceiver.cpp in Sources */,
+				1C62747E288B4C3E00CED3A2 /* CocoaHelpers.mm in Sources */,
 				49DC1DE127E5129100C1CB36 /* CSPExtensionUtilities.mm in Sources */,
 				522F792C28D531970069B45B /* CtapAuthenticator.cpp in Sources */,
 				526C5723284ADCBC00E08955 /* CtapCcidDriver.cpp in Sources */,


### PR DESCRIPTION
#### 485052b30901b36de44f76c560e60674c1518c76
<pre>
Add some Cocoa helper templates for getting objects of types and filtering containers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=245646">https://bugs.webkit.org/show_bug.cgi?id=245646</a>

Reviewed by Tim Horton.

These will be used in some forthcoming feature work. Instead of adding them as category methods in WebKit,
I made them template functions to avoid cluttering up Foundation classes with WebKit category methods.

* Source/WebKit/Platform/cocoa/CocoaHelpers.h: Added.
(WebKit::filterObjects):
(WebKit::mapObjects):
(WebKit::objectForKey):
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm: Added.
(WebKit::filterObjects&lt;NSArray&gt;):
(WebKit::filterObjects&lt;NSDictionary&gt;):
(WebKit::filterObjects&lt;NSSet&gt;):
(WebKit::mapObjects&lt;NSArray&gt;):
(WebKit::mapObjects&lt;NSDictionary&gt;):
(WebKit::mapObjects&lt;NSSet&gt;):
(WebKit::objectForKey&lt;NSString&gt;):
(WebKit::objectForKey&lt;NSArray&gt;):
(WebKit::objectForKey&lt;NSDictionary&gt;):
(WebKit::objectForKey&lt;NSSet&gt;):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/254877@main">https://commits.webkit.org/254877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f97c9386c9500aef456481c0e73b6ecb4f639c5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90562 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35146 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/99894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33646 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/82927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/96329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96217 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/82927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/82927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34745 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32560 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36325 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1476 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38239 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->