### PR TITLE
Scrolling with page granularity using keyboard smooth scrolling doesn't account for fixed content

### DIFF
--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -386,6 +386,7 @@ public:
     bool overscrollBehaviorAllowsRubberBand() const { return horizontalOverscrollBehavior() != OverscrollBehavior::None || verticalOverscrollBehavior() != OverscrollBehavior::None; }
     bool shouldBlockScrollPropagation(const FloatSize&) const;
     FloatSize deltaForPropagation(const FloatSize&) const;
+    WEBCORE_EXPORT virtual float adjustVerticalPageScrollStepForFixedContent(float step);
 
 protected:
     WEBCORE_EXPORT ScrollableArea();
@@ -394,7 +395,6 @@ protected:
     void setScrollOrigin(const IntPoint&);
     void resetScrollOriginChanged() { m_scrollOriginChanged = false; }
 
-    WEBCORE_EXPORT virtual float adjustVerticalPageScrollStepForFixedContent(float step);
     virtual void invalidateScrollbarRect(Scrollbar&, const IntRect&) = 0;
     virtual void invalidateScrollCornerRect(const IntRect&) = 0;
 

--- a/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
+++ b/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
@@ -259,6 +259,7 @@ static WebCore::BoxSide boxSide(WebCore::ScrollDirection direction)
     }();
 
     // FIXME (227461): Replace with call to WebCore::KeyboardScroll constructor.
+    // FIXME (245749): Use `ScrollableArea::adjustVerticalPageScrollStepForFixedContent` to account for fixed content
 
     CGFloat scrollDistance = [_scrollable distanceForIncrement:increment inDirection:direction];
 


### PR DESCRIPTION
#### fdd3720bd643eda26832e2155f1f939f08cd040a
<pre>
Scrolling with page granularity using keyboard smooth scrolling doesn&apos;t account for fixed content
<a href="https://bugs.webkit.org/show_bug.cgi?id=245746">https://bugs.webkit.org/show_bug.cgi?id=245746</a>
rdar://100469555

Reviewed by Tim Horton.

When keyboard smooth scrolling is enabled, `KeyboardScrollingAnimator::scrollDistance`
is used, which is analagous to `ScrollableArea::scroll`. However, while the
latter accounts for page&apos;s having fixed content when scrolling with page
granularity, the former never does.

This PR fixes this by including the same logic that `ScrollableArea::scroll` has
to adjust the scroll step into `KeyboardScrollingAnimator::scrollDistance`.

* LayoutTests/scrollbars/scrolling-backward-by-page-accounting-bottom-fixed-elements-on-keyboard-spacebar.html:
* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::KeyboardScrollingAnimator::scrollDistance const):
* Source/WebCore/platform/ScrollableArea.h:

Canonical link: <a href="https://commits.webkit.org/254963@main">https://commits.webkit.org/254963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c28a270cb7009ee0ecc67330b508676759a4311

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100077 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158593 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33858 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83124 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96462 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96437 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77587 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26773 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69803 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34946 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15507 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32749 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16488 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3461 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39433 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35577 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->