### PR TITLE
Send bogus registration if no credentials match for U2F authenticators

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f-silent.https.html
@@ -28,7 +28,7 @@
         };
 
         if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ silentFailure: true, hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64] } });
+            internals.setMockWebAuthenticationConfiguration({ silentFailure: true, hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64] } });
         return promiseRejects(t, "NotAllowedError", navigator.credentials.get(options), "Operation timed out.");
     }, "PublicKeyCredential's [[get]] with no matched allow credentials in a mock hid authenticator.");
 
@@ -42,7 +42,7 @@
         };
 
         if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ silentFailure: true, hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64] } });
+            internals.setMockWebAuthenticationConfiguration({ silentFailure: true, hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64] } });
         return promiseRejects(t, "NotAllowedError", navigator.credentials.get(options), "Operation timed out.");
     }, "PublicKeyCredential's [[get]] with no matched allow credentials in a mock hid authenticator. 2");
 </script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https.html
@@ -26,7 +26,7 @@
         };
 
         if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64] } });
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduNoErrorOnlyResponseBase64] } });
         return promiseRejects(t, "NotAllowedError", navigator.credentials.get(options), "No credentials from the allowCredentials list is found in the authenticator.");
     }, "PublicKeyCredential's [[get]] with no matched allow credentials in a mock hid authenticator.");
 
@@ -39,7 +39,7 @@
         };
 
         if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64] } });
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fApduNoErrorOnlyResponseBase64] } });
         return promiseRejects(t, "NotAllowedError", navigator.credentials.get(options), "No credentials from the allowCredentials list is found in the authenticator.");
     }, "PublicKeyCredential's [[get]] with no matched allow credentials in a mock hid authenticator. 2");
 
@@ -54,7 +54,7 @@
         };
 
         if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64] } });
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fApduNoErrorOnlyResponseBase64] } });
         return promiseRejects(t, "NotAllowedError", navigator.credentials.get(options), "No credentials from the allowCredentials list is found in the authenticator.");
     }, "PublicKeyCredential's [[get]] with no matched allow credentials in a mock hid authenticator. (AppID)");
 
@@ -68,7 +68,7 @@
         };
 
         if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64] } });
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fApduNoErrorOnlyResponseBase64] } });
         return promiseRejects(t, "NotAllowedError", navigator.credentials.get(options), "No credentials from the allowCredentials list is found in the authenticator.");
     }, "PublicKeyCredential's [[get]] with no matched allow credentials in a mock hid authenticator. 2 (AppID)");
 </script>

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.h
@@ -57,7 +57,8 @@ private:
     enum class CommandType : uint8_t {
         RegisterCommand,
         CheckOnlyCommand,
-        BogusCommand,
+        BogusCommandExcludeCredentialsMatch,
+        BogusCommandNoCredentials,
         SignCommand
     };
     void issueNewCommand(Vector<uint8_t>&& command, CommandType);
@@ -66,7 +67,8 @@ private:
     void responseReceived(Vector<uint8_t>&& response, CommandType);
     void continueRegisterCommandAfterResponseReceived(apdu::ApduResponse&&);
     void continueCheckOnlyCommandAfterResponseReceived(apdu::ApduResponse&&);
-    void continueBogusCommandAfterResponseReceived(apdu::ApduResponse&&);
+    void continueBogusCommandExcludeCredentialsMatchAfterResponseReceived(apdu::ApduResponse&&);
+    void continueBogusCommandNoCredentialsAfterResponseReceived(apdu::ApduResponse&&);
     void continueSignCommandAfterResponseReceived(apdu::ApduResponse&&);
 
     RunLoop::Timer<U2fAuthenticator> m_retryTimer;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/web-authentication-get-assertion-u2f-no-credentials.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/web-authentication-get-assertion-u2f-no-credentials.html
@@ -1,8 +1,9 @@
 <input type="text" id="input">
 <script>
     const testU2fApduWrongDataOnlyResponseBase64 = "aoA=";
+    const testU2fApduNoErrorOnlyResponseBase64 = "kAA=";
     if (window.internals) {
-        internals.setMockWebAuthenticationConfiguration({ silentFailure: true, hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64] } });
+        internals.setMockWebAuthenticationConfiguration({ silentFailure: true, hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduNoErrorOnlyResponseBase64] } });
         internals.withUserGesture(() => { input.focus(); });
     }
 


### PR DESCRIPTION
#### 848a8058df32588840ba1125a351816c765d7d24
<pre>
Send bogus registration if no credentials match for U2F authenticators
<a href="https://bugs.webkit.org/show_bug.cgi?id=245904">https://bugs.webkit.org/show_bug.cgi?id=245904</a>
&lt;rdar://100329828&gt;

Reviewed by Brent Fulgham.

U2F authenticators should wait for a tap before showing the no credentials status, just like
FIDO2 authenticators. This patch accomplishes that by sending a bogus register command whenever
there are no matching credentials from the allow list. The code already did that for registrations,
this starts doing it for assertions.

* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp:
(WebKit::U2fAuthenticator::issueSignCommand):
(WebKit::U2fAuthenticator::responseReceived):
(WebKit::U2fAuthenticator::continueCheckOnlyCommandAfterResponseReceived):
(WebKit::U2fAuthenticator::continueBogusCommandExcludeCredentialsMatchAfterResponseReceived):
(WebKit::U2fAuthenticator::continueBogusCommandNoCredentialsAfterResponseReceived):
(WebKit::U2fAuthenticator::continueBogusCommandAfterResponseReceived): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.h:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f-silent.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https.html:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/web-authentication-get-assertion-u2f-no-credentials.html:

Canonical link: <a href="https://commits.webkit.org/255273@main">https://commits.webkit.org/255273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96ac159defb31ee90ae5a89ed9c5809ab2ce332b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101542 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161664 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1109 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29595 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84191 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97938 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/680 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78440 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/27644 "Build was cancelled. Recent messages:Cleaned up git repository; Running checkout-specific-revision; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; 23 flakes 1 missing results 66 failures; 8 flakes 1 missing results 57 failures; Reverted pull request changes; Compiled WebKit (cancelled)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82601 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70683 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35969 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16231 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/33714 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17331 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3652 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37576 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40045 "Found 3 new test failures: http/wpt/service-workers/fetch-service-worker-preload.https.html, imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h264_annexb, imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_annexb (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36450 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->