### PR TITLE
SuspendableWorkQueue suspend semantics might cause data loss

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -790,6 +790,7 @@ void NetworkStorageManager::handleLowMemoryWarning()
 {
     ASSERT(RunLoop::isMain());
 
+    bool wasSuspended = m_queue->resume() == SuspendableWorkQueue::WasSuspended;
     m_queue->dispatch([this, protectedThis = Ref { *this }] {
         for (auto& manager : m_originStorageManagers.values()) {
             if (auto localStorageManager = manager->existingLocalStorageManager())
@@ -798,12 +799,15 @@ void NetworkStorageManager::handleLowMemoryWarning()
                 idbStorageManager->handleLowMemoryWarning();
         }
     });
+    if (wasSuspended)
+        m_queue->suspend();
 }
 
 void NetworkStorageManager::syncLocalStorage(CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
 
+    bool wasSuspended = m_queue->resume() == SuspendableWorkQueue::WasSuspended;
     m_queue->dispatch([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
         for (auto& manager : m_originStorageManagers.values()) {
             if (auto localStorageManager = manager->existingLocalStorageManager())
@@ -812,6 +816,8 @@ void NetworkStorageManager::syncLocalStorage(CompletionHandler<void()>&& complet
 
         RunLoop::main().dispatch(WTFMove(completionHandler));
     });
+    if (wasSuspended)
+        m_queue->suspend();
 }
 
 void NetworkStorageManager::registerTemporaryBlobFilePaths(IPC::Connection& connection, const Vector<String>& filePaths)


### PR DESCRIPTION
#### 33ca69ad6de0a2225ccda3291ba467802f68e29e
<pre>
SuspendableWorkQueue suspend semantics might cause data loss
<a href="https://bugs.webkit.org/show_bug.cgi?id=245877">https://bugs.webkit.org/show_bug.cgi?id=245877</a>
rdar://problem/100609420

Reviewed by NOBODY (OOPS!).

Problems with the API semantics
 - Would skip existing pre-suspend tasks, even though their typical use is to flush
   the critical data
 - Pre-suspend task would skip ahead of already submitted tasks, causing surprising
   ordering
 - Suspension would happen in non-deterministic way. Task sequence 1,2,3,s,4
   could get suspended anywhere between 1-3.
 - No notion of submitting critical tasks during suspension.

Instead redefine semantics:
 - Pre-suspend function is always run. This prevents issues like destroying the
   pre-suspend function in the calling thread instead of the expected run thread.
 - Suspension always happens at specific moment: after preceeding tasks have
   executed. 1,2,3,s,4 would suspend after 3.

Fix implementation issues:
 - Skipped pre-suspend function was destroyed under lock. This would cause a
   deadlock if the function destructor would try to lock the lock.
 - Active suspension of the work queue would reserve one dispatch queue thread
   needlessly.

Fix API consumer NetworkStorageManager:
 - When running syncLocalStorage during suspension, make sure the sync is
   actually run instead of suspended.

Fix the existing tests:
 - There are no more data races to shared variables, so remove the locking to
   avoid confusion.

* Source/WTF/wtf/SuspendableWorkQueue.cpp:
(WTF::SuspendableWorkQueue::SuspendableWorkQueue):
(WTF::SuspendableWorkQueue::suspend):
(WTF::SuspendableWorkQueue::resume):
(WTF::SuspendableWorkQueue::dispatch):
(WTF::SuspendableWorkQueue::dispatchAfter):
(WTF::SuspendableWorkQueue::dispatchSync):
(WTF::SuspendableWorkQueue::invokeAllSuspensionCompletionHandlers): Deleted.
(WTF::SuspendableWorkQueue::suspendIfNeeded): Deleted.
* Source/WTF/wtf/SuspendableWorkQueue.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::handleLowMemoryWarning):
(WebKit::NetworkStorageManager::syncLocalStorage):
* Tools/TestWebKitAPI/Tests/WTF/SuspendableWorkQueue.cpp:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33ca69ad6de0a2225ccda3291ba467802f68e29e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/66 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100533 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/159585 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/73 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29129 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83432 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97200 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/57 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77842 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27030 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70064 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82561 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35225 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15686 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77578 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33022 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16685 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26726 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39636 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80176 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35769 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17573 "Passed tests") | 
<!--EWS-Status-Bubble-End-->