### PR TITLE
WTF::ThreadAssertion is not useful as most of the code is run with a WorkQueue

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		7A6EBA3420746C34004F9C44 /* MachSendRight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A6EBA3320746C34004F9C44 /* MachSendRight.cpp */; };
 		7AF023B52061E17000A8EFD6 /* ProcessPrivilege.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AF023B42061E16F00A8EFD6 /* ProcessPrivilege.cpp */; };
 		7AFEC6B11EB22B5900DADE36 /* UUID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AFEC6B01EB22B5900DADE36 /* UUID.cpp */; };
+		7B0A23E828EC2C3B00F6625E /* CapabilityIsCurrent.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B0A23E728EC2C3B00F6625E /* CapabilityIsCurrent.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8134013815B092FD001FF0B8 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8134013615B092FD001FF0B8 /* Base64.cpp */; };
 		8348BA0E21FBC0D500FD3054 /* ObjectIdentifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8348BA0D21FBC0D400FD3054 /* ObjectIdentifier.cpp */; };
 		93853DD328755A6C00FF4E2B /* EscapedFormsForJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 93853DD228755A6600FF4E2B /* EscapedFormsForJSON.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1174,6 +1175,7 @@
 		7AF023B42061E16F00A8EFD6 /* ProcessPrivilege.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProcessPrivilege.cpp; sourceTree = "<group>"; };
 		7AFEC6AE1EB22AC600DADE36 /* UUID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UUID.h; sourceTree = "<group>"; };
 		7AFEC6B01EB22B5900DADE36 /* UUID.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UUID.cpp; sourceTree = "<group>"; };
+		7B0A23E728EC2C3B00F6625E /* CapabilityIsCurrent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CapabilityIsCurrent.h; sourceTree = "<group>"; };
 		7B2739DC2624DAAA0040F182 /* ThreadSafetyAnalysis.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadSafetyAnalysis.h; sourceTree = "<group>"; };
 		7B2739F12632A8940040F182 /* ThreadAssertions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadAssertions.h; sourceTree = "<group>"; };
 		7C137941222326C700D7A824 /* AUTHORS */ = {isa = PBXFileReference; lastKnownFileType = text; path = AUTHORS; sourceTree = "<group>"; };
@@ -1948,6 +1950,7 @@
 				0F5F3D681F3FEBA600B115A2 /* CagedUniquePtr.h */,
 				413FE8F51F8D2EAB00F6D7D7 /* CallbackAggregator.h */,
 				46209A27266D543A007F8F4A /* CancellableTask.h */,
+				7B0A23E728EC2C3B00F6625E /* CapabilityIsCurrent.h */,
 				A8A4726A151A825A004123FF /* CheckedArithmetic.h */,
 				A8A4726B151A825A004123FF /* CheckedBoolean.h */,
 				9BB91F512648EA4D00A56217 /* CheckedPtr.h */,
@@ -2880,6 +2883,7 @@
 				DD3DC95527A4BF8E007E5B61 /* CagedUniquePtr.h in Headers */,
 				DD3DC8E927A4BF8E007E5B61 /* CallbackAggregator.h in Headers */,
 				DD3DC99B27A4BF8E007E5B61 /* CancellableTask.h in Headers */,
