### PR TITLE
[JSC] Optimize String#substring

### DIFF
--- a/JSTests/microbenchmarks/string-starts-with-mod-prototype.js
+++ b/JSTests/microbenchmarks/string-starts-with-mod-prototype.js
@@ -1,0 +1,27 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+String.prototype._startsWith = function (find) {
+    return this.substring(0,find.length) === find
+}
+
+function test1() {
+    return "/assets/omfg"._startsWith('/assets/');
+}
+noInline(test1);
+
+function test2(string) {
+    return "/assets/omfg"._startsWith(string);
+}
+noInline(test2);
+
+var count = 0;
+for (var i = 0; i < 5e5; ++i) {
+    if (test1())
+        ++count;
+    if (test2('/assets/'))
+        ++count;
+}
+shouldBe(count, 1e6);

--- a/JSTests/microbenchmarks/string-starts-with-mod.js
+++ b/JSTests/microbenchmarks/string-starts-with-mod.js
@@ -1,0 +1,27 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function _startsWith(str, find) {
+    return str.substring(0,find.length) === find
+}
+
+function test1() {
+    return _startsWith("/assets/omfg", '/assets/');
+}
+noInline(test1);
+
+function test2(string) {
+    return _startsWith("/assets/omfg", string);
+}
+noInline(test2);
+
+var count = 0;
+for (var i = 0; i < 5e5; ++i) {
+    if (test1())
+        ++count;
+    if (test2('/assets/'))
+        ++count;
+}
+shouldBe(count, 1e6);

--- a/JSTests/microbenchmarks/string-starts-with.js
+++ b/JSTests/microbenchmarks/string-starts-with.js
@@ -1,0 +1,23 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1() {
+    return "/assets/omfg".startsWith('/assets/');
+}
+noInline(test1);
+
+function test2(string) {
+    return "/assets/omfg".startsWith(string);
+}
+noInline(test2);
+
+var count = 0;
+for (var i = 0; i < 1e5; ++i) {
+    if (test1())
+        ++count;
+    if (test2('/assets/'))
+        ++count;
+}
+shouldBe(count, 2e5);

--- a/JSTests/microbenchmarks/string-substring-constants-binary.js
+++ b/JSTests/microbenchmarks/string-substring-constants-binary.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1() {
+    return "/assets/omfg".substring(1) === 'assets/omfg';
+}
+noInline(test1);
+
+var count = 0;
+for (var i = 0; i < 1e6; ++i) {
+    if (test1())
+        ++count;
+}
+shouldBe(count, 1e6);

--- a/JSTests/microbenchmarks/string-substring-constants-identity.js
+++ b/JSTests/microbenchmarks/string-substring-constants-identity.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1() {
+    return "/assets/omfg".substring(0) === '/assets/';
+}
+noInline(test1);
+
+var count = 0;
+for (var i = 0; i < 1e6; ++i) {
+    if (!test1())
+        ++count;
+}
+shouldBe(count, 1e6);

--- a/JSTests/microbenchmarks/string-substring-constants.js
+++ b/JSTests/microbenchmarks/string-substring-constants.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1() {
+    return "/assets/omfg".substring(0,8) === '/assets/';
+}
+noInline(test1);
+
+var count = 0;
+for (var i = 0; i < 1e6; ++i) {
+    if (test1())
+        ++count;
+}
+shouldBe(count, 1e6);

--- a/JSTests/microbenchmarks/string-substring-length-constant.js
+++ b/JSTests/microbenchmarks/string-substring-length-constant.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1() {
+    return "/assets/omfg".substring(0,'/assets/'.length) === '/assets/';
+}
+noInline(test1);
+
+var count = 0;
+for (var i = 0; i < 1e6; ++i) {
+    if (test1())
+        ++count;
+}
+shouldBe(count, 1e6);

