### PR TITLE
[WGSL] SourceSpan operator== signature is incorrect

### DIFF
--- a/Source/WebGPU/WGSL/SourceSpan.h
+++ b/Source/WebGPU/WGSL/SourceSpan.h
@@ -46,23 +46,22 @@ struct SourceSpan {
         , m_lineOffset(lineOffset)
         , m_offset(offset)
         , m_length(length)
-    {
-    }
+    { }
     
     SourceSpan(SourcePosition start, SourcePosition end)
-        : m_line(start.m_line)
-        , m_lineOffset(start.m_lineOffset)
-        , m_offset(start.m_offset)
-        , m_length(end.m_offset - start.m_offset)
-    {
-    }
+        : SourceSpan(start.m_line, start.m_lineOffset, start.m_offset, end.m_offset - start.m_offset)
+    { }
 
-    bool operator==(const SourceSpan& other)
+    bool operator==(const SourceSpan& other) const
     {
         return (m_line == other.m_line
             && m_lineOffset == other.m_lineOffset
             && m_offset == other.m_offset
             && m_length == other.m_length);
+    }
+    bool operator!=(const SourceSpan& other) const
+    {
+        return !(*this == other);
     }
 };
 


### PR DESCRIPTION
#### c2a2543ba247f84808fc2848867051a4cc710c88
<pre>
[WGSL] SourceSpan operator== signature is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=245659">https://bugs.webkit.org/show_bug.cgi?id=245659</a>
rdar://problem/100401133

Reviewed by Yusuke Suzuki.

The signature of SourceSpan::operator== is missing a const specifier.  Took the
opportunity to refactor SourceSpan constructors to reduce repetition.

* Source/WebGPU/WGSL/SourceSpan.h:

Canonical link: <a href="https://commits.webkit.org/254881@main">https://commits.webkit.org/254881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eece1fce63b4c37675646ef941e9d2c72eec8a3d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99823 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33572 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28774 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82851 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96264 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26707 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77340 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26562 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69576 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34672 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15347 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32489 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16324 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3412 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39241 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38165 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35413 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->