### PR TITLE
Draft PR to see if the two commits can be merged

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4442,8 +4442,6 @@ webkit.org/b/221474 imported/w3c/web-platform-tests/css/css-flexbox/svg-root-as-
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-001.html [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-003.html [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-004.html [ ImageOnlyFailure ]
-webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-006.xhtml [ ImageOnlyFailure ]
-webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-007.xhtml [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-008.xhtml [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-baseline-multi-line-vert-001.html [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-baseline-multi-line-vert-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4442,8 +4442,6 @@ webkit.org/b/221474 imported/w3c/web-platform-tests/css/css-flexbox/svg-root-as-
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-001.html [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-003.html [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-004.html [ ImageOnlyFailure ]
-webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-001a.xhtml [ ImageOnlyFailure ]
-webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-001b.xhtml [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-006.xhtml [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-007.xhtml [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-008.xhtml [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-005-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 2
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 2
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-006-expected.txt
@@ -13,9 +13,7 @@ PASS .container > div 3
 FAIL .container > div 4 assert_equals:
 <div class="container"><div style="align-self: baseline" data-offset-x="2" data-offset-y="1"></div></div>
 offsetLeft expected 2 but got 10
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 2
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -29,9 +27,7 @@ PASS .container > div 15
 FAIL .container > div 16 assert_equals:
 <div class="container"><div style="align-self: baseline" data-offset-x="2" data-offset-y="1"></div></div>
 offsetLeft expected 2 but got -2
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 2
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-007-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="5"></div></div>
-offsetLeft expected 10 but got 2
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetLeft expected -2 but got 2
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-008-expected.txt
@@ -13,9 +13,7 @@ PASS .container > div 3
 FAIL .container > div 4 assert_equals:
 <div class="container"><div style="align-self: baseline" data-offset-x="2" data-offset-y="5"></div></div>
 offsetLeft expected 2 but got 10
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="5"></div></div>
-offsetLeft expected 10 but got 2
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -29,9 +27,7 @@ PASS .container > div 15
 FAIL .container > div 16 assert_equals:
 <div class="container"><div style="align-self: baseline" data-offset-x="2" data-offset-y="-3"></div></div>
 offsetLeft expected 2 but got -2
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetLeft expected -2 but got 2
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-003-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 10
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got -2
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-004-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 10
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got -2
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-002-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 10
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -27,9 +25,7 @@ PASS .container > div 15
 PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
-FAIL .container > div 19 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got -2
+PASS .container > div 19
 PASS .container > div 20
 PASS .container > div 21
 PASS .container > div 22

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-003-expected.txt
@@ -11,9 +11,7 @@ PASS .container > div 1
 PASS .container > div 2
 PASS .container > div 3
 PASS .container > div 4
-FAIL .container > div 5 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 1
+PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
@@ -25,9 +23,7 @@ PASS .container > div 13
 PASS .container > div 14
 PASS .container > div 15
 PASS .container > div 16
-FAIL .container > div 17 assert_equals:
-<div class="container"><div style="align-self: last baseline" data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got 1
+PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -62,6 +62,7 @@
 #include "RenderTheme.h"
 #include "RenderView.h"
 #include "Settings.h"
+#include <wtf/Assertions.h>
 
 namespace WebCore {
 namespace LayoutIntegration {
@@ -575,13 +576,29 @@ LayoutUnit LineLayout::firstLinePhysicalBaseline() const
     }
 
     auto& firstLine = m_inlineContent->lines.first();
+    return physicalBaselineFromWritingMode(firstLine); 
+}
+
+LayoutUnit LineLayout::lastLinePhysicalBaseline() const
+{
+    if (!m_inlineContent || m_inlineContent->lines.isEmpty()) {
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+
+    Line& lastLine = m_inlineContent->lines.last();
+    return physicalBaselineFromWritingMode(lastLine);
+}
+
+LayoutUnit LineLayout::physicalBaselineFromWritingMode(LayoutIntegration::Line& line) const
+{
     switch (rootLayoutBox().style().writingMode()) {
     case WritingMode::TopToBottom:
-        return LayoutUnit { firstLine.lineBoxTop() + firstLine.baseline() };
+        return LayoutUnit { line.lineBoxTop() + line.baseline() };
     case WritingMode::LeftToRight:
-        return LayoutUnit { firstLine.lineBoxLeft() + (firstLine.lineBoxWidth() - firstLine.baseline()) };
+        return LayoutUnit { line.lineBoxLeft() + (line.lineBoxWidth() - line.baseline()) };
     case WritingMode::RightToLeft:
-        return LayoutUnit { firstLine.lineBoxLeft() + firstLine.baseline() };
+        return LayoutUnit { line.lineBoxLeft() + line.baseline() };
     default:
         ASSERT_NOT_REACHED();
         return { };

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -33,6 +33,7 @@
 #include "LayoutPoint.h"
 #include "LayoutState.h"
 #include "RenderObjectEnums.h"
+#include "layout/integration/inline/LayoutIntegrationLine.h"
 #include <wtf/CheckedPtr.h>
 
 namespace WebCore {
@@ -102,6 +103,7 @@ public:
     size_t lineCount() const;
     bool hasVisualOverflow() const;
     LayoutUnit firstLinePhysicalBaseline() const;
+    LayoutUnit lastLinePhysicalBaseline() const;
     LayoutUnit lastLineLogicalBaseline() const;
     LayoutRect firstInlineBoxRect(const RenderInline&) const;
     LayoutRect enclosingBorderBoxRectFor(const RenderInline&) const;
@@ -137,6 +139,8 @@ private:
     void clearInlineContent();
     void releaseCaches();
 
+    LayoutUnit physicalBaselineFromWritingMode(LayoutIntegration::Line&) const;
+    
     BoxTree m_boxTree;
     Layout::LayoutState m_layoutState;
     Layout::InlineFormattingState& m_inlineFormattingState;

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2546,13 +2546,25 @@ std::optional<LayoutUnit> RenderBlock::firstLineBaseline() const
     if (isWritingModeRoot() && !isRubyRun())
         return std::optional<LayoutUnit>();
 
-    for (RenderBox* curr = firstChildBox(); curr; curr = curr->nextSiblingBox()) {
-        if (!curr->isFloatingOrOutOfFlowPositioned()) {
-            if (auto result = curr->firstLineBaseline())
-                return LayoutUnit { curr->logicalTop() + result.value() }; // Translate to our coordinate space.
-        }
+    for (RenderBox* child = firstInFlowChildBox(); child; child = child->nextInFlowSiblingBox()) {
+        if (auto baseline = child->firstLineBaseline())
+            return LayoutUnit { baseline.value() + child->logicalTop() };
     }
+    return std::optional<LayoutUnit>();
+}
 
+std::optional<LayoutUnit> RenderBlock::lastLineBaseline() const
+{
+    if (shouldApplyLayoutContainment())
+        return std::nullopt;
+
+    if (isWritingModeRoot() && !isRubyRun())
+        return std::optional<LayoutUnit>();
+
+    for (RenderBox* child = lastInFlowChildBox(); child; child = child->nextInFlowSiblingBox()) {
+        if (auto baseline = child->lastLineBaseline())
+            return LayoutUnit { baseline.value() + child->logicalTop() };
+    } 
     return std::optional<LayoutUnit>();
 }
 

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -356,6 +356,7 @@ protected:
     void computePreferredLogicalWidths() override;
     
     std::optional<LayoutUnit> firstLineBaseline() const override;
+    std::optional<LayoutUnit> lastLineBaseline() const override;
     std::optional<LayoutUnit> inlineBlockBaseline(LineDirectionMode) const override;
 
     // Delay updating scrollbars until endAndCommitUpdateScrollInfoAfterLayoutTransaction() is called. These functions are used

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -68,6 +68,7 @@
 #include "TextAutoSizing.h"
 #include "VerticalPositionCache.h"
 #include "VisiblePosition.h"
+#include "rendering/LegacyRootInlineBox.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -2996,6 +2997,32 @@ std::optional<LayoutUnit> RenderBlockFlow::firstLineBaseline() const
     if (style().isFlippedLinesWritingMode())
         return LayoutUnit { firstRootBox()->logicalTop() + firstLineStyle().metricsOfPrimaryFont().descent(firstRootBox()->baselineType()) };
     return LayoutUnit { firstRootBox()->logicalTop() + firstLineStyle().metricsOfPrimaryFont().ascent(firstRootBox()->baselineType()) };
+}
+
+std::optional<LayoutUnit> RenderBlockFlow::lastLineBaseline() const
+{
+    if (isWritingModeRoot() && !isRubyRun() && !isGridItem())
+        return std::nullopt;
+
+    if (shouldApplyLayoutContainment())
+        return std::nullopt;
+
+    if (!childrenInline())
+        return RenderBlock::lastLineBaseline();
+
+    if (!hasLines())
+        return std::nullopt;
+
+    const LayoutIntegration::LineLayout* lineLayout = modernLineLayout();
+    if (lineLayout)
+        return LayoutUnit { floorToInt(lineLayout->lastLinePhysicalBaseline()) };
+
+    ASSERT(lastRootBox()); 
+    LegacyRootInlineBox* rootBox = lastRootBox();
+    const RenderStyle& lastLineBoxStyle = InlineIterator::lastLineBoxFor(*this)->style();
+    if (style().isFlippedLinesWritingMode())
+        return LayoutUnit { rootBox->logicalTop() + lastLineBoxStyle.metricsOfPrimaryFont().descent(rootBox->baselineType()) };
+    return LayoutUnit { rootBox->logicalTop() + lastLineBoxStyle.metricsOfPrimaryFont().ascent(rootBox->baselineType()) };
 }
 
 std::optional<LayoutUnit> RenderBlockFlow::inlineBlockBaseline(LineDirectionMode lineDirection) const

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -430,6 +430,7 @@ protected:
     void createFloatingObjects();
 
     std::optional<LayoutUnit> firstLineBaseline() const override;
+    std::optional<LayoutUnit> lastLineBaseline() const override;
     std::optional<LayoutUnit> inlineBlockBaseline(LineDirectionMode) const override;
 
     bool isMultiColumnBlockFlow() const override { return multiColumnFlow(); }

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -186,9 +186,12 @@ public:
     // Note these functions are not equivalent of childrenOfType<RenderBox>
     RenderBox* parentBox() const;
     RenderBox* firstChildBox() const;
+    RenderBox* firstInFlowChildBox() const;
     RenderBox* lastChildBox() const;
+    RenderBox* lastInFlowChildBox() const;
     RenderBox* previousSiblingBox() const;
     RenderBox* nextSiblingBox() const;
+    RenderBox* nextInFlowSiblingBox() const;
 
     // Visual and layout overflow are in the coordinate space of the box.  This means that they aren't purely physical directions.
     // For horizontal-tb and vertical-lr they will match physical directions, but for horizontal-bt and vertical-rl, the top/bottom and left/right
@@ -562,6 +565,7 @@ override;
     RenderLayer* enclosingFloatPaintingLayer() const;
     
     virtual std::optional<LayoutUnit> firstLineBaseline() const { return std::optional<LayoutUnit>(); }
+    virtual std::optional<LayoutUnit> lastLineBaseline() const { return std::optional<LayoutUnit> (); }
     virtual std::optional<LayoutUnit> inlineBlockBaseline(LineDirectionMode) const { return std::optional<LayoutUnit>(); } // Returns empty if we should skip this box when computing the baseline of an inline-block.
 
     bool shrinkToAvoidFloats() const;
@@ -822,6 +826,11 @@ inline RenderBox* RenderBox::firstChildBox() const
     return nullptr;
 }
 
+inline RenderBox* RenderBox::firstInFlowChildBox() const
+{
+    return downcast<RenderBox>(firstInFlowChild());
+}
+
 inline RenderBox* RenderBox::lastChildBox() const
 {
     if (is<RenderBox>(lastChild()))
@@ -829,6 +838,11 @@ inline RenderBox* RenderBox::lastChildBox() const
 
     ASSERT(!lastChild());
     return nullptr;
+}
+
+inline RenderBox* RenderBox::lastInFlowChildBox() const 
+{
+    return downcast<RenderBox>(lastInFlowChild());
 }
 
 inline RenderBox* RenderBox::previousSiblingBox() const
@@ -846,6 +860,15 @@ inline RenderBox* RenderBox::nextSiblingBox() const
         return downcast<RenderBox>(nextSibling());
 
     ASSERT(!nextSibling());
+    return nullptr;
+}
+
+inline RenderBox* RenderBox::nextInFlowSiblingBox() const
+{
+    for (RenderBox* curr = nextSiblingBox(); curr; curr = curr->nextSiblingBox()) {
+        if (!curr->isFloatingOrOutOfFlowPositioned())
+            return curr;
+    }
     return nullptr;
 }
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1335,7 +1335,7 @@ bool RenderFlexibleBox::updateAutoMarginsInCrossAxis(RenderBox& child, LayoutUni
 
 LayoutUnit RenderFlexibleBox::marginBoxAscentForChild(const RenderBox& child)
 {
-    LayoutUnit ascent = child.firstLineBaseline().value_or(crossAxisExtentForChild(child));
+    LayoutUnit ascent = alignmentForChild(child) == ItemPosition::LastBaseline ? child.lastLineBaseline().value_or(crossAxisExtentForChild(child)) : child.firstLineBaseline().value_or(crossAxisExtentForChild(child));
     return ascent + flowAwareMarginBeforeForChild(child);
 }
 
@@ -1715,13 +1715,11 @@ static LayoutUnit alignmentOffset(LayoutUnit availableFreeSpace, ItemPosition po
     case ItemPosition::Center:
         return availableFreeSpace / 2;
     case ItemPosition::Baseline:
+    case ItemPosition::LastBaseline:
         // FIXME: If we get here in columns, we want the use the descent, except
         // we currently can't get the ascent/descent of orthogonal children.
         // https://bugs.webkit.org/show_bug.cgi?id=98076
         return maxAscent - ascent;
-    case ItemPosition::LastBaseline:
-        // FIXME: Implement last baseline.
-        break;
     }
     return 0;
 }
@@ -2050,7 +2048,7 @@ void RenderFlexibleBox::layoutAndPlaceChildren(LayoutUnit& crossAxisOffset, Vect
         updateAutoMarginsInMainAxis(child, autoMarginOffset);
 
         LayoutUnit childCrossAxisMarginBoxExtent;
-        if (alignmentForChild(child) == ItemPosition::Baseline && !hasAutoMarginsInCrossAxis(child)) {
+        if ((alignmentForChild(child) == ItemPosition::Baseline || alignmentForChild(child) == ItemPosition::LastBaseline) && !hasAutoMarginsInCrossAxis(child)) {
             LayoutUnit ascent = marginBoxAscentForChild(child);
             LayoutUnit descent = (crossAxisMarginExtentForChild(child) + crossAxisExtentForChild(child)) - ascent;
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -149,6 +149,7 @@ private:
     LayoutUnit crossAxisScrollbarExtent() const;
     LayoutUnit crossAxisScrollbarExtentForChild(const RenderBox& child) const;
     LayoutPoint flowAwareLocationForChild(const RenderBox& child) const;
+    bool childIsParticipatingInBaselineAlignment(const RenderBox& child) const;
     bool childHasComputableAspectRatio(const RenderBox&) const;
     bool childHasComputableAspectRatioAndCrossSizeIsConsideredDefinite(const RenderBox&);
     bool crossAxisIsPhysicalWidth() const;

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -873,9 +873,13 @@ std::optional<LayoutUnit> RenderTableSection::firstLineBaseline() const
     if (!m_grid.size())
         return std::optional<LayoutUnit>();
 
+    LayoutUnit tableMarginBefore;
+    if (RenderTable* parentTable = table())
+        tableMarginBefore = parentTable->style().marginBefore().value();
+
     LayoutUnit firstLineBaseline = m_grid[0].baseline;
     if (firstLineBaseline)
-        return firstLineBaseline + m_rowPos[0];
+        return firstLineBaseline + m_rowPos[0] + tableMarginBefore;
 
     std::optional<LayoutUnit> result;
     const Row& firstRow = m_grid[0].row;


### PR DESCRIPTION
#### 3023b98a7a37b8ced720145a31319a5a47443421
<pre>
Draft PR to see if the two commits can be merged

Reviewed by NOBODY (OOPS!).

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-008-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-003-expected.txt:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::LineContext::LineContext):
(WebCore::alignmentOffset):
(WebCore::RenderFlexibleBox::staticCrossAxisPositionForPositionedChild):
(WebCore::RenderFlexibleBox::layoutAndPlaceChildren):
(WebCore::RenderFlexibleBox::alignChildren):
(WebCore::RenderFlexibleBox::childIsParticipatingInBaselineAlignment const):
* Source/WebCore/rendering/RenderFlexibleBox.h:
</pre>
----------------------------------------------------------------------
#### 49f2d52482a3847d260293edc6425ef9ef8b787b
<pre>
Implement last baseline for block elements in a flex container.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244734">https://bugs.webkit.org/show_bug.cgi?id=244734</a>
rdar://99506835

Reviewed by NOBODY (OOPS!).

CSS Box Alignment Module Level 3 defines the last baseline of block
elements to be:  the dominant last baseline of the last in-flow line
box in the block container, or is taken from the last in-flow
block-level child in the block container that contributes a set of
last baselines, whichever comes first/last. The logic for this ends up
being very similar to the first baseline logic, but we are simply
starting from the last child and working our way up instead of the other
way around. Once we compute the last baseline value this way, we can
align the block elements in a flex container using this new value as
the ascent. We also need to take into consideration what the alignment
type is so that we can compute either the first baseline or last
baseline.

This patch also adds the “margin before” to the first baseline of table
elements since it was not being added before. This is needed in order to
properly align other elements alongside a table with margins. Without
this addition, we were rendering the expectation for both
css-flexbox/flexbox-align-self-baseline-horiz-001a and
css-flexbox/flexbox-align-self-baseline-horiz-001b incorrectly.

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::lastLineBaseline const):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::lastLineBaseline const):
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::lastLineBaseline const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::marginBoxAscentForChild):
(WebCore::alignmentOffset):
(WebCore::RenderFlexibleBox::layoutAndPlaceChildren):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::firstLineBaseline const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3023b98a7a37b8ced720145a31319a5a47443421

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99954 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158293 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33714 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28871 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96371 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26827 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77465 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26668 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69696 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34809 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15429 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32621 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16408 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39338 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35496 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->