### PR TITLE
Expose WebCodecs VideoEncoder Skeleton

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -1,13 +1,25 @@
 
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Emtpy codec Can't find variable: VideoEncoder
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Unrecognized codec Can't find variable: VideoEncoder
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is too large Can't find variable: VideoEncoder
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is too large Can't find variable: VideoEncoder
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Invalid scalability mode Can't find variable: VideoEncoder
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:AVC not supported by VP8 Can't find variable: VideoEncoder
-FAIL VideoEncoder.isConfigSupported() doesn't support config:Too strenuous accelerated encoding parameters promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"} promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality"} promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"} promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
+FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Emtpy codec promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Unrecognized codec promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is too large promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is too large promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Invalid scalability mode promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:AVC not supported by VP8 promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL VideoEncoder.isConfigSupported() doesn't support config:Too strenuous accelerated encoding parameters promise_test: Unhandled rejection with value: object "NotSupportedError: Not implemented"
+FAIL VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264 promise_test: Unhandled rejection with value: object "NotSupportedError: Not implemented"
+FAIL VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"} promise_test: Unhandled rejection with value: object "NotSupportedError: Not implemented"
+FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality"} promise_test: Unhandled rejection with value: object "NotSupportedError: Not implemented"
+FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"} promise_test: Unhandled rejection with value: object "NotSupportedError: Not implemented"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -1,13 +1,25 @@
 
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Emtpy codec Can't find variable: VideoEncoder
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Unrecognized codec Can't find variable: VideoEncoder
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is too large Can't find variable: VideoEncoder
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is too large Can't find variable: VideoEncoder
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Invalid scalability mode Can't find variable: VideoEncoder
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:AVC not supported by VP8 Can't find variable: VideoEncoder
-FAIL VideoEncoder.isConfigSupported() doesn't support config:Too strenuous accelerated encoding parameters promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"} promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality"} promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"} promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
+FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Emtpy codec promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Unrecognized codec promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is too large promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is too large promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Invalid scalability mode promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:AVC not supported by VP8 promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL VideoEncoder.isConfigSupported() doesn't support config:Too strenuous accelerated encoding parameters promise_test: Unhandled rejection with value: object "NotSupportedError: Not implemented"
+FAIL VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264 promise_test: Unhandled rejection with value: object "NotSupportedError: Not implemented"
+FAIL VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"} promise_test: Unhandled rejection with value: object "NotSupportedError: Not implemented"
+FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality"} promise_test: Unhandled rejection with value: object "NotSupportedError: Not implemented"
+FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"} promise_test: Unhandled rejection with value: object "NotSupportedError: Not implemented"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt
@@ -1,14 +1,12 @@
 
-FAIL Test VideoEncoder construction assert_throws_js: function "() => { new VideoEncoder({}); }" threw object "ReferenceError: Can't find variable: VideoEncoder" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Test VideoEncoder.configure() Can't find variable: VideoEncoder
-FAIL Test successful configure(), encode(), and flush() promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL encodeQueueSize test promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
+PASS Test VideoEncoder construction
+FAIL Test VideoEncoder.configure() assert_equals: expected "configured" but got "unconfigured"
+FAIL Test successful configure(), encode(), and flush() promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
+FAIL encodeQueueSize test promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
 FAIL Test successful reset() and re-confiugre() promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
-FAIL Test successful encode() after re-configure(). promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL Verify closed VideoEncoder operations promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL Verify unconfigured VideoEncoder operations promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL Verify encoding closed frames throws. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL Encode video with negative timestamp promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
+FAIL Test successful encode() after re-configure(). promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
+FAIL Verify closed VideoEncoder operations promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
+FAIL Verify unconfigured VideoEncoder operations promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
+FAIL Verify encoding closed frames throws. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
+FAIL Encode video with negative timestamp promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.worker-expected.txt
@@ -1,14 +1,12 @@
 
-FAIL Test VideoEncoder construction assert_throws_js: function "() => { new VideoEncoder({}); }" threw object "ReferenceError: Can't find variable: VideoEncoder" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Test VideoEncoder.configure() Can't find variable: VideoEncoder
-FAIL Test successful configure(), encode(), and flush() promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL encodeQueueSize test promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
+PASS Test VideoEncoder construction
+FAIL Test VideoEncoder.configure() assert_equals: expected "configured" but got "unconfigured"
+FAIL Test successful configure(), encode(), and flush() promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
+FAIL encodeQueueSize test promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
 FAIL Test successful reset() and re-confiugre() promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
