### PR TITLE
stagent.dev: Clicking email field on sign up form does not allow input until you click a second time

### DIFF
--- a/LayoutTests/fast/forms/auto-fill-button/show-auto-fill-button-while-selection-inside-field-expected.txt
+++ b/LayoutTests/fast/forms/auto-fill-button/show-auto-fill-button-while-selection-inside-field-expected.txt
@@ -1,0 +1,10 @@
+This test ensures clicking on an input field, and then adding an autofill button, leaves the selection inside the field.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.value is "Test"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/auto-fill-button/show-auto-fill-button-while-selection-inside-field.html
+++ b/LayoutTests/fast/forms/auto-fill-button/show-auto-fill-button-while-selection-inside-field.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+</head>
+<body onload="runTest()">
+<input id="input">
+<script>
+
+jsTestIsAsync = true;
+
+description("This test ensures clicking on an input field, and then adding an autofill button, leaves the selection inside the field.");
+
+async function runTest() {
+    if (!window.internals)
+        return;
+
+    await UIHelper.activateElement(input);
+
+    internals.setShowAutoFillButton(input, "Credentials");
+
+    document.execCommand("insertText", true, "Test");
+
+    shouldBeEqualToString("input.value", "Test");
+
+    finishJSTest();
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -82,6 +82,8 @@ public:
     void setSelectionRange(unsigned start, unsigned end, const String& direction, const AXTextStateChangeIntent& = AXTextStateChangeIntent());
     WEBCORE_EXPORT bool setSelectionRange(unsigned start, unsigned end, TextFieldSelectionDirection = SelectionHasNoDirection, SelectionRevealMode = SelectionRevealMode::DoNotReveal, const AXTextStateChangeIntent& = AXTextStateChangeIntent());
 
+    TextFieldSelectionDirection computeSelectionDirection() const;
+
     std::optional<SimpleRange> selection() const;
     String selectedText() const;
 
@@ -141,8 +143,6 @@ private:
     TextFieldSelectionDirection cachedSelectionDirection() const { return static_cast<TextFieldSelectionDirection>(m_cachedSelectionDirection); }
 
     bool isTextFormControlElement() const final { return true; }
-
-    TextFieldSelectionDirection computeSelectionDirection() const;
 
     void dispatchFocusEvent(RefPtr<Element>&& oldFocusedElement, const FocusOptions&) final;
     void dispatchBlurEvent(RefPtr<Element>&& newFocusedElement) final;


### PR DESCRIPTION
#### f3b946f8835cf3a07017221b7fff53d7a0518354
<pre>
stagent.dev: Clicking email field on sign up form does not allow input until you click a second time
<a href="https://bugs.webkit.org/show_bug.cgi?id=245976">https://bugs.webkit.org/show_bug.cgi?id=245976</a>
rdar://98341809

Reviewed by Ryosuke Niwa.

Safari&apos;s AutoFill heuristic recently began (correctly) detecting email fields
on stagent.dev as autofillable. Consequently, Safari now adds an autofill
button to their email field when it is clicked.

WebKit has a longstanding bug where the selection is lost when an input
decoration is added while the selection is inside the input. Adding a decoration,
such as the autofill button, changes the structure of the shadow subtree.
Specifically, the contenteditable element is removed from the shadow root and
added to a separate container. The removal of the contenteditable element wipes
out the selection. To work around this issue, Safari has logic to restore the
selection after adding an autofill button.

However, Safari&apos;s workaround is not robust, as the HTML spec limits which input
types support the input selection APIs, such as `setSelectionStart` and
`setSelectionEnd`. Email inputs do not support the selection API, hence Safari&apos;s
workaround fails to apply to email fields where an autofill button is added.

To fix, restore the selection in WebKit, following the addition of an input
decoration, such as the autofill button. Note that this change still results in
two &quot;selectionchange&quot; events getting dispatched when focusing an autofillable
field for the first time. However, this matches behavior in shipping Safari.

An alternate solution considered was to avoid moving the contenteditable element
when adding a decoration. However, this change would have a much larger surface
area, and is too risky in the short term.

* LayoutTests/fast/forms/auto-fill-button/show-auto-fill-button-while-selection-inside-field-expected.txt: Added.
* LayoutTests/fast/forms/auto-fill-button/show-auto-fill-button-while-selection-inside-field.html: Added.
* Source/WebCore/html/HTMLTextFormControlElement.h:

Expose a method returning the enumerated value of the selection direction so
that the variant of `setSelectionRange` that does not dispatch &quot;select&quot; events
can be used.

* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::createContainer):

Restore the selection after an input decoration is added.

Canonical link: <a href="https://commits.webkit.org/255229@main">https://commits.webkit.org/255229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c221a577f23c23fa3738652ef5567e2c24f226df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101344 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161434 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/873 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29481 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83963 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97676 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/506 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78302 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27468 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70506 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35768 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16107 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33523 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17203 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3621 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37364 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39954 "Found 1 new test failure: http/wpt/service-workers/fetch-service-worker-preload.https.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36320 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->