--- a/JSTests/microbenchmarks/string-substring.js
+++ b/JSTests/microbenchmarks/string-substring.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1(start, end) {
+    return "/assets/omfg".substring(start, end) === '/assets/';
+}
+noInline(test1);
+
+var count = 0;
+for (var i = 0; i < 1e6; ++i) {
+    if (test1(0, 8))
+        ++count;
+}
+shouldBe(count, 1e6);

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -178,7 +178,7 @@ namespace JSC {
     macro(stringIncludesInternal) \
     macro(stringIndexOfInternal) \
     macro(stringSplitFast) \
-    macro(stringSubstringInternal) \
+    macro(stringSubstring) \
     macro(makeBoundFunction) \
     macro(hasOwnLengthProperty) \
     macro(handleProxyGetTrapResult) \

--- a/Source/JavaScriptCore/builtins/RegExpPrototype.js
+++ b/Source/JavaScriptCore/builtins/RegExpPrototype.js
@@ -189,7 +189,7 @@ function getSubstitution(matched, str, position, captures, namedCaptures, replac
 
     for (var start = 0; start = @stringIndexOfInternal.@call(replacement, "$", lastStart), start !== -1; lastStart = start) {
         if (start - lastStart > 0)
-            result = result + @stringSubstringInternal.@call(replacement, lastStart, start);
+            result = result + @stringSubstring.@call(replacement, lastStart, start);
         start++;
         if (start >= replacementLength)
             result = result + "$";
@@ -207,12 +207,12 @@ function getSubstitution(matched, str, position, captures, namedCaptures, replac
                 break;
             case "`":
                 if (position > 0)
-                    result = result + @stringSubstringInternal.@call(str, 0, position);
+                    result = result + @stringSubstring.@call(str, 0, position);
                 start++;
                 break;
             case "'":
                 if (tailPos < stringLength)
-                    result = result + @stringSubstringInternal.@call(str, tailPos);
+                    result = result + @stringSubstring.@call(str, tailPos);
                 start++;
                 break;
             case "<":
@@ -220,7 +220,7 @@ function getSubstitution(matched, str, position, captures, namedCaptures, replac
                     var groupNameStartIndex = start + 1;
                     var groupNameEndIndex = @stringIndexOfInternal.@call(replacement, ">", groupNameStartIndex);
                     if (groupNameEndIndex !== -1) {
-                        var groupName = @stringSubstringInternal.@call(replacement, groupNameStartIndex, groupNameEndIndex);
+                        var groupName = @stringSubstring.@call(replacement, groupNameStartIndex, groupNameEndIndex);
                         var capture = namedCaptures[groupName];
                         if (capture !== @undefined)
                             result = result + @toString(capture);
@@ -241,7 +241,7 @@ function getSubstitution(matched, str, position, captures, namedCaptures, replac
 
                     var n = chCode - 0x30;
                     if (n > m) {
-                        result = result + @stringSubstringInternal.@call(replacement, originalStart, start);
+                        result = result + @stringSubstring.@call(replacement, originalStart, start);
                         break;
                     }
 
@@ -257,7 +257,7 @@ function getSubstitution(matched, str, position, captures, namedCaptures, replac
                     }
 
                     if (n == 0) {
-                        result = result + @stringSubstringInternal.@call(replacement, originalStart, start);
+                        result = result + @stringSubstring.@call(replacement, originalStart, start);
                         break;
                     }
 
@@ -271,7 +271,7 @@ function getSubstitution(matched, str, position, captures, namedCaptures, replac
         }
     }
 
-    return result + @stringSubstringInternal.@call(replacement, lastStart);
+    return result + @stringSubstring.@call(replacement, lastStart);
 }
 
 @overriddenName="[Symbol.replace]"
@@ -368,7 +368,7 @@ function replace(strArg, replace)
         }
 
         if (position >= nextSourcePosition) {
-            accumulatedResult = accumulatedResult + @stringSubstringInternal.@call(str, nextSourcePosition, position) + replacement;
+            accumulatedResult = accumulatedResult + @stringSubstring.@call(str, nextSourcePosition, position) + replacement;
             nextSourcePosition = position + matchLength;
         }
     }
@@ -376,7 +376,7 @@ function replace(strArg, replace)
     if (nextSourcePosition >= stringLength)
         return  accumulatedResult;
 
-    return accumulatedResult + @stringSubstringInternal.@call(str, nextSourcePosition);
+    return accumulatedResult + @stringSubstring.@call(str, nextSourcePosition);
 }
 
 // 21.2.5.9 RegExp.prototype[@@search] (string)
@@ -564,7 +564,7 @@ function split(string, limit)
             // iv. Else e != p,
             else {
                 // 1. Let T be a String value equal to the substring of S consisting of the elements at indices p (inclusive) through q (exclusive).
-                var subStr = @stringSubstringInternal.@call(str, position, matchPosition);
+                var subStr = @stringSubstring.@call(str, position, matchPosition);
                 // 2. Perform ! CreateDataProperty(A, ! ToString(lengthA), T).
                 // 3. Let lengthA be lengthA + 1.
                 @arrayPush(result, subStr);
@@ -599,7 +599,7 @@ function split(string, limit)
         }
     }
     // 20. Let T be a String value equal to the substring of S consisting of the elements at indices p (inclusive) through size (exclusive).
-    var remainingStr = @stringSubstringInternal.@call(str, position, size);
+    var remainingStr = @stringSubstring.@call(str, position, size);
     // 21. Perform ! CreateDataProperty(A, ! ToString(lengthA), T).
     @arrayPush(result, remainingStr);
     // 22. Return A.

--- a/Source/JavaScriptCore/builtins/StringPrototype.js
+++ b/Source/JavaScriptCore/builtins/StringPrototype.js
@@ -113,7 +113,7 @@ function repeatCharactersSlowPath(string, count)
         operand += operand;
     }
     if (remainingCharacters)
