### PR TITLE
WTFReportBacktrace fails to print backtrace and crashes on ASAN

### DIFF
--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -62,7 +62,7 @@ String Value::generateCompilerConstructionSite()
     int frames = framesToShow + framesToSkip;
 
     WTFGetBacktrace(samples, &frames);
-    StackTrace stackTrace(samples + framesToSkip, frames - framesToSkip, "");
+    StackTraceSymbolResolver stackTrace({ samples + framesToSkip, static_cast<size_t>(frames - framesToSkip) });
 
     s.print("[");
     bool firstPrinted = false;

--- a/Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp
@@ -301,9 +301,7 @@ void VerifierSlotVisitor::dumpMarkerData(HeapCell* cell)
             opaqueRoot = nullptr;
         }
 
-        markerData->stack()->dump(WTF::dataFile(), "    ");
-        dataLogLn();
-
+        dataLogLn(StackTracePrinter { *markerData->stack(), "    " });
     } while (cell || opaqueRoot);
 }
 

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -163,7 +163,7 @@ void JSGlobalObjectInspectorController::appendAPIBacktrace(ScriptCallStack& call
     void** stack = samples + framesToSkip;
     int size = frames - framesToSkip;
     for (int i = 0; i < size; ++i) {
-        auto demangled = StackTrace::demangle(stack[i]);
+        auto demangled = StackTraceSymbolResolver::demangle(stack[i]);
         if (demangled)
             callStack.append(ScriptCallFrame(String::fromLatin1(demangled->demangledName() ? demangled->demangledName() : demangled->mangledName()), "[native code]"_s, noSourceID, 0, 0));
         else

--- a/Source/JavaScriptCore/runtime/ExceptionScope.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionScope.cpp
@@ -55,13 +55,13 @@ CString ExceptionScope::unexpectedExceptionMessage()
 
     out.println("Unexpected exception observed on thread ", Thread::current(), " at:");
     auto currentStack = StackTrace::captureStackTrace(Options::unexpectedExceptionStackTraceLimit(), 1);
-    currentStack->dump(out, "    ");
+    out.print(StackTracePrinter { *currentStack, "    " });
 
     if (!m_vm.nativeStackTraceOfLastThrow())
         return CString();
     
     out.println("The exception was thrown from thread ", *m_vm.throwingThread(), " at:");
-    m_vm.nativeStackTraceOfLastThrow()->dump(out, "    ");
+    out.print(StackTracePrinter { *m_vm.nativeStackTraceOfLastThrow(), "    " });
 
     return out.toCString();
 }

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -809,7 +809,7 @@ String SamplingProfiler::StackFrame::displayName(VM& vm)
     case FrameType::C:
 #if HAVE(DLADDR)
         if (frameType == FrameType::C) {
-            auto demangled = WTF::StackTrace::demangle(const_cast<void*>(cCodePC));
+            auto demangled = StackTraceSymbolResolver::demangle(const_cast<void*>(cCodePC));
             if (demangled)
                 return String::fromLatin1(demangled->demangledName() ? demangled->demangledName() : demangled->mangledName());
             WTF::dataLog("couldn't get a name");

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1336,12 +1336,10 @@ void VM::verifyExceptionCheckNeedIsSatisfied(unsigned recursionDepth, ExceptionE
 
         if (Options::dumpSimulatedThrows()) {
             out.println("The simulated exception was thrown at:");
-            m_nativeStackTraceOfLastSimulatedThrow->dump(out, "    ");
-            out.println();
+            out.println(StackTracePrinter { *m_nativeStackTraceOfLastSimulatedThrow, "    " });
         }
         out.println("Unchecked exception detected at:");
-        currentTrace->dump(out, "    ");
-        out.println();
+        out.println(StackTracePrinter { *currentTrace, "    " });
 
         dataLog(out.toCString());
         RELEASE_ASSERT(!m_needExceptionCheck);

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -228,7 +228,7 @@ WTF_EXPORT_PRIVATE void WTFLogWithLevel(WTFLogChannel*, WTFLogLevel, const char*
 WTF_EXPORT_PRIVATE void WTFSetLogChannelLevel(WTFLogChannel*, WTFLogLevel);
 WTF_EXPORT_PRIVATE bool WTFWillLogWithLevel(WTFLogChannel*, WTFLogLevel);
 
-WTF_EXPORT_PRIVATE void WTFGetBacktrace(void** stack, int* size);
+WTF_EXPORT_PRIVATE NEVER_INLINE void WTFGetBacktrace(void** stack, int* size);
 WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefix(const char*);
 WTF_EXPORT_PRIVATE void WTFReportBacktrace(void);
 #ifdef __cplusplus

--- a/Source/WTF/wtf/StackCheck.cpp
+++ b/Source/WTF/wtf/StackCheck.cpp
@@ -48,11 +48,9 @@ NO_RETURN_DUE_TO_CRASH void StackCheck::Scope::reportVerificationFailureAndCrash
     dataLogLn();
     if constexpr (verboseStackCheckVerification) {
         dataLogLn("    Stack at previous checkpoint:");
-        m_savedLastCheckpointStackTrace->dump(WTF::dataFile(), "      ");
-        dataLogLn();
+        dataLogLn(StackTracePrinter { m_savedLastCheckpointStackTrace->stack(), "      " });
         dataLogLn("    Stack at current checkpoint:");
-        m_checker.m_lastCheckpointStackTrace->dump(WTF::dataFile(), "      ");
-        dataLogLn();
+        dataLogLn(StackTracePrinter { m_checker.m_lastCheckpointStackTrace->stack(), "      " });
     } else {
         dataLogLn("    To see the stack traces at the 2 checkpoints, set verboseStackCheckVerification to true in StackCheck.h, rebuild, and re-run your test.");
         dataLogLn();

--- a/Source/WTF/wtf/StackShotProfiler.h
+++ b/Source/WTF/wtf/StackShotProfiler.h
@@ -68,8 +68,7 @@ private:
                 for (size_t i = list.size(), count = 0; i-- && count < m_stacksToReport; count++) {
                     auto& entry = list[i];
                     dataLog("\nTop #", count + 1, " stack: ", entry.count * 100 / m_totalCount, "%\n");
-                    StackTrace trace(entry.key->array() + m_framesToSkip, entry.key->size() - m_framesToSkip);
-                    dataLog(trace);
+                    dataLog(StackTracePrinter { { entry.key->array() + m_framesToSkip, entry.key->size() - m_framesToSkip } });
                 }
                 dataLog("\n");
             }

--- a/Source/WTF/wtf/win/DbgHelperWin.h
+++ b/Source/WTF/wtf/win/DbgHelperWin.h
@@ -34,7 +34,7 @@ namespace WTF {
 
 namespace DbgHelper {
 
-bool SymFromAddress(HANDLE hProc, DWORD64 address, DWORD64* displacement, SYMBOL_INFO*);
+WTF_EXPORT_PRIVATE bool SymFromAddress(HANDLE hProc, DWORD64 address, DWORD64* displacement, SYMBOL_INFO*);
 
 };
 

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -93,6 +93,7 @@ set(TestWTF_SOURCES
     Tests/WTF/SentinelLinkedList.cpp
     Tests/WTF/SetForScope.cpp
     Tests/WTF/Span.cpp
+    Tests/WTF/StackTraceTest.cpp
     Tests/WTF/StdLibExtras.cpp
     Tests/WTF/StringBuilder.cpp
     Tests/WTF/StringCommon.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -574,6 +574,7 @@
 		7B9FC5D628A5326A007570E7 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F4FFAA01ED3D0DE00F7111F /* ImageIO.framework */; };
 		7BA3936C271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BA3936B271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm */; };
 		7BAA4A9028CA14AE004CE938 /* StreamConnectionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */; };
+		7BF5017828E55F7A0008BB16 /* StackTraceTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5017028E55F7A0008BB16 /* StackTraceTest.cpp */; };
 		7C3965061CDD74F90094DBB8 /* ColorTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C3965051CDD74F90094DBB8 /* ColorTests.cpp */; };
 		7C486BA11AA12567003F6F9B /* bundle-file.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7C486BA01AA1254B003F6F9B /* bundle-file.html */; };
 		7C74C8FA22DFBA9600DA2DAB /* WTFStringUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CBD5A2222DE42A6004A9E32 /* WTFStringUtilities.cpp */; };
