### PR TITLE
[macOS] Display thumbnail of selected file for <input type=file>

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -408,6 +408,7 @@ platform/graphics/cocoa/GraphicsContextGLIOSurfaceSwapChain.cpp
 platform/graphics/cocoa/HEVCUtilitiesCocoa.mm
 platform/graphics/cocoa/IOSurface.mm
 platform/graphics/cocoa/IOSurfacePoolCocoa.mm
+platform/graphics/cocoa/IconCocoa.mm
 platform/graphics/cocoa/IntRectCocoa.mm
 platform/graphics/cocoa/MediaEngineConfigurationFactoryCocoa.cpp
 platform/graphics/cocoa/MediaPlaybackTargetContext.mm

--- a/Source/WebCore/platform/graphics/Icon.h
+++ b/Source/WebCore/platform/graphics/Icon.h
@@ -26,11 +26,10 @@
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
+#include "NativeImage.h"
 #include "PlatformImage.h"
 #include <CoreGraphics/CoreGraphics.h>
-#elif PLATFORM(MAC)
-OBJC_CLASS NSImage;
 #elif PLATFORM(WIN)
 typedef struct HICON__* HICON;
 #endif
@@ -53,25 +52,20 @@ public:
     static Ref<Icon> create(HICON hIcon) { return adoptRef(*new Icon(hIcon)); }
 #endif
 
-#if PLATFORM(IOS_FAMILY)
-    // FIXME: Make this work for non-iOS ports and remove the PLATFORM(IOS_FAMILY)-guard.
+#if PLATFORM(COCOA)
     WEBCORE_EXPORT static RefPtr<Icon> createIconForImage(PlatformImagePtr&&);
+    RefPtr<NativeImage> image() const { return m_cgImage; }
 #endif
 
 #if PLATFORM(MAC)
     static RefPtr<Icon> createIconForUTI(const String&);
     static RefPtr<Icon> createIconForFileExtension(const String&);
-
-    RetainPtr<NSImage> nsImage() const { return m_nsImage; }
 #endif
 
 private:
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
     Icon(RefPtr<NativeImage>&&);
     RefPtr<NativeImage> m_cgImage;
-#elif PLATFORM(MAC)
-    Icon(NSImage*);
-    RetainPtr<NSImage> m_nsImage;
 #elif PLATFORM(WIN)
     Icon(HICON);
     HICON m_hIcon;

--- a/Source/WebCore/platform/graphics/cocoa/IconCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IconCocoa.mm
@@ -26,15 +26,43 @@
 #import "config.h"
 #import "Icon.h"
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
+
+#import "BitmapImage.h"
+#import "GraphicsContext.h"
 
 namespace WebCore {
 
-RefPtr<Icon> Icon::createIconForFiles(const Vector<String>& /*filenames*/)
+Icon::Icon(RefPtr<NativeImage>&& image)
+    : m_cgImage(WTFMove(image))
 {
-    return nullptr;
+    ASSERT(m_cgImage);
+}
+
+Icon::~Icon()
+{
+}
+
+RefPtr<Icon> Icon::createIconForImage(PlatformImagePtr&& image)
+{
+    if (!image)
+        return nullptr;
+
+    return adoptRef(new Icon(NativeImage::create(WTFMove(image))));
+}
+
+void Icon::paint(GraphicsContext& context, const FloatRect& destRect)
+{
+    if (context.paintingDisabled())
+        return;
+
+    GraphicsContextStateSaver stateSaver(context);
+
+    FloatRect srcRect(FloatPoint::zero(), m_cgImage->size());
+    context.setImageInterpolationQuality(InterpolationQuality::High);
+    context.drawNativeImage(*m_cgImage, srcRect.size(), destRect, srcRect);
 }
 
 }
 
-#endif // PLATFORM(IOS_FAMILY)
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
@@ -28,8 +28,14 @@
 
 #if ENABLE(VIDEO) && USE(AVFOUNDATION)
 #include "CVUtilities.h"
+#include "ImageTransferSessionVT.h"
+#include "Logging.h"
+#include "NativeImage.h"
 #include "PixelBuffer.h"
 #include "ProcessIdentity.h"
+#include <pal/avfoundation/MediaTimeAVFoundation.h>
+#include <pal/cf/AudioToolboxSoftLink.h>
+#include <pal/cf/CoreMediaSoftLink.h>
 #include <wtf/Scope.h>
 
 #include "CoreVideoSoftLink.h"

--- a/Source/WebCore/platform/graphics/mac/IconMac.mm
+++ b/Source/WebCore/platform/graphics/mac/IconMac.mm
@@ -27,23 +27,14 @@
 #import "IntRect.h"
 #import "LocalCurrentGraphicsContext.h"
 #import "UTIUtilities.h"
