### PR TITLE
Revert [254944@main] REGRESSION (Safari 16): Service worker clientId is empty for web worker fetches

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/sample-worker-interceptor.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/sample-worker-interceptor.js
@@ -5,25 +5,9 @@ const dedicated_worker_script = `postMessage('${text}');`;
 const shared_worker_script =
     `onconnect = evt => evt.ports[0].postMessage('${text}');`;
 
-let source;
-let resolveDone;
-let done = new Promise(resolve => resolveDone = resolve);
-
-// The page messages this worker to ask for the result. Keep the worker alive
-// via waitUntil() until the result is sent.
-self.addEventListener('message', event => {
-  source = event.data.port;
-  source.postMessage({id: event.source.id});
-  source.onmessage = resolveDone;
-  event.waitUntil(done);
-});
-
 self.onfetch = event => {
   const url = event.request.url;
   const destination = event.request.destination;
-
-  if (source)
-     source.postMessage({clientId:event.clientId, resultingClientId: event.resultingClientId});
 
   // Request handler for a synthesized response.
   if (url.indexOf('synthesized') != -1) {

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
@@ -1,5 +1,4 @@
 
-PASS Verify a dedicated worker script request gets correct client Ids
 PASS Verify a dedicated worker script request issued from a uncontrolled document is intercepted by worker's own service worker.
 PASS Verify an out-of-scope dedicated worker script request issued from a controlled document should not be intercepted by document's service worker.
 PASS Verify a shared worker script request issued from a uncontrolled document is intercepted by worker's own service worker.

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https.html
@@ -14,36 +14,7 @@ async function setup_service_worker(t, service_worker_url, scope) {
       t, service_worker_url, scope);
   t.add_cleanup(() => service_worker_unregister(t, scope));
   await wait_for_state(t, r.installing, 'activated');
-  return r.active;
 }
-
-promise_test(async t => {
-  const worker_url = 'resources/sample-synthesized-worker.js?dedicated';
-  const service_worker_url = 'resources/sample-worker-interceptor.js';
-  const scope = worker_url;
-
-  const serviceWorker = await setup_service_worker(t, service_worker_url, scope);
-
-  const channels = new MessageChannel();
-  serviceWorker.postMessage({port: channels.port1}, [channels.port1]);
-
-  const clientId = await new Promise(resolve => channels.port2.onmessage = (e) => resolve(e.data.id));
-
-  const resultPromise =  new Promise(resolve => channels.port2.onmessage = (e) => resolve(e.data));
-
-  const w = new Worker(worker_url);
-  const data = await new Promise((resolve, reject) => {
-    w.onmessage = e => resolve(e.data);
-    w.onerror = e => reject(e.message);
-  });
-  assert_equals(data, 'worker loading intercepted by service worker');
-
-  const results = await resultPromise;
-  assert_equals(results.clientId, clientId);
-  assert_true(!!results.resultingClientId.length);
-
-  channels.port2.postMessage("done");
-}, `Verify a dedicated worker script request gets correct client Ids`);
 
 promise_test(async t => {
   const worker_url = 'resources/sample-synthesized-worker.js?dedicated';

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
@@ -15,7 +15,6 @@ CONSOLE MESSAGE: Cannot load https://www1.web-platform.test:9443/service-workers
 CONSOLE MESSAGE: Response served by service worker is opaque
 CONSOLE MESSAGE: Cannot load https://www1.web-platform.test:9443/service-workers/service-worker/resources/postmessage-on-load-worker.js due to access control checks.
 
-PASS Verify a dedicated worker script request gets correct client Ids
 PASS Verify a dedicated worker script request issued from a uncontrolled document is intercepted by worker's own service worker.
 PASS Verify an out-of-scope dedicated worker script request issued from a controlled document should not be intercepted by document's service worker.
 PASS Verify a shared worker script request issued from a uncontrolled document is intercepted by worker's own service worker.

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2181,7 +2181,7 @@ void DocumentLoader::loadMainResource(ResourceRequest&& request)
         m_resultingClientId = ScriptExecutionContextIdentifier::generate();
         ASSERT(!scriptExecutionContextIdentifierToLoaderMap().contains(m_resultingClientId));
         scriptExecutionContextIdentifierToLoaderMap().add(m_resultingClientId, this);
-        mainResourceLoadOptions.resultingClientIdentifier = m_resultingClientId;
+        mainResourceLoadOptions.clientIdentifier = m_resultingClientId;
     }
 #endif
 

--- a/Source/WebCore/loader/FetchOptions.h
+++ b/Source/WebCore/loader/FetchOptions.h
@@ -61,10 +61,7 @@ struct FetchOptions {
     ReferrerPolicy referrerPolicy { ReferrerPolicy::EmptyString };
     String integrity;
     bool keepAlive { false };
-    // Identifier of https://fetch.spec.whatwg.org/#concept-request-client
     std::optional<ScriptExecutionContextIdentifier> clientIdentifier;
-    // Identifier of https://fetch.spec.whatwg.org/#concept-request-reserved-client
-    std::optional<ScriptExecutionContextIdentifier> resultingClientIdentifier;
 };
 
 inline FetchOptions::FetchOptions(Destination destination, Mode mode, Credentials credentials, Cache cache, Redirect redirect, ReferrerPolicy referrerPolicy, String&& integrity, bool keepAlive, std::optional<ScriptExecutionContextIdentifier> clientIdentifier)
@@ -265,7 +262,6 @@ inline void FetchOptions::encode(Encoder& encoder) const
 {
     encodePersistent(encoder);
     encoder << clientIdentifier;
-    encoder << resultingClientIdentifier;
 }
 
 template<class Decoder>
@@ -280,12 +276,6 @@ inline std::optional<FetchOptions> FetchOptions::decode(Decoder& decoder)
     if (!clientIdentifier)
         return std::nullopt;
     options.clientIdentifier = WTFMove(clientIdentifier.value());
-
-    std::optional<std::optional<ScriptExecutionContextIdentifier>> resultingClientIdentifier;
-    decoder >> resultingClientIdentifier;
-    if (!resultingClientIdentifier)
-        return std::nullopt;
-    options.resultingClientIdentifier = WTFMove(*resultingClientIdentifier.value());
 
     return options;
 }

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -162,9 +162,8 @@ void WorkerScriptLoader::loadAsynchronously(ScriptExecutionContext& scriptExecut
 #if ENABLE(SERVICE_WORKER)
     if ((m_destination == FetchOptions::Destination::Worker || m_destination == FetchOptions::Destination::Sharedworker) && is<Document>(scriptExecutionContext) && downcast<Document>(scriptExecutionContext).settings().serviceWorkersEnabled()) {
         m_topOriginForServiceWorkerRegistration = SecurityOriginData { scriptExecutionContext.topOrigin().data() };
-        options.clientIdentifier = scriptExecutionContext.identifier();
         ASSERT(clientIdentifier);
-        options.resultingClientIdentifier = m_clientIdentifier = clientIdentifier;
+        options.clientIdentifier = m_clientIdentifier = clientIdentifier;
         // In case of blob URLs, we reuse the document controlling service worker.
         if (request->url().protocolIsBlob() && scriptExecutionContext.activeServiceWorker())
             setControllingServiceWorker(ServiceWorkerData { scriptExecutionContext.activeServiceWorker()->data() });

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -591,7 +591,6 @@ void NetworkResourceLoader::transferToNewWebProcess(NetworkConnectionToWebProces
     m_parameters.webPageID = parameters.webPageID;
     m_parameters.webFrameID = parameters.webFrameID;
     m_parameters.options.clientIdentifier = parameters.options.clientIdentifier;
-    m_parameters.options.resultingClientIdentifier = parameters.options.resultingClientIdentifier;
 
 #if ENABLE(SERVICE_WORKER)
     ASSERT(m_responseCompletionHandler || m_cacheEntryWaitingForContinueDidReceiveResponse || m_serviceWorkerFetchTask);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -166,7 +166,7 @@ void ServiceWorkerFetchTask::startFetch()
     cleanHTTPRequestHeadersForAccessControl(request, m_loader.parameters().httpHeadersToKeep);
 
     String clientIdentifier;
-    if (m_loader.parameters().options.mode != FetchOptions::Mode::Navigate) {
+    if (m_loader.parameters().options.mode != FetchOptions::Mode::Navigate && m_loader.parameters().options.destination != FetchOptions::Destination::Worker) {
         if (auto identifier = m_loader.parameters().options.clientIdentifier)
             clientIdentifier = identifier->toString();
     }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -174,7 +174,7 @@ void WebSWServerConnection::controlClient(const NetworkResourceLoadParameters& p
     else
         clientType = ServiceWorkerClientType::Window;
 
-    auto clientIdentifier = *parameters.options.resultingClientIdentifier;
+    auto clientIdentifier = *parameters.options.clientIdentifier;
     // As per step 12 of https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm, the active service worker should be controlling the document.
     // We register the service worker client using the identifier provided by DocumentLoader and notify DocumentLoader about it.
     // If notification is successful, DocumentLoader is responsible to unregister the service worker client as needed.
@@ -211,8 +211,7 @@ std::unique_ptr<ServiceWorkerFetchTask> WebSWServerConnection::createFetchTask(N
 
         serviceWorkerRegistrationIdentifier = registration->identifier();
         controlClient(loader.parameters(), *registration, request);
-        if (auto resultingClientIdentifier = loader.parameters().options.resultingClientIdentifier)
-            loader.setResultingClientIdentifier(resultingClientIdentifier->toString());
+        loader.setResultingClientIdentifier(loader.parameters().options.clientIdentifier->toString());
         loader.setServiceWorkerRegistration(*registration);
     } else {
         if (!loader.parameters().serviceWorkerRegistrationIdentifier)

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -136,12 +136,7 @@ void WebSWContextManagerConnection::updatePreferencesStore(WebPreferencesStore&&
 
 void WebSWContextManagerConnection::updateAppInitiatedValue(ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::LastNavigationWasAppInitiated lastNavigationWasAppInitiated)
 {
-    if (!isMainRunLoop()) {
-        callOnMainRunLoop([protectedThis = Ref { *this }, serviceWorkerIdentifier, lastNavigationWasAppInitiated]() mutable {
-            protectedThis->updateAppInitiatedValue(serviceWorkerIdentifier, lastNavigationWasAppInitiated);
-        });
-        return;
-    }
+    ASSERT(isMainRunLoop());
 
     if (auto* serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(serviceWorkerIdentifier))
         serviceWorkerThreadProxy->setLastNavigationWasAppInitiated(lastNavigationWasAppInitiated == WebCore::LastNavigationWasAppInitiated::Yes);


### PR DESCRIPTION
#### 828a55516a7e994b1d2854869969b0244ae8034d
<pre>
Revert [254944@main] REGRESSION (Safari 16): Service worker clientId is empty for web worker fetches
<a href="https://bugs.webkit.org/show_bug.cgi?id=245425">https://bugs.webkit.org/show_bug.cgi?id=245425</a>
rdar://problem/100368228

Reviewed by Ryan Haddad.

Seems to have broken Speedometer and JetStream benchmarks.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/sample-worker-interceptor.js:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https.html:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::loadMainResource):
* Source/WebCore/loader/FetchOptions.h:
(WebCore::FetchOptions::encode const):
(WebCore::FetchOptions::decode):
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::loadAsynchronously):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::transferToNewWebProcess):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::startFetch):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::controlClient):
(WebKit::WebSWServerConnection::createFetchTask):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::updateAppInitiatedValue):

Canonical link: <a href="https://commits.webkit.org/254966@main">https://commits.webkit.org/254966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbf130819d829bcf6f7823b32d419b4bf207b0c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35446 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/100156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/94879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33947 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/96650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96526 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/27050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/83214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35030 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32831 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36608 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1512 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38533 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->