### PR TITLE
Land stubs for the Screen Orientation API

### DIFF
--- a/LayoutTests/fast/dom/Window/window-appendages-cleared-expected.txt
+++ b/LayoutTests/fast/dom/Window/window-appendages-cleared-expected.txt
@@ -29,6 +29,7 @@ PASS screen.availTop == "LEFTOVER" is false
 PASS screen.availWidth == "LEFTOVER" is false
 PASS screen.colorDepth == "LEFTOVER" is false
 PASS screen.height == "LEFTOVER" is false
+PASS screen.orientation == "LEFTOVER" is false
 PASS screen.pixelDepth == "LEFTOVER" is false
 PASS screen.width == "LEFTOVER" is false
 PASS scrollbars.visible == "LEFTOVER" is false

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/event-before-promise-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/event-before-promise-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (FAIL), message = Test named 'The 'change' event must fire before the [[orientationPendingPromise]] is resolved.' specified 1 'cleanup' function, and 1 failed.
-
 FAIL The 'change' event must fire before the [[orientationPendingPromise]] is resolved. promise_test: Unhandled rejection with value: object "TypeError: document.documentElement.requestFullscreen is not a function. (In 'document.documentElement.requestFullscreen()', 'document.documentElement.requestFullscreen' is undefined)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/idlharness.window-expected.txt
@@ -3,25 +3,25 @@ PASS idl_test setup
 PASS idl_test validation
 PASS Partial interface Screen: original interface defined
 PASS Partial interface Screen: member names are unique
-FAIL ScreenOrientation interface: existence and properties of interface object assert_own_property: self does not have own property "ScreenOrientation" expected property "ScreenOrientation" missing
-FAIL ScreenOrientation interface object length assert_own_property: self does not have own property "ScreenOrientation" expected property "ScreenOrientation" missing
-FAIL ScreenOrientation interface object name assert_own_property: self does not have own property "ScreenOrientation" expected property "ScreenOrientation" missing
-FAIL ScreenOrientation interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ScreenOrientation" expected property "ScreenOrientation" missing
-FAIL ScreenOrientation interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ScreenOrientation" expected property "ScreenOrientation" missing
-FAIL ScreenOrientation interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ScreenOrientation" expected property "ScreenOrientation" missing
-FAIL ScreenOrientation interface: operation lock(OrientationLockType) assert_own_property: self does not have own property "ScreenOrientation" expected property "ScreenOrientation" missing
-FAIL ScreenOrientation interface: operation unlock() assert_own_property: self does not have own property "ScreenOrientation" expected property "ScreenOrientation" missing
-FAIL ScreenOrientation interface: attribute type assert_own_property: self does not have own property "ScreenOrientation" expected property "ScreenOrientation" missing
-FAIL ScreenOrientation interface: attribute angle assert_own_property: self does not have own property "ScreenOrientation" expected property "ScreenOrientation" missing
-FAIL ScreenOrientation interface: attribute onchange assert_own_property: self does not have own property "ScreenOrientation" expected property "ScreenOrientation" missing
-FAIL ScreenOrientation must be primary interface of screen.orientation assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL Stringification of screen.orientation assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL ScreenOrientation interface: screen.orientation must inherit property "lock(OrientationLockType)" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL ScreenOrientation interface: calling lock(OrientationLockType) on screen.orientation with too few arguments must throw TypeError assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL ScreenOrientation interface: screen.orientation must inherit property "unlock()" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL ScreenOrientation interface: screen.orientation must inherit property "type" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL ScreenOrientation interface: screen.orientation must inherit property "angle" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL ScreenOrientation interface: screen.orientation must inherit property "onchange" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL Screen interface: attribute orientation assert_true: The prototype object must have a property "orientation" expected true got false
-FAIL Screen interface: screen must inherit property "orientation" with the proper type assert_inherits: property "orientation" not found in prototype chain
+PASS ScreenOrientation interface: existence and properties of interface object
+PASS ScreenOrientation interface object length
+PASS ScreenOrientation interface object name
+PASS ScreenOrientation interface: existence and properties of interface prototype object
+PASS ScreenOrientation interface: existence and properties of interface prototype object's "constructor" property
+PASS ScreenOrientation interface: existence and properties of interface prototype object's @@unscopables property
+PASS ScreenOrientation interface: operation lock(OrientationLockType)
+PASS ScreenOrientation interface: operation unlock()
+PASS ScreenOrientation interface: attribute type
+PASS ScreenOrientation interface: attribute angle
+PASS ScreenOrientation interface: attribute onchange
+PASS ScreenOrientation must be primary interface of screen.orientation
+PASS Stringification of screen.orientation
+PASS ScreenOrientation interface: screen.orientation must inherit property "lock(OrientationLockType)" with the proper type
+PASS ScreenOrientation interface: calling lock(OrientationLockType) on screen.orientation with too few arguments must throw TypeError
+PASS ScreenOrientation interface: screen.orientation must inherit property "unlock()" with the proper type
+PASS ScreenOrientation interface: screen.orientation must inherit property "type" with the proper type
+PASS ScreenOrientation interface: screen.orientation must inherit property "angle" with the proper type
+PASS ScreenOrientation interface: screen.orientation must inherit property "onchange" with the proper type
+PASS Screen interface: attribute orientation
+PASS Screen interface: screen must inherit property "orientation" with the proper type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-bad-argument-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-bad-argument-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL screen.orientation.lock() must throw given invalid input. undefined is not an object (evaluating 'screen.orientation.lock')
-FAIL screen.orientation.lock() must throw when the input is missing. undefined is not an object (evaluating 'screen.orientation.lock')
+PASS screen.orientation.lock() must throw given invalid input.
+PASS screen.orientation.lock() must throw when the input is missing.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt
@@ -1,10 +1,8 @@
 
