### PR TITLE
Add initial manifest parsing to the _WKWebExtension class.

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -64,6 +64,9 @@
 /* Visible name of the web process. The argument is the application name. */
 "%@ Web Content (Prewarmed)" = "%@ Web Content (Prewarmed)";
 
+/* Extension's process name that appears in Activity Monitor where the parameter is the name of the extension */
+"%@ Web Extension" = "%@ Web Extension";
+
 /* Visible name of Web Inspector's web process. The argument is the application name. */
 "%@ Web Inspector" = "%@ Web Inspector";
 
@@ -199,8 +202,14 @@
 /* Message for user microphone access prompt */
 "Allow “%@” to use your microphone?" = "Allow “%@” to use your microphone?";
 
+/* WKWebExtensionErrorUnknown description */
+"An unknown error has occurred." = "An unknown error has occurred.";
+
 /* WKErrorUnknown description */
 "An unknown error occurred" = "An unknown error occurred";
+
+/* WKWebExtensionErrorUnsupportedManifestVersion description */
+"An unsupported `manifest_version` was specified." = "An unsupported `manifest_version` was specified.";
 
 /* Label for the plain Apple Pay button. */
 "Apple Pay" = "Apple Pay";
@@ -451,6 +460,21 @@
 /* Display name for easy reader (i.e. 3rd-grade level) text tracks. */
 "Easy Reader (text track)" = "Easy Reader";
 
+/* WKWebExtensionErrorInvalidBackgroundContent description */
+"Empty or invalid `background` manifest entry." = "Empty or invalid `background` manifest entry.";
+
+/* WKWebExtensionErrorInvalidContentScripts description */
+"Empty or invalid `content_scripts` manifest entry." = "Empty or invalid `content_scripts` manifest entry.";
+
+/* WKWebExtensionErrorInvalidActionIcon description */
+"Empty or invalid `default_icon` for the `action`, `browser_action`, or `page_action` manifest entry." = "Empty or invalid `default_icon` for the `action`, `browser_action`, or `page_action` manifest entry.";
+
+/* WKWebExtensionErrorInvalidExternallyConnectable description */
+"Empty or invalid `externally_connectable` manifest entry." = "Empty or invalid `externally_connectable` manifest entry.";
+
+/* WKWebExtensionErrorInvalidURLOverrides description */
+"Empty or invalid url overrides manifest entry" = "Empty or invalid url overrides manifest entry";
+
 /* Video Enter Full Screen context menu item */
 "Enter Full Screen" = "Enter Full Screen";
 
@@ -574,6 +598,21 @@
 /* Inspect Element context menu item */
 "Inspect Element" = "Inspect Element";
 
+/* WKWebExtensionErrorInvalidBackgroundPersistence description */
+"Invalid `persistent` manifest entry." = "Invalid `persistent` manifest entry.";
+
+/* WKWebExtensionErrorInvalidBackgroundPersistence description for manifest v3 */
+"Invalid `persistent` manifest entry. A `manifest_version` greater-than or equal to `3` must be non-persistent." = "Invalid `persistent` manifest entry. A `manifest_version` greater-than or equal to `3` must be non-persistent.";
+
+/* WKWebExtensionErrorInvalidBackgroundPersistence description for service worker */
+"Invalid `persistent` manifest entry. A `service_worker` must be non-persistent." = "Invalid `persistent` manifest entry. A `service_worker` must be non-persistent.";
+
+/* WKWebExtensionErrorInvalidBackgroundPersistence description for iOS */
+"Invalid `persistent` manifest entry. A non-persistent background is required on iOS and iPadOS." = "Invalid `persistent` manifest entry. A non-persistent background is required on iOS and iPadOS.";
+
+/* WKWebExtensionErrorInvalidWebAccessibleResources description */
+"Invalid `web_accessible_resources` manifest entry." = "Invalid `web_accessible_resources` manifest entry.";
+
 /* Validation message for input form controls with a value not matching type */
 "Invalid value" = "Invalid value";
 
@@ -676,6 +715,18 @@
 /* Malware warning title */
 "Malware Website Warning" = "Malware Website Warning";
 
+/* WKWebExtensionErrorInvalidBackgroundContent description for missing background required keys */
+"Manifest `background` entry has missing or empty required key `scripts`, `page`, or `service_worker`." = "Manifest `background` entry has missing or empty required key `scripts`, `page`, or `service_worker`.";
+
+/* WKWebExtensionErrorInvalidContentScripts description for missing or empty 'js' and 'css' arrays */
+"Manifest `content_scripts` entry has missing or empty 'js' and 'css' arrays." = "Manifest `content_scripts` entry has missing or empty 'js' and 'css' arrays.";
+
+/* WKWebExtensionErrorInvalidContentScripts description for missing matches entry */
+"Manifest `content_scripts` entry has no specified `matches` entry." = "Manifest `content_scripts` entry has no specified `matches` entry.";
+
+/* WKWebExtensionErrorInvalidContentScripts description for unknown 'run_at' value */
+"Manifest `content_scripts` entry has unknown `run_at` value." = "Manifest `content_scripts` entry has unknown `run_at` value.";
+
 /* Validation message for input form controls requiring a constrained value according to pattern */
 "Match the requested format" = "Match the requested format";
 
@@ -687,6 +738,18 @@
 
 /* Label text to be used when a plugin is missing */
 "Missing Plug-in" = "Missing Plug-in";
+
+/* WKWebExtensionErrorInvalidDescription description */
+"Missing or empty `description` manifest entry." = "Missing or empty `description` manifest entry.";
+
+/* WKWebExtensionErrorInvalidIcon description */
+"Missing or empty `icons` manifest entry." = "Missing or empty `icons` manifest entry.";
+
+/* WKWebExtensionErrorInvalidName description */
+"Missing or empty `name` manifest entry." = "Missing or empty `name` manifest entry.";
+
+/* WKWebExtensionErrorInvalidVersion description */
+"Missing or empty `version` manifest entry." = "Missing or empty `version` manifest entry.";
 
 /* Media Mute context menu item */
 "Mute" = "Mute";
@@ -705,6 +768,9 @@
 
 /* Label for only item in menu that appears when clicking on the search field image, when no searches have been performed */
 "No recent searches" = "No recent searches";
+
+/* WKWebExtensionErrorInvalidBackgroundPersistence description for webRequest events */
+"Non-persistent background content cannot listen to `webRequest` events." = "Non-persistent background content cannot listen to `webRequest` events.";
 
 /* Option in segmented control for choosing list type in text editing */
 "None" = "None";
@@ -1075,6 +1141,9 @@
 /* WKErrorWebContentProcessTerminated description */
 "The Web Content process was terminated" = "The Web Content process was terminated";
 
+/* WKWebExtensionErrorBackgroundContentFailedToLoad description */
+"The background content failed to load due to an error." = "The background content failed to load due to an error.";
+
 /* WebKitErrorGeolocationLocationUnknown description */
 "The current location cannot be found." = "The current location cannot be found.";
 
@@ -1167,6 +1236,21 @@
 
 /* accessibility role description for a URL field. */
 "URL field" = "URL field";
+
+/* WKWebExtensionErrorManifestNotFound description */
+"Unable to find `manifest.json` in the extension bundle." = "Unable to find `manifest.json` in the extension bundle.";
+
+/* WKWebExtensionErrorInvalidDeclarativeNetRequest description */
+"Unable to parse `declarativeNetRequest` rules because of an unexpected error." = "Unable to parse `declarativeNetRequest` rules because of an unexpected error.";
+
+/* WKWebExtensionErrorInvalidDeclarativeNetRequest description, because of a JSON error */
+"Unable to parse `declarativeNetRequest` rules: %@" = "Unable to parse `declarativeNetRequest` rules: %@";
+
+/* WKWebExtensionErrorInvalidManifest description */
+"Unable to parse manifest because of an unexpected format." = "Unable to parse manifest because of an unexpected format.";
+
+/* WKWebExtensionErrorInvalidManifest description, because of a JSON error */
+"Unable to parse manifest: %@" = "Unable to parse manifest: %@";
 
 /* Unacceptable TLS certificate error */
 "Unacceptable TLS certificate" = "Unacceptable TLS certificate";

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -27,10 +27,71 @@
 
 #import <Foundation/Foundation.h>
 
+#import <WebKit/_WKWebExtensionPermission.h>
+#import <WebKit/_WKWebExtensionMatchPattern.h>
+
 NS_ASSUME_NONNULL_BEGIN
