### PR TITLE
Do not emit 'load' event more than once onto the same document

### DIFF
--- a/LayoutTests/dom/iframe-load-event-once-expected.txt
+++ b/LayoutTests/dom/iframe-load-event-once-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Dispatch 'load' event on iframe only once
+

--- a/LayoutTests/dom/iframe-load-event-once.html
+++ b/LayoutTests/dom/iframe-load-event-once.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(() => {
+    return new Promise((resolve, reject) => {
+        let counter = 0;
+        function handler() {
+            counter++;
+        }
+
+        const iframe = document.createElement("iframe");
+        window.onmessage = function(ev) {
+            try {
+                assert_equals(counter, 1);
+            } catch(error) {
+                reject(error);
+                return;
+            }
+            resolve();
+        };
+        iframe.src = "javascript:(function(){document.open();document.write('test');document.close();parent.postMessage('done','*');})();";
+        iframe.onload = handler;
+        document.body.appendChild(iframe);
+    });
+}, `Dispatch 'load' event on iframe only once`);
+</script>
+</body>

--- a/LayoutTests/http/tests/dom/iframe-dispatch-load-once-with-document-write-expected.txt
+++ b/LayoutTests/http/tests/dom/iframe-dispatch-load-once-with-document-write-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS iframe should not receive 'load' event more than once
+

--- a/LayoutTests/http/tests/dom/iframe-dispatch-load-once-with-document-write.html
+++ b/LayoutTests/http/tests/dom/iframe-dispatch-load-once-with-document-write.html
@@ -1,0 +1,25 @@
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(() => {
+    return new Promise((resolve, reject) => {
+        var counter = 0;
+        var iframe = document.createElement('iframe');
+        iframe.src = 'resources/dummy.html';
+        iframe.onload = function (ev) {
+            try {
+                counter++;
+                assert_equals(counter, 1);
+                iframe.contentDocument.write(`<script ` +  `src="not-found.js">` + `</` + `script>`);
+                iframe.contentDocument.close();
+            } catch (error) { reject(error); }
+            setTimeout(resolve, 100);
+        };
+        document.body.appendChild(iframe);
+    });
+}, `iframe should not receive 'load' event more than once`);
+</script>
+</body>

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1203,8 +1203,10 @@ public:
     void updateURLForPushOrReplaceState(const URL&);
     void statePopped(Ref<SerializedScriptValue>&&);
 
-    bool processingLoadEvent() const { return m_processingLoadEvent; }
-    bool loadEventFinished() const { return m_loadEventFinished; }
+    enum class LoadEventState : uint8_t { NotDispatched, Processing, Completed };
+    bool processingLoadEvent() const { return m_loadEventState == LoadEventState::Processing; }
+    bool loadEventFinished() const { return m_loadEventState == LoadEventState::Completed; }
+    bool canDispatchLoadEvent() const { return static_cast<unsigned>(m_loadEventState) < static_cast<unsigned>(LoadEventState::Processing); }
 
     bool isContextThread() const final;
     bool isSecureContext() const final;
@@ -2166,12 +2168,11 @@ private:
     DocumentCompatibilityMode m_compatibilityMode { DocumentCompatibilityMode::NoQuirksMode };
     bool m_compatibilityModeLocked { false }; // This is cheaper than making setCompatibilityMode virtual.
 
-    // FIXME: Merge these 2 variables into an enum. Also, FrameLoader::m_didCallImplicitClose
+    // FIXME: Also, FrameLoader::m_didCallImplicitClose
     // is almost a duplication of this data, so that should probably get merged in too.
-    // FIXME: Document::m_processingLoadEvent and DocumentLoader::m_wasOnloadDispatched are roughly the same
+    // FIXME: Document::m_loadEventState and DocumentLoader::m_wasOnloadDispatched are roughly the same
     // and should be merged.
