### PR TITLE
Automate deletion of temporary files on windows

### DIFF
--- a/Tools/CISupport/delete-stale-build-files
+++ b/Tools/CISupport/delete-stale-build-files
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2013-2020 Apple Inc.  All rights reserved.
+# Copyright (C) 2013-2022 Apple Inc.  All rights reserved.
 # Copyright (C) 2012 Google Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -25,6 +25,7 @@
 
 import optparse
 import os
+import shutil
 import subprocess
 import sys
 
@@ -38,15 +39,19 @@ def main():
 
     options, parameters = parser.parse_args()
     if not options.platform:
-        parser.error("Platform is required")
+        parser.error('Platform is required')
         return -1
+
+    if options.platform == 'win':
+        return deleteWindowsStaleFiles()
+
     if not options.configuration:
-        parser.error("Configuration is required")
+        parser.error('Configuration is required')
         return -2
 
     genericPlatform = options.platform.split('-', 1)[0]
     if genericPlatform not in ('mac', 'ios'):
-        print('Exited without removing any files.')
+        print(f'Exited without removing any files since platform {genericPlatform} is not supported by this script.')
         return 0
 
     if options.build_directory:
@@ -85,6 +90,20 @@ def webkitBuildDirectory(platform, fullPlatform, configuration):
         platform = 'device'
     return subprocess.Popen(['perl', os.path.join(os.path.dirname(__file__), "..", "Scripts", "webkit-build-directory"),
         "--" + platform, "--" + configuration, '--top-level'], stdout=subprocess.PIPE).communicate()[0].strip()
+
+def deleteWindowsStaleFiles():
+    directoriesToDelete = ['/cygdrive/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/sym/WebKit.pdb',
+                           '/cygdrive/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/sym/WTF.pdb',
+                           '/cygdrive/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/sym/JavaScriptCore.pdb',
+                           '/cygdrive/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/sym/DumpRenderTreeLib.pdb']
+    for directory in directoriesToDelete:
+        try:
+            print(f'Removing: {directory}')
+            shutil.rmtree(directory)
+        except OSError as e:
+            print(f'Failed to remove: {directory}, error: {e}')
+            continue
+        print('Done')
 
 
 if __name__ == '__main__':

