### PR TITLE
WebCodecsVideoFrameInit.visibleRect is not required

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt
@@ -1,9 +1,9 @@
 
 
 FAIL <video> and VideoFrame constructed VideoFrame assert_unreached: Reached unreachable code
-FAIL CSSImageValue constructed VideoFrame assert_throws_dom: CSSImageValues are currently always tainted function "_ => { new VideoFrame(bgImage, {timestamp: 0}); }" threw object "TypeError: Member VideoFrameInit.visibleRect is required and must be an instance of DOMRectInit" that is not a DOMException SecurityError: property "code" is equal to undefined, expected 18
-FAIL Image element constructed VideoFrame Member VideoFrameInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL CSSImageValue constructed VideoFrame assert_throws_dom: CSSImageValues are currently always tainted function "_ => { new VideoFrame(bgImage, {timestamp: 0}); }" did not throw
+FAIL Image element constructed VideoFrame Can't find variable: OffscreenCanvas
 FAIL SVGImageElement constructed VideoFrame Type error
-FAIL Canvas element constructed VideoFrame Member VideoFrameInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Copy of canvas element constructed VideoFrame Member VideoFrameInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL Canvas element constructed VideoFrame Type error
+FAIL Copy of canvas element constructed VideoFrame Type error
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
@@ -4,36 +4,35 @@ FAIL Test closed VideoFrame. Can't find variable: OffscreenCanvas
 FAIL Test we can construct a VideoFrame with a negative timestamp. Can't find variable: OffscreenCanvas
 FAIL Test that timestamp is required when constructing VideoFrame from ImageBitmap promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
 FAIL Test that timestamp is required when constructing VideoFrame from OffscreenCanvas promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
-FAIL Test that timestamp is NOT required when constructing VideoFrame from another VideoFrame promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
+FAIL Test that timestamp is NOT required when constructing VideoFrame from another VideoFrame promise_test: Unhandled rejection with value: object "TypeError: Type error"
 FAIL Test we can construct an odd-sized VideoFrame. Can't find variable: OffscreenCanvas
 FAIL Test constructing w/ unusable image argument throws: HAVE_NOTHING <video>. assert_throws_dom: function "() => {
     let frame = new VideoFrame(video, {timestamp: 10});
-  }" threw object "TypeError: Member VideoFrameInit.visibleRect is required and must be an instance of DOMRectInit" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
+  }" did not throw
 FAIL Test constructing w/ unusable image argument throws: emtpy Canvas. Can't find variable: OffscreenCanvas
 FAIL Test constructing w/ unusable image argument throws: closed ImageBitmap. Can't find variable: OffscreenCanvas
 FAIL Test constructing w/ unusable image argument throws: closed VideoFrame. Can't find variable: OffscreenCanvas
-FAIL Test invalid CanvasImageSource constructed VideoFrames Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test visibleRect metadata override where source display size = visible size Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test visibleRect metadata override where source display width = 2 * visible width (anamorphic) Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test visibleRect metadata override where source display size = 2 * visible size for both width and height Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL Test invalid CanvasImageSource constructed VideoFrames Can't find variable: OffscreenCanvas
+FAIL Test visibleRect metadata override where source display size = visible size Type error
+FAIL Test visibleRect metadata override where source display width = 2 * visible width (anamorphic) Type error
+FAIL Test visibleRect metadata override where source display size = 2 * visible size for both width and height Type error
 FAIL Test visibleRect + display size metadata override Can't find variable: OffscreenCanvas
 FAIL Test display size metadata override Can't find variable: OffscreenCanvas
-FAIL Test invalid buffer constructed VideoFrames assert_throws_js: invalid visible left/right function "() => constructFrame({
+FAIL Test invalid buffer constructed VideoFrames assert_throws_js: invalid coded size function "() => constructFrame({
                    timestamp: 1234,
-                   codedWidth: 4,
-                   codedHeight: 2,
-                   visibleRect: {x: 100, y: 100, width: 1, height: 1}
+                   codedWidth: Math.pow(2, 32) - 1,
+                   codedHeight: Math.pow(2, 32) - 1,
                  })" did not throw
