### PR TITLE
Allow selection to skip over contenteditable

### DIFF
--- a/LayoutTests/editing/selection/skip-over-contenteditable-expected.txt
+++ b/LayoutTests/editing/selection/skip-over-contenteditable-expected.txt
@@ -1,0 +1,19 @@
+Before the contenteditable
+
+After the contenteditable
+
+Ensure that extending a selection skips past a contentEditable.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS sel.focusNode is after
+PASS sel.focusNode.parentElement is before
+PASS sel.focusNode.parentElement is after
+PASS sel.focusNode.parentElement is before
+PASS sel.focusNode.parentElement is after
+PASS sel.focusNode.parentElement is before
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/skip-over-contenteditable.html
+++ b/LayoutTests/editing/selection/skip-over-contenteditable.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<p id="before">Before the contenteditable</p>
+<div contentEditable></div>
+<p id="after">After the contenteditable</p>
+<div id="console"></div>
+<script>
+description("Ensure that extending a selection skips past a contentEditable.");
+var before = document.getElementById("before");
+var after = document.getElementById("after");
+var sel = window.getSelection();
+sel.setBaseAndExtent(before, 0, before, 6);
+sel.modify("extend", "forward", "character");
+shouldBe("sel.focusNode", "after");
+sel.setBaseAndExtent(after, 5, after, 0);
+sel.modify("extend", "backward", "character");
+shouldBe("sel.focusNode.parentElement", "before");
+sel.setBaseAndExtent(before, 0, before, 6);
+sel.modify("extend", "forward", "word");
+shouldBe("sel.focusNode.parentElement", "after");
+sel.setBaseAndExtent(after, 5, after, 0);
+sel.modify("extend", "backward", "word");
+shouldBe("sel.focusNode.parentElement", "before");
+sel.setBaseAndExtent(before, 0, before, 6);
+sel.modify("extend", "forward", "line");
+shouldBe("sel.focusNode.parentElement", "after");
+sel.setBaseAndExtent(after, 5, after, 0);
+sel.modify("extend", "backward", "line");
+shouldBe("sel.focusNode.parentElement", "before");
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/skip-over-uneditable-in-contenteditable-expected.txt
+++ b/LayoutTests/editing/selection/skip-over-uneditable-in-contenteditable-expected.txt
@@ -1,0 +1,20 @@
+Before
+
+Middle
+
+After
+
+Ensure that extending a selection inside a contentEditable skips past an uneditable region.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS sel.focusNode is after
+PASS sel.focusNode.parentElement is before
+PASS sel.focusNode is after
+PASS sel.focusNode.parentElement is before
+PASS sel.focusNode.parentElement is after
+PASS sel.focusNode.parentElement is before
+PASS successfullyParsed is true
+
+TEST COMPLETE