+#import <AVFoundation/AVFoundation.h>
 #import <wtf/RefPtr.h>
 #import <wtf/text/WTFString.h>
 
+#import <pal/cf/CoreMediaSoftLink.h>
+#import <pal/cocoa/AVFoundationSoftLink.h>
+
 namespace WebCore {
-
-Icon::Icon(NSImage *image)
-    : m_nsImage(image)
-{
-    // Need this because WebCore uses AppKit's flipped coordinate system exclusively.
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [image setFlipped:YES];
-    ALLOW_DEPRECATED_DECLARATIONS_END
-}
-
-Icon::~Icon()
-{
-}
 
 // FIXME: Move the code to ChromeClient::iconForFiles().
 RefPtr<Icon> Icon::createIconForFiles(const Vector<String>& filenames)
@@ -63,13 +54,15 @@ RefPtr<Icon> Icon::createIconForFiles(const Vector<String>& filenames)
         if (!image)
             return nullptr;
 
-        return adoptRef(new Icon(image));
+        PlatformImagePtr platformImage = [image CGImageForProposedRect:nil context:nil hints:nil];
+        return adoptRef(new Icon(NativeImage::create(WTFMove(platformImage))));
     }
     NSImage *image = [NSImage imageNamed:NSImageNameMultipleDocuments];
     if (!image)
         return nullptr;
 
-    return adoptRef(new Icon(image));
+    PlatformImagePtr platformImage = [image CGImageForProposedRect:nil context:nil hints:nil];
+    return adoptRef(new Icon(NativeImage::create(WTFMove(platformImage))));
 }
 
 RefPtr<Icon> Icon::createIconForFileExtension(const String& fileExtension)
@@ -80,7 +73,8 @@ RefPtr<Icon> Icon::createIconForFileExtension(const String& fileExtension)
     if (!image)
         return nullptr;
 
-    return adoptRef(new Icon(image));
+    PlatformImagePtr platformImage = [image CGImageForProposedRect:nil context:nil hints:nil];
+    return adoptRef(new Icon(NativeImage::create(WTFMove(platformImage))));
 }
 
 RefPtr<Icon> Icon::createIconForUTI(const String& UTI)
@@ -91,17 +85,8 @@ RefPtr<Icon> Icon::createIconForUTI(const String& UTI)
     if (!image)
         return nullptr;
 
