### PR TITLE
[web-animations] avoid extra serialization and parsing when calling commitStyles()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-inline-value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-inline-value-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Interpolation between translateX(0px) and translateX(50px) gives the correct computed value halfway according to commitStyles.
 PASS Interpolation between translateX(0%) and translateX(50%) gives the correct computed value halfway according to commitStyles.
-PASS Interpolation between translateY(0%) and translateX(50%) gives the correct computed value halfway according to commitStyles.
+FAIL Interpolation between translateY(0%) and translateX(50%) gives the correct computed value halfway according to commitStyles. assert_equals: The value at 50% progress is as expected expected "translate(25%)" but got "translate(25%, 0px)"
 PASS Interpolation between translateX(50px) and translateY(50px) gives the correct computed value halfway according to commitStyles.
 PASS Interpolation between translateX(50px) and translateZ(50px) gives the correct computed value halfway according to commitStyles.
 PASS Interpolation between translateZ(50px) and translateX(50px) gives the correct computed value halfway according to commitStyles.

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt
@@ -15,8 +15,8 @@ FAIL Commits matrix-interpolated relative transforms assert_equals: Resolved tra
 PASS Commits "none" transform
 PASS Commits the intermediate value of an animation in the middle of stack
 PASS Commit composites on top of the underlying value
-PASS Triggers mutation observers when updating style
-FAIL Does NOT trigger mutation observers when the change to style is redundant assert_equals: Should have no mutation records expected 0 but got 1
+FAIL Triggers mutation observers when updating style assert_equals: Should have one mutation record expected 1 but got 0
+PASS Does NOT trigger mutation observers when the change to style is redundant
 PASS Throws if the target element is a pseudo element
 PASS Throws if the target element is not something with a style attribute
 PASS Throws if the target effect is display:none

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1475,8 +1475,6 @@ ExceptionOr<void> WebAnimation::commitStyles()
     }();
 
     auto computedStyleExtractor = ComputedStyleExtractor(&styledElement);
-    auto inlineStyle = styledElement.document().createCSSStyleDeclaration();
-    inlineStyle->setCssText(styledElement.getAttribute(HTMLNames::styleAttr));
 
     auto& keyframeStack = styledElement.ensureKeyframeEffectStack(PseudoId::None);
 
@@ -1513,11 +1511,11 @@ ExceptionOr<void> WebAnimation::commitStyles()
         WTF::switchOn(property,
             [&] (CSSPropertyID propertyId) {
                 if (auto cssValue = computedStyleExtractor.valueForPropertyInStyle(*animatedStyle, propertyId, nullptr))
-                    inlineStyle->setPropertyInternal(propertyId, cssValue->cssText(), false);
+                    styledElement.setInlineStyleProperty(propertyId, WTFMove(cssValue));
             },
             [&] (AtomString customProperty) {
                 if (auto cssValue = computedStyleExtractor.customPropertyValue(customProperty))
-                    inlineStyle->setProperty(customProperty, cssValue->cssText(), emptyString());
+                    styledElement.setInlineStyleCustomProperty(customProperty, WTFMove(cssValue));
             }
         );
     };
@@ -1532,8 +1530,6 @@ ExceptionOr<void> WebAnimation::commitStyles()
     auto customProperties = effect->animatedCustomProperties();
     for (auto customProperty : customProperties)
         commitProperty(customProperty);
-
-    styledElement.setAttribute(HTMLNames::styleAttr, AtomString { inlineStyle->cssText() });
 
     return { };
 }

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -1481,6 +1481,13 @@ bool MutableStyleProperties::setCustomProperty(const Document* document, const S
     return CSSParser::parseCustomPropertyValue(*this, AtomString { propertyName }, value, important, parserContext) == CSSParser::ParseResult::Changed;
 }
 
