### PR TITLE
[ New Test ] (254561@main): [ macOS wk2 ] fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html is a flaky failure (245482)

### DIFF
--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll-expected.txt
@@ -1,5 +1,5 @@
 PASS successfullyParsed is true
 
 TEST COMPLETE
-Successful.
+PASS didScrollPastPosition is false
 

--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html
@@ -11,29 +11,47 @@
             testRunner.dumpAsText();
             testRunner.waitUntilDone();
         }
-        
+
+        let startPosition = 0;
+        let delta = 0;
+        let position = 0;
+        let didScrollPastPosition = false;
+
         async function runTest()
         {
             eventSender.monitorWheelEvents();
             if (!window.testRunner || !testRunner.runUIScript)
                 return;
 
+            document.addEventListener('wheel', (event) => {
+                startPosition = window.scrollY;
+                // debug('startPosition = ' + startPosition);
+                delta = event.deltaY;
+                // debug('delta = ' + delta);
+
+                document.addEventListener('scroll', (event) => {
+                    position = window.scrollY;
+                    // debug('position = ' + position);
+                    if (startPosition + delta != position)
+                        didScrollPastPosition = true;
+                    // shouldBe('startPosition + delta', 'position');
+                    // testRunner.notifyDone();
+                })
+            });
+
             await UIHelper.rawKeyDown("downArrow");
             
             setTimeout(async () => {
                 await UIHelper.rawKeyUp("downArrow");
-                const startingPosition = window.scrollY;
+                await UIHelper.mouseWheelScrollAt(0, 0, 0, 0, 0, 1);
 
-                await UIHelper.mouseWheelScrollAt(0, 0, 0, 0, 0, 0);
+                await UIHelper.animationFrame();
+                await UIHelper.animationFrame();
+                await UIHelper.animationFrame();
 
-                const position = window.scrollY;
-                if (Math.abs(startingPosition - position) < 20)
-                    debug("Successful.");
-                else
-                    debug("Unsuccessful. window.scrollY after wheel event == " + position + "; window.scrollY before wheel event == " + startingPosition);
-
+                shouldBe('didScrollPastPosition', 'false')
                 testRunner.notifyDone();
-            }, 100);
+            }, 300);
         }
     </script>
 </head>


### PR DESCRIPTION
#### 9f652af3cac7610001411f655351a805894459c7
<pre>
[ New Test ] (254561@main): [ macOS wk2 ] fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html is a flaky failure (245482)
<a href="https://bugs.webkit.org/show_bug.cgi?id=245503">https://bugs.webkit.org/show_bug.cgi?id=245503</a>
rdar://100227233

Reviewed by NOBODY (OOPS!).

This test was re-written in a new way to avoid the race conditions that the
previous iterations of the test were privy to.

The previous tests were flaky due to `mouseWheelScrollAt` being async and
therefore the scroll position woudn&apos;t be guaranteed. The test now uses an
event listener to listen to any scroll event, so long as the scroll event
occurs strictly after the wheel event. The assertion of the test is that
there is no change in scroll position before and after the scroll event,
ensuring that the keyboard scrolling event doesn&apos;t continue after the wheel
event.

* LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll-expected.txt:
* LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f652af3cac7610001411f655351a805894459c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99923 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158270 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33680 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28849 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82957 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96348 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26802 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77436 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26641 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69665 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34777 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15413 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32589 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16391 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4943 "Commit message contains (OOPS!) and no reviewer found") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39318 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35480 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->