-    return adoptRef(new Icon(image));
-}
-
-void Icon::paint(GraphicsContext& context, const FloatRect& rect)
-{
-    if (context.paintingDisabled())
-        return;
-
-    LocalCurrentGraphicsContext localCurrentGC(context);
-
-    [m_nsImage drawInRect:rect fromRect:NSMakeRect(0, 0, [m_nsImage size].width, [m_nsImage size].height) operation:NSCompositingOperationSourceOver fraction:1.0f];
+    PlatformImagePtr platformImage = [image CGImageForProposedRect:nil context:nil hints:nil];
+    return adoptRef(new Icon(NativeImage::create(WTFMove(platformImage))));
 }
 
 }

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -178,7 +178,7 @@ void RenderFileUploadControl::paintObject(PaintInfo& paintInfo, const LayoutPoin
             else
                 iconX = contentLeft + contentWidth() - buttonWidth - afterButtonSpacing - iconWidth;
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
             if (RenderButton* buttonRenderer = downcast<RenderButton>(button->renderer())) {
                 // Draw the file icon and decorations.
                 IntRect iconRect(iconX, iconY, iconWidth, iconHeight);

--- a/Source/WebCore/rendering/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/RenderThemeCocoa.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "Icon.h"
 #include "RenderTheme.h"
 #include <wtf/RetainPtr.h>
 
@@ -36,10 +37,15 @@ class RenderThemeCocoa : public RenderTheme {
 public:
     WEBCORE_EXPORT static RenderThemeCocoa& singleton();
 
+protected:
+    virtual Color pictureFrameColor(const RenderObject&);
+
 private:
     void purgeCaches() override;
 
     bool shouldHaveCapsLockIndicator(const HTMLInputElement&) const final;
+
+    void paintFileUploadIconDecorations(const RenderObject& inputRenderer, const RenderObject& buttonRenderer, const PaintInfo&, const IntRect&, Icon*, FileUploadDecorations) override;
 
 #if ENABLE(APPLE_PAY)
     void adjustApplePayButtonStyle(RenderStyle&, const Element*) const override;

--- a/Source/WebCore/rendering/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/RenderThemeCocoa.mm
@@ -27,6 +27,7 @@
 #import "RenderThemeCocoa.h"
 
 #import "ApplePayLogoSystemImage.h"
+#import "FloatRoundedRect.h"
 #import "FontCacheCoreText.h"
 #import "GraphicsContextCG.h"
 #import "HTMLInputElement.h"
@@ -34,6 +35,7 @@
 #import "RenderText.h"
 #import "UserAgentScripts.h"
 #import "UserAgentStyleSheets.h"
+#import <CoreGraphics/CoreGraphics.h>
 #import <algorithm>
 #import <pal/spi/cf/CoreTextSPI.h>
 #import <wtf/Language.h>
@@ -62,6 +64,11 @@
 
 namespace WebCore {
 
+constexpr int kThumbnailBorderStrokeWidth = 1;
+constexpr int kThumbnailBorderCornerRadius = 1;
+constexpr int kVisibleBackgroundImageWidth = 1;
+constexpr int kMultipleThumbnailShrinkSize = 2;
+
 RenderThemeCocoa& RenderThemeCocoa::singleton()
 {
     return static_cast<RenderThemeCocoa&>(RenderTheme::singleton());
@@ -81,6 +88,45 @@ void RenderThemeCocoa::purgeCaches()
 bool RenderThemeCocoa::shouldHaveCapsLockIndicator(const HTMLInputElement& element) const
 {
     return element.isPasswordField();
+}
+
+Color RenderThemeCocoa::pictureFrameColor(const RenderObject& buttonRenderer)
+{
+    return systemColor(CSSValueAppleSystemControlBackground, buttonRenderer.styleColorOptions());
+}
+
+void RenderThemeCocoa::paintFileUploadIconDecorations(const RenderObject&, const RenderObject& buttonRenderer, const PaintInfo& paintInfo, const IntRect& rect, Icon* icon, FileUploadDecorations fileUploadDecorations)
+{
+    GraphicsContextStateSaver stateSaver(paintInfo.context());
+
+    IntSize cornerSize(kThumbnailBorderCornerRadius, kThumbnailBorderCornerRadius);
+
+    auto pictureFrameColor = this->pictureFrameColor(buttonRenderer);
+
+    auto thumbnailPictureFrameRect = rect;
+    auto thumbnailRect = rect;
+    thumbnailRect.contract(2 * kThumbnailBorderStrokeWidth, 2 * kThumbnailBorderStrokeWidth);
+    thumbnailRect.move(kThumbnailBorderStrokeWidth, kThumbnailBorderStrokeWidth);
+
+    if (fileUploadDecorations == MultipleFiles) {
+        // Smaller thumbnails for multiple selection appearance.
+        thumbnailPictureFrameRect.contract(kMultipleThumbnailShrinkSize, kMultipleThumbnailShrinkSize);
+        thumbnailRect.contract(kMultipleThumbnailShrinkSize, kMultipleThumbnailShrinkSize);
+
+        // Background picture frame and simple background icon with a gradient matching the button.
+        auto backgroundImageColor = buttonRenderer.style().visitedDependentColor(CSSPropertyBackgroundColor);
+        paintInfo.context().fillRoundedRect(FloatRoundedRect(thumbnailPictureFrameRect, cornerSize, cornerSize, cornerSize, cornerSize), pictureFrameColor);
+        paintInfo.context().fillRect(thumbnailRect, backgroundImageColor);
+
+        // Move the rects for the Foreground picture frame and icon.
+        auto inset = kVisibleBackgroundImageWidth + kThumbnailBorderStrokeWidth;
+        thumbnailPictureFrameRect.move(inset, inset);
+        thumbnailRect.move(inset, inset);
+    }
+
+    // Foreground picture frame and icon.
+    paintInfo.context().fillRoundedRect(FloatRoundedRect(thumbnailPictureFrameRect, cornerSize, cornerSize, cornerSize, cornerSize), pictureFrameColor);
+    icon->paint(paintInfo.context(), thumbnailRect);
 }
 
 #if ENABLE(APPLE_PAY)

--- a/Source/WebCore/rendering/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/RenderThemeIOS.h
@@ -87,8 +87,6 @@ private:
     void paintButtonDecorations(const RenderObject&, const PaintInfo&, const IntRect&) override;
     void paintPushButtonDecorations(const RenderObject&, const PaintInfo&, const IntRect&) override;
 
-    void paintFileUploadIconDecorations(const RenderObject& inputRenderer, const RenderObject& buttonRenderer, const PaintInfo&, const IntRect&, Icon*, FileUploadDecorations) override;
-
     void adjustTextFieldStyle(RenderStyle&, const Element*) const final;
     void paintTextFieldDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) override;
     void adjustTextAreaStyle(RenderStyle&, const Element*) const final;
@@ -200,6 +198,8 @@ private:
     FloatRect addRoundedBorderClip(const RenderObject& box, GraphicsContext&, const IntRect&);
 
     Color systemColor(CSSValueID, OptionSet<StyleColorOptions>) const override;
+
+    Color pictureFrameColor(const RenderObject&) override;
 
     Color controlTintColor(const RenderStyle&, OptionSet<StyleColorOptions>) const;
 

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -62,7 +62,6 @@
 #import "HTMLSelectElement.h"
 #import "HTMLTextAreaElement.h"
 #import "IOSurface.h"
-#import "Icon.h"
 #import "LocalCurrentTraitCollection.h"
 #import "LocalizedDateCache.h"
 #import "NodeRenderStyle.h"
@@ -1306,44 +1305,6 @@ void RenderThemeIOS::paintPushButtonDecorations(const RenderObject& box, const P
     }
 }
 
-const int kThumbnailBorderStrokeWidth = 1;
-const int kThumbnailBorderCornerRadius = 1;
-const int kVisibleBackgroundImageWidth = 1;
-const int kMultipleThumbnailShrinkSize = 2;
-
-void RenderThemeIOS::paintFileUploadIconDecorations(const RenderObject&, const RenderObject& buttonRenderer, const PaintInfo& paintInfo, const IntRect& rect, Icon* icon, FileUploadDecorations fileUploadDecorations)
-{
-    GraphicsContextStateSaver stateSaver(paintInfo.context());
-
-    IntSize cornerSize(kThumbnailBorderCornerRadius, kThumbnailBorderCornerRadius);
-    Color pictureFrameColor = buttonRenderer.style().visitedDependentColor(CSSPropertyBorderTopColor);
-
-    IntRect thumbnailPictureFrameRect = rect;
-    IntRect thumbnailRect = rect;
-    thumbnailRect.contract(2 * kThumbnailBorderStrokeWidth, 2 * kThumbnailBorderStrokeWidth);
-    thumbnailRect.move(kThumbnailBorderStrokeWidth, kThumbnailBorderStrokeWidth);
-
-    if (fileUploadDecorations == MultipleFiles) {
-        // Smaller thumbnails for multiple selection appearance.
-        thumbnailPictureFrameRect.contract(kMultipleThumbnailShrinkSize, kMultipleThumbnailShrinkSize);
-        thumbnailRect.contract(kMultipleThumbnailShrinkSize, kMultipleThumbnailShrinkSize);
-
-        // Background picture frame and simple background icon.
-        Color backgroundImageColor = buttonRenderer.style().visitedDependentColor(CSSPropertyBackgroundColor);
-        paintInfo.context().fillRoundedRect(FloatRoundedRect(thumbnailPictureFrameRect, cornerSize, cornerSize, cornerSize, cornerSize), pictureFrameColor);
-        paintInfo.context().fillRect(thumbnailRect, backgroundImageColor);
-
-        // Move the rects for the Foreground picture frame and icon.
-        int inset = kVisibleBackgroundImageWidth + kThumbnailBorderStrokeWidth;
-        thumbnailPictureFrameRect.move(inset, inset);
-        thumbnailRect.move(inset, inset);
-    }
-
-    // Foreground picture frame and icon.
-    paintInfo.context().fillRoundedRect(FloatRoundedRect(thumbnailPictureFrameRect, cornerSize, cornerSize, cornerSize, cornerSize), pictureFrameColor);
-    icon->paint(paintInfo.context(), thumbnailRect);
-}
-
 Color RenderThemeIOS::platformActiveSelectionBackgroundColor(OptionSet<StyleColorOptions>) const
 {
     return Color::transparentBlack;
@@ -1557,6 +1518,11 @@ Color RenderThemeIOS::systemColor(CSSValueID cssValueID, OptionSet<StyleColorOpt
             return *color;
         return RenderTheme::systemColor(cssValueID, options);
     }).iterator->value;
+}
+
+Color RenderThemeIOS::pictureFrameColor(const RenderObject& buttonRenderer)
+{
+    return buttonRenderer.style().visitedDependentColor(CSSPropertyBorderTopColor);
 }
 
 Color RenderThemeIOS::controlTintColor(const RenderStyle& style, OptionSet<StyleColorOptions> options) const

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -2593,7 +2593,8 @@ RetainPtr<NSImage> RenderThemeMac::iconForAttachment(const String& fileName, con
         return nil;
 
     if (auto icon = WebCore::iconForAttachment(fileName, attachmentType, title))
-        return icon->nsImage();
+        return adoptNS([[NSImage alloc] initWithCGImage:icon->image()->platformImage().get() size:NSZeroSize]);
+
     return nil;
 }
 

--- a/Source/WebKit/Shared/Cocoa/WebIconUtilities.h
+++ b/Source/WebKit/Shared/Cocoa/WebIconUtilities.h
@@ -25,18 +25,16 @@
 
 #pragma once
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
 
 #import <wtf/RetainPtr.h>
 
-@class UIImage;
-
 namespace WebKit {
 
-RetainPtr<UIImage> fallbackIconForFile(NSURL *file);
-RetainPtr<UIImage> iconForImageFile(NSURL *file);
-RetainPtr<UIImage> iconForVideoFile(NSURL *file);
-RetainPtr<UIImage> iconForFile(NSURL *file);
+WebCore::PlatformImagePtr fallbackIconForFile(NSURL *file);
+WebCore::PlatformImagePtr iconForImageFile(NSURL *file);
+WebCore::PlatformImagePtr iconForVideoFile(NSURL *file);
+WebCore::PlatformImagePtr iconForFiles(const Vector<String>& filenames);
 
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #import "RemoteLayerBackingStoreCollection.h"
+#import <WebCore/RenderingResourceIdentifier.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm
@@ -26,7 +26,10 @@
 #import "config.h"
 #import "RemoteLayerWithRemoteRenderingBackingStoreCollection.h"
 
+#import "ImageBufferBackendHandleSharing.h"
 #import "Logging.h"
+#import "PlatformCALayerRemote.h"
+#import "RemoteLayerBackingStore.h"
 #import "RemoteLayerTreeContext.h"
 #import "RemoteRenderingBackendProxy.h"
 #import "SwapBuffersDisplayRequirement.h"
@@ -109,7 +112,7 @@ void RemoteLayerWithRemoteRenderingBackingStoreCollection::prepareBackingStoresF
 RefPtr<WebCore::ImageBuffer> RemoteLayerWithRemoteRenderingBackingStoreCollection::allocateBufferForBackingStore(const RemoteLayerBackingStore& backingStore)
 {
     auto renderingMode = backingStore.type() == RemoteLayerBackingStore::Type::IOSurface ? WebCore::RenderingMode::Accelerated : WebCore::RenderingMode::Unaccelerated;
-    return remoteRenderingBackendProxy().createImageBuffer(backingStore.size(), renderingMode, RenderingPurpose::LayerBacking, backingStore.scale(), WebCore::DestinationColorSpace::SRGB(), backingStore.pixelFormat());
+    return remoteRenderingBackendProxy().createImageBuffer(backingStore.size(), renderingMode, WebCore::RenderingPurpose::LayerBacking, backingStore.scale(), WebCore::DestinationColorSpace::SRGB(), backingStore.pixelFormat());
 }
 
 bool RemoteLayerWithRemoteRenderingBackingStoreCollection::collectBackingStoreBufferIdentifiersToMarkVolatile(RemoteLayerBackingStore& backingStore, OptionSet<VolatilityMarkingBehavior> markingBehavior, MonotonicTime now, Vector<WebCore::RenderingResourceIdentifier>& identifiers)

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -176,6 +176,7 @@ Shared/Cocoa/WKNSURL.mm
 Shared/Cocoa/WKNSURLExtras.mm
 Shared/Cocoa/WKNSURLRequest.mm
 Shared/Cocoa/WKObject.mm
+Shared/Cocoa/WebIconUtilities.mm
 Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
 
 Shared/Daemon/DaemonUtilities.mm
@@ -190,7 +191,6 @@ Shared/ios/NativeWebKeyboardEventIOS.mm
 Shared/ios/NativeWebMouseEventIOS.mm
 Shared/ios/NativeWebTouchEventIOS.mm
 Shared/ios/WebAutocorrectionData.mm
-Shared/ios/WebIconUtilities.mm
 Shared/ios/WebIOSEventFactory.mm
 Shared/ios/WebPlatformTouchPointIOS.cpp
 Shared/ios/WebPreferencesDefaultValuesIOS.mm

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -146,7 +146,7 @@ static bool setContainsUTIThatConformsTo(NSSet<NSString *> *typeIdentifiers, UTT
 
 - (RetainPtr<UIImage>)displayImage
 {
-    return WebKit::iconForImageFile(self.fileURL);
+    return adoptNS([[UIImage alloc] initWithCGImage:WebKit::iconForImageFile(self.fileURL).get()]);
 }
 
 @end
@@ -164,7 +164,7 @@ static bool setContainsUTIThatConformsTo(NSSet<NSString *> *typeIdentifiers, UTT
 
 - (RetainPtr<UIImage>)displayImage
 {
-    return WebKit::iconForVideoFile(self.fileURL);
+    return adoptNS([[UIImage alloc] initWithCGImage:WebKit::iconForVideoFile(self.fileURL).get()]);
 }
 
 @end
@@ -891,7 +891,8 @@ static NSString *displayStringForDocumentsAtURLs(NSArray<NSURL *> *urls)
         auto [maybeMovedURLs, temporaryURLs] = copyToNewTemporaryDirectory(urlsFromUIKit.get());
         [retainedSelf->_view _removeTemporaryDirectoriesWhenDeallocated:WTFMove(temporaryURLs)];
         RunLoop::main().dispatch([retainedSelf = WTFMove(retainedSelf), maybeMovedURLs = WTFMove(maybeMovedURLs)] {
-            [retainedSelf _chooseFiles:maybeMovedURLs.get() displayString:displayStringForDocumentsAtURLs(maybeMovedURLs.get()) iconImage:WebKit::iconForFile(maybeMovedURLs.get()[0]).get()];
+            auto icon = adoptNS([[UIImage alloc] initWithCGImage:WebKit::iconForFiles({ maybeMovedURLs.get()[0].absoluteString }).get()]);
+            [retainedSelf _chooseFiles:maybeMovedURLs.get() displayString:displayStringForDocumentsAtURLs(maybeMovedURLs.get()) iconImage:icon.get()];
         });
     }).get());
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		00B9661618E24CBA00CE1F88 /* APIFindClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B9661518E24CBA00CE1F88 /* APIFindClient.h */; };
 		00B9661A18E25AE100CE1F88 /* FindClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B9661818E25AE100CE1F88 /* FindClient.h */; };
 		0701789E23BE9CFC005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0701789B23BAE261005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp */; };
