### PR TITLE
~NetworkStorageManager is run in the wrong thread in certain conditions

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -266,10 +266,7 @@ void NetworkProcess::didClose(IPC::Connection&)
 
     forEachNetworkSession([&](auto& session) {
         platformFlushCookies(session.sessionID(), [callbackAggregator] { });
-    });
-
-    NetworkStorageManager::forEach([&](auto& manager) {
-        manager.syncLocalStorage([callbackAggregator] { });
+        session.storageManager().syncLocalStorage([callbackAggregator] { });
     });
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -211,7 +211,7 @@ public:
     WebSharedWorkerServer* sharedWorkerServer() { return m_sharedWorkerServer.get(); }
     WebSharedWorkerServer& ensureSharedWorkerServer();
 
-    NetworkStorageManager& storageManager() { return m_storageManager.get(); }
+    NetworkStorageManager& storageManager() { return *m_storageManager; }
     CacheStorage::Engine& ensureCacheEngine();
     void clearCacheEngine();
 
@@ -317,7 +317,7 @@ protected:
 #endif
     std::unique_ptr<WebSharedWorkerServer> m_sharedWorkerServer;
 
-    Ref<NetworkStorageManager> m_storageManager;
+    std::unique_ptr<NetworkStorageManager> m_storageManager;
     String m_cacheStorageDirectory;
     RefPtr<CacheStorage::Engine> m_cacheEngine;
     Vector<Function<void(CacheStorage::Engine&)>> m_cacheStorageParametersCallbacks;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -71,17 +71,20 @@ class IDBStorageRegistry;
 class StorageAreaBase;
 class StorageAreaRegistry;
 
-class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver {
+class NetworkStorageManager final : public IPC::MessageReceiver {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(NetworkStorageManager);
 public:
-    static void forEach(const Function<void(NetworkStorageManager&)>&);
-    static Ref<NetworkStorageManager> create(PAL::SessionID, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, bool shouldUseCustomPaths);
+    NetworkStorageManager(PAL::SessionID, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, bool shouldUseCustomPaths);
+    ~NetworkStorageManager();
+
     static bool canHandleTypes(OptionSet<WebsiteDataType>);
 
     void startReceivingMessageFromConnection(IPC::Connection&);
     void stopReceivingMessageFromConnection(IPC::Connection&);
 
     PAL::SessionID sessionID() const { return m_sessionID; }
-    void close();
+    void close(CompletionHandler<void()>&&);
     void clearStorageForTesting(CompletionHandler<void()>&&);
     void clearStorageForWebPage(WebPageProxyIdentifier);
     void didIncreaseQuota(WebCore::ClientOrigin&&, QuotaIncreaseRequestIdentifier, std::optional<uint64_t> newQuota);
@@ -104,8 +107,6 @@ public:
 #endif
 
 private:
-    NetworkStorageManager(PAL::SessionID, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, bool shouldUseCustomPaths);
-    ~NetworkStorageManager();
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };
     OriginStorageManager& originStorageManager(const WebCore::ClientOrigin&, ShouldWriteOriginFile = ShouldWriteOriginFile::Yes);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
  
- messages -> NetworkStorageManager {
+ messages -> NetworkStorageManager NotRefCounted {
     Persisted(struct WebCore::ClientOrigin origin) -> (bool persisted)
     Persist(struct WebCore::ClientOrigin origin) -> (bool persisted)
     FileSystemGetDirectory(struct WebCore::ClientOrigin origin) -> (Expected<WebCore::FileSystemHandleIdentifier, WebKit::FileSystemStorageError> result) WantsConnection


### PR DESCRIPTION
#### e3beae1d292aa75a53ff584ef83b9723634a74aa
<pre>
~NetworkStorageManager is run in the wrong thread in certain conditions
<a href="https://bugs.webkit.org/show_bug.cgi?id=245869">https://bugs.webkit.org/show_bug.cgi?id=245869</a>
rdar://problem/100602521

Reviewed by NOBODY (OOPS!).

Short running tests would sometimes fail
ASSERT(!RunLoop::isMain()) during ~NetworkStorageManager().

This would happen when the NetworkStorageManager::close() would
be first called, invalidating the storage manager. Then
NetworkProcess::didClose() would call NetworkStorageManager::syncLocalStorage().

NetworkStorageManager was a ref counted class and close() was intended to
post the last shared ref back to the main thread, ensuring main thread destruction
when the real owning ref in NetworkSession::m_storageManager was lost.

However, posting the invalid syncLocalStorage() task after close() would put an
unexpected new ref to the work queue. This would mean that losing m_storageManager
ref was not losing the last ref.

Fix this by:
 - Make the NetworkStorageManager non-refcounted. It is really owned by NetworkSession.

Remove WeakPtr list allNetworkStorageManagers. It is not useful list, as each NetworkStorageManager
is accessible by iterating all network sessions.

This is part of the effort to fix some of the flakyness of tests invoking network storage, especially
API test flakyness.

The assert would fail on certain machines with:
Tools/Scripts/run-api-tests  TestWebKitAPI.WebKit.MigrateLocalStorageDataToGeneralStorageDirectory --repeat 100

Note: The assertion would not affect the success / failure of the test, at least typically.
It was invoked in sequence that typically ended with the XPC terminating the process during the assertion
backtrace print, so sometimes the partial backtrace was printed.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::didClose):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::createNetworkStorageManager):
* Source/WebKit/NetworkProcess/NetworkSession.h:
(WebKit::NetworkSession::storageManager):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::NetworkStorageManager):
(WebKit::NetworkStorageManager::~NetworkStorageManager):
(WebKit::NetworkStorageManager::close):
(WebKit::NetworkStorageManager::startReceivingMessageFromConnection):
(WebKit::NetworkStorageManager::stopReceivingMessageFromConnection):
(WebKit::NetworkStorageManager::clearStorageForTesting):
(WebKit::NetworkStorageManager::clearStorageForWebPage):
(WebKit::NetworkStorageManager::didIncreaseQuota):
(WebKit::NetworkStorageManager::fetchData):
(WebKit::NetworkStorageManager::deleteData):
(WebKit::NetworkStorageManager::deleteDataModifiedSince):
(WebKit::NetworkStorageManager::deleteDataForRegistrableDomains):
(WebKit::NetworkStorageManager::moveData):
(WebKit::NetworkStorageManager::getOriginDirectory):
(WebKit::NetworkStorageManager::suspend):
(WebKit::NetworkStorageManager::handleLowMemoryWarning):
(WebKit::NetworkStorageManager::syncLocalStorage):
(WebKit::NetworkStorageManager::registerTemporaryBlobFilePaths):
(WebKit::NetworkStorageManager::requestSpace):
(WebKit::NetworkStorageManager::resetQuotaForTesting):
(WebKit::NetworkStorageManager::resetQuotaUpdatedBasedOnUsageForTesting):
(WebKit::NetworkStorageManager::setBackupExclusionPeriodForTesting):
(WebKit::allNetworkStorageManagers): Deleted.
(WebKit::NetworkStorageManager::forEach): Deleted.
(WebKit::NetworkStorageManager::create): Deleted.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3beae1d292aa75a53ff584ef83b9723634a74aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101304 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/795 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29442 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97640 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/472 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78267 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27431 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82041 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70469 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/children-changed, /TestWTF:WTF_WordLock.ManyContendedLongSections (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35726 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16071 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33482 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17165 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39935 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36282 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->