-    bool m_processingLoadEvent { false };
-    bool m_loadEventFinished { false };
+    LoadEventState m_loadEventState { LoadEventState::NotDispatched };
 
     bool m_visuallyOrdered { false };
     bool m_bParsing { false }; // FIXME: rename

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3499,7 +3499,7 @@ void FrameLoader::executeJavaScriptURL(const URL& url, const NavigationAction& a
     m_frame.script().executeJavaScriptURL(url, action.requester() ? action.requester()->securityOrigin.ptr() : nullptr, action.shouldReplaceDocumentIfJavaScriptURL(), didReplaceDocument);
 
     // We need to communicate that a load happened, even if the JavaScript URL execution didn't end up replacing the document.
-    if (auto* document = m_frame.document(); isFirstNavigationInFrame && !didReplaceDocument)
+    if (auto* document = m_frame.document(); isFirstNavigationInFrame && !didReplaceDocument && document->canDispatchLoadEvent())
         document->dispatchWindowLoadEvent();
 
     checkCompleted();


### PR DESCRIPTION
#### bb6a3af38eb3e0c2ef6cd224c1deafb9001ed4b8
<pre>
Do not emit &apos;load&apos; event more than once onto the same document
<a href="https://bugs.webkit.org/show_bug.cgi?id=245719">https://bugs.webkit.org/show_bug.cgi?id=245719</a>
&lt;rdar://100443412&gt;

Reviewed by NOBODY (OOPS!).

We found that &apos;load&apos; event is emitted multiple times onto the same iframe without navigation.
This patch integrates LoadEventState enum and combine existing two bools into one enum.
And avoid dispatching &apos;load&apos; event multiple times onto the same document.
This change is necessary to unblock import-maps&apos; WPT test.

* LayoutTests/dom/iframe-load-event-once-expected.txt: Added.
* LayoutTests/dom/iframe-load-event-once.html: Added.
* LayoutTests/http/tests/dom/iframe-dispatch-load-once-with-document-write-expected.txt: Added.
* LayoutTests/http/tests/dom/iframe-dispatch-load-once-with-document-write.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::implicitClose):
(WebCore::Document::dispatchWindowLoadEvent):
* Source/WebCore/dom/Document.h:
(WebCore::Document::processingLoadEvent const):
(WebCore::Document::loadEventFinished const):
(WebCore::Document::canDispatchLoadEvent const):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::executeJavaScriptURL):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb6a3af38eb3e0c2ef6cd224c1deafb9001ed4b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99952 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158292 "Found 3 new test failures: fast/events/onload-after-document-close-no-subresource.html, fast/events/onload-after-document-close-with-subresource.html, jquery/core.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94643 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33712 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29791 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82991 "Hash bb6a3af3 for PR 4742 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96370 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96288 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77463 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26669 "Found 39 new test failures: fast/events/onload-after-document-close-no-subresource.html, http/tests/security/frame-loading-via-document-write-async-delegates.html, http/tests/security/frame-loading-via-document-write.html, imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/form-control-state.html, imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/fetch.https.html, imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/img-tag.https.html, imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/sharedworker-classic.https.html, imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/sharedworker-import-data.https.html, imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/sharedworker-module.https.html, imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/websocket.https.html ... (failure)") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69697 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34807 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15428 "Found 30 new test failures: fast/dom/frame-loading-via-document-write.html, fast/events/onload-after-document-close-no-subresource.html, fast/events/onload-after-document-close-with-subresource.html, http/tests/appcache/fail-on-update-2.html, http/tests/preload/onload_event.html, http/tests/security/frame-loading-via-document-write-async-delegates.html, http/tests/security/frame-loading-via-document-write.html, imported/w3c/web-platform-tests/css/css-images/object-position-interpolation.html, imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-select-menulist-button-border-top-right-radius-001.html, imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-N-EN-L.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32619 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16407 "Found 30 new test failures: fast/events/onload-after-document-close-no-subresource.html, fast/events/onload-after-document-close-with-subresource.html, http/tests/security/frame-loading-via-document-write-async-delegates.html, http/tests/security/frame-loading-via-document-write.html, http/tests/websocket/tests/hybi/bad-handshake-crash.html, http/wpt/cache-storage/cache-quota-after-restart.any.html, http/wpt/cache-storage/quota-third-party.https.html, imported/w3c/web-platform-tests/content-security-policy/navigation/javascript-url-navigation-inherits-csp.html, imported/w3c/web-platform-tests/css/css-transitions/retargetted-transition-with-box-sizing.html, imported/w3c/web-platform-tests/html/anonymous-iframe/cache-storage.tentative.https.window.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36385 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39337 "Found 30 new test failures: fast/events/onload-after-document-close-no-subresource.html, fast/events/onload-after-document-close-with-subresource.html, http/tests/security/frame-loading-via-document-write-async-delegates.html, http/tests/security/frame-loading-via-document-write.html, http/wpt/webauthn/public-key-credential-create-failure.https.html, imported/mozilla/svg/image/image-opacity-01.svg, imported/mozilla/svg/image/image-opacity-02.svg, imported/mozilla/svg/image/image-rotate-01.svg, imported/mozilla/svg/image/image-translate-01.svg, imported/mozilla/svg/image/image-x-01.svg ... (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38306 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35495 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->