### PR TITLE
[ews] Deprecate github checks UI on PRs in favor of status-bubbles

### DIFF
--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -27,11 +27,9 @@ import os
 import time
 import twisted
 
-from base64 import b64encode
 from buildbot.process.results import SUCCESS, FAILURE, CANCELLED, WARNINGS, SKIPPED, EXCEPTION, RETRY
 from buildbot.util import httpclientservice, service
 from buildbot.www.hooks.github import GitHubEventHandler
-from steps import GitHub
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet.defer import succeed
@@ -80,7 +78,6 @@ class JSONProducer(object):
 class Events(service.BuildbotService):
 
     EVENT_SERVER_ENDPOINT = 'https://ews.webkit{}.org/results/'.format(custom_suffix).encode()
-    MAX_GITHUB_DESCRIPTION = 140
     SHORT_STEPS = (
         'configure-build',
         'validate-change',
@@ -115,24 +112,6 @@ class Events(service.BuildbotService):
         body = JSONProducer(data)
 
         agent.request(b'POST', self.EVENT_SERVER_ENDPOINT, Headers({'Content-Type': ['application/json']}), body)
-
-    def sendDataToGitHub(self, repository, sha, data, user=None):
-        username, access_token = GitHub.credentials(user=user)
-
-        data['description'] = data.get('description', '')
-        if len(data['description']) > self.MAX_GITHUB_DESCRIPTION:
-            data['description'] = '{}...'.format(data['description'][:self.MAX_GITHUB_DESCRIPTION - 3])
-
-        auth_header = b64encode('{}:{}'.format(username, access_token).encode('utf-8')).decode('utf-8')
-
-        agent = Agent(reactor)
-        body = JSONProducer(data)
-        d = agent.request(b'POST', GitHub.commit_status_url(sha, repository).encode('utf-8'), Headers({
-            'Authorization': ['Basic {}'.format(auth_header)],
-            'User-Agent': ['python-twisted/{}'.format(twisted.__version__)],
-            'Accept': ['application/vnd.github.v3+json'],
-            'Content-Type': ['application/json'],
-        }), body)
 
     def getBuilderName(self, build):
         if not (build and 'properties' in build):
@@ -174,32 +153,6 @@ class Events(service.BuildbotService):
 
         self.sendDataToEWS(data)
 
-    def buildFinishedGitHub(self, build):
-        sha = self.extractProperty(build, 'github.head.sha')
-        repository = self.extractProperty(build, 'repository')
-
-        if not sha or not repository:
-            print('Pull request number defined, but sha is {} and repository {}, which are invalid'.format(sha, repository))
-            print('Not reporting build result to GitHub')
-            return
-
-        data_to_send = dict(
-            owner=(self.extractProperty(build, 'owners') or [None])[0],
-            repo=(self.extractProperty(build, 'github.head.repo.full_name') or '').split('/')[-1],
-            sha=sha,
-            target_url='{}#/builders/{}/builds/{}'.format(self.master.config.buildbotURL, build.get('builderid'), build.get('number')),
-            state={
-                SUCCESS: 'success',
-                WARNINGS: 'success',
-                SKIPPED: 'success',
-                RETRY: 'pending',
-                FAILURE: 'failure'
-            }.get(build.get('results'), 'error'),
-            description=build.get('state_string'),
-            context=build['description'] + custom_suffix,
-        )
-        self.sendDataToGitHub(repository, sha, data_to_send, user=GitHub.user_for_queue(self.extractProperty(build, 'buildername')))
-
     @defer.inlineCallbacks
     def buildFinished(self, key, build):
         if not build.get('properties'):
@@ -209,9 +162,6 @@ class Events(service.BuildbotService):
 
         builder = yield self.master.db.builders.getBuilder(build.get('builderid'))
         build['description'] = builder.get('description', '?')
-
-        if self.extractProperty(build, 'github.number'):
-            self.buildFinishedGitHub(build)
 
         data = {
             "type": self.type_prefix + "build",
@@ -235,49 +185,10 @@ class Events(service.BuildbotService):
         self.sendDataToEWS(data)
 
     @defer.inlineCallbacks
-    def stepStartedGitHub(self, build, state_string):
-        sha = self.extractProperty(build, 'github.head.sha')
-        repository = self.extractProperty(build, 'repository')
-        if not sha or not repository:
-            print('Pull request number defined, but sha is {} and repository {}, which are invalid'.format(sha, repository))
-            print('Not reporting step started to GitHub')
-            return
-
-        if 'WebKit/WebKit' in repository:
-            # Do not report status directly to GitHub for WebKit/WebKit, since we have status-bubbles for that.
-            return
-
-        builder = yield self.master.db.builders.getBuilder(build.get('builderid'))
-
-        data_to_send = dict(
-            owner=(self.extractProperty(build, 'owners') or [None])[0],
-            repo=(self.extractProperty(build, 'github.head.repo.full_name') or '').split('/')[-1],
-            sha=sha,
-            target_url='{}#/builders/{}/builds/{}'.format(self.master.config.buildbotURL, build.get('builderid'), build.get('number')),
-            state={
-                SUCCESS: 'pending',
-                WARNINGS: 'pending',
-                FAILURE: 'failure',
-                EXCEPTION: 'error',
-            }.get(build.get('results'), 'pending'),
-            description=state_string,
-            context=builder.get('description', '?') + custom_suffix,
-        )
-        self.sendDataToGitHub(repository, sha, data_to_send, user=GitHub.user_for_queue(self.extractProperty(build, 'buildername')))
-
-    @defer.inlineCallbacks
     def stepStarted(self, key, step):
         state_string = step.get('state_string')
         if state_string == 'pending':
             state_string = 'Running {}'.format(step.get('name'))
-
-        build = yield self.master.db.builds.getBuild(step.get('buildid'))
-        if not build.get('properties'):
-            build['properties'] = yield self.master.db.builds.getBuildProperties(step.get('buildid'))
-
-        # We need to force the defered properties to resolve
-        if build['properties'].get('github.number') and build.get('step') not in self.SHORT_STEPS:
-            self.stepStartedGitHub(build, state_string)
 
         data = {
             "type": self.type_prefix + "step",

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -124,13 +124,6 @@ class GitHub(object):
         return 'https://api.{}/repos/{}'.format(host, path)
 
     @classmethod
-    def commit_status_url(cls, sha, repository_url=None):
-        api_url = cls.api_url(repository_url)
-        if not sha or not api_url:
-            return ''
-        return '{}/statuses/{}'.format(api_url, sha)
-
-    @classmethod
     def credentials(cls, user=None):
         prefix = f"GITHUB_COM_{user.upper().replace('-', '_')}_" if user else 'GITHUB_COM_'
 


### PR DESCRIPTION
#### 93137c2bb17260ed260aa0097ae2b1fab6e9d927
<pre>
[ews] Deprecate github checks UI on PRs in favor of status-bubbles
<a href="https://bugs.webkit.org/show_bug.cgi?id=245748">https://bugs.webkit.org/show_bug.cgi?id=245748</a>

Reviewed by NOBODY (OOPS!).

* Tools/CISupport/ews-build/events.py:
(Events):
(Events.sendDataToEWS):
(Events.buildStarted):
(Events.buildFinished):
(Events.stepStarted):
(Events.sendDataToGitHub): Deleted.
(Events.buildFinishedGitHub): Deleted.
(Events.stepStartedGitHub): Deleted.
* Tools/CISupport/ews-build/steps.py:
(GitHub.api_url):
(GitHub.commit_status_url): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93137c2bb17260ed260aa0097ae2b1fab6e9d927

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100036 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158356 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33803 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28927 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83081 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96428 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/26915 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77544 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26746 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69777 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34893 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15485 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/89792 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32704 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16465 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39404 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35554 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->