+
+WK_EXTERN NSErrorDomain const _WKWebExtensionErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+typedef NS_ERROR_ENUM(_WKWebExtensionErrorDomain, _WKWebExtensionError) {
+    _WKWebExtensionErrorUnknown = 1,
+    _WKWebExtensionErrorManifestNotFound,
+    _WKWebExtensionErrorInvalidManifest,
+    _WKWebExtensionErrorUnsupportedManifestVersion,
+    _WKWebExtensionErrorInvalidActionIcon,
+    _WKWebExtensionErrorInvalidBackgroundContent,
+    _WKWebExtensionErrorInvalidBackgroundPersistence,
+    _WKWebExtensionErrorInvalidContentScripts,
+    _WKWebExtensionErrorInvalidDeclarativeNetRequest,
+    _WKWebExtensionErrorInvalidDescription,
+    _WKWebExtensionErrorInvalidExternallyConnectable,
+    _WKWebExtensionErrorInvalidIcon,
+    _WKWebExtensionErrorInvalidName,
+    _WKWebExtensionErrorInvalidURLOverrides,
+    _WKWebExtensionErrorInvalidVersion,
+    _WKWebExtensionErrorInvalidWebAccessibleResources,
+    _WKWebExtensionErrorBackgroundContentFailedToLoad,
+} NS_SWIFT_NAME(_WKWebExtension.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification NS_SWIFT_NAME(_WKWebExtension.errorsWereUpdatedNotification);
 
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @interface _WKWebExtension : NSObject
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL NS_DESIGNATED_INITIALIZER;
+
+@property (readonly, nullable, nonatomic) NSArray<NSError *> *errors;
+
+@property (readonly, nullable, nonatomic) NSDictionary<NSString *, id> *manifest;
+
+@property (readonly, nonatomic) double manifestVersion;
+- (BOOL)usesManifestVersion:(double)manifestVersion;
+
+@property (readonly, nullable, nonatomic) NSString *displayName;
+@property (readonly, nullable, nonatomic) NSString *displayShortName;
+@property (readonly, nullable, nonatomic) NSString *displayVersion;
+@property (readonly, nullable, nonatomic) NSString *displayDescription;
+
+@property (readonly, nullable, nonatomic) NSString *version;
+
+@property (readonly, nonatomic) NSSet<_WKWebExtensionPermission> *requestedPermissions;
+@property (readonly, nonatomic) NSSet<_WKWebExtensionPermission> *optionalPermissions;
+
+@property (readonly, nonatomic) NSSet<_WKWebExtensionMatchPattern *> *requestedPermissionOrigins;
+@property (readonly, nonatomic) NSSet<_WKWebExtensionMatchPattern *> *optionalPermissionOrigins;
+
+@property (readonly, nonatomic) NSSet<_WKWebExtensionMatchPattern *> *allRequestedOrigins;
+
+@property (readonly, nonatomic) BOOL hasBackgroundContent;
+@property (readonly, nonatomic) BOOL backgroundContentIsPersistent;
+
+- (BOOL)hasInjectedContentForURL:(NSURL *)url;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+#import <Foundation/Foundation.h>
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+typedef NSString * _WKWebExtensionPermission NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAME(_WKWebExtension.Permission);
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionActiveTab;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionAlarms;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionClipboardWrite;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionContextMenus;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionCookies;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionDeclarativeNetRequest;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionDeclarativeNetRequestFeedback;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionMenus;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionNativeMessaging;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionScripting;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionStorage;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionTabs;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionUnlimitedStorage;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionWebNavigation;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionWebRequest;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.mm
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "_WKWebExtensionPermission.h"
+
+_WKWebExtensionPermission const _WKWebExtensionPermissionActiveTab = @"activeTab";
+_WKWebExtensionPermission const _WKWebExtensionPermissionAlarms = @"alarms";
+_WKWebExtensionPermission const _WKWebExtensionPermissionClipboardWrite = @"clipboardWrite";
+_WKWebExtensionPermission const _WKWebExtensionPermissionContextMenus = @"contextMenus";
+_WKWebExtensionPermission const _WKWebExtensionPermissionCookies = @"cookies";
+_WKWebExtensionPermission const _WKWebExtensionPermissionDeclarativeNetRequest = @"declarativeNetRequest";
+_WKWebExtensionPermission const _WKWebExtensionPermissionDeclarativeNetRequestFeedback = @"declarativeNetRequestFeedback";
+_WKWebExtensionPermission const _WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess = @"declarativeNetRequestWithHostAccess";
+_WKWebExtensionPermission const _WKWebExtensionPermissionMenus = @"menus";
+_WKWebExtensionPermission const _WKWebExtensionPermissionNativeMessaging = @"nativeMessaging";
+_WKWebExtensionPermission const _WKWebExtensionPermissionScripting = @"scripting";
+_WKWebExtensionPermission const _WKWebExtensionPermissionStorage = @"storage";
+_WKWebExtensionPermission const _WKWebExtensionPermissionTabs = @"tabs";
+_WKWebExtensionPermission const _WKWebExtensionPermissionUnlimitedStorage = @"unlimitedStorage";
+_WKWebExtensionPermission const _WKWebExtensionPermissionWebNavigation = @"webNavigation";
+_WKWebExtensionPermission const _WKWebExtensionPermissionWebRequest = @"webRequest";

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h
@@ -25,6 +25,13 @@
 
 #import <WebKit/_WKWebExtension.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface _WKWebExtension ()
 
+- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest NS_DESIGNATED_INITIALIZER;
+- (instancetype)_initWithManifestData:(NSData *)manifestData NS_DESIGNATED_INITIALIZER;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -1,0 +1,783 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtension.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "_WKWebExtensionInternal.h"
+#import "_WKWebExtensionPermission.h"
+#import <WebCore/LocalizedStrings.h>
+#import <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+static NSString * const manifestVersionManifestKey = @"manifest_version";
+
+static NSString * const nameManifestKey = @"name";
+static NSString * const shortNameManifestKey = @"short_name";
+static NSString * const versionManifestKey = @"version";
+static NSString * const versionNameManifestKey = @"version_name";
+static NSString * const descriptionManifestKey = @"description";
+
+static NSString * const backgroundManifestKey = @"background";
+static NSString * const backgroundPageManifestKey = @"page";
+static NSString * const backgroundServiceWorkerManifestKey = @"service_worker";
+static NSString * const backgroundScriptsManifestKey = @"scripts";
+static NSString * const backgroundPersistentManifestKey = @"persistent";
+
+static NSString * const contentScriptsManifestKey = @"content_scripts";
+static NSString * const contentScriptsMatchesManifestKey = @"matches";
+static NSString * const contentScriptsExcludeMatchesManifestKey = @"exclude_matches";
+static NSString * const contentScriptsIncludeGlobsManifestKey = @"include_globs";
+static NSString * const contentScriptsExcludeGlobsManifestKey = @"exclude_globs";
+static NSString * const contentScriptsMatchesAboutBlankManifestKey = @"match_about_blank";
+static NSString * const contentScriptsRunAtManifestKey = @"run_at";
+static NSString * const contentScriptsDocumentIdleManifestKey = @"document_idle";
+static NSString * const contentScriptsDocumentStartManifestKey = @"document_start";
+static NSString * const contentScriptsDocumentEndManifestKey = @"document_end";
+static NSString * const contentScriptsAllFramesManifestKey = @"all_frames";
+static NSString * const contentScriptsJSManifestKey = @"js";
+static NSString * const contentScriptsCSSManifestKey = @"css";
+
+static NSString * const permissionsManifestKey = @"permissions";
+static NSString * const optionalPermissionsManifestKey = @"optional_permissions";
+static NSString * const hostPermissionsManifestKey = @"host_permissions";
+static NSString * const optionalHostPermissionsManifestKey = @"optional_host_permissions";
+
+WebExtension::WebExtension(NSBundle *appExtensionBundle)
+    : m_bundle(appExtensionBundle)
+    , m_resourceBaseURL(appExtensionBundle.resourceURL.absoluteURL)
+{
+    ASSERT(appExtensionBundle);
+}
+
+WebExtension::WebExtension(NSURL *resourceBaseURL)
+    : m_resourceBaseURL(resourceBaseURL)
+{
+    ASSERT(resourceBaseURL);
+    ASSERT([resourceBaseURL isFileURL]);
+    ASSERT([resourceBaseURL hasDirectoryPath]);
+}
+
+WebExtension::WebExtension(NSDictionary *manifest)
+    : m_manifest([manifest copy])
+    , m_parsedManifest(true)
+{
+    ASSERT(manifest);
+}
+
+WebExtension::WebExtension(NSData *manifestData)
+    : m_parsedManifest(true)
+{
+    ASSERT(manifestData);
+
+    parseManifest(manifestData);
+}
+
+bool WebExtension::manifestParsedSuccessfully()
+{
+    if (m_parsedManifest)
+        return !!m_manifest;
+    // If we haven't parsed yet, trigger a parse by calling the getter.
+    return !!manifest();
+}
+
+bool WebExtension::parseManifest(NSData *manifestData)
+{
+    NSError *parseError;
+    m_manifest = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:manifestData options:0 error:&parseError]);
+    if (!m_manifest) {
+        recordError(createError(Error::InvalidManifest, nil, parseError));
+        return false;
+    }
+
+    return true;
+}
+
+NSDictionary *WebExtension::manifest()
+{
+    if (m_parsedManifest)
+        return m_manifest.get();
+
+    m_parsedManifest = true;
+
+    // FIXME: This needs to check the bundle code signature (if a bundle is used).
+    NSURL *manifestURL = [NSURL fileURLWithPath:@"manifest.json" relativeToURL:m_resourceBaseURL.get()];
+    NSData *manifestData = [NSData dataWithContentsOfURL:manifestURL];
+    if (!manifestData) {
+        recordError(createError(Error::ManifestNotFound));
+        return nil;
+    }
+
+    if (!parseManifest(manifestData))
+        return nil;
+
+    // FIXME: Handle manifest localization.
+    // FIXME: Handle Safari version compatibility check.
+    // Likely do this version checking when the extension is added to the WKWebExtensionController,
+    // since that will need delegated to the app.
+
+    return m_manifest.get();
+}
+
+double WebExtension::manifestVersion()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version
+
+    return objectForKey<NSNumber>(manifest(), manifestVersionManifestKey).doubleValue;
+}
+
+bool WebExtension::hasRequestedPermission(NSString *permission) const
+{
+    return [m_permissions containsObject:permission];
+}
+
+NSError *WebExtension::createError(Error error, NSString *customLocalizedDescription, NSError *underlyingError)
+{
+    _WKWebExtensionError errorCode;
+    NSString *localizedDescription;
+
+    switch (error) {
+    case Error::Unknown:
+        errorCode = _WKWebExtensionErrorUnknown;
+        localizedDescription = WEB_UI_STRING("An unknown error has occurred.", "WKWebExtensionErrorUnknown description");
+        break;
+
+    case Error::ManifestNotFound:
+        errorCode = _WKWebExtensionErrorManifestNotFound;
+        localizedDescription = WEB_UI_STRING("Unable to find `manifest.json` in the extension bundle.", "WKWebExtensionErrorManifestNotFound description");
+        break;
+
+    case Error::InvalidManifest:
+        errorCode = _WKWebExtensionErrorInvalidManifest;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+        if (NSString *debugDescription = underlyingError.userInfo[NSDebugDescriptionErrorKey])
+            localizedDescription = [NSString stringWithFormat:WEB_UI_STRING("Unable to parse manifest: %@", "WKWebExtensionErrorInvalidManifest description, because of a JSON error"), debugDescription];
+        else
+            localizedDescription = WEB_UI_STRING("Unable to parse manifest because of an unexpected format.", "WKWebExtensionErrorInvalidManifest description");
+#pragma clang diagnostic pop
+        break;
+
+    case Error::UnsupportedManifestVersion:
+        errorCode = _WKWebExtensionErrorUnsupportedManifestVersion;
+        localizedDescription = WEB_UI_STRING("An unsupported `manifest_version` was specified.", "WKWebExtensionErrorUnsupportedManifestVersion description");
+        break;
+
+    case Error::InvalidActionIcon:
+        errorCode = _WKWebExtensionErrorInvalidActionIcon;
+        localizedDescription = WEB_UI_STRING("Empty or invalid `default_icon` for the `action`, `browser_action`, or `page_action` manifest entry.", "WKWebExtensionErrorInvalidActionIcon description");
+        break;
+
+    case Error::InvalidBackgroundContent:
+        errorCode = _WKWebExtensionErrorInvalidBackgroundContent;
+        localizedDescription = WEB_UI_STRING("Empty or invalid `background` manifest entry.", "WKWebExtensionErrorInvalidBackgroundContent description");
+        break;
+
+    case Error::InvalidContentScripts:
+        errorCode = _WKWebExtensionErrorInvalidContentScripts;
+        localizedDescription = WEB_UI_STRING("Empty or invalid `content_scripts` manifest entry.", "WKWebExtensionErrorInvalidContentScripts description");
+        break;
+
+    case Error::InvalidDeclarativeNetRequest:
+        errorCode = _WKWebExtensionErrorInvalidDeclarativeNetRequest;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+        if (NSString *debugDescription = underlyingError.userInfo[NSDebugDescriptionErrorKey])
+            localizedDescription = [NSString stringWithFormat:WEB_UI_STRING("Unable to parse `declarativeNetRequest` rules: %@", "WKWebExtensionErrorInvalidDeclarativeNetRequest description, because of a JSON error"), debugDescription];
+        else
+            localizedDescription = WEB_UI_STRING("Unable to parse `declarativeNetRequest` rules because of an unexpected error.", "WKWebExtensionErrorInvalidDeclarativeNetRequest description");
+#pragma clang diagnostic pop
+        break;
+
+    case Error::InvalidDescription:
+        errorCode = _WKWebExtensionErrorInvalidDescription;
+        localizedDescription = WEB_UI_STRING("Missing or empty `description` manifest entry.", "WKWebExtensionErrorInvalidDescription description");
+        break;
+
+    case Error::InvalidExternallyConnectable:
+        errorCode = _WKWebExtensionErrorInvalidExternallyConnectable;
+        localizedDescription = WEB_UI_STRING("Empty or invalid `externally_connectable` manifest entry.", "WKWebExtensionErrorInvalidExternallyConnectable description");
+        break;
+
+    case Error::InvalidIcon:
+        errorCode = _WKWebExtensionErrorInvalidIcon;
+        localizedDescription = WEB_UI_STRING("Missing or empty `icons` manifest entry.", "WKWebExtensionErrorInvalidIcon description");
+        break;
+
+    case Error::InvalidName:
+        errorCode = _WKWebExtensionErrorInvalidName;
+        localizedDescription = WEB_UI_STRING("Missing or empty `name` manifest entry.", "WKWebExtensionErrorInvalidName description");
+        break;
+
+    case Error::InvalidURLOverrides:
+        errorCode = _WKWebExtensionErrorInvalidURLOverrides;
+        localizedDescription = WEB_UI_STRING("Empty or invalid url overrides manifest entry", "WKWebExtensionErrorInvalidURLOverrides description");
+        break;
+
+    case Error::InvalidVersion:
+        errorCode = _WKWebExtensionErrorInvalidVersion;
+        localizedDescription = WEB_UI_STRING("Missing or empty `version` manifest entry.", "WKWebExtensionErrorInvalidVersion description");
+        break;
+
+    case Error::InvalidWebAccessibleResources:
+        errorCode = _WKWebExtensionErrorInvalidWebAccessibleResources;
+        localizedDescription = WEB_UI_STRING("Invalid `web_accessible_resources` manifest entry.", "WKWebExtensionErrorInvalidWebAccessibleResources description");
+        break;
+
+    case Error::InvalidBackgroundPersistence:
+        errorCode = _WKWebExtensionErrorInvalidBackgroundPersistence;
+        localizedDescription = WEB_UI_STRING("Invalid `persistent` manifest entry.", "WKWebExtensionErrorInvalidBackgroundPersistence description");
+        break;
+
+    case Error::BackgroundContentFailedToLoad:
+        errorCode = _WKWebExtensionErrorBackgroundContentFailedToLoad;
+        localizedDescription = WEB_UI_STRING("The background content failed to load due to an error.", "WKWebExtensionErrorBackgroundContentFailedToLoad description");
+        break;
+    }
+
+    if (customLocalizedDescription.length)
+        localizedDescription = customLocalizedDescription;
+
+    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: localizedDescription };
+    if (underlyingError)
+        userInfo = @{ NSLocalizedDescriptionKey: localizedDescription, NSUnderlyingErrorKey: underlyingError };
+
+    return [[NSError alloc] initWithDomain:_WKWebExtensionErrorDomain code:errorCode userInfo:userInfo];
+}
+
+void WebExtension::recordError(NSError *error, SuppressNotification suppressNotification)
+{
+    ASSERT(error);
+
+    if (!m_errors)
+        m_errors = [NSMutableArray array];
+
+    [m_errors addObject:error];
+
+    if (suppressNotification == SuppressNotification::No)
+        [NSNotificationCenter.defaultCenter postNotificationName:_WKWebExtensionErrorsWereUpdatedNotification object:WebKit::wrapper(this) userInfo:nil];
+}
+
+NSArray *WebExtension::errors()
+{
+    // FIXME: Include runtime and declarativeNetRequest errors.
+
+    populateDisplayStringsIfNeeded();
+    populateBackgroundPropertiesIfNeeded();
+    populateContentScriptPropertiesIfNeeded();
+    populatePermissionsPropertiesIfNeeded();
+
+    return [m_errors copy];
+}
+
+NSString *WebExtension::webProcessDisplayName()
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+    return [NSString stringWithFormat:WEB_UI_STRING("%@ Web Extension", "Extension's process name that appears in Activity Monitor where the parameter is the name of the extension"), displayShortName()];
+#pragma clang diagnostic pop
+}
+
+NSString *WebExtension::displayName()
+{
+    populateDisplayStringsIfNeeded();
+    return m_displayName.get();
+}
+
+NSString *WebExtension::displayShortName()
+{
+    populateDisplayStringsIfNeeded();
+    return m_displayShortName.get();
+}
+
+NSString *WebExtension::displayVersion()
+{
+    populateDisplayStringsIfNeeded();
+    return m_displayVersion.get();
+}
+
+NSString *WebExtension::displayDescription()
+{
+    populateDisplayStringsIfNeeded();
+    return m_displayDescription.get();
+}
+
+NSString *WebExtension::version()
+{
+    populateDisplayStringsIfNeeded();
+    return m_version.get();
+}
+
+void WebExtension::populateDisplayStringsIfNeeded()
+{
+    if (!manifestParsedSuccessfully())
+        return;
+
+    if (m_parsedManifestDisplayStrings)
+        return;
+
+    m_parsedManifestDisplayStrings = true;
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/name
+
+    m_displayName = objectForKey<NSString>(m_manifest, nameManifestKey);
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/short_name
+
+    m_displayShortName = objectForKey<NSString>(m_manifest, shortNameManifestKey);
+    if (!m_displayShortName)
+        m_displayShortName = m_displayName;
+
+    if (!m_displayName)
+        recordError(createError(Error::InvalidName));
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version
+
+    m_version = objectForKey<NSString>(m_manifest, versionManifestKey);
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version_name
+
+    m_displayVersion = objectForKey<NSString>(m_manifest, versionNameManifestKey);
+    if (!m_displayVersion)
+        m_displayVersion = m_version;
+
+    if (!m_version)
+        recordError(createError(Error::InvalidVersion));
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/description
+
+    m_displayDescription = objectForKey<NSString>(m_manifest, descriptionManifestKey);
+    if (!m_displayDescription)
+        recordError(createError(Error::InvalidDescription));
+}
+
+bool WebExtension::hasBackgroundContent()
+{
+    populateBackgroundPropertiesIfNeeded();
+    return m_backgroundScriptPaths.get().count || m_backgroundPagePath || m_backgroundServiceWorkerPath;
+}
+
+bool WebExtension::backgroundContentIsPersistent()
+{
+    populateBackgroundPropertiesIfNeeded();
+    return hasBackgroundContent() && m_backgroundContentIsPersistent;
+}
+
+bool WebExtension::backgroundContentIsServiceWorker()
+{
+    populateBackgroundPropertiesIfNeeded();
+    return !!m_backgroundServiceWorkerPath;
+}
+
+NSString *WebExtension::generatedBackgroundContent()
+{
+    if (m_generatedBackgroundContent)
+        return m_generatedBackgroundContent.get();
+
+    populateBackgroundPropertiesIfNeeded();
+
+    if (m_backgroundServiceWorkerPath)
+        return nil;
+
+    if (!m_backgroundScriptPaths.get().count)
+        return nil;
+
+    NSArray<NSString *> *scriptTagsArray = mapObjects(m_backgroundScriptPaths, ^(NSNumber *index, NSString *scriptPath) {
+        return [NSString stringWithFormat:@"<script src=\"%@\"></script>", scriptPath];
+    });
+
+    m_generatedBackgroundContent = [NSString stringWithFormat:@"<!DOCTYPE html>\n<body>\n%@\n</body>", [scriptTagsArray componentsJoinedByString:@"\n"]];
+
+    return m_generatedBackgroundContent.get();
+}
+
+void WebExtension::populateBackgroundPropertiesIfNeeded()
+{
+    if (!manifestParsedSuccessfully())
+        return;
+
+    if (m_parsedManifestBackgroundProperties)
+        return;
+
+    m_parsedManifestBackgroundProperties = true;
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background
+
+    NSDictionary<NSString *, id> *backgroundManifestDictionary = objectForKey<NSDictionary>(m_manifest, backgroundManifestKey);
+    if (!backgroundManifestDictionary.count) {
+        if ([m_manifest objectForKey:backgroundManifestKey])
+            recordError(createError(Error::InvalidBackgroundContent));
+        return;
+    }
+
+    m_backgroundScriptPaths = objectForKey<NSArray>(backgroundManifestDictionary, backgroundScriptsManifestKey, true, NSString.class);
+    m_backgroundPagePath = objectForKey<NSString>(backgroundManifestDictionary, backgroundPageManifestKey);
+    m_backgroundServiceWorkerPath = objectForKey<NSString>(backgroundManifestDictionary, backgroundServiceWorkerManifestKey);
+
+    m_backgroundScriptPaths = filterObjects(m_backgroundScriptPaths, ^(NSNumber *index, NSString *scriptPath) {
+        return !!scriptPath.length;
+    });
+
+    // Scripts takes precedence over page.
+    if (m_backgroundScriptPaths.get().count)
+        m_backgroundPagePath = nil;
+
+    // Service Worker takes precedence over page and scripts.
+    if (m_backgroundServiceWorkerPath) {
+        m_backgroundScriptPaths = nil;
+        m_backgroundPagePath = nil;
+    }
+
+    if (!m_backgroundScriptPaths.get().count && !m_backgroundPagePath && !m_backgroundServiceWorkerPath)
+        recordError(createError(Error::InvalidBackgroundContent, WEB_UI_STRING("Manifest `background` entry has missing or empty required key `scripts`, `page`, or `service_worker`.", "WKWebExtensionErrorInvalidBackgroundContent description for missing background required keys")));
+
+    NSNumber *persistentBoolean = objectForKey<NSNumber>(backgroundManifestDictionary, backgroundPersistentManifestKey);
+    m_backgroundContentIsPersistent = persistentBoolean ? persistentBoolean.boolValue : !(usesManifestVersion(3) || m_backgroundServiceWorkerPath);
+
+    if (m_backgroundContentIsPersistent && usesManifestVersion(3)) {
+        recordError(createError(Error::InvalidBackgroundPersistence, WEB_UI_STRING("Invalid `persistent` manifest entry. A `manifest_version` greater-than or equal to `3` must be non-persistent.", "WKWebExtensionErrorInvalidBackgroundPersistence description for manifest v3")));
+        m_backgroundContentIsPersistent = false;
+    }
+
+    if (m_backgroundContentIsPersistent && m_backgroundServiceWorkerPath) {
+        recordError(createError(Error::InvalidBackgroundPersistence, WEB_UI_STRING("Invalid `persistent` manifest entry. A `service_worker` must be non-persistent.", "WKWebExtensionErrorInvalidBackgroundPersistence description for service worker")));
+        m_backgroundContentIsPersistent = false;
+    }
+
+    if (!m_backgroundContentIsPersistent && hasRequestedPermission(_WKWebExtensionPermissionWebRequest))
+        recordError(createError(Error::InvalidBackgroundPersistence, WEB_UI_STRING("Non-persistent background content cannot listen to `webRequest` events.", "WKWebExtensionErrorInvalidBackgroundPersistence description for webRequest events")));
+
+#if PLATFORM(IOS)
+    if (m_backgroundContentIsPersistent)
+        recordError(createError(Error::InvalidBackgroundPersistence, WEB_UI_STRING("Invalid `persistent` manifest entry. A non-persistent background is required on iOS and iPadOS.", "WKWebExtensionErrorInvalidBackgroundPersistence description for iOS")));
+#endif
+}
+
+const Vector<WebExtension::InjectedContentData>& WebExtension::injectedContents()
+{
+    populateContentScriptPropertiesIfNeeded();
+    return m_injectedContents;
+}
+
+bool WebExtension::hasInjectedContentForURL(NSURL *url)
+{
+    ASSERT(url);
+
+    populateContentScriptPropertiesIfNeeded();
+
+    for (auto& injectedContent : m_injectedContents) {
+        // FIXME: rdar://problem/57375730 Add support for exclude globs.
+        bool isExcluded = false;
+        for (auto& excludeMatchPattern : injectedContent.excludeMatchPatterns) {
+            if (excludeMatchPattern->matchesURL(url)) {
+                isExcluded = true;
+                break;
+            }
+        }
+
+        if (isExcluded)
+            continue;
+
+        // FIXME: rdar://problem/57375730 Add support for include globs.
+        for (auto& includeMatchPattern : injectedContent.includeMatchPatterns) {
+            if (includeMatchPattern->matchesURL(url))
+                return true;
+        }
+    }
+
+    return false;
+}
+
+NSArray *WebExtension::InjectedContentData::expandedIncludeMatchPatternStrings() const
+{
+    NSMutableArray<NSString *> *result = [NSMutableArray array];
+
+    for (auto& includeMatchPattern : includeMatchPatterns)
+        [result addObjectsFromArray:includeMatchPattern->expandedStrings()];
+
+    return [result copy];
+}
+
+NSArray *WebExtension::InjectedContentData::expandedExcludeMatchPatternStrings() const
+{
+    NSMutableArray<NSString *> *result = [NSMutableArray array];
+
+    for (auto& excludeMatchPattern : excludeMatchPatterns)
+        [result addObjectsFromArray:excludeMatchPattern->expandedStrings()];
+
+    return [result copy];
+}
+
+void WebExtension::populateContentScriptPropertiesIfNeeded()
+{
+    if (!manifestParsedSuccessfully())
+        return;
+
+    if (m_parsedManifestContentScriptProperties)
+        return;
+
+    m_parsedManifestContentScriptProperties = true;
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts
+
+    NSArray<NSDictionary *> *contentScriptsManifestArray = objectForKey<NSArray>(m_manifest, contentScriptsManifestKey, true, NSDictionary.class);
+    if (!contentScriptsManifestArray.count) {
+        if ([m_manifest objectForKey:contentScriptsManifestKey])
+            recordError(createError(Error::InvalidContentScripts));
+        return;
+    }
+
+    auto addInjectedContentData = ^(NSDictionary<NSString *, id> *dictionary) {
+        HashSet<Ref<WebExtensionMatchPattern>> includeMatchPatterns;
+
+        // Required. Specifies which pages the specified scripts and stylesheets will be injected into.
+        NSArray<NSString *> *matchesArray = objectForKey<NSArray>(dictionary, contentScriptsMatchesManifestKey, true, NSString.class);
+        for (NSString *matchPatternString in matchesArray) {
+            if (!matchPatternString.length)
+                continue;
+
+            if (auto matchPattern = WebExtensionMatchPattern::getOrCreate(matchPatternString)) {
+                if (matchPattern->isSupported())
+                    includeMatchPatterns.add(matchPattern.releaseNonNull());
+            }
+        }
+
+        if (includeMatchPatterns.isEmpty()) {
+            recordError(createError(Error::InvalidContentScripts, WEB_UI_STRING("Manifest `content_scripts` entry has no specified `matches` entry.", "WKWebExtensionErrorInvalidContentScripts description for missing matches entry")));
+            return;
+        }
+
+        // Optional. The list of JavaScript files to be injected into matching pages. These are injected in the order they appear in this array.
+        NSArray *scriptPaths = objectForKey<NSArray>(dictionary, contentScriptsJSManifestKey, true, NSString.class);
+        scriptPaths = filterObjects(scriptPaths, ^(id key, NSString *string) {
+            return !!string.length;
+        });
+
+        // Optional. The list of CSS files to be injected into matching pages. These are injected in the order they appear in this array, before any DOM is constructed or displayed for the page.
+        NSArray *styleSheetPaths = objectForKey<NSArray>(dictionary, contentScriptsCSSManifestKey, true, NSString.class);
+        styleSheetPaths = filterObjects(styleSheetPaths, ^(id key, NSString *string) {
+            return !!string.length;
+        });
+
+        if (!scriptPaths.count && !styleSheetPaths.count) {
+            recordError(createError(Error::InvalidContentScripts, WEB_UI_STRING("Manifest `content_scripts` entry has missing or empty 'js' and 'css' arrays.", "WKWebExtensionErrorInvalidContentScripts description for missing or empty 'js' and 'css' arrays")));
+            return;
+        }
+
+        // Optional. Whether the script should inject into an about:blank frame where the parent or opener frame matches one of the patterns declared in matches. Defaults to false.
+        bool matchesAboutBlank = objectForKey<NSNumber>(dictionary, contentScriptsMatchesAboutBlankManifestKey).boolValue;
+
+        HashSet<Ref<WebExtensionMatchPattern>> excludeMatchPatterns;
+
+        // Optional. Excludes pages that this content script would otherwise be injected into.
+        NSArray<NSString *> *excludeMatchesArray = objectForKey<NSArray>(dictionary, contentScriptsExcludeMatchesManifestKey, true, NSString.class);
+        for (NSString *matchPatternString in excludeMatchesArray) {
+            if (!matchPatternString.length)
+                continue;
+
+            if (auto matchPattern = WebExtensionMatchPattern::getOrCreate(matchPatternString)) {
+                if (matchPattern->isSupported())
+                    excludeMatchPatterns.add(matchPattern.releaseNonNull());
+            }
+        }
+
+        // Optional. Applied after matches to include only those URLs that also match this glob.
+        NSArray *includeGlobPatternStrings = objectForKey<NSArray>(dictionary, contentScriptsIncludeGlobsManifestKey, true, NSString.class);
+        includeGlobPatternStrings = filterObjects(includeGlobPatternStrings, ^(id key, NSString *string) {
+            return !!string.length;
+        });
+
+        // Optional. Applied after matches to exclude URLs that match this glob.
+        NSArray *excludeGlobPatternStrings = objectForKey<NSArray>(dictionary, contentScriptsExcludeGlobsManifestKey, true, NSString.class);
+        excludeGlobPatternStrings = filterObjects(excludeGlobPatternStrings, ^(id key, NSString *string) {
+            return !!string.length;
+        });
+
+        // Optional. The "all_frames" field allows the extension to specify if JavaScript and CSS files should be injected into all frames matching the specified URL requirements or only into the
+        // topmost frame in a tab. Defaults to false, meaning that only the top frame is matched. If specified true, it will inject into all frames, even if the frame is not the topmost frame in
+        // the tab. Each frame is checked independently for URL requirements, it will not inject into child frames if the URL requirements are not met.
+        bool injectsIntoAllFrames = objectForKey<NSNumber>(dictionary, contentScriptsAllFramesManifestKey).boolValue;
+
+        InjectionTime injectionTime = InjectionTime::DocumentIdle;
+        NSString *runsAtString = objectForKey<NSString>(dictionary, contentScriptsRunAtManifestKey);
+        if (!runsAtString || [runsAtString isEqualToString:contentScriptsDocumentIdleManifestKey])
+            injectionTime = InjectionTime::DocumentIdle;
+        else if ([runsAtString isEqualToString:contentScriptsDocumentStartManifestKey])
+            injectionTime = InjectionTime::DocumentStart;
+        else if ([runsAtString isEqualToString:contentScriptsDocumentEndManifestKey])
+            injectionTime = InjectionTime::DocumentEnd;
+        else
+            recordError(createError(Error::InvalidContentScripts, WEB_UI_STRING("Manifest `content_scripts` entry has unknown `run_at` value.", "WKWebExtensionErrorInvalidContentScripts description for unknown 'run_at' value")));
+
+        m_injectedContents.append({ WTFMove(includeMatchPatterns), WTFMove(excludeMatchPatterns), injectionTime, matchesAboutBlank, injectsIntoAllFrames, scriptPaths, styleSheetPaths, includeGlobPatternStrings, excludeGlobPatternStrings });
+    };
+
+    for (NSDictionary<NSString *, id> *contentScriptsManifestEntry in contentScriptsManifestArray)
+        addInjectedContentData(contentScriptsManifestEntry);
+}
+
+NSSet *WebExtension::supportedPermissions()
+{
+    static NSSet *permissions = [NSSet setWithObjects:_WKWebExtensionPermissionActiveTab, _WKWebExtensionPermissionAlarms, _WKWebExtensionPermissionClipboardWrite,
+        _WKWebExtensionPermissionContextMenus, _WKWebExtensionPermissionCookies, _WKWebExtensionPermissionDeclarativeNetRequest, _WKWebExtensionPermissionDeclarativeNetRequestFeedback,
+        _WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess, _WKWebExtensionPermissionMenus, _WKWebExtensionPermissionNativeMessaging, _WKWebExtensionPermissionScripting,
+        _WKWebExtensionPermissionStorage, _WKWebExtensionPermissionTabs, _WKWebExtensionPermissionUnlimitedStorage, _WKWebExtensionPermissionWebNavigation, _WKWebExtensionPermissionWebRequest, nil];
+    return permissions;
+}
+
+NSSet *WebExtension::requestedPermissions()
+{
+    populatePermissionsPropertiesIfNeeded();
+    return m_permissions.get();
+}
+
+NSSet *WebExtension::optionalPermissions()
+{
+    populatePermissionsPropertiesIfNeeded();
+    return m_optionalPermissions.get();
+}
+
+const HashSet<Ref<WebExtensionMatchPattern>>& WebExtension::requestedPermissionOrigins()
+{
+    populatePermissionsPropertiesIfNeeded();
+    return m_permissionOrigins;
+}
+
+const HashSet<Ref<WebExtensionMatchPattern>>& WebExtension::optionalPermissionOrigins()
+{
+    populatePermissionsPropertiesIfNeeded();
+    return m_optionalPermissionOrigins;
+}
+
+const HashSet<Ref<WebExtensionMatchPattern>>&& WebExtension::allRequestedOrigins()
+{
+    populatePermissionsPropertiesIfNeeded();
+    populateContentScriptPropertiesIfNeeded();
+
+    HashSet<Ref<WebExtensionMatchPattern>> result;
+
+    for (auto& matchPattern : m_permissionOrigins)
+        result.add(matchPattern);
+
+    // FIXME: Add externally connectable match patterns.
+
+    for (auto& injectedContent : m_injectedContents) {
+        for (auto& matchPattern : injectedContent.includeMatchPatterns)
+            result.add(matchPattern);
+    }
+
+    return WTFMove(result);
+}
+
+void WebExtension::populatePermissionsPropertiesIfNeeded()
+{
+    if (!manifestParsedSuccessfully())
+        return;
+
+    if (m_parsedManifestPermissionProperties)
+        return;
+
+    m_parsedManifestPermissionProperties = YES;
+
+    bool findOriginsInPermissions = !usesManifestVersion(3);
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions
+
+    NSArray<NSString *> *permissions = objectForKey<NSArray>(m_manifest, permissionsManifestKey, true, NSString.class);
+    NSMutableSet<NSString *> *filteredPermissions = [NSMutableSet set];
+
+    for (NSString *permission in permissions) {
+        if (findOriginsInPermissions) {
+            if (auto matchPattern = WebExtensionMatchPattern::getOrCreate(permission)) {
+                if (matchPattern->isSupported())
+                    m_permissionOrigins.add(matchPattern.releaseNonNull());
+                continue;
+            }
+        }
+
+        if ([supportedPermissions() containsObject:permission])
+            [filteredPermissions addObject:permission];
+    }
+
+    m_permissions = filteredPermissions;
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions
+
+    if (!findOriginsInPermissions) {
+        NSArray<NSString *> *hostPermissions = objectForKey<NSArray>(m_manifest, hostPermissionsManifestKey, true, NSString.class);
+
+        for (NSString *hostPattern in hostPermissions) {
+            if (auto matchPattern = WebExtensionMatchPattern::getOrCreate(hostPattern)) {
+                if (matchPattern->isSupported())
+                    m_permissionOrigins.add(matchPattern.releaseNonNull());
+            }
+        }
+    }
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions
+
+    NSArray<NSString *> *optionalPermissions = objectForKey<NSArray>(m_manifest, optionalPermissionsManifestKey, true, NSString.class);
+    NSMutableSet<NSString *> *filteredOptionalPermissions = [NSMutableSet set];
+
+    for (NSString *optionalPermission in optionalPermissions) {
+        if (findOriginsInPermissions) {
+            if (auto matchPattern = WebExtensionMatchPattern::getOrCreate(optionalPermission)) {
+                if (matchPattern->isSupported() && !m_permissionOrigins.contains(*matchPattern))
+                    m_optionalPermissionOrigins.add(matchPattern.releaseNonNull());
+                continue;
+            }
+        }
+
+        if (![m_permissions containsObject:optionalPermission] && [supportedPermissions() containsObject:optionalPermission])
+            [filteredOptionalPermissions addObject:optionalPermission];
+    }
+
+    m_optionalPermissions = filteredOptionalPermissions;
+
+    // Documentation: https://github.com/w3c/webextensions/issues/119
+
+    if (!findOriginsInPermissions) {
+        NSArray<NSString *> *hostPermissions = objectForKey<NSArray>(m_manifest, optionalHostPermissionsManifestKey, true, NSString.class);
+
+        for (NSString *hostPattern in hostPermissions) {
+            if (auto matchPattern = WebExtensionMatchPattern::getOrCreate(hostPattern)) {
+                if (matchPattern->isSupported() && !m_permissionOrigins.contains(*matchPattern))
+                    m_optionalPermissionOrigins.add(matchPattern.releaseNonNull());
+            }
+        }
+    }
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 		1AFDE6621954E9B100C48FFA /* APISessionState.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AFDE6601954E9B100C48FFA /* APISessionState.h */; };
 		1AFE436618B6C081009C7A48 /* UIDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AFE436418B6C081009C7A48 /* UIDelegate.h */; };
 		1BBBE4A019B66C53006B7D81 /* RemoteWebInspectorUIMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1BBBE49E19B66C53006B7D81 /* RemoteWebInspectorUIMessageReceiver.cpp */; };
