### PR TITLE
REGRESSION (251454@main): Setting scrollTop on fixed element with overflow breaks scrolling on a 'overscroll-behavior:none' page

### DIFF
--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-fixed-element-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-fixed-element-expected.txt
@@ -1,0 +1,7 @@
+Can't scroll from here after 1 second
+
+PASS window.pageYOffset is 200
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-fixed-element.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-fixed-element.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+ <html>
+ <head>
+     <style>
+         :root {
+          overscroll-behavior: none;
+        }
+
+        body {
+          height: 4000px;
+        }
+
+        .fixed {
+          position: fixed;
+          overflow: hidden;
+          width: 400px;
+          height: 400px;
+          background-color: rgba(0, 0, 0, 0.2);
+        }
+
+        .content {
+          width: 100%;
+          height: 4000px;
+        }
+     </style>
+     <script src="../../../resources/ui-helper.js"></script>
+     <script src="../../../resources/js-test-pre.js"></script>
+     <script>
+         jsTestIsAsync = true;
+
+         async function runTest()
+         {
+            document.querySelector('.fixed').scrollTop = 0;            
+            eventSender.monitorWheelEvents();
+            await UIHelper.mouseWheelScrollAt(50, 50, 0, -10);
+            await UIHelper.waitForScrollCompletion();
+            shouldBe('window.pageYOffset', '200');
+            finishJSTest();
+         }
+         window.addEventListener('load', () => {
+             setTimeout(runTest, 0);
+         }, false);
+     </script>
+ </head>
+ <body>
+    <div class="fixed">
+    	<div class="content">
+            <p>Can't scroll from here after 1 second</p>
+    	</div>
+    </div>
+     <div id="console"></div>
+     <script src="../../../resources/js-test-post.js"></script>
+ </body>

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-iframe-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-iframe-expected.txt
@@ -1,0 +1,6 @@
+
+PASS window.pageYOffset is 200
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-iframe.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-iframe.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+ <html>
+ <head>
+     <style>
+         :root {
+          overscroll-behavior: none;
+        }
+
+        body {
+          height: 4000px;
+        }
+
+        .iframe {
+          position: fixed;
+          width: 400px;
+          height: 400px;
+        }
+
+        .content {
+          width: 100%;
+          height: 4000px;
+        }
+     </style>
+     <script src="../../../resources/ui-helper.js"></script>
+     <script src="../../../resources/js-test-pre.js"></script>
+     <script>
+         jsTestIsAsync = true;
+
+         async function runTest()
+         {
+            document.querySelector('.iframe').scrollTop = 0;            
+            eventSender.monitorWheelEvents();
+            await UIHelper.mouseWheelScrollAt(50, 50, 0, -10);
+            await UIHelper.waitForScrollCompletion();
+            shouldBe('window.pageYOffset', '200');
+            finishJSTest();
+         }
+         window.addEventListener('load', () => {
+             setTimeout(runTest, 0);
+         }, false);
+     </script>
+ </head>
+ <body>
+    <iframe src="../resources/smooth-scroll-iframe-helper-iframe.html" class="iframe"></iframe>
+     <div id="console"></div>
+     <script src="../../../resources/js-test-post.js"></script>
+ </body>

