### PR TITLE
[iOS][WK2] Add initial implementation for the Screen Orientation API

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1224,6 +1224,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/RemoteDOMWindow.h
     page/RemoteFrame.h
     page/RenderingUpdateScheduler.h
+    page/ScreenOrientationLockType.h
+    page/ScreenOrientationType.h
     page/ScrollBehavior.h
     page/ScrollIntoViewOptions.h
     page/ScrollLogicalPosition.h
@@ -1403,6 +1405,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/RemoteCommandListener.h
     platform/RuntimeApplicationChecks.h
     platform/SSLKeyGenerator.h
+    platform/ScreenOrientationManager.h
+    platform/ScreenOrientationProvider.h
     platform/ScreenProperties.h
     platform/ScriptExecutionContextIdentifier.h
     platform/ScrollAlignment.h

--- a/Source/WebCore/PAL/pal/ios/UIKitSoftLink.h
+++ b/Source/WebCore/PAL/pal/ios/UIKitSoftLink.h
@@ -40,6 +40,7 @@ SOFT_LINK_CONSTANT_FOR_HEADER(PAL, UIKit, UIApplicationWillEnterForegroundNotifi
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, UIKit, UIApplicationDidBecomeActiveNotification, NSNotificationName)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, UIKit, UIApplicationDidEnterBackgroundNotification, NSNotificationName)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, UIKit, UIContentSizeCategoryDidChangeNotification, NSNotificationName)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, UIKit, UIApplicationDidChangeStatusBarOrientationNotification, NSNotificationName)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, UIKit, UIFontTextStyleCallout, UIFontTextStyle)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, UIKit, UIPasteboardNameGeneral, UIPasteboardName)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, UIKit, UITextEffectsBeneathStatusBarWindowLevel, UIWindowLevel)

