### PR TITLE
[Cocoa] Instruct ArgumentCoderCocoa to use the full set of classes used by NSAttributedString

### DIFF
--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -59,6 +59,10 @@
 @property (nonatomic, readonly) CGColorRef wrappedColor;
 @end
 
+@interface NSAttributedString (NSAttributedString_SecureCoding)
+@property (class, readonly) NSSet<Class> *allowedSecureCodingClasses;
+@end
+
 @implementation WKSecureCodingArchivingDelegate
 
 - (id)archiver:(NSKeyedArchiver *)archiver willEncodeObject:(id)object
@@ -492,7 +496,10 @@ static std::optional<RetainPtr<id>> decodeSecureCodingInternal(Decoder& decoder,
     auto allowedClassSet = adoptNS([[NSMutableSet alloc] initWithArray:allowedClasses]);
     [allowedClassSet addObject:WKSecureCodingURLWrapper.class];
     [allowedClassSet addObject:WKSecureCodingCGColorWrapper.class];
-    
+
+    if ([allowedClasses containsObject:NSAttributedString.class])
+        [allowedClassSet unionSet:NSAttributedString.allowedSecureCodingClasses];
+
     @try {
         id result = [unarchiver decodeObjectOfClasses:allowedClassSet.get() forKey:NSKeyedArchiveRootObjectKey];
         ASSERT(!result || [result conformsToProtocol:@protocol(NSSecureCoding)]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdditionalReadAccessAllowedURLs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdditionalReadAccessAllowedURLs.mm
@@ -113,7 +113,6 @@ TEST(WebKit, AdditionalReadAccessAllowedURLs)
     TestWebKitAPI::Util::run(&done);
 }
 
-#if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
 TEST(WebKit, NSAttributedStringWithReadOnlyPaths)
 {
     __block bool done = false;
@@ -230,7 +229,6 @@ TEST(WebKit, NSAttributedStringWithAndWithoutReadOnlyPaths)
     }];
     TestWebKitAPI::Util::run(&done);
 }
-#endif
 
 TEST(WebKit, NSAttributedStringWithoutReadOnlyPaths)
 {


### PR DESCRIPTION
#### 171714d05e199d70810d76acfe3394583629ad4e
<pre>
[Cocoa] Instruct ArgumentCoderCocoa to use the full set of classes used by NSAttributedString
<a href="https://bugs.webkit.org/show_bug.cgi?id=245903">https://bugs.webkit.org/show_bug.cgi?id=245903</a>
&lt;rdar://problem/100640104&gt;

Reviewed by Chris Dumez.

This patch updates our ArgumentCodersCocoa logic to properly handle NSAttributedString. This
new implementation now matches the behavior of the Foundation framework. This also allows us
to unskip two tests on Big Sur (and earlier) that would fail during decoding.

* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::decodeSecureCodingInternal): Adopt NSAttributedString SPI for serialization.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AdditionalReadAccessAllowedURLs.mm:
(TEST): Unskip tests.

Canonical link: <a href="https://commits.webkit.org/255076@main">https://commits.webkit.org/255076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93ce58f6bfb032e076b425f344d7499f0f0a358d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100639 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/160068 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/142 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29169 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97249 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/106 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77885 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27081 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70115 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35279 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15727 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33075 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16734 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3525 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39659 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35818 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->