### PR TITLE
`change` event for input[type=file] does not fire when different file with same name is selected

### DIFF
--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -75,6 +75,15 @@ typedef int PlatformFileHandle;
 const PlatformFileHandle invalidPlatformFileHandle = -1;
 #endif
 
+// PlatformFileID
+#if USE(GLIB) && !OS(WINDOWS)
+typedef uint64_t PlatformFileID;
+#elif OS(WINDOWS)
+typedef FILE_ID_128 PlatformFileID;
+#else
+typedef ino_t PlatformFileID;
+#endif
+
 enum class FileOpenMode {
     Read,
     Write,
@@ -114,6 +123,7 @@ WTF_EXPORT_PRIVATE bool moveFile(const String& oldPath, const String& newPath);
 WTF_EXPORT_PRIVATE std::optional<uint64_t> fileSize(const String&); // Follows symlinks.
 WTF_EXPORT_PRIVATE std::optional<uint64_t> fileSize(PlatformFileHandle);
 WTF_EXPORT_PRIVATE std::optional<WallTime> fileModificationTime(const String&);
+WTF_EXPORT_PRIVATE std::optional<PlatformFileID> fileID(PlatformFileHandle);
 WTF_EXPORT_PRIVATE bool updateFileModificationTime(const String& path); // Sets modification time to now.
 WTF_EXPORT_PRIVATE std::optional<WallTime> fileCreationTime(const String&); // Not all platforms store file creation time.
 WTF_EXPORT_PRIVATE bool isHiddenFile(const String&);

--- a/Source/WTF/wtf/glib/FileSystemGlib.cpp
+++ b/Source/WTF/wtf/glib/FileSystemGlib.cpp
@@ -134,6 +134,12 @@ std::optional<uint64_t> fileSize(PlatformFileHandle handle)
     return g_file_info_get_size(info.get());
 }
 
+std::optional<PlatformFileID> fileID(PlatformFileHandle handle)
+{
+    // FIXME (246118): Implement this function properly.
+    return std::nullopt;
+}
+
 std::optional<WallTime> fileCreationTime(const String&)
 {
     // FIXME: Is there a way to retrieve file creation time with Gtk on platforms that support it?

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -190,6 +190,15 @@ std::optional<WallTime> fileCreationTime(const String& path)
 #endif
 }
 
+std::optional<PlatformFileID> fileID(PlatformFileHandle handle)
+{
+    struct stat fileInfo;
+    if (fstat(handle, &fileInfo))
+        return std::nullopt;
+
+    return fileInfo.st_ino;
+}
+
 std::optional<uint32_t> volumeFileBlockSize(const String& path)
 {
     struct statvfs fileStat;

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -112,6 +112,12 @@ std::optional<uint64_t> fileSize(PlatformFileHandle fileHandle)
     return getFileSizeFromByHandleFileInformationStructure(fileInformation);
 }
 