-        result += @stringSubstringInternal.@call(string, 0, remainingCharacters);
+        result += @stringSubstring.@call(string, 0, remainingCharacters);
     return result;
 }
 

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -105,7 +105,7 @@ class JSGlobalObject;
     v(stringIncludesInternal, nullptr) \
     v(stringIndexOfInternal, nullptr) \
     v(stringSplitFast, nullptr) \
-    v(stringSubstringInternal, nullptr) \
+    v(stringSubstring, nullptr) \
     v(makeBoundFunction, nullptr) \
     v(hasOwnLengthProperty, nullptr) \
     v(handleProxyGetTrapResult, nullptr) \

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -1404,6 +1404,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case StringSubstring:
     case StringSlice: {
         setTypeForNode(node, SpecString);
         break;

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -306,7 +306,8 @@ private:
             break;
         }
 
-        case StringSlice: {
+        case StringSlice:
+        case StringSubstring: {
             node->child1()->mergeFlags(NodeBytecodeUsesAsValue);
             node->child2()->mergeFlags(NodeBytecodeUsesAsNumber | NodeBytecodeUsesAsOther | NodeBytecodeUsesAsInt | NodeBytecodeUsesAsArrayIndex);
             if (node->child3())

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3685,6 +3685,7 @@ bool ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, Intrinsic
             return true;
         }
 
+        case StringPrototypeSubstringIntrinsic:
         case StringPrototypeSliceIntrinsic: {
             if (argumentCountIncludingThis < 2)
                 return false;
@@ -3698,7 +3699,7 @@ bool ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, Intrinsic
             Node* end = nullptr;
             if (argumentCountIncludingThis > 2)
                 end = get(virtualRegisterForArgumentIncludingThis(2, registerOffset));
-            Node* resultNode = addToGraph(StringSlice, thisString, start, end);
+            Node* resultNode = addToGraph(intrinsic == StringPrototypeSubstringIntrinsic ? StringSubstring : StringSlice, thisString, start, end);
             setResult(resultNode);
             return true;
         }

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2002,6 +2002,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
 
     case StringSlice:
+    case StringSubstring:
         def(PureValue(node));
         return;
 

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -400,6 +400,7 @@ bool doesGC(Graph& graph, Node* node)
     case StringReplaceRegExp:
     case StringReplaceString:
     case StringSlice:
+    case StringSubstring:
     case StringValueOf:
     case CreateRest:
     case ToLowerCase:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2680,7 +2680,8 @@ private:
             break;
         }
 