-Harness Error (FAIL), message = Test named 'Test that screen.orientation.unlock() doesn't throw when there is no lock with fullscreen' specified 1 'cleanup' function, and 1 failed.
-
 FAIL Test that screen.orientation.unlock() doesn't throw when there is no lock with fullscreen promise_test: Unhandled rejection with value: object "TypeError: document.documentElement.requestFullscreen is not a function. (In 'document.documentElement.requestFullscreen()', 'document.documentElement.requestFullscreen' is undefined)"
-FAIL Test that screen.orientation.unlock() doesn't throw when there is no lock undefined is not an object (evaluating 'screen.orientation.unlock')
-FAIL Test that screen.orientation.unlock() returns a void value undefined is not an object (evaluating 'screen.orientation.unlock')
-NOTRUN Test that screen.orientation.lock returns a promise which will be fulfilled with a void value.
-NOTRUN Test that screen.orientation.lock returns a pending promise.
-NOTRUN Test that screen.orientation.lock() is actually async
+PASS Test that screen.orientation.unlock() doesn't throw when there is no lock
+PASS Test that screen.orientation.unlock() returns a void value
+FAIL Test that screen.orientation.lock returns a promise which will be fulfilled with a void value. promise_test: Unhandled rejection with value: object "TypeError: document.documentElement.requestFullscreen is not a function. (In 'document.documentElement.requestFullscreen()', 'document.documentElement.requestFullscreen' is undefined)"
+FAIL Test that screen.orientation.lock returns a pending promise. promise_test: Unhandled rejection with value: object "TypeError: document.documentElement.requestFullscreen is not a function. (In 'document.documentElement.requestFullscreen()', 'document.documentElement.requestFullscreen' is undefined)"
+FAIL Test that screen.orientation.lock() is actually async promise_test: Unhandled rejection with value: object "TypeError: document.documentElement.requestFullscreen is not a function. (In 'document.documentElement.requestFullscreen()', 'document.documentElement.requestFullscreen' is undefined)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: Error while parsing the 'sandbox' attribute: 'allow-orientation-lock' is an invalid sandbox flag.
-CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'screen.orientation.unlock')
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: document.documentElement.requestFullscreen is not a function. (In 'document.documentElement.requestFullscreen()', 'document.documentElement.requestFullscreen' is undefined)
 
 
 Harness Error (TIMEOUT), message = null

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (FAIL), message = Test named 'Re-locking orientation during event dispatch must reject existing orientationPendingPromise' specified 1 'cleanup' function, and 1 failed.
-
 FAIL Re-locking orientation during event dispatch must reject existing orientationPendingPromise promise_test: Unhandled rejection with value: object "TypeError: document.documentElement.requestFullscreen is not a function. (In 'document.documentElement.requestFullscreen()', 'document.documentElement.requestFullscreen' is undefined)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Test named 'Test that orientationchange event is fired when the orientation changes.' specified 1 'cleanup' function, and 1 failed.
