### PR TITLE
Potential crash in FrameView::updateScrollCorner

### DIFF
--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -4358,24 +4358,21 @@ bool FrameView::scrollAnimatorEnabled() const
 
 void FrameView::updateScrollCorner()
 {
-    RenderElement* renderer = nullptr;
     std::unique_ptr<RenderStyle> cornerStyle;
     IntRect cornerRect = scrollCornerRect();
+    Document* doc = frame().document();
     
-    if (!cornerRect.isEmpty()) {
+    if (doc && !cornerRect.isEmpty()) {
         // Try the <body> element first as a scroll corner source.
-        Document* doc = frame().document();
-        Element* body = doc ? doc->bodyOrFrameset() : nullptr;
-        if (body && body->renderer()) {
-            renderer = body->renderer();
+        if (Element* body = doc->bodyOrFrameset()) {
+            if (RenderElement* renderer = body->renderer())
             cornerStyle = renderer->getUncachedPseudoStyle({ PseudoId::ScrollbarCorner }, &renderer->style());
         }
         
         if (!cornerStyle) {
             // If the <body> didn't have a custom style, then the root element might.
-            Element* docElement = doc ? doc->documentElement() : nullptr;
-            if (docElement && docElement->renderer()) {
-                renderer = docElement->renderer();
+            if (Element* docElement = doc->documentElement()) {
+                if (RenderElement* renderer = docElement->renderer())
                 cornerStyle = renderer->getUncachedPseudoStyle({ PseudoId::ScrollbarCorner }, &renderer->style());
             }
         }
@@ -4388,11 +4385,12 @@ void FrameView::updateScrollCorner()
         }
     }
 
+    RenderElement* renderer = nullptr;
     if (!cornerStyle || !renderer)
         m_scrollCorner = nullptr;
     else {
         if (!m_scrollCorner) {
-            m_scrollCorner = createRenderer<RenderScrollbarPart>(renderer->document(), WTFMove(*cornerStyle));
+            m_scrollCorner = createRenderer<RenderScrollbarPart>(doc, WTFMove(*cornerStyle));
             m_scrollCorner->initializeStyle();
         } else
             m_scrollCorner->setStyle(WTFMove(*cornerStyle));


### PR DESCRIPTION
<pre>
Potential crash in FrameView::updateScrollCorner

<a href="https://bugs.webkit.org/show_bug.cgi?id=117465">https://bugs.webkit.org/show_bug.cgi?id=117465</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/525efd3cc851df1545133547a172ddfdb55b2645">https://chromium.googlesource.com/chromium/blink/+/525efd3cc851df1545133547a172ddfdb55b2645</a>

Don't know how to reproduce but it seems the only possibility of crash:

If frameView::updateScrollCorner() is called when the FrameView doesn't have the document or (body and documentElement), and the owner iframe/frame element has scrollbar corner style, then |renderer| will be NULL and it will crash.

* Source/WebCore/page/FrameView.cpp:
(FrameView::scrollAnimatorEnabled): Update to fix potential crash
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae82e0d51badbff71e9ecc9fd32c3b84a472606c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93953 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3142 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24518 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103586 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163923 "Hash ae82e0d5 for PR 4854 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97946 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3158 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31381 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86275 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99616 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/3158 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80376 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/86275 "Hash ae82e0d5 for PR 4854 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/3158 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/24518 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/86275 "Hash ae82e0d5 for PR 4854 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37770 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/24518 "Hash ae82e0d5 for PR 4854 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35640 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/24518 "Hash ae82e0d5 for PR 4854 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39513 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/80376 "Hash ae82e0d5 for PR 4854 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41452 "Hash ae82e0d5 for PR 4854 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/24518 "Hash ae82e0d5 for PR 4854 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->