-FAIL Test Uint8Array(ArrayBuffer) constructed I420 VideoFrame Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test ArrayBuffer constructed I420 VideoFrame Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test planar constructed I420 VideoFrame with colorSpace Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test buffer constructed I420+Alpha VideoFrame Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test buffer constructed NV12 VideoFrame Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test buffer constructed RGB VideoFrames Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL Test Uint8Array(ArrayBuffer) constructed I420 VideoFrame assert_equals: plane format expected (string) "I420" but got (object) null
+FAIL Test ArrayBuffer constructed I420 VideoFrame assert_equals: plane format expected (string) "I420" but got (object) null
+FAIL Test planar constructed I420 VideoFrame with colorSpace null is not an object (evaluating 'frame.colorSpace.primaries')
+FAIL Test buffer constructed I420+Alpha VideoFrame assert_equals: plane format expected (string) "I420A" but got (object) null
+FAIL Test buffer constructed NV12 VideoFrame assert_equals: plane format expected (string) "NV12" but got (object) null
+FAIL Test buffer constructed RGB VideoFrames assert_equals: plane format expected (string) "RGBA" but got (object) null
 FAIL Test VideoFrame constructed VideoFrame Can't find variable: OffscreenCanvas
 FAIL Test we can construct a VideoFrame from an offscreen canvas. Can't find variable: OffscreenCanvas
 FAIL Test I420 VideoFrame with odd visible size assert_equals: format expected (string) "I420" but got (object) null
-FAIL Test I420A VideoFrame and alpha={keep,discard} Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test RGBA, BGRA VideoFrames with alpha={keep,discard} Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL Test I420A VideoFrame and alpha={keep,discard} assert_equals: plane format expected (string) "I420A" but got (object) null
+FAIL Test RGBA, BGRA VideoFrames with alpha={keep,discard} assert_equals: plane format expected (string) "RGBA" but got (object) null
 FAIL Test a VideoFrame constructed from canvas can drop the alpha channel. Can't find variable: OffscreenCanvas
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.worker-expected.txt
@@ -4,34 +4,33 @@ FAIL Test closed VideoFrame. Can't find variable: OffscreenCanvas
 FAIL Test we can construct a VideoFrame with a negative timestamp. Can't find variable: OffscreenCanvas
 FAIL Test that timestamp is required when constructing VideoFrame from ImageBitmap promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
 FAIL Test that timestamp is required when constructing VideoFrame from OffscreenCanvas promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
-FAIL Test that timestamp is NOT required when constructing VideoFrame from another VideoFrame promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
+FAIL Test that timestamp is NOT required when constructing VideoFrame from another VideoFrame promise_test: Unhandled rejection with value: object "TypeError: Type error"
 FAIL Test we can construct an odd-sized VideoFrame. Can't find variable: OffscreenCanvas
 PASS Test constructing w/ unusable image argument throws: HAVE_NOTHING <video>.
 FAIL Test constructing w/ unusable image argument throws: emtpy Canvas. Can't find variable: OffscreenCanvas
 FAIL Test constructing w/ unusable image argument throws: closed ImageBitmap. Can't find variable: OffscreenCanvas
 FAIL Test constructing w/ unusable image argument throws: closed VideoFrame. Can't find variable: OffscreenCanvas
-FAIL Test invalid CanvasImageSource constructed VideoFrames Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test visibleRect metadata override where source display size = visible size Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test visibleRect metadata override where source display width = 2 * visible width (anamorphic) Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test visibleRect metadata override where source display size = 2 * visible size for both width and height Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL Test invalid CanvasImageSource constructed VideoFrames Can't find variable: OffscreenCanvas
+FAIL Test visibleRect metadata override where source display size = visible size Type error
+FAIL Test visibleRect metadata override where source display width = 2 * visible width (anamorphic) Type error
+FAIL Test visibleRect metadata override where source display size = 2 * visible size for both width and height Type error
 FAIL Test visibleRect + display size metadata override Can't find variable: OffscreenCanvas
 FAIL Test display size metadata override Can't find variable: OffscreenCanvas
