### PR TITLE
Clean up UTF-8 conversion code

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRef.cpp
+++ b/Source/JavaScriptCore/API/JSStringRef.cpp
@@ -109,7 +109,7 @@ size_t JSStringGetUTF8CString(JSStringRef string, char* buffer, size_t bufferSiz
     } else {
         const UChar* source = string->characters16();
         auto result = convertUTF16ToUTF8(&source, source + string->length(), &destination, destination + bufferSize - 1);
-        failed = result != ConversionOK && result != TargetExhausted;
+        failed = result != ConversionResult::Success && result != ConversionResult::TargetExhausted;
     }
 
     *destination++ = '\0';

--- a/Source/JavaScriptCore/runtime/ConsoleClient.cpp
+++ b/Source/JavaScriptCore/runtime/ConsoleClient.cpp
@@ -210,7 +210,7 @@ void ConsoleClient::printConsoleMessageWithArguments(MessageSource source, Messa
     Ref<ScriptCallStack> callStack = createScriptCallStackForConsole(globalObject, stackSize);
     const ScriptCallFrame& lastCaller = callStack->at(0);
 
-    StringBuilder builder;
+    StringBuilder builder(StringBuilder::OverflowHandler::RecordOverflow);
 
     if (!lastCaller.sourceURL().isEmpty()) {
         appendURLAndPosition(builder, lastCaller.sourceURL(), lastCaller.lineNumber(), lastCaller.columnNumber());
@@ -226,7 +226,10 @@ void ConsoleClient::printConsoleMessageWithArguments(MessageSource source, Messa
         scope.clearException();
     }
 
-    WTFLogAlways("%s", builder.toString().utf8().data());
+    if (builder.hasOverflowed())
+        WTFLogAlways("Console message exceeded maximum length.");
+    else
+        WTFLogAlways("%s", builder.toString().utf8().data());
 
     if (isTraceMessage) {
         for (size_t i = 0; i < callStack->size(); ++i) {

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -557,7 +557,7 @@ template<typename StringType>
 static String percentEncodeCharacters(const StringType& input, bool(*shouldEncode)(UChar))
 {
     auto encode = [shouldEncode] (const StringType& input) {
-        auto result = input.tryGetUTF8ForRange([&](Span<const char> span) -> String {
+        auto result = input.tryGetUTF8([&](Span<const char> span) -> String {
             StringBuilder builder;
             for (unsigned j = 0; j < span.size(); j++) {
                 auto c = span[j];
@@ -569,7 +569,7 @@ static String percentEncodeCharacters(const StringType& input, bool(*shouldEncod
                     builder.append(c);
             }
             return builder.toString();
-        }, 0, input.length());
+        });
         RELEASE_ASSERT(result);
         return result.value();
     };

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -125,7 +125,7 @@ public:
     WTF_EXPORT_PRIVATE CString utf8(ConversionMode = LenientConversion) const;
 
     template<typename Func>
-    Expected<std::invoke_result_t<Func, Span<const char>>, UTF8ConversionError> tryGetUTF8ForRange(const Func&, unsigned offset, unsigned length, ConversionMode = LenientConversion) const;
+    Expected<std::invoke_result_t<Func, Span<const char>>, UTF8ConversionError> tryGetUTF8(const Func&, ConversionMode = LenientConversion) const;
 
     class UpconvertedCharacters;
     UpconvertedCharacters upconvertedCharacters() const;
@@ -1440,13 +1440,11 @@ inline bool AtomString::endsWithIgnoringASCIICase(StringView string) const
 }
 
 template<typename Func>
-inline Expected<std::invoke_result_t<Func, Span<const char>>, UTF8ConversionError> StringView::tryGetUTF8ForRange(const Func& function, unsigned offset, unsigned length, ConversionMode mode) const
+inline Expected<std::invoke_result_t<Func, Span<const char>>, UTF8ConversionError> StringView::tryGetUTF8(const Func& function, ConversionMode mode) const
 {
-    ASSERT(offset <= this->length());
-    ASSERT(length <= (this->length() - offset));
     if (is8Bit())
-        return StringImpl::tryGetUTF8ForCharacters(function, characters8() + offset, length);
-    return StringImpl::tryGetUTF8ForCharacters(function, characters16() + offset, length, mode);
+        return StringImpl::tryGetUTF8ForCharacters(function, characters8(), length());
+    return StringImpl::tryGetUTF8ForCharacters(function, characters16(), length(), mode);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/UTF8ConversionError.h
+++ b/Source/WTF/wtf/text/UTF8ConversionError.h
@@ -27,8 +27,7 @@
 
 namespace WTF {
 
-enum class UTF8ConversionError {
-    None,
+enum class UTF8ConversionError : uint8_t {
     OutOfMemory,
     IllegalSource,
     SourceExhausted

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -470,11 +470,6 @@ CString String::utf8(ConversionMode mode) const
     return expectedString.value();
 }
 
-CString String::utf8() const
-{
-    return utf8(LenientConversion);
-}
-
 String String::make8BitFrom16BitSource(const UChar* source, size_t length)
 {
     if (!length)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -129,11 +129,10 @@ public:
     WTF_EXPORT_PRIVATE CString ascii() const;
     WTF_EXPORT_PRIVATE CString latin1() const;
 
-    WTF_EXPORT_PRIVATE CString utf8(ConversionMode) const;
-    WTF_EXPORT_PRIVATE CString utf8() const;
+    WTF_EXPORT_PRIVATE CString utf8(ConversionMode = LenientConversion) const;
 
     template<typename Func>
-    Expected<std::invoke_result_t<Func, Span<const char>>, UTF8ConversionError> tryGetUTF8ForRange(const Func&, unsigned offset, unsigned length, ConversionMode = LenientConversion) const;
+    Expected<std::invoke_result_t<Func, Span<const char>>, UTF8ConversionError> tryGetUTF8(const Func&, ConversionMode = LenientConversion) const;
     WTF_EXPORT_PRIVATE Expected<CString, UTF8ConversionError> tryGetUTF8(ConversionMode) const;
     WTF_EXPORT_PRIVATE Expected<CString, UTF8ConversionError> tryGetUTF8() const;
 
@@ -527,15 +526,13 @@ inline String String::substring(unsigned position, unsigned length) const
 }
 
 template<typename Func>
-inline Expected<std::invoke_result_t<Func, Span<const char>>, UTF8ConversionError> String::tryGetUTF8ForRange(const Func& function, unsigned offset, unsigned length, ConversionMode mode) const
+inline Expected<std::invoke_result_t<Func, Span<const char>>, UTF8ConversionError> String::tryGetUTF8(const Func& function, ConversionMode mode) const
 {
-    ASSERT(offset <= this->length());
-    ASSERT(length <= (this->length() - offset));
     if (!m_impl) {
         constexpr const char* emptyString = "";
         return function(Span { emptyString, emptyString });
     }
-    return m_impl->tryGetUTF8ForRange(function, offset, length, mode);
+    return m_impl->tryGetUTF8(function, mode);
 }
 
 #ifdef __OBJC__

--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -31,20 +31,20 @@
 #include <wtf/text/StringHasher.h>
 #include <wtf/unicode/CharacterNames.h>
 
-namespace WTF {
-namespace Unicode {
+namespace WTF::Unicode {
 
 bool convertLatin1ToUTF8(const LChar** sourceStart, const LChar* sourceEnd, char** targetStart, char* targetEnd)
 {
     const LChar* source;
     char* target = *targetStart;
-    int i = 0;
+    int32_t i = 0;
     for (source = *sourceStart; source < sourceEnd; ++source) {
         UBool sawError = false;
         // Work around bug in either Windows compiler or old version of ICU, where passing a uint8_t to
         // U8_APPEND warns, by converting from uint8_t to a wider type.
         UChar32 character = *source;
         U8_APPEND(reinterpret_cast<uint8_t*>(target), i, targetEnd - *targetStart, character, sawError);
+        ASSERT_WITH_MESSAGE(!sawError, "UTF8 destination buffer was not big enough");
         if (sawError)
             return false;
     }
@@ -55,29 +55,29 @@ bool convertLatin1ToUTF8(const LChar** sourceStart, const LChar* sourceEnd, char
 
 ConversionResult convertUTF16ToUTF8(const UChar** sourceStart, const UChar* sourceEnd, char** targetStart, char* targetEnd, bool strict)
 {
-    ConversionResult result = ConversionOK;
+    auto result = ConversionResult::Success;
     const UChar* source = *sourceStart;
     char* target = *targetStart;
     UBool sawError = false;
-    int i = 0;
+    int32_t i = 0;
     while (source < sourceEnd) {
         UChar32 ch;
         int j = 0;
         U16_NEXT(source, j, sourceEnd - source, ch);
         if (U_IS_SURROGATE(ch)) {
             if (source + j == sourceEnd && U_IS_SURROGATE_LEAD(ch)) {
-                result = SourceExhausted;
+                result = ConversionResult::SourceExhausted;
                 break;
             }
             if (strict) {
-                result = SourceIllegal;
+                result = ConversionResult::SourceIllegal;
                 break;
             }
             ch = replacementCharacter;
         }
         U8_APPEND(reinterpret_cast<uint8_t*>(target), i, targetEnd - target, ch, sawError);
         if (sawError) {
-            result = TargetExhausted;
+            result = ConversionResult::TargetExhausted;
             break;
         }
         source += j;
@@ -207,5 +207,4 @@ bool equalLatin1WithUTF8(const LChar* a, const char* b, const char* bEnd)
     return true;
 }
 
-} // namespace Unicode
-} // namespace WTF
+} // namespace WTF::Unicode

--- a/Source/WTF/wtf/unicode/UTF8Conversion.h
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.h
@@ -31,8 +31,8 @@
 namespace WTF {
 namespace Unicode {
 
-enum ConversionResult {
-    ConversionOK, // conversion successful
+enum class ConversionResult : uint8_t {
+    Success, // conversion successful
     SourceExhausted, // partial character in source, but hit end
     TargetExhausted, // insufficient room in target for conversion
     SourceIllegal // source sequence is illegal/malformed
@@ -48,7 +48,6 @@ WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16(const char* sourceStart, const char* 
 WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16ReplacingInvalidSequences(const char* sourceStart, const char* sourceEnd, UChar** targetStart, UChar* targetEnd, bool* isSourceAllASCII = nullptr);
 WTF_EXPORT_PRIVATE bool convertLatin1ToUTF8(const LChar** sourceStart, const LChar* sourceEnd, char** targetStart, char* targetEnd);
 WTF_EXPORT_PRIVATE ConversionResult convertUTF16ToUTF8(const UChar** sourceStart, const UChar* sourceEnd, char** targetStart, char* targetEnd, bool strict = true);
-
 WTF_EXPORT_PRIVATE unsigned calculateStringHashAndLengthFromUTF8MaskingTop8Bits(const char* data, const char* dataEnd, unsigned& dataLength, unsigned& utf16Length);
 
 // Callers of these functions must check that the lengths are the same; accordingly we omit an end argument for UTF-16 and Latin-1.

--- a/Source/WebCore/dom/TextEncoder.cpp
+++ b/Source/WebCore/dom/TextEncoder.cpp
@@ -38,9 +38,9 @@ String TextEncoder::encoding() const
 
 RefPtr<Uint8Array> TextEncoder::encode(String&& input) const
 {
-    auto result = input.tryGetUTF8ForRange([&](Span<const char> span) -> RefPtr<Uint8Array> {
+    auto result = input.tryGetUTF8([&](Span<const char> span) -> RefPtr<Uint8Array> {
         return Uint8Array::tryCreate(reinterpret_cast<const uint8_t*>(span.data()), span.size());
-    }, 0, input.length());
+    });
     if (result)
         return result.value();
     return Uint8Array::tryCreate(nullptr, 0);

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -680,7 +680,7 @@ RefPtr<SharedBuffer> utf8Buffer(const String& string)
                 return nullptr;
         } else {
             const UChar* d = string.characters16();
-            if (WTF::Unicode::convertUTF16ToUTF8(&d, d + length, &p, p + buffer.size()) != WTF::Unicode::ConversionOK)
+            if (WTF::Unicode::convertUTF16ToUTF8(&d, d + length, &p, p + buffer.size()) != WTF::Unicode::ConversionResult::Success)
                 return nullptr;
         }
     }

--- a/Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp
+++ b/Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp
@@ -38,11 +38,11 @@ std::unique_ptr<KeyedEncoder> KeyedEncoder::encoder()
 
 void KeyedEncoderGeneric::encodeString(const String& key)
 {
-    auto result = key.tryGetUTF8ForRange([&](Span<const char> span) -> bool {
+    auto result = key.tryGetUTF8([&](Span<const char> span) -> bool {
         m_encoder << span.size();
         m_encoder.encodeFixedLengthData({ bitwise_cast<const uint8_t*>(span.data()), span.size() });
         return true;
-    }, 0, key.length());
+    });
     RELEASE_ASSERT(result);
 }
 

--- a/Source/WebCore/workers/ScriptBuffer.cpp
+++ b/Source/WebCore/workers/ScriptBuffer.cpp
@@ -64,10 +64,10 @@ bool ScriptBuffer::containsSingleFileMappedSegment() const
 
 void ScriptBuffer::append(const String& string)
 {
-    auto result = string.tryGetUTF8ForRange([&](Span<const char> span) -> bool {
+    auto result = string.tryGetUTF8([&](Span<const char> span) -> bool {
         m_buffer.append(span.data(), span.size());
         return true;
-    }, 0, string.length());
+    });
     RELEASE_ASSERT(result);
 }
 

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1191,7 +1191,7 @@ static size_t convertUTF16EntityToUTF8(const UChar* utf16Entity, size_t numberOf
 {
     const char* originalTarget = target;
     auto conversionResult = WTF::Unicode::convertUTF16ToUTF8(&utf16Entity, utf16Entity + numberOfCodeUnits, &target, target + targetSize);
-    if (conversionResult != WTF::Unicode::ConversionOK)
+    if (conversionResult != WTF::Unicode::ConversionResult::Success)
         return 0;
 
     // Even though we must pass the length, libxml expects the entity string to be null terminated.

--- a/Source/WebKit/Shared/API/c/WKString.cpp
+++ b/Source/WebKit/Shared/API/c/WKString.cpp
@@ -88,7 +88,7 @@ size_t WKStringGetUTF8CStringImpl(WKStringRef stringRef, char* buffer, size_t bu
     } else {
         const UChar* characters = stringView.characters16();
         auto result = WTF::Unicode::convertUTF16ToUTF8(&characters, characters + stringView.length(), &p, p + bufferSize - 1, strict);
-        if (result != WTF::Unicode::ConversionOK && result != WTF::Unicode::TargetExhausted)
+        if (result != WTF::Unicode::ConversionResult::Success && result != WTF::Unicode::ConversionResult::TargetExhausted)
             return 0;
     }
 


### PR DESCRIPTION
#### efec6c1b6e6da5be8d38c5d3f76b5be71db8f195
<pre>
Clean up UTF-8 conversion code
<a href="https://bugs.webkit.org/show_bug.cgi?id=233612">https://bugs.webkit.org/show_bug.cgi?id=233612</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/API/JSStringRef.cpp:
(JSStringGetUTF8CString):
* Source/JavaScriptCore/runtime/ConsoleClient.cpp:
(JSC::ConsoleClient::printConsoleMessageWithArguments):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::putUTF8Triple):
(WTF::StringImpl::utf8ForCharacters):
(WTF::StringImpl::utf8Impl): Deleted.
(WTF::StringImpl::tryGetUTF8ForRange const): Deleted.
(WTF::StringImpl::tryGetUTF8 const): Deleted.
(WTF::StringImpl::utf8 const): Deleted.
(WTF::StringImpl::hashSlowCase const): Deleted.
(WTF::StringImpl::concurrentHash const): Deleted.
* Source/WTF/wtf/text/UTF8ConversionError.h:
* Source/WTF/wtf/text/WTFString.cpp:
* Source/WTF/wtf/text/WTFString.h:
* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::convertLatin1ToUTF8):
(WTF::Unicode::convertUTF16ToUTF8):
* Source/WTF/wtf/unicode/UTF8Conversion.h:
(): Deleted.
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::utf8Buffer):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::convertUTF16EntityToUTF8):
* Source/WebKit/Shared/API/c/WKString.cpp:
(WKStringGetUTF8CStringImpl):

Canonical link: <a href="https://commits.webkit.org/255348@main">https://commits.webkit.org/255348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5a4fad2e07ffa63013594b1eb90fc07602c4c7e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101365 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161453 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/898 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29496 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97695 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/527 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78318 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27485 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70524 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83099 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35790 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16121 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78144 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33544 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17218 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26982 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3707 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39965 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80752 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36335 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17687 "Passed tests") | 
<!--EWS-Status-Bubble-End-->