### PR TITLE
REGRESSION (iOS 16): LocalStorage writes fail after ~2.5MB

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
@@ -69,13 +69,19 @@ private:
     WebCore::SQLiteStatementAutoResetScope cachedStatement(StatementType);
     Expected<String, StorageError> getItem(const String& key);
     Expected<String, StorageError> getItemFromDatabase(const String& key);
+    Expected<HashMap<String, String>, StorageError> getAllItemsFromDatabase();
+    void initializeCache(const HashMap<String, String>&);
 
     String m_path;
     Ref<WorkQueue> m_queue;
     std::unique_ptr<WebCore::SQLiteDatabase> m_database;
     std::unique_ptr<WebCore::SQLiteTransaction> m_transaction;
     Vector<std::unique_ptr<WebCore::SQLiteStatement>> m_cachedStatements;
-    std::optional<HashMap<String, String>> m_cache;
+    struct Cache {
+        HashMap<String, String> items;
+        uint64_t size { 0 };
+    };
+    std::optional<Cache> m_cache;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 0297f1253a4f4da904d242be3a70a4ba3cd9d44c
<pre>
REGRESSION (iOS 16): LocalStorage writes fail after ~2.5MB
<a href="https://bugs.webkit.org/show_bug.cgi?id=245479">https://bugs.webkit.org/show_bug.cgi?id=245479</a>
&lt;rdar://100252023&gt;

Reviewed by Chris Dumez.

We set the maximum size of LocalStorage database to be 5MB, because quota is 5MB. But SQLite has overhead, which means
the file size can reach 5MB when the stored content is much smaller than that. To avoid this issue, now we let
SQLiteStorageArea keep track of the actual content size and use that size to do quota computation, instead of setting
hard limit on database file.

* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
(WebKit::SQLiteStorageArea::isEmpty):
(WebKit::SQLiteStorageArea::prepareDatabase):
(WebKit::SQLiteStorageArea::startTransactionIfNecessary):
(WebKit::SQLiteStorageArea::getItem):
(WebKit::SQLiteStorageArea::getAllItemsFromDatabase):
(WebKit::SQLiteStorageArea::initializeCache):
(WebKit::SQLiteStorageArea::allItems):
(WebKit::SQLiteStorageArea::setItem):
(WebKit::SQLiteStorageArea::removeItem):
(WebKit::SQLiteStorageArea::clear):
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h:

Canonical link: <a href="https://commits.webkit.org/255044@main">https://commits.webkit.org/255044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7e1da26c84c21ca6952412ef3f6b8a26ad243dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21642 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/100597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/107 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83472 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97229 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96761 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/85 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/27071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/81686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35254 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/15711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33051 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16716 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3509 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36833 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35800 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->