### PR TITLE
[JSC] Support all rounding modes in Temporal

### DIFF
--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -280,8 +280,13 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/round/relativeto-sub-minute-offset.js
     - test/built-ins/Temporal/Duration/prototype/round/relativeto-wrong-type.js
     - test/built-ins/Temporal/Duration/prototype/round/roundingmode-ceil.js
+    - test/built-ins/Temporal/Duration/prototype/round/roundingmode-expand.js
     - test/built-ins/Temporal/Duration/prototype/round/roundingmode-floor.js
+    - test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfCeil.js
+    - test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfEven.js
     - test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfExpand.js
+    - test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfFloor.js
+    - test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfTrunc.js
     - test/built-ins/Temporal/Duration/prototype/round/roundingmode-trunc.js
     - test/built-ins/Temporal/Duration/prototype/round/throws-in-balance-duration-when-sign-mismatched-with-zoned-date-time.js
     - test/built-ins/Temporal/Duration/prototype/round/throws-in-unbalance-duration-relative-when-sign-mismatched.js
@@ -361,8 +366,13 @@ skip:
     - test/built-ins/Temporal/PlainDate/prototype/since/rounding-relative.js
     - test/built-ins/Temporal/PlainDate/prototype/since/roundingincrement.js
     - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-ceil.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-expand.js
     - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-floor.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfCeil.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfEven.js
     - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfExpand.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfFloor.js
+    - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfTrunc.js
     - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-trunc.js
     - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-undefined.js
     - test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-wrong-type.js
@@ -372,8 +382,13 @@ skip:
     - test/built-ins/Temporal/PlainDate/prototype/until/rounding-relative.js
     - test/built-ins/Temporal/PlainDate/prototype/until/roundingincrement.js
     - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-ceil.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-expand.js
     - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-floor.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfCeil.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfEven.js
     - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfExpand.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfFloor.js
+    - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfTrunc.js
     - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-trunc.js
     - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-undefined.js
     - test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-wrong-type.js

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1053,42 +1053,6 @@ test/built-ins/RegExp/prototype/exec/u-lastindex-adv.js:
 test/built-ins/RegExp/quantifier-integer-limit.js:
   default: 'SyntaxError: Invalid regular expression: number too large in {} quantifier'
   strict mode: 'SyntaxError: Invalid regular expression: number too large in {} quantifier'
-test/built-ins/Temporal/Duration/prototype/round/roundingmode-expand.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfCeil.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfEven.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfFloor.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Duration/prototype/round/roundingmode-halfTrunc.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Duration/prototype/toString/fractionalseconddigits-non-integer.js:
-  default: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
-  strict mode: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
-test/built-ins/Temporal/Duration/prototype/total/total-value-infinity.js:
-  default: 'Test262Error: Expected SameValue(«NaN», «Infinity») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«NaN», «Infinity») to be true'
-test/built-ins/Temporal/Instant/prototype/round/roundingmode-expand.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Instant/prototype/round/roundingmode-halfCeil.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Instant/prototype/round/roundingmode-halfEven.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Instant/prototype/round/roundingmode-halfFloor.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Instant/prototype/round/roundingmode-halfTrunc.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
 test/built-ins/Temporal/Instant/prototype/since/largestunit.js:
   default: 'Test262Error: does not include higher units than necessary (largest unit unspecified) nanoseconds result Expected SameValue(«40», «101») to be true'
   strict mode: 'Test262Error: does not include higher units than necessary (largest unit unspecified) nanoseconds result Expected SameValue(«40», «101») to be true'
@@ -1096,209 +1060,65 @@ test/built-ins/Temporal/Instant/prototype/since/roundingmode-ceil.js:
   default: 'Test262Error: rounds to milliseconds (roundingMode = ceil, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
   strict mode: 'Test262Error: rounds to milliseconds (roundingMode = ceil, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/since/roundingmode-expand.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  default: 'Test262Error: rounds to hours (rounding mode = expand, negative case) hours result Expected SameValue(«-376435», «-376436») to be true'