-
 FAIL Test that orientationchange event is not fired when the orientation does not change. promise_test: Unhandled rejection with value: object "TypeError: document.documentElement.requestFullscreen is not a function. (In 'document.documentElement.requestFullscreen()', 'document.documentElement.requestFullscreen' is undefined)"
 FAIL Test that orientationchange event is fired when the orientation changes. promise_test: Unhandled rejection with value: object "TypeError: document.documentElement.requestFullscreen is not a function. (In 'document.documentElement.requestFullscreen()', 'document.documentElement.requestFullscreen' is undefined)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'window.screen.orientation.addEventListener')
-
-Harness Error (FAIL), message = Test named 'Test subframes receive orientation change events' specified 1 'cleanup' function, and 1 failed.
 
 FAIL Test subframes receive orientation change events promise_test: Unhandled rejection with value: object "TypeError: document.documentElement.requestFullscreen is not a function. (In 'document.documentElement.requestFullscreen()', 'document.documentElement.requestFullscreen' is undefined)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
@@ -1,10 +1,8 @@
 
-Harness Error (FAIL), message = Test named 'Test that screen.orientation values change if the orientation changes' specified 1 'cleanup' function, and 1 failed.
-
-FAIL Test screen.orientation properties screen.orientation is not an Object. (evaluating '"type" in screen.orientation')
-FAIL Test screen.orientation default values. undefined is not an object (evaluating 'screen.orientation.type')
+PASS Test screen.orientation properties
+FAIL Test screen.orientation default values. assert_true: expected true got false
 FAIL Test the orientations and associated angles promise_test: Unhandled rejection with value: object "TypeError: document.documentElement.requestFullscreen is not a function. (In 'document.documentElement.requestFullscreen()', 'document.documentElement.requestFullscreen' is undefined)"
-FAIL Test that screen.orientation properties are not writable undefined is not an object (evaluating 'screen.orientation.type')
+PASS Test that screen.orientation properties are not writable
 PASS Test that screen.orientation is always the same object
 FAIL Test that screen.orientation values change if the orientation changes promise_test: Unhandled rejection with value: object "TypeError: document.documentElement.requestFullscreen is not a function. (In 'document.documentElement.requestFullscreen()', 'document.documentElement.requestFullscreen' is undefined)"
 

--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -1481,6 +1481,18 @@ ScreenCaptureEnabled:
     WebCore:
       default: false
 
