### PR TITLE
[PlayStation] Load JPEG library at runtime

### DIFF
--- a/Source/WebKit/WebProcess/EntryPoint/playstation/WebProcessMain.cpp
+++ b/Source/WebKit/WebProcess/EntryPoint/playstation/WebProcessMain.cpp
@@ -49,6 +49,9 @@ int main(int argc, char** argv)
 
     loadLibraryOrExit(ICU_LOAD_AT);
     loadLibraryOrExit(PNG_LOAD_AT);
+#if defined(JPEG_LOAD_AT)
+    loadLibraryOrExit(JPEG_LOAD_AT);
+#endif 
 #if defined(WebP_LOAD_AT)
     loadLibraryOrExit(WebP_LOAD_AT);
 #endif

--- a/Tools/MiniBrowser/playstation/main.cpp
+++ b/Tools/MiniBrowser/playstation/main.cpp
@@ -50,6 +50,9 @@ static void initialize()
 
     loadLibraryOrExit(ICU_LOAD_AT);
     loadLibraryOrExit(PNG_LOAD_AT);
+#if defined(JPEG_LOAD_AT)
+    loadLibraryOrExit(JPEG_LOAD_AT);
+#endif 
 #if defined(WebP_LOAD_AT)
     loadLibraryOrExit(WebP_LOAD_AT);
 #endif

--- a/Tools/TestWebKitAPI/playstation/main.cpp
+++ b/Tools/TestWebKitAPI/playstation/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char** argv)
     loadLibraryOrExit(ICU_LOAD_AT);
 #if defined(BUILDING_TestWebCore) || defined(BUILDING_TestWebKit)
     loadLibraryOrExit(PNG_LOAD_AT);
+#if defined(JPEG_LOAD_AT)
+    loadLibraryOrExit(JPEG_LOAD_AT);
+#endif 
 #if defined(WebP_LOAD_AT)
     loadLibraryOrExit(WebP_LOAD_AT);
 #endif


### PR DESCRIPTION
#### 201eb356315594d235dfae05c2bfa88642262c07
<pre>
[PlayStation] Load JPEG library at runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=245649">https://bugs.webkit.org/show_bug.cgi?id=245649</a>

Reviewed by Fujii Hironori.

Load the JPEG library at runtime if applicable. If `JPEG_LOAD_AT` isn&apos;t
defined then JPEG support is in the WebKitRequirements library.

* Source/WebKit/WebProcess/EntryPoint/playstation/WebProcessMain.cpp:
* Tools/MiniBrowser/playstation/main.cpp:
* Tools/TestWebKitAPI/playstation/main.cpp:

Canonical link: <a href="https://commits.webkit.org/254849@main">https://commits.webkit.org/254849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ae7e8124c2517042ab124df49ea0c09a80aab37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99794 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/157263 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33542 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28750 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82822 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96235 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96112 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77311 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26537 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69550 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34640 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15317 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32460 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16288 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3393 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39214 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35377 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->