+  strict mode: 'Test262Error: rounds to hours (rounding mode = expand, negative case) hours result Expected SameValue(«-376435», «-376436») to be true'
 test/built-ins/Temporal/Instant/prototype/since/roundingmode-floor.js:
   default: 'Test262Error: rounds to milliseconds (rounding mode = floor, negative case) nanoseconds result Expected SameValue(«-936», «0») to be true'
   strict mode: 'Test262Error: rounds to milliseconds (rounding mode = floor, negative case) nanoseconds result Expected SameValue(«-936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/since/roundingmode-halfCeil.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  default: 'Test262Error: rounds to milliseconds (roundingMode = halfCeil, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
+  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfCeil, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/since/roundingmode-halfEven.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  default: 'Test262Error: rounds to milliseconds (roundingMode = halfEven, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
+  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfEven, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/since/roundingmode-halfExpand.js:
   default: 'Test262Error: rounds to milliseconds (roundingMode = halfExpand, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
   strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfExpand, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/since/roundingmode-halfFloor.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  default: 'Test262Error: rounds to milliseconds (roundingMode = halfFloor, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
+  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfFloor, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/since/roundingmode-halfTrunc.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  default: 'Test262Error: rounds to milliseconds (roundingMode = halfTrunc, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
+  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfTrunc, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/since/roundingmode-trunc.js:
   default: 'Test262Error: rounds to hours (rounding mode = trunc, negative case) hours result Expected SameValue(«-376436», «-376435») to be true'
   strict mode: 'Test262Error: rounds to hours (rounding mode = trunc, negative case) hours result Expected SameValue(«-376436», «-376435») to be true'
-test/built-ins/Temporal/Instant/prototype/toString/fractionalseconddigits-non-integer.js:
-  default: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
-  strict mode: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
-test/built-ins/Temporal/Instant/prototype/toString/roundingmode-expand.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Instant/prototype/toString/roundingmode-halfCeil.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Instant/prototype/toString/roundingmode-halfEven.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Instant/prototype/toString/roundingmode-halfFloor.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/Instant/prototype/toString/roundingmode-halfTrunc.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
 test/built-ins/Temporal/Instant/prototype/until/roundingmode-ceil.js:
   default: 'Test262Error: rounds to milliseconds (roundingMode = ceil, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
   strict mode: 'Test262Error: rounds to milliseconds (roundingMode = ceil, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/until/roundingmode-expand.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  default: 'Test262Error: rounds to hours (rounding mode = expand, negative case) hours result Expected SameValue(«-376435», «-376436») to be true'
+  strict mode: 'Test262Error: rounds to hours (rounding mode = expand, negative case) hours result Expected SameValue(«-376435», «-376436») to be true'
 test/built-ins/Temporal/Instant/prototype/until/roundingmode-floor.js:
   default: 'Test262Error: rounds to milliseconds (rounding mode = floor, negative case) nanoseconds result Expected SameValue(«-936», «0») to be true'
   strict mode: 'Test262Error: rounds to milliseconds (rounding mode = floor, negative case) nanoseconds result Expected SameValue(«-936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/until/roundingmode-halfCeil.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  default: 'Test262Error: rounds to milliseconds (roundingMode = halfCeil, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
+  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfCeil, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/until/roundingmode-halfEven.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  default: 'Test262Error: rounds to milliseconds (roundingMode = halfEven, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
+  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfEven, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/until/roundingmode-halfExpand.js:
   default: 'Test262Error: rounds to milliseconds (roundingMode = halfExpand, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
   strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfExpand, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/until/roundingmode-halfFloor.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  default: 'Test262Error: rounds to milliseconds (roundingMode = halfFloor, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
+  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfFloor, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/until/roundingmode-halfTrunc.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
+  default: 'Test262Error: rounds to milliseconds (roundingMode = halfTrunc, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
+  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfTrunc, positive case) nanoseconds result Expected SameValue(«936», «0») to be true'
 test/built-ins/Temporal/Instant/prototype/until/roundingmode-trunc.js:
   default: 'Test262Error: rounds to hours (rounding mode = trunc, negative case) hours result Expected SameValue(«-376436», «-376435») to be true'
   strict mode: 'Test262Error: rounds to hours (rounding mode = trunc, negative case) hours result Expected SameValue(«-376436», «-376435») to be true'
-test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-expand.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfCeil.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfEven.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfFloor.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDate/prototype/since/roundingmode-halfTrunc.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-expand.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfCeil.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfEven.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfFloor.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDate/prototype/until/roundingmode-halfTrunc.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
 test/built-ins/Temporal/PlainDateTime/from/order-of-operations.js:
   default: 'Test262Error: Expected [get fields.calendar, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.year, get fields.year.valueOf, call fields.year.valueOf] and [get fields.calendar, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf, get fields.year, get fields.year.valueOf, call fields.year.valueOf] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get fields.calendar, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.year, get fields.year.valueOf, call fields.year.valueOf] and [get fields.calendar, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf, get fields.year, get fields.year.valueOf, call fields.year.valueOf] to have the same contents. order of operations'
-test/built-ins/Temporal/PlainDateTime/prototype/round/roundingmode-expand.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDateTime/prototype/round/roundingmode-halfCeil.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDateTime/prototype/round/roundingmode-halfEven.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDateTime/prototype/round/roundingmode-halfFloor.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDateTime/prototype/round/roundingmode-halfTrunc.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDateTime/prototype/toString/fractionalseconddigits-non-integer.js:
-  default: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
-  strict mode: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
-test/built-ins/Temporal/PlainDateTime/prototype/toString/roundingmode-expand.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDateTime/prototype/toString/roundingmode-halfCeil.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDateTime/prototype/toString/roundingmode-halfEven.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDateTime/prototype/toString/roundingmode-halfFloor.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainDateTime/prototype/toString/roundingmode-halfTrunc.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
 test/built-ins/Temporal/PlainDateTime/prototype/with/order-of-operations.js:
   default: 'Test262Error: Expected [get fields.calendar, get fields.timeZone, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.year, get fields.year.valueOf, call fields.year.valueOf, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf] and [get fields.calendar, get fields.timeZone, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf, get fields.year, get fields.year.valueOf, call fields.year.valueOf] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get fields.calendar, get fields.timeZone, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.year, get fields.year.valueOf, call fields.year.valueOf, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf] and [get fields.calendar, get fields.timeZone, get fields.day, get fields.day.valueOf, call fields.day.valueOf, get fields.hour, get fields.hour.valueOf, call fields.hour.valueOf, get fields.microsecond, get fields.microsecond.valueOf, call fields.microsecond.valueOf, get fields.millisecond, get fields.millisecond.valueOf, call fields.millisecond.valueOf, get fields.minute, get fields.minute.valueOf, call fields.minute.valueOf, get fields.month, get fields.month.valueOf, call fields.month.valueOf, get fields.monthCode, get fields.monthCode.toString, call fields.monthCode.toString, get fields.nanosecond, get fields.nanosecond.valueOf, call fields.nanosecond.valueOf, get fields.second, get fields.second.valueOf, call fields.second.valueOf, get fields.year, get fields.year.valueOf, call fields.year.valueOf] to have the same contents. order of operations'
 test/built-ins/Temporal/PlainDateTime/prototype/with/overflow-wrong-type.js:
   default: 'Test262Error: Expected [get overflow.toString, call overflow.toString] and [get overflow.toString, call overflow.toString, get overflow.toString, call overflow.toString] to have the same contents. order of operations'
   strict mode: 'Test262Error: Expected [get overflow.toString, call overflow.toString] and [get overflow.toString, call overflow.toString, get overflow.toString, call overflow.toString] to have the same contents. order of operations'
-test/built-ins/Temporal/PlainTime/prototype/round/roundingmode-expand.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/round/roundingmode-halfCeil.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/round/roundingmode-halfEven.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/round/roundingmode-halfFloor.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/round/roundingmode-halfTrunc.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/since/roundingmode-expand.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/since/roundingmode-halfCeil.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/since/roundingmode-halfEven.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/since/roundingmode-halfFloor.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/since/roundingmode-halfTrunc.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/toString/fractionalseconddigits-non-integer.js:
-  default: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
-  strict mode: "RangeError: fractionalSecondDigits must be 'auto' or 0 through 9, not 9.7"
-test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-expand.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-halfCeil.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-halfEven.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-halfFloor.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/toString/roundingmode-halfTrunc.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/until/roundingmode-expand.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/until/roundingmode-halfCeil.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/until/roundingmode-halfEven.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/until/roundingmode-halfFloor.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-test/built-ins/Temporal/PlainTime/prototype/until/roundingmode-halfTrunc.js:
-  default: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
-  strict mode: 'RangeError: roundingMode must be either "ceil", "floor", "trunc", or "halfExpand"'
 test/built-ins/Temporal/getOwnPropertyNames.js:
   default: 'Test262Error: ZonedDateTime'
   strict mode: 'Test262Error: ZonedDateTime'

--- a/Source/JavaScriptCore/runtime/TemporalDuration.h
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.h
@@ -74,7 +74,7 @@ public:
 
     static int sign(const ISO8601::Duration&);
     static double round(ISO8601::Duration&, double increment, TemporalUnit, RoundingMode);
-    static void balance(ISO8601::Duration&, TemporalUnit largestUnit);
+    static std::optional<double> balance(ISO8601::Duration&, TemporalUnit largestUnit);
 
 private:
     TemporalDuration(VM&, Structure*, ISO8601::Duration&&);


### PR DESCRIPTION
#### a8f81aab31317cd32026b3f895f309e02bc9089f
<pre>
[JSC] Support all rounding modes in Temporal
<a href="https://bugs.webkit.org/show_bug.cgi?id=245935">https://bugs.webkit.org/show_bug.cgi?id=245935</a>

Reviewed by Geoffrey Garen.

This patch implements the rest of the rounding modes for Temporal, namely,
`expand`, `halfCeil`, `halfFloor`, `halfTrunc`, and `halfEven`.

(As a bonus, it also addresses two adjacent spec tweaks related to fractionalSecondDigits and BalanceDuration.)

Note: Some tests still fail due to precision loss beyond MAX_SAFE_INTEGER...

* JSTests/test262/config.yaml:
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/TemporalDuration.cpp:
(JSC::TemporalDuration::balance):
(JSC::TemporalDuration::total const):
* Source/JavaScriptCore/runtime/TemporalDuration.h:
* Source/JavaScriptCore/runtime/TemporalObject.cpp:
(JSC::temporalFractionalSecondDigits):
(JSC::temporalRoundingMode):
(JSC::negateTemporalRoundingMode):
(JSC::roundNumberToIncrement):

Canonical link: <a href="https://commits.webkit.org/255068@main">https://commits.webkit.org/255068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37bf979bb99dd2e9ffa2e484db17e48771210f56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21769 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100798 "Hash 37bf979b for PR 4907 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/160514 "Reverted pull request changes (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/205 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29216 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83555 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97331 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96849 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27139 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82112 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/81745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70169 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82665 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35339 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15787 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77689 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33135 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16824 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26792 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3519 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36919 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80289 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35915 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17600 "Passed tests") | 
<!--EWS-Status-Bubble-End-->