--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -27,7 +27,7 @@ from buildbot.steps import trigger
 from steps import (AddReviewerToCommitMessage, ApplyPatch, ApplyWatchList, Canonicalize, CommitPatch,
                    CheckOutPullRequest, CheckOutSource, CheckOutSpecificRevision, CheckChangeRelevance,
                    CheckStatusOnEWSQueues, CheckStyle, CleanGitRepo, CompileJSC, CompileWebKit, ConfigureBuild,
-                   DownloadBuiltProduct, ExtractBuiltProduct, FetchBranches, FindModifiedLayoutTests,
+                   DeleteStaleBuildFiles, DownloadBuiltProduct, ExtractBuiltProduct, FetchBranches, FindModifiedLayoutTests,
                    InstallGtkDependencies, InstallWpeDependencies, KillOldProcesses, PrintConfiguration, PushCommitToWebKitRepo, PushPullRequestBranch,
                    RunAPITests, RunBindingsTests, RunBuildWebKitOrgUnitTests, RunBuildbotCheckConfigForBuildWebKit, RunBuildbotCheckConfigForEWS,
                    RunEWSUnitTests, RunResultsdbpyTests, RunJavaScriptCoreTests, RunWebKit1Tests, RunWebKitPerlTests, RunWebKitPyPython2Tests,
@@ -49,6 +49,8 @@ class Factory(factory.BuildFactory):
             self.addStep(FindModifiedLayoutTests())
         self.addStep(ValidateChange())
         self.addStep(PrintConfiguration())
+        if platform == 'win':
+            self.addStep(DeleteStaleBuildFiles())
         self.addStep(CleanGitRepo())
         self.addStep(CheckOutSource())
         self.addStep(FetchBranches())

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -350,6 +350,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'check-change-relevance',
             'validate-change',
             'configuration',
+            'delete-stale-build-files',
             'clean-up-git-repo',
             'checkout-source',
             'fetch-branch-references',

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5254,3 +5254,16 @@ class UpdatePullRequest(shell.ShellCommand, GitHubMixin, AddToLogMixin):
 
     def hideStepIf(self, results, step):
         return not self.doStepIf(step)
+
+
+class DeleteStaleBuildFiles(shell.ShellCommand):
+    name = 'delete-stale-build-files'
+    description = ['Deleting stale build files']
+    descriptionDone = ['Deleted stale build files']
+    command = ['python3', 'Tools/CISupport/delete-stale-build-files', WithProperties('--platform=%(fullPlatform)s')]
+    haltOnFailure = False
+    flunkOnFailure = False
+    warnOnFailure = False
+
+    def __init__(self, **kwargs):
+        super(DeleteStaleBuildFiles, self).__init__(logEnviron=False, timeout=600, **kwargs)

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -47,7 +47,8 @@ from steps import (AddReviewerToCommitMessage, AnalyzeAPITestsResults, AnalyzeCo
                    Canonicalize, CheckOutPullRequest, CheckOutSource, CheckOutSpecificRevision, CheckChangeRelevance, CheckStatusOnEWSQueues, CheckStyle,
                    CleanBuild, CleanUpGitIndexLock, CleanGitRepo, CleanWorkingDirectory, CompileJSC, CommitPatch, CompileJSCWithoutChange,
                    CompileWebKit, CompileWebKitWithoutChange, ConfigureBuild, ConfigureBuild, Contributors,
-                   DetermineLandedIdentifier, DownloadBuiltProduct, DownloadBuiltProductFromMaster, EWS_BUILD_HOSTNAME, ExtractBuiltProduct, ExtractTestResults,
+                   DeleteStaleBuildFiles, DetermineLandedIdentifier, DownloadBuiltProduct, DownloadBuiltProductFromMaster,
+                   EWS_BUILD_HOSTNAME, ExtractBuiltProduct, ExtractTestResults,
                    FetchBranches, FindModifiedLayoutTests, GitHub,
                    InstallBuiltProduct, InstallGtkDependencies, InstallWpeDependencies,
                    KillOldProcesses, PrintConfiguration, PushCommitToWebKitRepo, PushPullRequestBranch, ReRunAPITests, ReRunWebKitPerlTests,
@@ -6650,6 +6651,44 @@ Date:   Tue Mar 29 16:04:35 2022 -0700
             self.assertEqual(self.getProperty('bug_id'), '238553')
             self.assertEqual(self.getProperty('is_test_gardening'), False)
             return rc
+
+
+class TestDeleteStaleBuildFiles(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        return self.setUpBuildStep()
+
+    def tearDown(self):
+        return self.tearDownBuildStep()
+
+    def test_success(self):
+        self.setupStep(DeleteStaleBuildFiles())
+        self.setProperty('fullPlatform', 'win')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['python3', 'Tools/CISupport/delete-stale-build-files', '--platform=win'],
+                        logEnviron=False,
+                        timeout=600,
+                        )
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS, state_string='Deleted stale build files')
+        return self.runStep()
+
+    def test_failure(self):
+        self.setupStep(DeleteStaleBuildFiles())
+        self.setProperty('fullPlatform', 'win')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['python3', 'Tools/CISupport/delete-stale-build-files', '--platform=win'],
+                        logEnviron=False,
+                        timeout=600,
+                        )
+            + ExpectShell.log('stdio', stdout='Unexpected error.')
+            + 2,
+        )
+        self.expectOutcome(result=FAILURE, state_string='Deleted stale build files (failure)')
+        return self.runStep()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### a7ec0ec651a5c6c12cdd1aeee9b05bde45557fc9
<pre>
Automate deletion of temporary files on windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=245786">https://bugs.webkit.org/show_bug.cgi?id=245786</a>
rdar://72849252

Reviewed by Ryan Haddad.

* Tools/CISupport/delete-stale-build-files:
* Tools/CISupport/ews-build/factories.py:
* Tools/CISupport/ews-build/steps.py:
(DeleteStaleBuildFiles):
* Tools/CISupport/ews-build/steps_unittest.py: Added unit-tests.
* Tools/CISupport/ews-build/factories_unittest.py: Updated unit-tests.

Canonical link: <a href="https://commits.webkit.org/255045@main">https://commits.webkit.org/255045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c584cfa5b2518ccbf6cbb4e9d57d2a3f1702a03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100165 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158719 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33956 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29009 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83224 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97050 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/27055 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77677 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26864 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69895 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35037 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15574 "Found 1 new test failure: webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/89948 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32838 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16557 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36615 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39508 "Found 1 new test failure: fast/events/blur-remove-parent-crash.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1545 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35646 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->