### PR TITLE
Display can go to sleep when camera is on

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -222,6 +222,7 @@ class SelectorQuery;
 class SelectorQueryCache;
 class SerializedScriptValue;
 class Settings;
+class SleepDisabler;
 class SpeechRecognition;
 class StorageConnection;
 class StringCallback;
@@ -1713,6 +1714,8 @@ public:
     ReportingScope& reportingScope() const { return m_reportingScope.get(); }
     WEBCORE_EXPORT String endpointURIForToken(const String&) const final;
 
+    bool hasSleepDisabler() const { return !!m_sleepDisabler; }
+
 protected:
     enum ConstructionFlags { Synthesized = 1, NonRenderedPlaceholder = 1 << 1 };
     WEBCORE_EXPORT Document(Frame*, const Settings&, const URL&, DocumentClasses = { }, unsigned constructionFlags = 0, ScriptExecutionContextIdentifier = { });
@@ -1843,6 +1846,8 @@ private:
     void notifyReportObservers(Ref<Report>&&) final;
     void sendReportToEndpoints(const URL& baseURL, const Vector<String>& endpointURIs, const Vector<String>& endpointTokens, Ref<FormData>&& report, ViolationReportType) final;
     String httpUserAgent() const final;
+
+    void updateSleepDisablerIfNeeded();
 
     const Ref<const Settings> m_settings;
 
@@ -2317,6 +2322,8 @@ private:
 
     Ref<ReportingScope> m_reportingScope;
     std::unique_ptr<WakeLockManager> m_wakeLockManager;
+
+    std::unique_ptr<SleepDisabler> m_sleepDisabler;
 };
 
 Element* eventTargetElementForDocument(Document*);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6938,4 +6938,11 @@ void Internals::avoidIOSurfaceSizeCheckInWebProcess(HTMLCanvasElement& element)
     HTMLCanvasElement::setMaxPixelMemoryForTesting(UINT_MAX);
     element.setAvoidIOSurfaceSizeCheckInWebProcessForTesting();
 }
+
+bool Internals::hasSleepDisabler() const
+{
+    auto* document = contextDocument();
+    return document ? document->hasSleepDisabler() : false;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1350,6 +1350,7 @@ public:
 #endif
 
     void avoidIOSurfaceSizeCheckInWebProcess(HTMLCanvasElement&);
+    bool hasSleepDisabler() const;
 
 private:
     explicit Internals(Document&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1173,4 +1173,6 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     [Conditional=ARKIT_INLINE_PREVIEW_MAC] Promise<sequence<DOMString>> modelInlinePreviewUUIDs();
     [Conditional=ARKIT_INLINE_PREVIEW_MAC] DOMString modelInlinePreviewUUIDForModelElement(HTMLModelElement modelElement);
     undefined avoidIOSurfaceSizeCheckInWebProcess(HTMLCanvasElement element);
+
+    boolean hasSleepDisabler();
 };

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -848,6 +848,17 @@ function doTest()
     });
 }
 
+function hasSleepDisabler()
+{
+    return window.internals ? internals.hasSleepDisabler() : false;
+}
+
+function stop()
+{
+    if (localVideo.srcObject)
+        localVideo.srcObject.getVideoTracks()[0].stop();
+    window.webkit.messageHandlers.gum.postMessage("PASS");
+}
 </script>
 </body></html>
 )DOCDOCDOC"_s;
@@ -886,6 +897,9 @@ TEST(WebKit, AutoplayOnVisibilityChange)
     [webView stringByEvaluatingJavaScript:@"capture()"];
     TestWebKitAPI::Util::run(&done);
 
+    bool hasSleepDisabler = [webView stringByEvaluatingJavaScript:@"hasSleepDisabler()"].boolValue;
+    EXPECT_TRUE(hasSleepDisabler);
+
     done = false;
     [hostWindow deminiaturize:hostWindow];
     TestWebKitAPI::Util::run(&done);
@@ -893,6 +907,13 @@ TEST(WebKit, AutoplayOnVisibilityChange)
     done = false;
     [webView stringByEvaluatingJavaScript:@"doTest()"];
     TestWebKitAPI::Util::run(&done);
+
+    done = false;
+    [webView stringByEvaluatingJavaScript:@"stop()"];
+    TestWebKitAPI::Util::run(&done);
+
+    hasSleepDisabler = [webView stringByEvaluatingJavaScript:@"hasSleepDisabler()"].boolValue;
+    EXPECT_FALSE(hasSleepDisabler);
 }
 
 static constexpr auto getUserMediaFocusText = R"DOCDOCDOC(

