### PR TITLE
[webkitbugspy] Strip <> from radar links

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.8.2',
+    version='0.8.3',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 8, 2)
+version = Version(0, 8, 3)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -169,7 +169,7 @@ class Tracker(GenericTracker):
         return Issue(id=int(id), tracker=self)
 
     def populate(self, issue, member=None):
-        issue._link = '<rdar://{}>'.format(issue.id)
+        issue._link = 'rdar://{}'.format(issue.id)
         issue._labels = []
         if (not self.client or not self.library) and member:
             sys.stderr.write('radarclient inaccessible on this machine\n')

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -460,7 +460,7 @@ What version of 'WebKit' should the bug be associated with?:
                 self.assertEqual(issue.references, [])
                 self.assertIsNotNone(issue.cc_radar(block=True))
                 self.assertEqual(len(issue.references), 1)
-                self.assertEqual(issue.references[0].link, '<rdar://1>')
+                self.assertEqual(issue.references[0].link, 'rdar://1')
                 self.assertEqual(issue.references[0].title, None)
 
     def test_cc_with_radarclient(self):
@@ -478,7 +478,7 @@ What version of 'WebKit' should the bug be associated with?:
                 self.assertEqual(issue.references, [])
                 self.assertIsNotNone(issue.cc_radar(block=True))
                 self.assertEqual(len(issue.references), 1)
-                self.assertEqual(issue.references[0].link, '<rdar://4>')
+                self.assertEqual(issue.references[0].link, 'rdar://4')
                 self.assertEqual(issue.references[0].title, 'An example issue for testing (1)')
 
     def test_cc_existing_radar(self):
@@ -497,5 +497,5 @@ What version of 'WebKit' should the bug be associated with?:
                 self.assertIsNotNone(issue.cc_radar(block=True, radar=Tracker.from_string('<rdar://1>')))
                 self.assertEqual(issue.comments[-1].content, '<rdar://problem/1>')
                 self.assertEqual(len(issue.references), 1)
-                self.assertEqual(issue.references[0].link, '<rdar://1>')
+                self.assertEqual(issue.references[0].link, 'rdar://1')
                 self.assertEqual(issue.references[0].title, 'Example issue 1')

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -64,25 +64,25 @@ class TestRadar(unittest.TestCase):
     def test_link(self):
         with mocks.Radar(users=mocks.USERS):
             tracker = radar.Tracker()
-            self.assertEqual(tracker.issue(1234).link, '<rdar://1234>')
+            self.assertEqual(tracker.issue(1234).link, 'rdar://1234')
             self.assertEqual(
                 tracker.from_string('<rdar://problem/1234>').link,
-                '<rdar://1234>',
+                'rdar://1234',
             )
             self.assertEqual(
                 tracker.from_string('<radar://1234>').link,
-                '<rdar://1234>',
+                'rdar://1234',
             )
             self.assertEqual(
                 tracker.from_string('<radar://problem/1234>').link,
-                '<rdar://1234>',
+                'rdar://1234',
             )
 
     def test_title(self):
         with mocks.Radar(issues=mocks.ISSUES):
             tracker = radar.Tracker()
             self.assertEqual(tracker.issue(1).title, 'Example issue 1')
-            self.assertEqual(str(tracker.issue(1)), '<rdar://1> Example issue 1')
+            self.assertEqual(str(tracker.issue(1)), 'rdar://1 Example issue 1')
 
     def test_timestamp(self):
         with mocks.Radar(issues=mocks.ISSUES):

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.6.12',
+    version='5.6.13',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 6, 12)
+version = Version(5, 6, 13)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
@@ -118,7 +118,7 @@ class TestBranch(testing.PathTestCase):
 
             issue = Tracker.from_string('{}/show_bug.cgi?id=2'.format(self.BUGZILLA))
             self.assertEqual(len(issue.references), 2)