+std::optional<PlatformFileID> fileID(PlatformFileHandle fileHandle)
+{
+    // FIXME (246118): Implement this function properly.
+    return std::nullopt;
+}
+
 std::optional<WallTime> fileCreationTime(const String& path)
 {
     WIN32_FIND_DATAW findData;

--- a/Source/WebCore/fileapi/File.cpp
+++ b/Source/WebCore/fileapi/File.cpp
@@ -45,7 +45,7 @@ Ref<File> File::createWithRelativePath(ScriptExecutionContext* context, const St
     return file;
 }
 
-Ref<File> File::create(ScriptExecutionContext* context, const String& path, const String& replacementPath, const String& nameOverride)
+Ref<File> File::create(ScriptExecutionContext* context, const String& path, const String& replacementPath, const String& nameOverride, const std::optional<FileSystem::PlatformFileID>& fileID)
 {
     String name;
     String type;
@@ -55,7 +55,7 @@ Ref<File> File::create(ScriptExecutionContext* context, const String& path, cons
     auto internalURL = BlobURL::createInternalURL();
     ThreadableBlobRegistry::registerFileBlobURL(internalURL, path, replacementPath, type);
 
-    auto file = adoptRef(*new File(context, WTFMove(internalURL), WTFMove(type), WTFMove(effectivePath), WTFMove(name)));
+    auto file = adoptRef(*new File(context, WTFMove(internalURL), WTFMove(type), WTFMove(effectivePath), WTFMove(name), fileID));
     file->suspendIfNeeded();
     return file;
 }
@@ -64,6 +64,14 @@ File::File(ScriptExecutionContext* context, URL&& url, String&& type, String&& p
     : Blob(uninitializedContructor, context, WTFMove(url), WTFMove(type))
     , m_path(WTFMove(path))
     , m_name(WTFMove(name))
+{
+}
+
+File::File(ScriptExecutionContext* context, URL&& url, String&& type, String&& path, String&& name, const std::optional<FileSystem::PlatformFileID>& fileID)
+    : Blob(uninitializedContructor, context, WTFMove(url), WTFMove(type))
+    , m_path(WTFMove(path))
+    , m_name(WTFMove(name))
+    , m_fileID(fileID)
 {
 }
 

--- a/Source/WebCore/fileapi/File.h
+++ b/Source/WebCore/fileapi/File.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Blob.h"
+#include <wtf/FileSystem.h>
 #include <wtf/IsoMalloc.h>
 #include <wtf/Ref.h>
 #include <wtf/TypeCasts.h>
@@ -41,7 +42,7 @@ public:
     };
 
     // Create a file with an optional name exposed to the author (via File.name and associated DOM properties) that differs from the one provided in the path.
-    WEBCORE_EXPORT static Ref<File> create(ScriptExecutionContext*, const String& path, const String& replacementPath = { }, const String& nameOverride = { });
+    WEBCORE_EXPORT static Ref<File> create(ScriptExecutionContext*, const String& path, const String& replacementPath = { }, const String& nameOverride = { }, const std::optional<FileSystem::PlatformFileID>& fileID = { });
 
     // Create a File using the 'new File' constructor.
     static Ref<File> create(ScriptExecutionContext& context, Vector<BlobPartVariant>&& blobPartVariants, const String& filename, const PropertyBag& propertyBag)
@@ -82,6 +83,7 @@ public:
     const String& name() const { return m_name; }
     WEBCORE_EXPORT int64_t lastModified() const; // Number of milliseconds since Epoch.
     const std::optional<int64_t>& lastModifiedOverride() const { return m_lastModifiedDateOverride; } // Number of milliseconds since Epoch.
+    const std::optional<FileSystem::PlatformFileID> fileID() const { return m_fileID; }
 
     static String contentTypeForFile(const String& path);
 
@@ -95,6 +97,7 @@ private:
     WEBCORE_EXPORT explicit File(ScriptExecutionContext*, const String& path);
     File(ScriptExecutionContext*, URL&&, String&& type, String&& path, String&& name);
     File(ScriptExecutionContext&, Vector<BlobPartVariant>&& blobPartVariants, const String& filename, const PropertyBag&);
+    File(ScriptExecutionContext*, URL&&, String&& type, String&& path, String&& name, const std::optional<FileSystem::PlatformFileID>&);
     File(ScriptExecutionContext*, const Blob&, const String& name);
     File(ScriptExecutionContext*, const File&, const String& name);
 
@@ -113,6 +116,7 @@ private:
     String m_name;
 
     std::optional<int64_t> m_lastModifiedDateOverride;
+    std::optional<FileSystem::PlatformFileID> m_fileID;
     mutable std::optional<bool> m_isDirectory;
 };
 

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -374,7 +374,7 @@ void FileInputType::setFiles(RefPtr<FileList>&& files, RequestIcon shouldRequest
         pathsChanged = true;
     else {
         for (unsigned i = 0; i < length; ++i) {
-            if (files->file(i).path() != m_fileList->file(i).path()) {
+            if (files->file(i).path() != m_fileList->file(i).path() || files->file(i).fileID() != m_fileList->file(i).fileID()) {
                 pathsChanged = true;
                 break;
             }
@@ -415,7 +415,11 @@ void FileInputType::filesChosen(const Vector<FileChooserFileInfo>& paths, const 
     auto* document = element() ? &element()->document() : nullptr;
     if (!allowsDirectories()) {
         auto files = paths.map([document](auto& fileInfo) {
-            return File::create(document, fileInfo.path, fileInfo.replacementPath, fileInfo.displayName);
+            auto handle = FileSystem::openFile(fileInfo.path, FileSystem::FileOpenMode::Read);
+            auto fileID = FileSystem::fileID(handle);
+            FileSystem::closeFile(handle);
+
+            return File::create(document, fileInfo.path, fileInfo.replacementPath, fileInfo.displayName, fileID);
         });
         didCreateFileList(FileList::create(WTFMove(files)), icon);
         return;

--- a/Source/WebCore/platform/FileChooser.cpp
+++ b/Source/WebCore/platform/FileChooser.cpp
@@ -58,10 +58,6 @@ void FileChooser::chooseFile(const String& filename)
 
 void FileChooser::chooseFiles(const Vector<String>& filenames, const Vector<String>& replacementNames)
 {
-    // FIXME: This is inelegant. We should not be looking at settings here.
-    if (m_settings.selectedFiles == filenames)
-        return;
-
     if (!m_client)
         return;
 
@@ -78,10 +74,6 @@ void FileChooser::chooseFiles(const Vector<String>& filenames, const Vector<Stri
 // with FileChooser::chooseFiles() and hence remove the PLATFORM(IOS_FAMILY)-guard.
 void FileChooser::chooseMediaFiles(const Vector<String>& filenames, const String& displayString, Icon* icon)
 {
-    // FIXME: This is inelegant. We should not be looking at settings here.
-    if (m_settings.selectedFiles == filenames)
-        return;
-
     if (!m_client)
         return;
 
@@ -98,10 +90,6 @@ void FileChooser::chooseFiles(const Vector<FileChooserFileInfo>& files)
     auto paths = files.map([](auto& file) {
         return file.path;
     });
-
-    // FIXME: This is inelegant. We should not be looking at settings here.
-    if (m_settings.selectedFiles == paths)
-        return;
 
     if (m_client)
         m_client->filesChosen(files);


### PR DESCRIPTION
#### 5374937e8566ca95b1adefe78fc7b2d90f6497ee
<pre>
`change` event for input[type=file] does not fire when different file with same name is selected
<a href="https://bugs.webkit.org/show_bug.cgi?id=187084">https://bugs.webkit.org/show_bug.cgi?id=187084</a>
rdar://98460303

Reviewed by Ryosuke Niwa.

When a different file with the same name as the currently selected file is selected,
the `change` event does not currently fire, because a file&apos;s path is it&apos;s
identifier, so the two files are considered the same by the system.

This PR works around this by saving each file&apos;s unique id and then comparing the files
both based on their name and now their id too.

* Source/WebCore/fileapi/File.cpp:
(WebCore::File::create):
(WebCore::File::File):
* Source/WebCore/fileapi/File.h:
* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::setFiles):
* Source/WebCore/platform/FileChooser.cpp:
(WebCore::FileChooser::chooseFiles):

Canonical link: <a href="https://commits.webkit.org/255209@main">https://commits.webkit.org/255209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c025e3cf1df87f49900eb2cd8823e23bfaacc680

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101424 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161494 "Hash c025e3cf for PR 4943 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/956 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84042 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97730 "Hash c025e3cf for PR 4943 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/567 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27522 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82491 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83151 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35843 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78196 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33597 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17244 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26991 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3608 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37443 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80807 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36361 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17695 "Passed tests") | 
<!--EWS-Status-Bubble-End-->