### PR TITLE
[git-webkit] Pull branch name from commit message

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.6.13',
+    version='5.6.14',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 6, 13)
+version = Version(5, 6, 14)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py
@@ -25,6 +25,7 @@ import six
 import re
 
 from datetime import datetime
+from webkitbugspy import Tracker
 from webkitscmpy import Contributor
 
 
@@ -277,6 +278,27 @@ class Commit(object):
         if self.timestamp is None:
             return None
         return self.timestamp * self.UUID_MULTIPLIER + self.order
+
+    @property
+    def issues(self):
+        if not self.message:
+            return []
+        result = []
+        links = set()
+        seen_empty = False
+        for line in self.message.splitlines():
+            if not line and seen_empty:
+                break
+            elif not line:
+                seen_empty = True
+                continue
+            words = line.split()
+            for word in [words[0], words[-1]] if words[0] != words[-1] else [words[0]]:
+                candidate = Tracker.from_string(word)
+                if candidate and candidate.link not in links:
+                    result.append(candidate)
+                    links.add(candidate.link)
+        return result
 
     def __repr__(self):
         if self.branch_point and self.identifier is not None and self.branch:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py
@@ -27,13 +27,15 @@ import unittest
 
 from mock import patch
 from datetime import datetime
-from webkitbugspy import bugzilla, mocks as bmocks
+from webkitbugspy import bugzilla, mocks as bmocks, Tracker, radar
 from webkitcorepy import OutputCapture, testing
 from webkitcorepy.mocks import Environment
 from webkitscmpy import Contributor, Commit, program, mocks
 
 
 class TestCommit(unittest.TestCase):
+    BUGZILLA = 'https://bugs.example.com'
+
     def test_parse_hash(self):
         self.assertEqual(
             '1a2e41e3f7cdf51b1e1d02880cfb65eab9327ef2',
@@ -304,6 +306,46 @@ PRINTED
                 message='Message'
             ),
         )
+
+    def test_parse_issues(self):
+        contributor = Contributor.from_scm_log('Author: jbedard@apple.com <jbedard@apple.com>')
+        commit = Commit(
+            revision=1,
+            hash='c3bd784f8b88bd03f64467ddd3304ed8be28acbe',
+            identifier='1@main',
+            timestamp=1000,
+            author=Contributor.Encoder().default(contributor),
+            message='Commit title\n'
+                    'https://bugs.example.com/show_bug.cgi?id=1\n'
+                    '<rdar://problem/2>\n\n'
+                    'Reviewed by NOBODY (OOPS!)\n\n'
+                    'Will fix this in https://bugs.example.com/show_bug.cgi?id=3 and <rdar://problem/4>\n',
+        )
+
+        with patch('webkitbugspy.Tracker._trackers', []):
+            self.assertEqual([], commit.issues)
+
+        with bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual([
+                Tracker.from_string('https://bugs.example.com/show_bug.cgi?id=1'),
+            ], commit.issues)
+
+        with bmocks.Radar(), patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+            self.assertEqual([
+                Tracker.from_string('<rdar://problem/2>'),
+            ], commit.issues)
+
+        with bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+        ), bmocks.Radar(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA), radar.Tracker()]):
+            self.assertEqual([
+                Tracker.from_string('https://bugs.example.com/show_bug.cgi?id=1'),
+                Tracker.from_string('<rdar://problem/2>'),
+            ], commit.issues)
 
 
 class TestDoCommit(testing.PathTestCase):


### PR DESCRIPTION
#### 00b8477c7f93324fb03a3adb886ad0a4f3d6a72f
<pre>
[git-webkit] Pull branch name from commit message
<a href="https://bugs.webkit.org/show_bug.cgi?id=245675">https://bugs.webkit.org/show_bug.cgi?id=245675</a>
&lt;rdar://problem/100412099&gt;

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py:
(Commit.issues): Parse the commit message for issues.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.title_for): Handle case where commit message is empty.
(PullRequest.pull_request_branch_point): Extract the associated issue from the commit message of a local
commit, if possible.
(PullRequest.is_revert_commit): Handle case where commit message is empty.
(PullRequest.add_comment_to_reverted_commit_bug_tracker): Use Commit object&apos;s issues list.
(PullRequest.create_pull_request): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py:
(TestCommit):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/255245@main">https://commits.webkit.org/255245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c8b904b7e38ba443b8d66af574e05797879e42e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1134 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/101555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95891 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/1132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97548 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/1132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/84207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/95464 "webkitpy-tests (failure)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/1132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/35990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/90949 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/33727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/37600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1640 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/39484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->