### PR TITLE
Dynamic Content Scaling resource cache cannot cache images between layers

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -515,6 +515,7 @@ platform/graphics/mac/controls/TextFieldMac.mm
 platform/graphics/mac/controls/ToggleButtonMac.mm
 platform/graphics/mac/controls/WebControlView.mm
 platform/graphics/opentype/OpenTypeCG.cpp
+platform/graphics/re/DynamicContentScalingResourceCache.mm
 platform/image-decoders/avif/AVIFImageDecoder.cpp
 platform/image-decoders/avif/AVIFImageReader.cpp
 platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -38,6 +38,14 @@
 #include <wtf/RefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+#include "DynamicContentScalingResourceCache.h"
+#endif
+
+#if HAVE(IOSURFACE)
+#include "IOSurface.h"
+#endif
+
 namespace WTF {
 class TextStream;
 }
@@ -49,7 +57,6 @@ class DynamicContentScalingDisplayList;
 class Filter;
 class GraphicsClient;
 #if HAVE(IOSURFACE)
-class IOSurface;
 class IOSurfacePool;
 #endif
 class ScriptExecutionContext;
@@ -66,9 +73,12 @@ struct ImageBufferCreationContext {
     IOSurfacePool* surfacePool { nullptr };
     PlatformDisplayID displayID { 0 };
 #endif
-    WebCore::ProcessIdentity resourceOwner;
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    DynamicContentScalingResourceCache dynamicContentScalingResourceCache;
+#endif
+    ProcessIdentity resourceOwner;
 
-    ImageBufferCreationContext() = default; // To guarantee order in presence of ifdefs, use individual .property to initialize them.
+    ImageBufferCreationContext() = default;
 };
 
 struct ImageBufferParameters {

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -30,7 +30,7 @@
 #include "DestinationColorSpace.h"
 #include "IntSize.h"
 #include "ProcessIdentity.h"
-#include <CoreGraphics/CGImage.h>
+#include <CoreGraphics/CoreGraphics.h>
 #include <objc/objc.h>
 #include <wtf/spi/cocoa/IOSurfaceSPI.h>
 

--- a/Source/WebCore/platform/graphics/re/DynamicContentScalingResourceCache.h
+++ b/Source/WebCore/platform/graphics/re/DynamicContentScalingResourceCache.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class DynamicContentScalingResourceCache : public RetainPtr<id> {
+public:
+    WEBCORE_EXPORT static DynamicContentScalingResourceCache create();
+
+    DynamicContentScalingResourceCache()
+        : RetainPtr<id>()
+    {
+    }
+
+    DynamicContentScalingResourceCache(RetainPtr<id>&& object)
+        : RetainPtr<id>(WTFMove(object))
+    {
+    }
+};
+
+}
+
+#endif

--- a/Source/WebCore/platform/graphics/re/DynamicContentScalingResourceCache.mm
+++ b/Source/WebCore/platform/graphics/re/DynamicContentScalingResourceCache.mm
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import "config.h"
+#import "DynamicContentScalingResourceCache.h"
+
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+
+#import <CoreRE/RECGCommandsContext.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
+
+namespace WebCore {
+
+DynamicContentScalingResourceCache DynamicContentScalingResourceCache::create()
+{
+    return bridge_id_cast(adoptCF(RECGCommandsCacheCreate(nullptr)));
+}
+
+}
+
+#endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -277,8 +277,10 @@ RefPtr<ImageBuffer> RemoteRenderingBackend::allocateImageBuffer(const FloatSize&
     RefPtr<ImageBuffer> imageBuffer;
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    if (m_gpuConnectionToWebProcess->isDynamicContentScalingEnabled() && (purpose == RenderingPurpose::LayerBacking || purpose == RenderingPurpose::DOM))
+    if (m_gpuConnectionToWebProcess->isDynamicContentScalingEnabled() && (purpose == RenderingPurpose::LayerBacking || purpose == RenderingPurpose::DOM)) {
+        creationContext.dynamicContentScalingResourceCache = ensureDynamicContentScalingResourceCache();
         imageBuffer = allocateImageBufferInternal<DynamicContentScalingBifurcatedImageBuffer>(logicalSize, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat, creationContext, imageBufferIdentifier);
+    }
 #endif
 
     if (!imageBuffer)
