### PR TITLE
REGRESSION (iOS 16): New context menu (UIEditMenuInteraction) can't be disabled

### DIFF
--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -547,7 +547,14 @@ void WebPageProxy::prepareSelectionForContextMenuWithLocationInView(IntPoint poi
     if (!hasRunningProcess())
         return callbackFunction(false, RevealItem());
 
-    sendWithAsyncReply(Messages::WebPage::PrepareSelectionForContextMenuWithLocationInView(point), WTFMove(callbackFunction));
+    dispatchAfterCurrentContextMenuEvent([weakThis = WeakPtr { *this }, point, callbackFunction = WTFMove(callbackFunction)] (bool handled) mutable {
+        if (!weakThis || handled) {
+            callbackFunction(false, RevealItem());
+            return;
+        }
+
+        weakThis->sendWithAsyncReply(Messages::WebPage::PrepareSelectionForContextMenuWithLocationInView(point), WTFMove(callbackFunction));
+    });
 }
 #endif
 


### PR DESCRIPTION
#### 9ce57ec0f4b36f9483635955f11fda7250c13eff
<pre>
REGRESSION (iOS 16): New context menu (UIEditMenuInteraction) can&apos;t be disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=244149">https://bugs.webkit.org/show_bug.cgi?id=244149</a>
&lt;rdar://problem/98935540&gt;

Reviewed by Wenson Hsieh.

There doesn&apos;t really seem to be a common path or even a consistent ordering of events between the
page dispatching a JS `&quot;contextmenu&quot;` event and the UIProcess deciding whether to show the edit menu.

As such, we should keep track of whether the last JS `&quot;contextmenu&quot;` event was `preventDefault()`,
delaying relevant activity until that info is received in the UIProcess (from the WebProcess).

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleMouseEvent):
(WebKit::WebPageProxy::handlePreventableTouchEvent):
(WebKit::WebPageProxy::dispatchAfterCurrentContextMenuEvent): Added.
(WebKit::WebPageProxy::processContextMenuCallbacks): Added.
(WebKit::WebPageProxy::didReceiveEvent):
Rename `TouchMovePreventionState` to `EventPreventionState` so that more things can use it and split
`ReceivedReply` into `Prevented` and `Allowed` to make it easier to manage state (e.g. keeping track
of one variable is easier than two).

* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::prepareSelectionForContextMenuWithLocationInView):
If the last JS `&quot;contextmenu&quot;` event was `preventDefault()`, don&apos;t show the edit menu.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm:
(TEST.iOSMouseSupport.RightClickDoesNotShowMenuIfPreventDefault): Added.

Canonical link: <a href="https://commits.webkit.org/255193@main">https://commits.webkit.org/255193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34f596e12965ab85b8fd25961cd483e8e8f413c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101351 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161440 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/880 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83970 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/512 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27469 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82436 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35775 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33530 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17207 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3599 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37371 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36324 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->