### PR TITLE
Implement EncodedVideoChunk

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/chunk-serialization.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/chunk-serialization.any-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL Verify EncodedAudioChunk is serializable. Can't find variable: EncodedAudioChunk
-FAIL Verify EncodedVideoChunk is serializable. Can't find variable: EncodedVideoChunk
+FAIL Verify EncodedVideoChunk is serializable. The object can not be cloned.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test we can construct an EncodedVideoChunk. Can't find variable: EncodedVideoChunk
-FAIL Test copyTo() exception if destiation invalid Can't find variable: EncodedVideoChunk
+PASS Test we can construct an EncodedVideoChunk.
+PASS Test copyTo() exception if destiation invalid
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test we can construct an EncodedVideoChunk. Can't find variable: EncodedVideoChunk
-FAIL Test copyTo() exception if destiation invalid Can't find variable: EncodedVideoChunk
+PASS Test we can construct an EncodedVideoChunk.
+PASS Test copyTo() exception if destiation invalid
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.crossOriginIsolated.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.crossOriginIsolated.https.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test construction and copyTo() using a SharedArrayBuffer Can't find variable: EncodedVideoChunk
-FAIL Test construction and copyTo() using a Uint8Array(SharedArrayBuffer) Can't find variable: EncodedVideoChunk
+FAIL Test construction and copyTo() using a SharedArrayBuffer Type error
+FAIL Test construction and copyTo() using a Uint8Array(SharedArrayBuffer) Type error
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.crossOriginIsolated.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.crossOriginIsolated.https.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test construction and copyTo() using a SharedArrayBuffer Can't find variable: EncodedVideoChunk
-FAIL Test construction and copyTo() using a Uint8Array(SharedArrayBuffer) Can't find variable: EncodedVideoChunk
+FAIL Test construction and copyTo() using a SharedArrayBuffer Type error
+FAIL Test construction and copyTo() using a Uint8Array(SharedArrayBuffer) Type error
 

--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -1838,6 +1838,19 @@ WebAuthenticationEnabled:
     WebCore:
       default: true
 
+WebCodecsEnabled:
+  type: bool
+  humanReadableName: "Web Codecs"
+  humanReadableDescription: "Web Codecs"
+  condition: ENABLE(WEB_CODECS)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 WebGL2Enabled:
   type: bool
   humanReadableName: "WebGL 2.0"

--- a/Source/WTF/wtf/PlatformEnableCocoa.h
+++ b/Source/WTF/wtf/PlatformEnableCocoa.h
@@ -718,6 +718,10 @@
 #define ENABLE_WEB_RTC 1
 #endif
 
+#if !defined(ENABLE_WEB_CODECS) && !PLATFORM(MACCATALYST) && !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
+#define ENABLE_WEB_CODECS 1
+#endif
+
 #if !defined(ENABLE_WEB_CRYPTO)
 #define ENABLE_WEB_CRYPTO 1
 #endif

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -707,6 +707,8 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/webcodecs/VideoColorSpaceInit.idl
     Modules/webcodecs/VideoMatrixCoefficients.idl
     Modules/webcodecs/VideoTransferCharacteristics.idl
+    Modules/webcodecs/WebCodecsEncodedVideoChunk.idl
+    Modules/webcodecs/WebCodecsEncodedVideoChunkType.idl
 
     Modules/webdatabase/DOMWindow+WebDatabase.idl
     Modules/webdatabase/Database.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -773,11 +773,16 @@ $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredentialType.idl
 $(PROJECT_DIR)/Modules/webauthn/ResidentKeyRequirement.idl
 $(PROJECT_DIR)/Modules/webauthn/UserVerificationRequirement.idl
+$(PROJECT_DIR)/Modules/webcodecs/PlaneLayout.idl
 $(PROJECT_DIR)/Modules/webcodecs/VideoColorPrimaries.idl
 $(PROJECT_DIR)/Modules/webcodecs/VideoColorSpace.idl
 $(PROJECT_DIR)/Modules/webcodecs/VideoColorSpaceInit.idl
 $(PROJECT_DIR)/Modules/webcodecs/VideoMatrixCoefficients.idl
+$(PROJECT_DIR)/Modules/webcodecs/VideoPixelFormat.idl
 $(PROJECT_DIR)/Modules/webcodecs/VideoTransferCharacteristics.idl
