### PR TITLE
RunLoop lacks a create operation

### DIFF
--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -39,6 +39,7 @@
 #include <wtf/Seconds.h>
 #include <wtf/ThreadSafetyAnalysis.h>
 #include <wtf/ThreadSpecific.h>
+#include <wtf/Threading.h>
 #include <wtf/ThreadingPrimitives.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
@@ -86,6 +87,8 @@ public:
     WTF_EXPORT_PRIVATE static RunLoop& web();
     WTF_EXPORT_PRIVATE static RunLoop* webIfExists();
 #endif
+    WTF_EXPORT_PRIVATE static Ref<RunLoop> create(const char* threadName, ThreadType = ThreadType::Unknown, Thread::QOS = Thread::QOS::UserInitiated);
+
     WTF_EXPORT_PRIVATE static bool isMain();
     WTF_EXPORT_PRIVATE ~RunLoop() final;
 

--- a/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
+++ b/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
@@ -41,16 +41,15 @@ WorkQueueBase::WorkQueueBase(RunLoop& runLoop)
 
 void WorkQueueBase::platformInitialize(const char* name, Type, QOS qos)
 {
-    BinarySemaphore semaphore;
-    Thread::create(name, [&] {
+    m_runLoop = RunLoop::create(name, ThreadType::Unknown, qos).ptr();
 #if ASSERT_ENABLED
+    BinarySemaphore semaphore;
+    m_runLoop->dispatch([&] {
         m_threadID = Thread::current().uid();
-#endif
-        m_runLoop = &RunLoop::current();
         semaphore.signal();
-        m_runLoop->run();
-    }, ThreadType::Unknown, qos)->detach();
+    });
     semaphore.wait();
+#endif
 }
 
 void WorkQueueBase::platformInvalidate()

--- a/Source/WebCore/page/scrolling/ScrollingThread.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingThread.cpp
@@ -31,7 +31,6 @@
 #include <mutex>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
-#include <wtf/threads/BinarySemaphore.h>
 
 namespace WebCore {
 
@@ -47,21 +46,13 @@ ScrollingThread& ScrollingThread::singleton()
 }
 
 ScrollingThread::ScrollingThread()
+    : m_runLoop(RunLoop::create("WebCore: Scrolling"_s, ThreadType::Graphics, Thread::QOS::UserInteractive))
 {
-    BinarySemaphore semaphore;
-    m_thread = Thread::create("WebCore: Scrolling", [this, &semaphore] {
-        Thread::setCurrentThreadIsUserInteractive();
-        m_runLoop = &RunLoop::current();
-        semaphore.signal();
-        m_runLoop->run();
-    });
-
-    semaphore.wait();
 }
 
 bool ScrollingThread::isCurrentThread()
 {
-    return ScrollingThread::singleton().m_thread == &Thread::current();
+    return ScrollingThread::singleton().m_runLoop.ptr() == &RunLoop::current();
 }
 
 void ScrollingThread::dispatch(Function<void ()>&& function)

--- a/Source/WebCore/page/scrolling/ScrollingThread.h
+++ b/Source/WebCore/page/scrolling/ScrollingThread.h
@@ -58,10 +58,9 @@ private:
     ScrollingThread();
 
     void dispatchFunctionsFromScrollingThread();
-    RunLoop& runLoop() { return *m_runLoop; }
+    RunLoop& runLoop() { return m_runLoop; }
 
-    RefPtr<Thread> m_thread;
-    RunLoop* m_runLoop { nullptr };
+    Ref<RunLoop> m_runLoop;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h
@@ -68,7 +68,7 @@ private:
 
     void updateTimerFired();
 
-    RunLoop* m_runLoop { nullptr };
+    Ref<RunLoop> m_runLoop;
     RunLoop::Timer<CompositingRunLoop> m_updateTimer;
     Function<void ()> m_updateFunction;
     Lock m_dispatchSyncConditionLock;


### PR DESCRIPTION
#### 2b6f2e9cb51ed9c4a01ce76efdab7e1dff3c637b
<pre>
RunLoop lacks a create operation
<a href="https://bugs.webkit.org/show_bug.cgi?id=245673">https://bugs.webkit.org/show_bug.cgi?id=245673</a>
rdar://problem/100411103

Reviewed by Antti Koivisto and Žan Doberšek.

Move existing logic to RunLoop::create(). This makes future new invocations
less error prone.

* Source/WTF/wtf/RunLoop.cpp:
(WTF::RunLoop::create):
* Source/WTF/wtf/RunLoop.h:
* Source/WTF/wtf/generic/WorkQueueGeneric.cpp:
(WTF::WorkQueueBase::platformInitialize):
* Source/WebCore/page/scrolling/ScrollingThread.cpp:
(WebCore::ScrollingThread::ScrollingThread):
(WebCore::ScrollingThread::isCurrentThread):
* Source/WebCore/page/scrolling/ScrollingThread.h:
(WebCore::ScrollingThread::runLoop):
(): Deleted.
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.cpp:
(WebKit::CompositingRunLoop::CompositingRunLoop):
(WebKit::createRunLoop): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/254945@main">https://commits.webkit.org/254945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dca24bf2dd00932de83a4ef27c724f92a780557c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99995 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158317 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33758 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28893 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83038 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96394 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26866 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77503 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26710 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69738 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34850 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15454 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32662 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16434 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3450 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39372 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35523 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->