### PR TITLE
[WK2] Add initial implementation the Screen Wake Lock API behind an experimental flag

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -462,6 +462,8 @@ imported/w3c/web-platform-tests/html/webappapis/timers/negative-settimeout.any.w
 imported/w3c/web-platform-tests/html/webappapis/user-prompts/print-during-beforeunload.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/xhr.https.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/notifications/instance.https.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-resources.https.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/streams/readable-streams/patched-global.any.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/streams/transform-streams/terminate.any.html [ DumpJSConsoleLogInStdErr ]
@@ -6025,13 +6027,6 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/cs
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests.html [ Pass Failure ]
 
 webkit.org/b/245164 css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-relayouts.html [ Failure Pass ]
-
-# Screen Wake Lock tests that are timing out since their import.
-imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html [ Skip ]
-imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub.html [ Skip ]
-imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub.html [ Skip ]
-imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html [ Skip ]
-imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html [ Skip ]
 
 # Disable ShadowRealm (while running to ensure we do not crash)
 webkit.org/b/245680 http/tests/misc/iframe-shadow-realm.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/feature-policy/resources/feature-policy-screen-wakelock.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/feature-policy/resources/feature-policy-screen-wakelock.html
@@ -1,0 +1,18 @@
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+"use strict";
+
+Promise.resolve().then(async () => {
+  try {
+    await test_driver.set_permission(
+        { name: 'screen-wake-lock' }, 'granted', false);
+
+    const wakeLock = await navigator.wakeLock.request("screen");
+    await wakeLock.release();
+    window.parent.postMessage({ enabled: true }, "*");
+  } catch (e) {
+    window.parent.postMessage({ enabled: false }, "*");
+  }
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/feature-policy/resources/featurepolicy.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/feature-policy/resources/featurepolicy.js
@@ -13,9 +13,9 @@ function assert_feature_policy_supported() {
 //        "/feature-policy/resources/feature-policy-payment.html",
 //        "/feature-policy/resources/feature-policy-usb.html".
 //    expect_feature_available: a callback(data, feature_description) to
-//        verify if a feature is avaiable or unavailable as expected.
+//        verify if a feature is available or unavailable as expected.
 //        The file under the path "src" defines what "data" is sent back as a
-//        pistMessage. Inside the callback, some tests (e.g., EXPECT_EQ,
+//        postMessage. Inside the callback, some tests (e.g., EXPECT_EQ,
 //        EXPECT_TRUE, etc) are run accordingly to test a feature's
 //        availability.
 //        Example: expect_feature_available_default(data, feature_description).
@@ -24,8 +24,8 @@ function assert_feature_policy_supported() {
 //      feature (https://wicg.github.io/feature-policy/#features).
 //      See examples at:
 //      https://github.com/WICG/feature-policy/blob/master/features.md
-//    allow_attribute: Optional argument, only used for testing fullscreen or
-//      payment: either "allowfullscreen" or "allowpaymentrequest" is passed.
+//    allow_attribute: Optional argument, only used for testing fullscreen:
+//      "allowfullscreen"
 function test_feature_availability(
     feature_description, test, src, expect_feature_available, feature_name,
     allow_attribute) {
@@ -354,13 +354,9 @@ function test_subframe_header_policy(
     assert_feature_policy_supported()
     frame.src = src + '?pipe=sub|header(Feature-Policy,' + feature + ' '
         + frame_header_policy + ';)';
-    return new Promise(function(resolve, reject) {
-      let results = [];
+    return new Promise(function(resolve) {
       window.addEventListener('message', function handler(evt) {
-        results.push(evt.data);
-        if (results.length >= 6) {
-          resolve(results);
-        }
+        resolve(evt.data);
       });
       document.body.appendChild(frame);
     }).then(function(results) {
@@ -453,6 +449,6 @@ function expect_reports(report_count, policy_name, description) {
         if (num_received_reports >= report_count) {
             t.done();
         }
-   }), {types: ['feature-policy-violation'], buffered: true}).observe();
+   }), {types: ['permissions-policy-violation'], buffered: true}).observe();
   }, description);
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions/all-permissions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions/all-permissions-expected.txt
@@ -12,7 +12,7 @@ FAIL Query "gyroscope" permission promise_test: Unhandled rejection with value: 
 FAIL Query "magnetometer" permission promise_test: Unhandled rejection with value: object "NotSupportedError: Permissions::query does not support this API"
 FAIL Query "midi" permission promise_test: Unhandled rejection with value: object "NotSupportedError: Permissions::query does not support this API"
 FAIL Query "nfc" permission promise_test: Unhandled rejection with value: object "NotSupportedError: Permissions::query does not support this API"
-FAIL Query "screen-wake-lock" permission promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Query "screen-wake-lock" permission
 PASS Query "camera" permission
 FAIL Query "display-capture" permission promise_test: Unhandled rejection with value: object "NotSupportedError: Permissions::query does not support this API"
 PASS Query "microphone" permission

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js
@@ -305,6 +305,10 @@ window.test_driver_internal.set_permission = function(permission_params, context
         testRunner.setGeolocationPermission(permission_params.state == "granted");
         return Promise.resolve();
     }
+    if (window.testRunner && permission_params.descriptor.name == "screen-wake-lock") {
+        testRunner.setScreenWakeLockPermission(permission_params.state == "granted");
+        return Promise.resolve();
+    }
     return Promise.reject(new Error("unimplemented"));
 };
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/idlharness.https.window-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL idl_test setup promise_test: Unhandled rejection with value: object "Error: unimplemented"
+PASS idl_test setup
 PASS idl_test validation
 PASS Partial interface Navigator: original interface defined
 PASS Partial interface Navigator: member names are unique
@@ -32,12 +32,12 @@ PASS WakeLockSentinel interface: attribute released
 PASS WakeLockSentinel interface: attribute type
 PASS WakeLockSentinel interface: operation release()
 PASS WakeLockSentinel interface: attribute onrelease
-FAIL WakeLockSentinel must be primary interface of sentinel assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
-FAIL Stringification of sentinel assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
-FAIL WakeLockSentinel interface: sentinel must inherit property "released" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
-FAIL WakeLockSentinel interface: sentinel must inherit property "type" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
-FAIL WakeLockSentinel interface: sentinel must inherit property "release()" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
-FAIL WakeLockSentinel interface: sentinel must inherit property "onrelease" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: sentinel"
+PASS WakeLockSentinel must be primary interface of sentinel
+PASS Stringification of sentinel
+PASS WakeLockSentinel interface: sentinel must inherit property "released" with the proper type
+PASS WakeLockSentinel interface: sentinel must inherit property "type" with the proper type
+PASS WakeLockSentinel interface: sentinel must inherit property "release()" with the proper type
+PASS WakeLockSentinel interface: sentinel must inherit property "onrelease" with the proper type
 PASS Navigator interface: attribute wakeLock
 PASS Navigator interface: navigator must inherit property "wakeLock" with the proper type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-active-document.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-active-document.https.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL navigator.wakeLock.request() aborts if the document is not active. promise_rejects_dom: Inactive document, so must throw NotAllowedError function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException NotAllowedError: property "code" is equal to 9, expected 0
-FAIL navigator.wakeLock.request() aborts if the document is active, but not fully active. promise_rejects_dom: Active, but not fully active, so must throw NotAllowedError function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException NotAllowedError: property "code" is equal to 9, expected 0
+PASS navigator.wakeLock.request() aborts if the document is not active.
+PASS navigator.wakeLock.request() aborts if the document is active, but not fully active.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub-expected.txt
@@ -1,9 +1,6 @@
-Blocked access to external URL https://www.localhost:9443/feature-policy/resources/feature-policy-screen-wakelock.html
 
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Feature-Policy header {"screen-wake-lock" : []} disallows the top-level document. promise_rejects_dom: function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException NotAllowedError: property "code" is equal to 9, expected 0
-TIMEOUT Feature-Policy header {"screen-wake-lock" : []} disallows same-origin iframes. Test timed out
-TIMEOUT Feature-Policy header {"screen-wake-lock" : []} disallows cross-origin iframes. Test timed out
+PASS Feature-Policy header {"screen-wake-lock" : []} disallows the top-level document.
+FAIL Feature-Policy header {"screen-wake-lock" : []} disallows same-origin iframes. assert_false: navigator.wakeLock.request("screen") expected false got true
+PASS Feature-Policy header {"screen-wake-lock" : []} disallows cross-origin iframes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html
@@ -3,13 +3,14 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script>
   "use strict";
 
   const same_origin_src =
     "/feature-policy/resources/feature-policy-screen-wakelock.html";
   const cross_origin_src =
-    "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
+    get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
   promise_test(t => {
     return promise_rejects_dom(t, "NotAllowedError", navigator.wakeLock.request("screen"));

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,8 +1,5 @@
-Blocked access to external URL https://www.localhost:9443/feature-policy/resources/feature-policy-screen-wakelock.html
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Feature-Policy allow="screen-wake-lock" allows same-origin relocation Test timed out
-TIMEOUT Feature-Policy allow="screen-wake-lock" disallows cross-origin relocation Test timed out
+PASS Feature-Policy allow="screen-wake-lock" allows same-origin relocation
+FAIL Feature-Policy allow="screen-wake-lock" disallows cross-origin relocation assert_false: navigator.wakeLock.request("screen") expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script>
   "use strict";
 
@@ -10,7 +11,7 @@
   const base_src = "/feature-policy/resources/redirect-on-load.html#";
   const same_origin_src = base_src + relative_path;
   const cross_origin_src =
-    base_src + "https://{{domains[www]}}:{{ports[https][0]}}" + relative_path;
+    base_src + get_host_info().HTTPS_REMOTE_ORIGIN + relative_path;
 
   async_test(t => {
     test_feature_availability(

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub-expected.txt
@@ -1,8 +1,4 @@
-Blocked access to external URL https://www.localhost:9443/feature-policy/resources/feature-policy-screen-wakelock.html
 
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Feature policy "screen-wake-lock" can be enabled in same-origin iframe using allow="screen-wake-lock" attribute Test timed out
-TIMEOUT Feature policy "screen-wake-lock" can be enabled in cross-origin iframe using allow="screen-wake-lock" attribute Test timed out
+PASS Feature policy "screen-wake-lock" can be enabled in same-origin iframe using allow="screen-wake-lock" attribute
+PASS Feature policy "screen-wake-lock" can be enabled in cross-origin iframe using allow="screen-wake-lock" attribute
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub.html
@@ -3,13 +3,14 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script>
   "use strict";
 
   const same_origin_src =
     "/feature-policy/resources/feature-policy-screen-wakelock.html";
   const cross_origin_src =
-    "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
+    get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
   async_test(t => {
     test_feature_availability(

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub-expected.txt
@@ -1,9 +1,5 @@
-Blocked access to external URL https://www.localhost:9443/feature-policy/resources/feature-policy-screen-wakelock.html
 
-
-Harness Error (TIMEOUT), message = null
-
-FAIL Feature-Policy header {"screen-wake-lock" : ["*"]} allows the top-level document. promise_test: Unhandled rejection with value: object "Error: unimplemented"
-TIMEOUT Feature-Policy header {"screen-wake-lock" : ["*"]} allows same-origin iframes. Test timed out
-TIMEOUT Feature-Policy header {"screen-wake-lock" : ["*"]} allows cross-origin iframes. Test timed out
+PASS Feature-Policy header {"screen-wake-lock" : ["*"]} allows the top-level document.
+PASS Feature-Policy header {"screen-wake-lock" : ["*"]} allows same-origin iframes.
+PASS Feature-Policy header {"screen-wake-lock" : ["*"]} allows cross-origin iframes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html
@@ -5,13 +5,14 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script>
   "use strict";
 
   const same_origin_src =
     "/feature-policy/resources/feature-policy-screen-wakelock.html";
   const cross_origin_src =
-    "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
+    get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
   promise_test(async t => {
     await test_driver.set_permission(

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub-expected.txt
@@ -1,9 +1,5 @@
-Blocked access to external URL https://www.localhost:9443/feature-policy/resources/feature-policy-screen-wakelock.html
 
-
-Harness Error (TIMEOUT), message = null
-
-FAIL Feature-Policy header screen-wake-lock "self" allows the top-level document. promise_test: Unhandled rejection with value: object "Error: unimplemented"
-TIMEOUT Feature-Policy header screen-wake-lock "self" allows same-origin iframes. Test timed out
-TIMEOUT Feature-Policy header screen-wake-lock "self" disallows cross-origin iframes. Test timed out
+PASS Feature-Policy header screen-wake-lock "self" allows the top-level document.
+PASS Feature-Policy header screen-wake-lock "self" allows same-origin iframes.
+PASS Feature-Policy header screen-wake-lock "self" disallows cross-origin iframes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html
@@ -5,6 +5,7 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/feature-policy/resources/featurepolicy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 
 <script>
   "use strict";
@@ -12,7 +13,7 @@
   const same_origin_src =
     "/feature-policy/resources/feature-policy-screen-wakelock.html";
   const cross_origin_src =
-    "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
+    get_host_info().HTTPS_REMOTE_ORIGIN + same_origin_src;
 
   promise_test(async t => {
     await test_driver.set_permission(

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-onrelease.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-onrelease.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test onreleased event's basic properties promise_test: Unhandled rejection with value: object "Error: unimplemented"
-FAIL Ensure onreleased is called before WakeLockSentinel.release() resolves promise_test: Unhandled rejection with value: object "Error: unimplemented"
+PASS Test onreleased event's basic properties
+PASS Ensure onreleased is called before WakeLockSentinel.release() resolves
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-released.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-released.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL The released attribute inside an event handler promise_test: Unhandled rejection with value: object "Error: unimplemented"
+PASS The released attribute inside an event handler
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-request-denied.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-request-denied.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Denied requests should abort with NotAllowedError promise_test: Unhandled rejection with value: object "Error: unimplemented"
+PASS Denied requests should abort with NotAllowedError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-type.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-type.https.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL 'type' parameter in WakeLock.request() defaults to 'screen' promise_test: Unhandled rejection with value: object "Error: unimplemented"
+PASS 'type' parameter in WakeLock.request() defaults to 'screen'
 PASS 'TypeError' is thrown when set an invalid wake lock type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelockpermissiondescriptor.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelockpermissiondescriptor.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL PermissionDescriptor with name='screen-wake-lock' works promise_test: Unhandled rejection with value: object "Error: unimplemented"
+PASS PermissionDescriptor with name='screen-wake-lock' works
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -76,6 +76,9 @@ media/audio-session-category-at-most-recent-playback.html [ Skip ]
 imported/w3c/web-platform-tests/clear-site-data [ Skip ]
 http/tests/clear-site-data [ Skip ]
 
+# The Screen Wake Lock API is not supportted in WebKit1.
+imported/w3c/web-platform-tests/screen-wake-lock [ Skip ]
+
 # Shared workers are only implemented for WebKit2.
 http/tests/navigation/page-cache-shared-worker.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-allowed.sub.html [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -144,6 +144,9 @@ http/tests/clear-site-data [ Skip ]
 # color-filters are off by default
 webkit.org/b/185076 css3/color-filters [ Skip ]
 
+# The Screen Wake Lock API is not supportted in WebKit1.
+imported/w3c/web-platform-tests/screen-wake-lock [ Skip ]
+
 # IntersectionObserver is off by default
 webkit.org/b/188613 intersection-observer [ Skip ]
 webkit.org/b/188613 http/tests/intersection-observer [ Skip ]

--- a/Source/WebCore/Modules/permissions/PermissionName.h
+++ b/Source/WebCore/Modules/permissions/PermissionName.h
@@ -42,6 +42,7 @@ enum class PermissionName : uint8_t {
     Midi,
     Nfc,
     Notifications,
+    ScreenWakeLock,
     SpeakerSelection
 };
 
@@ -64,6 +65,7 @@ template<> struct EnumTraits<WebCore::PermissionName> {
         WebCore::PermissionName::Midi,
         WebCore::PermissionName::Nfc,
         WebCore::PermissionName::Notifications,
+        WebCore::PermissionName::ScreenWakeLock,
         WebCore::PermissionName::SpeakerSelection
     >;
 };

--- a/Source/WebCore/Modules/permissions/PermissionName.idl
+++ b/Source/WebCore/Modules/permissions/PermissionName.idl
@@ -39,5 +39,6 @@ enum PermissionName {
     "midi",
     "nfc",
     "notifications",
+    "screen-wake-lock",
     "speaker-selection"
 };

--- a/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
@@ -31,7 +31,8 @@
 
 namespace WebCore {
 
-NavigatorScreenWakeLock::NavigatorScreenWakeLock(Navigator&)
+NavigatorScreenWakeLock::NavigatorScreenWakeLock(Navigator& navigator)
+    : m_navigator(navigator)
 {
 }
 
@@ -61,7 +62,7 @@ WakeLock& NavigatorScreenWakeLock::wakeLock(Navigator& navigator)
 WakeLock& NavigatorScreenWakeLock::wakeLock()
 {
     if (!m_wakeLock)
-        m_wakeLock = WakeLock::create();
+        m_wakeLock = WakeLock::create(downcast<Document>(m_navigator.scriptExecutionContext()));
     return *m_wakeLock;
 }
 

--- a/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.h
+++ b/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.h
@@ -49,6 +49,7 @@ private:
     static const char* supplementName();
 
     RefPtr<WakeLock> m_wakeLock;
+    Navigator& m_navigator;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ContextDestructionObserver.h"
 #include "WakeLockType.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -32,19 +33,22 @@
 namespace WebCore {
 
 class DeferredPromise;
+class Document;
 class WakeLockSentinel;
 
-class WakeLock : public RefCounted<WakeLock> {
+class WakeLock : public ContextDestructionObserver, public RefCounted<WakeLock> {
 public:
-    static Ref<WakeLock> create()
+    static Ref<WakeLock> create(Document* document)
     {
-        return adoptRef(*new WakeLock);
+        return adoptRef(*new WakeLock(document));
     }
 
     void request(WakeLockType, Ref<DeferredPromise>&&);
 
 private:
-    WakeLock();
+    explicit WakeLock(Document*);
+
+    Document* document();
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WakeLockManager.h"
+
+#include "Document.h"
+#include "SleepDisabler.h"
+#include "WakeLockSentinel.h"
+
+namespace WebCore {
+
+WakeLockManager::WakeLockManager(Document& document)
+    : m_document(document)
+{
+    m_document.registerForVisibilityStateChangedCallbacks(*this);
+}
+
+WakeLockManager::~WakeLockManager()
+{
+    m_document.unregisterForVisibilityStateChangedCallbacks(*this);
+}
+
+void WakeLockManager::addWakeLock(Ref<WakeLockSentinel>&& lock)
+{
+    auto type = lock->type();
+    auto& locks = m_wakeLocks.ensure(type, [] { return Vector<RefPtr<WakeLockSentinel>>(); }).iterator->value;
+    ASSERT(!locks.contains(lock.ptr()));
+    locks.append(WTFMove(lock));
+
+    if (locks.size() != 1)
+        return;
+
+    switch (type) {
+    case WakeLockType::Screen:
+        m_screenLockDisabler = makeUnique<SleepDisabler>("Screen Wake Lock"_s, PAL::SleepDisabler::Type::Display);
+        break;
+    }
+}
+
+void WakeLockManager::removeWakeLock(WakeLockSentinel& lock)
+{
+    auto it = m_wakeLocks.find(lock.type());
+    if (it == m_wakeLocks.end())
+        return;
+    auto& locks = it->value;
+    locks.removeFirst(&lock);
+    ASSERT(!locks.contains(&lock));
+
+    if (!locks.isEmpty())
+        return;
+
+    m_wakeLocks.remove(it);
+    switch (lock.type()) {
+    case WakeLockType::Screen:
+        m_screenLockDisabler = nullptr;
+        break;
+    }
+}
+
+// https://www.w3.org/TR/screen-wake-lock/#handling-document-loss-of-visibility
+void WakeLockManager::visibilityStateChanged()
+{
+    if (m_document.visibilityState() != VisibilityState::Hidden)
+        return;
+
+    releaseAllLocks(WakeLockType::Screen);
+}
+
+void WakeLockManager::releaseAllLocks(WakeLockType type)
+{
+    auto it = m_wakeLocks.find(type);
+    if (it == m_wakeLocks.end())
+        return;
+
+    auto& locks = it->value;
+    while (!locks.isEmpty()) {
+        RefPtr lock = *locks.begin();
+        lock->release(*this);
+    }
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "VisibilityChangeClient.h"
+#include "WakeLockType.h"
+#include <wtf/HashMap.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class Document;
+class SleepDisabler;
+class WakeLockSentinel;
+
+class WakeLockManager final : public VisibilityChangeClient {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit WakeLockManager(Document&);
+    ~WakeLockManager();
+
+    void addWakeLock(Ref<WakeLockSentinel>&&);
+    void removeWakeLock(WakeLockSentinel&);
+
+    void releaseAllLocks(WakeLockType);
+
+private:
+    void visibilityStateChanged() final;
+
+    Document& m_document;
+    HashMap<WakeLockType, Vector<RefPtr<WakeLockSentinel>>, WTF::IntHash<WakeLockType>, WTF::StrongEnumHashTraits<WakeLockType>> m_wakeLocks;
+    std::unique_ptr<SleepDisabler> m_screenLockDisabler;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
@@ -33,6 +33,7 @@
 namespace WebCore {
 
 class DeferredPromise;
+class WakeLockManager;
 
 class WakeLockSentinel final : public RefCounted<WakeLockSentinel>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(WakeLockSentinel);
@@ -50,21 +51,25 @@ public:
     bool released() const { return m_wasReleased; }
     WakeLockType type() const { return m_type; }
     void release(Ref<DeferredPromise>&&);
+    void release(WakeLockManager&);
 
 private:
     WakeLockSentinel(Document&, WakeLockType);
 
     // ActiveDOMObject
     const char* activeDOMObjectName() const final;
+    bool virtualHasPendingActivity() const final;
 
     // EventTarget
     EventTargetInterface eventTargetInterface() const final { return WakeLockSentinelEventTargetInterfaceType; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { RefCounted::ref(); }
     void derefEventTarget() final { RefCounted::deref(); }
+    void eventListenersDidChange() final;
 
     WakeLockType m_type;
     bool m_wasReleased { false };
+    bool m_hasReleaseEventListener { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockType.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockType.h
@@ -27,6 +27,6 @@
 
 namespace WebCore  {
 
-enum class WakeLockType : bool { Screen };
+enum class WakeLockType : uint8_t { Screen };
 
 } // namespace WebCore

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -287,6 +287,7 @@ Modules/reporting/ReportingScope.cpp
 Modules/reporting/TestReportBody.cpp
 Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
 Modules/screen-wake-lock/WakeLock.cpp
+Modules/screen-wake-lock/WakeLockManager.cpp
 Modules/screen-wake-lock/WakeLockSentinel.cpp
 Modules/speech/SpeechRecognition.cpp
 Modules/speech/SpeechRecognitionAlternative.cpp

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -237,6 +237,7 @@ class TreeWalker;
 class UndoManager;
 class VisibilityChangeClient;
 class VisitedLinkState;
+class WakeLockManager;
 class WebAnimation;
 class WebGL2RenderingContext;
 class WebGLRenderingContext;
@@ -523,6 +524,8 @@ public:
 
     Ref<HTMLCollection> windowNamedItems(const AtomString&);
     Ref<HTMLCollection> documentNamedItems(const AtomString&);
+
+    WakeLockManager& wakeLockManager();
 
     // Other methods (not part of DOM)
     bool isSynthesized() const { return m_isSynthesized; }
@@ -2313,6 +2316,7 @@ private:
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_elementsWithPendingUserAgentShadowTreeUpdates;
 
     Ref<ReportingScope> m_reportingScope;
+    std::unique_ptr<WakeLockManager> m_wakeLockManager;
 };
 
 Element* eventTargetElementForDocument(Document*);

--- a/Source/WebCore/dom/TaskSource.h
+++ b/Source/WebCore/dom/TaskSource.h
@@ -42,6 +42,7 @@ enum class TaskSource : uint8_t {
     Permission,
     PostedMessageQueue,
     Reporting,
+    ScreenWakelock,
     Speech,
     UserInteraction,
     WebGL,

--- a/Source/WebCore/html/FeaturePolicy.cpp
+++ b/Source/WebCore/html/FeaturePolicy.cpp
@@ -53,6 +53,8 @@ static const char* policyTypeName(FeaturePolicy::Type type)
         return "Geolocation";
     case FeaturePolicy::Type::Payment:
         return "Payment";
+    case FeaturePolicy::Type::ScreenWakeLock:
+        return "ScreenWakeLock";
     case FeaturePolicy::Type::SyncXHR:
         return "SyncXHR";
     case FeaturePolicy::Type::Fullscreen:
@@ -180,6 +182,7 @@ FeaturePolicy FeaturePolicy::parse(Document& document, const HTMLIFrameElement& 
     bool isDisplayCaptureInitialized = false;
     bool isGeolocationInitialized = false;
     bool isPaymentInitialized = false;
+    bool isScreenWakeLockInitialized = false;
     bool isSyncXHRInitialized = false;
     bool isFullscreenInitialized = false;
     bool isWebShareInitialized = false;
@@ -224,6 +227,11 @@ FeaturePolicy FeaturePolicy::parse(Document& document, const HTMLIFrameElement& 
         if (item.startsWith("payment"_s)) {
             isPaymentInitialized = true;
             updateList(document, policy.m_paymentRule, item.substring(8));
+            continue;
+        }
+        if (item.startsWith("screen-wake-lock"_s)) {
+            isScreenWakeLockInitialized = true;
+            updateList(document, policy.m_screenWakeLockRule, item.substring(17));
             continue;
         }
         if (item.startsWith("sync-xhr"_s)) {
@@ -274,7 +282,7 @@ FeaturePolicy FeaturePolicy::parse(Document& document, const HTMLIFrameElement& 
 #endif
     }
 
-    // By default, camera, microphone, speaker-selection, display-capture, fullscreen and xr-spatial-tracking policy is 'self'.
+    // By default, camera, microphone, speaker-selection, display-capture, fullscreen and xr-spatial-tracking, screen-wake-lock policy is 'self'.
     if (!isCameraInitialized)
         policy.m_cameraRule.allowedList.add(document.securityOrigin().data());
     if (!isMicrophoneInitialized)
@@ -283,6 +291,8 @@ FeaturePolicy FeaturePolicy::parse(Document& document, const HTMLIFrameElement& 
         policy.m_speakerSelectionRule.allowedList.add(document.securityOrigin().data());
     if (!isDisplayCaptureInitialized)
         policy.m_displayCaptureRule.allowedList.add(document.securityOrigin().data());
+    if (!isScreenWakeLockInitialized)
+        policy.m_screenWakeLockRule.allowedList.add(document.securityOrigin().data());
     if (!isGeolocationInitialized)
         policy.m_geolocationRule.allowedList.add(document.securityOrigin().data());
     if (!isPaymentInitialized)
@@ -342,6 +352,8 @@ bool FeaturePolicy::allows(Type type, const SecurityOriginData& origin) const
         return isAllowedByFeaturePolicy(m_geolocationRule, origin);
     case Type::Payment:
         return isAllowedByFeaturePolicy(m_paymentRule, origin);
+    case Type::ScreenWakeLock:
+        return isAllowedByFeaturePolicy(m_screenWakeLockRule, origin);
     case Type::SyncXHR:
         return isAllowedByFeaturePolicy(m_syncXHRRule, origin);
     case Type::Fullscreen:

--- a/Source/WebCore/html/FeaturePolicy.h
+++ b/Source/WebCore/html/FeaturePolicy.h
@@ -45,6 +45,7 @@ public:
         DisplayCapture,
         Geolocation,
         Payment,
+        ScreenWakeLock,
         SyncXHR,
         Fullscreen,
         WebShare,
@@ -78,6 +79,7 @@ private:
     AllowRule m_syncXHRRule;
     AllowRule m_fullscreenRule;
     AllowRule m_webShareRule;
+    AllowRule m_screenWakeLockRule;
 
 #if ENABLE(DEVICE_ORIENTATION)
     AllowRule m_gyroscopeRule;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8881,6 +8881,9 @@ void WebPageProxy::queryPermission(const ClientOrigin& clientOrigin, const Permi
         if (m_notificationPermissionRequesters.contains(clientOrigin.topOrigin))
             shouldChangeDeniedToPrompt = false;
 #endif
+    } else if (descriptor.name == PermissionName::ScreenWakeLock) {
+        name = "screen-wake-lock"_s;
+        shouldChangeDeniedToPrompt = false;
     }
 
     if (name.isNull()) {

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -218,6 +218,9 @@ interface TestRunner {
     undefined setMockGeolocationPositionUnavailableError(DOMString errorMessage);
     boolean isGeolocationProviderActive();
 
+    // Screen Wake Lock
+    undefined setScreenWakeLockPermission(boolean value);
+
     // MediaStream
     undefined setUserMediaPermission(boolean value);
     undefined resetUserMediaPermission();

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -693,6 +693,11 @@ void InjectedBundle::setGeolocationPermission(bool enabled)
     postPageMessage("SetGeolocationPermission", adoptWK(WKBooleanCreate(enabled)));
 }
 
+void InjectedBundle::setScreenWakeLockPermission(bool enabled)
+{
+    postPageMessage("SetScreenWakeLockPermission", adoptWK(WKBooleanCreate(enabled)));
+}
+
 void InjectedBundle::setMockGeolocationPosition(double latitude, double longitude, double accuracy, std::optional<double> altitude, std::optional<double> altitudeAccuracy, std::optional<double> heading, std::optional<double> speed, std::optional<double> floorLevel)
 {
     auto body = adoptWK(WKMutableDictionaryCreate());

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -105,6 +105,9 @@ public:
     void setMockGeolocationPositionUnavailableError(WKStringRef errorMessage);
     bool isGeolocationProviderActive() const;
 
+    // Screen Wake Lock.
+    void setScreenWakeLockPermission(bool);
+
     // MediaStream.
     void setUserMediaPermission(bool);
     void resetUserMediaPermission();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -909,6 +909,11 @@ void TestRunner::setGeolocationPermission(bool enabled)
     InjectedBundle::singleton().setGeolocationPermission(enabled);
 }
 
+void TestRunner::setScreenWakeLockPermission(bool enabled)
+{
+    InjectedBundle::singleton().setScreenWakeLockPermission(enabled);
+}
+
 bool TestRunner::isGeolocationProviderActive()
 {
     return InjectedBundle::singleton().isGeolocationProviderActive();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -304,6 +304,9 @@ public:
     void setMockGeolocationPositionUnavailableError(JSStringRef message);
     bool isGeolocationProviderActive();
 
+    // Screen Wake Lock.
+    void setScreenWakeLockPermission(bool);
+
     // MediaStream
     void setUserMediaPermission(bool);
     void resetUserMediaPermission();

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -391,6 +391,16 @@ void TestController::handleQueryPermission(WKStringRef string, WKSecurityOriginR
         }
     }
 
+    if (toWTFString(string) == "screen-wake-lock"_s) {
+        if (m_screenWakeLockPermission) {
+            if (*m_screenWakeLockPermission)
+                WKQueryPermissionResultCallbackCompleteWithGranted(callback);
+            else
+                WKQueryPermissionResultCallbackCompleteWithDenied(callback);
+            return;
+        }
+    }
+
     WKQueryPermissionResultCallbackCompleteWithPrompt(callback);
 }
 
@@ -1139,6 +1149,9 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
     m_isGeolocationPermissionSet = false;
     m_isGeolocationPermissionAllowed = false;
     m_geolocationPermissionQueryOrigins.clear();
+
+    // Reset Screen Wake Lock permission.
+    m_screenWakeLockPermission = std::nullopt;
 
     // Reset UserMedia permissions.
     m_userMediaPermissionRequests.clear();
@@ -2499,6 +2512,11 @@ void TestController::setGeolocationPermission(bool enabled)
 
     for (auto& originString : m_geolocationPermissionQueryOrigins)
         WKPagePermissionChanged(toWK("geolocation").get(), toWK(originString).get());
+}
+
+void TestController::setScreenWakeLockPermission(bool enabled)
+{
+    m_screenWakeLockPermission = enabled;
 }
 
 void TestController::setMockGeolocationPosition(double latitude, double longitude, double accuracy, std::optional<double> altitude, std::optional<double> altitudeAccuracy, std::optional<double> heading, std::optional<double> speed, std::optional<double> floorLevel)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -136,6 +136,9 @@ public:
     void handleGeolocationPermissionRequest(WKGeolocationPermissionRequestRef);
     bool isGeolocationProviderActive() const;
 
+    // Screen Wake Lock.
+    void setScreenWakeLockPermission(bool);
+
     // MediaStream.
     String saltForOrigin(WKFrameRef, String);
     void getUserMediaInfoForOrigin(WKFrameRef, WKStringRef originKey, bool&, WKRetainPtr<WKStringRef>&);
@@ -623,6 +626,7 @@ private:
     Vector<WKRetainPtr<WKGeolocationPermissionRequestRef> > m_geolocationPermissionRequests;
     bool m_isGeolocationPermissionSet { false };
     bool m_isGeolocationPermissionAllowed { false };
+    std::optional<bool> m_screenWakeLockPermission;
 
     HashMap<String, RefPtr<OriginSettings>> m_cachedUserMediaPermissions;
 

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -418,6 +418,11 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "SetScreenWakeLockPermission")) {
+        TestController::singleton().setScreenWakeLockPermission(booleanValue(messageBody));
+        return;
+    }
+
     if (WKStringIsEqualToUTF8CString(messageName, "SetMockGeolocationPosition")) {
         auto messageBodyDictionary = dictionaryValue(messageBody);
         auto latitude = doubleValue(messageBodyDictionary, "latitude");


### PR DESCRIPTION
#### 95606b13126e82a5cf2534a05e107d0aa69ccc0a
<pre>
[WK2] Add initial implementation the Screen Wake Lock API behind an experimental flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=245712">https://bugs.webkit.org/show_bug.cgi?id=245712</a>

Reviewed by Alex Christensen, Brent Fulgham and Geoffrey Garen.

Add initial implementation the Screen Wake Lock API for WebKit2, behind an experimental flag:
- <a href="https://w3c.github.io/screen-wake-lock">https://w3c.github.io/screen-wake-lock</a>

The implementation should be complete but it is currently behind an experimental feature flag
that is off by default.

Some tests are still failing. The reason for that seems to be that our support for Feature
Policy is only partial. In particular, we seem to support the `allow` attribute on iframes
but not the Feature-Policy HTTP header.

We also have to make a decision about whether or not we want to prompt the user when the
Website tries to take a screen wake lock and if we need an indicator in the browser UI.
Currently, my implementation only requires a user gesture.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/feature-policy/resources/feature-policy-screen-wakelock.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/feature-policy/resources/featurepolicy.js:
(expect_reports):
* LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js:
(window.test_driver_internal.set_permission):
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/idlharness.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-active-document.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-disabled-by-feature-policy.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-on-self-origin-by-feature-policy.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-onrelease.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-released.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-request-denied.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-type.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelockpermissiondescriptor.https-expected.txt:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/Modules/permissions/PermissionName.h:
* Source/WebCore/Modules/permissions/PermissionName.idl:
* Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp:
(WebCore::NavigatorScreenWakeLock::NavigatorScreenWakeLock):
(WebCore::NavigatorScreenWakeLock::wakeLock):
* Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.h:
* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp:
(WebCore::WakeLock::WakeLock):
(WebCore::WakeLock::request):
(WebCore::WakeLock::document):
* Source/WebCore/Modules/screen-wake-lock/WakeLock.h:
(WebCore::WakeLock::create):
* Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp: Added.
(WebCore::WakeLockManager::WakeLockManager):
(WebCore::WakeLockManager::~WakeLockManager):
(WebCore::WakeLockManager::addWakeLock):
(WebCore::WakeLockManager::removeWakeLock):
(WebCore::WakeLockManager::visibilityStateChanged):
(WebCore::WakeLockManager::releaseAllLocks):
* Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h: Copied from Source/WebCore/Modules/screen-wake-lock/WakeLock.h.
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp:
(WebCore::WakeLockSentinel::release):
(WebCore::WakeLockSentinel::virtualHasPendingActivity const):
(WebCore::WakeLockSentinel::eventListenersDidChange):
(WebCore::WakeLockSentinel::wakeLockManager):
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h:
* Source/WebCore/Modules/screen-wake-lock/WakeLockType.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::wakeLockManager):
(WebCore::Document::stopActiveDOMObjects):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/TaskSource.h:
* Source/WebCore/html/FeaturePolicy.cpp:
(WebCore::policyTypeName):
(WebCore::FeaturePolicy::parse):
(WebCore::FeaturePolicy::allows const):
* Source/WebCore/html/FeaturePolicy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::queryPermission):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::setScreenWakeLockPermission):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setScreenWakeLockPermission):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::handleQueryPermission):
(WTR::TestController::resetStateToConsistentValues):
(WTR::TestController::setScreenWakeLockPermission):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/255019@main">https://commits.webkit.org/255019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/575238afbfbefdcc52d73b139fb44df509a85be0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90990 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100336 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158837 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/34061 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83334 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97124 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96646 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77773 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26947 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81890 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/81614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69982 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35140 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15635 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32938 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16622 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3496 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36718 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35706 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->