### PR TITLE
Remove some dead code after Bug 245396

### DIFF
--- a/Source/WebCore/plugins/PluginData.cpp
+++ b/Source/WebCore/plugins/PluginData.cpp
@@ -77,41 +77,6 @@ const Vector<PluginInfo>& PluginData::webVisiblePlugins() const
     return *m_cachedVisiblePlugins.pluginList;
 }
 
-static bool shouldBePubliclyVisible(const PluginInfo& plugin)
-{
-    // We can greatly reduce fingerprinting opportunities by only advertising plug-ins
-    // that are widely needed for general website compatibility. Since many users
-    // will have these plug-ins, we are not revealing much user-specific information.
-    //
-    // Web compatibility data indicate that Flash, QuickTime, Java, and PDF support
-    // are frequently accessed through the bad practice of iterating over the contents
-    // of the navigator.plugins list. Luckily, these plug-ins happen to be the least
-    // user-specific.
-    return plugin.name.containsIgnoringASCIICase("Shockwave"_s)
-        || plugin.name.containsIgnoringASCIICase("QuickTime"_s)
-        || plugin.name.containsIgnoringASCIICase("Java"_s)
-        || isBuiltInPDFPlugIn(plugin);
-}
-
-std::pair<Vector<PluginInfo>, Vector<PluginInfo>> PluginData::publiclyVisiblePluginsAndAdditionalWebVisiblePlugins() const
-{
-    auto plugins = webVisiblePlugins();
-
-    if (m_page.showAllPlugins())
-        return { plugins, { } };
-
-    Vector<PluginInfo> additionalWebVisiblePlugins;
-    plugins.removeAllMatching([&](auto& plugin) {
-        if (!shouldBePubliclyVisible(plugin)) {
-            additionalWebVisiblePlugins.append(plugin);
-            return true;
-        }
-        return false;
-    });
-
-    return { plugins, additionalWebVisiblePlugins };
-}
-
 Vector<MimeClassInfo> PluginData::webVisibleMimeTypes() const
 {
     Vector<MimeClassInfo> result;

--- a/Source/WebCore/plugins/PluginData.h
+++ b/Source/WebCore/plugins/PluginData.h
@@ -99,8 +99,6 @@ public:
 
     const Vector<PluginInfo>& plugins() const { return m_plugins; }
     WEBCORE_EXPORT const Vector<PluginInfo>& webVisiblePlugins() const;
-    std::pair<Vector<PluginInfo>, Vector<PluginInfo>> publiclyVisiblePluginsAndAdditionalWebVisiblePlugins() const;
-
     WEBCORE_EXPORT Vector<MimeClassInfo> webVisibleMimeTypes() const;
 
     enum AllowedPluginTypes {


### PR DESCRIPTION
#### af20d024151be38a6c90d8ebbb8df80454f44718
<pre>
Remove some dead code after Bug 245396
<a href="https://bugs.webkit.org/show_bug.cgi?id=245916">https://bugs.webkit.org/show_bug.cgi?id=245916</a>
&lt;rdar://problem/100643178&gt;

Reviewed by Chris Dumez.

SSIA.

* Source/WebCore/plugins/PluginData.cpp:
(WebCore::shouldBePubliclyVisible): Deleted.
(WebCore::PluginData::publiclyVisiblePluginsAndAdditionalWebVisiblePlugins const): Deleted.
* Source/WebCore/plugins/PluginData.h:

Canonical link: <a href="https://commits.webkit.org/255101@main">https://commits.webkit.org/255101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5de7685e96b08c5b726badef64441637269a14c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100653 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/160172 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/156 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29180 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97261 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96800 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/115 "Found 1 new test failure: fast/forms/ios/file-upload-panel-capture.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77896 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27096 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70129 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35291 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15736 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33087 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16745 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3546 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39665 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35829 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->