-        case StringSlice: {
+        case StringSlice:
+        case StringSubstring: {
             fixEdge<StringUse>(node->child1());
             fixEdge<Int32Use>(node->child2());
             if (node->child3())

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -537,6 +537,7 @@ namespace JSC { namespace DFG {
     \
     macro(StringValueOf, NodeMustGenerate | NodeResultJS) \
     macro(StringSlice, NodeResultJS) \
+    macro(StringSubstring, NodeResultJS) \
     macro(ToLowerCase, NodeResultJS) \
     /* Nodes for DOM JIT */\
     macro(CallDOMGetter, NodeResultJS | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2680,6 +2680,24 @@ JSC_DEFINE_JIT_OPERATION(operationStringSlice, JSCell*, (JSGlobalObject* globalO
     return stringSlice(globalObject, vm, string, string->length(), start, end);
 }
 
+JSC_DEFINE_JIT_OPERATION(operationStringSubstring, JSString*, (JSGlobalObject* globalObject, JSString* string, int32_t start))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    return stringSubstring(globalObject, string, start, std::nullopt);
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringSubstringWithEnd, JSString*, (JSGlobalObject* globalObject, JSString* string, int32_t start, int32_t end))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    return stringSubstring(globalObject, string, start, end);
+}
+
 JSC_DEFINE_JIT_OPERATION(operationToLowerCase, JSString*, (JSGlobalObject* globalObject, JSString* string, uint32_t failingIndex))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -250,6 +250,8 @@ JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringStringWithTable8, JSString
 JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringStringWithoutSubstitutionWithTable8, JSString*, (JSGlobalObject*, JSString*, JSString*, JSString*, const BoyerMooreHorspoolTable<uint8_t>*));
 JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringEmptyStringWithTable8, JSString*, (JSGlobalObject*, JSString*, JSString*, const BoyerMooreHorspoolTable<uint8_t>*));
 JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringGeneric, JSString*, (JSGlobalObject*, JSString*, JSString*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationStringSubstring, JSString*, (JSGlobalObject*, JSString*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationStringSubstringWithEnd, JSString*, (JSGlobalObject*, JSString*, int32_t, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationToLowerCase, JSString*, (JSGlobalObject*, JSString*, uint32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationInt32ToString, char*, (JSGlobalObject*, int32_t, int32_t));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1002,6 +1002,7 @@ private:
 
         case StringValueOf:
         case StringSlice:
+        case StringSubstring:
         case ToLowerCase:
             setPrediction(SpecString);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -306,6 +306,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case MapHash:
     case NormalizeMapKey:
     case StringSlice:
+    case StringSubstring:
     case ToLowerCase:
     case GetMapBucket:
     case GetMapBucketHead:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1515,6 +1515,7 @@ public:
     void compileDefineDataProperty(Node*);
     void compileDefineAccessorProperty(Node*);
     void compileStringSlice(Node*);
+    void compileStringSubstring(Node*);
     void compileToLowerCase(Node*);
     void compileThrow(Node*);
     void compileThrowStaticError(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2614,6 +2614,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringSubstring: {
+        compileStringSubstring(node);
+        break;
+    }
+
     case ToLowerCase: {
         compileToLowerCase(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5194,6 +5194,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringSubstring: {
+        compileStringSubstring(node);
+        break;
+    }
+
     case ToLowerCase: {
         compileToLowerCase(node);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -371,6 +371,7 @@ inline CapabilityLevel canCompile(Node* node)
     case DefineAccessorProperty:
     case StringValueOf:
     case StringSlice:
+    case StringSubstring:
     case ToLowerCase:
     case NumberToStringWithRadix:
     case NumberToStringWithValidRadixConstant:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1650,6 +1650,9 @@ private:
         case StringSlice:
             compileStringSlice();
             break;
+        case StringSubstring:
+            compileStringSubstring();
+            break;
         case ToLowerCase:
             compileToLowerCase();
             break;
@@ -15599,6 +15602,16 @@ IGNORE_CLANG_WARNINGS_END
         m_out.appendTo(continuation, lastNext);
         setJSValue(m_out.phi(pointerType(), results));
     }
+
+    void compileStringSubstring()
+    {
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        if (m_node->child3())
+            setJSValue(vmCall(pointerType(), operationStringSubstringWithEnd, weakPointer(globalObject), lowString(m_node->child1()), lowInt32(m_node->child2()), lowInt32(m_node->child3())));
+        else
+            setJSValue(vmCall(pointerType(), operationStringSubstring, weakPointer(globalObject), lowString(m_node->child1()), lowInt32(m_node->child2())));
+    }
+
 
     void compileToLowerCase()
     {

--- a/Source/JavaScriptCore/runtime/Intrinsic.cpp
+++ b/Source/JavaScriptCore/runtime/Intrinsic.cpp
@@ -185,6 +185,8 @@ const char* intrinsicName(Intrinsic intrinsic)
         return "StringPrototypeReplaceStringIntrinsic";
     case StringPrototypeSliceIntrinsic:
         return "StringPrototypeSliceIntrinsic";
+    case StringPrototypeSubstringIntrinsic:
+        return "StringPrototypeSubstringIntrinsic";
     case StringPrototypeToLowerCaseIntrinsic:
         return "StringPrototypeToLowerCaseIntrinsic";
     case NumberPrototypeToStringIntrinsic:

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -108,6 +108,7 @@ enum Intrinsic : uint8_t {
     StringPrototypeReplaceRegExpIntrinsic,
     StringPrototypeReplaceStringIntrinsic,
     StringPrototypeSliceIntrinsic,
+    StringPrototypeSubstringIntrinsic,
     StringPrototypeToLowerCaseIntrinsic,
     NumberPrototypeToStringIntrinsic,
     NumberIsIntegerIntrinsic,

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -866,6 +866,10 @@ void JSGlobalObject::init(VM& vm)
             init.set(JSFunction::create(init.vm, typedArrayPrototypeSortCodeGenerator(init.vm), init.owner));
         });
 
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::stringSubstring)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "substring"_s, stringProtoFuncSubstring, ImplementationVisibility::Public, StringPrototypeSubstringIntrinsic));
+        });
+
     m_functionProtoHasInstanceSymbolFunction.set(vm, this, hasInstanceSymbolFunction);
 
     m_nullGetterFunction.set(vm, this, NullGetterFunction::create(vm, NullGetterFunction::createStructure(vm, this, m_functionPrototype.get())));
@@ -1608,9 +1612,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::stringSplitFast)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, String(), stringProtoFuncSplitFast, ImplementationVisibility::Private));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::stringSubstringInternal)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, String(), builtinStringSubstringInternal, ImplementationVisibility::Private));
         });
 
     // Function prototype helpers.

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -835,6 +835,7 @@ public:
     JSFunction* functionProtoHasInstanceSymbolFunction() const { return m_functionProtoHasInstanceSymbolFunction.get(); }
     JSFunction* regExpProtoExecFunction() const;
     JSFunction* typedArrayProtoSort() const { return m_typedArrayProtoSort.get(this); }
