### PR TITLE
Don't dispatch blur/focus events if the element's page is not focused.

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4707,6 +4707,8 @@ bool Document::setFocusedElement(Element* element, const FocusOptions& options)
             }
 
             // Dispatch the blur event and let the node do any other blur related activities (important for text fields)
+            // If page lost focus, blur event will have already been dispatched
+            if (page() && (page()->focusController().isFocused())) {
             oldFocusedElement->dispatchBlurEvent(newFocusedElement.copyRef());
 
             if (m_focusedElement) {
@@ -4721,6 +4723,7 @@ bool Document::setFocusedElement(Element* element, const FocusOptions& options)
                 // handler shifted focus
                 focusChangeBlocked = true;
                 newFocusedElement = nullptr;
+            }
             }
         } else {
             // Match the order in HTMLTextFormControlElement::dispatchBlurEvent.
@@ -4774,6 +4777,8 @@ bool Document::setFocusedElement(Element* element, const FocusOptions& options)
         }
 
         // Dispatch the focus event and let the node do any other focus related activities (important for text fields)
+        // If page lost focus, event will be dispatched on page focus, don't duplicate
+        if (page() && (page()->focusController().isFocused())) {
         m_focusedElement->dispatchFocusEvent(oldFocusedElement.copyRef(), options);
 
         if (m_focusedElement != newFocusedElement) {
@@ -4786,6 +4791,7 @@ bool Document::setFocusedElement(Element* element, const FocusOptions& options)
         if (m_focusedElement != newFocusedElement) {
             // handler shifted focus
             return false;
+        }
         }
 
         if (m_focusedElement->isRootEditableElement())


### PR DESCRIPTION
<pre>
Don't dispatch blur/focus events if the element's page is not focused.

<a href="https://bugs.webkit.org/show_bug.cgi?id=125393">https://bugs.webkit.org/show_bug.cgi?id=125393</a>

Reviewed by NOBODY (OOPS!).

Partial Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=164069">https://src.chromium.org/viewvc/blink?view=revision&revision=164069</a>

When the page loses focus a blur event is dispatched once, prevent a second dispatch (via e.g. programmatic blur()-ing), when a page doesn't have focus, prevent a focus event dispatch (via e.g. programmatic focus()-ing), as it will receive a focus event when the page regains focus.

* Source/WebCore/dom/Document.cpp:
(Document::setFocusedElement): Added Comment and logic to trigger "blur" event upon focus

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0afaa96c614446c08a1959121eb28719646fd7f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100139 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158653 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33927 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28993 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83196 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96632 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/27033 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77652 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26834 "Found 1 new test failure: inspector/dom/focus.html (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81789 "Found 77 new API test failures: TestWebKitAPI.UIWKInteractionViewProtocol.SuppressSelectionChangesDuringDictation, TestWebKitAPI.InsertTextAlternatives.InsertNoBreakSpaceInMiddle, TestWebKitAPI.WebKitLegacy.TimeInputAccessoryViewTest, TestWebKitAPI.InsertTextAlternatives.InsertNonWhitespaceCharacterInMiddle, TestWebKitAPI.RequestTextInputContext.FocusingAssistedElementShouldNotScrollPage, TestWebKitAPI.UIWKInteractionViewProtocol.SelectPositionAtPointAfterBecomingFirstResponder, TestWebKitAPI.WebKit.CaptureTextFromCamera, TestWebKitAPI.KeyboardInputTests.CanHandleKeyEventInCompletionHandler, TestWebKitAPI.WebKit.FocusedElementInfo, TestWebKitAPI.KeyboardInputTests.CustomInputViewAndInputAccessoryView ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69865 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35011 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15555 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32813 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16537 "Found 1 new test failure: fast/forms/focus-option-control-on-page.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36589 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39488 "Found 1 new test failure: fast/forms/focus-option-control-on-page.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35626 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->