### PR TITLE
Set the correct style on the middle anonymous block in continuations

### DIFF
--- a/LayoutTests/fast/writing-mode/direction-of-middle-block-in-continuation-expected.html
+++ b/LayoutTests/fast/writing-mode/direction-of-middle-block-in-continuation-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0px;
+    padding: 0px;
+}
+</style>
+<span style="display: block; height: 100px; width: 88px; margin-top:10px; border: 1px solid green; background-color:green;"></span>
+<p>The middle anonymous block in a continuation should inherit the style of the containing block, just like the two other anonymous blocks do. There should be no red.</p>

--- a/LayoutTests/fast/writing-mode/direction-of-middle-block-in-continuation.html
+++ b/LayoutTests/fast/writing-mode/direction-of-middle-block-in-continuation.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0px;
+    padding: 0px;
+}
+</style>
+<div style="position:absolute; width: 90px; height: 100px; background-color:red; top: 10px; z-index: -1;"></div>
+<div style="direction: rtl; width: 100px;">
+    <span style="direction: ltr">
+        <span style="display: block; height: 100px; width: 88px; margin: 10px; border: 1px solid green; background-color:green;"></span>
+    </span>
+</div>
+<p>The middle anonymous block in a continuation should inherit the style of the containing block, just like the two other anonymous blocks do. There should be no red.</p>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -173,7 +173,7 @@ void RenderTreeBuilder::Inline::attachIgnoringContinuation(RenderInline& parent,
         // inline into continuations. This involves creating an anonymous block box to hold
         // |newChild|. We then make that block box a continuation of this inline. We take all of
         // the children after |beforeChild| and put them in a clone of this object.
-        auto newStyle = RenderStyle::createAnonymousStyleWithDisplay(parent.style(), DisplayType::Block);
+        auto newStyle = RenderStyle::createAnonymousStyleWithDisplay(pre()->parent.style(), DisplayType::Block);
 
         // If inside an inline affected by in-flow positioning the block needs to be affected by it too.
         // Giving the block a layer like this allows it to collect the x/y offsets from inline parents later.


### PR DESCRIPTION
<pre>
Set the correct style on the middle anonymous block in continuations

<a href="https://bugs.webkit.org/show_bug.cgi?id=245751">https://bugs.webkit.org/show_bug.cgi?id=245751</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/93aa8f022e5f79698d5e6ecd48f29eec8289f067">https://chromium.googlesource.com/chromium/src.git/+/93aa8f022e5f79698d5e6ecd48f29eec8289f067</a>

When we split an inline, ensure that the middle anonymous block gets the same style as the anonymous blocks on either side - i.e. the style of the block parent.

* Source/WebCore/rendering/updating/RenderTreeBuilerInline.cpp:
(RenderTreeBuilder::Inline::attachIgnorningContinuation): Update to link "containingBlock"
* LayoutTests/fast/writing-mode/direction-of-middle-block-in-continuation.html: Added Test Case
* LayoutTests/fast/writing-mode/direction-of-middle-block-in-continuation-expected.html: Added Test Case Expectations

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/008feebb5dc60eb488122ac5965d6882d6850c1b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90743 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35322 "Hash 008feebb for PR 4769 does not build (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/100049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94752 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33822 "Hash 008feebb for PR 4769 does not build (failure)") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/96437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96398 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/64/builds/33822 "Hash 008feebb for PR 4769 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77559 "Hash 008feebb for PR 4769 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/83093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/64/builds/33822 "Hash 008feebb for PR 4769 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34911 "Hash 008feebb for PR 4769 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36488 "Hash 008feebb for PR 4769 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/77559 "Hash 008feebb for PR 4769 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38412 "Hash 008feebb for PR 4769 does not build (failure)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->