+    JSFunction* stringProtoSubstringFunction() const;
     JSObject* regExpProtoSymbolReplaceFunction() const { return m_regExpProtoSymbolReplace.get(); }
     GetterSetter* regExpProtoGlobalGetter() const;
     GetterSetter* regExpProtoUnicodeGetter() const;

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -166,6 +166,7 @@ inline JSFunction* JSGlobalObject::rejectPromiseFunction() const { return jsCast
 inline JSFunction* JSGlobalObject::promiseProtoThenFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::defaultPromiseThen)); }
 inline JSFunction* JSGlobalObject::performPromiseThenFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performPromiseThen)); }
 inline JSFunction* JSGlobalObject::regExpProtoExecFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::regExpBuiltinExec)); }
+inline JSFunction* JSGlobalObject::stringProtoSubstringFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::stringSubstring)); }
 inline GetterSetter* JSGlobalObject::regExpProtoGlobalGetter() const { return bitwise_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoGlobalGetter)); }
 inline GetterSetter* JSGlobalObject::regExpProtoUnicodeGetter() const { return bitwise_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoUnicodeGetter)); }
 

--- a/Source/JavaScriptCore/runtime/JSString.cpp
+++ b/Source/JavaScriptCore/runtime/JSString.cpp
@@ -89,14 +89,18 @@ bool JSString::equalSlowCase(JSGlobalObject* globalObject, JSString* other) cons
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (length() != other->length())
+    unsigned length = this->length();
+    if (length != other->length())
         return false;
 
-    String str1 = value(globalObject);
+    auto str1 = unsafeView(globalObject);
     RETURN_IF_EXCEPTION(scope, false);
-    String str2 = other->value(globalObject);
+    auto str2 = other->unsafeView(globalObject);
     RETURN_IF_EXCEPTION(scope, false);
-    return WTF::equal(*str1.impl(), *str2.impl());
+
+    ensureStillAliveHere(this);
+    ensureStillAliveHere(other);
+    return WTF::equal(str1, str2, length);
 }
 
 size_t JSString::estimatedSize(JSCell* cell, VM& vm)

