### PR TITLE
Shrink shorthandPropertyUsed and shorthandPropertyAppeared

### DIFF
--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -1604,8 +1604,9 @@ StringBuilder StyleProperties::asTextInternal() const
     int positionXPropertyIndex = -1;
     int positionYPropertyIndex = -1;
 
-    std::bitset<numCSSProperties> shorthandPropertyUsed;
-    std::bitset<numCSSProperties> shorthandPropertyAppeared;
+    constexpr unsigned shorthandPropertyCount = lastShorthandProperty - firstShorthandProperty + 1;
+    std::bitset<shorthandPropertyCount> shorthandPropertyUsed;
+    std::bitset<shorthandPropertyCount> shorthandPropertyAppeared;
 
     unsigned size = propertyCount();
     unsigned numDecls = 0;
@@ -1866,7 +1867,8 @@ StringBuilder StyleProperties::asTextInternal() const
 
         bool alreadyUsedShorthand = false;
         for (auto& shorthandPropertyID : shorthands) {
-            unsigned shorthandPropertyIndex = shorthandPropertyID - firstCSSProperty;
+            ASSERT(isShorthandCSSProperty(shorthandPropertyID));
+            unsigned shorthandPropertyIndex = shorthandPropertyID - firstShorthandProperty;
 
             ASSERT(shorthandPropertyIndex < shorthandPropertyUsed.size());
             if (shorthandPropertyUsed[shorthandPropertyIndex]) {


### PR DESCRIPTION
#### 6f687d430ca3b583d595920c141d8f938f090250
<pre>
Shrink shorthandPropertyUsed and shorthandPropertyAppeared
<a href="https://bugs.webkit.org/show_bug.cgi?id=245901">https://bugs.webkit.org/show_bug.cgi?id=245901</a>

Reviewed by Tim Nguyen.

This patch should have no change in behavior.

* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::asTextInternal const):
This method uses two bitsets, which had a size of numCSSProperties.
But as the name implies, they are only used for shorthand properties,
which are sorted together since bug 238888.
So the bitset size can be reduced to the number of shorthand properties.

Canonical link: <a href="https://commits.webkit.org/255059@main">https://commits.webkit.org/255059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a61fce7fb2a96d68c8c378e42246da05f42a3d65

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100632 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/160114 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95134 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/140 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29167 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83490 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97247 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/102 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77883 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27087 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70120 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35277 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15728 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33073 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16735 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3514 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39657 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35819 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->