@@ -2703,6 +2704,7 @@
 		7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamConnectionTests.cpp; sourceTree = "<group>"; };
 		7BB754AF274E39A100D00EC1 /* TestUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestUtilities.h; sourceTree = "<group>"; };
 		7BB754B0274E39A100D00EC1 /* TestUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestUtilities.cpp; sourceTree = "<group>"; };
+		7BF5017028E55F7A0008BB16 /* StackTraceTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StackTraceTest.cpp; sourceTree = "<group>"; };
 		7C1AF7931E8DCBAB002645B9 /* PrepareForMoveToWindow.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PrepareForMoveToWindow.mm; sourceTree = "<group>"; };
 		7C3965051CDD74F90094DBB8 /* ColorTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ColorTests.cpp; sourceTree = "<group>"; };
 		7C3DB8E21D12129B00AE8CC3 /* CommandBackForward.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CommandBackForward.mm; sourceTree = "<group>"; };
@@ -5032,6 +5034,7 @@
 				33C2C9C02651F5B900E407F6 /* SmallSet.cpp */,
 				93FCDB33263631560046DD7D /* SortedArrayMap.cpp */,
 				BCA30C7D266D2F43000D230C /* Span.cpp */,
+				7BF5017028E55F7A0008BB16 /* StackTraceTest.cpp */,
 				FE2BCDC62470FC7000DEC33B /* StdLibExtras.cpp */,
 				81B50192140F232300D9EB58 /* StringBuilder.cpp */,
 				E3DE273B28A8D67700873DF2 /* StringCommon.cpp */,