+		1C049838289AF5AD0010308B /* _WKWebExtensionPermission.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C049837289AF5AD0010308B /* _WKWebExtensionPermission.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C0A19471C8FF1A800FE0EBB /* WebAutomationSessionProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0A19451C8FF1A800FE0EBB /* WebAutomationSessionProxy.h */; };
 		1C0A19531C8FFDFB00FE0EBB /* WebAutomationSessionProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C0A19511C8FFDFB00FE0EBB /* WebAutomationSessionProxyMessageReceiver.cpp */; };
 		1C0A19541C8FFDFB00FE0EBB /* WebAutomationSessionProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0A19521C8FFDFB00FE0EBB /* WebAutomationSessionProxyMessages.h */; };
@@ -402,11 +403,13 @@
 		1C56557F2745C5A1006300AF /* UnifiedSource101.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C56557C2745C5A0006300AF /* UnifiedSource101.cpp */; };
 		1C5655802745C5A1006300AF /* UnifiedSource102.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C56557D2745C5A1006300AF /* UnifiedSource102.cpp */; };
 		1C5655812745C5A1006300AF /* UnifiedSource103.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C56557E2745C5A1006300AF /* UnifiedSource103.cpp */; };
+		1C627478288A1E1D00CED3A2 /* WebExtensionCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C627477288A1DDE00CED3A2 /* WebExtensionCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C627479288B2F7400CED3A2 /* _WKWebExtension.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C3BEB6E288883E200E66E38 /* _WKWebExtension.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C62747A288B2F7400CED3A2 /* _WKWebExtensionController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C3BEB5528875CE400E66E38 /* _WKWebExtensionController.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C62747D288B4C3E00CED3A2 /* CocoaHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C62747B288B4C3E00CED3A2 /* CocoaHelpers.h */; };
 		1C62747E288B4C3E00CED3A2 /* CocoaHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C62747C288B4C3E00CED3A2 /* CocoaHelpers.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C891D6619B124FF00BA79DD /* WebInspectorUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C891D6319B124FF00BA79DD /* WebInspectorUI.h */; };
