### PR TITLE
Update MediaSessionInfo media elements with a srcObject

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -623,6 +623,8 @@ public:
     WEBCORE_EXPORT SpeechSynthesis& speechSynthesis();
 #endif
 
+    bool hasSource() const { return hasCurrentSrc() || srcObject(); }
+
 protected:
     HTMLMediaElement(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLMediaElement();

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1238,10 +1238,10 @@ void MediaElementSession::updateMediaUsageIfChanged()
     if (!page || page->sessionID().isEphemeral())
         return;
 
-    // Bail out early if the currentSrc() is empty, and so was the previous currentSrc(), to
-    // avoid doing a large amount of unnecessary work below.
-    auto currentSrc = m_element.currentSrc();
-    if (currentSrc.isEmpty() && (!m_mediaUsageInfo || m_mediaUsageInfo->mediaURL.isEmpty()))
+    // Bail out early if the element currently has no source (currentSrc or
+    // srcObject) and neither did the previous state, to avoid doing a large
+    // amount of unnecessary work below.
+    if (!m_element.hasSource() && (!m_mediaUsageInfo || !m_mediaUsageInfo->hasSource))
         return;
 
     bool isOutsideOfFullscreen = false;
@@ -1255,7 +1255,8 @@ void MediaElementSession::updateMediaUsageIfChanged()
     bool isPlaying = m_element.isPlaying();
 
     MediaUsageInfo usage = {
-        WTFMove(currentSrc),
+        m_element.currentSrc(),
+        m_element.hasSource(),
         state() == PlatformMediaSession::Playing,
         canShowControlsManager(PlaybackControlsPurpose::ControlsManager),
         !page->isVisibleAndActive(),

--- a/Source/WebCore/platform/graphics/MediaUsageInfo.h
+++ b/Source/WebCore/platform/graphics/MediaUsageInfo.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 struct MediaUsageInfo {
     URL mediaURL;
+    bool hasSource { false };
     bool isPlaying { false };
     bool canShowControlsManager { false };
     bool canShowNowPlayingControls { false };
@@ -70,6 +71,7 @@ struct MediaUsageInfo {
     bool operator==(const MediaUsageInfo& other) const
     {
         return mediaURL == other.mediaURL
+            && hasSource == other.hasSource
             && isPlaying == other.isPlaying
             && canShowControlsManager == other.canShowControlsManager
             && canShowNowPlayingControls == other.canShowNowPlayingControls
@@ -118,6 +120,7 @@ struct MediaUsageInfo {
 template<class Encoder> inline void MediaUsageInfo::encode(Encoder& encoder) const
 {
     encoder << mediaURL;
+    encoder << hasSource;
     encoder << isPlaying;
     encoder << canShowControlsManager;
     encoder << canShowNowPlayingControls;
@@ -158,6 +161,9 @@ template<class Decoder> inline std::optional<MediaUsageInfo> MediaUsageInfo::dec
     MediaUsageInfo info;
 
     if (!decoder.decode(info.mediaURL))
+        return { };
+
+    if (!decoder.decode(info.hasSource))
         return { };
 
     if (!decoder.decode(info.isPlaying))


### PR DESCRIPTION
#### 6cfe0a4e9efc3217d24a30f17e312b951695782b
<pre>
Update MediaSessionInfo media elements with a srcObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=245753">https://bugs.webkit.org/show_bug.cgi?id=245753</a>
rdar://problem/100477469

Reviewed by Jer Noble.

The optimization at the top of MediaElementSession::updateMediaUsageIfChanged
does not take into account media elements that have no currentSrc but do
have a srcObject. Don&apos;t exit early for such elements.

Store an additional bit of information on MediaSessionInfo to represent whether
the element has any source (currentSrc or srcObject).

* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::hasSource const):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::updateMediaUsageIfChanged):
* Source/WebCore/platform/graphics/MediaUsageInfo.h:
(WebCore::MediaUsageInfo::operator== const):
(WebCore::MediaUsageInfo::encode const):
(WebCore::MediaUsageInfo::decode):

Canonical link: <a href="https://commits.webkit.org/254948@main">https://commits.webkit.org/254948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f54ce0e4260ec09981aae753ae835be656613607

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100048 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158454 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33821 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83108 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96436 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96397 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77558 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26762 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81456 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69793 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34910 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15493 "Found 1 new test failure: webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32718 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3452 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36487 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35562 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->