--- a/Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm
+++ b/Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm
@@ -40,6 +40,7 @@ SOFT_LINK_CONSTANT_FOR_SOURCE(PAL, UIKit, UIApplicationWillEnterForegroundNotifi
 SOFT_LINK_CONSTANT_FOR_SOURCE(PAL, UIKit, UIApplicationDidBecomeActiveNotification, NSNotificationName)
 SOFT_LINK_CONSTANT_FOR_SOURCE(PAL, UIKit, UIApplicationDidEnterBackgroundNotification, NSNotificationName)
 SOFT_LINK_CONSTANT_FOR_SOURCE(PAL, UIKit, UIContentSizeCategoryDidChangeNotification, NSNotificationName)
+SOFT_LINK_CONSTANT_FOR_SOURCE(PAL, UIKit, UIApplicationDidChangeStatusBarOrientationNotification, NSNotificationName)
 SOFT_LINK_CONSTANT_FOR_SOURCE(PAL, UIKit, UIFontTextStyleCallout, UIFontTextStyle)
 SOFT_LINK_CONSTANT_FOR_SOURCE(PAL, UIKit, UIPasteboardNameGeneral, UIPasteboardName)
 SOFT_LINK_CONSTANT_FOR_SOURCE(PAL, UIKit, UITextEffectsBeneathStatusBarWindowLevel, UIWindowLevel)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1964,6 +1964,7 @@ platform/ReferrerPolicy.cpp
 platform/RemoteCommandListener.cpp
 platform/RuntimeApplicationChecks.cpp
 platform/SSLKeyGenerator.cpp
+platform/ScreenOrientationProvider.cpp
 platform/ScrollAlignment.cpp
 platform/ScrollAnimation.cpp
 platform/ScrollAnimationKinetic.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -478,6 +478,7 @@ platform/ios/PlatformScreenIOS.mm
 platform/ios/PlaybackSessionInterfaceAVKit.mm @no-unify
 platform/ios/PreviewConverterIOS.mm
 platform/ios/QuickLook.mm
+platform/ios/ScreenOrientationProviderIOS.mm
 platform/ios/ScrollAnimatorIOS.mm
 platform/ios/ScrollViewIOS.mm
 platform/ios/ScrollbarThemeIOS.mm

--- a/Source/WebCore/dom/Exception.h
+++ b/Source/WebCore/dom/Exception.h
@@ -42,6 +42,8 @@ public:
     Exception isolatedCopy() const & { return Exception { m_code, m_message.isolatedCopy() }; }
     Exception isolatedCopy() && { return Exception { m_code, WTFMove(m_message).isolatedCopy() }; }
 
+    template<class Encoder> void encode(Encoder&) const;
+    template<class Decoder> static std::optional<Exception> decode(Decoder&);
 private:
     ExceptionCode m_code;
     String m_message;
@@ -51,6 +53,31 @@ inline Exception::Exception(ExceptionCode code, String message)
     : m_code { code }
     , m_message { WTFMove(message) }
 {
+}
+
+template<class Encoder>
+void Exception::encode(Encoder& encoder) const
+{
+    encoder << m_code << m_message;
+}
+
+template<class Decoder>
+std::optional<Exception> Exception::decode(Decoder& decoder)
+{
+    std::optional<ExceptionCode> code;
+    decoder >> code;
+    if (!code)
+        return std::nullopt;
+
+    std::optional<String> message;
+    decoder >> message;
+    if (!message)
+        return std::nullopt;
+
+    return Exception {
+        *code,
+        WTFMove(*message)
+    };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -306,6 +306,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
     , m_pluginInfoProvider(*WTFMove(pageConfiguration.pluginInfoProvider))
     , m_storageNamespaceProvider(*WTFMove(pageConfiguration.storageNamespaceProvider))
     , m_userContentProvider(WTFMove(pageConfiguration.userContentProvider))
+    , m_screenOrientationManager(WTFMove(pageConfiguration.screenOrientationManager))
     , m_visitedLinkStore(*WTFMove(pageConfiguration.visitedLinkStore))
     , m_broadcastChannelRegistry(WTFMove(pageConfiguration.broadcastChannelRegistry))
     , m_sessionID(pageConfiguration.sessionID)
@@ -4023,6 +4024,11 @@ void Page::repaintAnimatedImages()
 {
     if (auto* view = mainFrame().view())
         view->repaintVisibleImageAnimationsIncludingSubframes();
+}
+
+ScreenOrientationManager* Page::screenOrientationManager() const
+{
+    return m_screenOrientationManager.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -155,6 +155,7 @@ class ProgressTracker;
 class RenderObject;
 class ResourceUsageOverlay;
 class RenderingUpdateScheduler;
+class ScreenOrientationManager;
 class ScrollLatchingController;
 class ScrollingCoordinator;
 class ServicesOverlayController;
@@ -783,6 +784,8 @@ public:
     WEBCORE_EXPORT UserContentProvider& userContentProvider();
     WEBCORE_EXPORT void setUserContentProvider(Ref<UserContentProvider>&&);
 
+    ScreenOrientationManager* screenOrientationManager() const;
+
     VisitedLinkStore& visitedLinkStore();
     WEBCORE_EXPORT void setVisitedLinkStore(Ref<VisitedLinkStore>&&);
 
@@ -1197,6 +1200,7 @@ private:
     Ref<PluginInfoProvider> m_pluginInfoProvider;
     Ref<StorageNamespaceProvider> m_storageNamespaceProvider;
     Ref<UserContentProvider> m_userContentProvider;
+    WeakPtr<ScreenOrientationManager> m_screenOrientationManager;
     Ref<VisitedLinkStore> m_visitedLinkStore;
     Ref<BroadcastChannelRegistry> m_broadcastChannelRegistry;
     RefPtr<WheelEventTestMonitor> m_wheelEventTestMonitor;

--- a/Source/WebCore/page/PageConfiguration.cpp
+++ b/Source/WebCore/page/PageConfiguration.cpp
@@ -43,6 +43,7 @@
 #include "PerformanceLoggingClient.h"
 #include "PluginInfoProvider.h"
 #include "ProgressTrackerClient.h"
+#include "ScreenOrientationManager.h"
 #include "SocketProvider.h"
 #include "SpeechRecognitionProvider.h"
 #include "SpeechSynthesisClient.h"

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -68,6 +68,7 @@ class PaymentCoordinatorClient;
 class PerformanceLoggingClient;
 class PluginInfoProvider;
 class ProgressTrackerClient;
+class ScreenOrientationManager;
 class SocketProvider;
 class SpeechRecognitionProvider;
 class SpeechSynthesisClient;
@@ -133,6 +134,7 @@ public:
     Ref<UserContentProvider> userContentProvider;
     RefPtr<VisitedLinkStore> visitedLinkStore;
     Ref<BroadcastChannelRegistry> broadcastChannelRegistry;
+    WeakPtr<ScreenOrientationManager> screenOrientationManager;
     
 #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
     RefPtr<DeviceOrientationUpdateProvider> deviceOrientationUpdateProvider;

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -27,6 +27,7 @@
 #include "ScreenOrientation.h"
 
 #include "Document.h"
+#include "Event.h"
 #include "EventNames.h"
 #include "JSDOMPromiseDeferred.h"
 #include <wtf/IsoMallocInlines.h>
@@ -45,6 +46,16 @@ Ref<ScreenOrientation> ScreenOrientation::create(Document* document)
 ScreenOrientation::ScreenOrientation(Document* document)
     : ActiveDOMObject(document)
 {
+    if (shouldListenForChangeNotification()) {
+        if (auto* manager = this->manager())
+            manager->addObserver(*this);
+    }
+}
+
+ScreenOrientation::~ScreenOrientation()
+{
+    if (auto* manager = this->manager())
+        manager->removeObserver(*this);
 }
 
 Document* ScreenOrientation::document() const
@@ -52,28 +63,117 @@ Document* ScreenOrientation::document() const
     return downcast<Document>(scriptExecutionContext());
 }
 
-void ScreenOrientation::lock(LockType, Ref<DeferredPromise>&& promise)
+ScreenOrientationManager* ScreenOrientation::manager() const
 {
-    promise->reject(Exception { NotSupportedError });
+    auto* document = this->document();
+    if (!document)
+        return nullptr;
+    auto* page = document->page();
+    return page ? page->screenOrientationManager() : nullptr;
+}
+
+void ScreenOrientation::lock(LockType lockType, Ref<DeferredPromise>&& promise)
+{
+    auto* manager = this->manager();
+    if (!manager) {
+        promise->reject(Exception { InvalidStateError, "No browsing context"_s });
+        return;
+    }
+    manager->lock(lockType, [promise = WTFMove(promise)](std::optional<Exception>&& exception) {
+        if (exception)
+            promise->reject(WTFMove(*exception));
+        else
+            promise->resolve();
+    });
 }
 
 void ScreenOrientation::unlock()
 {
+    if (auto* manager = this->manager())
+        manager->unlock();
 }
 
 auto ScreenOrientation::type() const -> Type
 {
-    return Type::PortraitPrimary;
+    auto* manager = this->manager();
+    if (!manager)
+        return Type::PortraitPrimary;
+    return manager->currentOrientation();
 }
 
 uint16_t ScreenOrientation::angle() const
 {
+    auto* manager = this->manager();
+    if (!manager)
+        return 0;
+
+    // The angle should depend on the device's natural orientation. We currently
+    // consider Portrait as the natural orientation.
+    switch (manager->currentOrientation()) {
+    case Type::PortraitPrimary:
+        return 0;
+    case Type::PortraitSecondary:
+        return 180;
+    case Type::LandscapePrimary:
+        return 90;
+    case Type::LandscapeSecondary:
+        return 270;
+    }
+    ASSERT_NOT_REACHED();
     return 0;
+}
+
+void ScreenOrientation::visibilityStateChanged()
+{
+    auto* document = this->document();
+    if (!document)
+        return;
+    auto* manager = this->manager();
+    if (!manager)
+        return;
+
+    if (shouldListenForChangeNotification())
+        manager->addObserver(*this);
+    else
+        manager->removeObserver(*this);
+}
+
+bool ScreenOrientation::shouldListenForChangeNotification() const
+{
+    auto* document = this->document();
+    if (!document || !document->frame())
+        return false;
+    return document->visibilityState() == VisibilityState::Visible;
+}
+
+void ScreenOrientation::screenOrientationDidChange(ScreenOrientationType)
+{
+    dispatchEvent(Event::create(eventNames().changeEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
 const char* ScreenOrientation::activeDOMObjectName() const
 {
     return "ScreenOrientation";
+}
+
+void ScreenOrientation::suspend(ReasonForSuspension)
+{
+    if (auto* manager = this->manager())
+        manager->removeObserver(*this);
+}
+
+void ScreenOrientation::resume()
+{
+    if (!shouldListenForChangeNotification())
+        return;
+    if (auto* manager = this->manager())
+        manager->addObserver(*this);
+}
+
+void ScreenOrientation::stop()
+{
+    if (auto* manager = this->manager())
+        manager->removeObserver(*this);
 }
 
 bool ScreenOrientation::virtualHasPendingActivity() const

--- a/Source/WebCore/page/ScreenOrientation.h
+++ b/Source/WebCore/page/ScreenOrientation.h
@@ -29,17 +29,20 @@
 #include "EventTarget.h"
 
 #include "ScreenOrientationLockType.h"
+#include "ScreenOrientationManager.h"
 #include "ScreenOrientationType.h"
+#include "VisibilityChangeClient.h"
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
 
 class DeferredPromise;
 
-class ScreenOrientation final : public ActiveDOMObject, public EventTarget, public RefCounted<ScreenOrientation> {
+class ScreenOrientation final : public ActiveDOMObject, public EventTarget, public ScreenOrientationManager::Observer, public VisibilityChangeClient, public RefCounted<ScreenOrientation> {
     WTF_MAKE_ISO_ALLOCATED(ScreenOrientation);
 public:
     static Ref<ScreenOrientation> create(Document*);
+    ~ScreenOrientation();
 
     using LockType = ScreenOrientationLockType;
     using Type = ScreenOrientationType;
@@ -56,6 +59,15 @@ private:
     ScreenOrientation(Document*);
 
     Document* document() const;
+    ScreenOrientationManager* manager() const;
+
+    bool shouldListenForChangeNotification() const;
+
+    // VisibilityChangeClient
+    void visibilityStateChanged() final;
+
+    // ScreenOrientationManager::Observer
+    void screenOrientationDidChange(ScreenOrientationType) final;
 
     // EventTarget
     EventTargetInterface eventTargetInterface() const final { return ScreenOrientationEventTargetInterfaceType; }
@@ -67,6 +79,9 @@ private:
     // ActiveDOMObject
     const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
+    void suspend(ReasonForSuspension) final;
+    void resume() final;
+    void stop() final;
 
     bool m_hasChangeEventListener { false };
 };

--- a/Source/WebCore/page/ScreenOrientationLockType.h
+++ b/Source/WebCore/page/ScreenOrientationLockType.h
@@ -39,3 +39,21 @@ enum class ScreenOrientationLockType : uint8_t {
 };
 
 } // namespace WebCore
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::ScreenOrientationLockType> {
+    using values = EnumValues<
+        WebCore::ScreenOrientationLockType,
+        WebCore::ScreenOrientationLockType::Any,
+        WebCore::ScreenOrientationLockType::Natural,
+        WebCore::ScreenOrientationLockType::Landscape,
+        WebCore::ScreenOrientationLockType::Portrait,
+        WebCore::ScreenOrientationLockType::PortraitPrimary,
+        WebCore::ScreenOrientationLockType::PortraitSecondary,
+        WebCore::ScreenOrientationLockType::LandscapePrimary,
+        WebCore::ScreenOrientationLockType::LandscapeSecondary
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebCore/page/ScreenOrientationType.h
+++ b/Source/WebCore/page/ScreenOrientationType.h
@@ -35,3 +35,17 @@ enum class ScreenOrientationType : uint8_t {
 };
 
 } // namespace WebCore
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::ScreenOrientationType> {
+    using values = EnumValues<
+        WebCore::ScreenOrientationType,
+        WebCore::ScreenOrientationType::PortraitPrimary,
+        WebCore::ScreenOrientationType::PortraitSecondary,
+        WebCore::ScreenOrientationType::LandscapePrimary,
+        WebCore::ScreenOrientationType::LandscapeSecondary
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebCore/platform/ScreenOrientationManager.h
+++ b/Source/WebCore/platform/ScreenOrientationManager.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ScreenOrientationLockType.h"
+#include "ScreenOrientationType.h"
+#include <wtf/CompletionHandler.h>
+#include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class Exception;
+
+class ScreenOrientationManager : public CanMakeWeakPtr<ScreenOrientationManager> {
+public:
+    virtual ~ScreenOrientationManager() { }
+
+    class Observer : public CanMakeWeakPtr<Observer> {
+    public:
+        virtual ~Observer() { }
+        virtual void screenOrientationDidChange(ScreenOrientationType) = 0;
+    };
+
+    virtual ScreenOrientationType currentOrientation() = 0;
+    virtual void lock(ScreenOrientationLockType, CompletionHandler<void(std::optional<Exception>&&)>&&) = 0;
+    virtual void unlock() = 0;
+    virtual void addObserver(Observer&) = 0;
+    virtual void removeObserver(Observer&) = 0;
+
+protected:
+    ScreenOrientationManager() = default;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/ScreenOrientationProvider.cpp
+++ b/Source/WebCore/platform/ScreenOrientationProvider.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScreenOrientationProvider.h"
+
+#include <wtf/NeverDestroyed.h>
+
+namespace WebCore {
+
+Ref<ScreenOrientationProvider> ScreenOrientationProvider::create()
+{
+    return adoptRef(*new ScreenOrientationProvider);
+}
+
+ScreenOrientationProvider::ScreenOrientationProvider() = default;
+
+ScreenOrientationProvider::~ScreenOrientationProvider()
+{
+    platformDestroy();
+}
+
+void ScreenOrientationProvider::addObserver(Observer& observer)
+{
+    bool wasEmpty = m_observers.computesEmpty();
+    m_observers.add(observer);
+    if (wasEmpty)
+        platformStartListeningForChanges();
+}
+
+void ScreenOrientationProvider::removeObserver(Observer& observer)
+{
+    m_observers.remove(observer);
+    if (m_observers.computesEmpty()) {
+        m_currentOrientation = std::nullopt;
+        platformStopListeningForChanges();
+    }
+}
+
+void ScreenOrientationProvider::screenOrientationDidChange()
+{
+    auto newOrientation = platformCurrentOrientation();
+    if (newOrientation == m_currentOrientation)
+        return;
+
+    m_currentOrientation = newOrientation;
+    for (auto& observer : m_observers)
+        observer.screenOrientationDidChange(newOrientation);
+}
+
+ScreenOrientationType ScreenOrientationProvider::currentOrientation()
+{
+    if (m_currentOrientation)
+        return *m_currentOrientation;
+
+    auto orientation = platformCurrentOrientation();
+    if (!m_observers.computesEmpty())
+        m_currentOrientation = orientation;
+    return orientation;
+}
+
+#if !PLATFORM(IOS_FAMILY)
+ScreenOrientationType ScreenOrientationProvider::platformCurrentOrientation()
+{
+    return ScreenOrientationType::PortraitPrimary;
+}
+
+void ScreenOrientationProvider::platformStartListeningForChanges()
+{
+}
+
+void ScreenOrientationProvider::platformStopListeningForChanges()
+{
+}
+
+void ScreenOrientationProvider::platformDestroy()
+{
+}
+#endif
+
+} // namespace WebCore

--- a/Source/WebCore/platform/ScreenOrientationProvider.h
+++ b/Source/WebCore/platform/ScreenOrientationProvider.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ScreenOrientationType.h"
+#include <wtf/RefCounted.h>
+#include <wtf/WeakHashSet.h>
+#include <wtf/WeakPtr.h>
+
+#if PLATFORM(IOS_FAMILY)
+#include <wtf/RetainPtr.h>
+#include <wtf/WeakObjCPtr.h>
+
+OBJC_CLASS UIWindow;
+OBJC_CLASS WebScreenOrientationObserver;
+#endif
+
+namespace WebCore {
+
+class ScreenOrientationProvider : public RefCounted<ScreenOrientationProvider>, public CanMakeWeakPtr<ScreenOrientationProvider> {
+public:
+    WEBCORE_EXPORT static Ref<ScreenOrientationProvider> create();
+    WEBCORE_EXPORT ~ScreenOrientationProvider();
+
+    class Observer : public CanMakeWeakPtr<Observer> {
+    public:
+        virtual ~Observer() { }
+        virtual void screenOrientationDidChange(ScreenOrientationType) = 0;
+    };
+
+    WEBCORE_EXPORT ScreenOrientationType currentOrientation();
+    WEBCORE_EXPORT void addObserver(Observer&);
+    WEBCORE_EXPORT void removeObserver(Observer&);
+
+#if PLATFORM(IOS_FAMILY)
+    WEBCORE_EXPORT void setWindow(UIWindow *);
+#endif
+
+    void screenOrientationDidChange();
+
+private:
+    explicit ScreenOrientationProvider();
+
+    ScreenOrientationType platformCurrentOrientation();
+    void platformStartListeningForChanges();
+    void platformStopListeningForChanges();
+    void platformDestroy();
+
+    WeakHashSet<Observer> m_observers;
+    std::optional<ScreenOrientationType> m_currentOrientation;
+
+#if PLATFORM(IOS_FAMILY)
+    WeakObjCPtr<UIWindow> m_window;
+    RetainPtr<WebScreenOrientationObserver> m_systemObserver;
+#endif
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/ios/ScreenOrientationProviderIOS.mm
+++ b/Source/WebCore/platform/ios/ScreenOrientationProviderIOS.mm
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY)
+#import "ScreenOrientationProvider.h"
+
+#import <pal/ios/UIKitSoftLink.h>
+
+@interface WebScreenOrientationObserver : NSObject
+@property (nonatomic) WebCore::ScreenOrientationProvider* provider;
+@end
+
+@implementation WebScreenOrientationObserver {
+}
+
+- (WebScreenOrientationObserver *)initWithProvider:(WebCore::ScreenOrientationProvider&)provider
+{
+    self = [super init];
+    if (!self)
+        return nil;
+
+    _provider = &provider;
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_screenOrientationDidChange) name:PAL::get_UIKit_UIApplicationDidChangeStatusBarOrientationNotification() object:nil];
+    return self;
+}
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:PAL::get_UIKit_UIApplicationDidChangeStatusBarOrientationNotification() object:nil];
+    [super dealloc];
+}
+
+- (void)_screenOrientationDidChange
+{
+    // We need to make sure we notify the client on the main thread.
+    callOnMainRunLoop([self, protectedSelf = RetainPtr<WebScreenOrientationObserver>(self)] {
+        if (_provider)
+            _provider->screenOrientationDidChange();
+    });
+}
+
+@end
+
+namespace WebCore {
+
+ScreenOrientationType ScreenOrientationProvider::platformCurrentOrientation()
+{
+    auto window = m_window.get();
+    if (!window)
+        return WebCore::ScreenOrientationType::PortraitPrimary;
+
+    UIWindowScene *scene = window.get().windowScene;
+    switch ([scene interfaceOrientation]) {
+    case UIInterfaceOrientationUnknown:
+    case UIInterfaceOrientationPortrait:
+        break;
+    case UIInterfaceOrientationPortraitUpsideDown:
+        return WebCore::ScreenOrientationType::PortraitSecondary;
+    case UIInterfaceOrientationLandscapeLeft:
+        return WebCore::ScreenOrientationType::LandscapePrimary;
+    case UIInterfaceOrientationLandscapeRight:
+        return WebCore::ScreenOrientationType::LandscapeSecondary;
+    }
+    return WebCore::ScreenOrientationType::PortraitPrimary;
+}
+
+void ScreenOrientationProvider::platformStartListeningForChanges()
+{
+    ASSERT(!m_systemObserver);
+    m_systemObserver = adoptNS([[WebScreenOrientationObserver alloc] initWithProvider:*this]);
+}
+
+void ScreenOrientationProvider::platformStopListeningForChanges()
+{
+    ASSERT(m_systemObserver);
+    m_systemObserver = nullptr;
+}
+
+void ScreenOrientationProvider::setWindow(UIWindow *window)
+{
+    m_window = window;
+    screenOrientationDidChange();
+}
+
+void ScreenOrientationProvider::platformDestroy()
+{
+    if (m_systemObserver)
+        m_systemObserver.get().provider = nullptr;
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -241,6 +241,7 @@ set(WebKit_MESSAGES_IN_FILES
     UIProcess/WebPermissionControllerProxy
     UIProcess/WebProcessPool
     UIProcess/WebProcessProxy
+    UIProcess/WebScreenOrientationManagerProxy
 
     UIProcess/Automation/WebAutomationSession
 
@@ -322,6 +323,7 @@ set(WebKit_MESSAGES_IN_FILES
     WebProcess/WebCoreSupport/WebBroadcastChannelRegistry
     WebProcess/WebCoreSupport/WebFileSystemStorageConnection
     WebProcess/WebCoreSupport/WebPermissionController
+    WebProcess/WebCoreSupport/WebScreenOrientationManager
     WebProcess/WebCoreSupport/WebSpeechRecognitionConnection
 
     WebProcess/WebPage/DrawingArea

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -207,6 +207,7 @@ $(PROJECT_DIR)/UIProcess/WebPasteboardProxy.messages.in
 $(PROJECT_DIR)/UIProcess/WebPermissionControllerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/WebProcessPool.messages.in
 $(PROJECT_DIR)/UIProcess/WebProcessProxy.messages.in
+$(PROJECT_DIR)/UIProcess/WebScreenOrientationManagerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/XR/PlatformXRSystem.messages.in
 $(PROJECT_DIR)/UIProcess/ios/EditableImageController.messages.in
 $(PROJECT_DIR)/UIProcess/ios/SmartMagnificationController.messages.in
@@ -277,6 +278,7 @@ $(PROJECT_DIR)/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.messages.in
 $(PROJECT_DIR)/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.messages.in
 $(PROJECT_DIR)/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages.in
 $(PROJECT_DIR)/WebProcess/WebCoreSupport/WebPermissionController.messages.in
+$(PROJECT_DIR)/WebProcess/WebCoreSupport/WebScreenOrientationManager.messages.in
 $(PROJECT_DIR)/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.messages.in
 $(PROJECT_DIR)/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.messages.in
 $(PROJECT_DIR)/WebProcess/WebPage/DrawingArea.messages.in

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -629,6 +629,12 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebSWServerConnectionMessagesReplies
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebSWServerToContextConnectionMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebSWServerToContextConnectionMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebSWServerToContextConnectionMessagesReplies.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebScreenOrientationManagerMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebScreenOrientationManagerMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebScreenOrientationManagerMessagesReplies.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebScreenOrientationManagerProxyMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebScreenOrientationManagerProxyMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebScreenOrientationManagerProxyMessagesReplies.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebSharedWorkerContextManagerConnectionMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebSharedWorkerContextManagerConnectionMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebSharedWorkerContextManagerConnectionMessagesReplies.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -178,6 +178,7 @@ MESSAGE_RECEIVERS = \
 	UIProcess/WebProcessProxy \
 	UIProcess/Automation/WebAutomationSession \
 	UIProcess/WebProcessPool \
+        UIProcess/WebScreenOrientationManagerProxy \
 	UIProcess/Downloads/DownloadProxy \
 	UIProcess/Extensions/WebExtensionController \
 	UIProcess/Media/AudioSessionRoutingArbitratorProxy \
@@ -228,6 +229,7 @@ MESSAGE_RECEIVERS = \
 	WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider \
 	WebProcess/WebCoreSupport/WebFileSystemStorageConnection \
 	WebProcess/WebCoreSupport/WebPermissionController \
+        WebProcess/WebCoreSupport/WebScreenOrientationManager \
 	WebProcess/WebCoreSupport/WebSpeechRecognitionConnection \
 	WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager \
 	WebProcess/Storage/WebSharedWorkerContextManagerConnection \

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -435,6 +435,7 @@ UIProcess/WebPreferences.cpp
 UIProcess/WebProcessCache.cpp
 UIProcess/WebProcessPool.cpp
 UIProcess/WebProcessProxy.cpp
+UIProcess/WebScreenOrientationManagerProxy.cpp
 UIProcess/WebURLSchemeHandler.cpp
 UIProcess/WebURLSchemeTask.cpp
 
@@ -802,6 +803,7 @@ WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
 WebProcess/WebCoreSupport/WebPopupMenu.cpp
 WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp
 WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
+WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
 WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp
 WebProcess/WebCoreSupport/WebUserMediaClient.cpp
 WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.cpp
@@ -882,6 +884,8 @@ WebBroadcastChannelRegistryMessageReceiver.cpp
 WebLockRegistryProxyMessageReceiver.cpp
 WebPermissionControllerMessageReceiver.cpp
 WebPermissionControllerProxyMessageReceiver.cpp
+WebScreenOrientationManagerMessageReceiver.cpp
+WebScreenOrientationManagerProxyMessageReceiver.cpp
 WebSharedWorkerContextManagerConnectionMessageReceiver.cpp
 WebSharedWorkerObjectConnectionMessageReceiver.cpp
 WebSharedWorkerServerConnectionMessageReceiver.cpp

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -481,6 +481,7 @@ UIProcess/ios/ViewGestureControllerIOS.mm
 UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
 UIProcess/ios/WebPageProxyIOS.mm
 UIProcess/ios/WebProcessProxyIOS.mm
+UIProcess/ios/WebScreenOrientationManagerProxyIOS.mm
 UIProcess/ios/WKActionSheet.mm
 UIProcess/ios/WKActionSheetAssistant.mm
 UIProcess/ios/WKApplicationStateTrackingView.mm

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -34,6 +34,7 @@
 #include <WebCore/FloatRect.h>
 #include <WebCore/ModalContainerTypes.h>
 #include <WebCore/PermissionState.h>
+#include <WebCore/ScreenOrientationLockType.h>
 #include <wtf/CompletionHandler.h>
 
 #if PLATFORM(COCOA)
@@ -138,6 +139,9 @@ public:
     {
         completionHandler(currentQuota);
     }
+
+    virtual bool lockScreenOrientation(WebCore::ScreenOrientationLockType) { return false; }
+    virtual void unlockScreenOrientation() { }
 
     virtual bool needsFontAttributes() const { return false; }
     virtual void didChangeFontAttributes(const WebCore::FontAttributes&) { }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -56,6 +56,16 @@
 @protocol UIDropSession;
 @protocol UIEditMenuInteractionAnimating;
 
+typedef NS_ENUM(NSInteger, _WKScreenOrientationLockType) {
+    _WKScreenOrientationLockTypeAny,
+    _WKScreenOrientationLockTypeLandscape,
+    _WKScreenOrientationLockTypeLandscapePrimary,
+    _WKScreenOrientationLockTypeLandscapeSecondary,
+    _WKScreenOrientationLockTypePortrait,
+    _WKScreenOrientationLockTypePortraitPrimary,
+    _WKScreenOrientationLockTypePortraitSecondary
+} WK_API_AVAILABLE(ios(WK_IOS_TBA));
+
 #else
 
 typedef NS_ENUM(NSInteger, _WKResourceLimit) {
@@ -257,6 +267,9 @@ struct UIEdgeInsets;
 - (NSArray<UIDragItem *> *)_webView:(WKWebView *)webView willPerformDropWithSession:(id <UIDropSession>)session WK_API_AVAILABLE(ios(11.0));
 - (NSInteger)_webView:(WKWebView *)webView dataOwnerForDropSession:(id <UIDropSession>)session WK_API_AVAILABLE(ios(11.0));
 - (NSInteger)_webView:(WKWebView *)webView dataOwnerForDragSession:(id <UIDragSession>)session WK_API_AVAILABLE(ios(11.0));
+
+- (void)_webViewLockScreenOrientation:(WKWebView *)webView lockType:(_WKScreenOrientationLockType)lockType WK_API_AVAILABLE(ios(WK_IOS_TBA));
+- (void)_webViewUnlockScreenOrientation:(WKWebView *)webView WK_API_AVAILABLE(ios(WK_IOS_TBA));
 #endif
 
 - (void)_webView:(WKWebView *)webView didChangeSafeAreaShouldAffectObscuredInsets:(BOOL)safeAreaShouldAffectObscuredInsets WK_API_AVAILABLE(ios(11.0));

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
@@ -46,7 +46,7 @@ NavigationSOAuthorizationSession::~NavigationSOAuthorizationSession()
     if (m_callback)
         m_callback(true);
     if (state() == State::Waiting && page())
-        page()->removeObserver(*this);
+        page()->removeDidMoveToWindowObserver(*this);
 }
 
 void NavigationSOAuthorizationSession::shouldStartInternal()
@@ -59,7 +59,7 @@ void NavigationSOAuthorizationSession::shouldStartInternal()
     if (!page->isInWindow()) {
         AUTHORIZATIONSESSION_RELEASE_LOG("shouldStartInternal: Starting Extensible SSO authentication for a web view that is not attached to a window. Loading will pause until a window is attached.");
         setState(State::Waiting);
-        page->addObserver(*this);
+        page->addDidMoveToWindowObserver(*this);
         ASSERT(page->mainFrame());
         m_waitingPageActiveURL = page->pageLoadState().activeURL();
         return;
@@ -75,11 +75,11 @@ void NavigationSOAuthorizationSession::webViewDidMoveToWindow()
         return;
     if (pageActiveURLDidChangeDuringWaiting()) {
         abort();
-        page->removeObserver(*this);
+        page->removeDidMoveToWindowObserver(*this);
         return;
     }
     start();
-    page->removeObserver(*this);
+    page->removeDidMoveToWindowObserver(*this);
 }
 
 bool NavigationSOAuthorizationSession::pageActiveURLDidChangeDuringWaiting() const

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -102,6 +102,8 @@ private:
         void runBeforeUnloadConfirmPanel(WebPageProxy&, const WTF::String&, WebFrameProxy*, FrameInfoData&&, Function<void(bool)>&& completionHandler) final;
         void exceededDatabaseQuota(WebPageProxy*, WebFrameProxy*, API::SecurityOrigin*, const WTF::String& databaseName, const WTF::String& displayName, unsigned long long currentQuota, unsigned long long currentOriginUsage, unsigned long long currentUsage, unsigned long long expectedUsage, Function<void(unsigned long long)>&& completionHandler) final;
         void reachedApplicationCacheOriginQuota(WebPageProxy*, const WebCore::SecurityOrigin&, uint64_t currentQuota, uint64_t totalBytesNeeded, Function<void(unsigned long long)>&& completionHandler) final;
+        bool lockScreenOrientation(WebCore::ScreenOrientationLockType) final;
+        void unlockScreenOrientation() final;
         void didResignInputElementStrongPasswordAppearance(WebPageProxy&, API::Object*) final;
         bool takeFocus(WebPageProxy*, WKFocusDirection) final;
         void handleAutoplayEvent(WebPageProxy&, WebCore::AutoplayEvent, OptionSet<WebCore::AutoplayEventFlags>) final;
@@ -240,6 +242,10 @@ private:
 #endif
         bool webViewDecideDatabaseQuotaForSecurityOriginCurrentQuotaCurrentOriginUsageCurrentDatabaseUsageExpectedUsageDecisionHandler : 1;
         bool webViewDecideDatabaseQuotaForSecurityOriginDatabaseNameDisplayNameCurrentQuotaCurrentOriginUsageCurrentDatabaseUsageExpectedUsageDecisionHandler : 1;
+#if PLATFORM(IOS)
+        bool webViewLockScreenOrientation : 1;
+        bool webViewUnlockScreenOrientation : 1;
+#endif
         bool webViewDecideWebApplicationCacheQuotaForSecurityOriginCurrentQuotaTotalBytesNeeded : 1;
         bool webViewPrintFrame : 1;
         bool webViewPrintFramePDFFirstPageSizeCompletionHandler : 1;

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -168,6 +168,10 @@ void UIDelegate::setDelegate(id <WKUIDelegate> delegate)
     m_delegateMethods.webViewDidNotHandleTapAsClickAtPoint = [delegate respondsToSelector:@selector(_webView:didNotHandleTapAsClickAtPoint:)];
     m_delegateMethods.webViewStatusBarWasTapped = [delegate respondsToSelector:@selector(_webViewStatusBarWasTapped:)];
 #endif
+#if PLATFORM(IOS)
+    m_delegateMethods.webViewLockScreenOrientation = [delegate respondsToSelector:@selector(_webViewLockScreenOrientation:lockType:)];
+    m_delegateMethods.webViewUnlockScreenOrientation = [delegate respondsToSelector:@selector(_webViewUnlockScreenOrientation:)];
+#endif
     m_delegateMethods.presentingViewControllerForWebView = [delegate respondsToSelector:@selector(_presentingViewControllerForWebView:)];
     m_delegateMethods.webViewIsMediaCaptureAuthorizedForFrameDecisionHandler = [delegate respondsToSelector:@selector(_webView:checkUserMediaPermissionForURL:mainFrameURL:frameIdentifier:decisionHandler:)] || [delegate respondsToSelector:@selector(_webView:includeSensitiveMediaDeviceDetails:)];
 
@@ -579,6 +583,61 @@ void UIDelegate::UIClient::exceededDatabaseQuota(WebPageProxy*, WebFrameProxy*, 
         checker->didCallCompletionHandler();
         completionHandler(newQuota);
     }).get()];
+}
+
+#if PLATFORM(IOS)
+static _WKScreenOrientationLockType toWKScreenOrientationLockType(WebCore::ScreenOrientationLockType lockType)
+{
+    switch (lockType) {
+    case WebCore::ScreenOrientationLockType::Natural:
+    case WebCore::ScreenOrientationLockType::Portrait:
+        break;
+    case WebCore::ScreenOrientationLockType::Any:
+        return _WKScreenOrientationLockTypeAny;
+    case WebCore::ScreenOrientationLockType::Landscape:
+        return _WKScreenOrientationLockTypeLandscape;
+    case WebCore::ScreenOrientationLockType::PortraitPrimary:
+        return _WKScreenOrientationLockTypePortraitPrimary;
+    case WebCore::ScreenOrientationLockType::PortraitSecondary:
+        return _WKScreenOrientationLockTypePortraitSecondary;
+    case WebCore::ScreenOrientationLockType::LandscapePrimary:
+        return _WKScreenOrientationLockTypeLandscapePrimary;
+    case WebCore::ScreenOrientationLockType::LandscapeSecondary:
+        return _WKScreenOrientationLockTypeLandscapeSecondary;
+    }
+    return _WKScreenOrientationLockTypePortrait;
+}
+#endif
+
+bool UIDelegate::UIClient::lockScreenOrientation(WebCore::ScreenOrientationLockType lockType)
+{
+#if PLATFORM(IOS)
+    if (!m_uiDelegate)
+        return false;
+    if (!m_uiDelegate->m_delegateMethods.webViewLockScreenOrientation)
+        return false;
+    auto delegate = m_uiDelegate->m_delegate.get();
+    if (!delegate)
+        return false;
+
+    [(id<WKUIDelegatePrivate>)delegate _webViewLockScreenOrientation:m_uiDelegate->m_webView.get().get() lockType:toWKScreenOrientationLockType(lockType)];
+    return true;
+#else
+    UNUSED_PARAM(lockType);
+    return false;
+#endif
+}
+
+void UIDelegate::UIClient::unlockScreenOrientation()
+{
+#if PLATFORM(IOS)
+    if (!m_uiDelegate)
+        return;
+    if (!m_uiDelegate->m_delegateMethods.webViewUnlockScreenOrientation)
+        return;
+    if (auto delegate = m_uiDelegate->m_delegate.get())
+        [(id<WKUIDelegatePrivate>)delegate _webViewUnlockScreenOrientation:m_uiDelegate->m_webView.get().get()];
+#endif
 }
 
 static inline _WKFocusDirection toWKFocusDirection(WKFocusDirection direction)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -50,6 +50,7 @@
 #import "WebPasteboardProxy.h"
 #import "WebProcessMessages.h"
 #import "WebProcessProxy.h"
+#import "WebScreenOrientationManagerProxy.h"
 #import "WebsiteDataStore.h"
 #import "WKErrorInternal.h"
 #import <Foundation/NSURLRequest.h>
@@ -937,6 +938,15 @@ void WebPageProxy::classifyModalContainerControls(Vector<String>&& texts, Comple
 void WebPageProxy::replaceSelectionWithPasteboardData(const Vector<String>& types, const IPC::DataReference& data)
 {
     send(Messages::WebPage::ReplaceSelectionWithPasteboardData(types, data));
+}
+
+void WebPageProxy::setCocoaView(WKWebView *view)
+{
+    m_cocoaView = view;
+#if PLATFORM(IOS_FAMILY)
+    if (m_screenOrientationManager)
+        m_screenOrientationManager->setWindow(view.window);
+#endif
 }
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -142,6 +142,7 @@
 #include "WebProcessProxy.h"
 #include "WebProtectionSpace.h"
 #include "WebResourceLoadStatisticsStore.h"
+#include "WebScreenOrientationManagerProxy.h"
 #include "WebURLSchemeHandler.h"
 #include "WebUserContentControllerProxy.h"
 #include "WebViewDidMoveToWindowObserver.h"
@@ -1098,6 +1099,8 @@ void WebPageProxy::didAttachToRunningProcess()
     ASSERT(!m_webDeviceOrientationUpdateProviderProxy);
     m_webDeviceOrientationUpdateProviderProxy = makeUnique<WebDeviceOrientationUpdateProviderProxy>(*this);
 #endif
+
+    m_screenOrientationManager = makeUnique<WebScreenOrientationManagerProxy>(*this);
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
     ASSERT(!m_xrSystem);
@@ -8213,6 +8216,8 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
     }
 #endif
 
+    m_screenOrientationManager = nullptr;
+
 #if ENABLE(MEDIA_USAGE)
     if (m_mediaUsageManager)
         m_mediaUsageManager->reset();
@@ -11046,13 +11051,13 @@ WebContentMode WebPageProxy::effectiveContentModeAfterAdjustingPolicies(API::Web
 
 #endif // !PLATFORM(IOS_FAMILY)
 
-void WebPageProxy::addObserver(WebViewDidMoveToWindowObserver& observer)
+void WebPageProxy::addDidMoveToWindowObserver(WebViewDidMoveToWindowObserver& observer)
 {
     auto result = m_webViewDidMoveToWindowObservers.add(&observer, observer);
     ASSERT_UNUSED(result, result.isNewEntry);
 }
 
-void WebPageProxy::removeObserver(WebViewDidMoveToWindowObserver& observer)
+void WebPageProxy::removeDidMoveToWindowObserver(WebViewDidMoveToWindowObserver& observer)
 {
     auto result = m_webViewDidMoveToWindowObservers.remove(&observer);
     ASSERT_UNUSED(result, result);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -382,6 +382,7 @@ class WebPageDebuggable;
 class WebPageGroup;
 class WebPageInspectorController;
 class WebProcessProxy;
+class WebScreenOrientationManagerProxy;
 class WebURLSchemeHandler;
 class WebUserContentControllerProxy;
 class WebViewDidMoveToWindowObserver;
@@ -1881,8 +1882,8 @@ public:
 
     void configureLoggingChannel(const String&, WTFLogChannelState, WTFLogLevel);
 
-    void addObserver(WebViewDidMoveToWindowObserver&);
-    void removeObserver(WebViewDidMoveToWindowObserver&);
+    void addDidMoveToWindowObserver(WebViewDidMoveToWindowObserver&);
+    void removeDidMoveToWindowObserver(WebViewDidMoveToWindowObserver&);
     void webViewDidMoveToWindow();
 
 #if HAVE(APP_SSO)
@@ -3264,6 +3265,8 @@ private:
     std::unique_ptr<WebDeviceOrientationUpdateProviderProxy> m_webDeviceOrientationUpdateProviderProxy;
 #endif
 
+    std::unique_ptr<WebScreenOrientationManagerProxy> m_screenOrientationManager;
+
 #if ENABLE(INTELLIGENT_TRACKING_PREVENTION)
     MonotonicTime m_didFinishDocumentLoadForMainFrameTimestamp;
 #endif
@@ -3321,11 +3324,6 @@ private:
 inline RetainPtr<WKWebView> WebPageProxy::cocoaView()
 {
     return m_cocoaView.get();
-}
-
-inline void WebPageProxy::setCocoaView(WKWebView *view)
-{
-    m_cocoaView = view;
 }
 
 #endif

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebScreenOrientationManagerProxy.h"
+
+#include "APIUIClient.h"
+#include "WebPageProxy.h"
+#include "WebScreenOrientationManagerMessages.h"
+#include "WebScreenOrientationManagerProxyMessages.h"
+#include <WebCore/Exception.h>
+#include <WebCore/ScreenOrientationProvider.h>
+
+namespace WebKit {
+
+WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy(WebPageProxy& page)
+    : m_page(page)
+    , m_provider(WebCore::ScreenOrientationProvider::create())
+{
+    m_page.process().addMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page.webPageID(), *this);
+    platformInitialize();
+}
+
+WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy()
+{
+    m_page.process().removeMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page.webPageID());
+    m_provider->removeObserver(*this);
+    platformDestroy();
+}
+
+void WebScreenOrientationManagerProxy::currentOrientation(CompletionHandler<void(WebCore::ScreenOrientationType)>&& completionHandler)
+{
+    completionHandler(m_provider->currentOrientation());
+}
+
+void WebScreenOrientationManagerProxy::lock(WebCore::ScreenOrientationLockType lockType, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
+{
+    if (!m_page.uiClient().lockScreenOrientation(lockType)) {
+        completionHandler(WebCore::Exception { WebCore::NotSupportedError, "Screen orientation locking is not supported"_s });
+        return;
+    }
+    completionHandler(std::nullopt);
+}
+
+void WebScreenOrientationManagerProxy::unlock()
+{
+    m_page.uiClient().unlockScreenOrientation();
+}
+
+void WebScreenOrientationManagerProxy::screenOrientationDidChange(WebCore::ScreenOrientationType orientation)
+{
+    m_page.send(Messages::WebScreenOrientationManager::OrientationDidChange(orientation));
+}
+
+void WebScreenOrientationManagerProxy::setShouldSendChangeNotification(bool shouldSend)
+{
+    if (shouldSend)
+        m_provider->addObserver(*this);
+    else
+        m_provider->removeObserver(*this);
+}
+
+#if !PLATFORM(IOS_FAMILY)
+void WebScreenOrientationManagerProxy::platformInitialize()
+{
+}
+
+void WebScreenOrientationManagerProxy::platformDestroy()
+{
+}
+#endif
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MessageReceiver.h"
+#include <WebCore/ScreenOrientationLockType.h>
+#include <WebCore/ScreenOrientationProvider.h>
+#include <WebCore/ScreenOrientationType.h>
+#include <wtf/CompletionHandler.h>
+
+#if PLATFORM(IOS_FAMILY)
+#include "WebViewDidMoveToWindowObserver.h"
+OBJC_CLASS UIView;
+#endif
+
+namespace WebCore {
+class Exception;
+}
+
+namespace WebKit {
+
+class WebPageProxy;
+
+class WebScreenOrientationManagerProxy final : public IPC::MessageReceiver, public WebCore::ScreenOrientationProvider::Observer
+#if PLATFORM(IOS_FAMILY)
+    , public WebViewDidMoveToWindowObserver
+#endif
+{
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit WebScreenOrientationManagerProxy(WebPageProxy&);
+    ~WebScreenOrientationManagerProxy();
+
+    // IPC::MessageReceiver
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+
+#if PLATFORM(IOS_FAMILY)
+    void setWindow(UIWindow *);
+#endif
+
+private:
+    void platformInitialize();
+    void platformDestroy();
+
+    // IPC message handlers.
+    void currentOrientation(CompletionHandler<void(WebCore::ScreenOrientationType)>&&);
+    void lock(WebCore::ScreenOrientationLockType, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
+    void unlock();
+    void setShouldSendChangeNotification(bool);
+
+    // WebCore::ScreenOrientationProvider::Observer
+    void screenOrientationDidChange(WebCore::ScreenOrientationType) final;
+
+#if PLATFORM(IOS_FAMILY)
+    // WebViewDidMoveToWindowObserver
+    void webViewDidMoveToWindow() final;
+#endif
+
+    WebPageProxy& m_page;
+    Ref<WebCore::ScreenOrientationProvider> m_provider;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.messages.in
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+messages -> WebScreenOrientationManagerProxy NotRefCounted {
+    CurrentOrientation() -> (enum:uint8_t WebCore::ScreenOrientationType orientation) Synchronous
+    Lock(enum:uint8_t WebCore::ScreenOrientationLockType orientation) -> (std::optional<WebCore::Exception> exception)
+    Unlock()
+    SetShouldSendChangeNotification(bool shouldSend)
+}

--- a/Source/WebKit/UIProcess/ios/WebScreenOrientationManagerProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebScreenOrientationManagerProxyIOS.mm
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY)
+#import "WebScreenOrientationManagerProxy.h"
+
+#import "WKWebView.h"
+#import "WebPageProxy.h"
+
+namespace WebKit {
+
+void WebScreenOrientationManagerProxy::platformInitialize()
+{
+    m_page.addDidMoveToWindowObserver(*this);
+    setWindow([m_page.cocoaView() window]);
+}
+
+void WebScreenOrientationManagerProxy::platformDestroy()
+{
+    m_page.removeDidMoveToWindowObserver(*this);
+}
+
+void WebScreenOrientationManagerProxy::setWindow(UIWindow *window)
+{
+    m_provider->setWindow(window);
+}
+
+void WebScreenOrientationManagerProxy::webViewDidMoveToWindow()
+{
+    setWindow([m_page.cocoaView() window]);
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -921,6 +921,8 @@
 		46C916AA2799D0A2001A4E7C /* WebSharedWorkerServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 46C916A92799D09D001A4E7C /* WebSharedWorkerServer.h */; };
 		46CE3B1123D8C8490016A96A /* WebBackForwardListCounts.h in Headers */ = {isa = PBXBuildFile; fileRef = 46CE3B1023D8C83D0016A96A /* WebBackForwardListCounts.h */; };
 		46D48FCE2799D7E1007D2014 /* WebSharedWorkerServerToContextConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 46D48FCD2799D7DE007D2014 /* WebSharedWorkerServerToContextConnection.h */; };
+		46DC53C328EB3D99005376B0 /* WebScreenOrientationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 46DC53C028EB3D90005376B0 /* WebScreenOrientationManager.h */; };
+		46DC53C728EB3DC8005376B0 /* WebScreenOrientationManagerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 46DC53C628EB3DBE005376B0 /* WebScreenOrientationManagerProxy.h */; };
 		46DF063C1F3905F8001980BB /* NetworkCORSPreflightChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 46DF063A1F3905E5001980BB /* NetworkCORSPreflightChecker.h */; };
 		46EE2849269E04AC00DD48AB /* WebBroadcastChannelRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 46EE2848269E049B00DD48AB /* WebBroadcastChannelRegistry.h */; };
 		46EE284D269E052500DD48AB /* NetworkBroadcastChannelRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 46EE284C269E051700DD48AB /* NetworkBroadcastChannelRegistry.h */; };
@@ -4741,6 +4743,7 @@
 		46AC532425DED81E003B57EC /* GPUProcessConnectionParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GPUProcessConnectionParameters.h; sourceTree = "<group>"; };
 		46B0524422668D2300265B97 /* WebDeviceOrientationAndMotionAccessController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebDeviceOrientationAndMotionAccessController.h; sourceTree = "<group>"; };
 		46B0524522668D2400265B97 /* WebDeviceOrientationAndMotionAccessController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebDeviceOrientationAndMotionAccessController.cpp; sourceTree = "<group>"; };
+		46B2452428ECA335000A5925 /* WebScreenOrientationManagerProxyIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WebScreenOrientationManagerProxyIOS.mm; path = ios/WebScreenOrientationManagerProxyIOS.mm; sourceTree = "<group>"; };
 		46C392282316EC4D008EED9B /* WebPageProxyIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebPageProxyIdentifier.h; sourceTree = "<group>"; };
 		46C5B7CB27AADDBE000C5B47 /* RemoteWorkerLibWebRTCProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteWorkerLibWebRTCProvider.h; sourceTree = "<group>"; };
 		46C5B7CC27AADDBE000C5B47 /* RemoteWorkerFrameLoaderClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteWorkerFrameLoaderClient.cpp; sourceTree = "<group>"; };
@@ -4751,6 +4754,12 @@
 		46D48FCC2799D7DD007D2014 /* WebSharedWorkerServerToContextConnection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSharedWorkerServerToContextConnection.cpp; sourceTree = "<group>"; };
 		46D48FCD2799D7DE007D2014 /* WebSharedWorkerServerToContextConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebSharedWorkerServerToContextConnection.h; sourceTree = "<group>"; };
 		46DA285727B73E760089D339 /* WebGeolocationManagerProxyCocoa.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebGeolocationManagerProxyCocoa.cpp; sourceTree = "<group>"; };
+		46DC53C028EB3D90005376B0 /* WebScreenOrientationManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebScreenOrientationManager.h; sourceTree = "<group>"; };
+		46DC53C128EB3D90005376B0 /* WebScreenOrientationManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebScreenOrientationManager.cpp; sourceTree = "<group>"; };
+		46DC53C228EB3D90005376B0 /* WebScreenOrientationManager.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebScreenOrientationManager.messages.in; sourceTree = "<group>"; };
+		46DC53C428EB3DBE005376B0 /* WebScreenOrientationManagerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebScreenOrientationManagerProxy.cpp; sourceTree = "<group>"; };
+		46DC53C528EB3DBE005376B0 /* WebScreenOrientationManagerProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebScreenOrientationManagerProxy.messages.in; sourceTree = "<group>"; };
+		46DC53C628EB3DBE005376B0 /* WebScreenOrientationManagerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebScreenOrientationManagerProxy.h; sourceTree = "<group>"; };
 		46DF06391F3905E5001980BB /* NetworkCORSPreflightChecker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkCORSPreflightChecker.cpp; sourceTree = "<group>"; };
 		46DF063A1F3905E5001980BB /* NetworkCORSPreflightChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkCORSPreflightChecker.h; sourceTree = "<group>"; };
 		46E9760A2757F6C900ACDD37 /* WebBroadcastChannelRegistry.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebBroadcastChannelRegistry.messages.in; sourceTree = "<group>"; };
@@ -9466,6 +9475,7 @@
 				E3866AE42397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm */,
 				2DA944AB1884E9BA00ED86DB /* WebPageProxyIOS.mm */,
 				2DA944AC1884E9BA00ED86DB /* WebProcessProxyIOS.mm */,
+				46B2452428ECA335000A5925 /* WebScreenOrientationManagerProxyIOS.mm */,
 				0FCB4E3818BBE044000FCFC9 /* WKActionSheet.h */,
 				0FCB4E3918BBE044000FCFC9 /* WKActionSheet.mm */,
 				0FCB4E3A18BBE044000FCFC9 /* WKActionSheetAssistant.h */,
@@ -11780,6 +11790,9 @@
 				1A1E093218861D3800D2DC49 /* WebProgressTrackerClient.h */,
 				4671FF1E23217EFF001B64C7 /* WebResourceLoadObserver.cpp */,
 				4671FF1D23217EFF001B64C7 /* WebResourceLoadObserver.h */,
+				46DC53C128EB3D90005376B0 /* WebScreenOrientationManager.cpp */,
+				46DC53C028EB3D90005376B0 /* WebScreenOrientationManager.h */,
+				46DC53C228EB3D90005376B0 /* WebScreenOrientationManager.messages.in */,
 				D3B9484411FF4B6500032B39 /* WebSearchPopupMenu.cpp */,
 				D3B9484511FF4B6500032B39 /* WebSearchPopupMenu.h */,
 				93D6B767254B7BC60058DD3A /* WebSpeechRecognitionConnection.cpp */,
@@ -12061,6 +12074,9 @@
 				BC111B0D112F5E4F00337BAB /* WebProcessProxy.cpp */,
 				BC032DCF10F4389F0058C15A /* WebProcessProxy.h */,
 				BCEE7AB312817095009827DA /* WebProcessProxy.messages.in */,
+				46DC53C428EB3DBE005376B0 /* WebScreenOrientationManagerProxy.cpp */,
+				46DC53C628EB3DBE005376B0 /* WebScreenOrientationManagerProxy.h */,
+				46DC53C528EB3DBE005376B0 /* WebScreenOrientationManagerProxy.messages.in */,
 				51D124241E6D3CC3002B2820 /* WebURLSchemeHandler.cpp */,
 				51D124251E6D3CC3002B2820 /* WebURLSchemeHandler.h */,
 				51E8B68D1E712873001B7132 /* WebURLSchemeTask.cpp */,
@@ -15249,6 +15265,8 @@
 				DDA0A36827E55E4F005E086E /* WebResourcePrivate.h in Headers */,
 				413075B01DE85F580039EC69 /* WebRTCMonitor.h in Headers */,
 				41FAF5F51E3C0649001AE678 /* WebRTCResolver.h in Headers */,
+				46DC53C328EB3D99005376B0 /* WebScreenOrientationManager.h in Headers */,
+				46DC53C728EB3DC8005376B0 /* WebScreenOrientationManagerProxy.h in Headers */,
 				DDA0A2C127E55E4E005E086E /* WebScriptDebugDelegate.h in Headers */,
 				7C361D731927FA360036A59D /* WebScriptMessageHandler.h in Headers */,
 				DDA0A38127E561C4005E086E /* WebScriptObject.h in Headers */,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebScreenOrientationManager.h"
+
+#include "WebProcess.h"
+#include "WebScreenOrientationManagerMessages.h"
+#include "WebScreenOrientationManagerProxyMessages.h"
+
+namespace WebKit {
+
+WebScreenOrientationManager::WebScreenOrientationManager(WebPage& page)
+    : m_page(page)
+{
+    WebProcess::singleton().addMessageReceiver(Messages::WebScreenOrientationManager::messageReceiverName(), m_page.identifier(), *this);
+}
+
+WebScreenOrientationManager::~WebScreenOrientationManager()
+{
+    WebProcess::singleton().removeMessageReceiver(Messages::WebScreenOrientationManager::messageReceiverName(), m_page.identifier());
+}
+
+WebCore::ScreenOrientationType WebScreenOrientationManager::currentOrientation()
+{
+    if (m_currentOrientation)
+        return *m_currentOrientation;
+
+    auto sendResult = m_page.sendSync(Messages::WebScreenOrientationManagerProxy::CurrentOrientation { });
+    auto [currentOrientation] = sendResult.takeReplyOr(WebCore::ScreenOrientationType::PortraitPrimary);
+    if (!m_observers.computesEmpty())
+        m_currentOrientation = currentOrientation;
+    return currentOrientation;
+}
+
+void WebScreenOrientationManager::orientationDidChange(WebCore::ScreenOrientationType orientation)
+{
+    m_currentOrientation = orientation;
+    for (auto& observer : m_observers)
+        observer.screenOrientationDidChange(orientation);
+}
+
+void WebScreenOrientationManager::lock(WebCore::ScreenOrientationLockType lockType, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
+{
+    m_page.sendWithAsyncReply(Messages::WebScreenOrientationManagerProxy::Lock { lockType }, WTFMove(completionHandler));
+}
+
+void WebScreenOrientationManager::unlock()
+{
+    m_page.send(Messages::WebScreenOrientationManagerProxy::Unlock { });
+}
+
+void WebScreenOrientationManager::addObserver(Observer& observer)
+{
+    bool wasEmpty = m_observers.computesEmpty();
+    m_observers.add(observer);
+    if (wasEmpty)
+        m_page.send(Messages::WebScreenOrientationManagerProxy::SetShouldSendChangeNotification { true });
+}
+
+void WebScreenOrientationManager::removeObserver(Observer& observer)
+{
+    m_observers.remove(observer);
+    if (m_observers.computesEmpty()) {
+        m_currentOrientation = std::nullopt;
+        m_page.send(Messages::WebScreenOrientationManagerProxy::SetShouldSendChangeNotification { false });
+    }
+}
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MessageReceiver.h"
+#include <WebCore/ScreenOrientationManager.h>
+#include <wtf/WeakHashSet.h>
+
+namespace WebKit {
+
+class WebPage;
+
+class WebScreenOrientationManager final : public WebCore::ScreenOrientationManager, public IPC::MessageReceiver {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit WebScreenOrientationManager(WebPage&);
+    ~WebScreenOrientationManager();
+
+    // IPC::MessageReceiver
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+
+private:
+    void orientationDidChange(WebCore::ScreenOrientationType);
+
+    // ScreenOrientationManager
+    WebCore::ScreenOrientationType currentOrientation() final;
+    void lock(WebCore::ScreenOrientationLockType, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&) final;
+    void unlock() final;
+    void addObserver(Observer&) final;
+    void removeObserver(Observer&) final;
+
+    WebPage& m_page;
+    WeakHashSet<Observer> m_observers;
+    mutable std::optional<WebCore::ScreenOrientationType> m_currentOrientation;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.messages.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.messages.in
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+messages -> WebScreenOrientationManager NotRefCounted {
+    OrientationDidChange(enum:uint8_t WebCore::ScreenOrientationType orientation)
+}

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -131,6 +131,7 @@
 #include "WebProcessPoolMessages.h"
 #include "WebProcessProxyMessages.h"
 #include "WebProgressTrackerClient.h"
+#include "WebScreenOrientationManager.h"
 #include "WebServiceWorkerProvider.h"
 #include "WebSocketProvider.h"
 #include "WebSpeechRecognitionProvider.h"
@@ -534,6 +535,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     , m_foundTextRangeController(makeUniqueRef<WebFoundTextRangeController>(*this))
     , m_inspectorTargetController(makeUnique<WebPageInspectorTargetController>(*this))
     , m_userContentController(WebUserContentController::getOrCreate(parameters.userContentControllerParameters.identifier))
+    , m_screenOrientationManager(makeUniqueRef<WebScreenOrientationManager>(*this))
 #if ENABLE(GEOLOCATION)
     , m_geolocationPermissionRequestManager(makeUniqueRef<GeolocationPermissionRequestManager>(*this))
 #endif
@@ -622,6 +624,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 
     pageConfiguration.diagnosticLoggingClient = makeUnique<WebDiagnosticLoggingClient>(*this);
     pageConfiguration.performanceLoggingClient = makeUnique<WebPerformanceLoggingClient>(*this);
+    pageConfiguration.screenOrientationManager = m_screenOrientationManager.get();
 
 #if ENABLE(WEBGL)
     pageConfiguration.webGLStateTracker = makeUnique<WebGLStateTracker>([this](bool isUsingHighPerformanceWebGL) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -322,6 +322,7 @@ class WebPageOverlay;
 class WebPaymentCoordinator;
 class WebPopupMenu;
 class WebRemoteObjectRegistry;
+class WebScreenOrientationManager;
 class WebTouchEvent;
 class WebURLSchemeHandlerProxy;
 class WebUndoStep;
@@ -2210,6 +2211,7 @@ private:
     RefPtr<NotificationPermissionRequestManager> m_notificationPermissionRequestManager;
 
     Ref<WebUserContentController> m_userContentController;
+    UniqueRef<WebScreenOrientationManager> m_screenOrientationManager;
 
 #if ENABLE(GEOLOCATION)
     UniqueRef<GeolocationPermissionRequestManager> m_geolocationPermissionRequestManager;


### PR DESCRIPTION
#### c9b695e3635533e21568064262dc1bca261c51ae
<pre>
[iOS][WK2] Add initial implementation for the Screen Orientation API
<a href="https://bugs.webkit.org/show_bug.cgi?id=245999">https://bugs.webkit.org/show_bug.cgi?id=245999</a>

Reviewed by Wenson Hsieh.

Add initial implementation for the Screen Orientation API on WebKit2 / iOS:
- <a href="https://w3c.github.io/screen-orientation/#dom-screenorientation-type">https://w3c.github.io/screen-orientation/#dom-screenorientation-type</a>
- <a href="https://w3c.github.io/screen-orientation/#angle-attribute-get-orientation-angle">https://w3c.github.io/screen-orientation/#angle-attribute-get-orientation-angle</a>
- <a href="https://w3c.github.io/screen-orientation/#Screen-orientation-change">https://w3c.github.io/screen-orientation/#Screen-orientation-change</a>

I tested manually on device that the API is working as intended.

The feature is still behind an experimental feature flag, off by defaut.

Things that are missing and will be implemented in a follow-up:
- Test harness changes for automated testing
- Pre-conditions for locking / unlocking (e.g. user gesture, full screen)

* Source/WebCore/Headers.cmake:
* Source/WebCore/PAL/pal/ios/UIKitSoftLink.h:
* Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm:
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Exception.h:
(WebCore::Exception::encode const):
(WebCore::Exception::decode):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::Page):
(WebCore::Page::screenOrientationManager const):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageConfiguration.cpp:
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::ScreenOrientation::ScreenOrientation):
(WebCore::ScreenOrientation::~ScreenOrientation):
(WebCore::ScreenOrientation::manager const):
(WebCore::ScreenOrientation::lock):
(WebCore::ScreenOrientation::unlock):
(WebCore::ScreenOrientation::type const):
(WebCore::ScreenOrientation::angle const):
(WebCore::ScreenOrientation::visibilityStateChanged):
(WebCore::ScreenOrientation::shouldListenForChangeNotification const):
(WebCore::ScreenOrientation::screenOrientationDidChange):
(WebCore::ScreenOrientation::suspend):
(WebCore::ScreenOrientation::resume):
(WebCore::ScreenOrientation::stop):
* Source/WebCore/page/ScreenOrientation.h:
* Source/WebCore/page/ScreenOrientationLockType.h:
* Source/WebCore/page/ScreenOrientationType.h:
* Source/WebCore/platform/ScreenOrientationManager.h: Copied from Source/WebCore/page/ScreenOrientationLockType.h.
(WebCore::ScreenOrientationManager::~ScreenOrientationManager):
(WebCore::ScreenOrientationManager::Observer::~Observer):
* Source/WebCore/platform/ScreenOrientationProvider.cpp: Added.
(WebCore::globalProvider):
(WebCore::ScreenOrientationProvider::getOrCreate):
(WebCore::ScreenOrientationProvider::~ScreenOrientationProvider):
(WebCore::ScreenOrientationProvider::addObserver):
(WebCore::ScreenOrientationProvider::removeObserver):
(WebCore::ScreenOrientationProvider::screenOrientationDidChange):
(WebCore::ScreenOrientationProvider::currentOrientation):
(WebCore::ScreenOrientationProvider::platformCurrentOrientation):
(WebCore::ScreenOrientationProvider::platformStartListeningForChanges):
(WebCore::ScreenOrientationProvider::platformStopListeningForChanges):
(WebCore::ScreenOrientationProvider::platformDestroy):
* Source/WebCore/platform/ScreenOrientationProvider.h: Copied from Source/WebCore/page/ScreenOrientation.h.
(WebCore::ScreenOrientationProvider::Observer::~Observer):
* Source/WebCore/platform/ios/ScreenOrientationProviderIOS.mm: Added.
(currentOrientationFromCurrentUIDevice):
(-[WebScreenOrientationObserver initWithProvider:]):
(-[WebScreenOrientationObserver dealloc]):
(-[WebScreenOrientationObserver _screenOrientationDidChange]):
(WebCore::ScreenOrientationProvider::platformCurrentOrientation):
(WebCore::ScreenOrientationProvider::platformStartListeningForChanges):
(WebCore::ScreenOrientationProvider::platformStopListeningForChanges):
(WebCore::ScreenOrientationProvider::platformDestroy):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.cpp:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didAttachToRunningProcess):
(WebKit::WebPageProxy::resetState):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp: Added.
(WebKit::WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy):
(WebKit::WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy):
(WebKit::WebScreenOrientationManagerProxy::currentOrientation):
(WebKit::WebScreenOrientationManagerProxy::lock):
(WebKit::WebScreenOrientationManagerProxy::unlock):
(WebKit::WebScreenOrientationManagerProxy::screenOrientationDidChange):
(WebKit::WebScreenOrientationManagerProxy::setShouldSendChangeNotification):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h: Copied from Source/WebCore/page/ScreenOrientation.h.
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.messages.in: Copied from Source/WebCore/page/ScreenOrientationType.h.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp: Added.
(WebKit::WebScreenOrientationManager::WebScreenOrientationManager):
(WebKit::WebScreenOrientationManager::~WebScreenOrientationManager):
(WebKit::WebScreenOrientationManager::currentOrientation):
(WebKit::WebScreenOrientationManager::orientationDidChange):
(WebKit::WebScreenOrientationManager::lock):
(WebKit::WebScreenOrientationManager::unlock):
(WebKit::WebScreenOrientationManager::addObserver):
(WebKit::WebScreenOrientationManager::removeObserver):
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h: Copied from Source/WebCore/page/ScreenOrientationLockType.h.
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.messages.in: Copied from Source/WebCore/page/ScreenOrientationType.h.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/255155@main">https://commits.webkit.org/255155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11e102d07c8ff324907b965110703589291c1b3e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101250 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161297 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/692 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83866 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97601 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/432 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27387 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82356 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70426 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35658 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33434 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17139 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3581 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37249 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36256 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->