+		1C8B2363289AE89400020CDC /* _WKWebExtensionPermission.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8B2362289AE89400020CDC /* _WKWebExtensionPermission.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C8E28201275D15400BC7BD0 /* WebInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8E281E1275D15400BC7BD0 /* WebInspector.h */; };
 		1C8E28341275D73800BC7BD0 /* WebInspectorUIProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8E28321275D73800BC7BD0 /* WebInspectorUIProxy.h */; };
 		1C8E293912761E5B00BC7BD0 /* WKInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8E293712761E5B00BC7BD0 /* WKInspector.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3408,6 +3411,7 @@
 		1AFE436418B6C081009C7A48 /* UIDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIDelegate.h; sourceTree = "<group>"; };
 		1AFF48FE1833DE78009AB15A /* WKDeprecatedFunctions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKDeprecatedFunctions.cpp; sourceTree = "<group>"; };
 		1BBBE49E19B66C53006B7D81 /* RemoteWebInspectorUIMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RemoteWebInspectorUIMessageReceiver.cpp; path = DerivedSources/WebKit/RemoteWebInspectorUIMessageReceiver.cpp; sourceTree = BUILT_PRODUCTS_DIR; };
+		1C049837289AF5AD0010308B /* _WKWebExtensionPermission.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionPermission.mm; sourceTree = "<group>"; };
 		1C0A19441C8FF1A800FE0EBB /* WebAutomationSessionProxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebAutomationSessionProxy.cpp; sourceTree = "<group>"; };
 		1C0A19451C8FF1A800FE0EBB /* WebAutomationSessionProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebAutomationSessionProxy.h; sourceTree = "<group>"; };
 		1C0A19481C8FF30E00FE0EBB /* WebAutomationSessionProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebAutomationSessionProxy.messages.in; sourceTree = "<group>"; };
@@ -3516,6 +3520,7 @@
 		1C56557E2745C5A1006300AF /* UnifiedSource103.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource103.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource103.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1C5A104E287BB1E90034FDA4 /* OverrideLanguages.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = OverrideLanguages.cpp; sourceTree = "<group>"; };
 		1C5A104F287BB1E90034FDA4 /* OverrideLanguages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OverrideLanguages.h; sourceTree = "<group>"; };
+		1C627477288A1DDE00CED3A2 /* WebExtensionCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionCocoa.mm; sourceTree = "<group>"; };
 		1C62747B288B4C3E00CED3A2 /* CocoaHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocoaHelpers.h; sourceTree = "<group>"; };
 		1C62747C288B4C3E00CED3A2 /* CocoaHelpers.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaHelpers.mm; sourceTree = "<group>"; };
 		1C739E852347BCF600C621EC /* CoreTextHelpers.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreTextHelpers.mm; sourceTree = "<group>"; };
@@ -3524,6 +3529,7 @@
 		1C891D6219B124FF00BA79DD /* WebInspectorUI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspectorUI.cpp; sourceTree = "<group>"; };
 		1C891D6319B124FF00BA79DD /* WebInspectorUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspectorUI.h; sourceTree = "<group>"; };
 		1C891D6419B124FF00BA79DD /* WebInspectorUI.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebInspectorUI.messages.in; sourceTree = "<group>"; };
+		1C8B2362289AE89400020CDC /* _WKWebExtensionPermission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionPermission.h; sourceTree = "<group>"; };
 		1C8E281E1275D15400BC7BD0 /* WebInspector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspector.h; sourceTree = "<group>"; };
 		1C8E281F1275D15400BC7BD0 /* WebInspector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspector.cpp; sourceTree = "<group>"; };
 		1C8E28321275D73800BC7BD0 /* WebInspectorUIProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspectorUIProxy.h; sourceTree = "<group>"; };
@@ -8529,6 +8535,7 @@
 		1C627476288A1DDE00CED3A2 /* Cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				1C627477288A1DDE00CED3A2 /* WebExtensionCocoa.mm */,
 				1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */,
 			);
 			path = Cocoa;
