### PR TITLE
Support extended color animation interpolation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/animation/color-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/animation/color-interpolation-expected.txt
@@ -119,76 +119,76 @@ PASS Web Animations: property <color> from [black] to [orange] at (0.3) should b
 PASS Web Animations: property <color> from [black] to [orange] at (0.6) should be [rgb(153, 99, 0)]
 PASS Web Animations: property <color> from [black] to [orange] at (1) should be [rgb(255, 165, 0)]
 PASS Web Animations: property <color> from [black] to [orange] at (1.5) should be [rgb(255, 248, 0)]
-FAIL CSS Transitions: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Transitions: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Transitions: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)] assert_equals: expected "oklab ( 0.3 0 0 ) " but got "rgb ( 77 , 77 , 77 ) "
-FAIL CSS Transitions: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)] assert_equals: expected "oklab ( 0.6 0 0 ) " but got "rgb ( 153 , 153 , 153 ) "
-FAIL CSS Transitions: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)] assert_equals: expected "oklab ( 1 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Transitions: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)] assert_equals: expected "oklab ( 1.5 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Transitions with transition: all: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Transitions with transition: all: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Transitions with transition: all: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)] assert_equals: expected "oklab ( 0.3 0 0 ) " but got "rgb ( 77 , 77 , 77 ) "
-FAIL CSS Transitions with transition: all: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)] assert_equals: expected "oklab ( 0.6 0 0 ) " but got "rgb ( 153 , 153 , 153 ) "
-FAIL CSS Transitions with transition: all: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)] assert_equals: expected "oklab ( 1 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Transitions with transition: all: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)] assert_equals: expected "oklab ( 1.5 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)] assert_equals: expected "oklab ( 0.3 0 0 ) " but got "rgb ( 77 , 77 , 77 ) "
-FAIL CSS Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)] assert_equals: expected "oklab ( 0.6 0 0 ) " but got "rgb ( 153 , 153 , 153 ) "
-FAIL CSS Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)] assert_equals: expected "oklab ( 1 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)] assert_equals: expected "oklab ( 1.5 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL Web Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL Web Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL Web Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)] assert_equals: expected "oklab ( 0.3 0 0 ) " but got "rgb ( 77 , 77 , 77 ) "
-FAIL Web Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)] assert_equals: expected "oklab ( 0.6 0 0 ) " but got "rgb ( 153 , 153 , 153 ) "
-FAIL Web Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)] assert_equals: expected "oklab ( 1 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL Web Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)] assert_equals: expected "oklab ( 1.5 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Transitions: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (-0.3) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Transitions: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Transitions: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.3) should be [oklab(0.3 0 0)] assert_equals: expected "oklab ( 0.3 0 0 ) " but got "rgb ( 77 , 77 , 77 ) "
-FAIL CSS Transitions: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.6) should be [oklab(0.6 0 0)] assert_equals: expected "oklab ( 0.6 0 0 ) " but got "rgb ( 153 , 153 , 153 ) "
-FAIL CSS Transitions: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1) should be [oklab(1 0 0)] assert_equals: expected "oklab ( 1 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Transitions: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1.5) should be [oklab(1.5 0 0)] assert_equals: expected "oklab ( 1.5 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (-0.3) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.3) should be [oklab(0.3 0 0)] assert_equals: expected "oklab ( 0.3 0 0 ) " but got "rgb ( 77 , 77 , 77 ) "
-FAIL CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.6) should be [oklab(0.6 0 0)] assert_equals: expected "oklab ( 0.6 0 0 ) " but got "rgb ( 153 , 153 , 153 ) "
-FAIL CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1) should be [oklab(1 0 0)] assert_equals: expected "oklab ( 1 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1.5) should be [oklab(1.5 0 0)] assert_equals: expected "oklab ( 1.5 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (-0.3) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.3) should be [oklab(0.3 0 0)] assert_equals: expected "oklab ( 0.3 0 0 ) " but got "rgb ( 77 , 77 , 77 ) "
-FAIL CSS Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.6) should be [oklab(0.6 0 0)] assert_equals: expected "oklab ( 0.6 0 0 ) " but got "rgb ( 153 , 153 , 153 ) "
-FAIL CSS Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1) should be [oklab(1 0 0)] assert_equals: expected "oklab ( 1 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1.5) should be [oklab(1.5 0 0)] assert_equals: expected "oklab ( 1.5 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL Web Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (-0.3) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL Web Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL Web Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.3) should be [oklab(0.3 0 0)] assert_equals: expected "oklab ( 0.3 0 0 ) " but got "rgb ( 77 , 77 , 77 ) "
-FAIL Web Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.6) should be [oklab(0.6 0 0)] assert_equals: expected "oklab ( 0.6 0 0 ) " but got "rgb ( 153 , 153 , 153 ) "
-FAIL Web Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1) should be [oklab(1 0 0)] assert_equals: expected "oklab ( 1 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL Web Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1.5) should be [oklab(1.5 0 0)] assert_equals: expected "oklab ( 1.5 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Transitions: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Transitions: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Transitions: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)] assert_equals: expected "oklab ( 0.3 0 0 ) " but got "rgb ( 77 , 77 , 77 ) "
-FAIL CSS Transitions: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)] assert_equals: expected "oklab ( 0.6 0 0 ) " but got "rgb ( 153 , 153 , 153 ) "
-FAIL CSS Transitions: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)] assert_equals: expected "oklab ( 1 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Transitions: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)] assert_equals: expected "oklab ( 1.5 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)] assert_equals: expected "oklab ( 0.3 0 0 ) " but got "rgb ( 77 , 77 , 77 ) "
-FAIL CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)] assert_equals: expected "oklab ( 0.6 0 0 ) " but got "rgb ( 153 , 153 , 153 ) "
-FAIL CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)] assert_equals: expected "oklab ( 1 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)] assert_equals: expected "oklab ( 1.5 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL CSS Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)] assert_equals: expected "oklab ( 0.3 0 0 ) " but got "rgb ( 77 , 77 , 77 ) "
-FAIL CSS Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)] assert_equals: expected "oklab ( 0.6 0 0 ) " but got "rgb ( 153 , 153 , 153 ) "
-FAIL CSS Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)] assert_equals: expected "oklab ( 1 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL CSS Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)] assert_equals: expected "oklab ( 1.5 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL Web Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL Web Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)] assert_equals: expected "oklab ( 0 0 0 ) " but got "rgb ( 0 , 0 , 0 ) "
-FAIL Web Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)] assert_equals: expected "oklab ( 0.3 0 0 ) " but got "rgb ( 77 , 77 , 77 ) "
-FAIL Web Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)] assert_equals: expected "oklab ( 0.6 0 0 ) " but got "rgb ( 153 , 153 , 153 ) "
-FAIL Web Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)] assert_equals: expected "oklab ( 1 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
-FAIL Web Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)] assert_equals: expected "oklab ( 1.5 0 0 ) " but got "rgb ( 255 , 255 , 255 ) "
+PASS CSS Transitions: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)]
+PASS CSS Transitions: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)]
+PASS CSS Transitions: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)]
+PASS CSS Transitions: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)]
+PASS CSS Transitions: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)]
+PASS CSS Transitions: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)]
+PASS CSS Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)]
+PASS CSS Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)]
+PASS CSS Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)]
+PASS CSS Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)]
+PASS CSS Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)]
+PASS CSS Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)]
+PASS Web Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)]
+PASS Web Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)]
+PASS Web Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)]
+PASS Web Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)]
+PASS Web Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)]
+PASS Web Animations: property <color> from [rgb(0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)]
+PASS CSS Transitions: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (-0.3) should be [oklab(0 0 0)]
+PASS CSS Transitions: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0) should be [oklab(0 0 0)]
+PASS CSS Transitions: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.3) should be [oklab(0.3 0 0)]
+PASS CSS Transitions: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.6) should be [oklab(0.6 0 0)]
+PASS CSS Transitions: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1) should be [oklab(1 0 0)]
+PASS CSS Transitions: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1.5) should be [oklab(1.5 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (-0.3) should be [oklab(0 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0) should be [oklab(0 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.3) should be [oklab(0.3 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.6) should be [oklab(0.6 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1) should be [oklab(1 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1.5) should be [oklab(1.5 0 0)]
+PASS CSS Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (-0.3) should be [oklab(0 0 0)]
+PASS CSS Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0) should be [oklab(0 0 0)]
+PASS CSS Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.3) should be [oklab(0.3 0 0)]
+PASS CSS Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.6) should be [oklab(0.6 0 0)]
+PASS CSS Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1) should be [oklab(1 0 0)]
+PASS CSS Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1.5) should be [oklab(1.5 0 0)]
+PASS Web Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (-0.3) should be [oklab(0 0 0)]
+PASS Web Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0) should be [oklab(0 0 0)]
+PASS Web Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.3) should be [oklab(0.3 0 0)]
+PASS Web Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (0.6) should be [oklab(0.6 0 0)]
+PASS Web Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1) should be [oklab(1 0 0)]
+PASS Web Animations: property <color> from [color(srgb 0 0 0)] to [rgb(255 255 255)] at (1.5) should be [oklab(1.5 0 0)]
+PASS CSS Transitions: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)]
+PASS CSS Transitions: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)]
+PASS CSS Transitions: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)]
+PASS CSS Transitions: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)]
+PASS CSS Transitions: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)]
+PASS CSS Transitions: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)]
+PASS CSS Transitions with transition: all: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)]
+PASS CSS Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)]
+PASS CSS Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)]
+PASS CSS Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)]
+PASS CSS Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)]
+PASS CSS Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)]
+PASS CSS Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)]
+PASS Web Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (-0.3) should be [oklab(0 0 0)]
+PASS Web Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0) should be [oklab(0 0 0)]
+PASS Web Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.3) should be [oklab(0.3 0 0)]
+PASS Web Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (0.6) should be [oklab(0.6 0 0)]
+PASS Web Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1) should be [oklab(1 0 0)]
+PASS Web Animations: property <color> from [color(srgb 0 0 0)] to [color(srgb 1 1 1)] at (1.5) should be [oklab(1.5 0 0)]
 

