### PR TITLE
Fix unused but set variable warnings

### DIFF
--- a/Source/JavaScriptCore/runtime/HashMapImplInlines.h
+++ b/Source/JavaScriptCore/runtime/HashMapImplInlines.h
@@ -492,7 +492,7 @@ ALWAYS_INLINE void HashMapImpl<HashMapBucketType>::checkConsistency() const
             ++size;
             iter = iter->next();
         }
-        ASSERT(size == m_keyCount);
+        ASSERT_UNUSED(size, size == m_keyCount);
     }
 }
 

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.h
@@ -383,7 +383,7 @@ private:
                     continue;
                 ++size;
             }
-            ASSERT(size == m_keyCount);
+            ASSERT_UNUSED(size, size == m_keyCount);
         }
     }
 

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -2302,11 +2302,9 @@ std::optional<uint32_t> URLParser::parseIPv4PieceInsideIPv6(CodePointIterator<Ch
         return std::nullopt;
     uint32_t piece = 0;
     bool leadingZeros = false;
-    size_t digitCount = 0;
     while (!iterator.atEnd()) {
         if (!isASCIIDigit(*iterator))
             return std::nullopt;
-        ++digitCount;
         if (!piece && *iterator == '0') {
             if (leadingZeros)
                 return std::nullopt;

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -433,7 +433,7 @@ void IDBDatabase::didCommitOrAbortTransaction(IDBTransaction& transaction)
     if (m_abortingTransactions.contains(transaction.info().identifier()))
         ++count;
 
-    ASSERT(count == 1);
+    ASSERT_UNUSED(count, count == 1);
 #endif
 
     m_activeTransactions.remove(transaction.info().identifier());

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8412,6 +8412,8 @@ MediaProducerMediaStateFlags HTMLMediaElement::mediaState() const
 
     if (hasActiveVideo && endedPlayback())
         state.add(MediaProducerMediaState::DidPlayToEnd);
+#else
+    UNUSED_VARIABLE(hasAudio);
 #endif
 
     if (!isPlaying())

--- a/Source/WebCore/inspector/InspectorOverlayLabel.cpp
+++ b/Source/WebCore/inspector/InspectorOverlayLabel.cpp
@@ -331,13 +331,11 @@ Path InspectorOverlayLabel::draw(GraphicsContext& context, float maximumLineWidt
     context.fillPath(labelPath);
     context.strokePath(labelPath);
 
-    int line = 0;
     float xOffset = 0;
     float yOffset = 0;
     for (auto& computedContentRun : computedContentRuns) {
         if (computedContentRun.startsNewLine) {
             xOffset = 0;
-            ++line;
             yOffset += lineHeight + labelAdditionalLineSpacing;
         }
 

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1661,7 +1661,7 @@ DashArray FontCascade::dashesForIntersectionsWithRect(const TextRun& run, const 
     FloatPoint origin = textOrigin + WebCore::size(glyphBuffer.initialAdvance());
     GlyphToPathTranslator translator(run, glyphBuffer, origin);
     DashArray result;
-    for (unsigned index = 0; translator.containsMorePaths(); ++index, translator.advance()) {
+    for (; translator.containsMorePaths(); translator.advance()) {
         GlyphIterationState info = { FloatPoint(0, 0), FloatPoint(0, 0), lineExtents.y(), lineExtents.y() + lineExtents.height(), lineExtents.x() + lineExtents.width(), lineExtents.x() };
         switch (translator.underlineType()) {
         case GlyphUnderlineType::SkipDescenders: {

--- a/Source/WebCore/xml/XPathGrammar.cpp
+++ b/Source/WebCore/xml/XPathGrammar.cpp
@@ -69,7 +69,6 @@
 #define yylval  xpathyylval
 #define yychar  xpathyychar
 #define yydebug xpathyydebug
-#define yynerrs xpathyynerrs
 
 
 /* Tokens.  */
@@ -1414,9 +1413,6 @@ int yychar;
 /* The semantic value of the look-ahead symbol.  */
 YYSTYPE yylval;
 
-/* Number of syntax errors so far.  */
-int yynerrs;
-
   int yystate;
   int yyn;
   int yyresult;
@@ -1468,7 +1464,6 @@ int yynerrs;
 
   yystate = 0;
   yyerrstatus = 0;
-  yynerrs = 0;
   yychar = YYEMPTY;		/* Cause a token to be read.  */
 
   /* Initialize stack pointers.
@@ -2082,7 +2077,6 @@ yyerrlab:
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
-      ++yynerrs;
 #if ! YYERROR_VERBOSE
       yyerror (parser, YY_("syntax error"));
 #else

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -504,8 +504,8 @@ void ResourceLoadStatisticsStore::debugLogDomainsInBatches(const char* action, c
 
     Vector<RegistrableDomain> batch;
     batch.reserveInitialCapacity(maxNumberOfDomainsInOneLogStatement);
-    auto batchNumber = 1;
 #if !RELEASE_LOG_DISABLED
+    auto batchNumber = 1;
     unsigned numberOfBatches = std::ceil(domains.size() / static_cast<float>(maxNumberOfDomainsInOneLogStatement));
 #endif
 
@@ -513,7 +513,9 @@ void ResourceLoadStatisticsStore::debugLogDomainsInBatches(const char* action, c
         if (batch.size() == maxNumberOfDomainsInOneLogStatement) {
             RELEASE_LOG_INFO(ITPDebug, "%" PUBLIC_LOG_STRING " to (%d of %u): %" PUBLIC_LOG_STRING ".", action, batchNumber, numberOfBatches, domainsToString(batch).utf8().data());
             batch.shrink(0);
+#if !RELEASE_LOG_DISABLED
             ++batchNumber;
+#endif
         }
         batch.append(domain);
     }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2170,8 +2170,10 @@ void NetworkProcess::terminateRemoteWorkerContextConnectionWhenPossible(RemoteWo
 
 void NetworkProcess::prepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime, CompletionHandler<void()>&& completionHandler)
 {
+#if !RELEASE_LOG_DISABLED
     auto nowTime = MonotonicTime::now();
     double remainingRunTime = estimatedSuspendTime > nowTime ? (estimatedSuspendTime - nowTime).value() : 0.0;
+#endif
     RELEASE_LOG(ProcessSuspension, "%p - NetworkProcess::prepareToSuspend(), isSuspensionImminent=%d, remainingRunTime=%fs", this, isSuspensionImminent, remainingRunTime);
 
     m_isSuspended = true;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1466,8 +1466,10 @@ void WebProcess::pageActivityStateDidChange(PageIdentifier, OptionSet<WebCore::A
 
 void WebProcess::prepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime, CompletionHandler<void()>&& completionHandler)
 {
+#if !RELEASE_LOG_DISABLED
     auto nowTime = MonotonicTime::now();
     double remainingRunTime = nowTime > estimatedSuspendTime ? (nowTime - estimatedSuspendTime).value() : 0.0;
+#endif
     WEBPROCESS_RELEASE_LOG(ProcessSuspension, "prepareToSuspend: isSuspensionImminent=%d, remainingRunTime=%fs", isSuspensionImminent, remainingRunTime);
     SetForScope suspensionScope(m_isSuspending, true);
     m_processIsSuspended = true;


### PR DESCRIPTION
#### d6fc4dd71912386c8fdcc171fc5044f28ebbd364
<pre>
Fix unused but set variable warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=245845">https://bugs.webkit.org/show_bug.cgi?id=245845</a>

Reviewed by Yusuke Suzuki.

Fixed unused but set variable warnings reported by Clang 15.

* Source/JavaScriptCore/runtime/HashMapImplInlines.h:
* Source/JavaScriptCore/runtime/WeakMapImpl.h:
* Source/WTF/wtf/URLParser.cpp:
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
* Source/WebCore/html/HTMLMediaElement.cpp:
* Source/WebCore/inspector/InspectorOverlayLabel.cpp:
* Source/WebCore/platform/graphics/FontCascade.cpp:
* Source/WebCore/xml/XPathGrammar.cpp:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
* Source/WebKit/WebProcess/WebProcess.cpp:

Canonical link: <a href="https://commits.webkit.org/255017@main">https://commits.webkit.org/255017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec04b802b6886c2288a2814889648adca75b83bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91016 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35587 "Reverted pull request changes (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/100392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/159007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/34087 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83362 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97146 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96672 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/26976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81914 "An unexpected error occured. Recent messages:Failed to print configuration") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/82518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35166 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77520 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32964 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26703 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3494 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36744 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80116 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38672 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17549 "Passed tests") | 
<!--EWS-Status-Bubble-End-->