+ScreenOrientationAPIEnabled:
+  type: bool
+  humanReadableName: "Screen Orientation API"
+  humanReadableDescription: "Enable Screen Orientation API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 ScreenWakeLockAPIEnabled:
   type: bool
   humanReadableName: "Screen Wake Lock API"

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1264,6 +1264,7 @@ set(WebCore_NON_SVG_IDL_FILES
     page/ResizeObserverOptions.idl
     page/ResizeObserverSize.idl
     page/Screen.idl
+    page/ScreenOrientation.idl
     page/ScrollBehavior.idl
     page/ScrollIntoViewOptions.idl
     page/ScrollLogicalPosition.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1476,6 +1476,7 @@ $(PROJECT_DIR)/page/ResizeObserverEntry.idl
 $(PROJECT_DIR)/page/ResizeObserverOptions.idl
 $(PROJECT_DIR)/page/ResizeObserverSize.idl
 $(PROJECT_DIR)/page/Screen.idl
+$(PROJECT_DIR)/page/ScreenOrientation.idl
 $(PROJECT_DIR)/page/ScrollBehavior.idl
 $(PROJECT_DIR)/page/ScrollIntoViewOptions.idl
 $(PROJECT_DIR)/page/ScrollLogicalPosition.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2530,6 +2530,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSVGZoomAndPan.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSVGZoomAndPan.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSScreen.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSScreen.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSScreenOrientation.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSScreenOrientation.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSScriptProcessorNode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSScriptProcessorNode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSScrollBehavior.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1309,6 +1309,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/page/ResizeObserverOptions.idl \
     $(WebCore)/page/ResizeObserverSize.idl \
     $(WebCore)/page/Screen.idl \
+    $(WebCore)/page/ScreenOrientation.idl \
     $(WebCore)/page/ScrollBehavior.idl \
     $(WebCore)/page/ScrollIntoViewOptions.idl \
     $(WebCore)/page/ScrollLogicalPosition.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1845,6 +1845,7 @@ page/ResizeObserver.cpp
 page/ResourceUsageOverlay.cpp
 page/ResourceUsageThread.cpp
 page/Screen.cpp
+page/ScreenOrientation.cpp
 page/ScrollBehavior.cpp
 page/SecurityOrigin.cpp
 page/SecurityOriginData.cpp
@@ -3971,6 +3972,7 @@ JSSVGViewElement.cpp
 JSSVGViewSpec.cpp
 JSSVGZoomAndPan.cpp
 JSScreen.cpp
+JSScreenOrientation.cpp
 JSScriptProcessorNode.cpp
 JSScrollBehavior.cpp
 JSScrollIntoViewOptions.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -364,6 +364,7 @@ namespace WebCore {
     macro(SQLResultSetRowList) \
     macro(SQLTransaction) \
     macro(ScreenLuminance) \
+    macro(ScreenOrientation) \
     macro(ServiceWorker) \
     macro(ServiceWorkerContainer) \
     macro(ServiceWorkerGlobalScope) \

--- a/Source/WebCore/dom/EventTargetFactory.in
+++ b/Source/WebCore/dom/EventTargetFactory.in
@@ -55,6 +55,7 @@ SharedWorker
 SharedWorkerGlobalScope
 SourceBuffer conditional=MEDIA_SOURCE
 SourceBufferList conditional=MEDIA_SOURCE
+ScreenOrientation
 SpeechRecognition
 SpeechSynthesis conditional=SPEECH_SYNTHESIS
 SpeechSynthesisUtterance conditional=SPEECH_SYNTHESIS

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -39,6 +39,7 @@
 #include "PlatformScreen.h"
 #include "Quirks.h"
 #include "ResourceLoadObserver.h"
+#include "ScreenOrientation.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -49,6 +50,8 @@ Screen::Screen(DOMWindow& window)
     : DOMWindowProperty(&window)
 {
 }
+
+Screen::~Screen() = default;
 
 unsigned Screen::height() const
 {
@@ -133,6 +136,13 @@ unsigned Screen::availWidth() const
     if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailWidth);
     return static_cast<unsigned>(screenAvailableRect(frame->view()).width());
+}
+
+ScreenOrientation& Screen::orientation()
+{
+    if (!m_screenOrientation)
+        m_screenOrientation = ScreenOrientation::create(window() ? window()->document() : nullptr);
+    return *m_screenOrientation;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Screen.h
+++ b/Source/WebCore/page/Screen.h
@@ -36,10 +36,13 @@
 
 namespace WebCore {
 
+class ScreenOrientation;
+
 class Screen final : public ScriptWrappable, public RefCounted<Screen>, public DOMWindowProperty {
     WTF_MAKE_ISO_ALLOCATED(Screen);
 public:
     static Ref<Screen> create(DOMWindow& window) { return adoptRef(*new Screen(window)); }
+    ~Screen();
 
     unsigned height() const;
     unsigned width() const;
@@ -50,8 +53,12 @@ public:
     unsigned availHeight() const;
     unsigned availWidth() const;
 
+    ScreenOrientation& orientation();
+
 private:
     explicit Screen(DOMWindow&);
+
+    RefPtr<ScreenOrientation> m_screenOrientation;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/Screen.idl
+++ b/Source/WebCore/page/Screen.idl
@@ -39,5 +39,8 @@
     readonly attribute long availTop;
     readonly attribute unsigned long availHeight;
     readonly attribute unsigned long availWidth;
+
+    // https://w3c.github.io/screen-orientation/#extensions-to-the-screen-interface
+    [SameObject, EnabledBySetting=ScreenOrientationAPIEnabled] readonly attribute ScreenOrientation orientation;
 };
 

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScreenOrientation.h"
+
+#include "Document.h"
+#include "EventNames.h"
+#include "JSDOMPromiseDeferred.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(ScreenOrientation);
+
+Ref<ScreenOrientation> ScreenOrientation::create(Document* document)
+{
+    auto screenOrientation = adoptRef(*new ScreenOrientation(document));
+    screenOrientation->suspendIfNeeded();
+    return screenOrientation;
+}
+
+ScreenOrientation::ScreenOrientation(Document* document)
+    : ActiveDOMObject(document)
+{
+}
+
+Document* ScreenOrientation::document() const
+{
+    return downcast<Document>(scriptExecutionContext());
+}
+
+void ScreenOrientation::lock(LockType, Ref<DeferredPromise>&& promise)
+{
+    promise->reject(Exception { NotSupportedError });
+}
+
+void ScreenOrientation::unlock()
+{
+}
+
+auto ScreenOrientation::type() const -> Type
+{
+    return Type::PortraitPrimary;
+}
+
+uint16_t ScreenOrientation::angle() const
+{
+    return 0;
+}
+
+const char* ScreenOrientation::activeDOMObjectName() const
+{
+    return "ScreenOrientation";
+}
+
+bool ScreenOrientation::virtualHasPendingActivity() const
+{
+    return m_hasChangeEventListener;
+}
+
+void ScreenOrientation::eventListenersDidChange()
+{
+    m_hasChangeEventListener = hasEventListeners(eventNames().changeEvent);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/ScreenOrientation.h
+++ b/Source/WebCore/page/ScreenOrientation.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ActiveDOMObject.h"
+#include "EventTarget.h"
+
+#include "ScreenOrientationLockType.h"
+#include "ScreenOrientationType.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+
+class ScreenOrientation final : public ActiveDOMObject, public EventTarget, public RefCounted<ScreenOrientation> {
+    WTF_MAKE_ISO_ALLOCATED(ScreenOrientation);
+public:
+    static Ref<ScreenOrientation> create(Document*);
+
+    using LockType = ScreenOrientationLockType;
+    using Type = ScreenOrientationType;
+
+    void lock(LockType, Ref<DeferredPromise>&&);
+    void unlock();
+    Type type() const;
+    uint16_t angle() const;
+
+    using RefCounted::ref;
+    using RefCounted::deref;
+
+private:
+    ScreenOrientation(Document*);
+
+    Document* document() const;
+
+    // EventTarget
+    EventTargetInterface eventTargetInterface() const final { return ScreenOrientationEventTargetInterfaceType; }
+    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    void refEventTarget() final { RefCounted::ref(); }
+    void derefEventTarget() final { RefCounted::deref(); }
+    void eventListenersDidChange() final;
+
+    // ActiveDOMObject
+    const char* activeDOMObjectName() const final;
+    bool virtualHasPendingActivity() const final;
+
+    bool m_hasChangeEventListener { false };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/ScreenOrientation.idl
+++ b/Source/WebCore/page/ScreenOrientation.idl
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    ActiveDOMObject,
+    EnabledBySetting=ScreenOrientationAPIEnabled,
+    Exposed=Window
+] interface ScreenOrientation : EventTarget {
+    Promise<undefined> lock(OrientationLockType orientation);
+    undefined unlock();
+    readonly attribute OrientationType type;
+    readonly attribute unsigned short angle;
+    attribute EventHandler onchange;
+};
+
+[
+    ImplementedAs=ScreenOrientationLockType
+] enum OrientationLockType {
+    "any",
+    "natural",
+    "landscape",
+    "portrait",
+    "portrait-primary",
+    "portrait-secondary",
+    "landscape-primary",
+    "landscape-secondary"
+};
+
+[
+    ImplementedAs=ScreenOrientationType
+] enum OrientationType {
+    "portrait-primary",
+    "portrait-secondary",
+    "landscape-primary",
+    "landscape-secondary"
+};

--- a/Source/WebCore/page/ScreenOrientationLockType.h
+++ b/Source/WebCore/page/ScreenOrientationLockType.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class ScreenOrientationLockType : uint8_t {
+    Any,
+    Natural,
+    Landscape,
+    Portrait,
+    PortraitPrimary,
+    PortraitSecondary,
+    LandscapePrimary,
+    LandscapeSecondary
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/ScreenOrientationType.h
+++ b/Source/WebCore/page/ScreenOrientationType.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class ScreenOrientationType : uint8_t {
+    PortraitPrimary,
+    PortraitSecondary,
+    LandscapePrimary,
+    LandscapeSecondary
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/csp/CSPViolationReportBody.cpp
+++ b/Source/WebCore/page/csp/CSPViolationReportBody.cpp
@@ -30,6 +30,7 @@
 #include "FormData.h"
 #include "SecurityPolicyViolationEvent.h"
 #include <wtf/IsoMallocInlines.h>
+#include <wtf/JSONValues.h>
 
 namespace WebCore {
 


### PR DESCRIPTION
#### 4747b6ca4137255b0bb05230d53bf701159e4511
<pre>
Land stubs for the Screen Orientation API
<a href="https://bugs.webkit.org/show_bug.cgi?id=245804">https://bugs.webkit.org/show_bug.cgi?id=245804</a>

Reviewed by Brent Fulgham.

Land stubs for the Screen Orientation API:
- <a href="https://w3c.github.io/screen-orientation">https://w3c.github.io/screen-orientation</a>

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/EventTargetFactory.in:
* Source/WebCore/page/Screen.cpp:
(WebCore::Screen::orientation):
* Source/WebCore/page/Screen.h:
* Source/WebCore/page/Screen.idl:
* Source/WebCore/page/ScreenOrientation.cpp: Added.
(WebCore::ScreenOrientation::create):
(WebCore::ScreenOrientation::ScreenOrientation):
(WebCore::ScreenOrientation::document const):
(WebCore::ScreenOrientation::lock):
(WebCore::ScreenOrientation::unlock):
(WebCore::ScreenOrientation::type const):
(WebCore::ScreenOrientation::angle const):
(WebCore::ScreenOrientation::activeDOMObjectName const):
(WebCore::ScreenOrientation::virtualHasPendingActivity const):
(WebCore::ScreenOrientation::eventListenersDidChange):
* Source/WebCore/page/ScreenOrientation.h: Added.
* Source/WebCore/page/ScreenOrientation.idl: Added.
* Source/WebCore/page/ScreenOrientationLockType.h: Added.
* Source/WebCore/page/ScreenOrientationType.h: Added.
* Source/WebCore/page/csp/CSPViolationReportBody.cpp:

Canonical link: <a href="https://commits.webkit.org/255032@main">https://commits.webkit.org/255032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3507140d8851b63bd4968e86609fd3039a7af2c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100328 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/158833 "Found 1 new test failure: fast/dom/Window/window-appendages-cleared.html (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/34054 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29071 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83328 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97120 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96638 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77769 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26945 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81887 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/81613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69980 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35134 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15633 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32934 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16620 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3502 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39581 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35704 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->