-FAIL Test invalid buffer constructed VideoFrames assert_throws_js: invalid visible left/right function "() => constructFrame({
+FAIL Test invalid buffer constructed VideoFrames assert_throws_js: invalid coded size function "() => constructFrame({
                    timestamp: 1234,
-                   codedWidth: 4,
-                   codedHeight: 2,
-                   visibleRect: {x: 100, y: 100, width: 1, height: 1}
+                   codedWidth: Math.pow(2, 32) - 1,
+                   codedHeight: Math.pow(2, 32) - 1,
                  })" did not throw
-FAIL Test Uint8Array(ArrayBuffer) constructed I420 VideoFrame Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test ArrayBuffer constructed I420 VideoFrame Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test planar constructed I420 VideoFrame with colorSpace Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test buffer constructed I420+Alpha VideoFrame Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test buffer constructed NV12 VideoFrame Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test buffer constructed RGB VideoFrames Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL Test Uint8Array(ArrayBuffer) constructed I420 VideoFrame assert_equals: plane format expected (string) "I420" but got (object) null
+FAIL Test ArrayBuffer constructed I420 VideoFrame assert_equals: plane format expected (string) "I420" but got (object) null
+FAIL Test planar constructed I420 VideoFrame with colorSpace null is not an object (evaluating 'frame.colorSpace.primaries')
+FAIL Test buffer constructed I420+Alpha VideoFrame assert_equals: plane format expected (string) "I420A" but got (object) null
+FAIL Test buffer constructed NV12 VideoFrame assert_equals: plane format expected (string) "NV12" but got (object) null
+FAIL Test buffer constructed RGB VideoFrames assert_equals: plane format expected (string) "RGBA" but got (object) null
 FAIL Test VideoFrame constructed VideoFrame Can't find variable: OffscreenCanvas
 FAIL Test we can construct a VideoFrame from an offscreen canvas. Can't find variable: OffscreenCanvas
 FAIL Test I420 VideoFrame with odd visible size assert_equals: format expected (string) "I420" but got (object) null
-FAIL Test I420A VideoFrame and alpha={keep,discard} Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test RGBA, BGRA VideoFrames with alpha={keep,discard} Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL Test I420A VideoFrame and alpha={keep,discard} assert_equals: plane format expected (string) "I420A" but got (object) null
+FAIL Test RGBA, BGRA VideoFrames with alpha={keep,discard} assert_equals: plane format expected (string) "RGBA" but got (object) null
 FAIL Test a VideoFrame constructed from canvas can drop the alpha channel. Can't find variable: OffscreenCanvas
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginIsolated.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginIsolated.https.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test SharedArrayBuffer constructed I420 VideoFrame Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test Uint8Array(SharedArrayBuffer) constructed I420 VideoFrame Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL Test SharedArrayBuffer constructed I420 VideoFrame assert_equals: plane format expected (string) "I420" but got (object) null
+FAIL Test Uint8Array(SharedArrayBuffer) constructed I420 VideoFrame assert_equals: plane format expected (string) "I420" but got (object) null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginIsolated.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginIsolated.https.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test SharedArrayBuffer constructed I420 VideoFrame Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL Test Uint8Array(SharedArrayBuffer) constructed I420 VideoFrame Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL Test SharedArrayBuffer constructed I420 VideoFrame assert_equals: plane format expected (string) "I420" but got (object) null
+FAIL Test Uint8Array(SharedArrayBuffer) constructed I420 VideoFrame assert_equals: plane format expected (string) "I420" but got (object) null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.window-expected.txt
@@ -1,7 +1,7 @@
 
 Harness Error (TIMEOUT), message = null
 
-FAIL Test that timestamp is required when constructing VideoFrame from HTMLImageElement promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameInit.visibleRect is required and must be an instance of DOMRectInit"
+FAIL Test that timestamp is required when constructing VideoFrame from HTMLImageElement assert_throws_js: timestamp required to construct VideoFrame from this source function "() => new VideoFrame(imageSource)" did not throw
 TIMEOUT Test that timestamp is required when constructing VideoFrame from SVGImageElement Test timed out
 NOTRUN Test that timeamp is required when constructing VideoFrame from HTMLCanvasElement
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any-expected.txt
@@ -1,17 +1,17 @@
 
