### PR TITLE
Make ResizeObserver and IntersectionObserver timing match other browsers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/ordering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/ordering-expected.txt
@@ -1,0 +1,3 @@
+
+PASS ResizeObserver and IntersectionObserver ordering
+

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/ordering.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/ordering.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<title>ResizeObserver and IntersectionObserver ordering</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  async_test(function(t) {
+    let sawResize = false;
+    let sawIo = false;
+    let resizeObserver = new ResizeObserver(t.step_func(function() {
+      assert_false(sawIo, "ResizeObserver notification should be delivered before IntersectionObserver notification");
+      sawResize = true;
+      resizeObserver.disconnect();
+    }));
+
+    let io = new IntersectionObserver(t.step_func_done(function() {
+      assert_true(sawResize, "IntersectionObserver notification should be delivered after ResizeObserver notification");
+      sawIo = true;
+      io.disconnect();
+    }));
+
+    resizeObserver.observe(document.documentElement);
+    io.observe(document.documentElement);
+  });
+</script>
+  

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1688,12 +1688,12 @@ void Page::updateRendering()
 
     layoutIfNeeded();
 
-    runProcessingStep(RenderingUpdateStep::IntersectionObservations, [] (Document& document) {
-        document.updateIntersectionObservations();
-    });
-
     runProcessingStep(RenderingUpdateStep::ResizeObservations, [&] (Document& document) {
         document.updateResizeObservations(*this);
+    });
+
+    runProcessingStep(RenderingUpdateStep::IntersectionObservations, [] (Document& document) {
+        document.updateIntersectionObservations();
     });
 
     runProcessingStep(RenderingUpdateStep::Images, [] (Document& document) {


### PR DESCRIPTION
#### 565a28303653d49dcb47855db613dcdbcf9519be
<pre>
Make ResizeObserver and IntersectionObserver timing match other browsers
<a href="https://bugs.webkit.org/show_bug.cgi?id=245946">https://bugs.webkit.org/show_bug.cgi?id=245946</a>

Reviewed by Simon Fraser.

Run IntersectionObservers after ResizeObservers to match Blink and Gecko.

Imported the test from <a href="https://github.com/web-platform-tests/wpt/pull/36216">https://github.com/web-platform-tests/wpt/pull/36216</a>

* LayoutTests/imported/w3c/web-platform-tests/resize-observer/ordering-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/ordering.html: Added.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):

Canonical link: <a href="https://commits.webkit.org/255132@main">https://commits.webkit.org/255132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6e499547f804e60de5120b549491545eb004362

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101139 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161120 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/475 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83759 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97508 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/351 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78126 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27309 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82276 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/81933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70340 "Updated gtk dependencies (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35548 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15959 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33333 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17049 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37133 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39845 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1589 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36161 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->