### PR TITLE
[GTK] The Debug bot has issues starting and checking the Xvfb driver when running layout tests.

### DIFF
--- a/Tools/Scripts/webkitpy/port/xvfbdriver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/xvfbdriver_unittest.py
@@ -98,11 +98,13 @@ class XvfbDriverTest(unittest.TestCase):
         with OutputCapture(level=logging.INFO) as captured:
             self.assertRaisesRegexp(RuntimeError, 'Unable to start Xvfb display server', driver.start, False, [])
             captured_log = captured.root.log.getvalue()
-            for retry in [1, 2, 3]:
-                self.assertTrue('Failed to start Xvfb display server ... retrying [ {} of 3 ].'.format(retry) in captured_log)
-                self.assertFalse('Failed to start Xvfb display server ... retrying [ 4 of 3 ].' in captured_log)
-            self.assertTrue('Failed to start Xvfb display server ... giving up after 3 retries.' in captured_log)
-            self.assertTrue('The print-screen-size tool returned non-zero status' in captured_log)
+            for retry in [1, 2, 3, 5, 6, 8, 9]:
+                self.assertTrue('Failed to check that the Xvfb display server is replying, retrying check [ {} of 9 ].'.format(retry) in captured_log)
+            for retry in [4, 7]:
+                self.assertTrue('Failed to check that the Xvfb display server is replying. Trying to restart server and retrying check [ {} of 9 ].'.format(retry) in captured_log)
+            self.assertFalse('[ 10 of 9 ].' in captured_log)
+            self.assertTrue('Failed to start and check that the Xvfb replies after 9 retries.' in captured_log)
+            self.assertTrue('the print-screen-size tool returned non-zero status' in captured_log)
         self.cleanup_driver(driver)
 
     def test_stop(self):
@@ -112,6 +114,9 @@ class XvfbDriverTest(unittest.TestCase):
 
         class FakeXvfbProcess(object):
             pid = 1234
+
+            def poll(self):
+                return None
 
         driver._xvfb_process = FakeXvfbProcess()
 


### PR DESCRIPTION
#### 7a5eef99ea503f13cc3bc44a6735e2de1084e98d
<pre>
[GTK] The Debug bot has issues starting and checking the Xvfb driver when running layout tests.
<a href="https://bugs.webkit.org/show_bug.cgi?id=245857">https://bugs.webkit.org/show_bug.cgi?id=245857</a>

Reviewed by Adrian Perez de Castro.

Rework how the Xvfb server is started and how the checks to see if it is reply are done.
The function _xvfb_check_if_ready() is simplified to only check if the server is replying,
and the logic for retrying the checks is moved to a new function named _start_and_check_xvfb()
which now can restart the server if needed.
The number of retries is also incremented to 9 (restarting the server each 3 retries).
Also is incremented the timeout to wait for the print-screen check tool.
Some cleaning related to not longer supported python2 is also done.

* Tools/Scripts/webkitpy/port/xvfbdriver.py:
(XvfbDriver.__init__):
(XvfbDriver._xvfb_stop):
(XvfbDriver._xvfb_check_if_ready):
(XvfbDriver):
(XvfbDriver._start_and_check_xvfb):
(XvfbDriver._setup_environ_for_test):
* Tools/Scripts/webkitpy/port/xvfbdriver_unittest.py:
(XvfbDriverTest.test_xvfb_not_replying):
(XvfbDriverTest.test_stop.FakeXvfbProcess.poll):
(XvfbDriverTest):

Canonical link: <a href="https://commits.webkit.org/255084@main">https://commits.webkit.org/255084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/794a28a5a550a86b5c9e95179de2d27417d1c613

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100443 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/159263 "Found 1 new test failure: fast/workers/worker-crash-with-invalid-location.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/44 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29105 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83390 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97162 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/41 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77815 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26999 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/94616 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70038 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35186 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15660 "Found 1 new test failure: webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/32983 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16648 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3531 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39617 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35732 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->