### PR TITLE
[JSC] Use destroying delete for ArrayBufferView

### DIFF
--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -2846,10 +2846,9 @@ bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
 void AccessCase::operator delete(AccessCase* accessCase, std::destroying_delete_t)
 {
     accessCase->runWithDowncast([](auto* accessCase) {
-        using T = std::decay_t<decltype(*accessCase)>;
-        accessCase->~T();
+        std::destroy_at(accessCase);
+        std::decay_t<decltype(*accessCase)>::freeAfterDestruction(accessCase);
     });
-    AccessCase::freeAfterDestruction(accessCase);
 }
 
 Ref<AccessCase> AccessCase::clone() const

--- a/Source/JavaScriptCore/bytecode/Watchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.cpp
@@ -64,10 +64,9 @@ inline void Watchpoint::runWithDowncast(const Func& func)
 void Watchpoint::operator delete(Watchpoint* watchpoint, std::destroying_delete_t)
 {
     watchpoint->runWithDowncast([](auto* derived) {
-        using T = std::decay_t<decltype(*derived)>;
-        derived->~T();
+        std::destroy_at(derived);
+        std::decay_t<decltype(*derived)>::freeAfterDestruction(derived);
     });
-    Watchpoint::freeAfterDestruction(watchpoint);
 }
 
 Watchpoint::~Watchpoint()

--- a/Source/JavaScriptCore/jit/JITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/JITStubRoutine.cpp
@@ -106,9 +106,8 @@ void JITStubRoutine::markRequiredObjects(SlotVisitor& visitor)
 void JITStubRoutine::operator delete(JITStubRoutine* stubRoutine, std::destroying_delete_t)
 {
     stubRoutine->runWithDowncast([&](auto* derived) {
-        using T = std::decay_t<decltype(*derived)>;
-        derived->~T();
-        T::freeAfterDestruction(derived);
+        std::destroy_at(derived);
+        std::decay_t<decltype(*derived)>::freeAfterDestruction(derived);
     });
 }
 

--- a/Source/JavaScriptCore/runtime/ArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBufferView.cpp
@@ -26,11 +26,14 @@
 #include "config.h"
 #include "ArrayBufferView.h"
 
