### PR TITLE
Keyboard scrolling spring damping animation doesn't finish and leads to endless flickering scrolling (229697)

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -268,16 +268,17 @@ EnterKeyHintEnabled:
       default: false
 
 EventHandlerDrivenSmoothKeyboardScrollingEnabled:
- type: bool
- humanReadableName: "EventHandler driven smooth keyboard scrolling"
- humanReadableDescription: "Enable EventHandler driven smooth keyboard scrolling"
- defaultValue:
-  WebKitLegacy:
-   default: false
-  WebKit:
-   default: true
-  WebCore:
-   default: false
+  type: bool
+  humanReadableName: "EventHandler driven smooth keyboard scrolling"
+  humanReadableDescription: "Enable EventHandler driven smooth keyboard scrolling"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      "PLATFORM(COCOA)": true
+      default: false
+    WebCore:
+      default: false
 
 FasterClicksEnabled:
   type: bool


### PR DESCRIPTION
#### 5f888cf9998e7399fdd1820a83067ecfb32ae1a9
<pre>
Keyboard scrolling spring damping animation doesn&apos;t finish and leads to endless flickering scrolling (229697)
<a href="https://bugs.webkit.org/show_bug.cgi?id=229697">https://bugs.webkit.org/show_bug.cgi?id=229697</a>
rdar://90106824

Reviewed by Wenson Hsieh.

`EventHandlerDrivenSmoothKeyboardScrollingEnabled` should not have been enabled
for non-Cocoa platforms. This PR fixes that.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:

Canonical link: <a href="https://commits.webkit.org/255099@main">https://commits.webkit.org/255099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d32b94f800d9614e20fd28da5a4a1e2f3fdde0c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/100946 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/160753 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/253 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29254 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97375 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/215 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/77982 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27182 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70213 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82707 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35382 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15843 "Found 1 new test failure: webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77736 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33180 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16908 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26842 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3545 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39738 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80337 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36009 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17610 "Passed tests") | 
<!--EWS-Status-Bubble-End-->