### PR TITLE
[ews] Add GitHub status-bubble support for PR against alternate remotes

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -138,7 +138,7 @@ class GitHub(object):
                 json=dict(body=ews_comment),
             )
             if response.status_code // 100 != 2:
-                _log.error('Failed to post comment to PR {}. Unexpected response code from GitHub: {}\n'.format(pr_number, response.status_code))
+                _log.error('Failed to post comment to PR {}. Unexpected response code from GitHub: {}, url: {}\n'.format(pr_number, response.status_code, comment_url))
                 return -1
             new_comment_id = response.json().get('id')
             comment_url = 'https://github.com/WebKit/WebKit/pull/{}#issuecomment-{}'.format(pr_number, new_comment_id)
@@ -335,10 +335,7 @@ class GitHubEWS(GitHub):
             _log.error('Invalid pr_id: {}'.format(pr_id))
             return -1
 
-        if pr_project and pr_project != 'WebKit/WebKit':
-            _log.error('custom pr_project is not support yet.')
-            # FIXME: Add support for custom pr_project (e.g.: apple/WebKit) https://bugs.webkit.org/show_bug.cgi?id=243987
-            return -1
+        repository_url = GITHUB_URL + pr_project if pr_project else None
 
         change = Change.get_change(sha)
         if not change:
@@ -347,7 +344,7 @@ class GitHubEWS(GitHub):
         gh = GitHubEWS()
         comment_text, folded_comment = gh.generate_comment_text_for_change(change)
         if not change.obsolete:
-            gh.update_pr_description_with_status_bubble(pr_id, comment_text)
+            gh.update_pr_description_with_status_bubble(pr_id, comment_text, repository_url)
 
         comment_id = change.comment_id
         if comment_id == -1:
@@ -355,16 +352,16 @@ class GitHubEWS(GitHub):
                 # FIXME: improve this logic to use locking instead
                 return -1
             _log.info('Adding comment for hash: {}, PR: {}'.format(sha, pr_id))
-            new_comment_id = gh.update_or_leave_comment_on_pr(pr_id, folded_comment, change=change)
+            new_comment_id = gh.update_or_leave_comment_on_pr(pr_id, folded_comment, repository_url=repository_url, change=change)
             obsolete_changes = Change.mark_old_changes_as_obsolete(pr_id, sha)
             for obsolete_change in obsolete_changes:
                 obsolete_comment_text, _ = gh.generate_comment_text_for_change(obsolete_change)
-                gh.update_or_leave_comment_on_pr(pr_id, obsolete_comment_text, comment_id=obsolete_change.comment_id, change=obsolete_change)
+                gh.update_or_leave_comment_on_pr(pr_id, obsolete_comment_text, repository_url=repository_url, comment_id=obsolete_change.comment_id, change=obsolete_change)
                 _log.info('Updated obsolete status-bubble on pr {} for hash: {}'.format(pr_id, obsolete_change.change_id))
 
         else:
             _log.info('Updating comment for hash: {}, pr_id: {}, pr_id from db: {}.'.format(sha, pr_id, change.pr_id))
-            new_comment_id = gh.update_or_leave_comment_on_pr(pr_id, folded_comment, comment_id=comment_id)
+            new_comment_id = gh.update_or_leave_comment_on_pr(pr_id, folded_comment, repository_url=repository_url, comment_id=comment_id)
 
         return comment_id
 


### PR DESCRIPTION
#### 60afff0cd0b6967758be7361233b1eedc49dc2ba
<pre>
[ews] Add GitHub status-bubble support for PR against alternate remotes
<a href="https://bugs.webkit.org/show_bug.cgi?id=243987">https://bugs.webkit.org/show_bug.cgi?id=243987</a>
&lt;rdar://99026301&gt;

Reviewed by Jonathan Bedard.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHub.update_or_leave_comment_on_pr):
(GitHubEWS.add_or_update_comment_for_change_id):

Canonical link: <a href="https://commits.webkit.org/254858@main">https://commits.webkit.org/254858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf7c887fad52286f32ec2874647a6560da655889

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35098 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99847 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/157922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33598 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82879 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96283 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96169 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77360 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/26585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/69601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34697 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32512 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36277 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1466 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38191 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->