@@ -9817,6 +9824,8 @@
 				1C1CE96E288DF5020098D3A1 /* _WKWebExtensionMatchPattern.mm */,
 				1C1CE96F288DF5020098D3A1 /* _WKWebExtensionMatchPatternInternal.h */,
 				1C1CE970288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h */,
+				1C8B2362289AE89400020CDC /* _WKWebExtensionPermission.h */,
+				1C049837289AF5AD0010308B /* _WKWebExtensionPermission.mm */,
 				1C3BEB6F288883E300E66E38 /* _WKWebExtensionPrivate.h */,
 				1AE286761C7E76510069AC4F /* _WKWebsiteDataSize.h */,
 				1AE286751C7E76510069AC4F /* _WKWebsiteDataSize.mm */,
@@ -14097,6 +14106,7 @@
 				1C1CE975288DF5030098D3A1 /* _WKWebExtensionMatchPattern.h in Headers */,
 				1C1CE973288DF5030098D3A1 /* _WKWebExtensionMatchPatternInternal.h in Headers */,
 				1C1CE974288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h in Headers */,
+				1C8B2363289AE89400020CDC /* _WKWebExtensionPermission.h in Headers */,
 				1C3BEB712888842A00E66E38 /* _WKWebExtensionPrivate.h in Headers */,
 				1AE286781C7E76510069AC4F /* _WKWebsiteDataSize.h in Headers */,
 				1AE286801C7F92C00069AC4F /* _WKWebsiteDataSizeInternal.h in Headers */,