-FAIL Test successful encode() after re-configure(). promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL Verify closed VideoEncoder operations promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL Verify unconfigured VideoEncoder operations promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL Verify encoding closed frames throws. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
-FAIL Encode video with negative timestamp promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoEncoder"
+FAIL Test successful encode() after re-configure(). promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
+FAIL Verify closed VideoEncoder operations promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
+FAIL Verify unconfigured VideoEncoder operations promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
+FAIL Verify encoding closed frames throws. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
+FAIL Encode video with negative timestamp promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -702,6 +702,8 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/webauthn/ResidentKeyRequirement.idl
     Modules/webauthn/UserVerificationRequirement.idl
 
+    Modules/webcodecs/BitrateMode.idl
+    Modules/webcodecs/LatencyMode.idl
     Modules/webcodecs/HardwareAcceleration.idl
     Modules/webcodecs/PlaneLayout.idl
     Modules/webcodecs/VideoColorPrimaries.idl
@@ -712,11 +714,17 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/webcodecs/VideoTransferCharacteristics.idl
     Modules/webcodecs/WebCodecsCodecState.idl
     Modules/webcodecs/WebCodecsEncodedVideoChunk.idl
+    Modules/webcodecs/WebCodecsEncodedVideoChunkMetadata.idl
+    Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.idl
     Modules/webcodecs/WebCodecsEncodedVideoChunkType.idl
     Modules/webcodecs/WebCodecsErrorCallback.idl
     Modules/webcodecs/WebCodecsVideoDecoder.idl
     Modules/webcodecs/WebCodecsVideoDecoderConfig.idl
     Modules/webcodecs/WebCodecsVideoDecoderSupport.idl
+    Modules/webcodecs/WebCodecsVideoEncoder.idl
+    Modules/webcodecs/WebCodecsVideoEncoderConfig.idl
+    Modules/webcodecs/WebCodecsVideoEncoderEncodeOptions.idl
+    Modules/webcodecs/WebCodecsVideoEncoderSupport.idl
     Modules/webcodecs/WebCodecsVideoFrameOutputCallback.idl
     Modules/webcodecs/WebCodecsVideoFrame.idl
 

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -773,7 +773,9 @@ $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredentialType.idl
 $(PROJECT_DIR)/Modules/webauthn/ResidentKeyRequirement.idl
 $(PROJECT_DIR)/Modules/webauthn/UserVerificationRequirement.idl
+$(PROJECT_DIR)/Modules/webcodecs/BitrateMode.idl
 $(PROJECT_DIR)/Modules/webcodecs/HardwareAcceleration.idl
+$(PROJECT_DIR)/Modules/webcodecs/LatencyMode.idl
 $(PROJECT_DIR)/Modules/webcodecs/PlaneLayout.idl
 $(PROJECT_DIR)/Modules/webcodecs/VideoColorPrimaries.idl
 $(PROJECT_DIR)/Modules/webcodecs/VideoColorSpace.idl
@@ -783,11 +785,17 @@ $(PROJECT_DIR)/Modules/webcodecs/VideoPixelFormat.idl
 $(PROJECT_DIR)/Modules/webcodecs/VideoTransferCharacteristics.idl
 $(PROJECT_DIR)/Modules/webcodecs/WebCodecsCodecState.idl
 $(PROJECT_DIR)/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl
+$(PROJECT_DIR)/Modules/webcodecs/WebCodecsEncodedVideoChunkMetadata.idl
+$(PROJECT_DIR)/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.idl
 $(PROJECT_DIR)/Modules/webcodecs/WebCodecsEncodedVideoChunkType.idl
 $(PROJECT_DIR)/Modules/webcodecs/WebCodecsErrorCallback.idl
 $(PROJECT_DIR)/Modules/webcodecs/WebCodecsVideoDecoder.idl
 $(PROJECT_DIR)/Modules/webcodecs/WebCodecsVideoDecoderConfig.idl
 $(PROJECT_DIR)/Modules/webcodecs/WebCodecsVideoDecoderSupport.idl