+$(PROJECT_DIR)/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl
+$(PROJECT_DIR)/Modules/webcodecs/WebCodecsEncodedVideoChunkType.idl
+$(PROJECT_DIR)/Modules/webcodecs/WebCodecsVideoFrame.idl
 $(PROJECT_DIR)/Modules/webdatabase/DOMWindow+WebDatabase.idl
 $(PROJECT_DIR)/Modules/webdatabase/Database.idl
 $(PROJECT_DIR)/Modules/webdatabase/DatabaseCallback.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1964,6 +1964,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPictureInPictureEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPictureInPictureEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPictureInPictureWindow.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPictureInPictureWindow.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPlaneLayout.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPlaneLayout.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPlaybackDirection.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPlaybackDirection.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPointerEvent.cpp
@@ -2736,6 +2738,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoFrameRequestCallback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoFrameRequestCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoMatrixCoefficients.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoMatrixCoefficients.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoPixelFormat.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoPixelFormat.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoPlaybackQuality.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoPlaybackQuality.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTrack+MediaSource.cpp
@@ -2768,6 +2772,12 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWaveShaperOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWaveShaperOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebAnimation.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebAnimation.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsEncodedVideoChunk.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsEncodedVideoChunk.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsEncodedVideoChunkType.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsEncodedVideoChunkType.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoFrame.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoFrame.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebFakeXRDevice.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebFakeXRDevice.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebFakeXRInputController.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -671,11 +671,13 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/webauthn/PublicKeyCredentialType.idl \
     $(WebCore)/Modules/webauthn/ResidentKeyRequirement.idl \
     $(WebCore)/Modules/webauthn/UserVerificationRequirement.idl \