--- a/Source/WebCore/platform/graphics/ColorNormalization.h
+++ b/Source/WebCore/platform/graphics/ColorNormalization.h
@@ -89,7 +89,7 @@ template<typename ComponentType> inline ComponentType normalizeHue(ComponentType
 
 template<typename ColorType> inline ColorType makeColorTypeByNormalizingComponents(const ColorComponents<float, 4>& colorComponents)
 {
-    return makeFromComponents<ColorType>(colorComponents);
+    return makeFromComponentsClamping<ColorType>(colorComponents);
 }
 
 template<> inline HWBA<float> makeColorTypeByNormalizingComponents<HWBA<float>>(const ColorComponents<float, 4>& colorComponents)
@@ -97,7 +97,7 @@ template<> inline HWBA<float> makeColorTypeByNormalizingComponents<HWBA<float>>(
     auto [hue, whiteness, blackness, alpha] = colorComponents;
     auto [normalizedWhitness, normalizedBlackness] = normalizeWhitenessBlackness(whiteness, blackness);
 
-    return { hue, normalizedWhitness, normalizedBlackness, alpha };
+    return makeFromComponentsClamping<HWBA<float>>(hue, normalizedWhitness, normalizedBlackness, alpha);
 }
 
 // MARK: - Canonicalization


### PR DESCRIPTION
#### 1140e61c63402f8b7f84b620960a1a28a2ce4513
<pre>
Support extended color animation interpolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=245645">https://bugs.webkit.org/show_bug.cgi?id=245645</a>
&lt;rdar://100437917&gt;

Reviewed by Dean Jackson and Antti Koivisto.

Adds support for animating non-sRGB colors by using the new default interpolation
method, OKLab, for cases where one or more of the two keyframes in an animation
interpolation are specified using a non-legacy color syntax (e.g. color(), lch(),
etc.).

For now, there is no syntax for specifying a specific interpolation method to use,
as none has been specified yet, so only the two default spaces, sRGB for legacy
and OKLab for non-legacy are available.

* LayoutTests/imported/w3c/web-platform-tests/css/css-color/animation/color-interpolation-expected.txt:
Update results for additional passing test cases.

* Source/WebCore/platform/graphics/ColorBlending.cpp:
(WebCore::requiresLegacyInterpolationRules): Helper to choose which
kind of interpolation to use.
(WebCore::blend): When using the legacy path, also continue to clamp
to the 8-bit per channel sRGB to avoid any change for existing content.

* Source/WebCore/platform/graphics/ColorNormalization.h:
(WebCore::makeColorTypeByNormalizingComponents):
(WebCore::makeColorTypeByNormalizingComponents&lt;HWBA&lt;float&gt;&gt;):
Interpolation can produce negative and otherwise out of range
values, so ensure we clamp here. Fixes test case where the
progress was set to -0.3.

Canonical link: <a href="https://commits.webkit.org/254960@main">https://commits.webkit.org/254960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ed6de0be8c8eddd88e6597d68b72e219f62c778

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99994 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158316 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33757 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28892 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83037 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96393 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26871 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77502 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26712 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81416 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69740 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/children-changed, /TestWTF:WTF_WordLock.ManyContendedLongSections (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34849 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15453 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32661 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16433 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3458 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39371 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35522 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->