+$(PROJECT_DIR)/Modules/webcodecs/WebCodecsVideoEncoder.idl
+$(PROJECT_DIR)/Modules/webcodecs/WebCodecsVideoEncoderConfig.idl
+$(PROJECT_DIR)/Modules/webcodecs/WebCodecsVideoEncoderEncodeOptions.idl
+$(PROJECT_DIR)/Modules/webcodecs/WebCodecsVideoEncoderSupport.idl
 $(PROJECT_DIR)/Modules/webcodecs/WebCodecsVideoFrame.idl
 $(PROJECT_DIR)/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.idl
 $(PROJECT_DIR)/Modules/webdatabase/DOMWindow+WebDatabase.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -292,6 +292,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBiquadFilterOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBiquadFilterOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBiquadFilterType.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBiquadFilterType.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBitrateMode.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBitrateMode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBlob.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBlob.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBlobCallback.cpp
@@ -1550,6 +1552,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSKeyframeEffect.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSKeyframeEffect.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSKeyframeEffectOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSKeyframeEffectOptions.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLatencyMode.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLatencyMode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLinkStyle.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLinkStyle.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLocation.cpp
@@ -2782,6 +2786,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsCodecState.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsCodecState.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsEncodedVideoChunk.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsEncodedVideoChunk.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsEncodedVideoChunkMetadata.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsEncodedVideoChunkMetadata.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsEncodedVideoChunkOutputCallback.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsEncodedVideoChunkOutputCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsEncodedVideoChunkType.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsEncodedVideoChunkType.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsErrorCallback.cpp
@@ -2792,6 +2800,14 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoDecoderConfig.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoDecoderConfig.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoDecoderSupport.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoDecoderSupport.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoEncoder.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoEncoder.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoEncoderConfig.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoEncoderConfig.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoEncoderEncodeOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoEncoderEncodeOptions.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoEncoderSupport.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoEncoderSupport.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoFrame.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoFrame.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebCodecsVideoFrameOutputCallback.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -671,6 +671,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/webauthn/PublicKeyCredentialType.idl \
     $(WebCore)/Modules/webauthn/ResidentKeyRequirement.idl \
     $(WebCore)/Modules/webauthn/UserVerificationRequirement.idl \
+    $(WebCore)/Modules/webcodecs/BitrateMode.idl \
+    $(WebCore)/Modules/webcodecs/LatencyMode.idl \
     $(WebCore)/Modules/webcodecs/HardwareAcceleration.idl \
     $(WebCore)/Modules/webcodecs/PlaneLayout.idl \
     $(WebCore)/Modules/webcodecs/VideoColorPrimaries.idl \
@@ -679,15 +681,21 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/webcodecs/VideoMatrixCoefficients.idl \
     $(WebCore)/Modules/webcodecs/VideoPixelFormat.idl \
     $(WebCore)/Modules/webcodecs/VideoTransferCharacteristics.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsEncodedVideoChunkMetadata.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsEncodedVideoChunkType.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsErrorCallback.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsCodecState.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsVideoDecoder.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsVideoDecoderConfig.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsVideoDecoderSupport.idl \
-    $(WebCore)/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.idl \
-    $(WebCore)/Modules/webcodecs/WebCodecsEncodedVideoChunkType.idl \
-    $(WebCore)/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsVideoEncoder.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsVideoEncoderConfig.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsVideoEncoderEncodeOptions.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsVideoEncoderSupport.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsVideoFrame.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.idl \
     $(WebCore)/Modules/webdatabase/DOMWindow+WebDatabase.idl \
     $(WebCore)/Modules/webdatabase/Database.idl \
     $(WebCore)/Modules/webdatabase/DatabaseCallback.idl \

--- a/Source/WebCore/Modules/webcodecs/BitrateMode.h
+++ b/Source/WebCore/Modules/webcodecs/BitrateMode.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+namespace WebCore {
+
+enum class BitrateMode {
+    Constant,
+    Variable
+};
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/BitrateMode.idl
+++ b/Source/WebCore/Modules/webcodecs/BitrateMode.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEB_CODECS
+] enum BitrateMode {
+    "constant",
+    "variable"
+};

