### PR TITLE
Follow-up build fix for 4a38830.

### DIFF
--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -108,7 +108,7 @@ static void alertForWindowSelection(WebPageProxy& page, const WebCore::SecurityO
     [accessoryView addSubview:menuLabel.get()];
     [alert setAccessoryView:accessoryView.get()];
 
-    NSButton *button = [alert addButtonWithTitle:WEB_UI_NSSTRING_KEY(@"Allow", "Allow (window sharing)", "Allow button title in window sharing prompt")];
+    NSButton *button = [alert addButtonWithTitle:WEB_UI_NSSTRING_KEY(@"Allow", @"Allow (window sharing)", "Allow button title in window sharing prompt")];
     button.keyEquivalent = @"";
     button = [alert addButtonWithTitle:WEB_UI_NSSTRING_KEY(@"Don’t Allow", @"Don’t Allow (window sharing)", "Disallow button title in window sharing prompt")];
     button.keyEquivalent = @"\E";
@@ -146,7 +146,7 @@ void DisplayCaptureSessionManager::alertForGetDisplayMedia(WebPageProxy& page, c
     NSString *alertTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to observe one of your windows or screens?", "Message for window and screen sharing prompt"), visibleOrigin];
     auto *allowWindowButtonString = WEB_UI_NSSTRING(@"Allow to Share Window", "Allow window button title in window and screen sharing prompt");
     auto *allowScreenButtonString = WEB_UI_NSSTRING(@"Allow to Share Screen", "Allow screen button title in window and screen sharing prompt");
-    auto *doNotAllowButtonString = WEB_UI_NSSTRING_KEY(@"Don’t Allow", "Don’t Allow (window and screen sharing)", "Disallow button title in window and screen sharing prompt");
+    auto *doNotAllowButtonString = WEB_UI_NSSTRING_KEY(@"Don’t Allow", @"Don’t Allow (window and screen sharing)", "Disallow button title in window and screen sharing prompt");
 
     auto alert = adoptNS([[NSAlert alloc] init]);
     [alert setMessageText:alertTitle];


### PR DESCRIPTION
#### 23e49d3ab0fe7eebe1fa25f004fde7f7fb65fa3e
<pre>
Follow-up build fix for 4a38830.

Unreviewed build fix.

* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::alertForWindowSelection): Use ObjC string literal.
(WebKit::DisplayCaptureSessionManager::alertForGetDisplayMedia): Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23e49d3ab0fe7eebe1fa25f004fde7f7fb65fa3e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/251 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/21899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/100981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96908 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/77995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/83614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/21899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/35392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/21899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/33190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/21899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/36975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/77995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1561 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/38898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/21899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->