### PR TITLE
Fix incorrectly positioned block element inside list-style-position:inside item

### DIFF
--- a/LayoutTests/css2.1/20110323/line-style-position-005.htm
+++ b/LayoutTests/css2.1/20110323/line-style-position-005.htm
@@ -1,0 +1,31 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+ <head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>CSS Test: Marker box position (inside principal box) - block box in normal flow (as child of principal box)</title>
+  <link rel="author" title="James Hopkins" href="http://idreamincode.co.uk/css21testsuite">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#block-boxes">
+  <meta name="flags" content="">
+  <meta name="assert" content="Since a marker box is the first inline element in the principal box when 'list-style-position:inside', the following block box (in normal flow) must create a new stacking context below the marker box">
+  <style type="text/css">
+  #test{
+  background:lime;
+  color:lime;
+  display:list-item;
+  font-size:85px;
+  list-style-position:inside;
+  }
+  #test div{
+  background:blue;
+  display:block;
+  }
+  </style>
+ </head>
+ <body>
+  <p>To pass, there <strong>must</strong> be a green bar stacked on top of a blue bar.</p>
+  <div id="test">
+   <div>&nbsp;</div>
+  </div>
+ </body>
+</html>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -85,7 +85,7 @@ RenderTreeBuilder::List::List(RenderTreeBuilder& builder)
 {
 }
 
-void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
+void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer, RenderListMarker& isInside)
 {
     auto& style = listItemRenderer.style();
 
@@ -108,7 +108,8 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
     }
 
     RenderElement* currentParent = markerRenderer->parent();
-    RenderBlock* newParent = getParentOfFirstLineBox(listItemRenderer, *markerRenderer);
+    // list-style-position:inside makes the ::marker pseudo an ordinary position:static element that should be attached to RenderListItem block.
+    RenderBlock* newParent = markerRenderer->isInside() ? listItemRenderer : getParentOfFirstLineBox(listItemRenderer, *markerRenderer);    
     if (!newParent) {
         // If the marker is currently contained inside an anonymous box,
         // then we are the only item in that anonymous box (since no line box

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.h
@@ -35,7 +35,7 @@ class RenderTreeBuilder::List {
 public:
     List(RenderTreeBuilder&);
 
-    void updateItemMarker(RenderListItem&);
+    void updateItemMarker(RenderListItem&, RenderListMarker&);
 
 private:
     RenderTreeBuilder& m_builder;


### PR DESCRIPTION
<pre>
Fix incorrectly positioned block element inside list-style-position:inside item

<a href="https://bugs.webkit.org/show_bug.cgi?id=245929">https://bugs.webkit.org/show_bug.cgi?id=245929</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/src/+/36d85fd5ae96048efcef076a209655ddf2bd02fe">https://chromium.googlesource.com/chromium/src/+/36d85fd5ae96048efcef076a209655ddf2bd02fe</a>

This fixes the interop issue with incorrectly positioned block element inside of LayoutListItem(list-style-position: inline).

CSS WG discussion: <a href="https://lists.w3.org/Archives/Public/www-style/2015Mar/0163.html">https://lists.w3.org/Archives/Public/www-style/2015Mar/0163.html</a>

Details:
list-style-position:inside makes the ::marker pseudo an ordinary position:static element that needs to be wrapped in an anonymous block before the block element. This patch changes the current behaviour where we try to position the marker as the first inline child of the block.

* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(RenderTreeBuilderList::updateItemMarker): Update "new Parent" to fix position of list items
* LayoutTests/css2.1/20110323/line-style-position-005.htm: Added Test Case
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b02da44a807f075000f9d682cfa367cc72d22ffb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91608 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/801 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22211 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101308 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161375 "Hash b02da44a for PR 4900 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95613 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/800 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29446 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83926 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97643 "Hash b02da44a for PR 4900 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97266 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/800 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78270 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/83926 "Hash b02da44a for PR 4900 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/800 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/22211 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/83926 "Hash b02da44a for PR 4900 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35731 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/22211 "Hash b02da44a for PR 4900 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33486 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/22211 "Hash b02da44a for PR 4900 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37326 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/78270 "Hash b02da44a for PR 4900 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39231 "Hash b02da44a for PR 4900 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/22211 "Hash b02da44a for PR 4900 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->