-FAIL Test closed frame. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test copying I420 frame to a non-shared ArrayBuffer promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test copying I420 frame to a non-shared ArrayBufferView promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test RGBA frame. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test undersized buffer. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test incorrect plane count. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test stride and offset work. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test stride and offset with padding. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test invalid stride. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test address overflow. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test codedRect. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test empty rect. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test unaligned rect. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test left crop. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test invalid rect. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
+FAIL Test closed frame. assert_throws_dom: allocationSize() function "() => frame.allocationSize()" threw object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
+FAIL Test copying I420 frame to a non-shared ArrayBuffer promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
+FAIL Test copying I420 frame to a non-shared ArrayBufferView promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
+FAIL Test RGBA frame. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
+PASS Test undersized buffer.
+PASS Test incorrect plane count.
+FAIL Test stride and offset work. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
+FAIL Test stride and offset with padding. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
+PASS Test invalid stride.
+PASS Test address overflow.
+FAIL Test codedRect. assert_equals: allocationSize() expected 12 but got 0
+FAIL Test empty rect. assert_throws_js: function "() => frame.allocationSize(options)" did not throw
+FAIL Test unaligned rect. assert_throws_js: function "() => frame.allocationSize(options)" did not throw
+FAIL Test left crop. assert_equals: allocationSize() expected 6 but got 0
+FAIL Test invalid rect. assert_throws_js: function "() => frame.allocationSize(options)" did not throw
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.worker-expected.txt
@@ -1,17 +1,17 @@
 
-FAIL Test closed frame. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test copying I420 frame to a non-shared ArrayBuffer promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test copying I420 frame to a non-shared ArrayBufferView promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test RGBA frame. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test undersized buffer. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test incorrect plane count. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test stride and offset work. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test stride and offset with padding. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test invalid stride. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test address overflow. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test codedRect. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test empty rect. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test unaligned rect. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test left crop. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test invalid rect. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
+FAIL Test closed frame. assert_throws_dom: allocationSize() function "() => frame.allocationSize()" threw object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
+FAIL Test copying I420 frame to a non-shared ArrayBuffer promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
+FAIL Test copying I420 frame to a non-shared ArrayBufferView promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
+FAIL Test RGBA frame. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
+PASS Test undersized buffer.
+PASS Test incorrect plane count.
+FAIL Test stride and offset work. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
+FAIL Test stride and offset with padding. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
+PASS Test invalid stride.
+PASS Test address overflow.
+FAIL Test codedRect. assert_equals: allocationSize() expected 12 but got 0
+FAIL Test empty rect. assert_throws_js: function "() => frame.allocationSize(options)" did not throw
+FAIL Test unaligned rect. assert_throws_js: function "() => frame.allocationSize(options)" did not throw
+FAIL Test left crop. assert_equals: allocationSize() expected 6 but got 0
+FAIL Test invalid rect. assert_throws_js: function "() => frame.allocationSize(options)" did not throw
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.crossOriginIsolated.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.crossOriginIsolated.https.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test copying I420 frame to SharedArrayBuffer. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test copying I420 frame to shared ArrayBufferView. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
+FAIL Test copying I420 frame to SharedArrayBuffer. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
+FAIL Test copying I420 frame to shared ArrayBufferView. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.crossOriginIsolated.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.crossOriginIsolated.https.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test copying I420 frame to SharedArrayBuffer. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
-FAIL Test copying I420 frame to shared ArrayBufferView. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
+FAIL Test copying I420 frame to SharedArrayBuffer. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
+FAIL Test copying I420 frame to shared ArrayBufferView. promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameCopyToOptions.rect is required and must be an instance of DOMRectInit"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any-expected.txt
@@ -5,5 +5,5 @@ FAIL ImageBitmap<->VideoFrame with canvas(48x36 display-p3 uint8). Can't find va
 FAIL ImageBitmap<->VideoFrame with canvas(480x360 display-p3 uint8). Can't find variable: OffscreenCanvas
 FAIL ImageBitmap<->VideoFrame with canvas(48x36 rec2020 uint8). Can't find variable: OffscreenCanvas
 FAIL ImageBitmap<->VideoFrame with canvas(480x360 rec2020 uint8). Can't find variable: OffscreenCanvas