+void MutableStyleProperties::setCustomProperty(const String& propertyName, RefPtr<CSSValue>&& value, bool important)
+{
+    removeCustomProperty(propertyName);
+    m_propertyVector.append({ CSSPropertyCustom, WTFMove(value), important });
+    return;
+}
+
 void MutableStyleProperties::setProperty(CSSPropertyID propertyID, RefPtr<CSSValue>&& value, bool important)
 {
     StylePropertyShorthand shorthand = shorthandForProperty(propertyID);

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -1481,25 +1481,29 @@ bool MutableStyleProperties::setCustomProperty(const Document* document, const S
     return CSSParser::parseCustomPropertyValue(*this, AtomString { propertyName }, value, important, parserContext) == CSSParser::ParseResult::Changed;
 }
 
-void MutableStyleProperties::setCustomProperty(const String& propertyName, RefPtr<CSSValue>&& value, bool important)
+bool MutableStyleProperties::setCustomProperty(const String& propertyName, RefPtr<CSSValue>&& value, bool important)
 {
+    bool changed = value != getCustomPropertyCSSValue(propertyName);
     removeCustomProperty(propertyName);
     m_propertyVector.append({ CSSPropertyCustom, WTFMove(value), important });
-    return;
+    return changed;
 }
 
-void MutableStyleProperties::setProperty(CSSPropertyID propertyID, RefPtr<CSSValue>&& value, bool important)
+bool MutableStyleProperties::setProperty(CSSPropertyID propertyID, RefPtr<CSSValue>&& value, bool important)
 {
     StylePropertyShorthand shorthand = shorthandForProperty(propertyID);
     if (!shorthand.length()) {
+        bool changed = value != getPropertyCSSValue(propertyID);
         setProperty(CSSProperty(propertyID, WTFMove(value), important));
-        return;
+        return changed;
     }
 
     removePropertiesInSet(shorthand.properties(), shorthand.length());
 
     for (auto longhand : shorthand)
         m_propertyVector.append(CSSProperty(longhand, value.copyRef(), important));
+
+    return true;
 }
 
 bool MutableStyleProperties::canUpdateInPlace(const CSSProperty& property, CSSProperty* toReplace) const

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -255,6 +255,7 @@ public:
 
     // Methods for querying and altering CSS custom properties.
     bool setCustomProperty(const Document*, const String& propertyName, const String& value, bool important, CSSParserContext);
+    void setCustomProperty(const String& propertyName, RefPtr<CSSValue>&&, bool important);
     bool removeCustomProperty(const String& propertyName, String* returnText = nullptr);
 
 private:

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -229,7 +229,7 @@ public:
     // These expand shorthand properties into multiple properties.
     bool setProperty(CSSPropertyID, const String& value, bool important, CSSParserContext);
     bool setProperty(CSSPropertyID, const String& value, bool important = false);
-    void setProperty(CSSPropertyID, RefPtr<CSSValue>&&, bool important = false);
+    bool setProperty(CSSPropertyID, RefPtr<CSSValue>&&, bool important = false);
 
     // These do not. FIXME: This is too messy, we can do better.
     bool setProperty(CSSPropertyID, CSSValueID identifier, bool important = false);
@@ -255,7 +255,7 @@ public:
 
     // Methods for querying and altering CSS custom properties.
     bool setCustomProperty(const Document*, const String& propertyName, const String& value, bool important, CSSParserContext);
-    void setCustomProperty(const String& propertyName, RefPtr<CSSValue>&&, bool important);
+    bool setCustomProperty(const String& propertyName, RefPtr<CSSValue>&&, bool important);
     bool removeCustomProperty(const String& propertyName, String* returnText = nullptr);
 
 private:

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -297,6 +297,18 @@ bool StyledElement::setInlineStyleProperty(CSSPropertyID propertyID, const Strin
     return changes;
 }
 
+void StyledElement::setInlineStyleProperty(CSSPropertyID propertyID, RefPtr<CSSValue>&& value, bool important)
+{
+    ensureMutableInlineStyle().setProperty(propertyID, WTFMove(value), important);
+    inlineStyleChanged();
+}
+
+void StyledElement::setInlineStyleCustomProperty(const String& propertyName, RefPtr<CSSValue>&& value, bool important)
+{
+    ensureMutableInlineStyle().setCustomProperty(propertyName, WTFMove(value), important);
+    inlineStyleChanged();
+}
+
 bool StyledElement::removeInlineStyleProperty(CSSPropertyID propertyID)
 {
     if (!inlineStyle())

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -297,16 +297,20 @@ bool StyledElement::setInlineStyleProperty(CSSPropertyID propertyID, const Strin
     return changes;
 }
 
-void StyledElement::setInlineStyleProperty(CSSPropertyID propertyID, RefPtr<CSSValue>&& value, bool important)
+bool StyledElement::setInlineStyleProperty(CSSPropertyID propertyID, RefPtr<CSSValue>&& value, bool important)
 {
-    ensureMutableInlineStyle().setProperty(propertyID, WTFMove(value), important);
-    inlineStyleChanged();
+    auto changed = ensureMutableInlineStyle().setProperty(propertyID, WTFMove(value), important);
+    if (changed)
+        inlineStyleChanged();
+    return changed;
 }
 
-void StyledElement::setInlineStyleCustomProperty(const String& propertyName, RefPtr<CSSValue>&& value, bool important)
+bool StyledElement::setInlineStyleCustomProperty(const String& propertyName, RefPtr<CSSValue>&& value, bool important)
 {
-    ensureMutableInlineStyle().setCustomProperty(propertyName, WTFMove(value), important);
-    inlineStyleChanged();
+    auto changed = ensureMutableInlineStyle().setCustomProperty(propertyName, WTFMove(value), important);
+    if (changed)
+        inlineStyleChanged();
+    return changed;
 }
 
 bool StyledElement::removeInlineStyleProperty(CSSPropertyID propertyID)

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -51,6 +51,8 @@ public:
     bool setInlineStyleProperty(CSSPropertyID, CSSPropertyID identifier, bool important = false);
     WEBCORE_EXPORT bool setInlineStyleProperty(CSSPropertyID, double value, CSSUnitType, bool important = false);
     WEBCORE_EXPORT bool setInlineStyleProperty(CSSPropertyID, const String& value, bool important = false);
+    void setInlineStyleProperty(CSSPropertyID, RefPtr<CSSValue>&&, bool important = false);
+    void setInlineStyleCustomProperty(const String& propertyName, RefPtr<CSSValue>&&, bool important = false);
     bool removeInlineStyleProperty(CSSPropertyID);
     void removeAllInlineStyleProperties();
 

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -51,8 +51,8 @@ public:
     bool setInlineStyleProperty(CSSPropertyID, CSSPropertyID identifier, bool important = false);
     WEBCORE_EXPORT bool setInlineStyleProperty(CSSPropertyID, double value, CSSUnitType, bool important = false);
     WEBCORE_EXPORT bool setInlineStyleProperty(CSSPropertyID, const String& value, bool important = false);
-    void setInlineStyleProperty(CSSPropertyID, RefPtr<CSSValue>&&, bool important = false);
-    void setInlineStyleCustomProperty(const String& propertyName, RefPtr<CSSValue>&&, bool important = false);
+    bool setInlineStyleProperty(CSSPropertyID, RefPtr<CSSValue>&&, bool important = false);
+    bool setInlineStyleCustomProperty(const String& propertyName, RefPtr<CSSValue>&&, bool important = false);
     bool removeInlineStyleProperty(CSSPropertyID);
     void removeAllInlineStyleProperties();
 


### PR DESCRIPTION
#### d3ee856e3c6507d580844ffb5864579c108d3214
<pre>
[web-animations] avoid extra serialization and parsing when calling commitStyles()
<a href="https://bugs.webkit.org/show_bug.cgi?id=245939">https://bugs.webkit.org/show_bug.cgi?id=245939</a>

Reviewed by NOBODY (OOPS!).

Add new methods on StyledElement and MutableStyleProperties to pass CSSValue directly
instead of strings.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-inline-value-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::commitStyles):
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::MutableStyleProperties::setCustomProperty):
* Source/WebCore/css/StyleProperties.h:
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::setInlineStyleProperty):
(WebCore::StyledElement::setInlineStyleCustomProperty):
* Source/WebCore/dom/StyledElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3a791149c42aaec6189e8c552a0bbb591f3e6ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101004 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/160924 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/277 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29272 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83632 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97397 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96921 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/241 "Found 1 new test failure: imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78008 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27206 "Found 1 new test failure: imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70239 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35405 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15865 "Found 1 new test failure: imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33203 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16945 "Found 1 new test failure: imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36988 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39761 "Found 1 new test failure: imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36053 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->