### PR TITLE
Add Media Capabilities Additions

### DIFF
--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1560,6 +1560,8 @@ JS_BINDING_IDLS := \
 ADDITIONAL_BINDING_IDLS = \
     DocumentTouch.idl \
     GestureEvent.idl \
+    Internals+Additions.idl \
+    InternalsAdditions.idl \
     Touch.idl \
     TouchEvent.idl \
     TouchList.idl \

--- a/Source/WebCore/SourcesCocoaInternalSDK.txt
+++ b/Source/WebCore/SourcesCocoaInternalSDK.txt
@@ -25,6 +25,7 @@
 // generate-unified-sources.sh script to look for it there.
 
 JSGestureEvent.cpp
+JSInternalsAdditions.cpp
 JSTouch.cpp
 JSTouchEvent.cpp
 JSTouchList.cpp

--- a/Source/WebCore/platform/graphics/cocoa/MediaEngineConfigurationFactoryCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/MediaEngineConfigurationFactoryCocoa.cpp
@@ -37,6 +37,10 @@
 #include <pal/avfoundation/OutputDevice.h>
 #include <wtf/Algorithms.h>
 
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/MediaCapabilitiesAdditions.h>
+#endif
+
 #include "VideoToolboxSoftLink.h"
 
 namespace WebCore {
@@ -122,6 +126,9 @@ static std::optional<MediaCapabilitiesInfo> computeMediaCapabilitiesInfo(const M
             if (!parsedInfo)
                 return std::nullopt;
             info = *parsedInfo;
+#endif
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/MediaCapabilitiesAdditions.cpp>
 #endif
         } else {
             if (alphaChannel || hdrSupported)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -52,6 +52,10 @@
 #include "AudioSession.h"
 #endif
 
+#if USE(APPLE_INTERNAL_SDK)
+#include "InternalsAdditions.h"
+#endif
+
 OBJC_CLASS DDScannerResult;
 OBJC_CLASS VKCImageAnalysis;
 


### PR DESCRIPTION
#### d32479a317297f60aa93ae00d01e36fb7ff4cd9f
<pre>
Add Media Capabilities Additions
<a href="https://bugs.webkit.org/show_bug.cgi?id=245849">https://bugs.webkit.org/show_bug.cgi?id=245849</a>
&lt;rdar://97803066&gt;

Reviewed by Eric Carlson.

* Source/WebCore/DerivedSources.make:
* Source/WebCore/SourcesCocoaInternalSDK.txt:
* Source/WebCore/platform/graphics/cocoa/MediaEngineConfigurationFactoryCocoa.cpp:
(WebCore::computeMediaCapabilitiesInfo):
* Source/WebCore/testing/Internals.h:

Canonical link: <a href="https://commits.webkit.org/255040@main">https://commits.webkit.org/255040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f998e9c7aca0affb5d82c9481764e50e6f3d4a6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/35588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100395 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/159024 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/34088 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29093 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83371 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97147 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96673 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77802 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26983 "Passed tests") | 
| | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81922 "An unexpected error occured. Recent messages:Failed to print configuration") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/81625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70019 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/hypertext/basic (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35167 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15647 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32965 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16634 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3508 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39604 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35718 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->