@@ -17206,6 +17216,7 @@
 				1C627479288B2F7400CED3A2 /* _WKWebExtension.mm in Sources */,
 				1C62747A288B2F7400CED3A2 /* _WKWebExtensionController.mm in Sources */,
 				1C1CE972288DF5030098D3A1 /* _WKWebExtensionMatchPattern.mm in Sources */,
+				1C049838289AF5AD0010308B /* _WKWebExtensionPermission.mm in Sources */,
 				572EBBDA2538F6B4000552B3 /* AppAttestInternalSoftLink.mm in Sources */,
 				517B5F7E275E97B6002DC22D /* AppBundleRequest.mm in Sources */,
 				EBA8D3B227A5E33F00CB7900 /* ApplePushServiceConnection.mm in Sources */,
@@ -17556,6 +17567,7 @@
 				E3866B0B2399A2DD00F88FE9 /* WebDeviceOrientationUpdateProviderMessageReceiver.cpp in Sources */,
 				E3866AE52397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm in Sources */,
 				E3866B092399A2D500F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp in Sources */,
+				1C627478288A1E1D00CED3A2 /* WebExtensionCocoa.mm in Sources */,
 				1C3BEB522887492F00E66E38 /* WebExtensionControllerMessageReceiver.cpp in Sources */,
 				1C3BEB532887492F00E66E38 /* WebExtensionControllerProxyMessageReceiver.cpp in Sources */,
 				1C1CE96D288DF46D0098D3A1 /* WebExtensionMatchPatternCocoa.mm in Sources */,

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -279,6 +279,7 @@ Tests/WebKitCocoa/WKProcessPoolConfiguration.mm
 Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-leaks.mm
+Tests/WebKitCocoa/WKWebExtension.mm
 Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
 Tests/WebKitCocoa/WKWebViewAlwaysShowsScroller.mm
 Tests/WebKitCocoa/WKWebViewCandidateTests.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2016,6 +2016,7 @@
 		1CF59ADF21E68925006E37EC /* ForceLightAppearanceInBundle.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ForceLightAppearanceInBundle.mm; sourceTree = "<group>"; };
 		1CF59AE021E68925006E37EC /* ForceLightAppearanceInBundle_Bundle.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ForceLightAppearanceInBundle_Bundle.mm; sourceTree = "<group>"; };
 		1CF59AE421E696FB006E37EC /* dark-mode.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "dark-mode.html"; sourceTree = "<group>"; };
+		1CFAA40828947999009F894D /* WKWebExtension.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtension.mm; sourceTree = "<group>"; };
 		1CFAA40928974405009F894D /* WKWebExtensionMatchPattern.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionMatchPattern.mm; sourceTree = "<group>"; };
 		1CFD5D3E2851B62100A0E30B /* EnumeratedArray.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EnumeratedArray.cpp; sourceTree = "<group>"; };
 		1D12BEBF245BEF85004C0B7A /* ExitPiPOnSuspendVideoElement.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ExitPiPOnSuspendVideoElement.mm; sourceTree = "<group>"; };
@@ -4028,6 +4029,7 @@
 				5E4B1D2C1D404C6100053621 /* WKScrollViewDelegate.mm */,
 				51C683DD1EA134DB00650183 /* WKURLSchemeHandler-1.mm */,
 				5182C22D1F2BCB410059BA7C /* WKURLSchemeHandler-leaks.mm */,
