### PR TITLE
File inputs with added files show ugly UUID filenames after resuming

### DIFF
--- a/Source/WebCore/html/FileInputType.h
+++ b/Source/WebCore/html/FileInputType.h
@@ -54,7 +54,7 @@ public:
     FileList& files() { return m_fileList; }
     void setFiles(RefPtr<FileList>&&, WasSetByJavaScript);
 
-    static Vector<FileChooserFileInfo> filesFromFormControlState(const FormControlState&);
+    static std::pair<Vector<FileChooserFileInfo>, String> filesFromFormControlState(const FormControlState&);
     bool canSetStringValue() const final;
     bool valueMissing(const String&) const final;
 

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -156,7 +156,8 @@ const AtomString& HTMLInputElement::name() const
 
 Vector<FileChooserFileInfo> HTMLInputElement::filesFromFileInputFormControlState(const FormControlState& state)
 {
-    return FileInputType::filesFromFormControlState(state);
+    auto [files, _] = FileInputType::filesFromFormControlState(state);
+    return files;
 }
 
 HTMLElement* HTMLInputElement::containerElement() const

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -260,8 +260,12 @@ String RenderFileUploadControl::fileTextValue() const
     auto& input = inputElement();
     if (!input.files())
         return { };
-    if (input.files()->length() && !input.displayString().isEmpty())
+    if (input.files()->length() && !input.displayString().isEmpty()) {
+        if (input.files()->length() == 1)
+            return StringTruncator::centerTruncate(input.displayString(), maxFilenameWidth(), style().fontCascade());
+
         return StringTruncator::rightTruncate(input.displayString(), maxFilenameWidth(), style().fontCascade());
+    }
     return theme().fileListNameForWidth(input.files(), style().fontCascade(), maxFilenameWidth(), input.multiple());
 }
     

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -417,6 +417,9 @@ static bool setContainsUTIThatConformsTo(NSSet<NSString *> *typeIdentifiers, UTT
 
     NSUInteger imageCount = mediaItems.count - videoCount;
 
+    // FIXME (245996): Match the macOS behavior of showing the file name in the case of a single file selected.
+    // Currently, the file names are UUIDs which are not pleasant to display, so this should be
+    // done once the files are saved using their actual names, which will be done once 245906 is resolved.
     NSString *displayString = (imageCount || videoCount) ? [NSString localizedStringWithFormat:WEB_UI_NSSTRING(@"%lu photo(s) and %lu video(s)", "label next to file upload control; parameters are the number of photos and the number of videos"), (unsigned long)imageCount, (unsigned long)videoCount] : nil;
 
     [self _dismissDisplayAnimated:YES];


### PR DESCRIPTION
#### 593e3b40fbb1123fcb9b67067a1d38d8902e4778
<pre>
File inputs with added files show ugly UUID filenames after resuming
<a href="https://bugs.webkit.org/show_bug.cgi?id=245932">https://bugs.webkit.org/show_bug.cgi?id=245932</a>
rdar://96566852

Reviewed by Aditya Keerthi.

Currently, media saved within `WKFileUploadPanel` are saved with UUIDs as their
file names. The displayed string of the media is then set to `x photo(s) and x video(s)`.
However, when force quitting the page and re-opening it, the display string
isn&apos;t preserved. This causes the displayed string to instead fallback to the
macOS behavior of creating the string, which uses it&apos;s file name. On macOS,
this is fine as the file has a reasonable name, but on iOS it displays the UUID.

In theory, the iOS behavior should match the macOS behavior, but because of iOS
having UUID-based file names, this is not a good solution for the time being.
Instead, this PR resolves the issue of the UUID being shown by preserving the
display name, so that it will always show `x photo(s) and x video(s)`, which
will be consistent when force quitting and re-opening the page.

Once <a href="https://bugs.webkit.org/show_bug.cgi?id=245906">https://bugs.webkit.org/show_bug.cgi?id=245906</a> is resolved, the file names
on iOS will no longer be UUIDs, and so the logic can then be changed to match
the macOS behavior of showing the file name.

This PR also addresses an inconsistency with truncating the string in the case
of there being a single file.

* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::filesFromFormControlState):
(WebCore::FileInputType::saveFormControlState const):
(WebCore::FileInputType::restoreFormControlState):
* Source/WebCore/html/FileInputType.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::filesFromFileInputFormControlState):
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::fileTextValue const):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(-[WKFileUploadPanel _chooseMediaItems:]):

Canonical link: <a href="https://commits.webkit.org/255135@main">https://commits.webkit.org/255135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74914787b4bef6b6a464f69f15e412cb290f2cf0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/590 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/101209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95485 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97138 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/83825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35611 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/33396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3570 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37199 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39117 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->