--- a/Source/WebCore/Modules/webcodecs/LatencyMode.h
+++ b/Source/WebCore/Modules/webcodecs/LatencyMode.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+namespace WebCore {
+
+enum class LatencyMode {
+    Quality,
+    Realtime
+};
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/LatencyMode.idl
+++ b/Source/WebCore/Modules/webcodecs/LatencyMode.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEB_CODECS
+] enum LatencyMode {
+    "quality",
+    "realtime"
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkMetadata.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkMetadata.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "WebCodecsVideoDecoderConfig.h"
+
+namespace WebCore {
+
+struct WebCodecsEncodedVideoChunkMetadata {
+    std::optional<WebCodecsVideoDecoderConfig> decoderConfig;
+};
+
+}
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkMetadata.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkMetadata.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEB_CODECS,
+    JSGenerateToJSObject,
+] dictionary WebCodecsEncodedVideoChunkMetadata {
+      WebCodecsVideoDecoderConfig decoderConfig;
+      // FIXME: Add svc and alphaSideData
+};
+

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "ActiveDOMCallback.h"
+#include "CallbackResult.h"
+#include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class WebCodecsEncodedVideoChunk;
+struct WebCodecsEncodedVideoChunkMetadata;
+
+class WebCodecsEncodedVideoChunkOutputCallback : public RefCounted<WebCodecsEncodedVideoChunkOutputCallback>, public ActiveDOMCallback {
+public:
+    using ActiveDOMCallback::ActiveDOMCallback;
+
+    virtual CallbackResult<void> handleEvent(WebCodecsEncodedVideoChunk&, const WebCodecsEncodedVideoChunkMetadata&) = 0;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.idl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEB_CODECS,
+] callback WebCodecsEncodedVideoChunkOutputCallback = undefined (WebCodecsEncodedVideoChunk chunk, optional WebCodecsEncodedVideoChunkMetadata metadata = {});

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -34,6 +34,7 @@
 #include "JSWebCodecsVideoDecoderSupport.h"
 #include "ScriptExecutionContext.h"
 #include "WebCodecsErrorCallback.h"
+#include "WebCodecsVideoFrame.h"
 #include "WebCodecsVideoFrameOutputCallback.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCodecsVideoEncoder.h"
