### PR TITLE
Use destroying delete for StyleRule

### DIFF
--- a/Source/WebCore/css/CSSCounterStyleRule.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRule.cpp
@@ -214,7 +214,7 @@ String CSSCounterStyleRule::cssText() const
 
 void CSSCounterStyleRule::reattach(StyleRuleBase& rule)
 {
-    m_counterStyleRule = static_cast<StyleRuleCounterStyle&>(rule);
+    m_counterStyleRule = downcast<StyleRuleCounterStyle>(rule);
 }
 
 // https://drafts.csswg.org/css-counter-styles-3/#dom-csscounterstylerule-name

--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -49,6 +49,8 @@ public:
     static Ref<StyleRuleCounterStyle> create(const AtomString& name, Ref<StyleProperties>&&);
     ~StyleRuleCounterStyle();
 
+    Ref<StyleRuleCounterStyle> copy() const { RELEASE_ASSERT_NOT_REACHED(); }
+
     const StyleProperties& properties() const { return m_properties; }
     MutableStyleProperties& mutableProperties();
 

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -27,8 +27,8 @@
 
 #include "FontSelectionValueInlines.h"
 #include "FontTaggedSettings.h"
+#include "RenderStyleConstants.h"
 #include "Settings.h"
-#include "StyleRule.h"
 #include "TextFlags.h"
 #include <memory>
 #include <wtf/Forward.h>
@@ -46,11 +46,14 @@ class CSSFontSelector;
 class CSSSegmentedFontFace;
 class CSSValue;
 class CSSValueList;
+class Font;
 class FontCreationContext;
 class FontDescription;
-class Font;
 class FontFace;
+class FontPaletteValues;
 class ScriptExecutionContext;
