### PR TITLE
[css-typed-om] css/css-typed-om/stylevalue-subclasses/cssTranslate.tentative.html has failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTranslate.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTranslate.tentative-expected.txt
@@ -1,14 +1,14 @@
 
 PASS Constructing a CSSTranslate with a CSSUnitValue with type other than length or percent for the coordinates throws a TypeError
 PASS Constructing a CSSTranslate with a CSSMathValue that doesn't match <length-percentage> for the coordinates throws a TypeError
-FAIL Constructing a CSSTranslate with a percent for the Z coordinate throws a TypeError assert_throws_js: function "() => new CSSTranslate(CSS.px(0), CSS.px(0), CSS.percent(0))" did not throw
+PASS Constructing a CSSTranslate with a percent for the Z coordinate throws a TypeError
 PASS Updating CSSTranslate.x to a CSSUnitValue with type other than length or percent throws a TypeError
 PASS Updating CSSTranslate.x to a CSSMathValue that doesn't match <length-percentage> throws a TypeError
 PASS Updating CSSTranslate.y to a CSSUnitValue with type other than length or percent throws a TypeError
 PASS Updating CSSTranslate.y to a CSSMathValue that doesn't match <length-percentage> throws a TypeError
 PASS Updating CSSTranslate.z to a CSSUnitValue with type other than length or percent throws a TypeError
 PASS Updating CSSTranslate.z to a CSSMathValue that doesn't match <length-percentage> throws a TypeError
-FAIL Updating CSSTranslate.z to a percent throws a TypeError assert_throws_js: function "() => result.z = CSS.percent(0)" did not throw
+PASS Updating CSSTranslate.z to a percent throws a TypeError
 PASS CSSTranslate can be constructed from two length or percent coordinates
 PASS CSSTranslate can be constructed from three length or percent coordinates
 PASS CSSTranslate can be constructed from CSSMathValues

--- a/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
@@ -54,7 +54,7 @@ ExceptionOr<Ref<CSSTranslate>> CSSTranslate::create(Ref<CSSNumericValue> x, Ref<
 
     if (!x->type().matchesTypeOrPercentage<CSSNumericBaseType::Length>()
         || !y->type().matchesTypeOrPercentage<CSSNumericBaseType::Length>()
-        || !z->type().matchesTypeOrPercentage<CSSNumericBaseType::Length>())
+        || !z->type().matches<CSSNumericBaseType::Length>())
         return Exception { TypeError };
 
     return adoptRef(*new CSSTranslate(is2D, WTFMove(x), WTFMove(y), z.releaseNonNull()));
@@ -131,6 +131,15 @@ void CSSTranslate::serialize(StringBuilder& builder) const
         m_z->serialize(builder);
     }
     builder.append(')');
+}
+
+ExceptionOr<void> CSSTranslate::setZ(Ref<CSSNumericValue> z)
+{
+    if (!z->type().matches<CSSNumericBaseType::Length>())
+        return Exception { TypeError };
+
+    m_z = WTFMove(z);
+    return { };
 }
 
 ExceptionOr<Ref<DOMMatrix>> CSSTranslate::toMatrix()

--- a/Source/WebCore/css/typedom/transform/CSSTranslate.h
+++ b/Source/WebCore/css/typedom/transform/CSSTranslate.h
@@ -48,7 +48,7 @@ public:
 
     void setX(Ref<CSSNumericValue> x) { m_x = WTFMove(x); }
     void setY(Ref<CSSNumericValue> y) { m_y = WTFMove(y); }
-    void setZ(Ref<CSSNumericValue> z) { m_z = WTFMove(z); }
+    ExceptionOr<void> setZ(Ref<CSSNumericValue>);
     
     void serialize(StringBuilder&) const final;
     ExceptionOr<Ref<DOMMatrix>> toMatrix() final;


### PR DESCRIPTION
#### db7c724fd6ea2982338724d04d3e09dde222a69e
<pre>
[css-typed-om] css/css-typed-om/stylevalue-subclasses/cssTranslate.tentative.html has failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=246018">https://bugs.webkit.org/show_bug.cgi?id=246018</a>

Reviewed by Alex Christensen.

Percentage is not an acceptable value type for z.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTranslate.tentative-expected.txt:
* Source/WebCore/css/typedom/transform/CSSTranslate.cpp:
(WebCore::CSSTranslate::create):
(WebCore::CSSTranslate::setZ):
* Source/WebCore/css/typedom/transform/CSSTranslate.h:
(WebCore::CSSTranslate::setZ): Deleted.

Canonical link: <a href="https://commits.webkit.org/255156@main">https://commits.webkit.org/255156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a895f083e6d71b55d9f10c3c1c63795f9a694bb0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101237 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161274 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/671 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83853 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97589 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/422 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27377 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82346 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70415 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35641 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16035 "Found 1 new test failure: webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33421 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17128 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37231 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1598 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36245 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->