### PR TITLE
https://github.com/webrtc/samples/tree/gh-pages/src/content/insertable-streams/endtoend-encryption is super slow in STP

### DIFF
--- a/LayoutTests/http/wpt/webrtc/audio-video-transform.js
+++ b/LayoutTests/http/wpt/webrtc/audio-video-transform.js
@@ -9,6 +9,8 @@ class AudioVideoRTCRtpTransformer {
                 this.trySendKeyFrameRequest = true;
             else if (event.data === "tryGenerateKeyFramePromiseHandling")
                 this.tryGenerateKeyFramePromiseHandling = true;
+            else if (event.data === "tryAccessingDataTwice")
+                this.tryAccessingDataTwice = true;
         };
         this.start();
     }
@@ -24,6 +26,13 @@ class AudioVideoRTCRtpTransformer {
         this.reader.read().then(chunk => {
             if (chunk.done)
                 return;
+
+            if (this.tryAccessingDataTwice) {
+                this.tryAccessingDataTwice = false;
+                const data1 = chunk.value.data;
+                const data2 = chunk.value.data;
+                this.context.options.port.postMessage(data1 === data2 ? "PASS" : "FAIL, data objects are different");
+            }
 
             this.writer.write(chunk.value);
 
@@ -67,7 +76,6 @@ class AudioVideoRTCRtpTransformer {
                         result = 'error 4';
                 });
             }
-
             this.process();
         });
     }

--- a/LayoutTests/http/wpt/webrtc/audiovideo-script-transform-expected.txt
+++ b/LayoutTests/http/wpt/webrtc/audiovideo-script-transform-expected.txt
@@ -6,4 +6,5 @@ PASS key frame on audio receiver
 PASS generate key frame on video receiver
 PASS send request key frame on video sender
 PASS generate key frame promise handling on video sender
+PASS Check data getter
 

--- a/LayoutTests/http/wpt/webrtc/audiovideo-script-transform.html
+++ b/LayoutTests/http/wpt/webrtc/audiovideo-script-transform.html
@@ -90,6 +90,20 @@ promise_test((test) => {
     videoSenderTransform.port.postMessage("tryGenerateKeyFramePromiseHandling");
     return waitForMessage(videoSenderTransform.port, "PASS");
 }, "generate key frame promise handling on video sender");
+
+promise_test(async (test) => {
+    audioReceiverTransform.port.postMessage("tryAccessingDataTwice");
+    await waitForMessage(audioReceiverTransform.port, "PASS");
+
+    audioSenderTransform.port.postMessage("tryAccessingDataTwice");
+    await waitForMessage(audioSenderTransform.port, "PASS");
+
+    videoReceiverTransform.port.postMessage("tryAccessingDataTwice");
+    await waitForMessage(videoReceiverTransform.port, "PASS");
+
+    videoSenderTransform.port.postMessage("tryAccessingDataTwice");
+    await waitForMessage(videoSenderTransform.port, "PASS");
+}, "Check data getter");
         </script>
     </body>
 </html>

