### PR TITLE
Non-unified build fixes, last installment of September 2022 edition

### DIFF
--- a/Source/JavaScriptCore/runtime/ImportMap.h
+++ b/Source/JavaScriptCore/runtime/ImportMap.h
@@ -33,6 +33,8 @@
 
 namespace JSC {
 
+class SourceCode;
+
 class ImportMap final : public RefCounted<ImportMap> {
 public:
     using SpecifierMap = HashMap<String, URL>;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyArrayPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyArrayPrototype.cpp
@@ -28,8 +28,8 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "JSCJSValueInlines.h"
 #include "JSWebAssemblyArray.h"
-
 #include "WebAssemblyArrayPrototype.lut.h"
 
 namespace JSC {

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -33,6 +33,7 @@
 #include "FormData.h"
 #include "FormDataConsumer.h"
 #include "HTTPHeaderField.h"
+#include "HTTPParsers.h"
 #include "JSBlob.h"
 #include "JSDOMFormData.h"
 #include "RFC7230.h"

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -33,6 +33,7 @@
 #include "FeaturePolicy.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWakeLockSentinel.h"
+#include "Page.h"
 #include "PermissionController.h"
 #include "PermissionQuerySource.h"
 #include "PermissionState.h"

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
@@ -29,6 +29,7 @@
 #include "WakeLockType.h"
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/CustomElementDefaultARIA.cpp
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.cpp
@@ -27,6 +27,7 @@
 #include "CustomElementDefaultARIA.h"
 
 #include "Element.h"
+#include "ElementInlines.h"
 #include "HTMLNames.h"
 #include "SpaceSplitString.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/dom/LoadableClassicScript.h
+++ b/Source/WebCore/dom/LoadableClassicScript.h
@@ -34,6 +34,8 @@
 
 namespace WebCore {
 
+class WeakPtrImplWithEventTargetData;
+
 // A CachedResourceHandle alone does not prevent the underlying CachedResource
 // from purging its data buffer. This class holds a client until this class is
 // destroyed in order to guarantee that the data buffer will not be purged.

--- a/Source/WebCore/dom/VisibilityChangeClient.h
+++ b/Source/WebCore/dom/VisibilityChangeClient.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/WeakPtr.h>
+
 namespace WebCore {
 
 class VisibilityChangeClient : public CanMakeWeakPtr<VisibilityChangeClient> {

--- a/Source/WebCore/html/HTMLTemplateElement.cpp
+++ b/Source/WebCore/html/HTMLTemplateElement.cpp
@@ -33,8 +33,10 @@
 
 #include "Document.h"
 #include "DocumentFragment.h"
+#include "ElementInlines.h"
 #include "ElementRareData.h"
 #include "HTMLNames.h"
+#include "NodeTraversal.h"
 #include "ShadowRoot.h"
 #include "ShadowRootInit.h"
 #include "SlotAssignmentMode.h"

--- a/Source/WebCore/platform/network/RFC7230.cpp
+++ b/Source/WebCore/platform/network/RFC7230.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include "RFC7230.h"
 
+#include <wtf/ASCIICType.h>
+#include <wtf/text/StringView.h>
+
 namespace RFC7230 {
 
 bool isTokenCharacter(UChar c)

--- a/Source/WebCore/platform/network/RFC7230.h
+++ b/Source/WebCore/platform/network/RFC7230.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <unicode/umachine.h>
 #include <wtf/Forward.h>
 
 namespace RFC7230 {


### PR DESCRIPTION
#### 228f5dadafce6303dbb6a9f66eb1469ec8c39bb0
<pre>
Non-unified build fixes, last installment of September 2022 edition

Unreviewed non-unified build fixes.

* Source/JavaScriptCore/runtime/ImportMap.h: Add missing forward
  declaration for the JSC::Source type.
* Source/JavaScriptCore/wasm/js/WebAssemblyArrayPrototype.cpp: Add
  missing inclusion of the JSCJSValueInlines.h header.
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp: Add missing
  inclusion of the HTTPParsers.h header.
* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp: Add missing
  inclusion of the Page.h header.
* Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h: Add missing
  inclusion of the wtf/WeakPtr.h header.
* Source/WebCore/dom/CustomElementDefaultARIA.cpp: Add missing inclusion
  of the ElementInlines.h header.
* Source/WebCore/dom/LoadableClassicScript.h: Add missing forward
  declaration for the WebCore::WeakPtrImplWithEventTargetData type.
* Source/WebCore/dom/VisibilityChangeClient.h: Add missing inclusion of
  the wtf/WeakPtr.h header.
* Source/WebCore/html/HTMLTemplateElement.cpp: Add missing inclusion of
  the ElementInlines.h and NodeTraversal.h headers.Source
* Source/WebCore/platform/network/RFC7230.cpp: Add missing inclusion of
  the wtf/ASCIICType.h and wtf/text/StringView.h headers.
* Source/WebCore/platform/network/RFC7230.h: Add missing inclusion of
  the unicode/umachine.h header to bring the definitions of the UChar
  and LChar types into scope.

Canonical link: <a href="https://commits.webkit.org/255025@main">https://commits.webkit.org/255025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58cbc1642bb26f419b9cdc134e70436c145add1a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/52 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100505 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/159544 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/58 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83419 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97187 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96719 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/49 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27024 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/81655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70058 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/82554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35212 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/15677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77565 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33009 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/16675 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26722 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3498 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36791 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80163 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35759 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17569 "Passed tests") | 
<!--EWS-Status-Bubble-End-->