### PR TITLE
Resync html/cross-origin-opener-policy from upstream WPT

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -273,6 +273,7 @@
     "web-platform-tests/html/canvas/offscreen": "import", 
     "web-platform-tests/html/canvas/resources": "import", 
     "web-platform-tests/html/canvas/tools": "import", 
+    "web-platform-tests/html/cross-origin-opener-policy": "import", 
     "web-platform-tests/html/dom": "import", 
     "web-platform-tests/html/dom/documents/dom-tree-accessors/Document.currentScript.sub.html": "skip", 
     "web-platform-tests/html/dom/elements/requirements-relating-to-bidirectional-algorithm-formatting-characters": "skip", 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/popup-redirect-cache.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/popup-redirect-cache.https.html
@@ -8,40 +8,50 @@
 <meta name="variant" content="?8-last">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <script src="/common/subset-tests.js"></script>
+<script src="/common/utils.js"></script>
 <script src="resources/common.js"></script>
 
 <div id=log></div>
 <script>
 
-function url_test_cache(t, url, channelName, hasOpener) {
-  const bc = new BroadcastChannel(channelName);
-  bc.onmessage = t.step_func(event => {
-    const payload = event.data;
-    validate_results(() => {
-      bc.close()
-      // test the same url for cache
-      url_test(t, url, channelName, hasOpener);
-    }, t, w, channelName, hasOpener, undefined /* OpenerDomAccess */, payload)
+function url_test_cache(t, url, responseToken, iframeToken, hasOpener) {
+  return new Promise(async (resolve, reject) => {
+    try {
+      await dispatcher_url_test(t, url, responseToken, iframeToken, hasOpener, undefined /* OpenerDomAccess */, resolve);
+    } catch(e) {
+      reject(e);
+    }
+  }).then(() => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        // Test the same url for cache.
+        // Note that at this point the popup from the first
+        // `dispatcher_url_test()` call hasn't been closed yet, but once this
+        // test has finished both will be cleaned up.
+        await dispatcher_url_test(t, url, responseToken, iframeToken, hasOpener, undefined /* OpenerDomAccess */, resolve);
+      } catch(e) {
+        reject(e);
+      }
+    });
   });
-
-  const w = window.open(url, channelName);
-
-  // The popup is closed by url_test.
 }
 
 // Redirect from hostA to hostB with same coop and coep.
 // Cache the hostA page if redirectCache is true.
 // Cache the hostB page if destCache is true.