+				1CFAA40828947999009F894D /* WKWebExtension.mm */,
 				1CFAA40928974405009F894D /* WKWebExtensionMatchPattern.mm */,
 				5C7148942123A40700FDE3C5 /* WKWebsiteDatastore.mm */,
 				371195AA1FE5797700A1FB92 /* WKWebViewAlwaysShowsScroller.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -1,0 +1,527 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "TestCocoa.h"
+#import <WebKit/WKFoundation.h>
+#import <WebKit/_WKWebExtensionMatchPatternPrivate.h>
+#import <WebKit/_WKWebExtensionPrivate.h>
+
+namespace TestWebKitAPI {
+
+static NSError *matchingError(NSArray<NSError *> *errors, _WKWebExtensionError code)
+{
+    for (NSError *error in errors) {
+        if ([error.domain isEqualToString:_WKWebExtensionErrorDomain] && error.code == code)
+            return error;
+    }
+
+    return nil;
+}
+
+TEST(WKWebExtension, BasicManifestParsing)
+{
+    auto parse = ^(NSString *manifestString) {
+        return [[_WKWebExtension alloc] _initWithManifestData:[manifestString dataUsingEncoding:NSUTF8StringEncoding]].manifest;
+    };
+
+    EXPECT_NULL(parse(@""));
+    EXPECT_NULL(parse(@"[]"));
+
+    EXPECT_NS_EQUAL(parse(@"{}"), @{ });
+    EXPECT_NS_EQUAL(parse(@"{ \"manifest_version\": 1 }"), @{ @"manifest_version" : @1 });
+    EXPECT_NS_EQUAL(parse(@"{ \"manifest_version\": 4 }"), @{ @"manifest_version" : @4 });
+    EXPECT_NS_EQUAL(parse(@"{ \"manifest_version\": -2 }"), @{ @"manifest_version" : @(-2) });
+    EXPECT_NS_EQUAL(parse(@"{ \"manifest_version\": 0 }"), @{ @"manifest_version" : @0 });
+    EXPECT_NS_EQUAL(parse(@"{ \"manifest_version\": \"1\" }"), @{ @"manifest_version" : @"1" });
+
+    EXPECT_NS_EQUAL(parse(@"{ \"manifest_version\": 2 }"), @{ @"manifest_version" : @2 });
+    EXPECT_NS_EQUAL(parse(@"{ \"manifest_version\": 3 }"), @{ @"manifest_version" : @3 });
+
+    NSDictionary *testResult = @{ @"manifest_version": @2, @"name": @"Test", @"version": @"1.0" };
+    EXPECT_NS_EQUAL(parse(@"{ \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\" }"), testResult);
+
+    testResult = @{ @"manifest_version": @3, @"name": @"Test", @"version": @"1.0" };
+    EXPECT_NS_EQUAL(parse(@"{ \"manifest_version\": 3, \"name\": \"Test\", \"version\": \"1.0\" }"), testResult);
+}
+
+TEST(WKWebExtension, DisplayStringParsing)
+{
+    NSMutableDictionary *testManifestDictionary = [@{ @"manifest_version": @2 } mutableCopy];
+    auto testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NULL(testExtension.displayName);
+    EXPECT_NULL(testExtension.displayShortName);
+    EXPECT_NULL(testExtension.displayVersion);
+    EXPECT_NULL(testExtension.version);
+    EXPECT_NULL(testExtension.displayDescription);
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidName));
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidDescription));
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidVersion));
+
+    testManifestDictionary[@"name"] = @"Test";
+    testManifestDictionary[@"version"] = @"1.0";
+    testManifestDictionary[@"description"] = @"Test description.";
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.displayName, @"Test");
+    EXPECT_NS_EQUAL(testExtension.displayShortName, @"Test");
+    EXPECT_NS_EQUAL(testExtension.displayVersion, @"1.0");
+    EXPECT_NS_EQUAL(testExtension.version, @"1.0");
+    EXPECT_NS_EQUAL(testExtension.displayDescription, @"Test description.");
+    EXPECT_NULL(testExtension.errors);
+
+    testManifestDictionary[@"short_name"] = @"Tst";
+    testManifestDictionary[@"version_name"] = @"1.0 Final";
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.displayName, @"Test");
+    EXPECT_NS_EQUAL(testExtension.displayShortName, @"Tst");
+    EXPECT_NS_EQUAL(testExtension.displayVersion, @"1.0 Final");
+    EXPECT_NS_EQUAL(testExtension.version, @"1.0");
+    EXPECT_NS_EQUAL(testExtension.displayDescription, @"Test description.");
+    EXPECT_NULL(testExtension.errors);
+}
+
+TEST(WKWebExtension, ContentScriptsParsing)
+{
+    NSMutableDictionary *testManifestDictionary = [@{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0" } mutableCopy];
+
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*/" ] } ];
+    auto testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    auto webkitURL = [NSURL URLWithString:@"https://webkit.org/"];
+    auto exampleURL = [NSURL URLWithString:@"https://example.com/"];
+
+    EXPECT_NULL(testExtension.errors);
+    EXPECT_TRUE([testExtension hasInjectedContentForURL:webkitURL]);
+    EXPECT_TRUE([testExtension hasInjectedContentForURL:exampleURL]);
+
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*/" ], @"exclude_matches": @[ @"*://*.example.com/" ] } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NULL(testExtension.errors);
+    EXPECT_TRUE([testExtension hasInjectedContentForURL:webkitURL]);
+    EXPECT_FALSE([testExtension hasInjectedContentForURL:exampleURL]);
+
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*.example.com/" ] } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NULL(testExtension.errors);
+    EXPECT_FALSE([testExtension hasInjectedContentForURL:webkitURL]);
+    EXPECT_TRUE([testExtension hasInjectedContentForURL:exampleURL]);
+
+    // Invalid cases
+
+    testManifestDictionary[@"content_scripts"] = @[ ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidContentScripts));
+    EXPECT_FALSE([testExtension hasInjectedContentForURL:webkitURL]);
+    EXPECT_FALSE([testExtension hasInjectedContentForURL:exampleURL]);
+
+    testManifestDictionary[@"content_scripts"] = @{ @"invalid": @YES };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidContentScripts));
+    EXPECT_FALSE([testExtension hasInjectedContentForURL:webkitURL]);
+    EXPECT_FALSE([testExtension hasInjectedContentForURL:exampleURL]);
+
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ ] } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidContentScripts));
+    EXPECT_FALSE([testExtension hasInjectedContentForURL:webkitURL]);
+    EXPECT_FALSE([testExtension hasInjectedContentForURL:exampleURL]);
+
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ @"*://*.example.com/" ], @"run_at": @"invalid" } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidContentScripts));
+    EXPECT_FALSE([testExtension hasInjectedContentForURL:webkitURL]);
+    EXPECT_TRUE([testExtension hasInjectedContentForURL:exampleURL]);
+}
+
+TEST(WKWebExtension, PermissionsParsing)
+{
+    // Neither of the "permissions" and "optional_permissions" keys are defined.
+    NSDictionary *testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0" };
+    auto testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NOT_NULL(testExtension.requestedPermissions);
+    EXPECT_EQ(testExtension.requestedPermissions.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
+    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.optionalPermissions);
+    EXPECT_EQ(testExtension.optionalPermissions.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+
+    // The "permissions" key alone is defined but is empty.
+    testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @[ ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NOT_NULL(testExtension.requestedPermissions);
+    EXPECT_EQ(testExtension.requestedPermissions.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
+    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.optionalPermissions);
+    EXPECT_EQ(testExtension.optionalPermissions.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+
+    // The "optional_permissions" key alone is defined but is empty.
+    testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NOT_NULL(testExtension.requestedPermissions);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
+    EXPECT_NOT_NULL(testExtension.optionalPermissions);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_EQ(testExtension.requestedPermissions.count, 0ul);
+    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+    EXPECT_EQ(testExtension.optionalPermissions.count, 0ul);
+    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+
+    // The "permissions" and "optional_permissions" keys are defined as invalid types.
+    testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @(1), @"optional_permissions": @"foo" };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NOT_NULL(testExtension.requestedPermissions);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
+    EXPECT_NOT_NULL(testExtension.optionalPermissions);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_EQ(testExtension.requestedPermissions.count, 0ul);
+    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+    EXPECT_EQ(testExtension.optionalPermissions.count, 0ul);
+    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+
+    // The "permissions" key is defined with an invalid permission.
+    testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @[ @"invalid" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.requestedPermissions, [NSSet set]);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
+    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+
+    // The "permissions" key is defined with a valid permission.
+    testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @[ @"tabs" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.requestedPermissions, [NSSet setWithArray:@[ @"tabs" ]]);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
+    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+
+    // The "permissions" key is defined with a valid and an invalid permission.
+    testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @[ @"tabs", @"invalid" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.requestedPermissions, [NSSet setWithArray:(@[ @"tabs" ])]);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
+    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+
+    // The "permissions" key is defined with a valid permission and a valid origin.
+    testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @[ @"tabs", @"http://www.webkit.org/" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.requestedPermissions, [NSSet setWithArray:@[ @"tabs" ]]);
+    EXPECT_NS_EQUAL(testExtension.requestedPermissionOrigins.anyObject.description, @"http://www.webkit.org/");
+
+    // The "permissions" key is defined with a valid permission and an invalid origin.
+    testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @[ @"tabs", @"foo://www.webkit.org/" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.requestedPermissions, [NSSet setWithArray:(@[ @"tabs" ])]);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
+    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+
+    // The "optional_permissions" key is defined with an invalid permission.
+    testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ @"invalid" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.optionalPermissions, [NSSet set]);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+
+    // The "optional_permissions" key is defined with a valid permission.
+    testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ @"tabs" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.optionalPermissions, [NSSet setWithArray:@[ @"tabs" ]]);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+
+    // The "optional_permissions" key is defined with a valid and an invalid permission.
+    testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ @"tabs", @"invalid" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.optionalPermissions, [NSSet setWithArray:(@[ @"tabs" ])]);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+
+    // The "optional_permissions" key is defined with a valid permission and a valid origin.
+    testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ @"tabs", @"http://www.webkit.org/" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.optionalPermissions, [NSSet setWithArray:@[ @"tabs" ]]);
+    EXPECT_NS_EQUAL(testExtension.optionalPermissionOrigins.anyObject.description, @"http://www.webkit.org/");
+
+    // The "optional_permissions" key is defined with a valid permission and an invalid origin.
+    testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ @"tabs", @"foo://www.webkit.org/" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.optionalPermissions, [NSSet setWithArray:(@[ @"tabs" ])]);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+
+    // The "optional_permissions" key is defined with a valid permission and a forbidden optional permission.
+    testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ @"tabs", @"geolocation" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.optionalPermissions, [NSSet setWithArray:(@[ @"tabs" ])]);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+
+    // The "optional_permissions" key contains a permission already defined in the "permissions" key.
+    testManifestDictionary = @{ @"manifest_version": @2, @"permissions" : @[ @"tabs", @"geolocation" ], @"optional_permissions": @[@"tabs"] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.requestedPermissions, [NSSet setWithArray:(@[ @"tabs" ])]);
+    EXPECT_NOT_NULL(testExtension.optionalPermissions);
+    EXPECT_EQ(testExtension.optionalPermissions.count, 0ul);
+
+    // The "optional_permissions" key contains an origin already defined in the "permissions" key.
+    testManifestDictionary = @{ @"manifest_version": @2, @"permissions" : @[ @"http://www.webkit.org/" ], @"optional_permissions": @[ @"http://www.webkit.org/" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.requestedPermissionOrigins.anyObject.description, @"http://www.webkit.org/");
+    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+
+    // Make sure manifest v2 extensions ignore hosts from host_permissions (this should only be checked for manifest v3).
+    testManifestDictionary = @{ @"manifest_version": @2, @"permissions" : @[ @"http://www.webkit.org/" ], @"optional_permissions": @[ @"http://www.example.com/" ], @"host_permissions": @[ @"https://webkit.org/" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 1ul);
+    EXPECT_TRUE([testExtension.requestedPermissionOrigins containsObject:[_WKWebExtensionMatchPattern matchPatternWithString:@"http://www.webkit.org/"]]);
+    EXPECT_FALSE([testExtension.requestedPermissionOrigins containsObject:[_WKWebExtensionMatchPattern matchPatternWithString:@"https://webkit.org/"]]);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 1ul);
+    EXPECT_TRUE([testExtension.optionalPermissionOrigins containsObject:[_WKWebExtensionMatchPattern matchPatternWithString:@"http://www.example.com/"]]);
+    EXPECT_FALSE([testExtension.optionalPermissionOrigins containsObject:[_WKWebExtensionMatchPattern matchPatternWithString:@"https://webkit.org/"]]);
+
+    // Make sure manifest v3 parses hosts from host_permissions, and ignores hosts in permissions and optional_permissions.
+    testManifestDictionary = @{ @"manifest_version": @3, @"permissions" : @[ @"http://www.webkit.org/" ], @"optional_permissions": @[ @"http://www.example.com/" ], @"host_permissions": @[ @"https://webkit.org/" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 1ul);
+    EXPECT_NS_EQUAL(testExtension.requestedPermissionOrigins.anyObject.description, @"https://webkit.org/");
+    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+
+    // Make sure manifest v3 parses optional_host_permissions.
+    testManifestDictionary = @{ @"manifest_version": @3, @"optional_host_permissions": @[ @"http://www.example.com/" ], @"host_permissions": @[ @"https://webkit.org/" ] };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 1ul);
+    EXPECT_NS_EQUAL(testExtension.requestedPermissionOrigins.anyObject.description, @"https://webkit.org/");
+    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 1ul);
+    EXPECT_NS_EQUAL(testExtension.optionalPermissionOrigins.anyObject.description, @"http://www.example.com/");
+}
+
+TEST(WKWebExtension, BackgroundParsing)
+{
+    NSMutableDictionary *testManifestDictionary = [@{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0" } mutableCopy];
+
+#if TARGET_OS_IPHONE
+    testManifestDictionary[@"background"] = @{ @"scripts": @[ @"test.js" ], @"persistent": @NO };
+#else
+    testManifestDictionary[@"background"] = @{ @"scripts": @[ @"test.js" ] };
+#endif
+
+    auto testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+#if TARGET_OS_IPHONE
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+#else
+    EXPECT_TRUE(testExtension.backgroundContentIsPersistent);
+#endif
+    EXPECT_NULL(testExtension.errors);
+
+    testManifestDictionary[@"background"] = @{ @"page": @"test.html", @"persistent": @NO };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NULL(testExtension.errors);
+
+#if TARGET_OS_IPHONE
+    testManifestDictionary[@"background"] = @{ @"scripts": @[ @"test-1.js", @"", @"test-2.js" ], @"persistent": @NO };
+#else
+    testManifestDictionary[@"background"] = @{ @"scripts": @[ @"test-1.js", @"", @"test-2.js" ], @"persistent": @YES };
+#endif
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+#if TARGET_OS_IPHONE
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+#else
+    EXPECT_TRUE(testExtension.backgroundContentIsPersistent);
+#endif
+    EXPECT_NULL(testExtension.errors);
+
+    testManifestDictionary[@"background"] = @{ @"service_worker": @"test.js" };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NULL(testExtension.errors);
+
+    testManifestDictionary[@"background"] = @{ @"service_worker": @"test.js", @"persistent": @NO };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NULL(testExtension.errors);
+
+    // Invalid cases
+
+#if TARGET_OS_IPHONE
+    testManifestDictionary[@"background"] = @{ @"page": @"test.html", @"persistent": @YES };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_TRUE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundContent));
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
+#endif
+
+    testManifestDictionary[@"manifest_version"] = @3;
+    testManifestDictionary[@"background"] = @{ @"page": @"test.html", @"persistent": @YES };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundContent));
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
+
+    testManifestDictionary[@"manifest_version"] = @2;
+    testManifestDictionary[@"background"] = @{ @"service_worker": @"test.js", @"persistent": @YES };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundContent));
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
+
+    testManifestDictionary[@"background"] = @{ };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_FALSE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundContent));
+    EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
+
+    testManifestDictionary[@"background"] = @[ @"invalid" ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_FALSE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundContent));
+    EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
+
+    testManifestDictionary[@"background"] = @{ @"scripts": @[ ], @"persistent": @NO };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_FALSE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundContent));
+    EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
+
+    testManifestDictionary[@"background"] = @{ @"page": @"", @"persistent": @NO };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_FALSE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundContent));
+    EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
+
+    testManifestDictionary[@"background"] = @{ @"page": @[ @"test.html" ], @"persistent": @NO };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_FALSE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundContent));
+    EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
+
+    testManifestDictionary[@"background"] = @{ @"scripts": @[ @[ @"test.js" ] ], @"persistent": @NO };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_FALSE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundContent));
+    EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
+
+    testManifestDictionary[@"background"] = @{ @"service_worker": @"", @"persistent": @NO };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_FALSE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundContent));
+    EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
+
+    testManifestDictionary[@"background"] = @{ @"service_worker": @[ @"test.js" ], @"persistent": @NO };
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_FALSE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
+    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundContent));
+    EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### ad4088694f4c49f6b80b91f590815a30d57b4649
<pre>
Add initial manifest parsing to the _WKWebExtension class.
<a href="https://bugs.webkit.org/show_bug.cgi?id=245980">https://bugs.webkit.org/show_bug.cgi?id=245980</a>

