### PR TITLE
Migrate from UIImagePickerController to PHPickerViewController for image/video upload UI

### DIFF
--- a/Source/WebKit/Platform/spi/ios/PhotosUISPI.h
+++ b/Source/WebKit/Platform/spi/ios/PhotosUISPI.h
@@ -23,19 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if HAVE(PHOTOS_UI)
+
+#import <PhotosUI/PhotosUI.h>
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #if HAVE(PHOTOS_UI_PRIVATE)
 #import <PhotosUIPrivate/PUActivityProgressController.h>
-#elif HAVE(PHOTOS_UI)
+#else
 #import <PhotosUI/PUActivityProgressController.h>
 #endif
+
+#import <PhotosUI/PHPicker_Private.h>
 
 #else
 
 #import "UIKitSPI.h"
-
-#if HAVE(PHOTOS_UI)
 
 @interface PUActivityProgressController : NSObject
 
@@ -52,6 +56,12 @@
 
 @end
 
-#endif // HAVE(PHOTOS_UI)
+@interface PHPickerConfiguration ()
+
+@property (nonatomic, setter=_setAllowsDownscaling:) BOOL _allowsDownscaling;
+
+@end
 
 #endif // USE(APPLE_INTERNAL_SDK)
+
+#endif // HAVE(PHOTOS_UI)

--- a/Source/WebKit/Shared/Cocoa/WebIconUtilities.mm
+++ b/Source/WebKit/Shared/Cocoa/WebIconUtilities.mm
@@ -116,6 +116,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 }
 
+const CFStringRef kCGImageSourceEnableRestrictedDecoding = CFSTR("kCGImageSourceEnableRestrictedDecoding");
+
 PlatformImagePtr iconForImageFile(NSURL *file)
 {
     ASSERT_ARG(file, [file isFileURL]);
@@ -124,6 +126,7 @@ PlatformImagePtr iconForImageFile(NSURL *file)
         (id)kCGImageSourceCreateThumbnailFromImageIfAbsent: @YES,
         (id)kCGImageSourceThumbnailMaxPixelSize: @(iconSideLength),
         (id)kCGImageSourceCreateThumbnailWithTransform: @YES,
+        (id)kCGImageSourceEnableRestrictedDecoding: @YES
     };
     RetainPtr<CGImageSource> imageSource = adoptCF(CGImageSourceCreateWithURL((CFURLRef)file, 0));
     RetainPtr<CGImageRef> thumbnail = adoptCF(CGImageSourceCreateThumbnailAtIndex(imageSource.get(), 0, (CFDictionaryRef)options));


### PR DESCRIPTION
#### b82f73d063f37521fa94194d4cba86d0538c31df
<pre>
Migrate from UIImagePickerController to PHPickerViewController for image/video upload UI
<a href="https://bugs.webkit.org/show_bug.cgi?id=245906">https://bugs.webkit.org/show_bug.cgi?id=245906</a>
rdar://82449143

Reviewed by Aditya Keerthi.

Adopts the `PHPickerViewController` API for selecting media for file input fields
as `UIImagePickerController` is deprecated for the purpose of selecting media
from the Photo Library.

* Source/WebKit/Platform/spi/ios/PhotosUISPI.h:
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(firstUTIThatConformsTo):
(-[WKFileUploadPanel presentWithParameters:resultListener:]):
(-[WKFileUploadPanel _dismissDisplayAnimated:]):
(-[WKFileUploadPanel contextMenuInteraction:configurationForMenuAtLocation:]):
(-[WKFileUploadPanel _showCamera]):
(-[WKFileUploadPanel _showPhotoPicker]):
(-[WKFileUploadPanel picker:didFinishPicking:]):
(-[WKFileUploadPanel _processPickerResults:successBlock:failureBlock:]):
(-[WKFileUploadPanel _processPickerResults:atIndex:processedResults:successBlock:failureBlock:]):
(-[WKFileUploadPanel _uploadItemFromResult:successBlock:failureBlock:]):
(-[WKFileUploadPanel _showPhotoPickerWithSourceType:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/255435@main">https://commits.webkit.org/255435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97af1083c79a50b0cf70d3a32db017da6ae56d0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102168 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1626 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30009 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84830 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98326 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1078 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78914 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28016 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82688 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36424 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16630 "Found 1 new test failure: webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34192 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17801 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3769 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40417 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36952 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->