@@ -5990,6 +5993,7 @@
 				BCA30C7E266D2F43000D230C /* Span.cpp in Sources */,
 				44B28A0628D18AD50010172C /* SpanCF.cpp in Sources */,
 				44B28A0828D18AE70010172C /* SpanCocoa.mm in Sources */,
+				7BF5017828E55F7A0008BB16 /* StackTraceTest.cpp in Sources */,
 				FE2BCDC72470FDA300DEC33B /* StdLibExtras.cpp in Sources */,
 				7C83DF321D0A590C00FEBCF3 /* StringBuilder.cpp in Sources */,
 				E3DE273C28A8D67800873DF2 /* StringCommon.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/StackTraceTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StackTraceTest.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/StackTrace.h>
+
+#include "Utilities.h"
+#include "WTFStringUtilities.h"
+#include <wtf/StringPrintStream.h>
+#include <wtf/unicode/CharacterNames.h>
+
+#if ((PLATFORM(GTK) || PLATFORM(WPE)) && defined(NDEBUG)) || (PLATFORM(WIN) && !defined(NDEBUG))
+#define MAYBE(name) DISABLED_##name
+#else
+#define MAYBE(name) name
+#endif
+
+namespace TestWebKitAPI {
+
+TEST(StackTraceTest, MAYBE(StackTraceWorks))
+{
+    static constexpr int framesToShow = 31;
+    void* samples[framesToShow];
+    int frames = framesToShow;
+    WTFGetBacktrace(samples, &frames);
+    StackTracePrinter stackTrace { { samples, static_cast<size_t>(frames) } };
+    StringPrintStream out;
+    out.print(stackTrace);
+    auto results = out.toString().split(newlineCharacter);
+    ASSERT_GT(results.size(), 2u);
+    EXPECT_TRUE(results[0].contains("WTFGetBacktrace"_s));
+    EXPECT_TRUE(results[1].contains("StackTraceWorks"_s));
+}
+
+namespace {
+struct Frame {
+    int number;
+    void* address;
+    String name;
+};
+}
+
+static void expectEqualFrames(Span<void* const> expectedStack, StackTrace& testedStack, bool skipFirstFrameAddress)
+{
+    Vector<Frame> expected;
+    StackTraceSymbolResolver { expectedStack }.forEach([&expected](int number, void* address, const char* name) {
+        expected.append({ number, address, String::fromLatin1(name) });
+    });
+    Vector<Frame> tested;
+    StackTraceSymbolResolver { testedStack }.forEach([&tested](int number, void* address, const char* name) {
+        tested.append({ number, address, String::fromLatin1(name) });
+    });
+    ASSERT_EQ(expected.size(), tested.size());
+
+    for (size_t j = 0; j < expected.size(); ++j) {
+        EXPECT_EQ(expected[j].number, tested[j].number) << " j:" << j;
+        EXPECT_EQ(expected[j].name, tested[j].name) << " j:" << j << " " << expected[j].name << " != " << tested[j].name;
+        // Address of tested capture call in vs the verification capture call is different.
+        if (skipFirstFrameAddress && !j)
+            continue;
+        EXPECT_EQ(expected[j].address, tested[j].address) << "j:" << j;
+    }
+}
+
+// Test that captureStackTrace() returns [a, b, c, ...].
+// Test that captureStackTrace(limit, skip) is able to respect the requested limit and skip.
+TEST(StackTraceTest, MAYBE(CaptureStackTraceLimitAndSkip))
+{
+    // Verify captureStackTrace() results by manually inspecting WTFGetBacktrace().
+    // WTFGetBacktrace() returns [WTFGetBacktrace, a, b, c, ...].
+    static constexpr int maxFramesToCapture = 100;
+    void* stack[maxFramesToCapture];
+    int frames = maxFramesToCapture;
+    WTFGetBacktrace(stack, &frames);
+    // Skip WTFGetBacktrace.
+    --frames;
+    void** expectedStack = stack + 1;
+
+    // Test odd case where StackTrace::captureStackTrace(0) returns 1 result.
+    {
+        Span<void* const> expected { expectedStack, 1 };
+        {
+            SCOPED_TRACE("Zero returns one result case");
+            auto tested = StackTrace::captureStackTrace(0);
+            expectEqualFrames(expected, *tested, true);
+        }
+        {
+            SCOPED_TRACE("Zero returns one result case example 1");
+            // The above is odd because using 0 is the same as using 1.
+            auto tested = StackTrace::captureStackTrace(1);
+            expectEqualFrames(expected, *tested, true);
+        }
+    }
+
+    // Test limiting the frame capture depth to `i = 1..` works.
+    // Test also 7 more than what's really available.
+    size_t testedMaxFrames = static_cast<size_t>(frames + 7);
+    for (size_t maxFrames = 1; maxFrames < testedMaxFrames; ++maxFrames) {
+        for (size_t skipFrames = 0; skipFrames < testedMaxFrames; ++skipFrames) {
+            SCOPED_TRACE(makeString("maxFrames: ", maxFrames, " skipFrames: ", skipFrames));
+            size_t expectedFrameCount = std::min(maxFrames + skipFrames, static_cast<size_t>(frames));
+            size_t expectedSkipFrames = std::min(skipFrames, expectedFrameCount);
+            Span<void* const> expected { expectedStack + expectedSkipFrames, expectedFrameCount - expectedSkipFrames };
+
+            auto tested = StackTrace::captureStackTrace(maxFrames, skipFrames);
+
+            bool shouldSkipFirstFrameAddressComparison = !skipFrames;
+            expectEqualFrames(expected, *tested, shouldSkipFirstFrameAddressComparison);
+        }
+    }
+}
+
+}
+
+#undef MAYBE


### PR DESCRIPTION
#### 5b5a2dc989fa65afa3eef1c084b690a01fa17813
<pre>
WTFReportBacktrace fails to print backtrace and crashes on ASAN
<a href="https://bugs.webkit.org/show_bug.cgi?id=245826">https://bugs.webkit.org/show_bug.cgi?id=245826</a>
rdar://problem/100557350

Reviewed by Mark Lam and Yusuke Suzuki.

WTFReportBacktrace() would use StackTrace in the &quot;borrowed&quot; mode.
The borrowed mode stack pointer would be obtained by reading
uninitialized !m_capacity. This would cause read to random memory.

Fix by removing the StackTrace borrowed mode. When printing
the backtrace, use the new class StackTracePrinter which
is able to use the void* array WTFGetStacktrace returns.

Move the size/isBorrowed members out of the union that was
intended to optimize skipping of the two initial, skipped
frames. This was relying on two counts of UB:
- reading of non-active member of the union:
  Filled the m_stack by writing into one union m_skippedFrame0
  making it active, but then reading from passive union
  member m_size.

- Writing into one member, and expecting the overflowing
  of the write being defined to match the subsequent member:
  Oversized write into union member m_skippedFrame0
  was assumend to spill over to member of other, subsequent union
  member m_stack. This is not well-defined.

The above UB invocations were done to trying to save two
void* worth of memory in the StackTrace, while avoiding
copying of the void* array.

Instead, first read the stack trace into the memory storage
of StackTrace, then overwrite the initial portion with the
real class data.

Fix bugs in the unborrowed mode, where
captureStackTrace(maxFrames, framesToSkip)
would not actually skip the framesToSkip amount of frames.
If left unfixed, we could not assert that the borrowed
mode fix did not accidentally cause regressions to the
unborrowed mode.

Move the printing related StackTrace::m_prefix to
StackTracePrinter::m_prefix. This way StackTrace size shrinks.

Test the equivalent of WTFReportBacktrace in a scenario
that caused the uninitialized read.

Test the captureStackTrace().

(WTF::StackTrace::instanceSize):
(WTF::StackTrace::captureStackTrace):
* Source/WTF/wtf/StackTrace.h:
(WTF::StackTrace::StackTrace):
(WTF::StackTrace::stack const):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/StackTraceTest.cpp: Added.
(TestWebKitAPI::TEST):
(TestWebKitAPI::expectEqualFrames):

Canonical link: <a href="https://commits.webkit.org/255164@main">https://commits.webkit.org/255164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ed7653d9919eeeb40270ec68d80c29f6fc97fa4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101186 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161200 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/575 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97549 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97118 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/389 "Found 1 new test failure: fast/forms/ios/file-upload-panel-capture.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78181 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27349 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82313 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/81973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70384 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35594 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16001 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33380 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17094 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3586 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39888 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36211 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->