--- a/Source/JavaScriptCore/runtime/StringPrototype.h
+++ b/Source/JavaScriptCore/runtime/StringPrototype.h
@@ -58,8 +58,8 @@ void substituteBackreferencesSlow(StringBuilder& result, StringView replacement,
 
 JSC_DECLARE_HOST_FUNCTION(stringProtoFuncRepeatCharacter);
 JSC_DECLARE_HOST_FUNCTION(stringProtoFuncSplitFast);
+JSC_DECLARE_HOST_FUNCTION(stringProtoFuncSubstring);
 
-JSC_DECLARE_HOST_FUNCTION(builtinStringSubstringInternal);
 JSC_DECLARE_HOST_FUNCTION(builtinStringIncludesInternal);
 JSC_DECLARE_HOST_FUNCTION(builtinStringIndexOfInternal);
 

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -48,6 +48,33 @@ ALWAYS_INLINE JSString* stringSlice(JSGlobalObject* globalObject, VM& vm, JSStri
     return jsEmptyString(vm);
 }
 
+ALWAYS_INLINE std::tuple<int32_t, int32_t> extractSubstringOffsets(int32_t length, int32_t startValue, std::optional<int32_t> endValue)
+{
+    int32_t start = std::min<int32_t>(std::max<int32_t>(startValue, 0), length);
+    int32_t end = length;
+    if (endValue)
+        end = std::min<int32_t>(std::max<int32_t>(endValue.value(), 0), length);
+
+    ASSERT(start >= 0);
+    ASSERT(end >= 0);
+    if (start > end)
+        std::swap(start, end);
+    return { start, end };
+}
+
+ALWAYS_INLINE JSString* stringSubstring(JSGlobalObject* globalObject, JSString* string, int32_t startValue, std::optional<int32_t> endValue)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    int length = string->length();
+    RELEASE_ASSERT(length >= 0);
+
+    auto [start, end] = extractSubstringOffsets(length, startValue, endValue);
+
+    RELEASE_AND_RETURN(scope, jsSubstring(globalObject, string, start, end - start));
+}
+
 ALWAYS_INLINE JSString* jsSpliceSubstringsWithSeparators(JSGlobalObject* globalObject, JSString* sourceVal, const String& source, const Range<int32_t>* substringRanges, int rangeCount, const String* separators, int separatorCount)
 {
     VM& vm = getVM(globalObject);

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -296,12 +296,8 @@ ALWAYS_INLINE bool equal(const LChar* a, const UChar* b, unsigned length)
 ALWAYS_INLINE bool equal(const UChar* a, const LChar* b, unsigned length) { return equal(b, a, length); }
 
 template<typename StringClassA, typename StringClassB>
-ALWAYS_INLINE bool equalCommon(const StringClassA& a, const StringClassB& b)
+ALWAYS_INLINE bool equalCommon(const StringClassA& a, const StringClassB& b, unsigned length)
 {
-    unsigned length = a.length();
-    if (length != b.length())
-        return false;
-
     if (a.is8Bit()) {
         if (b.is8Bit())
             return equal(a.characters8(), b.characters8(), length);
@@ -313,6 +309,16 @@ ALWAYS_INLINE bool equalCommon(const StringClassA& a, const StringClassB& b)
         return equal(a.characters16(), b.characters8(), length);
 
     return equal(a.characters16(), b.characters16(), length);
+}
+
+template<typename StringClassA, typename StringClassB>
+ALWAYS_INLINE bool equalCommon(const StringClassA& a, const StringClassB& b)
+{
+    unsigned length = a.length();
+    if (length != b.length())
+        return false;
+
+    return equalCommon(a, b, length);
 }
 
 template<typename StringClassA, typename StringClassB>

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -197,6 +197,7 @@ private:
     explicit StringView(const char*);
 
     friend bool equal(StringView, StringView);
+    friend bool equal(StringView, StringView, unsigned length);
     friend WTF_EXPORT_PRIVATE bool equalRespectingNullity(StringView, StringView);
 
     void initialize(const LChar*, unsigned length);
@@ -687,7 +688,17 @@ template<typename CharacterType, size_t inlineCapacity> void append(Vector<Chara
     string.getCharactersWithUpconvert(buffer.data() + oldSize);
 }
 
-inline bool equal(StringView a, StringView b)
+ALWAYS_INLINE bool equal(StringView a, StringView b, unsigned length)
+{
+    if (a.m_characters == b.m_characters) {
+        ASSERT(a.is8Bit() == b.is8Bit());
+        return true;
+    }
+
+    return equalCommon(a, b, length);
+}
+
+ALWAYS_INLINE bool equal(StringView a, StringView b)
 {
     if (a.m_characters == b.m_characters) {
         ASSERT(a.is8Bit() == b.is8Bit());


### PR DESCRIPTION
#### 3de7e6fba239b0a69f618faa82c7cd642c57726b
<pre>
[JSC] Optimize String#substring
<a href="https://bugs.webkit.org/show_bug.cgi?id=244754">https://bugs.webkit.org/show_bug.cgi?id=244754</a>
&lt;rdar://99770218&gt;

Reviewed by Mark Lam.

This patch optimizes String#substring.

1. We avoid allocating the whole string when just comparing with substring. (JSString::equalSlowCase change).
   We get StringView with unsafeView, and use ensureStillAliveHere to keep both string cells alive.
2. We optimize JSString::equalSlowCase&apos;s equal function using StringView.
3. Optimize String#substring runtime function with int32 input fast path.
4. Add DFG StringSubstring node to handle String#substring efficiently in DFG / FTL. We also add StrengthReduction rule
   for String#substring so that we can constant-fold the result if arguments are the constants.

We observed improvements in microbenchmarks.
                                                    ToT                     Patched

    string-substring-constants                30.9691+-0.7392     ^      6.9364+-0.1119        ^ definitely 4.4647x faster
    string-substring-constants-binary         29.5540+-0.0829     ^     12.0035+-0.2692        ^ definitely 2.4621x faster
    string-starts-with-mod-prototype          69.7019+-0.6867     ^     56.8859+-0.4956        ^ definitely 1.2253x faster
    string-substring                          30.9168+-0.2336     ^     18.9088+-0.1950        ^ definitely 1.6350x faster
    string-substring-length-constant          30.6379+-0.2457     ^      6.9260+-0.1237        ^ definitely 4.4236x faster
    string-substring-constants-identity        9.5178+-0.1149     ^      2.9170+-0.0326        ^ definitely 3.2629x faster
    string-starts-with                         2.9473+-0.0220            2.9296+-0.0749
    string-starts-with-mod                    31.1585+-0.1608     ^     12.9144+-0.0646        ^ definitely 2.4127x faster

* JSTests/microbenchmarks/string-starts-with-mod-prototype.js: Added.
(shouldBe):
(String.prototype._startsWith):
(test1):
(test2):
* JSTests/microbenchmarks/string-starts-with-mod.js: Added.
(shouldBe):
(_startsWith):
(test1):
(test2):
* JSTests/microbenchmarks/string-starts-with.js: Added.
(shouldBe):
(test1):
(test2):
* JSTests/microbenchmarks/string-substring-constants-binary.js: Added.
(shouldBe):
(test1):
* JSTests/microbenchmarks/string-substring-constants-identity.js: Added.
(shouldBe):
(test1):
* JSTests/microbenchmarks/string-substring-constants.js: Added.
(shouldBe):
(test1):
* JSTests/microbenchmarks/string-substring-length-constant.js: Added.
(shouldBe):
(test1):
* JSTests/microbenchmarks/string-substring.js: Added.
(shouldBe):
(test1):
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/RegExpPrototype.js:
(linkTimeConstant.getSubstitution):
(overriddenName.string_appeared_here.replace):
(overriddenName.string_appeared_here.split):
* Source/JavaScriptCore/builtins/StringPrototype.js:
(linkTimeConstant.repeatCharactersSlowPath):
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileStringSubstring):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/Intrinsic.cpp:
(JSC::intrinsicName):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::stringProtoSubstringFunction const):
* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC::JSString::equalSlowCase const):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::stringSubstringImpl): Deleted.
* Source/JavaScriptCore/runtime/StringPrototype.h:
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::extractSubstringOffsets):
(JSC::stringSubstring):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::equalCommon):
* Source/WTF/wtf/text/StringView.h:
(WTF::equal):

Canonical link: <a href="https://commits.webkit.org/255030@main">https://commits.webkit.org/255030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e78d8f150ed312a9c065bd38fed901f6a15e2687

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91050 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/35 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100475 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/159570 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/40 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97174 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96706 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/37 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27018 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/81989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/81646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70052 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82545 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35199 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15668 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77552 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32996 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16662 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26716 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3500 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36778 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80150 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35746 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17563 "Passed tests") | 
<!--EWS-Status-Bubble-End-->