--- a/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
@@ -40,13 +40,25 @@ RTCEncodedFrame::RTCEncodedFrame(Ref<RTCRtpTransformableFrame>&& frame)
 
 RefPtr<JSC::ArrayBuffer> RTCEncodedFrame::data() const
 {
-    auto data = m_frame->data();
-    return JSC::ArrayBuffer::create(data.data(), data.size());
+    if (!m_data) {
+        auto data = m_frame->data();
+        m_data = JSC::ArrayBuffer::create(data.data(), data.size());
+    }
+    return m_data;
 }
 
 void RTCEncodedFrame::setData(JSC::ArrayBuffer& buffer)
 {
-    m_frame->setData({ static_cast<const uint8_t*>(buffer.data()), buffer.byteLength() });
+    m_data = &buffer;
+}
+
+Ref<RTCRtpTransformableFrame> RTCEncodedFrame::rtcFrame()
+{
+    if (m_data) {
+        m_frame->setData({ static_cast<const uint8_t*>(m_data->data()), m_data->byteLength() });
+        m_data = nullptr;
+    }
+    return m_frame;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCEncodedFrame.h
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedFrame.h
@@ -43,12 +43,13 @@ public:
     RefPtr<JSC::ArrayBuffer> data() const;
     void setData(JSC::ArrayBuffer&);
 
-    RTCRtpTransformableFrame& rtcFrame() { return m_frame.get(); }
+    Ref<RTCRtpTransformableFrame> rtcFrame();
 
 protected:
     explicit RTCEncodedFrame(Ref<RTCRtpTransformableFrame>&&);
 
     Ref<RTCRtpTransformableFrame> m_frame;
+    mutable RefPtr<JSC::ArrayBuffer> m_data;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -204,12 +204,13 @@ static void transformFrame(Span<const uint8_t> data, JSDOMGlobalObject& globalOb
 template<typename Frame>
 void transformFrame(Frame& frame, JSDOMGlobalObject& globalObject, RTCRtpSFrameTransformer& transformer, SimpleReadableStreamSource& source, ScriptExecutionContextIdentifier identifier, const WeakPtr<RTCRtpSFrameTransform, WeakPtrImplWithEventTargetData>& weakTransform)
 {
-    auto chunk = frame.rtcFrame().data();
+    auto rtcFrame = frame.rtcFrame();
+    auto chunk = rtcFrame->data();
     auto result = processFrame(chunk, transformer, identifier, weakTransform);
     Span<const uint8_t> transformedChunk;
     if (result)
         transformedChunk = { result->data(), result->size() };
-    frame.rtcFrame().setData(transformedChunk);
+    rtcFrame->setData(transformedChunk);
     source.enqueue(toJS(&globalObject, &globalObject, frame));
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -102,9 +102,9 @@ ExceptionOr<Ref<WritableStream>> RTCRtpScriptTransformer::writable()
                 return Exception { ExistingExceptionError };
 
             auto rtcFrame = WTF::switchOn(frame, [&](RefPtr<RTCEncodedAudioFrame>& value) {
-                return Ref { value->rtcFrame() };
+                return value->rtcFrame();
             }, [&](RefPtr<RTCEncodedVideoFrame>& value) {
-                return Ref { value->rtcFrame() };
+                return value->rtcFrame();
             });
 
             // If no data, skip the frame since there is nothing to packetize or decode.


### PR DESCRIPTION
#### db1f321d704cad6cbbfe878267cde47fc284a835
<pre>
<a href="https://github.com/webrtc/samples/tree/gh-pages/src/content/insertable-streams/endtoend-encryption">https://github.com/webrtc/samples/tree/gh-pages/src/content/insertable-streams/endtoend-encryption</a> is super slow in STP
<a href="https://bugs.webkit.org/show_bug.cgi?id=229190">https://bugs.webkit.org/show_bug.cgi?id=229190</a>
rdar://problem/82290756

Reviewed by Eric Carlson.

We were creating a new array each time RTCEncodedFrame data getter was called.
Instead, we now return the same array each time.

* LayoutTests/http/wpt/webrtc/audio-video-transform.js:
(AudioVideoRTCRtpTransformer):
(AudioVideoRTCRtpTransformer.prototype.process):
* LayoutTests/http/wpt/webrtc/audiovideo-script-transform-expected.txt:
* LayoutTests/http/wpt/webrtc/audiovideo-script-transform.html:
* Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp:
(WebCore::RTCEncodedFrame::data const):
(WebCore::RTCEncodedFrame::setData):
(WebCore::RTCEncodedFrame::rtcFrame):
* Source/WebCore/Modules/mediastream/RTCEncodedFrame.h:
(WebCore::RTCEncodedFrame::rtcFrame): Deleted.
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
(WebCore::transformFrame):

Canonical link: <a href="https://commits.webkit.org/255133@main">https://commits.webkit.org/255133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d448c3f497f88e3feca368f9bec3b0cb190ff51

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/21921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101008 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/160921 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/280 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29274 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83633 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97399 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/96924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/236 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78010 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27205 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/81844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70238 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35407 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15869 "Found 1 new test failure: webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33205 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16949 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3568 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/36991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39764 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/38914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36057 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->