### PR TITLE
Prototype declarative shadow DOM

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popups/popup-light-dismiss.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popups/popup-light-dismiss.tentative-expected.txt
@@ -1,4 +1,5 @@
-CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'document.querySelector('#myElement').shadowRoot.querySelector')
+CONSOLE MESSAGE: TypeError: popup7.showPopUp is not a function. (In 'popup7.showPopUp()', 'popup7.showPopUp' is undefined)
+CONSOLE MESSAGE: TypeError: popup7.showPopUp is not a function. (In 'popup7.showPopUp()', 'popup7.showPopUp' is undefined)
 Popup 1 Popup 1 Popup1 anchor (no action) Outside all popups
 Inside popup 1  Popup 2 Inside popup 1 after button
 Inside popup 2
@@ -25,7 +26,7 @@ Popup
 Hint
 Manual
 
-Harness Error (FAIL), message = TypeError: null is not an object (evaluating 'document.querySelector('#myElement').shadowRoot.querySelector')
+Harness Error (FAIL), message = TypeError: popup7.showPopUp is not a function. (In 'popup7.showPopUp()', 'popup7.showPopUp' is undefined)
 
 FAIL Clicking outside a popup will dismiss the popup promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
 FAIL Clicking inside a popup does not close that popup promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
@@ -40,6 +41,8 @@ FAIL Dragging from an open popup outside an open popup should leave the popup op
 FAIL An invoking element should be part of the ancestor chain promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
 FAIL An invoking element that was not used to invoke the popup can still be part of the ancestor chain promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
 FAIL Scrolling within a popup should not close the popup promise_test: Unhandled rejection with value: object "TypeError: popup6.showPopUp is not a function. (In 'popup6.showPopUp()', 'popup6.showPopUp' is undefined)"
+FAIL Clicking inside a shadow DOM popup does not close that popup promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
+FAIL Clicking outside a shadow DOM popup should close that popup promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
 FAIL Moving focus back to the anchor element should not dismiss the popup promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
 FAIL Moving focus back to the active trigger element should not dismiss the popup promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
 FAIL Moving focus back to an inactive trigger element should also *not* dismiss the popup promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-attachment.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-attachment.tentative-expected.txt
@@ -1,21 +1,21 @@
 
-FAIL Declarative Shadow DOM as a child of <article>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <aside>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <blockquote>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <div>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <footer>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h1>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h2>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h3>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h4>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h5>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h6>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <header>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <main>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <nav>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <p>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <section>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <span>, with mode=open, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
+PASS Declarative Shadow DOM as a child of <article>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <aside>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <blockquote>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <div>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <footer>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h1>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h2>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h3>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h4>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h5>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h6>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <header>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <main>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <nav>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <p>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <section>, with mode=open, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <span>, with mode=open, delegatesFocus=false. Should be safelisted.
 PASS Declarative Shadow DOM as a child of <a>, with mode=open, delegatesFocus=false. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <abbr>, with mode=open, delegatesFocus=false. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <address>, with mode=open, delegatesFocus=false. Should be disallowed.
@@ -107,23 +107,23 @@ PASS Declarative Shadow DOM as a child of <ul>, with mode=open, delegatesFocus=f
 PASS Declarative Shadow DOM as a child of <var>, with mode=open, delegatesFocus=false. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <video>, with mode=open, delegatesFocus=false. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <wbr>, with mode=open, delegatesFocus=false. Should be disallowed.
-FAIL Declarative Shadow DOM as a child of <article>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <aside>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <blockquote>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <div>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <footer>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h1>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h2>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h3>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h4>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h5>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h6>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <header>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <main>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <nav>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <p>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <section>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <span>, with mode=closed, delegatesFocus=false. Should be safelisted. assert_true: expected true got false
+PASS Declarative Shadow DOM as a child of <article>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <aside>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <blockquote>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <div>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <footer>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h1>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h2>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h3>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h4>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h5>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h6>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <header>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <main>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <nav>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <p>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <section>, with mode=closed, delegatesFocus=false. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <span>, with mode=closed, delegatesFocus=false. Should be safelisted.
 PASS Declarative Shadow DOM as a child of <a>, with mode=closed, delegatesFocus=false. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <abbr>, with mode=closed, delegatesFocus=false. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <address>, with mode=closed, delegatesFocus=false. Should be disallowed.
@@ -323,23 +323,23 @@ PASS Declarative Shadow DOM as a child of <ul>, with mode=invalid, delegatesFocu
 PASS Declarative Shadow DOM as a child of <var>, with mode=invalid, delegatesFocus=false. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <video>, with mode=invalid, delegatesFocus=false. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <wbr>, with mode=invalid, delegatesFocus=false. Should be disallowed.
-FAIL Declarative Shadow DOM as a child of <article>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <aside>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <blockquote>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <div>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <footer>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h1>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h2>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h3>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h4>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h5>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h6>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <header>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <main>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <nav>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <p>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <section>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <span>, with mode=open, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
+PASS Declarative Shadow DOM as a child of <article>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <aside>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <blockquote>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <div>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <footer>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h1>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h2>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h3>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h4>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h5>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h6>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <header>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <main>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <nav>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <p>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <section>, with mode=open, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <span>, with mode=open, delegatesFocus=true. Should be safelisted.
 PASS Declarative Shadow DOM as a child of <a>, with mode=open, delegatesFocus=true. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <abbr>, with mode=open, delegatesFocus=true. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <address>, with mode=open, delegatesFocus=true. Should be disallowed.
@@ -431,23 +431,23 @@ PASS Declarative Shadow DOM as a child of <ul>, with mode=open, delegatesFocus=t
 PASS Declarative Shadow DOM as a child of <var>, with mode=open, delegatesFocus=true. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <video>, with mode=open, delegatesFocus=true. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <wbr>, with mode=open, delegatesFocus=true. Should be disallowed.
-FAIL Declarative Shadow DOM as a child of <article>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <aside>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <blockquote>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <div>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <footer>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h1>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h2>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h3>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h4>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h5>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <h6>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <header>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <main>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <nav>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <p>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <section>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
-FAIL Declarative Shadow DOM as a child of <span>, with mode=closed, delegatesFocus=true. Should be safelisted. assert_true: expected true got false
+PASS Declarative Shadow DOM as a child of <article>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <aside>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <blockquote>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <div>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <footer>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h1>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h2>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h3>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h4>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h5>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <h6>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <header>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <main>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <nav>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <p>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <section>, with mode=closed, delegatesFocus=true. Should be safelisted.
+PASS Declarative Shadow DOM as a child of <span>, with mode=closed, delegatesFocus=true. Should be safelisted.
 PASS Declarative Shadow DOM as a child of <a>, with mode=closed, delegatesFocus=true. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <abbr>, with mode=closed, delegatesFocus=true. Should be disallowed.
 PASS Declarative Shadow DOM as a child of <address>, with mode=closed, delegatesFocus=true. Should be disallowed.

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic.tentative-expected.txt
@@ -1,18 +1,12 @@
 
-FAIL Declarative Shadow DOM: Basic test assert_equals: No leftover template node expected null but got Element node <template shadowroot="open">
-    <slot id="s1" name="slot...
+PASS Declarative Shadow DOM: Basic test
 FAIL Declarative Shadow DOM: Feature detection assert_true: Unable to feature detect expected true got false
-FAIL Declarative Shadow DOM: Fragment parser basic test assert_equals: No leftover template node expected null but got Element node <template shadowroot="open">
-        <slot id="s1" name="...
+PASS Declarative Shadow DOM: Fragment parser basic test
 PASS Declarative Shadow DOM: Invalid shadow root attribute
-FAIL Declarative Shadow DOM: Closed shadow root attribute assert_equals: No template - converted to shadow root expected null but got Element node <template shadowroot="closed">
-      </template>
-FAIL Declarative Shadow DOM: Missing closing tag assert_equals: No leftover template node expected null but got Element node <template shadowroot="open">
-        <slot id="s1" name="...
-FAIL Declarative Shadow DOM: delegates focus attribute assert_true: No shadow root found expected true got false
-FAIL Declarative Shadow DOM: Multiple roots assert_equals: No leftover template nodes from either root expected null but got Element node <template shadowroot="open">
-    <span>root 1</span>
-  </...
+PASS Declarative Shadow DOM: Closed shadow root attribute
+PASS Declarative Shadow DOM: Missing closing tag
+PASS Declarative Shadow DOM: delegates focus attribute
+PASS Declarative Shadow DOM: Multiple roots
 FAIL Declarative Shadow DOM: template containing declarative shadow root assert_true: Inner div should have a shadow root expected true got false
 FAIL Declarative Shadow DOM: template containing (deeply nested) declarative shadow root assert_true: Inner div should have a shadow root expected true got false
 FAIL Declarative Shadow DOM: template containing a template containing declarative shadow root assert_true: Inner div should have a shadow root expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-opt-in.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-opt-in.tentative-expected.txt
@@ -1,7 +1,7 @@
 
 
 
-FAIL Non-fragment parsing needs no opt-in assert_true: Shadow root NOT FOUND. expected true got false
+PASS Non-fragment parsing needs no opt-in
 PASS innerHTML on a <a>
 PASS innerHTML on a <abbr>
 PASS innerHTML on a <address>
@@ -106,17 +106,17 @@ PASS innerHTML on a <wbr>
 PASS innerHTML on template
 PASS innerHTML on template, with nested template content
 PASS innerHTML on shadowRoot
-FAIL DOMParser assert_true: Shadow root NOT FOUND. expected true got false
+PASS DOMParser
 PASS createHTMLDocument with innerHTML - not supported
 PASS createContextualFragment - not supported
 PASS XMLHttpRequest - not supported
 PASS insertAdjacentHTML on element - not supported
-FAIL document.write allowed from synchronous script loaded from main document assert_true: Shadow root NOT FOUND. expected true got false
+PASS document.write allowed from synchronous script loaded from main document
 PASS document.write disallowed on fresh document
-FAIL iframe assert_true: Shadow root NOT FOUND. expected true got false
-FAIL iframe, no sandbox assert_true: Shadow root NOT FOUND. expected true got false
-FAIL sandboxed iframe allows declarative Shadow DOM assert_true: expected true got false
-FAIL iframe with no sandbox allows declarative Shadow DOM assert_true: expected true got false
+PASS iframe
+PASS iframe, no sandbox
+PASS sandboxed iframe allows declarative Shadow DOM
+PASS iframe with no sandbox allows declarative Shadow DOM
 
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/innerhtml-before-closing-tag.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/innerhtml-before-closing-tag.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Declarative Shadow DOM: innerHTML should work while parsing declarative shadow root <template> assert_true: Declarative shadow template should not be left over expected true got false
+PASS Declarative Shadow DOM: innerHTML should work while parsing declarative shadow root <template>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/move-template-before-closing-tag-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/move-template-before-closing-tag-expected.txt
@@ -1,5 +1,0 @@
-
-FAIL Moving the template node during parsing should attach to initial parent (content before observer) assert_true: Declarative shadow template should not be left over expected true got false
-FAIL Moving the template node during parsing should attach to initial parent (content after observer) assert_true: Declarative shadow template should not be left over expected true got false
-PASS Moving the template node from invalid parent to valid parent should still not attach
-

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/move-template-before-closing-tag.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/move-template-before-closing-tag.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Moving the template node during parsing should attach to initial parent (content before observer) assert_true: Declarative shadow template should not be left over expected true got false
-FAIL Moving the template node during parsing should attach to initial parent (content after observer) assert_true: Declarative shadow template should not be left over expected true got false
+PASS Moving the template node during parsing should attach to initial parent (content before observer)
+PASS Moving the template node during parsing should attach to initial parent (content after observer)
 PASS Moving the template node from invalid parent to valid parent should still not attach
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/script-access.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/script-access.tentative-expected.txt
@@ -1,5 +1,6 @@
 CONSOLE MESSAGE: Error: assert_equals: Declarative template content should be null expected null but got DocumentFragment node with 3 children
 CONSOLE MESSAGE: Error: assert_unreached: Unrecognized template Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: Unrecognized template Reached unreachable code
 
 Harness Error (FAIL), message = Error: assert_equals: Declarative template content should be null expected null but got DocumentFragment node with 3 children
 

--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -581,6 +581,18 @@ CrossOriginOpenerPolicyEnabled:
     WebCore:
       default: false
 
+DeclarativeShadowDOMEnabled:
+  type: bool
+  humanReadableName: "Declarative Shadow DOM"
+  humanReadableDescription: "Enable Declarative Shadow DOM"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 DefaultARIAForCustomElementsEnabled:
   type: bool
   humanReadableName: "Default ARIA for Custom Elements"

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1325,6 +1325,7 @@ set(WebCore_NON_SVG_IDL_FILES
 
     xml/CustomXPathNSResolver.idl
     xml/DOMParser.idl
+    xml/ParseFromStringOptions.idl
     xml/XMLHttpRequest.idl
     xml/XMLHttpRequestEventTarget.idl
     xml/XMLHttpRequestProgressEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1720,6 +1720,7 @@ $(PROJECT_DIR)/worklets/WorkletGlobalScope.idl
 $(PROJECT_DIR)/worklets/WorkletOptions.idl
 $(PROJECT_DIR)/xml/CustomXPathNSResolver.idl
 $(PROJECT_DIR)/xml/DOMParser.idl
+$(PROJECT_DIR)/xml/ParseFromStringOptions.idl
 $(PROJECT_DIR)/xml/XMLHttpRequest.idl
 $(PROJECT_DIR)/xml/XMLHttpRequestEventTarget.idl
 $(PROJECT_DIR)/xml/XMLHttpRequestProgressEvent.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1862,6 +1862,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPanningModelType.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPanningModelType.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSParentNode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSParentNode.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSParseFromStringOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSParseFromStringOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPath2D.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPath2D.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPayerErrorFields.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1535,6 +1535,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/worklets/WorkletOptions.idl \
     $(WebCore)/xml/CustomXPathNSResolver.idl \
     $(WebCore)/xml/DOMParser.idl \
+    $(WebCore)/xml/ParseFromStringOptions.idl \
     $(WebCore)/xml/XMLHttpRequest.idl \
     $(WebCore)/xml/XMLHttpRequestEventTarget.idl \
     $(WebCore)/xml/XMLHttpRequestProgressEvent.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3643,6 +3643,7 @@ JSPannerNode.cpp
 JSPannerOptions.cpp
 JSPanningModelType.cpp
 JSParentNode.cpp
+JSParseFromStringOptions.cpp
 JSPath2D.cpp
 JSPayerErrorFields.cpp
 JSPaymentAddress.cpp

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -84,16 +84,21 @@ ExceptionOr<Ref<DocumentType>> DOMImplementation::createDocumentType(const AtomS
 
 static inline Ref<XMLDocument> createXMLDocument(const String& namespaceURI, const Settings& settings)
 {
+    RefPtr<XMLDocument> document;
     if (namespaceURI == SVGNames::svgNamespaceURI)
-        return SVGDocument::create(nullptr, settings, URL());
-    if (namespaceURI == HTMLNames::xhtmlNamespaceURI)
-        return XMLDocument::createXHTML(nullptr, settings, URL());
-    return XMLDocument::create(nullptr, settings, URL());
+        document = SVGDocument::create(nullptr, settings, URL());
+    else if (namespaceURI == HTMLNames::xhtmlNamespaceURI)
+        document = XMLDocument::createXHTML(nullptr, settings, URL());
+    else
+        document = XMLDocument::create(nullptr, settings, URL());
+    document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    return document.releaseNonNull();
 }
 
 ExceptionOr<Ref<XMLDocument>> DOMImplementation::createDocument(const AtomString& namespaceURI, const AtomString& qualifiedName, DocumentType* documentType)
 {
     auto document = createXMLDocument(namespaceURI, m_document.settings());
+    document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
     document->setContextDocument(m_document.contextDocument());
     document->setSecurityOriginPolicy(m_document.securityOriginPolicy());
 
@@ -126,6 +131,7 @@ Ref<CSSStyleSheet> DOMImplementation::createCSSStyleSheet(const String&, const S
 Ref<HTMLDocument> DOMImplementation::createHTMLDocument(String&& title)
 {
     auto document = HTMLDocument::create(nullptr, m_document.settings(), URL(), { });
+    document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
     document->open();
     document->write(nullptr, { "<!doctype html><html><head></head><body></body></html>"_s });
     if (!title.isNull()) {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -544,6 +544,7 @@ Document::Document(Frame* frame, const Settings& settings, const URL& url, Docum
     , FrameDestructionObserver(frame)
     , m_settings(settings)
     , m_quirks(makeUniqueRef<Quirks>(*this))
+    , m_parserContentPolicy(DefaultParserContentPolicy)
     , m_cachedResourceLoader(createCachedResourceLoader(frame))
     , m_creationURL(url)
     , m_domTreeVersion(++s_globalTreeVersion)
@@ -2885,7 +2886,7 @@ void Document::setVisuallyOrdered()
 Ref<DocumentParser> Document::createParser()
 {
     // FIXME: this should probably pass the frame instead
-    return XMLDocumentParser::create(*this, view());
+    return XMLDocumentParser::create(*this, view(), m_parserContentPolicy);
 }
 
 bool Document::hasHighlight() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -37,6 +37,7 @@
 #include "DocumentEventTiming.h"
 #include "FocusOptions.h"
 #include "FontSelectorClient.h"
+#include "FragmentScriptingPermission.h"
 #include "FrameDestructionObserver.h"
 #include "FrameIdentifier.h"
 #include "FrameLoaderTypes.h"
@@ -891,6 +892,9 @@ public:
 
     Document& contextDocument() const;
     void setContextDocument(Document& document) { m_contextDocument = document; }
+    
+    OptionSet<ParserContentPolicy> parserContentPolicy() const { return m_parserContentPolicy; }
+    void setParserContentPolicy(OptionSet<ParserContentPolicy> policy) { m_parserContentPolicy = policy; }
 
     // Helper functions for forwarding DOMWindow event related tasks to the DOMWindow if it exists.
     void setWindowAttributeEventListener(const AtomString& eventType, const QualifiedName& attributeName, const AtomString& value, DOMWrapperWorld&);
@@ -1842,6 +1846,7 @@ private:
 
     RefPtr<DOMWindow> m_domWindow;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_contextDocument;
+    OptionSet<ParserContentPolicy> m_parserContentPolicy;
 
     Ref<CachedResourceLoader> m_cachedResourceLoader;
     RefPtr<DocumentParser> m_parser;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2690,14 +2690,31 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init)
 {
     if (!canAttachAuthorShadowRoot(*this))
         return Exception { NotSupportedError };
-    if (shadowRoot())
+    if (RefPtr shadowRoot = this->shadowRoot()) {
+        if (shadowRoot->isDeclarativeShadowRoot()) {
+            ChildListMutationScope mutation(*shadowRoot);
+            shadowRoot->removeChildren();
+            shadowRoot->setIsDeclarativeShadowRoot(false);
+            return *shadowRoot;
+        }
         return Exception { NotSupportedError };
+    }
     if (init.mode == ShadowRootMode::UserAgent)
         return Exception { TypeError };
     auto shadow = ShadowRoot::create(document(), init.mode, init.slotAssignment, init.delegatesFocus ? ShadowRoot::DelegatesFocus::Yes : ShadowRoot::DelegatesFocus::No, isPrecustomizedOrDefinedCustomElement() ? ShadowRoot::AvailableToElementInternals::Yes : ShadowRoot::AvailableToElementInternals::No);
     auto& result = shadow.get();
     addShadowRoot(WTFMove(shadow));
     return result;
+}
+
+ExceptionOr<ShadowRoot&> Element::attachDeclarativeShadow(ShadowRootMode mode, bool delegatesFocus)
+{
+    auto exceptionOrShadowRoot = attachShadow({ mode, delegatesFocus });
+    if (exceptionOrShadowRoot.hasException())
+        return exceptionOrShadowRoot.releaseException();
+    auto& shadowRoot = exceptionOrShadowRoot.releaseReturnValue();
+    shadowRoot.setIsDeclarativeShadowRoot(true);
+    return shadowRoot;
 }
 
 ShadowRoot* Element::shadowRootForBindings(JSC::JSGlobalObject& lexicalGlobalObject) const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -334,6 +334,7 @@ public:
     ShadowRoot* shadowRootForBindings(JSC::JSGlobalObject&) const;
 
     WEBCORE_EXPORT ExceptionOr<ShadowRoot&> attachShadow(const ShadowRootInit&);
+    ExceptionOr<ShadowRoot&> attachDeclarativeShadow(ShadowRootMode, bool delegatesFocus);
 
     RefPtr<ShadowRoot> userAgentShadowRoot() const;
     WEBCORE_EXPORT ShadowRoot& ensureUserAgentShadowRoot();

--- a/Source/WebCore/dom/FragmentScriptingPermission.h
+++ b/Source/WebCore/dom/FragmentScriptingPermission.h
@@ -35,7 +35,10 @@ enum class ParserContentPolicy {
     AllowScriptingContent = 1 << 0,
     AllowPluginContent = 1 << 1,
     DoNotMarkAlreadyStarted = 1 << 2,
+    AllowDeclarativeShadowDOM = 1 << 3,
 };
+
+constexpr OptionSet<ParserContentPolicy> DefaultParserContentPolicy = { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent, ParserContentPolicy::AllowDeclarativeShadowDOM };
 
 static inline bool scriptingContentIsAllowed(OptionSet<ParserContentPolicy> parserContentPolicy) 
 {

--- a/Source/WebCore/dom/ScriptableDocumentParser.h
+++ b/Source/WebCore/dom/ScriptableDocumentParser.h
@@ -51,10 +51,11 @@ public:
     void setWasCreatedByScript(bool wasCreatedByScript) { m_wasCreatedByScript = wasCreatedByScript; }
     bool wasCreatedByScript() const { return m_wasCreatedByScript; }
 
-    OptionSet<ParserContentPolicy> parserContentPolicy() { return m_parserContentPolicy; }
+    OptionSet<ParserContentPolicy> parserContentPolicy() const { return m_parserContentPolicy; }
+    void setParserContentPolicy(OptionSet<ParserContentPolicy> policy) { m_parserContentPolicy = policy; }
 
 protected:
-    explicit ScriptableDocumentParser(Document&, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    explicit ScriptableDocumentParser(Document&, OptionSet<ParserContentPolicy> = { DefaultParserContentPolicy });
 
     virtual void executeScriptsWaitingForStylesheets() { }
 

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -78,6 +78,8 @@ public:
     void setContainsFocusedElement(bool flag) { m_containsFocusedElement = flag; }
 
     bool isAvailableToElementInternals() const { return m_availableToElementInternals; }
+    bool isDeclarativeShadowRoot() const { return m_isDeclarativeShadowRoot; }
+    void setIsDeclarativeShadowRoot(bool flag) { m_isDeclarativeShadowRoot = flag; }
 
     Element* host() const { return m_host.get(); }
     void setHost(WeakPtr<Element, WeakPtrImplWithEventTargetData>&& host) { m_host = WTFMove(host); }
@@ -143,6 +145,7 @@ private:
     bool m_delegatesFocus { false };
     bool m_containsFocusedElement { false };
     bool m_availableToElementInternals { false };
+    bool m_isDeclarativeShadowRoot { false };
     ShadowRootMode m_type { ShadowRootMode::UserAgent };
     SlotAssignmentMode m_slotAssignmentMode { SlotAssignmentMode::Named };
 

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -389,6 +389,8 @@ scrolldelay
 scrolling
 select
 selected
+shadowroot
+shadowrootdelegatesfocus
 shape
 size
 sizes

--- a/Source/WebCore/html/HTMLDocument.cpp
+++ b/Source/WebCore/html/HTMLDocument.cpp
@@ -118,7 +118,7 @@ int HTMLDocument::height()
 
 Ref<DocumentParser> HTMLDocument::createParser()
 {
-    return HTMLDocumentParser::create(*this);
+    return HTMLDocumentParser::create(*this, parserContentPolicy());
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#dom-document-nameditem

--- a/Source/WebCore/html/HTMLTemplateElement.h
+++ b/Source/WebCore/html/HTMLTemplateElement.h
@@ -46,6 +46,8 @@ public:
     DocumentFragment& content() const;
     DocumentFragment* contentIfAvailable() const;
 
+    void attachAsDeclarativeShadowRootIfNeeded(Element&);
+
 private:
     HTMLTemplateElement(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -50,6 +50,7 @@
 #include "JSCustomElementInterface.h"
 #include "NotImplemented.h"
 #include "SVGElementInlines.h"
+#include "Settings.h"
 #include "Text.h"
 #include <unicode/ubrk.h>
 #include <wtf/text/TextBreakIterator.h>
@@ -728,6 +729,12 @@ inline Document& HTMLConstructionSite::ownerDocumentForCurrentNode()
     if (is<HTMLTemplateElement>(currentNode()))
         return downcast<HTMLTemplateElement>(currentNode()).content().document();
     return currentNode().document();
+}
+
+void HTMLConstructionSite::attachDeclarativeShadowRootIfNeeded(Element& shadowHost, HTMLTemplateElement& templateElement)
+{
+    if (m_parserContentPolicy.contains(ParserContentPolicy::AllowDeclarativeShadowDOM) && m_document.settings().declarativeShadowDOMEnabled() && !shadowHost.document().templateDocumentHost())
+        templateElement.attachAsDeclarativeShadowRootIfNeeded(shadowHost);
 }
 
 static inline JSCustomElementInterface* findCustomElementInterface(Document& ownerDocument, const AtomString& localName)

--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -99,6 +99,7 @@ struct CustomElementConstructionData;
 class Document;
 class Element;
 class HTMLFormElement;
+class HTMLTemplateElement;
 class JSCustomElementInterface;
 class WhitespaceCache;
 
@@ -174,6 +175,8 @@ public:
     RefPtr<HTMLFormElement> takeForm();
 
     OptionSet<ParserContentPolicy> parserContentPolicy() { return m_parserContentPolicy; }
+
+    void attachDeclarativeShadowRootIfNeeded(Element& host, HTMLTemplateElement&);
 
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
     bool isTelephoneNumberParsingEnabled() { return m_document.isTelephoneNumberParsingEnabled(); }

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -58,8 +58,8 @@ static bool isMainDocumentLoadingFromHTTP(const Document& document)
     return !document.ownerElement() && document.url().protocolIsInHTTPFamily();
 }
 
-HTMLDocumentParser::HTMLDocumentParser(HTMLDocument& document)
-    : ScriptableDocumentParser(document)
+HTMLDocumentParser::HTMLDocumentParser(HTMLDocument& document, OptionSet<ParserContentPolicy> policy)
+    : ScriptableDocumentParser(document, policy)
     , m_options(document)
     , m_tokenizer(m_options)
     , m_scriptRunner(makeUnique<HTMLScriptRunner>(document, static_cast<HTMLScriptRunnerHost&>(*this)))
@@ -70,9 +70,9 @@ HTMLDocumentParser::HTMLDocumentParser(HTMLDocument& document)
 {
 }
 
-Ref<HTMLDocumentParser> HTMLDocumentParser::create(HTMLDocument& document)
+Ref<HTMLDocumentParser> HTMLDocumentParser::create(HTMLDocument& document, OptionSet<ParserContentPolicy> policy)
 {
-    return adoptRef(*new HTMLDocumentParser(document));
+    return adoptRef(*new HTMLDocumentParser(document, policy));
 }
 
 inline HTMLDocumentParser::HTMLDocumentParser(DocumentFragment& fragment, Element& contextElement, OptionSet<ParserContentPolicy> rawPolicy)

--- a/Source/WebCore/html/parser/HTMLDocumentParser.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.h
@@ -48,7 +48,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HTMLDocumentParser);
 class HTMLDocumentParser : public ScriptableDocumentParser, private HTMLScriptRunnerHost, private PendingScriptClient {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(HTMLDocumentParser);
 public:
-    static Ref<HTMLDocumentParser> create(HTMLDocument&);
+    static Ref<HTMLDocumentParser> create(HTMLDocument&, OptionSet<ParserContentPolicy> = DefaultParserContentPolicy);
     virtual ~HTMLDocumentParser();
 
     static void parseDocumentFragment(const String&, DocumentFragment&, Element& contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
@@ -61,7 +61,7 @@ public:
     TextPosition textPosition() const final;
 
 protected:
-    explicit HTMLDocumentParser(HTMLDocument&);
+    explicit HTMLDocumentParser(HTMLDocument&, OptionSet<ParserContentPolicy> = DefaultParserContentPolicy);
 
     void insert(SegmentedString&&) final;
     void append(RefPtr<StringImpl>&&) override;

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -38,13 +38,17 @@ Ref<DOMParser> DOMParser::create(Document& contextDocument)
     return adoptRef(*new DOMParser(contextDocument));
 }
 
-ExceptionOr<Ref<Document>> DOMParser::parseFromString(const String& string, const String& contentType)
+ExceptionOr<Ref<Document>> DOMParser::parseFromString(const String& string, const String& contentType, ParseFromStringOptions options)
 {
     if (contentType != "text/html"_s && contentType != "text/xml"_s && contentType != "application/xml"_s && contentType != "application/xhtml+xml"_s && contentType != "image/svg+xml"_s)
         return Exception { TypeError };
     auto document = DOMImplementation::createDocument(contentType, nullptr, m_settings, URL { });
     if (m_contextDocument)
         document->setContextDocument(*m_contextDocument.get());
+    if (options.includeShadowRoots)
+        document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent, ParserContentPolicy::AllowDeclarativeShadowDOM });
+    else
+        document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
     document->setContent(string);
     if (m_contextDocument) {
         document->setURL(m_contextDocument->url());

--- a/Source/WebCore/xml/DOMParser.h
+++ b/Source/WebCore/xml/DOMParser.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "ExceptionOr.h"
+#include "ParseFromStringOptions.h"
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -32,7 +33,7 @@ public:
     static Ref<DOMParser> create(Document& contextDocument);
     ~DOMParser();
 
-    ExceptionOr<Ref<Document>> parseFromString(const String&, const String& contentType);
+    ExceptionOr<Ref<Document>> parseFromString(const String&, const String& contentType, ParseFromStringOptions);
 
 private:
     explicit DOMParser(Document& contextDocument);

--- a/Source/WebCore/xml/DOMParser.idl
+++ b/Source/WebCore/xml/DOMParser.idl
@@ -22,5 +22,5 @@
 ] interface DOMParser {
     [CallWith=CurrentDocument] constructor();
 
-    [NewObject] Document parseFromString(DOMString string, DOMString contentType);
+    [NewObject] Document parseFromString(DOMString string, DOMString contentType, optional ParseFromStringOptions options = {});
 };

--- a/Source/WebCore/xml/ParseFromStringOptions.h
+++ b/Source/WebCore/xml/ParseFromStringOptions.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+struct ParseFromStringOptions {
+    bool includeShadowRoots { false };
+};
+
+}

--- a/Source/WebCore/xml/ParseFromStringOptions.idl
+++ b/Source/WebCore/xml/ParseFromStringOptions.idl
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+dictionary ParseFromStringOptions {
+    boolean includeShadowRoots = false;
+};

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -184,6 +184,7 @@ ExceptionOr<Document*> XMLHttpRequest::responseXML()
                 responseDocument = HTMLDocument::create(nullptr, context.settings(), m_response.url(), { });
             else
                 responseDocument = XMLDocument::create(nullptr, context.settings(), m_response.url());
+            responseDocument->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
             responseDocument->overrideLastModified(m_response.lastModified());
             responseDocument->setContextDocument(context);
             responseDocument->setSecurityOriginPolicy(context.securityOriginPolicy());

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -63,9 +63,9 @@ private:
 class XMLDocumentParser final : public ScriptableDocumentParser, public PendingScriptClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<XMLDocumentParser> create(Document& document, FrameView* view)
+    static Ref<XMLDocumentParser> create(Document& document, FrameView* view, OptionSet<ParserContentPolicy> policy = DefaultParserContentPolicy)
     {
-        return adoptRef(*new XMLDocumentParser(document, view));
+        return adoptRef(*new XMLDocumentParser(document, view, policy));
     }
     static Ref<XMLDocumentParser> create(DocumentFragment& fragment, HashMap<AtomString, AtomString>&& prefixToNamespaceMap, const AtomString& defaultNamespaceURI, OptionSet<ParserContentPolicy> parserContentPolicy)
     {
@@ -88,7 +88,7 @@ public:
     static bool supportsXMLVersion(const String&);
 
 private:
-    explicit XMLDocumentParser(Document&, FrameView* = nullptr);
+    explicit XMLDocumentParser(Document&, FrameView*, OptionSet<ParserContentPolicy>);
     XMLDocumentParser(DocumentFragment&, HashMap<AtomString, AtomString>&&, const AtomString&, OptionSet<ParserContentPolicy>);
 
     void insert(SegmentedString&&) final;

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -598,8 +598,8 @@ bool XMLDocumentParser::supportsXMLVersion(const String& version)
     return version == "1.0"_s;
 }
 
-XMLDocumentParser::XMLDocumentParser(Document& document, FrameView* frameView)
-    : ScriptableDocumentParser(document)
+XMLDocumentParser::XMLDocumentParser(Document& document, FrameView* frameView, OptionSet<ParserContentPolicy> policy)
+    : ScriptableDocumentParser(document, policy)
     , m_view(frameView)
     , m_pendingCallbacks(makeUnique<PendingCallbacks>())
     , m_currentNode(&document)


### PR DESCRIPTION
#### 46837e56d6f57f7e52bf92c9534cc7683909eee5
<pre>
Prototype declarative shadow DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=245556">https://bugs.webkit.org/show_bug.cgi?id=245556</a>

Reviewed by Chris Dumez.

Implement the declarative shadow DOM an experimental feature.

See <a href="https://github.com/whatwg/html/pull/5465">https://github.com/whatwg/html/pull/5465</a> and <a href="https://github.com/whatwg/dom/pull/892">https://github.com/whatwg/dom/pull/892</a>

There are a few differences between what&apos;s being proposed and what we implement:
1. getInnerHTML method is not added; we&apos;ve given quite a few feedback on this method, and it&apos;s nowhere near ready for implementation.
2. Declarative shadow DOMs inside another template element doesn&apos;t automatically get converted to a shadow tree,
and there is no special treatment of declarative shadow DOM when cloning Nodes.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popups/popup-light-dismiss.tentative-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-attachment.tentative-expected.txt:
Rebaselined the test now that we pass more test cases.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic.tentative-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-opt-in.tentative-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/innerhtml-before-closing-tag.tentative-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/move-template-before-closing-tag-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/move-template-before-closing-tag.tentative-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/script-access.tentative-expected.txt: Rebaselined.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml: Added a runtime flag.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

* Source/WebCore/dom/DOMImplementation.cpp:
(WebCore::createXMLDocument): Disable declarative shadow DOM in a document created by DOMImplementation.createDocument.
(WebCore::DOMImplementation::createDocument): Ditto.
(WebCore::DOMImplementation::createHTMLDocument): Ditto.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::Document): Initialize newly introduced m_parserContentPolicy with DefaultParserContentPolicy.
(WebCore::Document::createParser): Specify m_parserContentPolicy as an argument to XMLDocumentParser::create.

* Source/WebCore/dom/Document.h:
(WebCore::Document::parserContentPolicy const): Added.
(WebCore::Document::setParserContentPolicy): Added.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::attachShadow): Returns the shadow root of declarative shadow DOM if one is available. This happens exactly once
since this function then clears the flag from ShadowRoot.
(WebCore::Element::attachDeclarativeShadow): Added.

* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/FragmentScriptingPermission.h:
(WebCore::ParserContentPolicy): Added AllowDeclarativeShadowDOM.

* Source/WebCore/dom/ScriptableDocumentParser.h:
(WebCore::ScriptableDocumentParser::parserContentPolicy const): Made this const.
(WebCore::ScriptableDocumentParser::setParserContentPolicy): Added.
(WebCore::ScriptableDocumentParser::ScriptableDocumentParser): Added

* Source/WebCore/dom/ShadowRoot.h:
(WebCore::ShadowRoot::isDeclarativeShadowRoot): Added.
(WebCore::ShadowRoot::setIsDeclarativeShadowRoot): Added.

* Source/WebCore/html/HTMLAttributeNames.in:

* Source/WebCore/html/HTMLDocument.cpp:
(WebCore::HTMLDocument::createParser): Pass in the parser content policy.

* Source/WebCore/html/HTMLTemplateElement.cpp:
(WebCore::HTMLTemplateElement::attachAsDeclarativeShadowRootIfNeeded): Added. Implements the main logic of declarative shadow DOM.

* Source/WebCore/html/HTMLTemplateElement.h:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::attachDeclarativeShadowRootIfNeeded): Added.

* Source/WebCore/html/parser/HTMLConstructionSite.h:

* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::HTMLDocumentParser): Takes OptionSet&lt;ParserContentPolicy&gt; as an argument.
(WebCore::HTMLDocumentParser::create): Ditto.

* Source/WebCore/html/parser/HTMLDocumentParser.h:

* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::processTemplateEndTag): Attach the template content as the declarative shadow DOM if applicable.

* Source/WebCore/xml/DOMParser.cpp:
(WebCore::DOMParser::parseFromString): Added ParseFromStringOptions as an argument.

* Source/WebCore/xml/DOMParser.h:
* Source/WebCore/xml/DOMParser.idl:

* Source/WebCore/xml/ParseFromStringOptions.h: Added.
* Source/WebCore/xml/ParseFromStringOptions.idl: Added.

* Source/WebCore/xml/XMLHttpRequest.cpp:
(XMLHttpRequest::responseXML): Disable declarative shadow DOM in the response document.

* Source/WebCore/xml/parser/XMLDocumentParser.h:
(WebCore::XMLDocumentParser::create): Takes OptionSet&lt;ParserContentPolicy&gt; as an argument.

* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::XMLDocumentParser): Ditto.

Canonical link: <a href="https://commits.webkit.org/254964@main">https://commits.webkit.org/254964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2561ad4601853a83739e9ba3b895847328358b0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100082 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158597 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33864 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83129 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96469 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96443 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77592 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26778 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81475 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69808 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82308 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34952 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15511 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77299 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32755 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16492 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26656 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3462 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36529 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39436 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/79890 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35581 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17497 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode (failure)") | 
<!--EWS-Status-Bubble-End-->