### PR TITLE
Updating Text nodes children of an OPTION element should not reset selection of the owner SELECT element

### DIFF
--- a/LayoutTests/fast/forms/select/select-selection-reset-by-option-text-expected.txt
+++ b/LayoutTests/fast/forms/select/select-selection-reset-by-option-text-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Updating Text nodes children of an OPTION element should not reset selection of the owner SELECT element.
+

--- a/LayoutTests/fast/forms/select/select-selection-reset-by-option-text.html
+++ b/LayoutTests/fast/forms/select/select-selection-reset-by-option-text.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<select>
+<option></option>
+<option></option>
+<option></option>
+<option></option>
+</select>
+<script>
+test(function() {
+    var select = document.querySelector('select');
+    var option = document.querySelector('option');
+    select.selectedIndex = -1;
+    assert_equals(select.selectedIndex, -1);
+    option.textContent = 'First choice';
+    assert_equals(select.selectedIndex, -1);
+    option.firstChild.insertData(5, ' awesome');
+    assert_equals(select.selectedIndex, -1);
+}, 'Updating Text nodes children of an OPTION element should not reset selection of the owner SELECT element.');
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -417,7 +417,6 @@ void HTMLSelectElement::childrenChanged(const ChildChange& change)
 
 void HTMLSelectElement::optionElementChildrenChanged()
 {
-    setRecalcListItems();
     updateValidity();
     if (auto* cache = document().existingAXObjectCache())
         cache->childrenChanged(this);


### PR DESCRIPTION
#### f0cfd47bb7213572bf6c78a98f0acd07c4e9fdf2
<pre>
Updating Text nodes children of an OPTION element should not reset selection of the owner SELECT element

Updating Text nodes children of an OPTION element should not reset selection of the owner SELECT element.

<a href="https://bugs.webkit.org/show_bug.cgi?id=245928">https://bugs.webkit.org/show_bug.cgi?id=245928</a>

Reviewed by Aditya Keerthi.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/d7d375b3c7777f6b7149fd26d9d892d5c5a8006a">https://chromium.googlesource.com/chromium/src.git/+/d7d375b3c7777f6b7149fd26d9d892d5c5a8006a</a>

The new behavior matches to the standard, Gecko and Chrome.

Web Spec: <a href="https://html.spec.whatwg.org/multipage/forms.html#ask-for-a-reset">https://html.spec.whatwg.org/multipage/forms.html#ask-for-a-reset</a>
&gt; If nodes are inserted or nodes are removed causing the list of options to gain or lose one or more option elements, or if an option element in the list of options asks for a reset, then, ...

An option element asks for a reset only when its selected IDL attribute is updated.

* Source/WebCore/html/HTMLSelectElement.cpp:
(HTMLSelectElement::childrenChanged): Removed &quot;setRecalcListItems&quot;
* LayoutTests/fast/forms/select/select-selection-reset-by-option-text.html: Added Test Case
* LayoutTests/fast/forms/select/select-selection-reset-by-option-text-expected.txt: Added Test Expectations

Canonical link: <a href="https://commits.webkit.org/255086@main">https://commits.webkit.org/255086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83f6aed7b599fbf783e4d710592946817c880c37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100783 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/160364 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/195 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29208 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83544 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97321 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/155 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77928 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27132 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70163 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35329 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15781 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33125 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16816 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3533 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39694 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35906 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->