Reviewed by Alex Christensen.

Support for parsing these top-level keys: &quot;name&quot;, &quot;short_name&quot;, &quot;description&quot;, &quot;version&quot;, &quot;version_name&quot;, &quot;background&quot;,
&quot;content_scripts&quot;, &quot;permissions&quot;, &quot;optional_permissions&quot;, &quot;host_permissions&quot;, and &quot;optional_host_permissions&quot;.

Includes error reporting and exposing most of the properties as API.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
(NS_ERROR_ENUM):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(-[_WKWebExtension initWithAppExtensionBundle:]):
(-[_WKWebExtension initWithResourceBaseURL:]):
(-[_WKWebExtension _initWithManifestDictionary:]):
(-[_WKWebExtension _initWithManifestData:]):
(-[_WKWebExtension manifest]):
(-[_WKWebExtension manifestVersion]):
(-[_WKWebExtension usesManifestVersion:]):
(-[_WKWebExtension displayName]):
(-[_WKWebExtension displayShortName]):
(-[_WKWebExtension displayVersion]):
(-[_WKWebExtension displayDescription]):
(-[_WKWebExtension version]):
(-[_WKWebExtension requestedPermissions]):
(-[_WKWebExtension optionalPermissions]):
(-[_WKWebExtension requestedPermissionOrigins]):
(-[_WKWebExtension optionalPermissionOrigins]):
(-[_WKWebExtension allRequestedOrigins]):
(-[_WKWebExtension errors]):
(-[_WKWebExtension hasBackgroundContent]):
(-[_WKWebExtension backgroundContentIsPersistent]):
(-[_WKWebExtension hasInjectedContentForURL:]):
(-[_WKWebExtension init]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.mm: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm: Added.
(WebKit::WebExtension::WebExtension):
(WebKit::WebExtension::manifestParsedSuccessfully):
(WebKit::WebExtension::parseManifest):
(WebKit::WebExtension::manifest):
(WebKit::WebExtension::manifestVersion):
(WebKit::WebExtension::hasRequestedPermission const):
(WebKit::WebExtension::createError):
(WebKit::WebExtension::recordError):
(WebKit::WebExtension::errors):
(WebKit::WebExtension::webProcessDisplayName):
(WebKit::WebExtension::displayName):
(WebKit::WebExtension::displayShortName):
(WebKit::WebExtension::displayVersion):
(WebKit::WebExtension::displayDescription):
(WebKit::WebExtension::version):
(WebKit::WebExtension::populateDisplayStringsIfNeeded):
(WebKit::WebExtension::hasBackgroundContent):
(WebKit::WebExtension::backgroundContentIsPersistent):
(WebKit::WebExtension::backgroundContentIsServiceWorker):
(WebKit::WebExtension::generatedBackgroundContent):
(WebKit::WebExtension::populateBackgroundPropertiesIfNeeded):
(WebKit::WebExtension::injectedContents):
(WebKit::WebExtension::hasInjectedContentForURL):
(WebKit::WebExtension::InjectedContentData::expandedIncludeMatchPatternStrings const):
(WebKit::WebExtension::InjectedContentData::expandedExcludeMatchPatternStrings const):
(WebKit::WebExtension::populateContentScriptPropertiesIfNeeded):
(WebKit::WebExtension::supportedPermissions):
(WebKit::WebExtension::requestedPermissions):
(WebKit::WebExtension::optionalPermissions):
(WebKit::WebExtension::requestedPermissionOrigins):
(WebKit::WebExtension::optionalPermissionOrigins):
(WebKit::WebExtension::allRequestedOrigins):
(WebKit::WebExtension::populatePermissionsPropertiesIfNeeded):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::usesManifestVersion):
(WebKit::WebExtension::WebExtension): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm: Added.

Canonical link: <a href="https://commits.webkit.org/255123@main">https://commits.webkit.org/255123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecac1cdb1e05c6fd3269949962fa59480ba1a62a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91379 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101111 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161087 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/417 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97488 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/352 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78097 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27287 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82251 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/81921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70318 "Updated gtk dependencies (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35514 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15947 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33305 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17034 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39826 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1584 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39020 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36143 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->