### PR TITLE
REGRESSION (254919@main): [iPadOS] 5X scrolling related layout tests are constant failures

### DIFF
--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -119,10 +119,3 @@ webkit.org/b/229656 fast/forms/ios/ipad/open-picker-using-keyboard.html [ Pass T
 
 webkit.org/b/244674 [ Release ] imported/w3c/web-platform-tests/IndexedDB/idbfactory-databases-opaque-origin.html [ Pass Failure ]
 webkit.org/b/244674 [ Release ] imported/w3c/web-platform-tests/IndexedDB/idbfactory-deleteDatabase-opaque-origin.html [ Pass Failure ]
-
-# webkit.org/b/245737 5X scrolling related layout tests are constant failures
-compositing/overflow/scrolling-content-clip-to-viewport.html [ Failure ]
-fast/scrolling/ios/subpixel-overflow-scrolling-with-ancestor.html [ Failure ]
-fast/scrolling/ios/overflow-scrolling-ancestor-clip.html [ Failure ]
-fast/scrolling/ios/overflow-scrolling-ancestor-clip-size.html [ Failure ]
-compositing/rtl/rtl-scrolling-with-transformed-descendants.html [ Failure ]

--- a/LayoutTests/platform/ipad/compositing/overflow/scrolling-content-clip-to-viewport-expected.txt
+++ b/LayoutTests/platform/ipad/compositing/overflow/scrolling-content-clip-to-viewport-expected.txt
@@ -24,10 +24,14 @@
           (bounds 320.00 340.00)
           (children 1
             (GraphicsLayer
-              (position 10.00 10.00)
-              (bounds 284.00 1204.00)
-              (contentsOpaque 1)
-              (drawsContent 1)
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 284.00 1204.00)
+                  (contentsOpaque 1)
+                  (drawsContent 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/platform/ipad/compositing/rtl/rtl-scrolling-with-transformed-descendants-expected.txt
+++ b/LayoutTests/platform/ipad/compositing/rtl/rtl-scrolling-with-transformed-descendants-expected.txt
@@ -32,53 +32,69 @@
         )
         (GraphicsLayer
           (position 10.00 10.00)
-          (bounds origin 366.00 0.00)
           (bounds 400.00 205.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 462.00 0.00)
-              (anchor 0.00 0.00)
-              (bounds 150.00 200.00)
-              (contentsOpaque 1)
+              (bounds origin 366.00 0.00)
+              (children 1
+                (GraphicsLayer
+                  (position 462.00 0.00)
+                  (anchor 0.00 0.00)
+                  (bounds 150.00 200.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
         (GraphicsLayer
           (position 10.00 10.00)
-          (bounds origin 366.00 0.00)
           (bounds 400.00 205.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 308.00 0.00)
-              (bounds 150.00 200.00)
-              (contentsOpaque 1)
+              (bounds origin 366.00 0.00)
+              (children 1
+                (GraphicsLayer
+                  (position 308.00 0.00)
+                  (bounds 150.00 200.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
         (GraphicsLayer
           (position 10.00 10.00)
-          (bounds origin 366.00 0.00)
           (bounds 400.00 205.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (position 154.00 0.00)
-              (bounds 150.00 200.00)
-              (contentsOpaque 1)
+              (bounds origin 366.00 0.00)
+              (children 1
+                (GraphicsLayer
+                  (position 154.00 0.00)
+                  (bounds 150.00 200.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )
         (GraphicsLayer
           (position 10.00 10.00)
-          (bounds origin 366.00 0.00)
           (bounds 400.00 205.00)
           (clips 1)
           (children 1
             (GraphicsLayer
-              (bounds 150.00 200.00)
-              (contentsOpaque 1)
+              (bounds origin 366.00 0.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 150.00 200.00)
+                  (contentsOpaque 1)
+                )
+              )
             )
           )
         )

--- a/LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scrolling-ancestor-clip-expected.txt
+++ b/LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scrolling-ancestor-clip-expected.txt
@@ -30,16 +30,20 @@
         )
         (GraphicsLayer
           (position 9.00 9.00)
-          (bounds origin 0.00 30.00)
           (bounds 300.00 400.00)
           (children 1
             (GraphicsLayer
-              (position 20.00 50.00)
-              (bounds 260.00 800.00)
+              (bounds origin 0.00 30.00)
               (children 1
                 (GraphicsLayer
+                  (position 20.00 50.00)
                   (bounds 260.00 800.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 260.00 800.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scrolling-ancestor-clip-size-expected.txt
+++ b/LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scrolling-ancestor-clip-size-expected.txt
@@ -30,16 +30,20 @@
         )
         (GraphicsLayer
           (position 19.00 19.00)
-          (bounds origin 0.00 30.00)
           (bounds 300.00 400.00)
           (children 1
             (GraphicsLayer
-              (position 20.00 50.00)
-              (bounds 260.00 800.00)
+              (bounds origin 0.00 30.00)
               (children 1
                 (GraphicsLayer
+                  (position 20.00 50.00)
                   (bounds 260.00 800.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 260.00 800.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )

--- a/LayoutTests/platform/ipad/fast/scrolling/ios/subpixel-overflow-scrolling-with-ancestor-expected.txt
+++ b/LayoutTests/platform/ipad/fast/scrolling/ios/subpixel-overflow-scrolling-with-ancestor-expected.txt
@@ -26,16 +26,20 @@
         )
         (GraphicsLayer
           (position 8.00 8.00)
-          (bounds origin 0.00 30.00)
           (bounds 300.00 400.00)
           (children 1
             (GraphicsLayer
-              (position 20.00 50.00)
-              (bounds 260.00 800.00)
+              (bounds origin 0.00 30.00)
               (children 1
                 (GraphicsLayer
+                  (position 20.00 50.00)
                   (bounds 260.00 800.00)
-                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 260.00 800.00)
+                      (contentsOpaque 1)
+                    )
+                  )
                 )
               )
             )


### PR DESCRIPTION
#### f3ec83d54c538a457361de30279803d0cde66d83
<pre>
REGRESSION (254919@main): [iPadOS] 5X scrolling related layout tests are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=245737">https://bugs.webkit.org/show_bug.cgi?id=245737</a>
&lt;rdar://100461359&gt;

Unreviewed test gardening; update iPad results after 254919@main.

* LayoutTests/platform/ipad/TestExpectations:
* LayoutTests/platform/ipad/compositing/overflow/scrolling-content-clip-to-viewport-expected.txt:
* LayoutTests/platform/ipad/compositing/rtl/rtl-scrolling-with-transformed-descendants-expected.txt:
* LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scrolling-ancestor-clip-expected.txt:
* LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scrolling-ancestor-clip-size-expected.txt:
* LayoutTests/platform/ipad/fast/scrolling/ios/subpixel-overflow-scrolling-with-ancestor-expected.txt:

Canonical link: <a href="https://commits.webkit.org/255104@main">https://commits.webkit.org/255104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62329b4895120368efb4063662b359c645f1fb28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101100 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/403 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83719 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97024 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/27278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/81911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70306 "Updated gtk dependencies (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35502 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/15937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33294 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/17023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3548 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37088 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39009 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/36132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->