--- a/Tools/TestWebKitAPI/Tests/WebKit/getDisplayMedia.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/getDisplayMedia.html
@@ -49,6 +49,11 @@
             {
                 return stream !== null;
             }
+
+            function hasSleepDisabler()
+            {
+                return window.internals ? internals.hasSleepDisabler() : false;
+            }
         </script>
     <head>
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetDisplayMediaWindowAndScreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetDisplayMediaWindowAndScreen.mm
@@ -150,9 +150,16 @@ TEST(WebKit2, GetDisplayMediaWindowAndScreenPrompt)
     EXPECT_TRUE([webView _displayCaptureState] == WKDisplayCaptureStateNone);
     EXPECT_TRUE([webView _displayCaptureSurfaces] == WKDisplayCaptureSurfaceNone);
 
+    auto hasSleepDisabler = [m_webView stringByEvaluatingJavaScript:@"hasSleepDisabler()"].booleanValue;
+    EXPECT_TRUE(hasSleepDisabler);
+
     // Check "Allow Screen"
     [webView stringByEvaluatingJavaScript:@"stop()"];
     [delegate resetWasPrompted];
+
+    hasSleepDisabler = [m_webView stringByEvaluatingJavaScript:@"hasSleepDisabler()"].booleanValue;
+    EXPECT_FALSE(hasSleepDisabler);
+
     [webView _setIndexOfGetDisplayMediaDeviceSelectedForTesting:@0];
     [delegate setGetDisplayMediaDecision:WKDisplayCapturePermissionDecisionScreenPrompt];
     [webView stringByEvaluatingJavaScript:@"promptForCapture({ video : true })"];

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/video-with-audio.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/video-with-audio.html
@@ -37,10 +37,35 @@
         go();
     }
 
+    function playAudio() {
+        window.webkit.messageHandlers.testHandler.postMessage('playAudio');
+        const audio = document.getElementsByTagName('audio')[0];
+        audio.play().then(playing).catch(notPlaying);
+    }
+
+    let canvasTimer;
+    function startCanvasUpdate()
+    {
+        stopCanvasUpdate();
+        canvasTimer = setInterval(() => {
+            window.webkit.messageHandlers.testHandler.postMessage('canvasClearFill');
+            myCanvas.getContext('2d').clearRect(0, 0, 50, 50);
+            myCanvas.getContext('2d').fillRect(0, 0, 100, 100);
+        }, 50);
+    }
+
+    function stopCanvasUpdate()
+    {
+        if (canvasTimer)
+            clearInterval(canvasTimer);
+    }
+
     document.addEventListener('pageshow', go);
    </script>
 </head>
 <body onload="go()">
     <video src="video-with-audio.mp4" webkit-playsinline></video>
+    <audio src="video-with-audio.mp4" webkit-playsinline></video>
+    <canvas id="myCanvas" width="200" height="200"></canvas>
 </body>
 </html>


### PR DESCRIPTION
#### 79a3c4d8d291353d877baa33fd41bb4c104e2abc
<pre>
Display can go to sleep when camera is on
<a href="https://bugs.webkit.org/show_bug.cgi?id=245726">https://bugs.webkit.org/show_bug.cgi?id=245726</a>
rdar://100423979

Reviewed by Eric Carlson.

In case a document is capturing or screen, it is good to keep the display on so that the preview stays visible.
To do so, the document creates a SleepDisabler when capturing.

Covered by updated API tests.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::mediaStreamCaptureStateChanged):
(WebCore::Document::canvasChanged):
(WebCore::Document::updateSleepDisablerIfNeeded):
* Source/WebCore/dom/Document.h:
(WebCore::Document::hasSleepDisabler const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::hasSleepDisabler const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
* Tools/TestWebKitAPI/Tests/WebKit/SleepDisabler.mm:
(TEST_F):
* Tools/TestWebKitAPI/Tests/WebKit/getDisplayMedia.html:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GetDisplayMediaWindowAndScreen.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/video-with-audio.html:

Canonical link: <a href="https://commits.webkit.org/255636@main">https://commits.webkit.org/255636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ad7cd31870502097961db8d477908ddbcf578e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102799 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2300 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30620 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85482 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98917 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1585 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79566 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28505 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71614 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37013 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17148 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34825 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18381 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3905 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40923 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40626 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37585 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->