+				7B0A23E828EC2C3B00F6625E /* CapabilityIsCurrent.h in Headers */,
 				DDF306DA27C08654006A526F /* CFBundleSPI.h in Headers */,
 				63F9BED42898D96400371416 /* CFPrivSPI.h in Headers */,
 				DDF306D927C08654006A526F /* CFRunLoopSPI.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -29,6 +29,7 @@ set(WTF_PUBLIC_HEADERS
     CagedUniquePtr.h
     CallbackAggregator.h
     CancellableTask.h
+    CapabilityIsCurrent.h
     CheckedArithmetic.h
     CheckedBoolean.h
     CheckedPtr.h

--- a/Source/WTF/wtf/CapabilityIsCurrent.h
+++ b/Source/WTF/wtf/CapabilityIsCurrent.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ThreadSafetyAnalysis.h>
+
+// Functions implementing "is current" capability, declared by WTF_CAPABILITY("is current").
+
+namespace WTF {
+
+class IsCurrentAssertion;
+
+// Class to inherit when creating a new "threadlike sequence" type, a type that can be current.
+class ImplementsIsCurrent {
+protected:
+    static std::atomic<uint32_t> s_sequenceID;
+    static IsCurrentAssertion createIsCurrentAssertion(uint32_t sequenceID);
+    friend class IsCurrentAssertion;
+};
+
+// A type to use for asserting that private member functions or private member variables
+// of a class are accessed from correct threads and work queues.
+// Supports run-time checking with assertion enabled builds.
+// Supports compile-time declaration and checking.
+// Example:
+// struct MyClass {
+//     void doTask() { assertIsCurrent(m_ownerThread); doTaskImpl(); }
+//     template<typename> void doTaskCompileFailure() { doTaskImpl(); }
+// private:
+//     void doTaskImpl() WTF_REQUIRES_CAPABILITY(m_ownerThread);
+//     int m_value WTF_GUARDED_BY_CAPABILITY(m_ownerThread) { 0 };
+//     NO_UNIQUE_ADDRESS IsCurrentAssertion m_ownerThread;
+// };
+class WTF_CAPABILITY("is current") IsCurrentAssertion {
+public:
+    IsCurrentAssertion() = default;
+    enum UninitializedTag { Uninitialized };
+    constexpr IsCurrentAssertion(UninitializedTag)
+        : IsCurrentAssertion { 0 }
+    {
+    }
+    ~IsCurrentAssertion() { assertIsCurrent(*this); }
+    void reset() { *this = IsCurrentAssertion { }; }
+private:
+    explicit constexpr IsCurrentAssertion(uint32_t sequenceID)
+#if ASSERT_ENABLED
+        : m_uid(sequenceID)
+#endif
+    {
+#if !ASSERT_ENABLED
+        UNUSED_PARAM(sequenceID);
+#endif
+    }
+    // Returns unique id for current work queue or thread.
+    // Return value is never 0.
+    WTF_EXPORT_PRIVATE static uint32_t currentExecutionSequenceID();
+
+#if ASSERT_ENABLED
+    uint32_t m_uid { currentExecutionSequenceID() };
+#endif
+
+    friend void assertIsCurrent(const IsCurrentAssertion&);
+    friend class ImplementsIsCurrent;
+};
+
+inline void assertIsCurrent(const IsCurrentAssertion& assertion) WTF_ASSERTS_ACQUIRED_CAPABILITY(assertion)
+{
+    ASSERT_UNUSED(assertion, IsCurrentAssertion { }.m_uid == assertion.m_uid);
+}
+
+inline IsCurrentAssertion ImplementsIsCurrent::createIsCurrentAssertion(uint32_t sequenceID)
+{
+    return IsCurrentAssertion { sequenceID };
+}
+
+}
+
+using WTF::ImplementsIsCurrent;
+using WTF::IsCurrentAssertion;
+using WTF::assertIsCurrent;

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -124,7 +124,16 @@ static std::optional<size_t> stackSize(ThreadType threadType)
 #endif
 }
 
-std::atomic<uint32_t> Thread::s_uid { 0 };
+std::atomic<uint32_t> ImplementsIsCurrent::s_sequenceID;
+
+uint32_t IsCurrentAssertion::currentExecutionSequenceID()
+{
+#if PLATFORM(COCOA)
+    if (uint32_t uid = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(dispatch_get_specific(&ImplementsIsCurrent::s_sequenceID))))
+        return uid;
+#endif
+    return Thread::current().uid();
+}
 
 struct Thread::NewThreadContext : public ThreadSafeRefCounted<NewThreadContext> {
 public:

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -33,6 +33,7 @@
 #include <mutex>
 #include <stdint.h>
 #include <wtf/Atomics.h>
+#include <wtf/CapabilityIsCurrent.h>
 #include <wtf/Expected.h>
 #include <wtf/FastTLS.h>
 #include <wtf/Function.h>
@@ -45,7 +46,6 @@
 #include <wtf/StackBounds.h>
 #include <wtf/StackStats.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/ThreadSafetyAnalysis.h>
 #include <wtf/Vector.h>
 #include <wtf/WordLock.h>
 #include <wtf/text/AtomStringTable.h>
@@ -77,6 +77,7 @@ enum class ThreadGroupAddResult;
 
 class ThreadGroup;
 class PrintStream;
+class WorkQueue;
 
 WTF_EXPORT_PRIVATE void initialize();
 
@@ -103,8 +104,7 @@ public:
     WTF_EXPORT_PRIVATE ~ThreadSuspendLocker();
 };
 
-class WTF_CAPABILITY("is current") Thread : public ThreadSafeRefCounted<Thread> {
-    static std::atomic<uint32_t> s_uid;
+class WTF_CAPABILITY("is current") Thread : public ThreadSafeRefCounted<Thread>, ImplementsIsCurrent {
 public:
     friend class ThreadGroup;
     friend WTF_EXPORT_PRIVATE void initialize();
@@ -277,8 +277,10 @@ public:
 
     struct NewThreadContext;
     static void entryPoint(NewThreadContext*);
+
+    IsCurrentAssertion isCurrentAssertion() const { return createIsCurrentAssertion(m_uid); }
 protected:
-    Thread();
+    Thread() = default;
 
     void initializeInThread();
 
@@ -369,7 +371,7 @@ protected:
     StackBounds m_stack { StackBounds::emptyBounds() };
     HashMap<ThreadGroup*, std::weak_ptr<ThreadGroup>> m_threadGroupMap;
     PlatformThreadHandle m_handle;
-    uint32_t m_uid;
+    uint32_t m_uid { ++s_sequenceID };
 #if OS(WINDOWS)
     ThreadIdentifier m_id { 0 };
 #elif OS(DARWIN)
@@ -398,11 +400,6 @@ public:
     void* m_apiData { nullptr };
     RefPtr<ClientData> m_clientData { nullptr };
 };
-
-inline Thread::Thread()
-    : m_uid(++s_uid)
-{
-}
 
 #if !OS(WINDOWS)
 inline Thread* Thread::currentMayBeNull()
@@ -435,11 +432,7 @@ inline Thread& Thread::current()
 
 inline void assertIsCurrent(const Thread& thread) WTF_ASSERTS_ACQUIRED_CAPABILITY(thread)
 {
-#if ASSERT_ENABLED
-    ASSERT(&thread == &Thread::current());
-#else
-    UNUSED_PARAM(thread);
-#endif
+    assertIsCurrent(thread.isCurrentAssertion());
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
@@ -86,6 +86,13 @@ void WorkQueueBase::platformInitialize(const char* name, Type type, QOS qos)
     attr = dispatch_queue_attr_make_with_qos_class(attr, Thread::dispatchQOSClass(qos), 0);
     m_dispatchQueue = adoptOSObject(dispatch_queue_create(name, attr));
     dispatch_set_context(m_dispatchQueue.get(), this);
+#if ASSERT_ENABLED
+    // We use &s_sequenceID for the key, since it's convenient. Dispatch does not dereference it.
+    // We use s_sequenceID to generate the id so that WorkQueues and Threads share the id namespace.
+    // This makes it possible to assert that code runs in the expected sequence, regardless of if it is
+    // in a thread or a work queue.
+    dispatch_queue_set_specific(m_dispatchQueue.get(), &s_sequenceID, reinterpret_cast<void*>(static_cast<uintptr_t>(++s_sequenceID)), nullptr);
+#endif
 }
 
 void WorkQueueBase::platformInvalidate()
@@ -95,6 +102,7 @@ void WorkQueueBase::platformInvalidate()
 WorkQueue::WorkQueue(OSObjectPtr<dispatch_queue_t>&& queue)
     : WorkQueueBase(WTFMove(queue))
 {
+    // Note: for main work queue we do not create a sequence id, the main thread id will be used.
 }
 
 Ref<WorkQueue> WorkQueue::constructMainWorkQueue()
@@ -103,9 +111,12 @@ Ref<WorkQueue> WorkQueue::constructMainWorkQueue()
 }
 
 #if ASSERT_ENABLED
-void WorkQueue::assertIsCurrent() const
+IsCurrentAssertion WorkQueue::isCurrentAssertion() const
 {
-    dispatch_assert_queue(m_dispatchQueue.get());
+    auto sequenceID = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(dispatch_queue_get_specific(m_dispatchQueue.get(), &s_sequenceID)));
+    if (!sequenceID)
+        sequenceID =  Thread::current().uid(); // Main thread sequence id.
+    return createIsCurrentAssertion(sequenceID);
 }
 #endif
 

--- a/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
+++ b/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
@@ -63,6 +63,13 @@ void WorkQueueBase::platformInvalidate()
     }
 }
 
+#if ASSERT_ENABLED
+IsCurrentAssertion WorkQueueBase::isCurrentAssertion() const
+{
+    return createIsCurrentAssertion(m_threadID);
+}
+#endif
+
 void WorkQueueBase::dispatch(Function<void()>&& function)
 {
     m_runLoop->dispatch([protectedThis = Ref { *this }, function = WTFMove(function)] {
@@ -86,12 +93,5 @@ Ref<WorkQueue> WorkQueue::constructMainWorkQueue()
 {
     return adoptRef(*new WorkQueue(RunLoop::main()));
 }
-
-#if ASSERT_ENABLED
-void WorkQueue::assertIsCurrent() const
-{
-    ASSERT(m_threadID == Thread::current().uid());
-}
-#endif
 
 }

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -34,8 +34,8 @@
 #include "SampleBufferDisplayLayerIdentifier.h"
 #include "SharedVideoFrame.h"
 #include <WebCore/SampleBufferDisplayLayer.h>
+#include <wtf/CapabilityIsCurrent.h>
 #include <wtf/MediaTime.h>
-#include <wtf/ThreadAssertions.h>
 
 namespace WebCore {
 class ImageTransferSessionVT;
@@ -95,8 +95,7 @@ private:
     std::unique_ptr<WebCore::LocalSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
     std::unique_ptr<LayerHostingContext> m_layerHostingContext;
     SharedVideoFrameReader m_sharedVideoFrameReader;
-    ThreadAssertion m_consumeThread NO_UNIQUE_ADDRESS;
-
+    NO_UNIQUE_ADDRESS IsCurrentAssertion m_consumeThread;
 };
 
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/ThreadAssertionsTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/ThreadAssertionsTest.cpp
@@ -48,7 +48,7 @@ public:
 private:
     int doTaskImpl(int n) WTF_REQUIRES_CAPABILITY(m_ownerThread) { return n + 1; }
     int m_value WTF_GUARDED_BY_CAPABILITY(m_ownerThread) { 0 };
-    NO_UNIQUE_ADDRESS ThreadAssertion m_ownerThread;
+    NO_UNIQUE_ADDRESS IsCurrentAssertion m_ownerThread;
 };
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/WorkQueue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WorkQueue.cpp
@@ -28,6 +28,7 @@
 #include "Test.h"
 #include <wtf/Condition.h>
 #include <wtf/Lock.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 #include <wtf/WorkQueue.h>
 #include <memory>
@@ -277,24 +278,25 @@ TEST(WTF_WorkQueue, DispatchSync)
 
 // Tests that the Function passed to WorkQueue::dispatch is destructed on the thread that
 // runs the Function. It is a common pattern to capture a owning reference into a Function
-// and dispatch that to a queue to ensure ordering (or thread affinity) of the object destruction.
+// and dispatch that to a queue to ensure ordering or work queue affinity of the object destruction.
 TEST(WTF_WorkQueue, DestroyDispatchedOnDispatchQueue)
 {
     std::atomic<size_t> counter = 0;
     class DestructionWorkQueueTester {
+        WTF_MAKE_FAST_ALLOCATED;
     public:
-        DestructionWorkQueueTester(std::atomic<size_t>& counter)
+        DestructionWorkQueueTester(std::atomic<size_t>& counter, WorkQueue& queue)
             : m_counter(counter)
+            , m_ownerAssertion(queue.isCurrentAssertion()) // Queue is not yet current, but we expect it to be the time destructor runs.
         {
         }
         ~DestructionWorkQueueTester()
         {
-            EXPECT_NE(m_createdInThread, Thread::current().uid());
             m_counter++;
         }
     private:
-        uint32_t m_createdInThread = Thread::current().uid();
         std::atomic<size_t>& m_counter;
+        NO_UNIQUE_ADDRESS IsCurrentAssertion m_ownerAssertion;
     };
     constexpr size_t queueCount = 50;
     constexpr size_t iterationCount = 10000;
@@ -304,7 +306,8 @@ TEST(WTF_WorkQueue, DestroyDispatchedOnDispatchQueue)
 
     for (size_t i = 0; i < iterationCount; ++i) {
         for (size_t j = 0; j < queueCount; ++j)
-            queue[j]->dispatch([instance = std::make_unique<DestructionWorkQueueTester>(counter)]() { }); // NOLINT
+            queue[j]->dispatch([instance = makeUnique<DestructionWorkQueueTester>(counter, *queue[j])]() {
+            });
     }
     for (size_t j = 0; j < queueCount; ++j)
         queue[j]->dispatchSync([] { });


### PR DESCRIPTION
#### ba1341c6f2ef258fbf7b50ede0606106d9d2917a
<pre>
WTF::ThreadAssertion is not useful as most of the code is run with a WorkQueue
<a href="https://bugs.webkit.org/show_bug.cgi?id=237026">https://bugs.webkit.org/show_bug.cgi?id=237026</a>
rdar://problem/89608226

Reviewed by NOBODY (OOPS!).

Rename ThreadAssertion to IsCurrentAssertion, and assert that if the assertion is created in a WorkQueue,
the assertion checks for the work queue. If it is created on a Thread, it checks for that.

Implement for non-Cocoa by just using thread id for the sequence id. All WorkQueues have unique threads
and all Threads have unique ids. This means WorkQueues can be distinquished from Threads without WorkQueues.

Implement for Cocoa by using the same uid id namespace for WorkQueues as Threads have. Store the uid
in a Dispatch dispatch queue specific field. If the code is not running in Dispatch, return the current
thread uid. Since the uid namespace is the same, WorkQueues can be distinuished from Threads without WorkQueues.

In both cases, non-WebKit platform threads get also a Thread, so they&apos;re distinquished from WorkQueues.

Currently it is common in WebKit code to use a pattern of:
ASSERT(RunLoop::isMain()) -- This is not run in a work queue or a specific thread
ASSERT(!RunLoop::isMain()) -- This is run in a specific thread, but because we use WorkQueues,
we cannot actually assert the specific thread.

This pattern could be for example used to assert that object is created and destroyed in
correct thread.

After this commit, that can be expressed more exactly as:
 NO_UNIQUE_ADDRESS IsCurrentAssertion m_owner;

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/ThreadAssertions.h:
* Source/WTF/wtf/Threading.cpp:
(WTF::IsCurrentAssertion::currentExecutionSequenceID):
* Source/WTF/wtf/Threading.h:
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):
(WTF::Thread::Thread): Deleted.
* Source/WTF/wtf/WorkQueue.h:
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):
* Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp:
(WTF::WorkQueueBase::platformInitialize):
(WTF::WorkQueue::WorkQueue):
(WTF::WorkQueue::isCurrentAssertion const):
(WTF::WorkQueue::assertIsCurrent const): Deleted.
* Source/WTF/wtf/generic/WorkQueueGeneric.cpp:
(WTF::WorkQueueBase::isCurrentAssertion const):
(WTF::WorkQueue::assertIsCurrent const): Deleted.
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h:
* Tools/TestWebKitAPI/Tests/WTF/ThreadAssertionsTest.cpp:
* Tools/TestWebKitAPI/Tests/WTF/WorkQueue.cpp:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba1341c6f2ef258fbf7b50ede0606106d9d2917a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101167 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161168 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/537 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29357 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97530 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/372 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78162 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27341 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82296 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/81956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70375 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/82882 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35575 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/15984 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/77926 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33361 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17074 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26913 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37161 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39880 "Found 30 new test failures: accessibility/attachment-element.html, accessibility/mac/attachment-element-replacement-character.html, accessibility/mac/caret-browsing-tab-selection.html, accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html, accessibility/mac/selection-element-tabbing-to-link.html, accessibility/model-element-attributes.html, animations/cross-fade-border-image-source.html, animations/cross-fade-webkit-mask-box-image.html, applicationmanifest/display-mode-bad-manifest.html, applicationmanifest/display-mode-subframe.html ... (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80530 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36191 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17652 "Passed tests") | 
<!--EWS-Status-Bubble-End-->