### PR TITLE
[Gardening]: [ New Test ] (254620@main): [ Monterey wk2 ] imported/w3c/web-platform-tests/notifications/idlharness.https.any.sharedworker.html is a consistent failure

### DIFF
--- a/LayoutTests/platform/mac-monterey-wk2/imported/w3c/web-platform-tests/notifications/idlharness.https.any.sharedworker-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2/imported/w3c/web-platform-tests/notifications/idlharness.https.any.sharedworker-expected.txt
@@ -1,0 +1,66 @@
+
+FAIL idl_test setup promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Notification"
+PASS idl_test validation
+PASS Partial interface ServiceWorkerRegistration: original interface defined
+PASS Partial interface ServiceWorkerRegistration: member names are unique
+PASS Partial interface ServiceWorkerGlobalScope: original interface defined
+PASS Partial interface ServiceWorkerGlobalScope: member names are unique
+PASS WorkerGlobalScope includes WindowOrWorkerGlobalScope: member names are unique
+FAIL Notification interface: existence and properties of interface object assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface object length assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface object name assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: existence and properties of interface prototype object assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute permission assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: member requestPermission undefined is not an Object. (evaluating 'member.name in this.get_interface_object()')
+FAIL Notification interface: attribute maxActions assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute onclick assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute onshow assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute onerror assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute onclose assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute title assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute dir assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute lang assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute body assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute tag assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute image assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute icon assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute badge assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute vibrate assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute timestamp assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute renotify assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute silent assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute requireInteraction assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute data assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: attribute actions assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification interface: operation close() assert_own_property: self does not have own property "Notification" expected property "Notification" missing
+FAIL Notification must be primary interface of notification assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Stringification of notification assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "permission" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must not have property "requestPermission" assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "maxActions" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "onclick" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "onshow" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "onerror" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "onclose" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "title" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "dir" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "lang" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "body" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "tag" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "image" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "icon" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "badge" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "vibrate" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "timestamp" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "renotify" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "silent" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "requireInteraction" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "data" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "actions" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+FAIL Notification interface: notification must inherit property "close()" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: notification"
+PASS NotificationEvent interface: existence and properties of interface object
+FAIL ServiceWorkerRegistration interface: operation showNotification(DOMString, optional NotificationOptions) assert_own_property: interface prototype object missing non-static operation expected property "showNotification" missing
+FAIL ServiceWorkerRegistration interface: operation getNotifications(optional GetNotificationOptions) assert_own_property: interface prototype object missing non-static operation expected property "getNotifications" missing
+


### PR DESCRIPTION
#### 356c4a2e2a29c493c3225df89e65a2f299addbab
<pre>
[Gardening]: [ New Test ] (254620@main): [ Monterey wk2 ] imported/w3c/web-platform-tests/notifications/idlharness.https.any.sharedworker.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=245727">https://bugs.webkit.org/show_bug.cgi?id=245727</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-monterey-wk2/imported/w3c/web-platform-tests/notifications/idlharness.https.any.sharedworker-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/254927@main">https://commits.webkit.org/254927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b9e856e160e8fad7b6e74cbb4c4e08a5119a5a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35298 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/100030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33797 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/96424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96373 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/83075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/34887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/36464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1497 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/38387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->