+
+#if ENABLE(WEB_CODECS)
+
+#include "DOMException.h"
+#include "WebCodecsEncodedVideoChunkOutputCallback.h"
+#include "WebCodecsErrorCallback.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(WebCodecsVideoEncoder);
+
+Ref<WebCodecsVideoEncoder> WebCodecsVideoEncoder::create(ScriptExecutionContext& context, Init&& init)
+{
+    auto decoder = adoptRef(*new WebCodecsVideoEncoder(context, WTFMove(init)));
+    decoder->suspendIfNeeded();
+    return decoder;
+}
+
+
+WebCodecsVideoEncoder::WebCodecsVideoEncoder(ScriptExecutionContext& context, Init&& init)
+    : ActiveDOMObject(&context)
+    , m_output(init.output.releaseNonNull())
+    , m_error(init.error.releaseNonNull())
+{
+}
+
+WebCodecsVideoEncoder::~WebCodecsVideoEncoder()
+{
+}
+
+void WebCodecsVideoEncoder::isConfigSupported(WebCodecsVideoEncoderConfig&&, Ref<DeferredPromise>&& promise)
+{
+    // FIXME: Implement.
+    promise->reject(Exception { NotSupportedError, "Not implemented"_s });
+}
+
+void WebCodecsVideoEncoder::close()
+{
+    // FIXME: Implement.
+}
+
+void WebCodecsVideoEncoder::flush(Ref<DeferredPromise>&& promise)
+{
+    // FIXME: Implement.
+    promise->reject(Exception { NotSupportedError, "Not implemented"_s });
+}
+
+void WebCodecsVideoEncoder::reset()
+{
+    // FIXME: Implement.
+}
+
+void WebCodecsVideoEncoder::encode(Ref<WebCodecsVideoFrame>&&, WebCodecsVideoEncoderEncodeOptions&&)
+{
+    // FIXME: Implement.
+    m_error->handleEvent(DOMException::create(Exception { NotSupportedError, "Not implemented"_s }).get());
+}
+
+void WebCore::WebCodecsVideoEncoder::suspend(ReasonForSuspension)
+{
+    // FIXME: Implement.
+}
+
+void WebCodecsVideoEncoder::configure(WebCodecsVideoEncoderConfig&&)
+{
+    // FIXME: Implement.
+}
+
+void WebCodecsVideoEncoder::stop()
+{
+    // FIXME: Implement.
+}
+
+const char* WebCodecsVideoEncoder::activeDOMObjectName() const
+{
+    return "VideoEncoder";
+}
+
+bool WebCodecsVideoEncoder::virtualHasPendingActivity() const
+{
+    return m_state == WebCodecsCodecState::Configured && m_encodeQueueSize;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "ActiveDOMObject.h"
+#include "EventTarget.h"
+#include "JSDOMPromiseDeferred.h"
+#include "WebCodecsCodecState.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class WebCodecsEncodedVideoChunk;
+class WebCodecsErrorCallback;
+class WebCodecsEncodedVideoChunkOutputCallback;
+class WebCodecsVideoFrame;
+struct WebCodecsVideoEncoderConfig;
+struct WebCodecsVideoEncoderEncodeOptions;
+
+class WebCodecsVideoEncoder
+    : public RefCounted<WebCodecsVideoEncoder>
+    , public ActiveDOMObject
+    , public EventTarget {
+    WTF_MAKE_ISO_ALLOCATED(WebCodecsVideoEncoder);
+public:
+    ~WebCodecsVideoEncoder();
+
+    struct Init {
+        RefPtr<WebCodecsEncodedVideoChunkOutputCallback> output;
+        RefPtr<WebCodecsErrorCallback> error;
+    };
+
+    static Ref<WebCodecsVideoEncoder> create(ScriptExecutionContext&, Init&&);
+
+    WebCodecsCodecState state() const { return m_state; }
+    size_t encodeQueueSize() const { return m_encodeQueueSize; }
+
+    void configure(WebCodecsVideoEncoderConfig&&);
+    void encode(Ref<WebCodecsVideoFrame>&&, WebCodecsVideoEncoderEncodeOptions&&);
+    void flush(Ref<DeferredPromise>&&);
+    void reset();
+    void close();
+
+    static void isConfigSupported(WebCodecsVideoEncoderConfig&&, Ref<DeferredPromise>&&);
+
+    using RefCounted::ref;
+    using RefCounted::deref;
+
+private:
+    WebCodecsVideoEncoder(ScriptExecutionContext&, Init&&);
+
+    // ActiveDOMObject API.
+    void stop() final;
+    const char* activeDOMObjectName() const final;
+    void suspend(ReasonForSuspension) final;
+    bool virtualHasPendingActivity() const final;
+
+    // EventTarget
+    void refEventTarget() final { ref(); }
+    void derefEventTarget() final { deref(); }
+    EventTargetInterface eventTargetInterface() const final { return WebCodecsVideoEncoderEventTargetInterfaceType; }
+    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+
+    WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
+    size_t m_encodeQueueSize { 0 };
+    Ref<WebCodecsEncodedVideoChunkOutputCallback> m_output;
+    Ref<WebCodecsErrorCallback> m_error;
+};
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.idl
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// FIXME: Support Serializable and Transferable.
+[
+    ActiveDOMObject,
+    Conditional=WEB_CODECS,
+    EnabledBySetting=WebCodecsEnabled,
+    Exposed=(Window,DedicatedWorker),
+    InterfaceName=VideoEncoder,
+] interface WebCodecsVideoEncoder : EventTarget {
+    [CallWith=CurrentScriptExecutionContext] constructor(WebCodecsVideoEncoderInit init);
+
+    readonly attribute WebCodecsCodecState state;
+    readonly attribute unsigned long encodeQueueSize;
+    attribute EventHandler ondequeue;
+
+    undefined configure(WebCodecsVideoEncoderConfig config);
+    undefined encode(WebCodecsVideoFrame frame, optional WebCodecsVideoEncoderEncodeOptions options = {});
+    Promise<undefined> flush();
+    undefined reset();
+    undefined close();
+
+    static Promise<WebCodecsVideoEncoderSupport> isConfigSupported(WebCodecsVideoEncoderConfig config);
+};
+
+[
+    Conditional=WEB_CODECS,
+] dictionary WebCodecsVideoEncoderInit {
+    required WebCodecsEncodedVideoChunkOutputCallback output;
+    required WebCodecsErrorCallback error;
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "BitrateMode.h"
+#include "HardwareAcceleration.h"
+#include "LatencyMode.h"
+#include <optional>
+
+namespace WebCore {
+
+struct WebCodecsVideoEncoderConfig {
+    String codec;
+    size_t width;
+    size_t height;
+    std::optional<size_t> displayWidth;
+    std::optional<size_t> displayHeight;
+    std::optional<uint64_t> bitrate;
+    std::optional<double> framerate;
+    HardwareAcceleration hardwareAcceleration { HardwareAcceleration::NoPreference };
+    String scalabilityMode;
+    BitrateMode bitrateMode { BitrateMode::Variable };
+    LatencyMode latencyMode { LatencyMode::Quality };
+};
+
+}
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.idl
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+typedef [EnforceRange] unsigned long WebCodecsVideoEncoderConfigSize;
+typedef [EnforceRange] unsigned long long WebCodecsVideoEncoderConfigBitrate;
+
+[
+    Conditional=WEB_CODECS,
+    JSGenerateToJSObject,
+] dictionary WebCodecsVideoEncoderConfig {
+    required DOMString codec;
+    required WebCodecsVideoEncoderConfigSize width;
+    required WebCodecsVideoEncoderConfigSize height;
+    WebCodecsVideoEncoderConfigSize displayWidth;
+    WebCodecsVideoEncoderConfigSize displayHeight;
+    WebCodecsVideoEncoderConfigBitrate bitrate;
+    double framerate;
+    HardwareAcceleration hardwareAcceleration = "no-preference";
+    // FIXME: Add AlphaOption alpha = "discard";
+    DOMString scalabilityMode;
+    BitrateMode bitrateMode = "variable";
+    LatencyMode latencyMode = "quality";
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderEncodeOptions.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderEncodeOptions.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+namespace WebCore {
+
+struct WebCodecsVideoEncoderEncodeOptions {
+    bool keyFrame { false };
+};
+
+}
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderEncodeOptions.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderEncodeOptions.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEB_CODECS,
+] dictionary WebCodecsVideoEncoderEncodeOptions {
+  boolean keyFrame = false;
+};
+

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderSupport.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderSupport.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "WebCodecsVideoEncoderConfig.h"
+
+namespace WebCore {
+
+struct WebCodecsVideoEncoderSupport {
+    std::optional<bool> supported;
+    std::optional<WebCodecsVideoEncoderConfig> config;
+};
+
+}
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderSupport.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderSupport.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEB_CODECS,
+    JSGenerateToJSObject,
+] dictionary WebCodecsVideoEncoderSupport {
+  boolean supported;
+  WebCodecsVideoEncoderConfig config;
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h
@@ -29,13 +29,12 @@
 
 #include "ActiveDOMCallback.h"
 #include "CallbackResult.h"
-#include "WebCodecsVideoFrame.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
 
-class AudioWorkletProcessor;
+class WebCodecsVideoFrame;
 
 class WebCodecsVideoFrameOutputCallback : public RefCounted<WebCodecsVideoFrameOutputCallback>, public ActiveDOMCallback {
 public:
@@ -46,4 +45,4 @@ public:
 
 } // namespace WebCore
 
-#endif // ENABLE(WEB_AUDIO)
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -395,6 +395,7 @@ Modules/webauthn/fido/U2fCommandConstructor.cpp
 Modules/webauthn/fido/U2fResponseConverter.cpp
 Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
 Modules/webcodecs/WebCodecsVideoDecoder.cpp
+Modules/webcodecs/WebCodecsVideoEncoder.cpp
 Modules/webcodecs/WebCodecsVideoFrame.cpp
 Modules/webdatabase/ChangeVersionWrapper.cpp
 Modules/webdatabase/DOMWindowWebDatabase.cpp
@@ -3022,6 +3023,7 @@ JSBeforeUnloadEvent.cpp
 JSBiquadFilterNode.cpp
 JSBiquadFilterOptions.cpp
 JSBiquadFilterType.cpp
+JSBitrateMode.cpp
 JSBlob.cpp
 JSBlobCallback.cpp
 JSBlobEvent.cpp
@@ -3540,6 +3542,7 @@ JSKeyboardEvent.cpp
 JSKeyframeAnimationOptions.cpp
 JSKeyframeEffect.cpp
 JSKeyframeEffectOptions.cpp
+JSLatencyMode.cpp
 JSLocation.cpp
 JSLongRange.cpp
 JSMathMLElement.cpp
@@ -4129,13 +4132,19 @@ JSWakeLockType.cpp
 JSWaveShaperNode.cpp
 JSWaveShaperOptions.cpp
 JSWebAnimation.cpp
-JSWebCodecsEncodedVideoChunkType.cpp
 JSWebCodecsEncodedVideoChunk.cpp
+JSWebCodecsEncodedVideoChunkMetadata.cpp
+JSWebCodecsEncodedVideoChunkOutputCallback.cpp
+JSWebCodecsEncodedVideoChunkType.cpp
 JSWebCodecsErrorCallback.cpp
 JSWebCodecsCodecState.cpp
 JSWebCodecsVideoDecoder.cpp
 JSWebCodecsVideoDecoderConfig.cpp
 JSWebCodecsVideoDecoderSupport.cpp
+JSWebCodecsVideoEncoder.cpp
+JSWebCodecsVideoEncoderConfig.cpp
+JSWebCodecsVideoEncoderEncodeOptions.cpp
+JSWebCodecsVideoEncoderSupport.cpp
 JSWebCodecsVideoFrameOutputCallback.cpp
 JSWebCodecsVideoFrame.cpp
 JSWebGL2RenderingContext.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -399,6 +399,7 @@ namespace WebCore {
     macro(UndoItem) \
     macro(UndoManager) \
     macro(VideoDecoder) \
+    macro(VideoEncoder) \
     macro(VideoFrame) \
     macro(VisualViewport) \
     macro(WakeLock) \

--- a/Source/WebCore/dom/EventTargetFactory.in
+++ b/Source/WebCore/dom/EventTargetFactory.in
@@ -68,6 +68,7 @@ VisualViewport
 WakeLockSentinel
 WebAnimation
 WebCodecsVideoDecoder conditional=WEB_CODECS
+WebCodecsVideoEncoder conditional=WEB_CODECS
 WebKitMediaKeySession conditional=LEGACY_ENCRYPTED_MEDIA
 WebSocket
 Worker


### PR DESCRIPTION
#### 17e6c79e178c796faa212b716388ea717d9f8b9b
<pre>
Expose WebCodecs VideoEncoder Skeleton
<a href="https://bugs.webkit.org/show_bug.cgi?id=245823">https://bugs.webkit.org/show_bug.cgi?id=245823</a>
rdar://problem/100554145

Reviewed by Eric Carlson.

Add WebIDL and skeleton classes related to WebCodecs VideoEncoder.
We reuse the same model as for decoders, with WebCodecsVideoEncoder wrapping a VideoEncoder.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.worker-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/webcodecs/BitrateMode.h: Added.
* Source/WebCore/Modules/webcodecs/BitrateMode.idl: Added.
* Source/WebCore/Modules/webcodecs/LatencyMode.h: Added.
* Source/WebCore/Modules/webcodecs/LatencyMode.idl: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkMetadata.h: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkMetadata.idl: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.idl: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp: Added.
(WebCore::WebCodecsVideoEncoder::create):
(WebCore::WebCodecsVideoEncoder::WebCodecsVideoEncoder):
(WebCore::WebCodecsVideoEncoder::~WebCodecsVideoEncoder):
(WebCore::WebCodecsVideoEncoder::isConfigSupported):
(WebCore::WebCodecsVideoEncoder::close):
(WebCore::WebCodecsVideoEncoder::flush):
(WebCore::WebCodecsVideoEncoder::reset):
(WebCore::WebCodecsVideoEncoder::encode):
(WebCore::WebCore::WebCodecsVideoEncoder::suspend):
(WebCore::WebCodecsVideoEncoder::configure):
(WebCore::WebCodecsVideoEncoder::stop):
(WebCore::WebCodecsVideoEncoder::activeDOMObjectName const):
(WebCore::WebCodecsVideoEncoder::virtualHasPendingActivity const):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h: Added.
(WebCore::WebCodecsVideoEncoder::state const):
(WebCore::WebCodecsVideoEncoder::encodeQueueSize const):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.idl: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.h: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.idl: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderEncodeOptions.h: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderEncodeOptions.idl: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderSupport.h: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderSupport.idl: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/EventTargetFactory.in:

Canonical link: <a href="https://commits.webkit.org/255160@main">https://commits.webkit.org/255160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18704b6cddac9acbb13b3777938f4e0ce242cde5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/777 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101296 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/776 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83912 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97252 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27421 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35717 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33474 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3582 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37312 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39218 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->