### PR TITLE
Fix !ENABLE(CONTEXT_MENUS) build after 255052@main

### DIFF
--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -294,6 +294,13 @@ String contextMenuItemTagLearnSpelling()
     return WEB_UI_STRING_WITH_MNEMONIC("Learn Spelling", "_Learn Spelling", "Learn Spelling context menu item");
 }
 
+#if !PLATFORM(COCOA)
+String contextMenuItemTagSearchWeb()
+{
+    return WEB_UI_STRING_WITH_MNEMONIC("Search the Web", "_Search the Web", "Search the Web context menu item");
+}
+#endif
+
 String contextMenuItemTagLookUpInDictionary(const String& selectedString)
 {
 #if USE(CF)
@@ -305,16 +312,6 @@ String contextMenuItemTagLookUpInDictionary(const String& selectedString)
     return makeStringByReplacingAll(WEB_UI_STRING("Look Up “<selection>”", "Look Up context menu item with selected word"), "<selection>"_s, truncatedStringForMenuItem(selectedString));
 #endif
 }
-
-#if HAVE(TRANSLATION_UI_SERVICES)
-
-String contextMenuItemTagTranslate(const String& selectedString)
-{
-    auto selectedCFString = truncatedStringForMenuItem(selectedString).createCFString();
-    return WEB_UI_FORMAT_CFSTRING("Translate “%@”", "Translate context menu item with selected word", selectedCFString.get());
-}
-
-#endif
 
 String contextMenuItemTagOpenLink()
 {
@@ -487,6 +484,14 @@ String contextMenuItemTagInspectElement()
     return WEB_UI_STRING_WITH_MNEMONIC("Inspect Element", "Inspect _Element", "Inspect Element context menu item");
 }
 
+#if HAVE(TRANSLATION_UI_SERVICES)
+String contextMenuItemTagTranslate(const String& selectedString)
+{
+    auto selectedCFString = truncatedStringForMenuItem(selectedString).createCFString();
+    return WEB_UI_FORMAT_CFSTRING("Translate “%@”", "Translate context menu item with selected word", selectedCFString.get());
+}
+#endif
+
 #if ENABLE(PDFJS)
 String contextMenuItemPDFAutoSize()
 {
@@ -538,21 +543,15 @@ String contextMenuItemPDFPreviousPage()
     return WEB_UI_STRING_WITH_MNEMONIC("Previous Page", "_Previous Page", "Previous Page context menu item");
 }
 #endif
+#endif // ENABLE(CONTEXT_MENUS)
 
 #if !PLATFORM(COCOA)
-String contextMenuItemTagSearchWeb()
-{
-    return WEB_UI_STRING_WITH_MNEMONIC("Search the Web", "_Search the Web", "Search the Web context menu item");
-}
-
 String pdfDocumentTypeDescription()
 {
     // Also exposed to DOM.
     return WEB_UI_STRING("Portable Document Format", "Description of the primary type supported by the PDF pseudo plug-in.");
 }
 #endif // !PLATFORM(COCOA)
-
-#endif // ENABLE(CONTEXT_MENUS)
 
 #if !PLATFORM(IOS_FAMILY)
 

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -159,8 +159,9 @@ namespace WebCore {
     String contextMenuItemTagMediaPause();
     String contextMenuItemTagMediaMute();
     WEBCORE_EXPORT String contextMenuItemTagInspectElement();
-#endif // ENABLE(CONTEXT_MENUS)
-
+#if HAVE(TRANSLATION_UI_SERVICES)
+    String contextMenuItemTagTranslate(const String& selectedString);
+#endif
 #if ENABLE(PDFJS)
     String contextMenuItemPDFAutoSize();
     String contextMenuItemPDFZoomIn();
@@ -173,6 +174,9 @@ namespace WebCore {
     String contextMenuItemPDFNextPage();
     String contextMenuItemPDFPreviousPage();
 #endif
+#endif // ENABLE(CONTEXT_MENU)
+
+    WEBCORE_EXPORT String pdfDocumentTypeDescription();
 
 #if !PLATFORM(IOS_FAMILY)
     String searchMenuNoRecentSearchesText();
@@ -269,8 +273,6 @@ namespace WebCore {
     String uploadFileText();
     String allFilesText();
 #endif
-
-    WEBCORE_EXPORT String pdfDocumentTypeDescription();
 
 #if PLATFORM(COCOA)
     WEBCORE_EXPORT String builtInPDFPluginName();
@@ -394,10 +396,6 @@ namespace WebCore {
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
     WEBCORE_EXPORT String contextMenuItemTagCopySubject();
     WEBCORE_EXPORT String contextMenuItemTitleRemoveBackground();
-#endif
-
-#if HAVE(TRANSLATION_UI_SERVICES)
-    String contextMenuItemTagTranslate(const String& selectedString);
 #endif
 
 #if USE(CF) && !PLATFORM(WIN)


### PR DESCRIPTION
#### b017588f8835f16d5df19beea8832e34449c7ba9
<pre>
Fix !ENABLE(CONTEXT_MENUS) build after 255052@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=245948">https://bugs.webkit.org/show_bug.cgi?id=245948</a>

Reviewed by Chris Dumez.

Reorganize the LocalizedStrings header so all functions in the
`ENABLE(CONTEXT_MENUS)` block are also guarded. Modify the source file
to use the same ordering for definitions.

Move `pdfDocumentTypeDescription` so it is no longer guarded by
`ENABLE(CONTEXT_MENUS).

* Source/WebCore/platform/LocalizedStrings.cpp:
* Source/WebCore/platform/LocalizedStrings.h:

Canonical link: <a href="https://commits.webkit.org/255078@main">https://commits.webkit.org/255078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/deaeb48dbfbccb3fe08ba589a624600c8fbe0c2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100939 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/160751 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/251 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29252 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83601 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97373 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96895 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77978 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27181 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70212 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35380 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15838 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33178 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16902 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3526 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39735 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36003 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->