+		0712654928EE06F800AE69D7 /* WebChromeClientCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0712654728EE06F800AE69D7 /* WebChromeClientCocoa.mm */; };
 		071BC58F23CE1EAA00680D7C /* RemoteMediaPlayerProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 071BC58C23CE1EA900680D7C /* RemoteMediaPlayerProxyMessageReceiver.cpp */; };
 		071BC59023CE1EAA00680D7C /* RemoteMediaPlayerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 071BC58D23CE1EAA00680D7C /* RemoteMediaPlayerProxyMessages.h */; };
 		071BC59123CE1EAA00680D7C /* RemoteMediaPlayerProxyMessagesReplies.h in Headers */ = {isa = PBXBuildFile; fileRef = 071BC58E23CE1EAA00680D7C /* RemoteMediaPlayerProxyMessagesReplies.h */; };
@@ -2881,6 +2882,7 @@
 		0701789B23BAE261005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaPlayerMIMETypeCache.cpp; sourceTree = "<group>"; };
 		0701789C23BAE262005F0FAA /* RemoteMediaPlayerMIMETypeCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaPlayerMIMETypeCache.h; sourceTree = "<group>"; };
 		070259BE2522841C00153405 /* UserMediaPermissionRequestManagerProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UserMediaPermissionRequestManagerProxy.mm; sourceTree = "<group>"; };
+		0712654728EE06F800AE69D7 /* WebChromeClientCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebChromeClientCocoa.mm; sourceTree = "<group>"; };
 		071BC57723C93BB700680D7C /* AudioTrackPrivateRemote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AudioTrackPrivateRemote.h; sourceTree = "<group>"; };
 		071BC57923C93BB900680D7C /* AudioTrackPrivateRemote.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AudioTrackPrivateRemote.cpp; sourceTree = "<group>"; };
 		071BC57B23CA532400680D7C /* TrackPrivateRemoteConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackPrivateRemoteConfiguration.h; sourceTree = "<group>"; };
@@ -7360,8 +7362,8 @@
 		F446EDF1265EB3B60031DA8F /* WKRevealItemPresenter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKRevealItemPresenter.mm; sourceTree = "<group>"; };
 		F44815622387820000982657 /* WKDeferringGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKDeferringGestureRecognizer.h; path = ios/WKDeferringGestureRecognizer.h; sourceTree = "<group>"; };
 		F44815632387820000982657 /* WKDeferringGestureRecognizer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKDeferringGestureRecognizer.mm; path = ios/WKDeferringGestureRecognizer.mm; sourceTree = "<group>"; };
-		F44DFEB01E9E752F0038D196 /* WebIconUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebIconUtilities.h; path = ios/WebIconUtilities.h; sourceTree = "<group>"; };
-		F44DFEB11E9E752F0038D196 /* WebIconUtilities.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WebIconUtilities.mm; path = ios/WebIconUtilities.mm; sourceTree = "<group>"; };
+		F44DFEB01E9E752F0038D196 /* WebIconUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebIconUtilities.h; sourceTree = "<group>"; };
+		F44DFEB11E9E752F0038D196 /* WebIconUtilities.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebIconUtilities.mm; sourceTree = "<group>"; };
 		F4517D7726FBCCE4004C8475 /* RemoteRenderingBackendMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RemoteRenderingBackendMessageReceiver.cpp; path = DerivedSources/WebKit/RemoteRenderingBackendMessageReceiver.cpp; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4517D7926FBCD38004C8475 /* RemoteRenderingBackendMessagesReplies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteRenderingBackendMessagesReplies.h; path = DerivedSources/WebKit/RemoteRenderingBackendMessagesReplies.h; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4517D7A26FBCD38004C8475 /* RemoteRenderingBackendMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteRenderingBackendMessages.h; path = DerivedSources/WebKit/RemoteRenderingBackendMessages.h; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -9432,8 +9434,6 @@
 				F40D1B68220BDC0F00B49A01 /* WebAutocorrectionContext.h */,
 				F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */,
 				F42D634022A0EFD300D2FB3A /* WebAutocorrectionData.mm */,
