### PR TITLE
Do not dispatch 'focus' or 'blur' event twice when window active state is changed

### DIFF
--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -922,7 +922,7 @@ void FocusController::setActive(bool active)
     m_page.setActivityState(active ? m_activityState | ActivityState::WindowIsActive : m_activityState - ActivityState::WindowIsActive);
 }
 
-void FocusController::setActiveInternal(bool active)
+void FocusController::setActiveInternal()
 {
     if (FrameView* view = m_page.mainFrame().view()) {
         if (!view->platformWidget()) {
@@ -932,9 +932,6 @@ void FocusController::setActiveInternal(bool active)
     }
 
     focusedOrMainFrame().selection().pageActivationChanged();
-    
-    if (m_focusedFrame && isFocused())
-        dispatchEventsOnWindowAndFocusedElement(m_focusedFrame->document(), active);
 }
 
 static void contentAreaDidShowOrHide(ScrollableArea* scrollableArea, bool didShow)

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -82,7 +82,7 @@ public:
     WEBCORE_EXPORT bool relinquishFocusToChrome(FocusDirection);
 
 private:
-    void setActiveInternal(bool);
+    virtual void setActiveInternal(bool) override;
     void setFocusedInternal(bool);
     void setIsVisibleAndActiveInternal(bool);
 


### PR DESCRIPTION
<pre>
Do not dispatch 'focus' or 'blur' event twice when window active state is changed

<a href="https://bugs.webkit.org/show_bug.cgi?id=119727">https://bugs.webkit.org/show_bug.cgi?id=119727</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=155558">https://src.chromium.org/viewvc/blink?view=revision&revision=155558</a>

Focus/blur event is dispatched in dispatchEventsOnWindowAndFocusedNode in these cases. FocusController::setFocused(bool) calls it, and FocusController::setActive(bool) also calls it if setFocused(true) was already called.

On OSX, these functions are called in the following sequence:
  Activation:
    WebView::setIsActive(true)
      FocusController::setActive(true)
    WebView::setFocus(true)
      FocusController::setFocused(true)
      FocusController::setActive(true)
  Inactivation:
    WebView::setIsActive(false)
      FocusController::setActive(false)
    WebView::setFocus(false)
      FocusController::setFocused(false);

We don't need to call dispatchEventsOnWindowAndFocusedNode in setActive() because we don't make a window focused state true when the window is inactive.

* Source/WebCore/page/FocusController.cpp:
(FocusController::setActiveInternal): Removed "dispatchEventsOnWindowAndFocusedElement" condition
* Source/WebCore/page/FocusController.h: Update "setActiveInternal" to remove 'bool' considering 'bool active' is removed from FocusController.cpp

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81a33aab74cfb1cd4a1f023f4b245a68df5bdbc5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91011 "1 style error") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35582 "Hash 81a33aab for PR 4808 does not build (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/100383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95017 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/34082 "Hash 81a33aab for PR 4808 does not build (failure)") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83356 "Hash 81a33aab for PR 4808 does not build (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96667 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/64/builds/34082 "Hash 81a33aab for PR 4808 does not build (failure)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/83356 "Hash 81a33aab for PR 4808 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/64/builds/34082 "Hash 81a33aab for PR 4808 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/83356 "Hash 81a33aab for PR 4808 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35161 "Hash 81a33aab for PR 4808 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32959 "Hash 81a33aab for PR 4808 does not build (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36739 "Hash 81a33aab for PR 4808 does not build (failure)") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38667 "Hash 81a33aab for PR 4808 does not build (failure)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->