--- a/LayoutTests/editing/selection/skip-over-uneditable-in-contenteditable.html
+++ b/LayoutTests/editing/selection/skip-over-uneditable-in-contenteditable.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<div contentEditable>
+<p id="before">Before</p>
+<p id="middle" contentEditable="false">Middle</p>
+<p id="after">After</p>
+</div>
+<div id="console"></div>
+<script>
+description("Ensure that extending a selection inside a contentEditable skips past an uneditable region.");
+var before = document.getElementById("before");
+var after = document.getElementById("after");
+var sel = window.getSelection();
+sel.setBaseAndExtent(before, 0, before, 6);
+sel.modify("extend", "forward", "character");
+shouldBe("sel.focusNode", "after");
+sel.setBaseAndExtent(after, 5, after, 0);
+sel.modify("extend", "backward", "character");
+shouldBe("sel.focusNode.parentElement", "before");
+sel.setBaseAndExtent(before, 0, before, 6);
+sel.modify("extend", "forward", "word");
+shouldBe("sel.focusNode", "after");
+sel.setBaseAndExtent(after, 5, after, 0);
+sel.modify("extend", "backward", "word");
+shouldBe("sel.focusNode.parentElement", "before");
+sel.setBaseAndExtent(before, 0, before, 6);
+sel.modify("extend", "forward", "line");
+shouldBe("sel.focusNode.parentElement", "after");
+sel.setBaseAndExtent(after, 5, after, 0);
+sel.modify("extend", "backward", "line");
+shouldBe("sel.focusNode.parentElement", "before");
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/stay-in-textarea-expected.txt
+++ b/LayoutTests/editing/selection/stay-in-textarea-expected.txt
@@ -1,0 +1,27 @@
+Before
+
+
+After
+
+Ensure that extending a selection beyond a textarea does not escape outside its shadow root.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS textareaSelection.focusOffset is 2
+PASS textareaSelection.focusNode is initialTextareaFocusNode
+PASS textareaSelection.focusOffset is 3
+PASS textareaSelection.focusNode is initialTextareaFocusNode
+PASS textareaSelection.focusOffset is 4
+PASS textareaSelection.focusNode is initialTextareaFocusNode
+PASS textareaSelection.focusOffset is 4
+PASS textareaSelection.focusNode is initialTextareaFocusNode
+PASS textareaSelection.focusOffset is 4
+PASS textareaSelection.focusNode is initialTextareaFocusNode
+PASS textareaSelection.focusOffset is 4
+PASS window.getSelection().focusNode is initialFocusNode
+PASS window.getSelection().focusOffset is initialFocusOffset
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/stay-in-textarea.html
+++ b/LayoutTests/editing/selection/stay-in-textarea.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<p id="before">Before</p>
+<textarea id="textarea">Text</textarea>
+<p id="after">After</p>
+<div id="console"></div>
+<script>
+description("Ensure that extending a selection beyond a textarea does not escape outside its shadow root.");
+var before = document.getElementById("before");
+var after = document.getElementById("after");
+var textarea = document.getElementById("textarea");
+textarea.setSelectionRange(0, 2);
+var textareaSelection = internals.youngestShadowRoot(textarea).getSelection();
+var initialTextareaFocusNode = textareaSelection.focusNode;
+var initialFocusNode = window.getSelection().focusNode;
+var initialFocusOffset = window.getSelection().focusOffset;
+shouldBe("textareaSelection.focusOffset", "2");
+textareaSelection.modify("extend", "forward", "character");
+shouldBe("textareaSelection.focusNode", "initialTextareaFocusNode");
+shouldBe("textareaSelection.focusOffset", "3");
+textareaSelection.modify("extend", "forward", "character");
+shouldBe("textareaSelection.focusNode", "initialTextareaFocusNode");
+shouldBe("textareaSelection.focusOffset", "4");
+// We're at the end - none of these should modify the selection any more.
+textareaSelection.modify("extend", "forward", "character");
+shouldBe("textareaSelection.focusNode", "initialTextareaFocusNode");
+shouldBe("textareaSelection.focusOffset", "4");
+textareaSelection.modify("extend", "forward", "word");
+shouldBe("textareaSelection.focusNode", "initialTextareaFocusNode");
+shouldBe("textareaSelection.focusOffset", "4");
+textareaSelection.modify("extend", "forward", "line");
+shouldBe("textareaSelection.focusNode", "initialTextareaFocusNode");
+shouldBe("textareaSelection.focusOffset", "4");
+shouldBe("window.getSelection().focusNode", "initialFocusNode");
+shouldBe("window.getSelection().focusOffset", "initialFocusOffset");
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -831,9 +831,9 @@ VisiblePosition FrameSelection::modifyExtendingRight(TextGranularity granularity
     switch (granularity) {
     case TextGranularity::CharacterGranularity:
         if (directionOfEnclosingBlock() == TextDirection::LTR)
-            pos = pos.next(CannotCrossEditingBoundary);
+            pos = pos.next(CanSkipOverEditingBoundary);
         else
-            pos = pos.previous(CannotCrossEditingBoundary);
+            pos = pos.previous(CanSkipOverEditingBoundary);
         break;
     case TextGranularity::WordGranularity:
         if (directionOfEnclosingBlock() == TextDirection::LTR)
@@ -869,7 +869,7 @@ VisiblePosition FrameSelection::modifyExtendingForward(TextGranularity granulari
     VisiblePosition pos(m_selection.extent(), m_selection.affinity());
     switch (granularity) {
     case TextGranularity::CharacterGranularity:
-        pos = pos.next(CannotCrossEditingBoundary);
+        pos = pos.next(CanSkipOverEditingBoundary);
         break;
     case TextGranularity::WordGranularity:
         pos = nextWordPositionForPlatform(pos);
@@ -976,7 +976,7 @@ VisiblePosition FrameSelection::modifyMovingForward(TextGranularity granularity,
         if (isRange())
             pos = VisiblePosition(m_selection.end(), m_selection.affinity());
         else
-            pos = VisiblePosition(m_selection.extent(), m_selection.affinity()).next(CannotCrossEditingBoundary, reachedBoundary);
+            pos = VisiblePosition(m_selection.extent(), m_selection.affinity()).next(CanSkipOverEditingBoundary, reachedBoundary);
         break;
     case TextGranularity::WordGranularity:
         pos = nextWordPositionForPlatform(currentPosition);
@@ -1044,9 +1044,9 @@ VisiblePosition FrameSelection::modifyExtendingLeft(TextGranularity granularity)
     switch (granularity) {
     case TextGranularity::CharacterGranularity:
         if (directionOfEnclosingBlock() == TextDirection::LTR)
-            pos = pos.previous(CannotCrossEditingBoundary);
+            pos = pos.previous(CanSkipOverEditingBoundary);
         else
-            pos = pos.next(CannotCrossEditingBoundary);
+            pos = pos.next(CanSkipOverEditingBoundary);
         break;
     case TextGranularity::WordGranularity:
         if (directionOfEnclosingBlock() == TextDirection::LTR)
@@ -1086,7 +1086,7 @@ VisiblePosition FrameSelection::modifyExtendingBackward(TextGranularity granular
     // over everything.
     switch (granularity) {
     case TextGranularity::CharacterGranularity:
-        pos = pos.previous(CannotCrossEditingBoundary);
+        pos = pos.previous(CanSkipOverEditingBoundary);
         break;
     case TextGranularity::WordGranularity:
         pos = previousWordPosition(pos);
@@ -1192,7 +1192,7 @@ VisiblePosition FrameSelection::modifyMovingBackward(TextGranularity granularity
         if (isRange())
             pos = VisiblePosition(m_selection.start(), m_selection.affinity());
         else
-            pos = VisiblePosition(m_selection.extent(), m_selection.affinity()).previous(CannotCrossEditingBoundary, reachedBoundary);
+            pos = VisiblePosition(m_selection.extent(), m_selection.affinity()).previous(CanSkipOverEditingBoundary, reachedBoundary);
         break;
     case TextGranularity::WordGranularity:
         pos = previousWordPosition(currentPosition);

--- a/Source/WebCore/editing/VisiblePosition.h
+++ b/Source/WebCore/editing/VisiblePosition.h
@@ -57,6 +57,8 @@ public:
 
     VisiblePosition honorEditingBoundaryAtOrBefore(const VisiblePosition&, bool* reachedBoundary = nullptr) const;
     VisiblePosition honorEditingBoundaryAtOrAfter(const VisiblePosition&, bool* reachedBoundary = nullptr) const;
+    VisiblePosition skipToStartOfEditingBoundary(const VisiblePosition&) const;
+    VisiblePosition skipToEndOfEditingBoundary(const VisiblePosition&) const;
 
     WEBCORE_EXPORT VisiblePosition left(bool stayInEditableContent = false, bool* reachedBoundary = nullptr) const;
     WEBCORE_EXPORT VisiblePosition right(bool stayInEditableContent = false, bool* reachedBoundary = nullptr) const;


### PR DESCRIPTION
<pre>
Allow selection to skip over contenteditable

<a href="https://bugs.webkit.org/show_bug.cgi?id=122797">https://bugs.webkit.org/show_bug.cgi?id=122797</a>

Reviewed by NOBODY (OOPS!).

Partial Merge (Caret Mode bits were not added) - <a href="https://chromium.googlesource.com/chromium/blink/+/b6af644f3fa0f51d94ab374648e56ec3e390a517">https://chromium.googlesource.com/chromium/blink/+/b6af644f3fa0f51d94ab374648e56ec3e390a517</a>

This patch will allow the caret and selection to move past contenteditable on page from top to bottom on any document without without getting stuck.

* Source/WebCore/editing/FrameSelection.cpp:
(FrameSelection:modifyExtendingRight): Update for "Character Granularity" to accept "CanSkipOverEditingBoundary"
(FrameSelection:modifyExtendingForward): Update for "Character Granularity" to accept "CanSkipOverEditingBoundary"
(FrameSelection:modifyMovingForward): Update for "Character Granularity" to accept "CanSkipOverEditingBoundary"
(FrameSelection:modifyExtendingLeft): Update for "Character Granularity" to accept "CanSkipOverEditingBoundary"
(FrameSelection:modifyExtendingBackward): Update for "Character Granularity" to accept "CanSkipOverEditingBoundary"
(FrameSelection:modifyMovingBackward): Update for "Character Granularity" to accept "CanSkipOverEditingBoundary"
* Source/WebCore/editing/VisiblePosition.cpp: Removed FIXME to add "CanSkipEditingBoundary"
(VisiblePosition::next): Added Cases for CanSkipEditingBoundary
(VisiblePosition::prev): Added Cases for CanSkipEditingBoundary
(VisiblePosition::honorEditingBoundaryAtOrAfter): Added "skipToStartOfEditingBoundary" & "skipToEndOfEditingBoundary" to support "CanSkipEditingBoundary"
* LayoutTests/editing/selection/stay-in-textarea.html: Added Test Case
* LayoutTests/editing/selection/stay-in-textarea-expected.txt: Added Test Case Expectations
* LayoutTests/editing/selection/skip-over-contenteditable.html: Added Test Case
* LayoutTests/editing/selection/skip-over-contenteditable-expected.txt: Added Test Case Expectations
* LayoutTests/editing/selection/skip-over-uneditable-in-contenteditable.html: Added Test Case
* LayoutTests/editing/selection/skip-over-uneditable-in-contenteditable.txt: Added Test Case Expectations

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2685f3fa45091bb31a19e5589a774c8898cf8532

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90810 "2 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35387 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21371 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100101 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158608 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94818 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33886 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/28964 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83153 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/96494 "Hash 2685f3fa for PR 4780 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96465 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/64/builds/33886 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77613 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/83153 "Hash 2685f3fa for PR 4780 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/64/builds/33886 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/21371 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/83153 "Hash 2685f3fa for PR 4780 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/34973 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/21371 "Hash 2685f3fa for PR 4780 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32774 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/21371 "Hash 2685f3fa for PR 4780 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36550 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/77613 "Hash 2685f3fa for PR 4780 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38475 "Hash 2685f3fa for PR 4780 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/21371 "Hash 2685f3fa for PR 4780 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->