-				F44DFEB01E9E752F0038D196 /* WebIconUtilities.h */,
-				F44DFEB11E9E752F0038D196 /* WebIconUtilities.mm */,
 				2DA944991884E4F000ED86DB /* WebIOSEventFactory.h */,
 				2DA9449A1884E4F000ED86DB /* WebIOSEventFactory.mm */,
 				2DA9449B1884E4F000ED86DB /* WebPlatformTouchPointIOS.cpp */,
@@ -10066,6 +10066,8 @@
 				1AB1F78E1D1B34A6007C9BD1 /* WebCoreArgumentCodersCocoa.mm */,
 				86AE2A9628D61EDD007F5A1C /* WebCoreArgumentCodersCocoa.serialization.in */,
 				7AF236221E79A43100438A05 /* WebErrorsCocoa.mm */,
+				F44DFEB01E9E752F0038D196 /* WebIconUtilities.h */,
+				F44DFEB11E9E752F0038D196 /* WebIconUtilities.mm */,
 				465250E51ECF52CD002025CB /* WebKit2InitializeCocoa.mm */,
 				1DE076D92460CCBD00B211E8 /* WebPreferencesDefaultValuesCocoa.mm */,
 				517B5F98275EC600002DC22D /* WebPushMessageCocoa.mm */,