@@ -576,6 +578,15 @@ void RemoteRenderingBackend::terminateWebProcess(ASCIILiteral message)
         m_gpuConnectionToWebProcess->terminateWebProcess();
     }
 }
+
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+DynamicContentScalingResourceCache RemoteRenderingBackend::ensureDynamicContentScalingResourceCache()
+{
+    if (!m_dynamicContentScalingResourceCache)
+        m_dynamicContentScalingResourceCache = DynamicContentScalingResourceCache::create();
+    return m_dynamicContentScalingResourceCache;
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -177,6 +177,10 @@ private:
     void createDisplayListRecorder(RefPtr<WebCore::ImageBuffer>, WebCore::RenderingResourceIdentifier);
     void releaseDisplayListRecorder(WebCore::RenderingResourceIdentifier);
 
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    WebCore::DynamicContentScalingResourceCache ensureDynamicContentScalingResourceCache();
+#endif
+
     Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     RemoteResourceCache m_remoteResourceCache;
@@ -186,6 +190,9 @@ private:
     RefPtr<SharedMemory> m_getPixelBufferSharedMemory;
 #if HAVE(IOSURFACE)
     Ref<WebCore::IOSurfacePool> m_ioSurfacePool;
+#endif
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    WebCore::DynamicContentScalingResourceCache m_dynamicContentScalingResourceCache;
 #endif
 
     HashMap<WebCore::RenderingResourceIdentifier, IPC::ScopedActiveMessageReceiveQueue<RemoteDisplayListRecorder>> m_remoteDisplayLists WTF_GUARDED_BY_CAPABILITY(workQueue());

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.h
@@ -50,6 +50,8 @@ public:
 
     WebCore::GraphicsContext& context() const final;
 
+    static WebCore::DynamicContentScalingResourceCache createResourceCache();
+
 protected:
     std::optional<WebCore::DynamicContentScalingDisplayList> dynamicContentScalingDisplayList() final;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm
@@ -29,6 +29,7 @@
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
 
 #import "DynamicContentScalingImageBufferBackend.h"
+#import <CoreRE/RECGCommandsContext.h>
 #import <WebCore/BifurcatedGraphicsContext.h>
 #import <WebCore/DynamicContentScalingDisplayList.h>
 #import <wtf/MachSendRight.h>

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
@@ -84,7 +84,7 @@ std::unique_ptr<DynamicContentScalingImageBufferBackend> DynamicContentScalingIm
 
 DynamicContentScalingImageBufferBackend::DynamicContentScalingImageBufferBackend(const Parameters& parameters, const WebCore::ImageBufferCreationContext& creationContext, WebCore::RenderingMode renderingMode)
     : ImageBufferCGBackend { parameters }
-    , m_resourceCache(bridge_id_cast(adoptCF(RECGCommandsCacheCreate(nullptr))))
+    , m_resourceCache(creationContext.dynamicContentScalingResourceCache)
     , m_renderingMode(renderingMode)
 {
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -240,8 +240,11 @@ RefPtr<WebCore::ImageBuffer> RemoteLayerWithInProcessRenderingBackingStore::allo
     creationContext.surfacePool = &WebCore::IOSurfacePool::sharedPool();
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    if (m_parameters.includeDisplayList == IncludeDisplayList::Yes)
+    if (m_parameters.includeDisplayList == IncludeDisplayList::Yes) {
+        if (auto* context = m_layer->context())
+            creationContext.dynamicContentScalingResourceCache = context->ensureDynamicContentScalingResourceCache();
         return allocateBufferInternal<DynamicContentScalingBifurcatedImageBuffer>(type(), size(), purpose, scale(), colorSpace(), pixelFormat(), creationContext);
+    }
 #endif
 
     return allocateBufferInternal<ImageBuffer>(type(), size(), purpose, scale(), colorSpace(), pixelFormat(), creationContext);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -92,6 +92,10 @@ public:
     bool useDynamicContentScalingDisplayListsForDOMRendering() const { return m_useDynamicContentScalingDisplayListsForDOMRendering; }
     void setUseDynamicContentScalingDisplayListsForDOMRendering(bool useDynamicContentScalingDisplayLists) { m_useDynamicContentScalingDisplayListsForDOMRendering = useDynamicContentScalingDisplayLists; }
 
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    WebCore::DynamicContentScalingResourceCache ensureDynamicContentScalingResourceCache();
+#endif
+
     void gpuProcessConnectionWasDestroyed();
 
 #if PLATFORM(IOS_FAMILY)
@@ -122,6 +126,10 @@ private:
     WebCore::LayerPool m_layerPool;
 
     RemoteLayerTreeTransaction* m_currentTransaction { nullptr };
+
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    WebCore::DynamicContentScalingResourceCache m_dynamicContentScalingResourceCache;
+#endif
 
     bool m_nextRenderingUpdateRequiresSynchronousImageDecoding { false };
     bool m_useDynamicContentScalingDisplayListsForDOMRendering { false };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -43,6 +43,10 @@
 #import <wtf/SetForScope.h>
 #import <wtf/SystemTracing.h>
 
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+#import "DynamicContentScalingBifurcatedImageBuffer.h"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -238,5 +242,17 @@ void RemoteLayerTreeContext::gpuProcessConnectionWasDestroyed()
 {
     m_backingStoreCollection->gpuProcessConnectionWasDestroyed();
 }
+
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+
+DynamicContentScalingResourceCache RemoteLayerTreeContext::ensureDynamicContentScalingResourceCache()
+{
+    if (!m_dynamicContentScalingResourceCache)
+        m_dynamicContentScalingResourceCache = DynamicContentScalingResourceCache::create();
+    return m_dynamicContentScalingResourceCache;
+}
+
+#endif
+
 
 } // namespace WebKit


### PR DESCRIPTION
#### e8c0db1780a3059ff32170d89dfe8be43aed1937
<pre>
Dynamic Content Scaling resource cache cannot cache images between layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=245920">https://bugs.webkit.org/show_bug.cgi?id=245920</a>
<a href="https://rdar.apple.com/100336143">rdar://100336143</a>

Reviewed by Said Abou-Hallawa.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::allocateImageBuffer):
(WebKit::RemoteRenderingBackend::ensureDynamicContentScalingResourceCache):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.h:
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm:
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::ensureDynamicContentScalingResourceCache):
* Source/WebCore/platform/graphics/re/DynamicContentScalingResourceCache.h: Added.
(WebCore::DynamicContentScalingResourceCache::DynamicContentScalingResourceCache):
* Source/WebCore/platform/graphics/re/DynamicContentScalingResourceCache.mm: Added.
(WebCore::DynamicContentScalingResourceCache::create):
Move CGDisplayList&apos;s image cache object up to RemoteLayerTreeContext (in the in-process case)
and RemoteRenderingBackend (in the GPU-process case), so that resources can be cached
across multiple layers.

* Source/WebCore/platform/graphics/ImageBuffer.h:
Note that it is not safe in a unified-sources world to forward-declare WebCore::IOSurface
because of the name conflict with ::IOSurface; we need to strictly order the declarations,
which is easiest to achieve by just importing our header.

Canonical link: <a href="https://commits.webkit.org/273240@main">https://commits.webkit.org/273240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/434a27564d5e9796c36bb354cd79644a59931877

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34828 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37516 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10738 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35357 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/11574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31014 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10107 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10186 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/31091 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38781 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31418 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34191 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12115 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7989 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10832 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->