### PR TITLE
Fix ASAN false positives when dumping dissassembly

### DIFF
--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -237,7 +237,8 @@ void Value::deepDump(const Procedure* proc, PrintStream& out) const
             out.print(comma, string);
     }
 
-    if (m_origin)
+    // This origin is cleared by freeDFGIRAfterLowering()
+    if (m_origin && Options::dumpDisassembly())
         out.print(comma, OriginDump(proc, m_origin));
 
     out.print(")");

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -733,7 +733,7 @@ private:
 #if ASSERT_ENABLED
     String m_compilerConstructionSite { generateCompilerConstructionSite() };
 
-    static String generateCompilerConstructionSite();
+    static SUPPRESS_ASAN String generateCompilerConstructionSite();
 #endif
 
 public:

--- a/Source/JavaScriptCore/b3/air/AirInst.cpp
+++ b/Source/JavaScriptCore/b3/air/AirInst.cpp
@@ -89,7 +89,8 @@ unsigned Inst::jsHash() const
 void Inst::dump(PrintStream& out) const
 {
     out.print(kind, " ", listDump(args));
-    if (origin) {
+    // origin is freed by freeUnneededB3ValuesAfterLowering unless shouldPreserveB3Origins() is true.
+    if (origin && Options::dumpDisassembly()) {
         if (args.size())
             out.print(", ");
         out.print(*origin);

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2196,6 +2196,14 @@ DFG::CapabilityLevel CodeBlock::computeCapabilityLevel()
 
 #endif // ENABLE(JIT)
 
+#if ENABLE(DFG_JIT)
+SUPPRESS_ASAN
+static void dumpDetail(const FireDetail* detail)
+{
+    dataLog(*detail);
+}
+#endif
+
 void CodeBlock::jettison(Profiler::JettisonReason reason, ReoptimizationMode mode, const FireDetail* detail)
 {
 #if !ENABLE(DFG_JIT)
@@ -2218,8 +2226,10 @@ void CodeBlock::jettison(Profiler::JettisonReason reason, ReoptimizationMode mod
         if (mode == CountReoptimization)
             dataLog(" and counting reoptimization");
         dataLog(" due to ", reason);
-        if (detail)
-            dataLog(", ", *detail);
+        if (detail) {
+            dataLog(", ");
+            dumpDetail(detail);
+        }
         dataLog(".\n");
     }
     

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -228,14 +228,14 @@ WTF_EXPORT_PRIVATE void WTFLogWithLevel(WTFLogChannel*, WTFLogLevel, const char*
 WTF_EXPORT_PRIVATE void WTFSetLogChannelLevel(WTFLogChannel*, WTFLogLevel);
 WTF_EXPORT_PRIVATE bool WTFWillLogWithLevel(WTFLogChannel*, WTFLogLevel);
 
-WTF_EXPORT_PRIVATE NEVER_INLINE void WTFGetBacktrace(void** stack, int* size);
-WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefix(const char*);
-WTF_EXPORT_PRIVATE void WTFReportBacktrace(void);
+WTF_EXPORT_PRIVATE SUPPRESS_ASAN NEVER_INLINE void WTFGetBacktrace(void** stack, int* size);
+WTF_EXPORT_PRIVATE SUPPRESS_ASAN void WTFReportBacktraceWithPrefix(const char*);
+WTF_EXPORT_PRIVATE SUPPRESS_ASAN void WTFReportBacktrace(void);
 #ifdef __cplusplus
-WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, const char*);
-WTF_EXPORT_PRIVATE void WTFPrintBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, void** stack, int size, const char* prefix);
+WTF_EXPORT_PRIVATE SUPPRESS_ASAN void WTFReportBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, const char*);
+WTF_EXPORT_PRIVATE SUPPRESS_ASAN void WTFPrintBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, void** stack, int size, const char* prefix);
 #endif
-WTF_EXPORT_PRIVATE void WTFPrintBacktrace(void** stack, int size);
+WTF_EXPORT_PRIVATE SUPPRESS_ASAN void WTFPrintBacktrace(void** stack, int size);
 #if !RELEASE_LOG_DISABLED
 WTF_EXPORT_PRIVATE void WTFReleaseLogStackTrace(WTFLogChannel*);
 #endif


### PR DESCRIPTION
#### 1a39dd6a08839e5567bcbd356e9e78114388598f
<pre>
Fix ASAN false positives when dumping dissassembly
<a href="https://bugs.webkit.org/show_bug.cgi?id=245896">https://bugs.webkit.org/show_bug.cgi?id=245896</a>

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::dumpDetail):
(JSC::CodeBlock::jettison):
* Source/WTF/wtf/Assertions.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4e2d2b0d3da16ac1e06537387eb66389cebdac3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104808 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165067 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4464 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33511 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100703 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3257 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82001 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30221 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/86993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73123 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/86311 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38940 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18551 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/81577 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36756 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19834 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28073 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42731 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/84251 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39076 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19039 "Passed tests") | 
<!--EWS-Status-Bubble-End-->