### PR TITLE
svg/filters/feDisplacementMap-filterUnits.svg fails

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2029,7 +2029,6 @@ webkit.org/b/61932 [ Debug ] jquery/manipulation.html [ Slow ]
 [ Debug ] jquery/traversing.html [ Slow ]
 
 webkit.org/b/139638 [ Debug ] svg/filters/svg-deeply-nested-crash.html [ Slow ]
-webkit.org/b/112265 svg/filters/feDisplacementMap-filterUnits.svg [ Pass ImageOnlyFailure ]
 webkit.org/b/126420 svg/custom/resource-invalidation-crash.svg [ Failure Pass ]
 
 webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ Slow ]
@@ -4828,6 +4827,7 @@ http/tests/media/video-canplaythrough-webm.html [ Skip ]
 media/media-session/mock-coordinator.html [ Skip ]
 media/track/track-description-cue.html [ Skip ]
 media/track/track-extended-descriptions.html [ Skip ]
+svg/filters/feDisplacementMap-filterUnits.svg [ Skip ]
 
 # These tests rely on webkit-test-runner flags that aren't implemented for DumpRenderTree, so they will fail under legacy WebKit.
 editing/selection/expando.html [ Failure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -60,6 +60,7 @@ imported/w3c/web-platform-tests/speech-api/ [ Pass ]
 http/tests/media/fairplay [ Pass ]
 media/track/track-description-cue.html [ Pass ]
 media/track/track-extended-descriptions.html [ Pass ]
+svg/filters/feDisplacementMap-filterUnits.svg [ Pass ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -93,6 +93,7 @@ imported/w3c/web-platform-tests/speech-api [ Pass ]
 http/tests/media/fairplay [ Pass ]
 media/track/track-description-cue.html [ Pass ]
 media/track/track-extended-descriptions.html [ Pass ]
+svg/filters/feDisplacementMap-filterUnits.svg [ Pass ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.

--- a/LayoutTests/svg/filters/feDisplacementMap-filterUnits-expected.svg
+++ b/LayoutTests/svg/filters/feDisplacementMap-filterUnits-expected.svg
@@ -5,5 +5,5 @@
 
   <rect fill="rgb(50%,50%,50%)" stroke="green" x="44" y="164" width="76" height="76"/>
   <rect fill="rgb(50%,50%,50%)" stroke="green" x="140" y="140" width="75" height="75"/>
-  <rect fill="rgb(50%,50%,50%)" stroke="green" x="287" y="167" width="73" height="73"/>
+  <rect fill="rgb(50%,50%,50%)" stroke="green" x="288" y="168" width="72" height="72"/>
 </svg>

--- a/LayoutTests/svg/filters/feDisplacementMap-filterUnits.svg
+++ b/LayoutTests/svg/filters/feDisplacementMap-filterUnits.svg
@@ -45,5 +45,5 @@
   <rect filter="url(#OBBUSOUWhite)" fill="none" stroke="none" x="140" y="140" width="100" height="100"/>
   <rect fill="none" stroke="green" x="140" y="140" width="75" height="75"/>
   <rect filter="url(#USOUUSOUGrey)" fill="none" stroke="none" x="260" y="140" width="100" height="100"/>
-  <rect fill="none" stroke="green" x="287" y="167" width="73" height="73"/>
+  <rect fill="none" stroke="green" x="288" y="168" width="72" height="72"/>
 </svg>


### PR DESCRIPTION
#### 9bcb2d190f62a188fb5b9261703b14ae051f537c
<pre>
svg/filters/feDisplacementMap-filterUnits.svg fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=112265">https://bugs.webkit.org/show_bug.cgi?id=112265</a>
rdar://100519857

Reviewed by Simon Fraser.

feDisplacementMap uses the pixels of its &apos;in2&apos; to displace the pixels of its &apos;in&apos;
in its image result. When the color-space is linearSRGB, only one problem happens
in one of the filters in this layout test.

The calculations in FEDisplacementMapSoftwareApplier::apply() say that the
displacement for this filter should be at pixel (28, 28). But the test and its
expectation assume the displacement is at pixel (27, 27).

Enable this test for Cocoa platforms since they support linear-sRGB for SVG
filters. Other platforms use sRGB color spacing and the displacement will be
different since the values of the color channels of &apos;in2&apos; will be different.

* LayoutTests/TestExpectations:
* LayoutTests/svg/filters/feDisplacementMap-filterUnits-expected.svg:
* LayoutTests/svg/filters/feDisplacementMap-filterUnits.svg:

Canonical link: <a href="https://commits.webkit.org/255006@main">https://commits.webkit.org/255006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dff734cc6648cc24470f68f473e4766e2c75091

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35566 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/100348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/34066 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83339 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96651 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/26949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/69984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35145 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32943 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3487 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36723 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38651 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->