### PR TITLE
'run-benchmark' should only use 'local_git_archive' when commit exists

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
@@ -110,14 +110,13 @@ class BenchmarkBuilder(object):
     def _local_git_archive_eligible(self):
         if 'local_git_archive' not in self._plan:
             return False
-        if not self.LOCAL_GIT_ARCHIVE_SCHEMA.match(self._plan['local_git_archive']):
+
+        match = self.LOCAL_GIT_ARCHIVE_SCHEMA.match(self._plan['local_git_archive'])
+        if not match:
             return False
-        try:
-            is_git_checkout = subprocess.check_output(['git', '-C', os.path.dirname(__file__), 'rev-parse',
-                                                       '--is-inside-work-tree'], encoding='utf-8').strip() == 'true'
-        except subprocess.CalledProcessError:
-            return False
-        return is_git_checkout
+
+        return not subprocess.call(['git', '-C', os.path.dirname(__file__), 'cat-file', '-e', match.group('reference')],
+                                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     def _prepare_content_from_local_git_archive(self, local_git_archive):
         match = self.LOCAL_GIT_ARCHIVE_SCHEMA.match(local_git_archive)


### PR DESCRIPTION
#### c45d277678274c219990c8c630d678ec9b646c89
<pre>
&apos;run-benchmark&apos; should only use &apos;local_git_archive&apos; when commit exists
<a href="https://bugs.webkit.org/show_bug.cgi?id=245812">https://bugs.webkit.org/show_bug.cgi?id=245812</a>
&lt;rdar://100539553&gt;

Reviewed by Stephanie Lewis.

Fix a bug that &apos;local_git_archive&apos; will always be used as long as the benchmark_builder.py
is inside a git checkout. This will fail if the commit/reference does not exist.
* Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py:
(BenchmarkBuilder._local_git_archive_eligible):

Canonical link: <a href="https://commits.webkit.org/255012@main">https://commits.webkit.org/255012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef81e2fee603ae419dcdd20c004092080d0a4d67

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35574 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/100362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/158857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/34074 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83348 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96659 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77787 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26957 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/94582 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/69997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35153 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32951 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3489 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36731 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38659 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->