### PR TITLE
[webkit-patch] Parse non-utf characters

### DIFF
--- a/Tools/Scripts/webkitpy/common/checkout/diff_parser.py
+++ b/Tools/Scripts/webkitpy/common/checkout/diff_parser.py
@@ -87,7 +87,7 @@ def get_diff_converter(lines):
              converter from git to SVN.
     """
     for i, line in enumerate(lines[:-1]):
-        line = string_utils.decode(line)
+        line = string_utils.decode(line, errors='replace')
 
         # Stop when we find the first patch
         if line[:3] == "+++" and lines[i + 1] == "---":
@@ -159,7 +159,7 @@ class DiffParser(object):
         new_diff_line = None
         transform_line = get_diff_converter(diff_input)
         for line in diff_input:
-            line = string_utils.decode(line).rstrip("\n")
+            line = string_utils.decode(line, errors='replace').rstrip("\n")
             line = transform_line(line)
 
             file_declaration = match(r"^Index: (?P<FilePath>.+)", line)

--- a/Tools/Scripts/webkitpy/common/checkout/diff_parser_unittest.py
+++ b/Tools/Scripts/webkitpy/common/checkout/diff_parser_unittest.py
@@ -29,7 +29,7 @@
 import re
 import unittest
 
-from webkitcorepy import StringIO
+from webkitcorepy import StringIO, string_utils
 
 import webkitpy.common.checkout.diff_parser as diff_parser
 from webkitpy.common.checkout.diff_test_data import DIFF_TEST_DATA
@@ -79,6 +79,15 @@ class DiffParserTest(unittest.TestCase):
         diff = parser.files['LayoutTests/platform/mac/fast/flexbox/box-orient-button-expected.checksum']
         self.assertEqual(1, len(diff.lines))
         self.assertEqual((0, 1), diff.lines[0][0:2])
+
+    def test_diff_parser_latin(self):
+        data = string_utils.encode(DIFF_TEST_DATA).replace(b'(o.boxOrient)', b'(o.boxOrient) // With comment, \xa3\xa3')
+        parser = diff_parser.DiffParser(data.splitlines())
+        self.assertEqual(3, len(parser.files))
+        self.assertEqual(
+            string_utils.encode(parser.files['WebCore/rendering/style/StyleRareInheritedData.cpp'].lines[10][2]),
+            b'    , boxOrient(o.boxOrient) // With comment, \xef\xbf\xbd\xef\xbf\xbd',
+        )
 
     def test_diff_converter(self):
         comment_lines = [

--- a/Tools/Scripts/webkitpy/style/patchreader.py
+++ b/Tools/Scripts/webkitpy/style/patchreader.py
@@ -57,7 +57,7 @@ class PatchReader(object):
     def check(self, patch_string, fs=None):
         """Check style in the given patch."""
         fs = fs or FileSystem()
-        patch_string = string_utils.decode(patch_string, target_type=str)
+        patch_string = string_utils.decode(patch_string, target_type=str, errors='replace')
         patch_files = DiffParser(patch_string.splitlines()).files
 
         # If the user uses git, checking subversion config file only once is enough.


### PR DESCRIPTION
#### cd13c6e5c9e2da091877b656c3ad34cce5657245
<pre>
[webkit-patch] Parse non-utf characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=245742">https://bugs.webkit.org/show_bug.cgi?id=245742</a>
&lt;rdar://100466774&gt;

Reviewed by Elliott Williams.

* Tools/Scripts/webkitpy/common/checkout/diff_parser.py:
(get_diff_converter): Replace unparseable characters.
(DiffParser._parse_into_diff_files): Ditto.
* Tools/Scripts/webkitpy/common/checkout/diff_parser_unittest.py:
(DiffParserTest.test_diff_parser_latin):
* Tools/Scripts/webkitpy/style/patchreader.py:
(PatchReader.check): Replace unparseable characters.

Canonical link: <a href="https://commits.webkit.org/254967@main">https://commits.webkit.org/254967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52dce89cdd143a6000afb49b939aa749990cce6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100038 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158346 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33792 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28920 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83070 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96421 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26902 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77533 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26732 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/94294 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69763 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34882 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15477 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32693 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16457 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39393 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1513 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35546 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->