-FAIL createImageBitmap uses frame display size promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
+FAIL createImageBitmap uses frame display size promise_test: Unhandled rejection with value: object "TypeError: Type error"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker-expected.txt
@@ -5,5 +5,5 @@ FAIL ImageBitmap<->VideoFrame with canvas(48x36 display-p3 uint8). Can't find va
 FAIL ImageBitmap<->VideoFrame with canvas(480x360 display-p3 uint8). Can't find variable: OffscreenCanvas
 FAIL ImageBitmap<->VideoFrame with canvas(48x36 rec2020 uint8). Can't find variable: OffscreenCanvas
 FAIL ImageBitmap<->VideoFrame with canvas(480x360 rec2020 uint8). Can't find variable: OffscreenCanvas
-FAIL createImageBitmap uses frame display size promise_test: Unhandled rejection with value: object "TypeError: Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit"
+FAIL createImageBitmap uses frame display size promise_test: Unhandled rejection with value: object "TypeError: Type error"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-drawImage.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-drawImage.any-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL drawImage(VideoFrame) with canvas(48x36 srgb uint8). Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL drawImage(VideoFrame) with canvas(480x360 srgb uint8). Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL drawImage(VideoFrame) with canvas(48x36 display-p3 uint8). Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL drawImage(VideoFrame) with canvas(480x360 display-p3 uint8). Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL drawImage(VideoFrame) with canvas(48x36 rec2020 uint8). Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL drawImage on a closed VideoFrame throws InvalidStateError. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL drawImage(VideoFrame) with canvas(48x36 srgb uint8). Can't find variable: OffscreenCanvas
+FAIL drawImage(VideoFrame) with canvas(480x360 srgb uint8). Can't find variable: OffscreenCanvas
+FAIL drawImage(VideoFrame) with canvas(48x36 display-p3 uint8). Can't find variable: OffscreenCanvas
+FAIL drawImage(VideoFrame) with canvas(480x360 display-p3 uint8). Can't find variable: OffscreenCanvas
+FAIL drawImage(VideoFrame) with canvas(48x36 rec2020 uint8). Can't find variable: OffscreenCanvas
+FAIL drawImage on a closed VideoFrame throws InvalidStateError. Can't find variable: OffscreenCanvas
 FAIL drawImage of nested frame works properly Can't find variable: OffscreenCanvas
-FAIL drawImage with display size != visible size Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL drawImage with display size != visible size Can't find variable: OffscreenCanvas
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-drawImage.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-drawImage.any.worker-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL drawImage(VideoFrame) with canvas(48x36 srgb uint8). Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL drawImage(VideoFrame) with canvas(480x360 srgb uint8). Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL drawImage(VideoFrame) with canvas(48x36 display-p3 uint8). Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL drawImage(VideoFrame) with canvas(480x360 display-p3 uint8). Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL drawImage(VideoFrame) with canvas(48x36 rec2020 uint8). Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL drawImage on a closed VideoFrame throws InvalidStateError. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL drawImage(VideoFrame) with canvas(48x36 srgb uint8). Can't find variable: OffscreenCanvas
+FAIL drawImage(VideoFrame) with canvas(480x360 srgb uint8). Can't find variable: OffscreenCanvas
+FAIL drawImage(VideoFrame) with canvas(48x36 display-p3 uint8). Can't find variable: OffscreenCanvas
+FAIL drawImage(VideoFrame) with canvas(480x360 display-p3 uint8). Can't find variable: OffscreenCanvas
+FAIL drawImage(VideoFrame) with canvas(48x36 rec2020 uint8). Can't find variable: OffscreenCanvas
+FAIL drawImage on a closed VideoFrame throws InvalidStateError. Can't find variable: OffscreenCanvas
 FAIL drawImage of nested frame works properly Can't find variable: OffscreenCanvas