-function coop_redirect_cache_test(t, hostA, hostB, coop, coep, redirectCache, destCache, channelName, hasOpener) {
+function coop_redirect_cache_test(t, hostA, hostB, coop, coep, redirectCache, destCache, hasOpener) {
   let redirectUrl = `${hostA.origin}/html/cross-origin-opener-policy/resources/coop-coep.py`;
   let redirectCacheString = redirectCache ? "&cache=1" : "";
   let destCacheString = destCache ? "&cache=1" : "";
-  let destUrl = `${hostB.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${coop}&coep=${coep}${destCacheString}&channel=${channelName}`;
+  let responseToken = token();
+  let iframeToken = token();
+  let destUrl = `${hostB.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${coop}&coep=${coep}${destCacheString}&responseToken=${responseToken}&iframeToken=${iframeToken}`;
   let url = `${redirectUrl}?coop=${coop}&coep=${coep}${redirectCacheString}&redirect=${encodeURIComponent(destUrl)}`;
 
-  url_test_cache(t, url, channelName, hasOpener);
+  return url_test_cache(t, url, responseToken, iframeToken, hasOpener);
 }
 
 function run_redirect_cache_tests(documentCOOPValueTitle, testArray) {
@@ -51,10 +61,8 @@ function run_redirect_cache_tests(documentCOOPValueTitle, testArray) {
       return;
     }
 
-    async_test(t => {
-      // Use a consistent channel name for deterministic failure output
-      let channelName = `${test[0].name}_${test[1].name}${test[2] ? "" : "_not"}_cache_redirect${test[3] ? "" : "_not"}_cache_destination`;
-      coop_redirect_cache_test(t, test[0], test[1], "same-origin", "require-corp", test[2], test[3], channelName, test[4]);
+    promise_test(t => {
+      return coop_redirect_cache_test(t, test[0], test[1], "same-origin", "require-corp", test[2], test[3], test[4]);
     }, `${documentCOOPValueTitle} document opening popup redirect from ${test[0].origin} to ${test[1].origin} with redirectCache ${test[2]} and destCache ${test[3]}`);
   });
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/document-reporting/report-to-both_coop-ro.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/document-reporting/report-to-both_coop-ro.https.html
@@ -17,11 +17,6 @@ const directory = "/html/cross-origin-opener-policy";
 const origin_opener = get_host_info().HTTPS_ORIGIN;
 const origin_openee = get_host_info().HTTPS_REMOTE_ORIGIN;
 
-function reportToken() {
-  // Report endpoint name must start with lower case alphabet.
-  return token().replace(/./, 'a');
-}
-
 let escapeComma = url => url.replace(/,/g, '\\,');
 
 let genericSetup = async function(test) {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/document-reporting/reporting-redirect-with-same-origin-allow-popups.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/document-reporting/reporting-redirect-with-same-origin-allow-popups.https.html
@@ -20,11 +20,6 @@ const cross_origin = {
   name: "Cross origin"
 };
 
-function reportToken() {
-  // Report endpoint name must start with lower case alphabet.
-  return token().replace(/./, 'a');
-}
-
 // Tests the redirect interaction with COOP same-origin-allow-popups and
 // reporting:
 // 1 - open the opener document on origin same_origin wit COOP

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/document-reporting/reporting-redirect-with-unsafe-none.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/document-reporting/reporting-redirect-with-unsafe-none.https.html
@@ -20,11 +20,6 @@ const cross_origin = {
   name: "Cross origin"
 };
 
-function reportToken() {
-  // Report endpoint name must start with lower case alphabet.
-  return token().replace(/./, 'a');
-}
-
 // Repeated call receive() to fetch all reports received within 1 second.
 async function fetchReportsByID(uuid){
   let timeStart = new Date().getTime();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-opener.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-opener.https.html
@@ -17,7 +17,7 @@ let escapeComma = url => url.replace(/,/g, '\\,');
 
 promise_test(async t => {
   // The test window.
- const this_window_token = token();
+  const this_window_token = token();
 
   // The "opener" window.
   const opener_token = token();
@@ -28,7 +28,7 @@ promise_test(async t => {
   const openee_url = same_origin + executor_path + `&uuid=${openee_token}`;
 
   // The "final" url the opener will navigate to. It has COOP and a reporter.
-  const final_report_token= token();
+  const final_report_token = reportToken();
   const final_token = token();
   const final_reportTo = reportingEndpointsHeaders(final_report_token);
   const final_url =  same_origin + executor_path + final_reportTo.header +
@@ -41,14 +41,13 @@ promise_test(async t => {
   // 2. The opener opens a window.
   send(opener_token, `
     openee = window.open('${escapeComma(openee_url)}');
-    send("${this_window_token}", "ACK 1");
   `);
 
   // 3. Ensure the openee loads.
   send(openee_token, `
-    send("${this_window_token}", "ACK 1");
+    send("${this_window_token}", "ACK");
   `);
-  assert_equals("ACK 1", await receive(this_window_token));
+  assert_equals("ACK", await receive(this_window_token));
 
   // 4. The opener navigates.
   send(opener_token, `

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-redirect-with-same-origin-allow-popups.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-redirect-with-same-origin-allow-popups.https.html
@@ -50,8 +50,8 @@ function redirect_test( popup_origin ) {
 
     // The "opener" window. This has COOP same-origin-allow-popups and a
     // reporter.
-    const opener_report_token= token();
-    const opener_token = token();
+    const opener_report_token = reportToken();
+    const opener_token = reportToken();
     const opener_reportTo = reportingEndpointsHeaders(opener_report_token);
     const opener_url = same_origin.host + executor_path +
       opener_reportTo.header + opener_reportTo.coopSameOriginAllowPopupsHeader +

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/resources/reporting-common.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/resources/reporting-common.js
@@ -1,6 +1,12 @@
 const executor_path = "/common/dispatcher/executor.html?pipe=";
 const coep_header = '|header(Cross-Origin-Embedder-Policy,require-corp)';
 
+// Report endpoint keys must start with a lower case alphabet character.
+// https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-header-structure-15#section-4.2.3.3
+const reportToken = () => {
+  return token().replace(/./, 'a');
+}
+
 const isWPTSubEnabled = "{{GET[pipe]}}".includes("sub");
 
 const getReportEndpointURL = (reportID) =>
@@ -385,6 +391,10 @@ const reportToHeaders = function(uuid) {
 // matching 'Reporting-Endpoints', 'Cross-Origin-Opener-Policy' and
 // 'Cross-Origin-Opener-Policy-Report-Only' headers.
 const reportingEndpointsHeaders = function (uuid) {
+  // Report endpoint keys must start with a lower case alphabet:
+  // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-header-structure-15#section-4.2.3.3
+  assert_true(uuid.match(/^[a-z].*/) != null, 'Use reportToken() instead.');
+
   const report_endpoint_url = dispatcher_path + `?uuid=${uuid}`;
   const reporting_endpoints_header = `${uuid}="${report_endpoint_url}"`;
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resources/coop-coep.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resources/coop-coep.py
@@ -29,11 +29,10 @@ def main(request, response):
 
     # Collect relevant params to be visible to response JS
     params = {}
-    for key in (b"navHistory", b"avoidBackAndForth", b"navigate", b"channel"):
+    for key in (b"navHistory", b"avoidBackAndForth", b"navigate", b"channel", b"responseToken", b"iframeToken"):
         value = requestData.first(key, None)
         params[key.decode()] = value and value.decode()
 
-    # This uses an <iframe> as BroadcastChannel is same-origin bound.
     response.content = b"""
 <!doctype html>
 <meta charset=utf-8>
@@ -72,7 +71,12 @@ def main(request, response):
       iframe.contentWindow.postMessage(payload, "*");
     };
     const channelName = params.channel;
-    iframe.src = `${get_host_info().HTTPS_ORIGIN}/html/cross-origin-opener-policy/resources/postback.html?channel=${encodeURIComponent(channelName)}`;
+    const responseToken = params.responseToken;
+    const iframeToken = params.iframeToken;
+    iframe.src = `${get_host_info().HTTPS_ORIGIN}/html/cross-origin-opener-policy/resources/postback.html` +
+                 `?channel=${encodeURIComponent(channelName)}` +
+                 `&responseToken=${responseToken}` +
+                 `&iframeToken=${iframeToken}`;
     document.body.appendChild(iframe);
   }
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resources/postback.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resources/postback.html
@@ -1,19 +1,45 @@
 <!doctype html>
 <meta charset=utf-8>
+<script src="/common/dispatcher/dispatcher.js"></script>
 <script>
-const channelName = new URL(location).searchParams.get("channel");
-const bc = new BroadcastChannel(channelName);
+const params = new URL(location).searchParams;
+const channelName = params.get("channel");
+const responseToken = params.get("responseToken");
+const iframeToken = params.get("iframeToken");
 
-// Handle the close message from the test-cleanup, forwarding it to the
-// top level document, as this iframe and the opening document might not
-// be able to close the popup.
-bc.onmessage = event => {
-  if (event.data == "close") {
-    top.postMessage("close", "*");
+// If the channel parameter is set, use the BroadcastChannel-based communication
+// method. Otherwise, use the dispatcher (useful in cases where this is embedded
+// in a third-party iframe that doesn't share a partition with the top-level
+// site).
+if (channelName != "null") {
+  const bc = new BroadcastChannel(channelName);
+  // Handle the close message from the test-cleanup, forwarding it to the
+  // top level document, as this iframe and the opening document might not
+  // be able to close the popup.
+  bc.onmessage = event => {
+    if (event.data == "close") {
+       top.postMessage("close", "*");
+     }
+  };
+
+  window.addEventListener("message", event => {
+    bc.postMessage(event.data);
+  });
+
+} else {
+  window.addEventListener("message", event => {
+    send(responseToken, JSON.stringify(event.data));
+  });
+
+  async function waitToClose() {
+    response = await receive(iframeToken);
+    // Handle the close message from the test-cleanup, forwarding it to the
+    // top level document, as this iframe and the opening document might not
+    // be able to close the popup.
+    if (response == "close") {
+      top.postMessage("close", "*");
+    }
   }
-};
-
-window.addEventListener("message", event => {
-  bc.postMessage(event.data);
-});
+  waitToClose();
+}
 </script>


### PR DESCRIPTION
#### a55f20a3ec083db794710afce87d7fb678e88ab1
<pre>
Resync html/cross-origin-opener-policy from upstream WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=245750">https://bugs.webkit.org/show_bug.cgi?id=245750</a>

Reviewed by Geoffrey Garen.

Resync html/cross-origin-opener-policy from upstream WPT 2fa24e23d0cdb65a89f.

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/popup-redirect-cache.https.html:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/document-reporting/report-to-both_coop-ro.https.html:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/document-reporting/reporting-redirect-with-same-origin-allow-popups.https.html:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/document-reporting/reporting-redirect-with-unsafe-none.https.html:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-opener.https.html:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-redirect-with-same-origin-allow-popups.https.html:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/resources/reporting-common.js:
(const.reportToken):
(const.reportingEndpointsHeaders):
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resources/common.js:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resources/coop-coep.py:
(main):
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resources/postback.html:

Canonical link: <a href="https://commits.webkit.org/254939@main">https://commits.webkit.org/254939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0ea1ebbdc3b134419822408fe553958d10f7acb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100045 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33818 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83110 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/96434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96394 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77555 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/26765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81452 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/69796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34907 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15489 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32715 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16469 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36484 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1504 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35558 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->