-	$(WebCore)/Modules/webcodecs/VideoColorPrimaries.idl \
-	$(WebCore)/Modules/webcodecs/VideoColorSpace.idl \
-	$(WebCore)/Modules/webcodecs/VideoColorSpaceInit.idl \
-	$(WebCore)/Modules/webcodecs/VideoMatrixCoefficients.idl \
-	$(WebCore)/Modules/webcodecs/VideoTransferCharacteristics.idl \
+    $(WebCore)/Modules/webcodecs/VideoColorPrimaries.idl \
+    $(WebCore)/Modules/webcodecs/VideoColorSpace.idl \
+    $(WebCore)/Modules/webcodecs/VideoColorSpaceInit.idl \
+    $(WebCore)/Modules/webcodecs/VideoMatrixCoefficients.idl \
+    $(WebCore)/Modules/webcodecs/VideoTransferCharacteristics.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsEncodedVideoChunkType.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl \
     $(WebCore)/Modules/webdatabase/DOMWindow+WebDatabase.idl \
     $(WebCore)/Modules/webdatabase/Database.idl \
     $(WebCore)/Modules/webdatabase/DatabaseCallback.idl \

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCodecsEncodedVideoChunk.h"
+
+#if ENABLE(WEB_CODECS)
+
+#include "ExceptionOr.h"
+
+namespace WebCore {
+
+WebCodecsEncodedVideoChunk::WebCodecsEncodedVideoChunk(Init&& init)
+    : m_type(init.type)
+    , m_timestamp(init.timestamp)
+    , m_duration(init.duration)
+    , m_data(Span<const uint8_t> { init.data.data(), init.data.length() })
+{
+}
+
+ExceptionOr<void> WebCodecsEncodedVideoChunk::copyTo(BufferSource&& source)
+{
+    if (source.length() < m_data.size())
+        return Exception { TypeError, "buffer is too small"_s };
+
+    std::memcpy(source.mutableData(), m_data.data(), m_data.size());
+    return { };
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "BufferSource.h"
+#include "ExceptionOr.h"
+#include "WebCodecsEncodedVideoChunkType.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class WebCodecsEncodedVideoChunk : public RefCounted<WebCodecsEncodedVideoChunk> {
+public:
+    ~WebCodecsEncodedVideoChunk() = default;
+
+    struct Init {
+        WebCodecsEncodedVideoChunkType type { WebCodecsEncodedVideoChunkType::Key };
+        int64_t timestamp { 0 };
+        std::optional<uint64_t> duration;
+        BufferSource data;
+    };
+
+    static Ref<WebCodecsEncodedVideoChunk> create(Init&& init) { return adoptRef(*new WebCodecsEncodedVideoChunk(WTFMove(init))); }
+
+    WebCodecsEncodedVideoChunkType type() const { return m_type; };
+    int64_t timestamp() const { return m_timestamp; }
+    std::optional<uint64_t> duration() const { return m_duration; }
+    size_t byteLength() const { return m_data.capacity(); }
+
+    ExceptionOr<void> copyTo(BufferSource&&);
+
+private:
+    explicit WebCodecsEncodedVideoChunk(Init&&);
+
+    WebCodecsEncodedVideoChunkType m_type { WebCodecsEncodedVideoChunkType::Key };
+    int64_t m_timestamp { 0 };
+    std::optional<uint64_t> m_duration { 0 };
+    Vector<uint8_t> m_data;
+};
+
+}
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// FIXME: Support Serializable and Transferable.
+[
+    Conditional=WEB_CODECS,
+    EnabledBySetting=WebCodecsEnabled,
+    Exposed=(Window,DedicatedWorker),
+    InterfaceName=EncodedVideoChunk,
+] interface WebCodecsEncodedVideoChunk {
+  constructor(WebCodecsEncodedVideoChunkInit init);
+  readonly attribute WebCodecsEncodedVideoChunkType type;
+  readonly attribute long long timestamp;
+  readonly attribute unsigned long long? duration;
+  readonly attribute unsigned long byteLength;
+
+  undefined copyTo([AllowShared] BufferSource destination);
+};
+
+typedef [EnforceRange] long long WebCodecsEncodedVideoChunkInitTimestamp;
+typedef [EnforceRange] unsigned long long WebCodecsEncodedVideoChunkInitDuration;
+
+[
+    Conditional=WEB_CODECS
+] dictionary WebCodecsEncodedVideoChunkInit {
+  required WebCodecsEncodedVideoChunkType type;
+  WebCodecsEncodedVideoChunkInitTimestamp timestamp;
+  WebCodecsEncodedVideoChunkInitDuration duration;
+  required BufferSource data;
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkType.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkType.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+namespace WebCore {
+
+enum class WebCodecsEncodedVideoChunkType {
+    Key,
+    Delta
+};
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkType.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkType.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+[
+    Conditional=WEB_CODECS
+] enum WebCodecsEncodedVideoChunkType {
+    "key",
+    "delta",
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -392,6 +392,7 @@ Modules/webauthn/fido/FidoParsingUtils.cpp
 Modules/webauthn/fido/Pin.cpp
 Modules/webauthn/fido/U2fCommandConstructor.cpp
 Modules/webauthn/fido/U2fResponseConverter.cpp
+Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
 Modules/webdatabase/ChangeVersionWrapper.cpp
 Modules/webdatabase/DOMWindowWebDatabase.cpp
 Modules/webdatabase/Database.cpp
@@ -4111,6 +4112,8 @@ JSWakeLockType.cpp
 JSWaveShaperNode.cpp
 JSWaveShaperOptions.cpp
 JSWebAnimation.cpp
+JSWebCodecsEncodedVideoChunkType.cpp
+JSWebCodecsEncodedVideoChunk.cpp
 JSWebGL2RenderingContext.cpp
 JSWebGLActiveInfo.cpp
 JSWebGLBuffer.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -163,6 +163,7 @@ namespace WebCore {
     macro(DocumentTimeline) \
     macro(DynamicsCompressorNode) \
     macro(ElementInternals) \
+    macro(EncodedVideoChunk) \
     macro(ExtendableEvent) \
     macro(ExtendableMessageEvent) \
     macro(FakeXRDevice) \


### PR DESCRIPTION
#### fb9116e45d33db2050315c4915ad2ed9fe4036fe
<pre>
Implement EncodedVideoChunk
<a href="https://bugs.webkit.org/show_bug.cgi?id=245665">https://bugs.webkit.org/show_bug.cgi?id=245665</a>
rdar://problem/100401981

Reviewed by Eric Carlson.

Add WEB_CODECS compilation guard and runtime flag.
Implement WebCodecsEncodedVideoChunk and expose EncodedVideoChunk
as per <a href="https://w3c.github.io/webcodecs/#encodedvideochunk-interface.">https://w3c.github.io/webcodecs/#encodedvideochunk-interface.</a>

We do not support yet Transferable/Serializable.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/chunk-serialization.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.crossOriginIsolated.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.crossOriginIsolated.https.any.worker-expected.txt:
* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WTF/wtf/PlatformEnableCocoa.h:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp: Added.
(WebCore::WebCodecsEncodedVideoChunk::WebCodecsEncodedVideoChunk):
(WebCore::WebCodecsEncodedVideoChunk::copyTo):
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.h: Added.
(WebCore::WebCodecsEncodedVideoChunk::create):
(WebCore::WebCodecsEncodedVideoChunk::type const):
(WebCore::WebCodecsEncodedVideoChunk::timestamp const):
(WebCore::WebCodecsEncodedVideoChunk::duration const):
(WebCore::WebCodecsEncodedVideoChunk::byteLength const):
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkType.h: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkType.idl: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/254953@main">https://commits.webkit.org/254953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b3504f6f95850d3fd190ace7a604ad3114615a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100103 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33888 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83155 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/96498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96468 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77615 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26803 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69832 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82327 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34975 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/15525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77324 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32776 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16506 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26666 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3456 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36552 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/79916 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35595 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17508 "Passed tests") | 
<!--EWS-Status-Bubble-End-->