@@ -13469,6 +13471,7 @@
 		CD6178111E6DE98000FDA57D /* cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				0712654728EE06F800AE69D7 /* WebChromeClientCocoa.mm */,
 			);
 			name = cocoa;
 			sourceTree = "<group>";
@@ -17615,6 +17618,7 @@
 				1C0A19571C90068F00FE0EBB /* WebAutomationSessionMessageReceiver.cpp in Sources */,
 				575B1BB823CE9BFC0020639A /* WebAutomationSessionProxy.cpp in Sources */,
 				1C0A19531C8FFDFB00FE0EBB /* WebAutomationSessionProxyMessageReceiver.cpp in Sources */,
+				0712654928EE06F800AE69D7 /* WebChromeClientCocoa.mm in Sources */,
 				1A1FEC1C1627B45700700F6D /* WebConnectionMessageReceiver.cpp in Sources */,
 				330934471315B9220097A7BC /* WebCookieManagerMessageReceiver.cpp in Sources */,
 				E39628DE23960CC600658ECD /* WebDeviceOrientationUpdateProvider.cpp in Sources */,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -131,6 +131,10 @@
 #include "TiledCoreAnimationScrollingCoordinator.h"
 #endif
 
+#if PLATFORM(COCOA)
+#include "WebIconUtilities.h"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
@@ -823,7 +827,7 @@ void WebChromeClient::setCursorHiddenUntilMouseMoves(bool hiddenUntilMouseMoves)
     m_page.send(Messages::WebPageProxy::SetCursorHiddenUntilMouseMoves(hiddenUntilMouseMoves));
 }
 