+class StyleRuleFontFace;
+
 enum class ExternalResourceDownloadPolicy;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSFontFace);

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -38,6 +38,8 @@ namespace WebCore {
 class CSSPrimitiveValue;
 class FontFaceSet;
 
+template<typename> class ExceptionOr;
+
 class CSSFontFaceSet final : public RefCounted<CSSFontFaceSet>, public CSSFontFace::Client {
 public:
     static Ref<CSSFontFaceSet> create(CSSFontSelector* owningFontSelector = nullptr)

--- a/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
@@ -120,7 +120,7 @@ String CSSFontPaletteValuesRule::cssText() const
 
 void CSSFontPaletteValuesRule::reattach(StyleRuleBase& rule)
 {
-    m_fontPaletteValuesRule = static_cast<StyleRuleFontPaletteValues&>(rule);
+    m_fontPaletteValuesRule = downcast<StyleRuleFontPaletteValues>(rule);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSFontPaletteValuesRule.h
+++ b/Source/WebCore/css/CSSFontPaletteValuesRule.h
@@ -27,14 +27,12 @@
 
 #include "CSSRule.h"
 
-#include "StyleRule.h"
-
 namespace WebCore {
 
 class CSSStyleDeclaration;
 class DOMMapAdapter;
-class StyleRuleFontFace;
 class StyleRuleCSSStyleDeclaration;
+class StyleRuleFontPaletteValues;
 
 class CSSFontPaletteValuesRule final : public CSSRule {
 public:

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -48,6 +48,7 @@ class CSSValueList;
 class CachedFont;
 class ScriptExecutionContext;
 class StyleRuleFontFace;
+class StyleRuleFontPaletteValues;
 
 class CSSFontSelector final : public FontSelector, public CSSFontFace::Client, public CanMakeWeakPtr<CSSFontSelector>, public ActiveDOMObject {
 public:

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -128,7 +128,7 @@ CSSRule* CSSGroupingRule::item(unsigned index) const
     ASSERT(m_childRuleCSSOMWrappers.size() == m_groupRule->childRules().size());
     auto& rule = m_childRuleCSSOMWrappers[index];
     if (!rule)
-        rule = m_groupRule->childRules()[index]->createCSSOMWrapper(const_cast<CSSGroupingRule*>(this));
+        rule = m_groupRule->childRules()[index]->createCSSOMWrapper(const_cast<CSSGroupingRule&>(*this));
     return rule.get();
 }
 
@@ -141,7 +141,7 @@ CSSRuleList& CSSGroupingRule::cssRules() const
 
 void CSSGroupingRule::reattach(StyleRuleBase& rule)
 {
-    m_groupRule = static_cast<StyleRuleGroup&>(rule);
+    m_groupRule = downcast<StyleRuleGroup>(rule);
     for (unsigned i = 0; i < m_childRuleCSSOMWrappers.size(); ++i) {
         if (m_childRuleCSSOMWrappers[i])
             m_childRuleCSSOMWrappers[i]->reattach(*m_groupRule.get().childRules()[i]);

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include "CSSRule.h"
-#include "StyleRule.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSKeyframeRule.h
+++ b/Source/WebCore/css/CSSKeyframeRule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007, 2008, 2012, 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,14 +32,16 @@
 namespace WebCore {
 
 class CSSStyleDeclaration;
-class StyleRuleCSSStyleDeclaration;
 class CSSKeyframesRule;
+class StyleRuleCSSStyleDeclaration;
 
 class StyleRuleKeyframe final : public StyleRuleBase {
 public:
     static Ref<StyleRuleKeyframe> create(Ref<StyleProperties>&&);
     static Ref<StyleRuleKeyframe> create(Vector<double>&& keys, Ref<StyleProperties>&&);
     ~StyleRuleKeyframe();
+
+    Ref<StyleRuleKeyframe> copy() const { RELEASE_ASSERT_NOT_REACHED(); }
 
     String keyText() const;
     bool setKeyText(const String&);

--- a/Source/WebCore/css/CSSKeyframesRule.cpp
+++ b/Source/WebCore/css/CSSKeyframesRule.cpp
@@ -201,8 +201,7 @@ CSSRuleList& CSSKeyframesRule::cssRules()
 
 void CSSKeyframesRule::reattach(StyleRuleBase& rule)
 {
-    ASSERT_WITH_SECURITY_IMPLICATION(rule.isKeyframesRule());
-    m_keyframesRule = static_cast<StyleRuleKeyframes&>(rule);
+    m_keyframesRule = downcast<StyleRuleKeyframes>(rule);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSLayerBlockRule.h
+++ b/Source/WebCore/css/CSSLayerBlockRule.h
@@ -30,9 +30,13 @@
 #pragma once
 
 #include "CSSGroupingRule.h"
-#include "StyleRule.h"
+#include "StyleRuleType.h"
 
 namespace WebCore {
+
+class StyleRuleLayer;
+
+using CascadeLayerName = Vector<AtomString>;
 
 class CSSLayerBlockRule final : public CSSGroupingRule {
 public:

--- a/Source/WebCore/css/CSSLayerStatementRule.cpp
+++ b/Source/WebCore/css/CSSLayerStatementRule.cpp
@@ -49,6 +49,8 @@ Ref<CSSLayerStatementRule> CSSLayerStatementRule::create(StyleRuleLayer& rule, C
     return adoptRef(*new CSSLayerStatementRule(rule, parent));
 }
 
+CSSLayerStatementRule::~CSSLayerStatementRule() = default;
+
 String CSSLayerStatementRule::cssText() const
 {
     StringBuilder result;
@@ -78,7 +80,7 @@ Vector<String> CSSLayerStatementRule::nameList() const
 
 void CSSLayerStatementRule::reattach(StyleRuleBase& rule)
 {
-    m_layerRule = static_cast<StyleRuleLayer&>(rule);
+    m_layerRule = downcast<StyleRuleLayer>(rule);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSLayerStatementRule.h
+++ b/Source/WebCore/css/CSSLayerStatementRule.h
@@ -29,14 +29,16 @@
 
 #pragma once
 
-#include "CSSGroupingRule.h"
-#include "StyleRule.h"
+#include "CSSRule.h"
 
 namespace WebCore {
+
+class StyleRuleLayer;
 
 class CSSLayerStatementRule final : public CSSRule {
 public:
     static Ref<CSSLayerStatementRule> create(StyleRuleLayer&, CSSStyleSheet* parent);
+    virtual ~CSSLayerStatementRule();
 
     String cssText() const final;
     Vector<String> nameList() const;

--- a/Source/WebCore/css/CSSPropertySourceData.h
+++ b/Source/WebCore/css/CSSPropertySourceData.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "StyleRule.h"
+#include "StyleRuleType.h"
 #include <utility>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -297,7 +297,7 @@ CSSRule* CSSStyleSheet::item(unsigned index)
 
     RefPtr<CSSRule>& cssRule = m_childRuleCSSOMWrappers[index];
     if (!cssRule)
-        cssRule = m_contents->ruleAt(index)->createCSSOMWrapper(this);
+        cssRule = m_contents->ruleAt(index)->createCSSOMWrapper(*this);
     return cssRule.get();
 }
 

--- a/Source/WebCore/css/CSSSupportsRule.h
+++ b/Source/WebCore/css/CSSSupportsRule.h
@@ -34,7 +34,6 @@
 
 namespace WebCore {
 
-class CSSRule;
 class StyleRuleSupports;
 
 class CSSSupportsRule final : public CSSConditionRule {

--- a/Source/WebCore/css/StyleRuleImport.h
+++ b/Source/WebCore/css/StyleRuleImport.h
@@ -1,7 +1,7 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * (C) 2002-2003 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2002, 2006, 2008, 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -36,12 +36,13 @@ class StyleRuleImport final : public StyleRuleBase {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<StyleRuleImport> create(const String& href, Ref<MediaQuerySet>&&, std::optional<CascadeLayerName>&&);
-
     ~StyleRuleImport();
-    
+
+    Ref<StyleRuleImport> copy() const { RELEASE_ASSERT_NOT_REACHED(); }
+
     StyleSheetContents* parentStyleSheet() const { return m_parentStyleSheet; }
     void setParentStyleSheet(StyleSheetContents* sheet) { ASSERT(sheet); m_parentStyleSheet = sheet; }
-    void clearParentStyleSheet() { m_parentStyleSheet = 0; }
+    void clearParentStyleSheet() { m_parentStyleSheet = nullptr; }
     void cancelLoad();
 
     String href() const { return m_strHref; }

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -32,8 +32,6 @@
 #include "CSSParser.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyNames.h"
-#include "StyleRule.h"
-
 #include <memory>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/css/parser/CSSParserObserver.h
+++ b/Source/WebCore/css/parser/CSSParserObserver.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include "StyleRule.h"
+#include "StyleRuleType.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -25,7 +25,7 @@
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParserHelpers.h"
 #include "CSSPropertyParserWorkerSafe.h"
-#include "StyleRule.h"
+#include "StyleRuleType.h"
 #include <wtf/text/StringView.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -56,6 +56,7 @@
 #include "CSSValueList.h"
 #include "CSSVariableData.h"
 #include "CSSVariableReferenceValue.h"
+#include "StyleProperties.h"
 #include "StylePropertyShorthand.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -40,7 +40,7 @@
 #include "HTMLParserIdioms.h"
 #include "ISOVTTCue.h"
 #include "ProcessingInstruction.h"
-#include "StyleRule.h"
+#include "StyleProperties.h"
 #include "StyleRuleImport.h"
 #include "StyleSheetContents.h"
 #include "Text.h"

--- a/Source/WebCore/svg/properties/SVGAttributeAnimator.cpp
+++ b/Source/WebCore/svg/properties/SVGAttributeAnimator.cpp
@@ -29,6 +29,7 @@
 #include "CSSComputedStyleDeclaration.h"
 #include "CSSPropertyParser.h"
 #include "SVGElementInlines.h"
+#include "StyleProperties.h"
 
 namespace WebCore {
 


### PR DESCRIPTION
#### 435426cf4b3bc0f9f62a2c6f9c1306efc2b54083
<pre>
Use destroying delete for StyleRule
<a href="https://bugs.webkit.org/show_bug.cgi?id=245886">https://bugs.webkit.org/show_bug.cgi?id=245886</a>
rdar://problem/100624114

Reviewed by Sam Weinig.

* Source/WebCore/css/CSSCounterStyleRule.h: Added a
StyleRuleCounterStyle::copy function that asserts it is never reached,
replacing code that was previously in StyleRuleBase::copy.

* Source/WebCore/css/CSSCounterStyleRule.cpp:
(WebCore::CSSCounterStyleRule::reattach): Use downcast.

* Source/WebCore/css/CSSFontFace.h: Removed unnecessary include of
StyleRule.h, updated other includes and forward declarations as needed.
* Source/WebCore/css/CSSFontFaceSet.h: Ditto.

* Source/WebCore/css/CSSFontPaletteValuesRule.cpp:
(WebCore::CSSFontPaletteValuesRule::reattach): Use downcast.

* Source/WebCore/css/CSSFontPaletteValuesRule.h: Removed unnecessary
include of StyleRule.h, updated other includes and forward declarations
as needed.
* Source/WebCore/css/CSSFontSelector.h: Ditto.

* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::item const): Pass reference to createCSSOMWrapper.
(WebCore::CSSGroupingRule::reattach): Use downcast.

* Source/WebCore/css/CSSImportRule.h: Removed unnecessary include of
StyleRule.h, updated other includes and forward declarations as needed.

* Source/WebCore/css/CSSKeyframeRule.h: Added a
StyleRuleKeyframe::copy function that asserts it is never reached,
replacing code that was previously in StyleRuleBase::copy.

* Source/WebCore/css/CSSKeyframesRule.cpp:
(WebCore::CSSKeyframesRule::reattach): Use downcast.

* Source/WebCore/css/CSSLayerBlockRule.h: Removed unnecessary include of
StyleRule.h, updated other includes and forward declarations as needed.

* Source/WebCore/css/CSSLayerStatementRule.cpp:
(WebCore::CSSLayerStatementRule::~CSSLayerStatementRule): Defined this
virtual destructor explicitly here so we can compile the header file
without including StyleRule.h.
(WebCore::CSSLayerStatementRule::reattach): Use downcast.

* Source/WebCore/css/CSSLayerStatementRule.h: Removed unnecessary include of
StyleRule.h, updated other includes and forward declarations as needed.
* Source/WebCore/css/CSSPropertySourceData.h: Ditto.

* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::item): Pass reference to createCSSOMWrapper.

* Source/WebCore/css/CSSSupportsRule.h: Removed unneeded forward declaration.

* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::visitDerived): Added. This is now the only function
that needs the mapping of type to the correct derived class.
(WebCore::StyleRuleBase::visitDerived const): Added.
(WebCore::StyleRuleBase::operator delete): Added a destroying delete, using
visitDerived in its implementation, to replace the destroy function.
(WebCore::StyleRuleBase::copy const): Use visitDerived.
(WebCore::StyleRuleBase::createCSSOMWrapper const): Ditto.
(WebCore::StyleRuleFontPaletteValues::create): Moved here from the header.

* Source/WebCore/css/StyleRule.h: Use RefCounted for StyleRuleBase and
removed the custom deref function. Improved the comment about why we
allow createCSSOMWrapper with no parent and refactored to take references
rather than pointers since we we are passing &quot;this&quot;. Added a destroying
delete to replace the destroy function. Added a private visitDerived
function for use in functions that involve polymorphism. Fixed the
formatting of all the one-liner functions in StyleRuleFontPaletteValues,
following our informal rule that larger functions should be outside the
class definition to keep it readable. Removed explicit implementations
of various copy constructors and destructors where the automatically
generated ones work correctly and can compile in the header without
introducing additional dependencies. Removed include of StyleProperties.h,
which isn&apos;t needed for the header and can be included by implementation
files instead.

* Source/WebCore/css/StyleRuleImport.h: Added a
StyleRuleKeyframe::copy function that asserts it is never reached,
replacing code that was previously in StyleRuleBase::copy.

* Source/WebCore/css/parser/CSSParserImpl.h: Removed unnecessary include
of StyleRule.h, updated other includes and forward declarations as needed.
* Source/WebCore/css/parser/CSSParserObserver.h: Ditto.
* Source/WebCore/css/parser/CSSPropertyParser.h: Ditto.

* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp: Added include of
StyleProperties.h that is now needed.

* Source/WebCore/html/track/WebVTTParser.cpp: Removed unnecessary include
of StyleRule.h, updated other includes and forward declarations as needed.

* Source/WebCore/svg/properties/SVGAttributeAnimator.cpp: Added include of
StyleProperties.h that is now needed.

Canonical link: <a href="https://commits.webkit.org/255252@main">https://commits.webkit.org/255252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad66cb4749e159b7819c90621d8b22c873476dc2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100980 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/160770 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/263 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29262 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97383 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/230 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77994 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27189 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81833 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70226 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35391 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15856 "Found 1 new test failure: webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33189 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16930 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3635 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36974 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39751 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36035 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->