--- a/LayoutTests/fast/scrolling/resources/smooth-scroll-iframe-helper-iframe.html
+++ b/LayoutTests/fast/scrolling/resources/smooth-scroll-iframe-helper-iframe.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html> 
+<html>
+<style>
+    html,body{
+        overflow: hidden;
+        background-color: rgba(0, 0, 0, 0.2);
+    }
+</style>
+<head>
+</head>
+<body>
+</body>
+<html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4487,11 +4487,14 @@ void Document::runScrollSteps()
     if (frameView) {
         MonotonicTime now = MonotonicTime::now();
         bool scrollAnimationsInProgress = serviceScrollAnimationForScrollableArea(frameView.get(), now);
-        if (auto* scrollableAreas = frameView->scrollableAreas()) {
-            for (auto* scrollableArea : *scrollableAreas) {
-                if (serviceScrollAnimationForScrollableArea(scrollableArea, now))
-                    scrollAnimationsInProgress = true;
-            }
+        HashSet<ScrollableArea*> scrollableAreasToUpdate;
+        if (auto userScrollableAreas = frameView->scrollableAreas())
+            scrollableAreasToUpdate.add(userScrollableAreas->begin(), userScrollableAreas->end());
+        if (auto nonUserScrollableAreas = frameView->scrollableAreasForAnimatedScroll())
+            scrollableAreasToUpdate.add(nonUserScrollableAreas->begin(), nonUserScrollableAreas->end());
+        for (auto* scrollableArea : scrollableAreasToUpdate) {
+            if (serviceScrollAnimationForScrollableArea(scrollableArea, now))
+                scrollAnimationsInProgress = true;
         }
         if (scrollAnimationsInProgress)
             page()->scheduleRenderingUpdate({ RenderingUpdateStep::Scroll });

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -5541,6 +5541,20 @@ String FrameView::trackedRepaintRectsAsText() const
     return ts.release();
 }
 
+void FrameView::addScrollableAreaForAnimatedScroll(ScrollableArea* scrollableArea)
+{
+    if (!m_scrollableAreasForAnimatedScroll)
+        m_scrollableAreasForAnimatedScroll = makeUnique<ScrollableAreaSet>();
+    
+    m_scrollableAreasForAnimatedScroll->add(scrollableArea);
+}
+
+void FrameView::removeScrollableAreaForAnimatedScroll(ScrollableArea* scrollableArea)
+{
+    if (m_scrollableAreasForAnimatedScroll)
+        m_scrollableAreasForAnimatedScroll->remove(scrollableArea);
+}
+
 bool FrameView::addScrollableArea(ScrollableArea* scrollableArea)
 {
     if (!m_scrollableAreas)

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -594,6 +594,10 @@ public:
     WEBCORE_EXPORT bool removeScrollableArea(ScrollableArea*);
     bool containsScrollableArea(ScrollableArea*) const;
     const ScrollableAreaSet* scrollableAreas() const { return m_scrollableAreas.get(); }
+    
+    void addScrollableAreaForAnimatedScroll(ScrollableArea*);
+    void removeScrollableAreaForAnimatedScroll(ScrollableArea*);
+    const ScrollableAreaSet* scrollableAreasForAnimatedScroll() const { return m_scrollableAreasForAnimatedScroll.get(); }
 
     WEBCORE_EXPORT void addChild(Widget&) final;
     WEBCORE_EXPORT void removeChild(Widget&) final;
@@ -981,6 +985,7 @@ private:
     IntSize m_autoSizeContentSize;
 
     std::unique_ptr<ScrollableAreaSet> m_scrollableAreas;
+    std::unique_ptr<ScrollableAreaSet> m_scrollableAreasForAnimatedScroll;
     std::unique_ptr<WeakHashSet<RenderLayerModelObject>> m_viewportConstrainedObjects;
 
     OptionSet<LayoutMilestone> m_milestonesPendingPaint;

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -482,8 +482,10 @@ void AsyncScrollingCoordinator::animatedScrollDidEndForNode(ScrollingNodeID scro
         return;
     }
 
-    if (auto* scrollableArea = frameView->scrollableAreaForScrollingNodeID(scrollingNodeID))
+    if (auto* scrollableArea = frameView->scrollableAreaForScrollingNodeID(scrollingNodeID)) {
         scrollableArea->setScrollAnimationStatus(ScrollAnimationStatus::NotAnimating);
+        scrollableArea->animatedScrollDidEnd();
+    }
 }
 
 void AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll(ScrollingNodeID scrollingNodeID, const FloatPoint& scrollPosition, std::optional<FloatPoint> layoutViewportOrigin, ScrollingLayerPositionAction scrollingLayerPositionAction, ScrollType scrollType)

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -287,6 +287,7 @@ void ScrollAnimator::willStartAnimatedScroll()
 void ScrollAnimator::didStopAnimatedScroll()
 {
     m_scrollableArea.setScrollAnimationStatus(ScrollAnimationStatus::NotAnimating);
+    m_scrollableArea.animatedScrollDidEnd();
 }
 
 #if HAVE(RUBBER_BANDING)

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -287,6 +287,7 @@ public:
     // This reflects animated scrolls triggered by CSS OM View "smooth" scrolls.
     ScrollAnimationStatus scrollAnimationStatus() { return m_scrollAnimationStatus; }
     void setScrollAnimationStatus(ScrollAnimationStatus status) { m_scrollAnimationStatus = status; }
+    virtual void animatedScrollDidEnd() { };
 
     bool scrollShouldClearLatchedState() const { return m_scrollShouldClearLatchedState; }
     void setScrollShouldClearLatchedState(bool shouldClear) { m_scrollShouldClearLatchedState = shouldClear; }
@@ -394,6 +395,7 @@ public:
     bool shouldBlockScrollPropagation(const FloatSize&) const;
     FloatSize deltaForPropagation(const FloatSize&) const;
     WEBCORE_EXPORT virtual float adjustVerticalPageScrollStepForFixedContent(float step);
+    virtual bool needsAnimatedScroll() const { return false; }
 
 protected:
     WEBCORE_EXPORT ScrollableArea();

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -303,9 +303,6 @@ ScrollOffset RenderLayerScrollableArea::scrollToOffset(const ScrollOffset& scrol
         scrollAnimator().cancelAnimations();
         stopAsyncAnimatedScroll();
     }
-    
-    registerScrollableArea();
-
     ScrollOffset clampedScrollOffset = options.clamping == ScrollClamping::Clamped ? clampScrollOffset(scrollOffset) : scrollOffset;
     if (clampedScrollOffset == this->scrollOffset())
         return clampedScrollOffset;
@@ -315,9 +312,10 @@ ScrollOffset RenderLayerScrollableArea::scrollToOffset(const ScrollOffset& scrol
 
     ScrollOffset snappedOffset = ceiledIntPoint(scrollAnimator().scrollOffsetAdjustedForSnapping(clampedScrollOffset, options.snapPointSelectionMethod));
     auto snappedPosition = scrollPositionFromOffset(snappedOffset);
-    if (options.animated == ScrollIsAnimated::Yes)
+    if (options.animated == ScrollIsAnimated::Yes) {
+        registerScrollableAreaForAnimatedScroll();
         ScrollableArea::scrollToPositionWithAnimation(snappedPosition);
-    else if (!requestScrollPositionUpdate(snappedPosition, options.type, options.clamping))
+    } else if (!requestScrollPositionUpdate(snappedPosition, options.type, options.clamping))
         scrollToPositionWithoutAnimation(snappedPosition, options.clamping);
 
     setCurrentScrollType(previousScrollType);
@@ -1709,14 +1707,13 @@ void RenderLayerScrollableArea::updateScrollableAreaSet(bool hasOverflow)
 #endif
 }
 
-void RenderLayerScrollableArea::registerScrollableArea()
+void RenderLayerScrollableArea::registerScrollableAreaForAnimatedScroll()
 {
     auto& renderer = m_layer.renderer();
     FrameView& frameView = renderer.view().frameView();
-
     if (!m_registeredScrollableArea) {
-        frameView.addScrollableArea(this);
-        m_registeredScrollableArea = true;
+        frameView.addScrollableAreaForAnimatedScroll(this);
+        m_isRegisteredForAnimatedScroll = true;
     }
 }
 
@@ -1949,6 +1946,16 @@ String RenderLayerScrollableArea::debugDescription() const
 void RenderLayerScrollableArea::didStartScrollAnimation()
 {
     m_layer.page().scheduleRenderingUpdate({ RenderingUpdateStep::Scroll });
+}
+
+void RenderLayerScrollableArea::animatedScrollDidEnd()
+{
+    if (m_isRegisteredForAnimatedScroll) {
+        auto& renderer = m_layer.renderer();
+        FrameView& frameView = renderer.view().frameView();
+        m_isRegisteredForAnimatedScroll = false;
+        frameView.removeScrollableAreaForAnimatedScroll(this);
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -104,6 +104,8 @@ public:
     void setHasHorizontalScrollbar(bool);
     void setHasVerticalScrollbar(bool);
     
+    bool needsAnimatedScroll() const final { return m_isRegisteredForAnimatedScroll; }
+    
     OverscrollBehavior horizontalOverscrollBehavior() const final;
     OverscrollBehavior verticalOverscrollBehavior() const final;
 
@@ -244,6 +246,7 @@ public:
 
     std::optional<LayoutRect> updateScrollPosition(const ScrollPositionChangeOptions&, const LayoutRect& revealRect, const LayoutRect& localExposeRect);
     bool isVisibleToHitTesting() const final;
+    void animatedScrollDidEnd() final;
     LayoutRect scrollRectToVisible(const LayoutRect& absoluteRect, const ScrollRectToVisibleOptions&);
     std::optional<LayoutRect> updateScrollPositionForScrollIntoView(const ScrollPositionChangeOptions&, const LayoutRect& revealRect, const LayoutRect& localExposeRect);
 
@@ -272,7 +275,7 @@ private:
     void clearResizer();
 
     void updateScrollbarPresenceAndState(std::optional<bool> hasHorizontalOverflow = std::nullopt, std::optional<bool> hasVerticalOverflow = std::nullopt);
-    void registerScrollableArea();
+    void registerScrollableAreaForAnimatedScroll();
 
 private:
     bool m_scrollDimensionsDirty { true };
@@ -286,6 +289,8 @@ private:
     bool m_requiresScrollPositionReconciliation { false };
     bool m_containsDirtyOverlayScrollbars { false };
     bool m_updatingMarqueePosition { false };
+    
+    bool m_isRegisteredForAnimatedScroll { false };
 
     // The width/height of our scrolled area.
     int m_scrollWidth { 0 };


### PR DESCRIPTION
#### b08436732d9d451b70e9d6cd5061d65d6fd54497
<pre>
REGRESSION (251454@main): Setting scrollTop on fixed element with overflow breaks scrolling on a &apos;overscroll-behavior:none&apos; page
<a href="https://bugs.webkit.org/show_bug.cgi?id=245300">https://bugs.webkit.org/show_bug.cgi?id=245300</a>
&lt;rdar://100057532&gt;

Reviewed by Simon Fraser.

This fixes a few issues with <a href="https://commits.webkit.org/251454@main.">https://commits.webkit.org/251454@main.</a> The first is the fix was originally only intended for
scroll-behavior: smooth, so only add the scrollable area when we are doing an animated scroll. The second is to be more
strict when these non-user scrollable areas are in the frame view&apos;s list of sccrollable areas. We accomplish this by
adding a call when the animation completes to updateScrollableAreaSet, which will determine if the particular scrollable
area should be in the set after the animation completes. Finally, we add a check to absoluteEventTrackingRegionsForFrame(),
to see if the scrollable area was added only because it needed to do an animation.

* LayoutTests/fast/scrolling/mac/smooth-scroll-fixed-element-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/smooth-scroll-fixed-element.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::runScrollSteps):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::animatedScrollDidEndForNode):
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::absoluteEventTrackingRegionsForFrame const):
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::ScrollAnimator::didStopAnimatedScroll):
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::animatedScrollDidEnd):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollToOffset):
(WebCore::RenderLayerScrollableArea::registerScrollableAreaForAnimatedScroll):
(WebCore::RenderLayerScrollableArea::animatedScrollDidEnd):
(WebCore::RenderLayerScrollableArea::registerScrollableArea): Deleted.
* Source/WebCore/rendering/RenderLayerScrollableArea.h:

Canonical link: <a href="https://commits.webkit.org/257665@main">https://commits.webkit.org/257665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/891ab0db21a5ef7440097d69578d608b5d5ab60d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108958 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169195 "Failed to checkout and rebase branch from PR 4810") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86075 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92071 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106875 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105373 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34035 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21948 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2609 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23462 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2544 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42935 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4404 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2698 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->