-#if !PLATFORM(IOS_FAMILY)
+#if !PLATFORM(COCOA)
 
 RefPtr<Icon> WebChromeClient::createIconForFiles(const Vector<String>& filenames)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClientCocoa.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClientCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007, 2008, 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,17 +24,21 @@
  */
 
 #import "config.h"
-#import "Icon.h"
+#import "WebChromeClient.h"
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
 
-namespace WebCore {
+#import "WebIconUtilities.h"
+#import <WebCore/Icon.h>
 
-RefPtr<Icon> Icon::createIconForFiles(const Vector<String>& /*filenames*/)
+namespace WebKit {
+using namespace WebCore;
+
+RefPtr<Icon> WebChromeClient::createIconForFiles(const Vector<String>& filenames)
 {
-    return nullptr;
+    return Icon::createIconForImage(iconForFiles(filenames).get());
 }
 
-}
+} // namespace WebKit
 
-#endif // PLATFORM(IOS_FAMILY)
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm
@@ -150,20 +150,6 @@ int WebChromeClient::deviceOrientation() const
 }
 #endif
 
-RefPtr<Icon> WebChromeClient::createIconForFiles(const Vector<String>& filenames)
-{
-    if (!filenames.size())
-        return nullptr;
-
-    // FIXME: We should generate an icon showing multiple files here, if applicable. Currently, if there are multiple
-    // files, we only use the first URL to generate an icon.
-    NSURL *url = [NSURL fileURLWithPath:filenames[0] isDirectory:NO];
-    if (!url)
-        return nullptr;
-
-    return Icon::createIconForImage(iconForFile(url).get().CGImage);
-}
-
 bool WebChromeClient::shouldUseMouseEventForSelection(const WebCore::PlatformMouseEvent& event)
 {
     // In iPadOS and macCatalyst, despite getting mouse events, we still want UITextInteraction and friends to own selection gestures.


### PR DESCRIPTION
#### 43b96844e7e9fc0ceb95e46f46d0b515864d3fa2
<pre>
[macOS] Display thumbnail of selected file for &lt;input type=file&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=245993">https://bugs.webkit.org/show_bug.cgi?id=245993</a>
rdar://100570349

Reviewed by Aditya Keerthi.

On iOS, we show a thumbnail of the selected file, but on macOS, we just
sure the generic file icon based on the file&apos;s extension.

This PR adopts the iOS behavior for macOS, and refactors out the thumbnail
decoration logic into `RenderThemeCocoa`. It also refactors out some of the
icon creation logic into common places for both iOS and macOS.

Adding a new file broke some unified build files so it also fixes those.

* Source/WebCore/platform/graphics/Icon.h:
(WebCore::Icon::image const):
(WebCore::Icon::nsImage const): Deleted.
* Source/WebCore/platform/graphics/mac/IconMac.mm:
(WebCore::Icon::Icon):
(WebCore::Icon::~Icon):
(WebCore::Icon::createIconForImage):
(WebCore::Icon::createIconForFiles):
(WebCore::Icon::createIconForFileExtension):
(WebCore::Icon::createIconForUTI):
(WebCore::Icon::paint):
(WebCore::squareCropRectForSize): Deleted.
(WebCore::squareImage): Deleted.
(WebCore::thumbnailSizedImageForImage): Deleted.
(WebCore::iconForImageFile): Deleted.
(WebCore::iconForVideoFile): Deleted.
(WebCore::iconForFile): Deleted.
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::iconForAttachment):
* Source/WebKit/Shared/Cocoa/WebIconUtilities.h: Copied from Source/WebKit/Shared/ios/WebIconUtilities.h.
* Source/WebKit/Shared/Cocoa/WebIconUtilities.mm: Renamed from Source/WebKit/Shared/ios/WebIconUtilities.mm.
(WebKit::squareCropRectForSize):
(WebKit::squareImage):
(WebKit::thumbnailSizedImageForImage):
(WebKit::fallbackIconForFile):
(WebKit::iconForImageFile):
(WebKit::iconForVideoFile):
(WebKit::iconForFiles):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStoreCollection::allocateBufferForBackingStore):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(-[_WKImageFileUploadItem displayImage]):
(-[_WKVideoFileUploadItem displayImage]):
(-[WKFileUploadPanel documentPicker:didPickDocumentsAtURLs:]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferBackendHandleSharing.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createIconForFiles): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClientCocoa.mm: Renamed from Source/WebKit/Shared/ios/WebIconUtilities.h.
(WebKit::WebChromeClient::createIconForFiles):
* Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm:
(WebKit::WebChromeClient::createIconForFiles): Deleted.
* Source/WebKitLegacy/mac/WebCoreSupport/WebOpenPanelResultListener.mm:

Canonical link: <a href="https://commits.webkit.org/255355@main">https://commits.webkit.org/255355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb7f8d725d11b4063316fb924bd0da99d199bf5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101875 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161930 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1311 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29712 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84524 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98051 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/823 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78607 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27764 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82343 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70806 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36138 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16357 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33890 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17459 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3712 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37761 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40169 "Found 3 new test failures: http/wpt/service-workers/fetch-service-worker-preload.https.html, imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h264_annexb, imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_annexb (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36585 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->