### PR TITLE
Add _WKWebExtensionMatchPattern class.

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -66,4 +66,6 @@ T *objectForKey(const RetainPtr<NSDictionary>& dictionary, id key, bool returnin
     return objectForKey<T>(dictionary.get(), key, returningNilIfEmpty, containingObjectsOfClass);
 }
 
+NSString *escapeCharactersInString(NSString *, NSString *charactersToEscape);
+
 } // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -186,4 +186,31 @@ NSSet *objectForKey<NSSet>(NSDictionary *dictionary, id key, bool nilIfEmpty, Cl
     });
 }
 
+NSString *escapeCharactersInString(NSString *string, NSString *charactersToEscape)
+{
+    ASSERT(string);
+    ASSERT(charactersToEscape);
+
+    if (!string.length || !charactersToEscape.length)
+        return string;
+
+    NSCharacterSet *characterSet = [NSCharacterSet characterSetWithCharactersInString:charactersToEscape];
+    NSRange range = [string rangeOfCharacterFromSet:characterSet];
+
+    if (!range.length)
+        return string;
+
+    NSMutableString *result = [string mutableCopy];
+    while (range.length > 0) {
+        [result insertString:@"\\" atIndex:range.location];
+
+        if (NSMaxRange(range) + 1 >= result.length)
+            break;
+
+        range = [result rangeOfCharacterFromSet:characterSet options:0 range:NSMakeRange(NSMaxRange(range) + 1, result.length - NSMaxRange(range) - 1)];
+    }
+
+    return result;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -178,6 +178,7 @@ public:
 #if ENABLE(WK_WEB_EXTENSIONS)
         WebExtension,
         WebExtensionController,
+        WebExtensionMatchPattern,
 #endif
         WebResourceLoadStatisticsManager,
         WebsiteDataRecord,
@@ -431,6 +432,7 @@ template<> struct EnumTraits<API::Object::Type> {
 #if ENABLE(WK_WEB_EXTENSIONS)
         API::Object::Type::WebExtension,
         API::Object::Type::WebExtensionController,
+        API::Object::Type::WebExtensionMatchPattern,
 #endif
         API::Object::Type::WebResourceLoadStatisticsManager,
         API::Object::Type::WebsiteDataRecord,

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -107,6 +107,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 #import "_WKWebExtensionControllerInternal.h"
 #import "_WKWebExtensionInternal.h"
+#import "_WKWebExtensionMatchPatternInternal.h"
 #endif
 
 static const size_t minimumObjectAlignment = alignof(std::aligned_storage<std::numeric_limits<size_t>::max()>::type);
@@ -403,6 +404,10 @@ void* Object::newObject(size_t size, Type type)
 
     case Type::WebExtensionController:
         wrapper = [_WKWebExtensionController alloc];
+        break;
+
+    case Type::WebExtensionMatchPattern:
+        wrapper = [_WKWebExtensionMatchPattern alloc];
         break;
 #endif
 

--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -27,6 +27,7 @@
 
 #import <type_traits>
 #import <wtf/RefPtr.h>
+#import <wtf/RetainPtr.h>
 
 namespace API {
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+WK_EXTERN NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+typedef NS_ERROR_ENUM(_WKWebExtensionMatchPatternErrorDomain, _WKWebExtensionMatchPatternError) {
+    _WKWebExtensionMatchPatternErrorUnknown,
+    _WKWebExtensionMatchPatternErrorInvalidScheme,
+    _WKWebExtensionMatchPatternErrorInvalidHost,
+    _WKWebExtensionMatchPatternErrorInvalidPath,
+} NS_SWIFT_NAME(_WKWebExtensionMatchPattern.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+typedef NS_OPTIONS(NSUInteger, _WKWebExtensionMatchPatternOptions) {
+    _WKWebExtensionMatchPatternOptionsNone                 = 0,
+    _WKWebExtensionMatchPatternOptionsIgnoreSchemes        = 1 << 0,
+    _WKWebExtensionMatchPatternOptionsIgnorePaths          = 1 << 1,
+    _WKWebExtensionMatchPatternOptionsMatchBidirectionally = 1 << 2,
+} NS_SWIFT_NAME(_WKWebExtensionMatchPattern.Options) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@interface _WKWebExtensionMatchPattern : NSObject <NSSecureCoding, NSCopying>
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)allURLsMatchPattern;
++ (instancetype)allHostsAndSchemesMatchPattern;
+
++ (nullable instancetype)matchPatternWithString:(NSString *)string NS_SWIFT_UNAVAILABLE("Use error version");
++ (nullable instancetype)matchPatternWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path NS_SWIFT_UNAVAILABLE("Use error version");
+
+- (nullable instancetype)initWithString:(NSString *)string NS_SWIFT_UNAVAILABLE("Use error version");
+- (nullable instancetype)initWithString:(NSString *)string error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+
+- (nullable instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path NS_SWIFT_UNAVAILABLE("Use error version");
+- (nullable instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+
+@property (nonatomic, readonly) NSString *string;
+
+@property (nonatomic, nullable, readonly) NSString *scheme;
+@property (nonatomic, nullable, readonly) NSString *host;
+@property (nonatomic, nullable, readonly) NSString *path;
+
+@property (nonatomic, readonly) BOOL matchesAllURLs;
+@property (nonatomic, readonly) BOOL matchesAllHosts;
+
+- (BOOL)matchesURL:(NSURL *)url NS_SWIFT_NAME(matches(url:));
+- (BOOL)matchesURL:(NSURL *)url options:(_WKWebExtensionMatchPatternOptions)options NS_SWIFT_NAME(matches(url:options:));
+
+- (BOOL)matchesPattern:(_WKWebExtensionMatchPattern *)pattern NS_SWIFT_NAME(matches(pattern:));
+- (BOOL)matchesPattern:(_WKWebExtensionMatchPattern *)pattern options:(_WKWebExtensionMatchPatternOptions)options NS_SWIFT_NAME(matches(pattern:options:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
@@ -1,0 +1,352 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "_WKWebExtensionMatchPatternInternal.h"
+
+#import "WebExtensionMatchPattern.h"
+#import <WebCore/WebCoreObjCExtras.h>
+
+static NSString * const stringCodingKey = @"string";
+
+NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMatchPatternErrorDomain";
+
+@implementation _WKWebExtensionMatchPattern
+
++ (BOOL)supportsSecureCoding
+{
+    return YES;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    NSParameterAssert(coder);
+
+    return [self initWithString:[coder decodeObjectOfClass:[NSString class] forKey:stringCodingKey]];
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+    NSParameterAssert(coder);
+
+    [coder encodeObject:self.string forKey:stringCodingKey];
+}
+
+- (instancetype)copyWithZone:(NSZone *)zone
+{
+    // _WKWebExtensionMatchPattern is immutable.
+    return self;
+}
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
++ (instancetype)allURLsMatchPattern
+{
+    return WebKit::wrapper(WebKit::WebExtensionMatchPattern::allURLsMatchPattern());
+}
+
++ (instancetype)allHostsAndSchemesMatchPattern
+{
+    return WebKit::wrapper(WebKit::WebExtensionMatchPattern::allHostsAndSchemesMatchPattern());
+}
+
++ (instancetype)matchPatternWithString:(NSString *)patternString
+{
+    NSParameterAssert(patternString);
+
+    return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(patternString));
+}
+
++ (instancetype)matchPatternWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path
+{
+    NSParameterAssert(scheme);
+    NSParameterAssert(host);
+    NSParameterAssert(path);
+
+    return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(scheme, host, path));
+}
+
+- (instancetype)initWithString:(NSString *)string
+{
+    return [self initWithString:string error:nullptr];
+}
+
+- (instancetype)initWithString:(NSString *)string error:(NSError **)error
+{
+    NSParameterAssert(string);
+
+    if (!error) {
+        // Balance the destructor in dealloc with the empty constructor.
+        API::Object::constructInWrapper<WebKit::WebExtensionMatchPattern>(self);
+
+        // Use the pattern cache instead for better performance, since an error isn't needed.
+        return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(string));
+    }
+
+    API::Object::constructInWrapper<WebKit::WebExtensionMatchPattern>(self, string, error);
+
+    return _webExtensionMatchPattern->isValid() ? self : nil;
+}
+
+- (instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path
+{
+    return [self initWithScheme:scheme host:host path:path error:nullptr];
+}
+
+- (instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path error:(NSError **)error
+{
+    NSParameterAssert(scheme);
+    NSParameterAssert(host);
+    NSParameterAssert(path);
+
+    if (!error) {
+        // Balance the destructor in dealloc with the empty constructor.
+        API::Object::constructInWrapper<WebKit::WebExtensionMatchPattern>(self);
+
+        // Use the pattern cache instead for better performance, since an error isn't needed.
+        return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(scheme, host, path));
+    }
+
+    API::Object::constructInWrapper<WebKit::WebExtensionMatchPattern>(self, scheme, host, path, error);
+
+    return _webExtensionMatchPattern->isValid() ? self : nil;
+}
+
+- (void)dealloc
+{
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtensionMatchPattern.class, self))
+        return;
+
+    _webExtensionMatchPattern->~WebExtensionMatchPattern();
+}
+
+- (NSUInteger)hash
+{
+    return self.string.hash;
+}
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object)
+        return YES;
+
+    _WKWebExtensionMatchPattern *other = dynamic_objc_cast<_WKWebExtensionMatchPattern>(object);
+    if (!other)
+        return NO;
+
+    return *_webExtensionMatchPattern == *other->_webExtensionMatchPattern;
+}
+
+- (NSString *)description
+{
+    return self.string;
+}
+
+- (NSString *)debugDescription
+{
+    if (self.matchesAllURLs)
+        return [NSString stringWithFormat:@"<%@: %p; matchesAllURLs = YES>", NSStringFromClass(self.class), self];
+    return [NSString stringWithFormat:@"<%@: %p; scheme = %@; host = %@; path = %@>", NSStringFromClass(self.class), self, self.scheme, self.host, self.path];
+}
+
+- (NSString *)scheme
+{
+    return _webExtensionMatchPattern->scheme();
+}
+
+- (NSString *)host
+{
+    return _webExtensionMatchPattern->host();
+}
+
+- (NSString *)path
+{
+    return _webExtensionMatchPattern->path();
+}
+
+- (NSString *)string
+{
+    return _webExtensionMatchPattern->string();
+}
+
+- (BOOL)matchesAllURLs
+{
+    return _webExtensionMatchPattern->matchesAllURLs();
+}
+
+- (BOOL)matchesAllHosts
+{
+    return _webExtensionMatchPattern->matchesAllHosts();
+}
+
+- (BOOL)matchesURL:(NSURL *)urlToMatch
+{
+    return [self matchesURL:urlToMatch options:0];
+}
+
+static OptionSet<WebKit::WebExtensionMatchPattern::Options> toImpl(_WKWebExtensionMatchPatternOptions options)
+{
+    OptionSet<WebKit::WebExtensionMatchPattern::Options> result;
+
+    if (options & _WKWebExtensionMatchPatternOptionsIgnoreSchemes)
+        result.add(WebKit::WebExtensionMatchPattern::Options::IgnoreSchemes);
+
+    if (options & _WKWebExtensionMatchPatternOptionsIgnorePaths)
+        result.add(WebKit::WebExtensionMatchPattern::Options::IgnorePaths);
+
+    if (options & _WKWebExtensionMatchPatternOptionsMatchBidirectionally)
+        result.add(WebKit::WebExtensionMatchPattern::Options::MatchBidirectionally);
+
+    return result;
+}
+
+- (BOOL)matchesURL:(NSURL *)urlToMatch options:(_WKWebExtensionMatchPatternOptions)options
+{
+    return _webExtensionMatchPattern->matchesURL(urlToMatch, toImpl(options));
+}
+
+- (BOOL)matchesPattern:(_WKWebExtensionMatchPattern *)patternToMatch
+{
+    return [self matchesPattern:patternToMatch options:0];
+}
+
+- (BOOL)matchesPattern:(_WKWebExtensionMatchPattern *)patternToMatch options:(_WKWebExtensionMatchPatternOptions)options
+{
+    if (!patternToMatch)
+        return NO;
+    return _webExtensionMatchPattern->matchesPattern(patternToMatch._webExtensionMatchPattern, toImpl(options));
+}
+
+#pragma mark WKObject protocol implementation
+
+- (API::Object&)_apiObject
+{
+    return *_webExtensionMatchPattern;
+}
+
+- (WebKit::WebExtensionMatchPattern&)_webExtensionMatchPattern
+{
+    return *_webExtensionMatchPattern;
+}
+
+#else // ENABLE(WK_WEB_EXTENSIONS)
+
++ (instancetype)allURLsMatchPattern
+{
+    return nil;
+}
+
++ (instancetype)allHostsAndSchemesMatchPattern
+{
+    return nil;
+}
+
++ (instancetype)matchPatternWithString:(NSString *)patternString
+{
+    return nil;
+}
+
++ (instancetype)matchPatternWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path
+{
+    return nil;
+}
+
+- (instancetype)initWithString:(NSString *)string
+{
+    return [self initWithString:string error:nullptr];
+}
+
+- (instancetype)initWithString:(NSString *)string error:(NSError **)error
+{
+    return nil;
+}
+
+- (instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path
+{
+    return [self initWithScheme:scheme host:host path:path error:nullptr];
+}
+
+- (instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path error:(NSError **)error
+{
+    return nil;
+}
+
+- (NSString *)scheme
+{
+    return nil;
+}
+
+- (NSString *)host
+{
+    return nil;
+}
+
+- (NSString *)path
+{
+    return nil;
+}
+
+- (NSString *)string
+{
+    return nil;
+}
+
+- (BOOL)matchesAllURLs
+{
+    return NO;
+}
+
+- (BOOL)matchesAllHosts
+{
+    return NO;
+}
+
+- (BOOL)matchesURL:(NSURL *)urlToMatch
+{
+    return NO;
+}
+
+- (BOOL)matchesURL:(NSURL *)urlToMatch options:(_WKWebExtensionMatchPatternOptions)options
+{
+    return NO;
+}
+
+- (BOOL)matchesPattern:(_WKWebExtensionMatchPattern *)patternToMatch
+{
+    return NO;
+}
+
+- (BOOL)matchesPattern:(_WKWebExtensionMatchPattern *)patternToMatch options:(_WKWebExtensionMatchPatternOptions)options
+{
+    return NO;
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPatternInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPatternInternal.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2014-2018 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "_WKWebExtensionMatchPatternPrivate.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "WKObject.h"
+#import "WebExtensionMatchPattern.h"
+
+namespace WebKit {
+template<> struct WrapperTraits<WebExtensionMatchPattern> {
+    using WrapperClass = _WKWebExtensionMatchPattern;
+};
+}
+
+@interface _WKWebExtensionMatchPattern () <WKObject> {
+@package
+    API::ObjectStorage<WebKit::WebExtensionMatchPattern> _webExtensionMatchPattern;
+}
+
+@property (nonatomic, readonly) WebKit::WebExtensionMatchPattern& _webExtensionMatchPattern;
+
+@end
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPatternPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPatternPrivate.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/_WKWebExtensionMatchPattern.h>
+
+@interface _WKWebExtensionMatchPattern ()
+
+@end

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
@@ -1,0 +1,452 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionMatchPattern.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "_WKWebExtensionMatchPatternInternal.h"
+#import <wtf/HashMap.h>
+#import <wtf/NeverDestroyed.h>
+#import <wtf/RunLoop.h>
+#import <wtf/text/StringHash.h>
+
+namespace WebKit {
+
+static NSString * const allURLsPattern = @"<all_urls>";
+static NSString * const allHostsAndSchemesPattern = @"*://*/*";
+static NSString * const patternFormat = @"%@://%@%@";
+
+NSSet *WebExtensionMatchPattern::validSchemes()
+{
+    // FIXME: Add extension schemes to this set.
+    static NSSet<NSString *> *schemes = [NSSet setWithObjects:@"*", @"http", @"https", @"file", @"ftp", nil];
+    return schemes;
+}
+
+NSSet *WebExtensionMatchPattern::supportedSchemes()
+{
+    // FIXME: Add extension schemes to this set.
+    static NSSet<NSString *> *schemes = [NSSet setWithObjects:@"*", @"http", @"https", nil];
+    ASSERT([schemes isSubsetOfSet:validSchemes()]);
+    return schemes;
+}
+
+static HashMap<String, RefPtr<WebExtensionMatchPattern>>& patternCache()
+{
+    ASSERT(RunLoop::isMain());
+    static NeverDestroyed<HashMap<String, RefPtr<WebExtensionMatchPattern>>> cache;
+    return cache;
+}
+
+RefPtr<WebExtensionMatchPattern> WebExtensionMatchPattern::getOrCreate(NSString *pattern)
+{
+    ASSERT(pattern);
+
+    return patternCache().ensure(pattern, [&] {
+        return create(pattern);
+    }).iterator->value;
+}
+
+RefPtr<WebExtensionMatchPattern> WebExtensionMatchPattern::getOrCreate(NSString *scheme, NSString *host, NSString *path)
+{
+    ASSERT(scheme);
+    ASSERT(host);
+    ASSERT(path);
+
+    NSString *pattern = [NSString stringWithFormat:patternFormat, scheme, host, path];
+
+    return patternCache().ensure(pattern, [&] {
+        return create(scheme, host, path);
+    }).iterator->value;
+}
+
+Ref<WebExtensionMatchPattern> WebExtensionMatchPattern::allURLsMatchPattern()
+{
+    return getOrCreate(allURLsPattern).releaseNonNull();
+}
+
+Ref<WebExtensionMatchPattern> WebExtensionMatchPattern::allHostsAndSchemesMatchPattern()
+{
+    return getOrCreate(allHostsAndSchemesPattern).releaseNonNull();
+}
+
+WebExtensionMatchPattern::WebExtensionMatchPattern(NSString *pattern, NSError **outError)
+{
+    ASSERT(pattern);
+
+    m_valid = parse(pattern, outError);
+    m_hash = string().hash;
+}
+
+static inline NSError *error(_WKWebExtensionMatchPatternError code, NSString *debugDescription)
+{
+    return [NSError errorWithDomain:_WKWebExtensionMatchPatternErrorDomain code:code userInfo:@{ NSDebugDescriptionErrorKey: debugDescription }];
+}
+
+WebExtensionMatchPattern::WebExtensionMatchPattern(NSString *scheme, NSString *host, NSString *path, NSError **outError)
+    : m_scheme(scheme)
+    , m_host(host)
+    , m_path(path)
+{
+    ASSERT(scheme);
+    ASSERT(host);
+    ASSERT(path);
+    ASSERT(!m_matchesAllURLs);
+
+    if (outError)
+        *outError = nil;
+
+    m_valid = true;
+
+    auto markInvalid = [&](NSError *error) {
+        if (outError)
+            *outError = error;
+
+        m_valid = false;
+        m_scheme = nil;
+        m_host = nil;
+        m_path = nil;
+        m_hash = 0;
+    };
+
+    if (!isValidScheme(scheme)) {
+        markInvalid(error(_WKWebExtensionMatchPatternErrorInvalidScheme, [NSString stringWithFormat:@"Scheme \"%@\" is invalid.", scheme]));
+        return;
+    }
+
+    if (!isValidHost(host)) {
+        markInvalid(error(_WKWebExtensionMatchPatternErrorInvalidHost, [NSString stringWithFormat:@"Host \"%@\" is invalid.", host]));
+        return;
+    }
+
+    if (!isValidPath(path)) {
+        markInvalid(error(_WKWebExtensionMatchPatternErrorInvalidPath, [NSString stringWithFormat:@"Path \"%@\" is invalid.", path]));
+        return;
+    }
+
+    m_hash = string().hash;
+}
+
+bool WebExtensionMatchPattern::isSupported() const
+{
+    return isValid() && (m_matchesAllURLs || [supportedSchemes() containsObject:m_scheme.get()]);
+}
+
+bool WebExtensionMatchPattern::operator==(const WebExtensionMatchPattern& other) const
+{
+    if (this == &other)
+        return true;
+
+    if (!isValid() && !other.isValid()) {
+        ASSERT(!m_hash && !other.m_hash);
+        return true;
+    }
+
+    if (m_matchesAllURLs && other.m_matchesAllURLs)
+        return true;
+
+    if (m_matchesAllURLs || other.m_matchesAllURLs)
+        return false;
+
+    if (![m_host isEqualToString:other.m_host.get()])
+        return false;
+
+    if (![m_scheme isEqualToString:other.m_scheme.get()])
+        return false;
+
+    if (![m_path isEqualToString:other.m_path.get()])
+        return false;
+
+    ASSERT(m_hash == other.m_hash);
+
+    return true;
+}
+
+NSString *WebExtensionMatchPattern::stringWithScheme(NSString *differentScheme) const
+{
+    if (!isValid())
+        return nil;
+
+    ASSERT(!m_matchesAllURLs || (m_matchesAllURLs && !differentScheme));
+    return m_matchesAllURLs ? allURLsPattern : [NSString stringWithFormat:patternFormat, differentScheme ?: m_scheme.get(), m_host.get(), m_path.get()];
+}
+
+NSArray *WebExtensionMatchPattern::expandedStrings() const
+{
+    if (!isValid())
+        return @[ ];
+
+    if (m_matchesAllURLs) {
+        NSMutableArray<NSString *> *result = [NSMutableArray arrayWithCapacity:2];
+        for (NSString *scheme in supportedSchemes()) {
+            if ([scheme isEqualToString:@"*"])
+                continue;
+            [result addObject:[NSString stringWithFormat:patternFormat, scheme, @"*", @"/*"]];
+        }
+
+        return result;
+    }
+
+    if ([m_scheme isEqualToString:@"*"])
+        return @[ stringWithScheme(@"http"), stringWithScheme(@"https") ];
+
+    return @[ string() ];
+}
+
+bool WebExtensionMatchPattern::matchesAllHosts() const
+{
+    return isValid() && (m_matchesAllURLs || [m_host isEqualToString:@"*"]);
+}
+
+bool WebExtensionMatchPattern::isValidScheme(NSString *scheme)
+{
+    return [validSchemes() containsObject:scheme];
+}
+
+bool WebExtensionMatchPattern::isValidHost(NSString *host)
+{
+    return [host isEqualToString:@"*"] || ![host containsString:@"*"] || ([host hasPrefix:@"*."] && host.length > 2 && ![[host substringFromIndex:2] containsString:@"*"]);
+}
+
+bool WebExtensionMatchPattern::isValidPath(NSString *path)
+{
+    return [path hasPrefix:@"/"];
+}
+
+bool WebExtensionMatchPattern::parse(NSString *pattern, NSError **outError)
+{
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns
+
+    // <url-pattern> := <scheme>://<host><path>
+    // <scheme> := '*' | 'http' | 'https' | 'file' | 'ftp'
+    // <host> := '*' | '*.' <any char except '/' and '*'>+
+    // <path> := '/' <any chars>
+
+    if (outError)
+        *outError = nil;
+
+    m_matchesAllURLs = [pattern isEqualToString:allURLsPattern];
+    if (m_matchesAllURLs)
+        return true;
+
+    NSRange schemeDelimiterRange = [pattern rangeOfString:@"://"];
+    if (schemeDelimiterRange.location == NSNotFound || !schemeDelimiterRange.location) {
+        if (outError)
+            *outError = error(_WKWebExtensionMatchPatternErrorInvalidScheme, [NSString stringWithFormat:@"\"%@\" cannot be parsed because it doesn't have a scheme.", pattern]);
+        return false;
+    }
+
+    NSString *scheme = [pattern substringToIndex:schemeDelimiterRange.location];
+    if (!isValidScheme(scheme)) {
+        if (outError)
+            *outError = error(_WKWebExtensionMatchPatternErrorInvalidScheme, [NSString stringWithFormat:@"\"%@\" cannot be parsed because the scheme \"%@\" is invalid.", pattern, scheme]);
+        return false;
+    }
+
+    NSString *hostAndPath = [pattern substringFromIndex:(schemeDelimiterRange.location + schemeDelimiterRange.length)];
+    NSRange hostAndPathDelimitationRange = [hostAndPath rangeOfString:@"/"];
+    if (hostAndPathDelimitationRange.location == NSNotFound) {
+        if (outError)
+            *outError = error(_WKWebExtensionMatchPatternErrorInvalidPath, [NSString stringWithFormat:@"\"%@\" cannot be parsed because it doesn't have a path.", pattern]);
+        return false;
+    }
+
+    // Host is only required for non-file URL patterns.
+    if (![scheme isEqualToString:@"file"] && !hostAndPathDelimitationRange.location) {
+        if (outError)
+            *outError = error(_WKWebExtensionMatchPatternErrorInvalidHost, [NSString stringWithFormat:@"\"%@\" cannot be parsed because it doesn't have a host.", pattern]);
+        return false;
+    }
+
+    NSString *host = [hostAndPath substringToIndex:hostAndPathDelimitationRange.location];
+    if (!isValidHost(host)) {
+        if (outError)
+            *outError = error(_WKWebExtensionMatchPatternErrorInvalidHost, [NSString stringWithFormat:@"\"%@\" cannot be parsed because the host \"%@\" is invalid.", pattern, host]);
+        return false;
+    }
+
+    m_scheme = scheme;
+    m_host = host;
+    m_path = [hostAndPath substringFromIndex:hostAndPathDelimitationRange.location];
+
+    return true;
+}
+
+bool WebExtensionMatchPattern::matchesURL(NSURL *urlToMatch, OptionSet<Options> options)
+{
+    if (!isValid() || !urlToMatch || !urlToMatch.scheme || !urlToMatch.path)
+        return false;
+
+    ASSERT(!options.contains(Options::MatchBidirectionally));
+
+    if (m_matchesAllURLs)
+        return [supportedSchemes() containsObject:urlToMatch.scheme];
+
+    // If this is a file URL, the host can be nil. Pass empty string instead of nil to match our non-nil expectations.
+    return schemeMatches(urlToMatch.scheme, options) && hostMatches(urlToMatch.host ?: @"", options) && pathMatches(urlToMatch.path, options);
+}
+
+bool WebExtensionMatchPattern::matchesPattern(const WebExtensionMatchPattern& patternToMatch, OptionSet<Options> options)
+{
+    if (!isValid())
+        return false;
+
+    if (*this == patternToMatch)
+        return true;
+
+    auto compareAllURLs = ^(const WebExtensionMatchPattern& a, const WebExtensionMatchPattern& b) {
+        return a.matchesAllURLs() && (b.matchesAllURLs() || [supportedSchemes() containsObject:b.scheme()]);
+    };
+
+    if (compareAllURLs(*this, patternToMatch))
+        return true;
+
+    if (options.contains(Options::MatchBidirectionally) && compareAllURLs(patternToMatch, *this))
+        return true;
+
+    // If we get here, and either pattern matchesAllURLs, one of the patterns has an unsupported, but parsable, scheme.
+    // Bail now, since scheme, host, and path are nil for matchesAllURLs patterns and can't be used by the component matches.
+    // For example: matching "<all_urls>" against "ftp://*/*" will not return true above, but should return false here.
+    if (m_matchesAllURLs || patternToMatch.matchesAllURLs())
+        return false;
+
+    return schemeMatches(patternToMatch.scheme(), options) && hostMatches(patternToMatch.host(), options) && pathMatches(patternToMatch.path(), options);
+}
+
+bool WebExtensionMatchPattern::schemeMatches(NSString *schemeToMatch, OptionSet<Options> options)
+{
+    ASSERT(m_scheme);
+    ASSERT(schemeToMatch);
+
+    if (options.contains(Options::IgnoreSchemes))
+        return true;
+
+    if ([m_scheme isEqualToString:schemeToMatch])
+        return true;
+
+    auto compare = ^(NSString *a, NSString *b) {
+        // If the scheme is *, then it matches either http or https, and not file, or ftp.
+        return [a isEqualToString:@"*"] && [b hasPrefix:@"http"];
+    };
+
+    if (compare(m_scheme.get(), schemeToMatch))
+        return true;
+
+    if (options.contains(Options::MatchBidirectionally) && compare(schemeToMatch, m_scheme.get()))
+        return true;
+
+    return false;
+}
+
+bool WebExtensionMatchPattern::hostMatches(NSString *hostToMatch, OptionSet<Options> options)
+{
+    ASSERT(m_host);
+    ASSERT(hostToMatch);
+
+    if ([m_host isEqualToString:hostToMatch])
+        return true;
+
+    auto compare = ^(NSString *a, NSString *b) {
+        // If the host is just *, then it matches any host.
+        if ([a isEqualToString:@"*"])
+            return true;
+
+        if ([a hasPrefix:@"*."]) {
+            // Matches "example.com" when the pattern is "*.example.com".
+            NSString *domainSuffix = [a substringFromIndex:2];
+            if ([b isEqualToString:domainSuffix])
+                return true;
+
+            // Matches "www.example.com" when the pattern is "*.example.com".
+            // Does not match "the-example.com" or "www.the-example.com".
+            domainSuffix = [a substringFromIndex:1];
+            if ([b hasSuffix:domainSuffix])
+                return true;
+        }
+
+        return false;
+    };
+
+    if (compare(m_host.get(), hostToMatch))
+        return true;
+
+    if (options.contains(Options::MatchBidirectionally) && compare(hostToMatch, m_host.get()))
+        return true;
+
+    return false;
+}
+
+bool WebExtensionMatchPattern::pathMatches(NSString *pathToMatch, OptionSet<Options> options)
+{
+    ASSERT(m_path);
+    ASSERT(pathToMatch);
+
+    if (options.contains(Options::IgnorePaths))
+        return true;
+
+    if ([m_path isEqualToString:pathToMatch])
+        return true;
+
+    auto compare = ^(NSString *a, NSString *b) {
+        // Special case matches for any path to avoid the cost of NSRegularExpression.
+        if ([a isEqualToString:@"/*"])
+            return true;
+
+        // If this is not a wildcard pattern, the paths should have been equal in the check above.
+        if (![a containsString:@"*"])
+            return false;
+
+        // In the path section, each '*' matches 0 or more characters.
+        NSString *regExpString = [NSString stringWithFormat:@"^%@$", [escapeCharactersInString(a, @"?+[(){}$|\\.") stringByReplacingOccurrencesOfString:@"*" withString:@".*"]];
+
+        NSError *error;
+        NSRegularExpression *regExp = [NSRegularExpression regularExpressionWithPattern:regExpString options:0 error:&error];
+        if (error)
+            return false;
+
+        if ([regExp firstMatchInString:b options:0 range:NSMakeRange(0, b.length)])
+            return true;
+        return false;
+    };
+
+    if (compare(m_path.get(), pathToMatch))
+        return true;
+
+    if (options.contains(Options::MatchBidirectionally) && compare(pathToMatch, m_path.get()))
+        return true;
+
+    return false;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "APIObject.h"
+#include <wtf/Forward.h>
+#include <wtf/OptionSet.h>
+#include <wtf/RetainPtr.h>
+
+#if PLATFORM(COCOA)
+OBJC_CLASS NSArray;
+OBJC_CLASS NSError;
+OBJC_CLASS NSSet;
+OBJC_CLASS NSString;
+OBJC_CLASS NSURL;
+#endif
+
+namespace WebKit {
+
+class WebExtensionMatchPattern : public API::ObjectImpl<API::Object::Type::WebExtensionMatchPattern> {
+    WTF_MAKE_NONCOPYABLE(WebExtensionMatchPattern);
+
+public:
+    template<typename... Args>
+    static RefPtr<WebExtensionMatchPattern> create(Args&&... args)
+    {
+        auto result = adoptRef(new WebExtensionMatchPattern(std::forward<Args>(args)...));
+        return result && result->isValid() ? WTFMove(result) : nullptr;
+    }
+
+#if PLATFORM(COCOA)
+    static RefPtr<WebExtensionMatchPattern> getOrCreate(NSString *pattern);
+    static RefPtr<WebExtensionMatchPattern> getOrCreate(NSString *scheme, NSString *host, NSString *path);
+
+    static Ref<WebExtensionMatchPattern> allURLsMatchPattern();
+    static Ref<WebExtensionMatchPattern> allHostsAndSchemesMatchPattern();
+
+    explicit WebExtensionMatchPattern() { }
+    explicit WebExtensionMatchPattern(NSString *pattern, NSError **outError = nullptr);
+    explicit WebExtensionMatchPattern(NSString *scheme, NSString *host, NSString *path, NSError **outError = nullptr);
+#endif
+
+    ~WebExtensionMatchPattern() { }
+
+    enum class Options : uint8_t {
+        IgnoreSchemes        = 1 << 0, // Ignore the scheme component when matching.
+        IgnorePaths          = 1 << 1, // Ignore the path component when matching.
+        MatchBidirectionally = 1 << 2, // Match two patterns in either direction (A matches B, or B matches A). Invalid for matching URLs.
+    };
+
+#if PLATFORM(COCOA)
+    static NSSet *validSchemes();
+    static NSSet *supportedSchemes();
+
+    bool operator==(const WebExtensionMatchPattern&) const;
+    bool operator!=(const WebExtensionMatchPattern& other) const { return !(*this == other); }
+
+    bool isValid() const { return m_valid; }
+    bool isSupported() const;
+
+    NSString *scheme() const { return m_scheme.get(); }
+    NSString *host() const { return m_host.get(); }
+    NSString *path() const { return m_path.get(); }
+
+    bool matchesAllURLs() const { return m_matchesAllURLs; }
+    bool matchesAllHosts() const;
+
+    bool matchesURL(NSURL *, OptionSet<Options> = { });
+    bool matchesPattern(const WebExtensionMatchPattern&, OptionSet<Options> = { });
+
+    NSString *string() const { return stringWithScheme(nil); }
+    NSArray *expandedStrings() const;
+
+    unsigned hash() const { return m_hash; }
+#endif
+
+private:
+#if PLATFORM(COCOA)
+    NSString *stringWithScheme(NSString *differentScheme) const;
+
+    static bool isValidScheme(NSString *);
+    static bool isValidHost(NSString *);
+    static bool isValidPath(NSString *);
+
+    bool parse(NSString *pattern, NSError **outError = nullptr);
+
+    bool schemeMatches(NSString *schemeToMatch, OptionSet<Options> = { });
+    bool hostMatches(NSString *hostToMatch, OptionSet<Options> = { });
+    bool pathMatches(NSString *pathToMatch, OptionSet<Options> = { });
+
+    RetainPtr<NSString> m_scheme;
+    RetainPtr<NSString> m_host;
+    RetainPtr<NSString> m_path;
+    bool m_matchesAllURLs = false;
+    bool m_valid = false;
+    unsigned m_hash = 0;
+#endif
+};
+
+} // namespace WebKit
+
+namespace WTF {
+
+struct WebExtensionMatchPatternHash {
+    static unsigned hash(const WebKit::WebExtensionMatchPattern& pattern) { return pattern.hash(); }
+    static bool equal(const WebKit::WebExtensionMatchPattern& a, const WebKit::WebExtensionMatchPattern& b) { return a == b; }
+    static const bool safeToCompareToEmptyOrDeleted = false;
+};
+
+template<typename T> struct DefaultHash;
+template<> struct DefaultHash<WebKit::WebExtensionMatchPattern> : WebExtensionMatchPatternHash { };
+
+template<> struct HashTraits<WebKit::WebExtensionMatchPattern> : SimpleClassHashTraits<WebKit::WebExtensionMatchPattern> {
+    static const bool emptyValueIsZero = false;
+    static const bool hasIsEmptyValueFunction = true;
+    static bool isEmptyValue(const WebKit::WebExtensionMatchPattern& pattern) { return pattern.isValid(); }
+};
+
+} // namespace WTF
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -376,6 +376,11 @@
 		1C0A19571C90068F00FE0EBB /* WebAutomationSessionMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C0A19551C90068F00FE0EBB /* WebAutomationSessionMessageReceiver.cpp */; };
 		1C0A19581C90068F00FE0EBB /* WebAutomationSessionMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0A19561C90068F00FE0EBB /* WebAutomationSessionMessages.h */; };
 		1C0A195C1C916E1B00FE0EBB /* WebAutomationSessionProxyScriptSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0A195B1C916E1B00FE0EBB /* WebAutomationSessionProxyScriptSource.h */; };
+		1C1CE96D288DF46D0098D3A1 /* WebExtensionMatchPatternCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C1CE972288DF5030098D3A1 /* _WKWebExtensionMatchPattern.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1CE96E288DF5020098D3A1 /* _WKWebExtensionMatchPattern.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C1CE973288DF5030098D3A1 /* _WKWebExtensionMatchPatternInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1CE96F288DF5020098D3A1 /* _WKWebExtensionMatchPatternInternal.h */; };
+		1C1CE974288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1CE970288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C1CE975288DF5030098D3A1 /* _WKWebExtensionMatchPattern.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1CE971288DF5030098D3A1 /* _WKWebExtensionMatchPattern.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C20936022318CB000026A39 /* NSAttributedString.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C20935E22318CB000026A39 /* NSAttributedString.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1C2184022233872800BAC700 /* NSAttributedStringPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C2184012233872800BAC700 /* NSAttributedStringPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C3BEB4F2887492F00E66E38 /* WebExtensionControllerMessagesReplies.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C3BEB4C2887492600E66E38 /* WebExtensionControllerMessagesReplies.h */; };
@@ -3413,6 +3418,12 @@
 		1C0A19591C9006EA00FE0EBB /* WebAutomationSession.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebAutomationSession.messages.in; sourceTree = "<group>"; };
 		1C0A195A1C91669500FE0EBB /* WebAutomationSessionProxy.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = WebAutomationSessionProxy.js; sourceTree = "<group>"; };
 		1C0A195B1C916E1B00FE0EBB /* WebAutomationSessionProxyScriptSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAutomationSessionProxyScriptSource.h; path = DerivedSources/WebKit/WebAutomationSessionProxyScriptSource.h; sourceTree = BUILT_PRODUCTS_DIR; };
+		1C1CE96A288DF31E0098D3A1 /* WebExtensionMatchPattern.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionMatchPattern.h; sourceTree = "<group>"; };
+		1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionMatchPatternCocoa.mm; sourceTree = "<group>"; };
+		1C1CE96E288DF5020098D3A1 /* _WKWebExtensionMatchPattern.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionMatchPattern.mm; sourceTree = "<group>"; };
+		1C1CE96F288DF5020098D3A1 /* _WKWebExtensionMatchPatternInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionMatchPatternInternal.h; sourceTree = "<group>"; };
+		1C1CE970288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionMatchPatternPrivate.h; sourceTree = "<group>"; };
+		1C1CE971288DF5030098D3A1 /* _WKWebExtensionMatchPattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionMatchPattern.h; sourceTree = "<group>"; };
 		1C20935E22318CB000026A39 /* NSAttributedString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSAttributedString.h; sourceTree = "<group>"; };
 		1C20935F22318CB000026A39 /* NSAttributedString.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NSAttributedString.mm; sourceTree = "<group>"; };
 		1C2184012233872800BAC700 /* NSAttributedStringPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSAttributedStringPrivate.h; sourceTree = "<group>"; };
@@ -8515,6 +8526,14 @@
 			path = Automation;
 			sourceTree = "<group>";
 		};
+		1C627476288A1DDE00CED3A2 /* Cocoa */ = {
+			isa = PBXGroup;
+			children = (
+				1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */,
+			);
+			path = Cocoa;
+			sourceTree = "<group>";
+		};
 		1C98C01C27446926002CCB78 /* WebGPU */ = {
 			isa = PBXGroup;
 			children = (
@@ -8807,10 +8826,12 @@
 		1CC23B1A288732A800D0A65A /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				1C627476288A1DDE00CED3A2 /* Cocoa */,
 				1C3BEB5E2888710500E66E38 /* WebExtension.h */,
 				1CC23B1D288732A800D0A65A /* WebExtensionController.cpp */,
 				1CC23B1C288732A800D0A65A /* WebExtensionController.h */,
 				1CC23B1B288732A800D0A65A /* WebExtensionController.messages.in */,
+				1C1CE96A288DF31E0098D3A1 /* WebExtensionMatchPattern.h */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -9792,6 +9813,10 @@
 				1C3BEB5628875CE400E66E38 /* _WKWebExtensionControllerInternal.h */,
 				1C3BEB5828875CE500E66E38 /* _WKWebExtensionControllerPrivate.h */,
 				1C3BEB6D288883E200E66E38 /* _WKWebExtensionInternal.h */,
+				1C1CE971288DF5030098D3A1 /* _WKWebExtensionMatchPattern.h */,
+				1C1CE96E288DF5020098D3A1 /* _WKWebExtensionMatchPattern.mm */,
+				1C1CE96F288DF5020098D3A1 /* _WKWebExtensionMatchPatternInternal.h */,
+				1C1CE970288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h */,
 				1C3BEB6F288883E300E66E38 /* _WKWebExtensionPrivate.h */,
 				1AE286761C7E76510069AC4F /* _WKWebsiteDataSize.h */,
 				1AE286751C7E76510069AC4F /* _WKWebsiteDataSize.mm */,
@@ -14069,6 +14094,9 @@
 				1C3BEB5A28875CE500E66E38 /* _WKWebExtensionControllerInternal.h in Headers */,
 				1C3BEB5C28875CE500E66E38 /* _WKWebExtensionControllerPrivate.h in Headers */,
 				1C3BEB722888842F00E66E38 /* _WKWebExtensionInternal.h in Headers */,
+				1C1CE975288DF5030098D3A1 /* _WKWebExtensionMatchPattern.h in Headers */,
+				1C1CE973288DF5030098D3A1 /* _WKWebExtensionMatchPatternInternal.h in Headers */,
+				1C1CE974288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h in Headers */,
 				1C3BEB712888842A00E66E38 /* _WKWebExtensionPrivate.h in Headers */,
 				1AE286781C7E76510069AC4F /* _WKWebsiteDataSize.h in Headers */,
 				1AE286801C7F92C00069AC4F /* _WKWebsiteDataSizeInternal.h in Headers */,
@@ -17177,6 +17205,7 @@
 				99E7189A21F79D9E0055E975 /* _WKTouchEventGenerator.mm in Sources */,
 				1C627479288B2F7400CED3A2 /* _WKWebExtension.mm in Sources */,
 				1C62747A288B2F7400CED3A2 /* _WKWebExtensionController.mm in Sources */,
+				1C1CE972288DF5030098D3A1 /* _WKWebExtensionMatchPattern.mm in Sources */,
 				572EBBDA2538F6B4000552B3 /* AppAttestInternalSoftLink.mm in Sources */,
 				517B5F7E275E97B6002DC22D /* AppBundleRequest.mm in Sources */,
 				EBA8D3B227A5E33F00CB7900 /* ApplePushServiceConnection.mm in Sources */,
@@ -17529,6 +17558,7 @@
 				E3866B092399A2D500F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp in Sources */,
 				1C3BEB522887492F00E66E38 /* WebExtensionControllerMessageReceiver.cpp in Sources */,
 				1C3BEB532887492F00E66E38 /* WebExtensionControllerProxyMessageReceiver.cpp in Sources */,
+				1C1CE96D288DF46D0098D3A1 /* WebExtensionMatchPatternCocoa.mm in Sources */,
 				93E799852756FA550074008A /* WebFileSystemStorageConnectionMessageReceiver.cpp in Sources */,
 				CD73BA4E131ACDB700EEDED2 /* WebFullScreenManagerMessageReceiver.cpp in Sources */,
 				CD73BA47131ACC9A00EEDED2 /* WebFullScreenManagerProxyMessageReceiver.cpp in Sources */,

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -279,6 +279,7 @@ Tests/WebKitCocoa/WKProcessPoolConfiguration.mm
 Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-leaks.mm
+Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
 Tests/WebKitCocoa/WKWebViewAlwaysShowsScroller.mm
 Tests/WebKitCocoa/WKWebViewCandidateTests.mm
 Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2016,6 +2016,7 @@
 		1CF59ADF21E68925006E37EC /* ForceLightAppearanceInBundle.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ForceLightAppearanceInBundle.mm; sourceTree = "<group>"; };
 		1CF59AE021E68925006E37EC /* ForceLightAppearanceInBundle_Bundle.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ForceLightAppearanceInBundle_Bundle.mm; sourceTree = "<group>"; };
 		1CF59AE421E696FB006E37EC /* dark-mode.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "dark-mode.html"; sourceTree = "<group>"; };
+		1CFAA40928974405009F894D /* WKWebExtensionMatchPattern.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionMatchPattern.mm; sourceTree = "<group>"; };
 		1CFD5D3E2851B62100A0E30B /* EnumeratedArray.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EnumeratedArray.cpp; sourceTree = "<group>"; };
 		1D12BEBF245BEF85004C0B7A /* ExitPiPOnSuspendVideoElement.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ExitPiPOnSuspendVideoElement.mm; sourceTree = "<group>"; };
 		1D5BE6AD2673EC5F00CB0B12 /* audio-buffer-size.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "audio-buffer-size.html"; sourceTree = "<group>"; };
@@ -4027,6 +4028,7 @@
 				5E4B1D2C1D404C6100053621 /* WKScrollViewDelegate.mm */,
 				51C683DD1EA134DB00650183 /* WKURLSchemeHandler-1.mm */,
 				5182C22D1F2BCB410059BA7C /* WKURLSchemeHandler-leaks.mm */,
+				1CFAA40928974405009F894D /* WKWebExtensionMatchPattern.mm */,
 				5C7148942123A40700FDE3C5 /* WKWebsiteDatastore.mm */,
 				371195AA1FE5797700A1FB92 /* WKWebViewAlwaysShowsScroller.mm */,
 				2EFF06D61D8AF34A0004BB30 /* WKWebViewCandidateTests.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
@@ -1,0 +1,484 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "TestCocoa.h"
+#import <WebKit/WKFoundation.h>
+#import <WebKit/_WKWebExtensionMatchPatternPrivate.h>
+
+namespace TestWebKitAPI {
+
+static _WKWebExtensionMatchPattern *toPattern(NSString *string)
+{
+    return [_WKWebExtensionMatchPattern matchPatternWithString:string];
+}
+
+static _WKWebExtensionMatchPattern *toPatternAlloc(NSString *string, NSError **error = nullptr)
+{
+    return [[_WKWebExtensionMatchPattern alloc] initWithString:string error:error];
+}
+
+static _WKWebExtensionMatchPattern *toPattern(NSString *scheme, NSString *host, NSString *path)
+{
+    return [_WKWebExtensionMatchPattern matchPatternWithScheme:scheme host:host path:path];
+}
+
+static _WKWebExtensionMatchPattern *toPatternAlloc(NSString *scheme, NSString *host, NSString *path, NSError **error = nullptr)
+{
+    return [[_WKWebExtensionMatchPattern alloc] initWithScheme:scheme host:host path:path error:error];
+}
+
+TEST(WKWebExtensionMatchPattern, PatternValidity)
+{
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"\"\" cannot be parsed because it doesn't have a scheme.");
+    }
+
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"http://www.example.com", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"\"http://www.example.com\" cannot be parsed because it doesn't have a path.");
+    }
+
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"file://localhost", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"\"file://localhost\" cannot be parsed because it doesn't have a path.");
+    }
+
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"file://", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"\"file://\" cannot be parsed because it doesn't have a path.");
+    }
+
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"http://*foo/bar", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"\"http://*foo/bar\" cannot be parsed because the host \"*foo\" is invalid.");
+    }
+
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"http://foo.*.bar/baz", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"\"http://foo.*.bar/baz\" cannot be parsed because the host \"foo.*.bar\" is invalid.");
+    }
+
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"http:/bar", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"\"http:/bar\" cannot be parsed because it doesn't have a scheme.");
+    }
+
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"foo://*", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"\"foo://*\" cannot be parsed because the scheme \"foo\" is invalid.");
+    }
+
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"foo", @"*", @"/", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"Scheme \"foo\" is invalid.");
+    }
+
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"https", @"example.*", @"/", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"Host \"example.*\" is invalid.");
+    }
+
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"https", @"example.com", @"*", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"Path \"*\" is invalid.");
+    }
+}
+
+TEST(WKWebExtensionMatchPattern, MatchPatternMatchesPattern)
+{
+    // Matches any URL that uses the http scheme.
+    EXPECT_TRUE([toPattern(@"http://*/*") matchesPattern:toPattern(@"http://www.example.com/")]);
+    EXPECT_TRUE([toPattern(@"http://*/*") matchesPattern:toPattern(@"http://example.com/foo/bar.html")]);
+
+    // Matches any URL that uses the http scheme, on any host, as long as the path starts with /foo.
+    EXPECT_TRUE([toPattern(@"http://*/foo*") matchesPattern:toPattern(@"http://example.com/foo/bar.html")]);
+    EXPECT_TRUE([toPattern(@"http://*/*") matchesPattern:toPattern(@"http://www.example.com/foo")]);
+
+    // Matches any URL that uses the https scheme, is on a example.com host (such as www.example.com, bar.example.com,
+    // or example.com), as long as the path starts with /foo and ends with bar.
+    EXPECT_TRUE([toPattern(@"https://*.example.com/foo*bar") matchesPattern:toPattern(@"https://www.example.com/foo/baz/bar")]);
+    EXPECT_TRUE([toPattern(@"https://*.example.com/foo*bar") matchesPattern:toPattern(@"https://bar.example.com/foobar")]);
+
+    // Matches the specified URL.
+    EXPECT_TRUE([toPattern(@"http://example.com/foo/bar.html") matchesPattern:toPattern(@"http://example.com/foo/bar.html")]);
+
+    // Matches any file whose path starts with /foo.
+    EXPECT_TRUE([toPattern(@"file:///foo*") matchesPattern:toPattern(@"file:///foo/bar.html")]);
+    EXPECT_TRUE([toPattern(@"file:///foo*") matchesPattern:toPattern(@"file:///foo")]);
+    EXPECT_TRUE([toPattern(@"file://localhost/foo*") matchesPattern:toPattern(@"file://localhost/foo")]);
+    EXPECT_FALSE([toPattern(@"file://localhost/foo*") matchesPattern:toPattern(@"file:///foo")]);
+    EXPECT_FALSE([toPattern(@"file:///foo*") matchesPattern:toPattern(@"file://localhost/foo")]);
+    EXPECT_TRUE([toPattern(@"file://*/foo*") matchesPattern:toPattern(@"file:///foo/bar.html")]);
+    EXPECT_TRUE([toPattern(@"file://*/foo*") matchesPattern:toPattern(@"file://localhost/foo/bar.html")]);
+    EXPECT_TRUE([toPattern(@"file://*/foo*") matchesPattern:toPattern(@"file://test.local/foo/bar.html")]);
+    EXPECT_TRUE([toPattern(@"file://*/foo*") matchesPattern:toPattern(@"file://apple.com/foo/bar.html")]);
+    EXPECT_TRUE([toPattern(@"file://*.local/foo*") matchesPattern:toPattern(@"file://test.local/foo")]);
+    EXPECT_FALSE([toPattern(@"file://*.local/foo*") matchesPattern:toPattern(@"file://apple.com/foo")]);
+
+    // Matches ignoring scheme.
+    EXPECT_FALSE([toPattern(@"http://*.example.com/*") matchesPattern:toPattern(@"https://*.example.com/*") options:0]);
+    EXPECT_FALSE([toPattern(@"https://*.example.com/*") matchesPattern:toPattern(@"http://*.example.com/*") options:0]);
+    EXPECT_FALSE([toPattern(@"http://*.example.com/*") matchesPattern:toPattern(@"*://*.example.com/*") options:0]);
+    EXPECT_TRUE([toPattern(@"http://*.example.com/*") matchesPattern:toPattern(@"https://*.example.com/*") options:_WKWebExtensionMatchPatternOptionsIgnoreSchemes]);
+    EXPECT_TRUE([toPattern(@"https://*.example.com/*") matchesPattern:toPattern(@"http://*.example.com/*") options:_WKWebExtensionMatchPatternOptionsIgnoreSchemes]);
+    EXPECT_TRUE([toPattern(@"http://*.example.com/*") matchesPattern:toPattern(@"*://*.example.com/*") options:_WKWebExtensionMatchPatternOptionsIgnoreSchemes]);
+
+    // Matches ignoring path.
+    EXPECT_FALSE([toPattern(@"https://*.example.com/foo*bar") matchesPattern:toPattern(@"https://www.example.com/baz") options:0]);
+    EXPECT_FALSE([toPattern(@"*://*.example.com/foo*bar") matchesPattern:toPattern(@"http://www.example.com/test") options:0]);
+    EXPECT_FALSE([toPattern(@"*://*.example.com/test*") matchesPattern:toPattern(@"*://*.example.com/bar") options:0]);
+    EXPECT_FALSE([toPattern(@"*://*.example.com/*bar") matchesPattern:toPattern(@"*://example.com/baz") options:0]);
+    EXPECT_TRUE([toPattern(@"https://*.example.com/foo*bar") matchesPattern:toPattern(@"https://www.example.com/baz") options:_WKWebExtensionMatchPatternOptionsIgnorePaths]);
+    EXPECT_TRUE([toPattern(@"*://*.example.com/foo*bar") matchesPattern:toPattern(@"http://www.example.com/test") options:_WKWebExtensionMatchPatternOptionsIgnorePaths]);
+    EXPECT_TRUE([toPattern(@"*://*.example.com/test*") matchesPattern:toPattern(@"*://*.example.com/bar") options:_WKWebExtensionMatchPatternOptionsIgnorePaths]);
+    EXPECT_TRUE([toPattern(@"*://*.example.com/*bar") matchesPattern:toPattern(@"*://example.com/baz") options:_WKWebExtensionMatchPatternOptionsIgnorePaths]);
+
+    // Matches any URL that uses the http scheme and is on the host 127.0.0.1.
+    EXPECT_TRUE([toPattern(@"http://127.0.0.1/*") matchesPattern:toPattern(@"http://127.0.0.1/")]);
+    EXPECT_TRUE([toPattern(@"http://127.0.0.1/*") matchesPattern:toPattern(@"http://127.0.0.1/foo/bar.html")]);
+
+    // Matches any URL that starts with http://foo.example.com or https://foo.example.com.
+    EXPECT_TRUE([toPattern(@"*://foo.example.com/*") matchesPattern:toPattern(@"http://foo.example.com/foo/baz/bar")]);
+    EXPECT_TRUE([toPattern(@"*://foo.example.com/*") matchesPattern:toPattern(@"https://foo.example.com/foobar")]);
+
+    // Test missing hosts.
+    EXPECT_FALSE([toPattern(@"*:///*") matchesPattern:toPattern(@"https://example.com/foobar")]);
+    EXPECT_FALSE([toPattern(@"https:///*") matchesPattern:toPattern(@"https://example.com/foobar")]);
+    EXPECT_FALSE([toPattern(@"ftp:///*") matchesPattern:toPattern(@"ftp://example.com/foobar")]);
+    EXPECT_TRUE([toPattern(@"file:///*") matchesPattern:toPattern(@"file:///foobar")]);
+
+    // Matches any URL that uses a permitted scheme. (See the beginning of this section for the list of permitted schemes.)
+    EXPECT_TRUE([toPattern(@"<all_urls>") matchesPattern:toPattern(@"http://example.com/foo/bar.html")]);
+    EXPECT_FALSE([toPattern(@"<all_urls>") matchesPattern:toPattern(@"file:///bar/baz.html")]);
+    EXPECT_FALSE([toPattern(@"<all_urls>") matchesPattern:toPattern(@"favorites://")]);
+    EXPECT_FALSE([toPattern(@"<all_urls>") matchesPattern:toPattern(@"bookmarks://")]);
+    EXPECT_FALSE([toPattern(@"<all_urls>") matchesPattern:toPattern(@"history://")]);
+
+    // All matches.
+    EXPECT_TRUE([toPattern(@"<all_urls>") matchesPattern:toPattern(@"<all_urls>")]);
+    EXPECT_TRUE([toPattern(@"<all_urls>") matchesPattern:toPattern(@"*://*/*")]);
+    EXPECT_FALSE([toPattern(@"*://*/*") matchesPattern:toPattern(@"<all_urls>")]);
+    EXPECT_TRUE([toPattern(@"*://*/*") matchesPattern:toPattern(@"*://*/*")]);
+
+    // Matching domain patterns.
+    EXPECT_TRUE([toPattern(@"*://*.example.com/*") matchesPattern:toPattern(@"*://www.example.com/test/*")]);
+    EXPECT_TRUE([toPattern(@"*://*/*") matchesPattern:toPattern(@"*://*.example.com/*")]);
+    EXPECT_FALSE([toPattern(@"*://*.example.com/*") matchesPattern:toPattern(@"*://*/*")]);
+    EXPECT_TRUE([toPattern(@"<all_urls>") matchesPattern:toPattern(@"*://*.example.com/*")]);
+    EXPECT_TRUE([toPattern(@"*://*.example.com/*") matchesPattern:toPattern(@"*://www.example.com/test/*")]);
+    EXPECT_FALSE([toPattern(@"*://*.example.com/*") matchesPattern:toPattern(@"*://the-example.com/test/*")]);
+    EXPECT_FALSE([toPattern(@"*://*.example.com/*") matchesPattern:toPattern(@"*://www.the-example.com/test/*")]);
+
+    // Bidirectional matching.
+    EXPECT_FALSE([toPattern(@"*://*.example.com/*") matchesPattern:toPattern(@"*://*/*") options:0]);
+    EXPECT_FALSE([toPattern(@"*://*.example.com/*") matchesPattern:toPattern(@"<all_urls>") options:0]);
+    EXPECT_FALSE([toPattern(@"http://*.example.com/*") matchesPattern:toPattern(@"<all_urls>") options:0]);
+    EXPECT_FALSE([toPattern(@"ftp://*.example.com/*") matchesPattern:toPattern(@"<all_urls>") options:0]);
+    EXPECT_FALSE([toPattern(@"*://*.en.wikipedia.org/*") matchesPattern:toPattern(@"*://*.wikipedia.org/*") options:0]);
+    EXPECT_FALSE([toPattern(@"https://*.en.wikipedia.org/*") matchesPattern:toPattern(@"*://*.wikipedia.org/*") options:0]);
+    EXPECT_FALSE([toPattern(@"*://*.en.wikipedia.org/*") matchesPattern:toPattern(@"https://*.wikipedia.org/*") options:0]);
+    EXPECT_FALSE([toPattern(@"https://*/*") matchesPattern:toPattern(@"*://*.example.com/*") options:0]);
+    EXPECT_FALSE([toPattern(@"http://*/*") matchesPattern:toPattern(@"*://*.example.com/*") options:0]);
+    EXPECT_FALSE([toPattern(@"http://*/*") matchesPattern:toPattern(@"*://*/foo*") options:0]);
+    EXPECT_FALSE([toPattern(@"*://*.example.com/*") matchesPattern:toPattern(@"https://*/*") options:0]);
+    EXPECT_FALSE([toPattern(@"*://*.example.com/*") matchesPattern:toPattern(@"http://*/*") options:0]);
+    EXPECT_TRUE([toPattern(@"*://*.example.com/*") matchesPattern:toPattern(@"*://*/*") options:_WKWebExtensionMatchPatternOptionsMatchBidirectionally]);
+    EXPECT_TRUE([toPattern(@"*://*.example.com/*") matchesPattern:toPattern(@"<all_urls>") options:_WKWebExtensionMatchPatternOptionsMatchBidirectionally]);
+    EXPECT_TRUE([toPattern(@"http://*.example.com/*") matchesPattern:toPattern(@"<all_urls>") options:_WKWebExtensionMatchPatternOptionsMatchBidirectionally]);
+    EXPECT_FALSE([toPattern(@"ftp://*.example.com/*") matchesPattern:toPattern(@"<all_urls>") options:_WKWebExtensionMatchPatternOptionsMatchBidirectionally]);
+    EXPECT_TRUE([toPattern(@"*://*.en.wikipedia.org/*") matchesPattern:toPattern(@"*://*.wikipedia.org/*") options:_WKWebExtensionMatchPatternOptionsMatchBidirectionally]);
+    EXPECT_TRUE([toPattern(@"https://*.en.wikipedia.org/*") matchesPattern:toPattern(@"*://*.wikipedia.org/*") options:_WKWebExtensionMatchPatternOptionsMatchBidirectionally]);
+    EXPECT_TRUE([toPattern(@"*://*.en.wikipedia.org/*") matchesPattern:toPattern(@"https://*.wikipedia.org/*") options:_WKWebExtensionMatchPatternOptionsMatchBidirectionally]);
+    EXPECT_TRUE([toPattern(@"https://*/*") matchesPattern:toPattern(@"*://*.example.com/*") options:_WKWebExtensionMatchPatternOptionsMatchBidirectionally]);
+    EXPECT_TRUE([toPattern(@"http://*/*") matchesPattern:toPattern(@"*://*.example.com/*") options:_WKWebExtensionMatchPatternOptionsMatchBidirectionally]);
+    EXPECT_TRUE([toPattern(@"http://*/*") matchesPattern:toPattern(@"*://*/foo*") options:_WKWebExtensionMatchPatternOptionsMatchBidirectionally]);
+    EXPECT_TRUE([toPattern(@"*://*.example.com/*") matchesPattern:toPattern(@"https://*/*") options:_WKWebExtensionMatchPatternOptionsMatchBidirectionally]);
+    EXPECT_TRUE([toPattern(@"*://*.example.com/*") matchesPattern:toPattern(@"http://*/*") options:_WKWebExtensionMatchPatternOptionsMatchBidirectionally]);
+
+    // Matches with regex special characters in pattern.
+    EXPECT_TRUE([toPattern(@"*://*/foo?bar*") matchesPattern:toPattern(@"*://*/foo?bar") options:0]);
+    EXPECT_FALSE([toPattern(@"*://*/foo?bar*") matchesPattern:toPattern(@"*://*/fobar") options:0]);
+    EXPECT_TRUE([toPattern(@"*://*/foo[ba]r*") matchesPattern:toPattern(@"*://*/foo[ba]r") options:0]);
+    EXPECT_FALSE([toPattern(@"*://*/foo[ba]r*") matchesPattern:toPattern(@"*://*/fooar") options:0]);
+    EXPECT_TRUE([toPattern(@"*://*/foo|bar*") matchesPattern:toPattern(@"*://*/foo|bar") options:0]);
+    EXPECT_FALSE([toPattern(@"*://*/foo|bar*") matchesPattern:toPattern(@"*://*/foo") options:0]);
+
+    // Matches a URL that is less permissive.
+    EXPECT_FALSE([toPattern(@"https://www.apple.com/foo/bar/baz/*") matchesPattern:toPattern(@"*://www.apple.com/foo/*")]);
+    EXPECT_TRUE([toPattern(@"https://www.apple.com/foo/bar/baz/*") matchesPattern:toPattern(@"*://www.apple.com/foo/*") options:_WKWebExtensionMatchPatternOptionsMatchBidirectionally]);
+
+    // Connivence methods
+    EXPECT_NS_EQUAL([_WKWebExtensionMatchPattern allURLsMatchPattern].string, @"<all_urls>");
+    EXPECT_NS_EQUAL([_WKWebExtensionMatchPattern allHostsAndSchemesMatchPattern].string, @"*://*/*");
+}
+
+TEST(WKWebExtensionMatchPattern, MatchPatternMatchesURL)
+{
+    // Matches any URL that uses the http scheme.
+    EXPECT_TRUE([toPattern(@"http://*/*") matchesURL:[NSURL URLWithString:@"http://www.example.com/"]]);
+    EXPECT_TRUE([toPattern(@"http://*/*") matchesURL:[NSURL URLWithString:@"http://example.com/foo/bar.html"]]);
+
+    // Matches any URL that uses the http scheme, on any host, as long as the path starts with /foo.
+    EXPECT_TRUE([toPattern(@"http://*/foo*") matchesURL:[NSURL URLWithString:@"http://example.com/foo/bar.html"]]);
+    EXPECT_TRUE([toPattern(@"http://*/*") matchesURL:[NSURL URLWithString:@"http://www.example.com/foo"]]);
+
+    // Matches any URL that uses the https scheme, is on a example.com host (such as www.example.com, bar.example.com,
+    // or example.com), as long as the path starts with /foo and ends with bar.
+    EXPECT_TRUE([toPattern(@"https://*.example.com/foo*bar") matchesURL:[NSURL URLWithString:@"https://www.example.com/foo/baz/bar"]]);
+    EXPECT_TRUE([toPattern(@"https://*.example.com/foo*bar") matchesURL:[NSURL URLWithString:@"https://bar.example.com/foobar"]]);
+
+    // Matches the specified URL.
+    EXPECT_TRUE([toPattern(@"http://example.com/foo/bar.html") matchesURL:[NSURL URLWithString:@"http://example.com/foo/bar.html"]]);
+
+    // Matches any file whose path starts with /foo.
+    EXPECT_TRUE([toPattern(@"file:///foo*") matchesURL:[NSURL URLWithString:@"file:///foo/bar.html"]]);
+    EXPECT_TRUE([toPattern(@"file:///foo*") matchesURL:[NSURL URLWithString:@"file:///foo"]]);
+    EXPECT_TRUE([toPattern(@"file://localhost/foo*") matchesURL:[NSURL URLWithString:@"file://localhost/foo"]]);
+    EXPECT_FALSE([toPattern(@"file://localhost/foo*") matchesURL:[NSURL URLWithString:@"file:///foo"]]);
+    EXPECT_FALSE([toPattern(@"file:///foo*") matchesURL:[NSURL URLWithString:@"file://localhost/foo"]]);
+    EXPECT_TRUE([toPattern(@"file://*/foo*") matchesURL:[NSURL URLWithString:@"file:///foo/bar.html"]]);
+    EXPECT_TRUE([toPattern(@"file://*/foo*") matchesURL:[NSURL URLWithString:@"file://localhost/foo/bar.html"]]);
+    EXPECT_TRUE([toPattern(@"file://*/foo*") matchesURL:[NSURL URLWithString:@"file://test.local/foo/bar.html"]]);
+    EXPECT_TRUE([toPattern(@"file://*/foo*") matchesURL:[NSURL URLWithString:@"file://apple.com/foo/bar.html"]]);
+    EXPECT_TRUE([toPattern(@"file://*.local/foo*") matchesURL:[NSURL URLWithString:@"file://test.local/foo"]]);
+    EXPECT_FALSE([toPattern(@"file://*.local/foo*") matchesURL:[NSURL URLWithString:@"file://apple.com/foo"]]);
+
+    // Matches ignoring scheme.
+    EXPECT_FALSE([toPattern(@"http://*.example.com/*") matchesURL:[NSURL URLWithString:@"https://example.com/"] options:0]);
+    EXPECT_FALSE([toPattern(@"https://*.example.com/*") matchesURL:[NSURL URLWithString:@"http://example.com/"] options:0]);
+    EXPECT_FALSE([toPattern(@"http://*.example.com/*") matchesURL:[NSURL URLWithString:@"ftp://example.com/"] options:0]);
+    EXPECT_TRUE([toPattern(@"http://*.example.com/*") matchesURL:[NSURL URLWithString:@"https://example.com/"] options:_WKWebExtensionMatchPatternOptionsIgnoreSchemes]);
+    EXPECT_TRUE([toPattern(@"https://*.example.com/*") matchesURL:[NSURL URLWithString:@"http://example.com/"] options:_WKWebExtensionMatchPatternOptionsIgnoreSchemes]);
+    EXPECT_TRUE([toPattern(@"http://*.example.com/*") matchesURL:[NSURL URLWithString:@"ftp://example.com/"] options:_WKWebExtensionMatchPatternOptionsIgnoreSchemes]);
+
+    // Matches ignoring path.
+    EXPECT_FALSE([toPattern(@"https://*.example.com/foo*bar") matchesURL:[NSURL URLWithString:@"https://www.example.com/baz"] options:0]);
+    EXPECT_FALSE([toPattern(@"*://*.example.com/foo*bar") matchesURL:[NSURL URLWithString:@"http://www.example.com/test"] options:0]);
+    EXPECT_FALSE([toPattern(@"*://*.example.com/test*") matchesURL:[NSURL URLWithString:@"https://www.example.com/bar"] options:0]);
+    EXPECT_FALSE([toPattern(@"*://*.example.com/*bar") matchesURL:[NSURL URLWithString:@"http://example.com/baz"] options:0]);
+    EXPECT_TRUE([toPattern(@"https://*.example.com/foo*bar") matchesURL:[NSURL URLWithString:@"https://www.example.com/baz"] options:_WKWebExtensionMatchPatternOptionsIgnorePaths]);
+    EXPECT_TRUE([toPattern(@"*://*.example.com/foo*bar") matchesURL:[NSURL URLWithString:@"http://www.example.com/test"] options:_WKWebExtensionMatchPatternOptionsIgnorePaths]);
+    EXPECT_TRUE([toPattern(@"*://*.example.com/test*") matchesURL:[NSURL URLWithString:@"https://www.example.com/bar"] options:_WKWebExtensionMatchPatternOptionsIgnorePaths]);
+    EXPECT_TRUE([toPattern(@"*://*.example.com/*bar") matchesURL:[NSURL URLWithString:@"http://example.com/baz"] options:_WKWebExtensionMatchPatternOptionsIgnorePaths]);
+
+    // Matches host.
+    EXPECT_TRUE([toPattern(@"https://*.example.com/*") matchesURL:[NSURL URLWithString:@"https://example.com/"] options:0]);
+    EXPECT_TRUE([toPattern(@"https://*.example.com/*") matchesURL:[NSURL URLWithString:@"https://www.example.com/"] options:0]);
+    EXPECT_FALSE([toPattern(@"https://*.example.com/*") matchesURL:[NSURL URLWithString:@"https://the-example.com/"] options:0]);
+    EXPECT_FALSE([toPattern(@"https://*.example.com/*") matchesURL:[NSURL URLWithString:@"https://www.the-example.com/"] options:0]);
+
+    // Matches any URL that uses the http scheme and is on the host 127.0.0.1.
+    EXPECT_TRUE([toPattern(@"http://127.0.0.1/*") matchesURL:[NSURL URLWithString:@"http://127.0.0.1/"]]);
+    EXPECT_TRUE([toPattern(@"http://127.0.0.1/*") matchesURL:[NSURL URLWithString:@"http://127.0.0.1/foo/bar.html"]]);
+
+    // Matches any URL that starts with http://foo.example.com or https://foo.example.com.
+    EXPECT_TRUE([toPattern(@"*://foo.example.com/*") matchesURL:[NSURL URLWithString:@"http://foo.example.com/foo/baz/bar"]]);
+    EXPECT_TRUE([toPattern(@"*://foo.example.com/*") matchesURL:[NSURL URLWithString:@"https://foo.example.com/foobar"]]);
+
+    // Test missing hosts.
+    EXPECT_FALSE([toPattern(@"*:///*") matchesURL:[NSURL URLWithString:@"https://example.com/foobar"]]);
+    EXPECT_FALSE([toPattern(@"https:///*") matchesURL:[NSURL URLWithString:@"https://example.com/foobar"]]);
+    EXPECT_FALSE([toPattern(@"ftp:///*") matchesURL:[NSURL URLWithString:@"ftp://example.com/foobar"]]);
+    EXPECT_TRUE([toPattern(@"file:///*") matchesURL:[NSURL URLWithString:@"file:///foobar"]]);
+
+    // Matches any URL that uses a permitted scheme. (See the beginning of this section for the list of permitted schemes.)
+    EXPECT_TRUE([toPattern(@"<all_urls>") matchesURL:[NSURL URLWithString:@"http://example.com/foo/bar.html"]]);
+    EXPECT_FALSE([toPattern(@"<all_urls>") matchesURL:[NSURL URLWithString:@"file:///bar/baz.html"]]);
+    EXPECT_FALSE([toPattern(@"<all_urls>") matchesURL:[NSURL URLWithString:@"favorites://"]]);
+    EXPECT_FALSE([toPattern(@"<all_urls>") matchesURL:[NSURL URLWithString:@"bookmarks://"]]);
+    EXPECT_FALSE([toPattern(@"<all_urls>") matchesURL:[NSURL URLWithString:@"history://"]]);
+
+    // Matches with regex special characters in pattern.
+    EXPECT_TRUE([toPattern(@"*://*/foo?bar*") matchesURL:[NSURL URLWithString:@"https://example.com/foo%3Fbar"]]);
+    EXPECT_FALSE([toPattern(@"*://*/foo?bar*") matchesURL:[NSURL URLWithString:@"https://example.com/fobar"]]);
+    EXPECT_TRUE([toPattern(@"*://*/foo[ba]r*") matchesURL:[NSURL URLWithString:@"https://example.com/foo%5Bba%5Dr"]]);
+    EXPECT_FALSE([toPattern(@"*://*/foo[ba]r*") matchesURL:[NSURL URLWithString:@"https://example.com/fooar"]]);
+    EXPECT_TRUE([toPattern(@"*://*/foo|bar*") matchesURL:[NSURL URLWithString:@"https://example.com/foo%7Cbar"]]);
+    EXPECT_FALSE([toPattern(@"*://*/foo|bar*") matchesURL:[NSURL URLWithString:@"https://example.com/foo"]]);
+}
+
+TEST(WKWebExtensionMatchPattern, PatternDescriptions)
+{
+    EXPECT_NS_EQUAL(toPattern(@"<all_urls>").description, @"<all_urls>");
+    EXPECT_NS_EQUAL(toPattern(@"*://*/*").description, @"*://*/*");
+    EXPECT_NS_EQUAL(toPattern(@"http://*.example.com/*").description, @"http://*.example.com/*");
+    EXPECT_NS_EQUAL(toPattern(@"file:///*").description, @"file:///*");
+    EXPECT_NS_EQUAL(toPattern(@"file://localhost/*").description, @"file://localhost/*");
+}
+
+TEST(WKWebExtensionMatchPattern, MatchesAllHosts)
+{
+    EXPECT_TRUE(toPattern(@"<all_urls>").matchesAllHosts);
+    EXPECT_TRUE(toPattern(@"*://*/*").matchesAllHosts);
+    EXPECT_TRUE(toPattern(@"http://*/*").matchesAllHosts);
+    EXPECT_TRUE(toPattern(@"https://*/*").matchesAllHosts);
+    EXPECT_TRUE(toPattern(@"file://*/*").matchesAllHosts);
+    EXPECT_FALSE(toPattern(@"file:///*").matchesAllHosts);
+}
+
+TEST(WKWebExtensionMatchPattern, MatchesAllURLs)
+{
+    EXPECT_TRUE(toPattern(@"<all_urls>").matchesAllURLs);
+    EXPECT_FALSE(toPattern(@"*://*/*").matchesAllURLs);
+    EXPECT_FALSE(toPattern(@"http://*/*").matchesAllURLs);
+    EXPECT_FALSE(toPattern(@"https://*/*").matchesAllURLs);
+    EXPECT_FALSE(toPattern(@"file://*/*").matchesAllURLs);
+    EXPECT_FALSE(toPattern(@"file:///*").matchesAllURLs);
+}
+
+TEST(WKWebExtensionMatchPattern, PatternCacheAndEquality)
+{
+    // All these patterns should come from the cache and have pointer equality.
+    EXPECT_EQ(toPattern(@"<all_urls>"), toPattern(@"<all_urls>"));
+    EXPECT_EQ(toPattern(@"<all_urls>"), toPatternAlloc(@"<all_urls>"));
+    EXPECT_EQ(toPattern(@"<all_urls>"), [_WKWebExtensionMatchPattern allURLsMatchPattern]);
+    EXPECT_EQ(toPatternAlloc(@"<all_urls>"), toPatternAlloc(@"<all_urls>"));
+    EXPECT_EQ(toPattern(@"*://*/*"), toPattern(@"*://*/*"));
+    EXPECT_EQ(toPattern(@"*://*/*"), toPatternAlloc(@"*://*/*"));
+    EXPECT_EQ(toPattern(@"*://*/*"), [_WKWebExtensionMatchPattern allHostsAndSchemesMatchPattern]);
+    EXPECT_EQ(toPatternAlloc(@"*://*/*"), toPatternAlloc(@"*://*/*"));
+    EXPECT_EQ(toPattern(@"*", @"*", @"/*"), toPattern(@"*", @"*", @"/*"));
+    EXPECT_EQ(toPattern(@"*", @"*", @"/*"), toPatternAlloc(@"*", @"*", @"/*"));
+    EXPECT_EQ(toPatternAlloc(@"*", @"*", @"/*"), toPatternAlloc(@"*", @"*", @"/*"));
+    EXPECT_EQ(toPattern(@"*://*/*"), toPattern(@"*", @"*", @"/*"));
+    EXPECT_EQ(toPattern(@"*://*/*"), toPatternAlloc(@"*", @"*", @"/*"));
+
+    // All these patterns should be equal.
+    EXPECT_NS_EQUAL(toPattern(@"<all_urls>"), toPattern(@"<all_urls>"));
+    EXPECT_NS_EQUAL(toPattern(@"<all_urls>"), toPatternAlloc(@"<all_urls>"));
+    EXPECT_NS_EQUAL(toPattern(@"<all_urls>"), [_WKWebExtensionMatchPattern allURLsMatchPattern]);
+    EXPECT_NS_EQUAL(toPatternAlloc(@"<all_urls>"), toPatternAlloc(@"<all_urls>"));
+    EXPECT_NS_EQUAL(toPattern(@"*://*/*"), toPattern(@"*://*/*"));
+    EXPECT_NS_EQUAL(toPattern(@"*://*/*"), toPatternAlloc(@"*://*/*"));
+    EXPECT_NS_EQUAL(toPattern(@"*://*/*"), [_WKWebExtensionMatchPattern allHostsAndSchemesMatchPattern]);
+    EXPECT_NS_EQUAL(toPatternAlloc(@"*://*/*"), toPatternAlloc(@"*://*/*"));
+    EXPECT_NS_EQUAL(toPattern(@"*", @"*", @"/*"), toPattern(@"*", @"*", @"/*"));
+    EXPECT_NS_EQUAL(toPattern(@"*", @"*", @"/*"), toPatternAlloc(@"*", @"*", @"/*"));
+    EXPECT_NS_EQUAL(toPatternAlloc(@"*", @"*", @"/*"), toPatternAlloc(@"*", @"*", @"/*"));
+    EXPECT_NS_EQUAL(toPattern(@"*://*/*"), toPattern(@"*", @"*", @"/*"));
+    EXPECT_NS_EQUAL(toPattern(@"*://*/*"), toPatternAlloc(@"*", @"*", @"/*"));
+
+    // All the first patterns should not come from the cache since they check for errors.
+    // They should still be equal, just not via pointer equality.
+    {
+        NSError *error;
+        auto* a = toPatternAlloc(@"<all_urls>", &error);
+        auto* b = toPatternAlloc(@"<all_urls>");
+
+        EXPECT_NULL(error);
+        EXPECT_NE(a, b);
+        EXPECT_NS_EQUAL(a, b);
+    }
+
+    {
+        NSError *error;
+        auto* a = toPatternAlloc(@"<all_urls>", &error);
+        auto* b = toPattern(@"<all_urls>");
+
+        EXPECT_NULL(error);
+        EXPECT_NE(a, b);
+        EXPECT_NS_EQUAL(a, b);
+    }
+
+    {
+        NSError *error;
+        auto* a = toPatternAlloc(@"*://*/*", &error);
+        auto* b = toPatternAlloc(@"*://*/*");
+
+        EXPECT_NULL(error);
+        EXPECT_NE(a, b);
+        EXPECT_NS_EQUAL(a, b);
+    }
+
+    {
+        NSError *error;
+        auto* a = toPatternAlloc(@"*://*/*", &error);
+        auto* b = toPattern(@"*://*/*");
+
+        EXPECT_NULL(error);
+        EXPECT_NE(a, b);
+        EXPECT_NS_EQUAL(a, b);
+    }
+
+    {
+        NSError *error;
+        auto* a = toPatternAlloc(@"*://*/*", &error);
+        auto* b = toPattern(@"*", @"*", @"/*");
+
+        EXPECT_NULL(error);
+        EXPECT_NE(a, b);
+        EXPECT_NS_EQUAL(a, b);
+    }
+
+    {
+        NSError *error;
+        auto* a = toPatternAlloc(@"*://*/*", &error);
+        auto* b = toPatternAlloc(@"*", @"*", @"/*");
+
+        EXPECT_NULL(error);
+        EXPECT_NE(a, b);
+        EXPECT_NS_EQUAL(a, b);
+    }
+
+    {
+        NSError *error;
+        auto* a = toPatternAlloc(@"*", @"*", @"/*", &error);
+        auto* b = toPattern(@"*", @"*", @"/*");
+
+        EXPECT_NULL(error);
+        EXPECT_NE(a, b);
+        EXPECT_NS_EQUAL(a, b);
+    }
+
+    {
+        NSError *error;
+        auto* a = toPatternAlloc(@"*", @"*", @"/*", &error);
+        auto* b = toPatternAlloc(@"*", @"*", @"/*");
+
+        EXPECT_NULL(error);
+        EXPECT_NE(a, b);
+        EXPECT_NS_EQUAL(a, b);
+    }
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### a26a124c5da0fc285e9bf1119b8e85c09242f5dd
<pre>
Add _WKWebExtensionMatchPattern class.
<a href="https://bugs.webkit.org/show_bug.cgi?id=245921">https://bugs.webkit.org/show_bug.cgi?id=245921</a>

Reviewed by Alex Christensen.

Introduce a new class that handles match pattern parsing and checks for Web Extensions.
<a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns</a>

* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::escapeCharactersInString): Added.
* Source/WebKit/Shared/API/APIObject.h:
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/Shared/Cocoa/WKObject.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm: Added.
(+[_WKWebExtensionMatchPattern supportsSecureCoding]):
(-[_WKWebExtensionMatchPattern initWithCoder:]):
(-[_WKWebExtensionMatchPattern copyWithZone:]):
(+[_WKWebExtensionMatchPattern allURLsMatchPattern]):
(+[_WKWebExtensionMatchPattern allHostsAndSchemesMatchPattern]):
(+[_WKWebExtensionMatchPattern matchPatternWithString:]):
(+[_WKWebExtensionMatchPattern matchPatternWithScheme:host:path:]):
(-[_WKWebExtensionMatchPattern initWithString:]):
(-[_WKWebExtensionMatchPattern initWithString:error:]):
(-[_WKWebExtensionMatchPattern initWithScheme:host:path:]):
(-[_WKWebExtensionMatchPattern initWithScheme:host:path:error:]):
(-[_WKWebExtensionMatchPattern dealloc]):
(-[_WKWebExtensionMatchPattern hash]):
(-[_WKWebExtensionMatchPattern isEqual:]):
(-[_WKWebExtensionMatchPattern description]):
(-[_WKWebExtensionMatchPattern debugDescription]):
(-[_WKWebExtensionMatchPattern scheme]):
(-[_WKWebExtensionMatchPattern host]):
(-[_WKWebExtensionMatchPattern path]):
(-[_WKWebExtensionMatchPattern string]):
(-[_WKWebExtensionMatchPattern matchesAllURLs]):
(-[_WKWebExtensionMatchPattern matchesAllHosts]):
(-[_WKWebExtensionMatchPattern matchesURL:]):
(-[_WKWebExtensionMatchPattern matchesURL:options:]):
(-[_WKWebExtensionMatchPattern matchesPattern:]):
(-[_WKWebExtensionMatchPattern matchesPattern:options:]):
(-[_WKWebExtensionMatchPattern _apiObject]):
(-[_WKWebExtensionMatchPattern _webExtensionMatchPattern]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPatternInternal.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPatternPrivate.h: Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm: Added.
(WebKit::WebExtensionMatchPattern::validSchemes):
(WebKit::WebExtensionMatchPattern::supportedSchemes):
(WebKit::WebExtensionMatchPattern::getOrCreate):
(WebKit::WebExtensionMatchPattern::allURLsMatchPattern):
(WebKit::WebExtensionMatchPattern::allHostsAndSchemesMatchPattern):
(WebKit::WebExtensionMatchPattern::WebExtensionMatchPattern):
(WebKit::WebExtensionMatchPattern::isSupported const):
(WebKit::WebExtensionMatchPattern::operator== const):
(WebKit::WebExtensionMatchPattern::stringWithScheme const):
(WebKit::WebExtensionMatchPattern::expandedStrings const):
(WebKit::WebExtensionMatchPattern::matchesAllHosts const):
(WebKit::WebExtensionMatchPattern::isValidScheme):
(WebKit::WebExtensionMatchPattern::isValidHost):
(WebKit::WebExtensionMatchPattern::isValidPath):
(WebKit::WebExtensionMatchPattern::parse):
(WebKit::WebExtensionMatchPattern::matchesURL):
(WebKit::WebExtensionMatchPattern::matchesPattern):
(WebKit::WebExtensionMatchPattern::schemeMatches):
(WebKit::WebExtensionMatchPattern::hostMatches):
(WebKit::WebExtensionMatchPattern::pathMatches):
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h: Added.
(WebKit::WebExtensionMatchPattern::create):
(WebKit::WebExtensionMatchPattern::WebExtensionMatchPattern):
(WebKit::WebExtensionMatchPattern::~WebExtensionMatchPattern):
(WebKit::WebExtensionMatchPattern::operator!= const):
(WebKit::WebExtensionMatchPattern::isValid const):
(WebKit::WebExtensionMatchPattern::scheme const):
(WebKit::WebExtensionMatchPattern::host const):
(WebKit::WebExtensionMatchPattern::path const):
(WebKit::WebExtensionMatchPattern::matchesAllURLs const):
(WebKit::WebExtensionMatchPattern::matchesURL):
(WebKit::WebExtensionMatchPattern::matchesPattern):
(WebKit::WebExtensionMatchPattern::string const):
(WebKit::WebExtensionMatchPattern::hash const):
(WebKit::WebExtensionMatchPattern::schemeMatches):
(WebKit::WebExtensionMatchPattern::hostMatches):
(WebKit::WebExtensionMatchPattern::pathMatches):
(WTF::WebExtensionMatchPatternHash::hash):
(WTF::WebExtensionMatchPatternHash::equal):
(WTF::HashTraits&lt;WebKit::WebExtensionMatchPattern&gt;::isEmptyValue):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm: Added.

Canonical link: <a href="https://commits.webkit.org/255094@main">https://commits.webkit.org/255094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fdd2581b8b711c0ee7651415e321f6a05b1e9fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91325 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/325 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/101069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/337 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96982 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/83686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/35462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/33258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37048 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1565 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/38970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->