+#include "DataView.h"
+#include "TypedArrayInlines.h"
+
 namespace JSC {
 
-ArrayBufferView::ArrayBufferView(
-    RefPtr<ArrayBuffer>&& buffer, size_t byteOffset, size_t byteLength)
-        : m_byteOffset(byteOffset)
+ArrayBufferView::ArrayBufferView(TypedArrayType type, RefPtr<ArrayBuffer>&& buffer, size_t byteOffset, size_t byteLength)
+        : m_type(type)
+        , m_byteOffset(byteOffset)
         , m_byteLength(byteLength)
         , m_buffer(WTFMove(buffer))
 {
@@ -41,10 +44,40 @@ ArrayBufferView::ArrayBufferView(
         m_baseAddress = BaseAddress(static_cast<char*>(m_buffer->data()) + m_byteOffset, byteLength);
 }
 
-ArrayBufferView::~ArrayBufferView()
+template<typename Visitor> constexpr decltype(auto) ArrayBufferView::visitDerived(Visitor&& visitor)
 {
-    if (!m_isDetachable)
-        m_buffer->unpin();
+    switch (m_type) {
+    case TypedArrayType::NotTypedArray:
+    case TypedArrayType::TypeDataView:
+        return std::invoke(std::forward<Visitor>(visitor), static_cast<DataView&>(*this));
+#define DECLARE_TYPED_ARRAY_TYPE(name) \
+    case TypedArrayType::Type##name: \
+        return std::invoke(std::forward<Visitor>(visitor), static_cast<name##Array&>(*this));
+    FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(DECLARE_TYPED_ARRAY_TYPE)
+#undef DECLARE_TYPED_ARRAY_TYPE
+    }
+    ASSERT_NOT_REACHED();
+}
+
+template<typename Visitor> constexpr decltype(auto) ArrayBufferView::visitDerived(Visitor&& visitor) const
+{
+    return const_cast<ArrayBufferView&>(*this).visitDerived([&](auto& value) {
+        return std::invoke(std::forward<Visitor>(visitor), std::as_const(value));
+    });
+}
+
+JSArrayBufferView* ArrayBufferView::wrap(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject)
+{
+    return visitDerived([&](auto& derived) { return derived.wrapImpl(lexicalGlobalObject, globalObject); });
+}
+
+void ArrayBufferView::operator delete(ArrayBufferView* value, std::destroying_delete_t)
+{
+    value->visitDerived([](auto& value) {
+        using T = std::decay_t<decltype(value)>;
+        std::destroy_at(&value);
+        T::freeAfterDestruction(&value);
+    });
 }
 
 void ArrayBufferView::setDetachable(bool flag)

--- a/Source/JavaScriptCore/runtime/DataView.cpp
+++ b/Source/JavaScriptCore/runtime/DataView.cpp
@@ -33,7 +33,7 @@
 namespace JSC {
 
 DataView::DataView(RefPtr<ArrayBuffer>&& buffer, size_t byteOffset, size_t byteLength)
-    : ArrayBufferView(WTFMove(buffer), byteOffset, byteLength)
+    : ArrayBufferView(TypeDataView, WTFMove(buffer), byteOffset, byteLength)
 {
 }
 
@@ -49,7 +49,7 @@ Ref<DataView> DataView::create(RefPtr<ArrayBuffer>&& buffer)
     return create(WTFMove(buffer), 0, byteLength);
 }
 
-JSArrayBufferView* DataView::wrap(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject)
+JSArrayBufferView* DataView::wrapImpl(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject)
 {
     return JSDataView::create(
         lexicalGlobalObject, globalObject->typedArrayStructure(TypeDataView), possiblySharedBuffer(), byteOffset(),

--- a/Source/JavaScriptCore/runtime/DataView.h
+++ b/Source/JavaScriptCore/runtime/DataView.h
@@ -34,13 +34,8 @@ class DataView final : public ArrayBufferView {
 public:
     JS_EXPORT_PRIVATE static Ref<DataView> create(RefPtr<ArrayBuffer>&&, size_t byteOffset, size_t length);
     static Ref<DataView> create(RefPtr<ArrayBuffer>&&);
-    
-    TypedArrayType getType() const final
-    {
-        return TypeDataView;
-    }
 
-    JSArrayBufferView* wrap(JSGlobalObject*, JSGlobalObject*) final;
+    JSArrayBufferView* wrapImpl(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject);
     
     template<typename T>
     T get(size_t offset, bool littleEndian, bool* status = nullptr)

--- a/Source/JavaScriptCore/runtime/GenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/GenericTypedArrayView.h
@@ -102,13 +102,8 @@ public:
     {
         return isSumSmallerThanOrEqual(offset, count, this->length());
     }
-    
-    TypedArrayType getType() const final
-    {
-        return Adaptor::typeValue;
-    }
 
-    JSArrayBufferView* wrap(JSGlobalObject*, JSGlobalObject*) final;
+    JSArrayBufferView* wrapImpl(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject);
 
 private:
     GenericTypedArrayView(RefPtr<ArrayBuffer>&&, size_t byteOffset, size_t length);

--- a/Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h
@@ -33,7 +33,7 @@ namespace JSC {
 template<typename Adaptor>
 GenericTypedArrayView<Adaptor>::GenericTypedArrayView(
 RefPtr<ArrayBuffer>&& buffer, size_t byteOffset, size_t length)
-    : ArrayBufferView(WTFMove(buffer), byteOffset, length * sizeof(typename Adaptor::Type))
+    : ArrayBufferView(Adaptor::typeValue, WTFMove(buffer), byteOffset, length * sizeof(typename Adaptor::Type))
 {
     ASSERT((length / sizeof(typename Adaptor::Type)) < std::numeric_limits<size_t>::max());
 }
@@ -120,7 +120,7 @@ GenericTypedArrayView<Adaptor>::tryCreateUninitialized(size_t length)
 }
 
 template<typename Adaptor>
-JSArrayBufferView* GenericTypedArrayView<Adaptor>::wrap(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject)
+JSArrayBufferView* GenericTypedArrayView<Adaptor>::wrapImpl(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject)
 {
     UNUSED_PARAM(lexicalGlobalObject);
     return Adaptor::JSViewType::create(globalObject->vm(), globalObject->typedArrayStructure(Adaptor::typeValue), this);

--- a/Source/JavaScriptCore/runtime/TypedArrayType.h
+++ b/Source/JavaScriptCore/runtime/TypedArrayType.h
@@ -50,7 +50,7 @@ struct ClassInfo;
     FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(macro) \
     macro(DataView)
 
-enum TypedArrayType {
+enum TypedArrayType : uint8_t {
     NotTypedArray,
 #define DECLARE_TYPED_ARRAY_TYPE(name) Type ## name,
     FOR_EACH_TYPED_ARRAY_TYPE(DECLARE_TYPED_ARRAY_TYPE)

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -123,10 +123,9 @@ void Callee::operator delete(Callee* callee, std::destroying_delete_t)
 {
     CalleeRegistry::singleton().unregisterCallee(callee);
     callee->runWithDowncast([](auto* derived) {
-        using T = std::decay_t<decltype(*derived)>;
-        derived->~T();
+        std::destroy_at(derived);
+        std::decay_t<decltype(*derived)>::freeAfterDestruction(derived);
     });
-    Callee::freeAfterDestruction(callee);
 }
 
 const HandlerInfo* Callee::handlerForIndex(Instance& instance, unsigned index, const Tag* tag)

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -259,8 +259,8 @@ void CSSValue::operator delete(CSSValue* value, std::destroying_delete_t)
 {
     value->visitDerived([](auto& value) {
         std::destroy_at(&value);
+        std::decay_t<decltype(value)>::freeAfterDestruction(&value);
     });
-    freeAfterDestruction(value);
 }
 
 Ref<DeprecatedCSSOMValue> CSSValue::createDeprecatedCSSOMWrapper(CSSStyleDeclaration& styleDeclaration) const

--- a/Source/WebCore/css/DeprecatedCSSOMValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMValue.cpp
@@ -33,18 +33,22 @@ namespace WebCore {
 
 void DeprecatedCSSOMValue::operator delete(DeprecatedCSSOMValue* value, std::destroying_delete_t)
 {
+    auto destroyAndFree = [&](auto& value) {
+        std::destroy_at(&value);
+        std::decay_t<decltype(value)>::freeAfterDestruction(&value);
+    };
+
     switch (value->classType()) {
     case ClassType::Complex:
-        std::destroy_at(downcast<DeprecatedCSSOMComplexValue>(value));
+        destroyAndFree(downcast<DeprecatedCSSOMComplexValue>(*value));
         break;
     case ClassType::Primitive:
-        std::destroy_at(downcast<DeprecatedCSSOMPrimitiveValue>(value));
+        destroyAndFree(downcast<DeprecatedCSSOMPrimitiveValue>(*value));
         break;
     case ClassType::List:
-        std::destroy_at(downcast<DeprecatedCSSOMValueList>(value));
+        destroyAndFree(downcast<DeprecatedCSSOMValueList>(*value));
         break;
     }
-    freeAfterDestruction(value);
 }
 
 unsigned short DeprecatedCSSOMValue::cssValueType() const

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -345,11 +345,15 @@ void Node::trackForDebugging()
 
 inline void NodeRareData::operator delete(NodeRareData* nodeRareData, std::destroying_delete_t)
 {
+    auto destroyAndFree = [&](auto& value) {
+        std::destroy_at(&value);
+        std::decay_t<decltype(value)>::freeAfterDestruction(&value);
+    };
+
     if (nodeRareData->m_isElementRareData)
-        static_cast<ElementRareData*>(nodeRareData)->~ElementRareData();
+        destroyAndFree(static_cast<ElementRareData&>(*nodeRareData));
     else
-        nodeRareData->~NodeRareData();
-    NodeRareData::freeAfterDestruction(nodeRareData);
+        destroyAndFree(*nodeRareData);
 }
 
 Node::Node(Document& document, ConstructionType type)


### PR DESCRIPTION
#### 4f3aa596bc546e675bd4cc421b1e125051ec7352
<pre>
[JSC] Use destroying delete for ArrayBufferView
<a href="https://bugs.webkit.org/show_bug.cgi?id=245653">https://bugs.webkit.org/show_bug.cgi?id=245653</a>

Reviewed by Darin Adler.

Set TypedArrayType in ArrayBufferView field and use destroying delete for destruction and the other tiny functions.
So, we remove vtable pointer for that class.

* Source/JavaScriptCore/runtime/ArrayBufferView.cpp:
(JSC::ArrayBufferView::ArrayBufferView):
(JSC::ArrayBufferView::visitDerived):
(JSC::ArrayBufferView::visitDerived const):
(JSC::ArrayBufferView::wrap):
(JSC::ArrayBufferView::operator delete):
* Source/JavaScriptCore/runtime/ArrayBufferView.h:
(JSC::ArrayBufferView::getType const):
* Source/JavaScriptCore/runtime/DataView.cpp:
(JSC::DataView::DataView):
(JSC::DataView::wrapImpl):
(JSC::DataView::wrap): Deleted.
* Source/JavaScriptCore/runtime/DataView.h:
* Source/JavaScriptCore/runtime/GenericTypedArrayView.h:
* Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h:
(JSC::GenericTypedArrayView&lt;Adaptor&gt;::GenericTypedArrayView):
(JSC::GenericTypedArrayView&lt;Adaptor&gt;::wrapImpl):
(JSC::GenericTypedArrayView&lt;Adaptor&gt;::wrap): Deleted.
* Source/JavaScriptCore/runtime/TypedArrayType.h:

Canonical link: <a href="https://commits.webkit.org/254891@main">https://commits.webkit.org/254891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d25f79a857b8d05b791fc1361e33b3de4599a22b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90571 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99904 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33655 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82935 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96334 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96226 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77416 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26629 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69652 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82144 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34754 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15402 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77093 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32569 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/16380 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26620 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3419 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36334 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/79679 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35469 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17461 "Passed tests") | 
<!--EWS-Status-Bubble-End-->