### PR TITLE
SUMMARY element: click() for invisible SUMMARY should toggle DETAILS element

### DIFF
--- a/LayoutTests/fast/html/summary-invisible-click-expected.txt
+++ b/LayoutTests/fast/html/summary-invisible-click-expected.txt
@@ -1,0 +1,3 @@
+
+PASS click() on hidden SUMMARY should toggle DETAILS.
+

--- a/LayoutTests/fast/html/summary-invisible-click.html
+++ b/LayoutTests/fast/html/summary-invisible-click.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<details style="display:none">
+<summary>Click me</summary>
+Blah, blah, ...
+</detail>
+
+<script>
+test(() => {
+  const summary = document.querySelector('summary');
+  const details = document.querySelector('details');
+  assert_false(details.open);
+  summary.click();
+  assert_true(details.open);
+  summary.click();
+  assert_false(details.open);
+}, 'click() on hidden SUMMARY should toggle DETAILS.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/activation-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/activation-behavior-expected.txt
@@ -1,18 +1,26 @@
 
-FAIL Should open a closed details if all conditions are met assert_equals: After activation: expected open to be true expected true but got false
-FAIL Should close an open details if all conditions are met assert_equals: After activation: expected open to be false expected false but got true
-FAIL Should open a closed details even if the details is not being rendered assert_equals: After activation: expected open to be true expected true but got false
-FAIL Should open a closed details even if the summary is not being rendered assert_equals: After activation: expected open to be true expected true but got false
-FAIL Should open a closed details if a span element precedes the summary assert_equals: After activation: expected open to be true expected true but got false
+PASS Should open a closed details if all conditions are met
+PASS Should close an open details if all conditions are met
+PASS Should open a closed details even if the details is not being rendered
+PASS Should open a closed details even if the summary is not being rendered
+PASS Should open a closed details if a span element precedes the summary
 PASS Should stay closed if another summary element precedes the summary
-FAIL Should open a closed details if another summary element *nested inside a span* precedes the summary assert_equals: After activation: expected open to be true expected true but got false
+PASS Should open a closed details if another summary element *nested inside a span* precedes the summary
 PASS Should stay closed if the summary element is nested inside a span element
-FAIL toggle events should be coalesced even when using the activation behavior of a summary assert_equals: Expected toggle to fire exactly once expected 1 but got 0
-Summary
+PASS toggle events should be coalesced even when using the activation behavior of a summary
 Summary
 Contents
 
 Summary
+Contents
+
+Summary
+Contents
+
+Summary 1
 Summary 1
 Summary 2
+Contents
+
 Summary
+Contents

--- a/Source/WebCore/html/HTMLSummaryElement.cpp
+++ b/Source/WebCore/html/HTMLSummaryElement.cpp
@@ -116,7 +116,7 @@ bool HTMLSummaryElement::supportsFocus() const
 
 void HTMLSummaryElement::defaultEventHandler(Event& event)
 {
-    if (isActiveSummary() && renderer()) {
+    if (isActiveSummary()) {
         auto& eventNames = WebCore::eventNames();
         if (event.type() == eventNames.DOMActivateEvent && !isClickableControl(event.target())) {
             if (RefPtr<HTMLDetailsElement> details = detailsElement())
@@ -158,10 +158,7 @@ void HTMLSummaryElement::defaultEventHandler(Event& event)
 
 bool HTMLSummaryElement::willRespondToMouseClickEventsWithEditability(Editability editability) const
 {
-    if (isActiveSummary() && renderer())
-        return true;
-
-    return HTMLElement::willRespondToMouseClickEventsWithEditability(editability);
+    return isActiveSummary() || HTMLElement::willRespondToMouseClickEventsWithEditability(editability);
 }
 
 }


### PR DESCRIPTION
#### 19b515f0605328883ede9f5dcae2c07d571dd209
<pre>
SUMMARY element: click() for invisible SUMMARY should toggle DETAILS element

SUMMARY element: click() for invisible SUMMARY should toggle DETAILS element

<a href="https://bugs.webkit.org/show_bug.cgi?id=245937">https://bugs.webkit.org/show_bug.cgi?id=245937</a>

Reviewed by Tim Nguyen.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/c162ebcbfa71bfbdd8e3fdba2137c382f752b4b2">https://chromium.googlesource.com/chromium/src.git/+/c162ebcbfa71bfbdd8e3fdba2137c382f752b4b2</a>

This is to align Webkit behavior with Gecko (Firefox) and Blink (Chrome).

We had unreasonable renderer() existence check for activate event handling. It is not defined by the standard.

* Source/WebCore/html/HTMLSummaryElement.cpp:
(HTMLSummaryElement::supportsFocus): Remove &quot;renderer&quot; condition
(HTMLSummaryElement::defaultEventHandler): Simplified and removed &quot;renderer&quot; condition
* LayoutTests/fast/html/summary-invisible-click.html: Added Test Case
* LayoutTests/fast/html/summary-invisible-click-expected.txt: Added Test Case Expectations
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/activation-behavior-expected.txt: Updated Test Expectations

Canonical link: <a href="https://commits.webkit.org/255073@main">https://commits.webkit.org/255073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5e554616278d1eaf8a7a2a3e6b31308f215d576

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100869 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/160686 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/229 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29234 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97352 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/184 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77957 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27161 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70191 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35360 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15808 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33156 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16858 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3522 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36942 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39716 "Found 1 new test failure: fast/events/blur-remove-parent-crash.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35952 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->