-FAIL drawImage with display size != visible size Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL drawImage with display size != visible size Can't find variable: OffscreenCanvas
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL texImage2D with 48x36 srgb VideoFrame. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL texSubImage2D with 48x36 srgb VideoFrame. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL texImage2D with 480x360 srgb VideoFrame. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL texSubImage2D with 480x360 srgb VideoFrame. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL texImage2D with a closed VideoFrame. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL texSubImage2D with a closed VideoFrame. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL texImage2D with 48x36 srgb VideoFrame. Can't find variable: OffscreenCanvas
+FAIL texSubImage2D with 48x36 srgb VideoFrame. Can't find variable: OffscreenCanvas
+FAIL texImage2D with 480x360 srgb VideoFrame. Can't find variable: OffscreenCanvas
+FAIL texSubImage2D with 480x360 srgb VideoFrame. Can't find variable: OffscreenCanvas
+FAIL texImage2D with a closed VideoFrame. Can't find variable: OffscreenCanvas
+FAIL texSubImage2D with a closed VideoFrame. Can't find variable: OffscreenCanvas
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL texImage2D with 48x36 srgb VideoFrame. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL texSubImage2D with 48x36 srgb VideoFrame. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL texImage2D with 480x360 srgb VideoFrame. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL texSubImage2D with 480x360 srgb VideoFrame. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL texImage2D with a closed VideoFrame. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
-FAIL texSubImage2D with a closed VideoFrame. Member VideoFrameBufferInit.visibleRect is required and must be an instance of DOMRectInit
+FAIL texImage2D with 48x36 srgb VideoFrame. Can't find variable: OffscreenCanvas
+FAIL texSubImage2D with 48x36 srgb VideoFrame. Can't find variable: OffscreenCanvas
+FAIL texImage2D with 480x360 srgb VideoFrame. Can't find variable: OffscreenCanvas
+FAIL texSubImage2D with 480x360 srgb VideoFrame. Can't find variable: OffscreenCanvas
+FAIL texImage2D with a closed VideoFrame. Can't find variable: OffscreenCanvas
+FAIL texSubImage2D with a closed VideoFrame. Can't find variable: OffscreenCanvas
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
@@ -69,7 +69,7 @@ dictionary VideoFrameInit {
     unsigned long long duration;
     long long timestamp;
 
-    required DOMRectInit visibleRect;
+    DOMRectInit visibleRect;
 
     [EnforceRange] unsigned long displayWidth;
     [EnforceRange] unsigned long displayHeight;
@@ -85,7 +85,7 @@ dictionary VideoFrameBufferInit {
 
     sequence<PlaneLayout> layout;
 
-    required DOMRectInit visibleRect;
+    DOMRectInit visibleRect;
 
     [EnforceRange] unsigned long displayWidth;
     [EnforceRange] unsigned long displayHeight;


### PR DESCRIPTION
#### 9608a52178b03409eb88846e4c4563deb4cd62d5
<pre>
WebCodecsVideoFrameInit.visibleRect is not required
<a href="https://bugs.webkit.org/show_bug.cgi?id=245825">https://bugs.webkit.org/show_bug.cgi?id=245825</a>
rdar://problem/100556962

Reviewed by Eric Carlson.

Update WebIDL according spec and rebase tests.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginIsolated.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginIsolated.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.crossOriginIsolated.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.crossOriginIsolated.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-drawImage.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-drawImage.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl:

Canonical link: <a href="https://commits.webkit.org/255115@main">https://commits.webkit.org/255115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9178f341a5101af1bb7bf3d104c004307ad53c9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/70 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100538 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/159649 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/77 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29131 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83435 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97203 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/61 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77844 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27033 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81662 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70067 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/attributes (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35228 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15687 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33025 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16686 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3555 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36807 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39637 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35770 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->