-            self.assertEqual(issue.references[0].link, '<rdar://4>')
+            self.assertEqual(issue.references[0].link, 'rdar://4')
             self.assertEqual(issue.comments[-1].content, '<rdar://problem/4>')
 
         self.assertEqual(
@@ -152,7 +152,7 @@ class TestBranch(testing.PathTestCase):
 
             issue = Tracker.from_string('{}/show_bug.cgi?id=2'.format(self.BUGZILLA))
             self.assertEqual(len(issue.references), 2)
-            self.assertEqual(issue.references[0].link, '<rdar://4>')
+            self.assertEqual(issue.references[0].link, 'rdar://4')
             self.assertEqual(issue.comments[-1].content, '<rdar://problem/4>')
 
         self.assertEqual(
@@ -186,7 +186,7 @@ class TestBranch(testing.PathTestCase):
 
             issue = Tracker.from_string('{}/show_bug.cgi?id=2'.format(self.BUGZILLA))
             self.assertEqual(len(issue.references), 2)
-            self.assertEqual(issue.references[0].link, '<rdar://4>')
+            self.assertEqual(issue.references[0].link, 'rdar://4')
             self.assertEqual(issue.comments[-1].content, '<rdar://problem/4>')
 
         self.assertEqual(
@@ -316,7 +316,7 @@ What version of 'WebKit SVG' should the bug be associated with?:
     3) Safari Technology Preview
     4) WebKit Local Build
 : 
-Created '<rdar://4> [Area] New Issue'
+Created 'rdar://4 [Area] New Issue'
 Created the local development branch 'eng/Area-New-Issue'
 ''',
         )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py
@@ -69,8 +69,8 @@ class TestCherryPick(testing.PathTestCase):
                 args=('cherry-pick', 'd8bce26fa65c', '-i', '<rdar://problem/123>'),
                 path=self.path,
             ))
-            self.assertEqual(repo.head.hash, '200db1e4faae82ff005f1b826a12ad8c8260b179')
-            self.assertEqual(repo.head.message, 'Cherry-pick 5@main (d8bce26fa65c). <rdar://123>\n    Patch Series\n')
+            self.assertEqual(repo.head.hash, 'bae505f206a290592fd251b057874d2d9d931202')
+            self.assertEqual(repo.head.message, 'Cherry-pick 5@main (d8bce26fa65c). rdar://123\n    Patch Series\n')
 
         self.assertEqual(captured.stdout.getvalue(), '')
         self.assertEqual(captured.stderr.getvalue(), '')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -1174,7 +1174,7 @@ No pre-PR checks to run""")
         self.assertEqual(
             captured.stdout.getvalue(),
             "Created 'PR 1 | <rdar://problem/1> [Testing] Existing commit'!\n"
-            'Posted pull request link to <rdar://1>\n'
+            'Posted pull request link to rdar://1\n'
             'https://bitbucket.example.com/projects/WEBKIT/repos/webkit/pull-requests/1/overview\n',
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -1227,7 +1227,7 @@ No pre-PR checks to run""")
         self.assertEqual(
             captured.stdout.getvalue(),
             "Created 'PR 1 | <rdar://problem/1> [Testing] Existing commit'!\n"
-            'Posted pull request link to <rdar://1>\n'
+            'Posted pull request link to rdar://1\n'
             'https://bitbucket.example.com/projects/WEBKIT/repos/webkit/pull-requests/1/overview\n',
         )
         self.assertEqual(captured.stderr.getvalue(), '')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
@@ -103,7 +103,7 @@ class TestCommitsStory(TestCase):
                 message='Cherry-pick 123@main (0123456789ab). <rdar://54321>',
             )
             story = CommitsStory([commit])
-            self.assertEqual(story.by_issue.get('<rdar://54321>', []), [commit])
+            self.assertEqual(story.by_issue.get('rdar://54321', []), [commit])
             self.assertEqual(
                 [str(rel) for rel in story.relations.get('123@main', [])],
                 ['1234@main cherry-picked'],


### PR DESCRIPTION
#### 2f4d1f5b893eab4164abd5a910d1ea1f6fa571ba
<pre>
[webkitbugspy] Strip &lt;&gt; from radar links
<a href="https://bugs.webkit.org/show_bug.cgi?id=245987">https://bugs.webkit.org/show_bug.cgi?id=245987</a>
rdar://100737006

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.populate):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:
(TestRadar.test_link):
(TestRadar.test_title):
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py:
(TestBranch.test_automatic_radar_cc):
(TestBranch.test_manual_radar_cc):
(TestBranch.test_manual_radar_cc_integer):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py:
(TestCherryPick.test_alternate_issue):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py:
(TestCommitsStory.test_cherry_pick):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f4d1f5b893eab4164abd5a910d1ea1f6fa571ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91547 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/101260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95552 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97205 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/83876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/95127 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/35673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/90612 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/33444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37265 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1596 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/39175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->