### PR TITLE
[GStreamer][EME] Decryptor should be able to work in passthrough mode

### DIFF
--- a/LayoutTests/media/encrypted-media/encrypted-media-append-encrypted-unencrypted-expected.txt
+++ b/LayoutTests/media/encrypted-media/encrypted-media-append-encrypted-unencrypted-expected.txt
@@ -12,5 +12,8 @@ EVENT(keystatuseschange)
 Session: keyId=b0b1b2b3b4b5b6b7b8b9babbbcbdbebf status=usable OK
 All appends are completed
 EXPECTED (video.duration >= '15') OK
+RUN(video.currentTime = 2)
+Playing from second 2 to 4, switch from encrypted to unencrypted happens in second 3.
+EXPECTED (video.currentTime >= '4') OK
 END OF TEST
 

--- a/LayoutTests/media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html
+++ b/LayoutTests/media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html
@@ -21,7 +21,14 @@
          function checkEndTest() {
              consoleWrite("All appends are completed");
              testExpected('video.duration', 15, '>=');
-             endTest();
+             run('video.currentTime = 2');
+             consoleWrite("Playing from second 2 to 4, switch from encrypted to unencrypted happens in second 3.");
+             video.addEventListener('timeupdate', function onTimeUpdate(event) {
+                 if (video.currentTime >= 4) {
+                     testExpected('video.currentTime', 4, '>=');
+                     endTest();
+                 }
+             });
          }
 
          consoleWrite("Appending chunks...");


### PR DESCRIPTION
#### 9610941b7e544003021f04faf8f1f033be125866
<pre>
[GStreamer][EME] Decryptor should be able to work in passthrough mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=245575">https://bugs.webkit.org/show_bug.cgi?id=245575</a>

Reviewed by Philippe Normand.

In some cases, some websites append unencrypted content (ads) while encrypted content is playing.
To make this work we can set the decryptor in passthrough mode. For that we check the sink caps
against the source caps and if they match, we can set the object in passthrough mode and let the
super class handle the buffers.

Test: media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html.

* LayoutTests/media/encrypted-media/encrypted-media-append-encrypted-unencrypted-expected.txt:
* LayoutTests/media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html:
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(webkit_media_common_encryption_decrypt_class_init):
(transformCaps):
(acceptCaps):

Canonical link: <a href="https://commits.webkit.org/254910@main">https://commits.webkit.org/254910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/095ddc668be601b785f26b1b00a7a3e616bc617e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99872 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158230 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33623 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28810 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82904 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96307 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26760 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77385 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26603 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69623 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34722 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15382 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32537 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16360 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3432 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36302 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39279 "Found 1 new test failure: css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-relayouts.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35449 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->