### PR TITLE
Implement cancel event on <input type=file>

### DIFF
--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -400,7 +400,9 @@ void FileInputType::setFiles(RefPtr<FileList>&& files, RequestIcon shouldRequest
         // input instance is safe since it is ref-counted.
         protectedInputElement->dispatchInputEvent();
         protectedInputElement->dispatchChangeEvent();
-    }
+    } else
+        protectedInputElement->dispatchCancelEvent();
+
     protectedInputElement->setChangedSinceLastFormControlChangeEvent(false);
 }
 
@@ -448,6 +450,14 @@ void FileInputType::filesChosen(const Vector<String>& paths, const Vector<String
         files.uncheckedAppend({ paths[i], i < replacementPaths.size() ? replacementPaths[i] : nullString(), { } });
 
     filesChosen(WTFMove(files));
+}
+
+void FileInputType::fileChoosingCancelled()
+{
+    ASSERT(element());
+    Ref<HTMLInputElement> protectedInputElement(*element());
+
+    protectedInputElement->dispatchCancelEvent();
 }
 
 void FileInputType::didCreateFileList(Ref<FileList>&& fileList, RefPtr<Icon>&& icon)

--- a/Source/WebCore/html/FileInputType.h
+++ b/Source/WebCore/html/FileInputType.h
@@ -86,6 +86,7 @@ private:
 
     void filesChosen(const Vector<FileChooserFileInfo>&, const String& displayString = { }, Icon* = nullptr) final;
     void filesChosen(const Vector<String>& paths, const Vector<String>& replacementPaths = { });
+    void fileChoosingCancelled();
 
     // FileIconLoaderClient implementation.
     void iconLoaded(RefPtr<Icon>&&) final;

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -299,6 +299,11 @@ void HTMLFormControlElement::dispatchChangeEvent()
     dispatchScopedEvent(Event::create(eventNames().changeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
 }
 
+void HTMLFormControlElement::dispatchCancelEvent()
+{
+    dispatchScopedEvent(Event::create(eventNames().cancelEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
+}
+
 void HTMLFormControlElement::dispatchFormControlChangeEvent()
 {
     dispatchChangeEvent();

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -70,6 +70,7 @@ public:
 
     virtual void dispatchFormControlChangeEvent();
     void dispatchChangeEvent();
+    void dispatchCancelEvent();
     void dispatchFormControlInputEvent();
 
     bool isDisabledFormControl() const final { return m_disabled || m_disabledByAncestorFieldset; }

--- a/Source/WebCore/platform/FileChooser.cpp
+++ b/Source/WebCore/platform/FileChooser.cpp
@@ -68,6 +68,14 @@ void FileChooser::chooseFiles(const Vector<String>& filenames, const Vector<Stri
     m_client->filesChosen(WTFMove(files));
 }
 
+void FileChooser::cancelFileChoosing()
+{
+    if (!m_client)
+        return;
+
+    m_client->fileChoosingCancelled();
+}
+
 #if PLATFORM(IOS_FAMILY)
 
 // FIXME: This function is almost identical to FileChooser::chooseFiles(). We should merge this function
@@ -87,10 +95,6 @@ void FileChooser::chooseMediaFiles(const Vector<String>& filenames, const String
 
 void FileChooser::chooseFiles(const Vector<FileChooserFileInfo>& files)
 {
-    auto paths = files.map([](auto& file) {
-        return file.path;
-    });
-
     if (m_client)
         m_client->filesChosen(files);
 }

--- a/Source/WebCore/platform/FileChooser.h
+++ b/Source/WebCore/platform/FileChooser.h
@@ -70,6 +70,8 @@ public:
     virtual ~FileChooserClient() = default;
 
     virtual void filesChosen(const Vector<FileChooserFileInfo>&, const String& displayString = { }, Icon* = nullptr) = 0;
+
+    virtual void fileChoosingCancelled() = 0;
 };
 
 class FileChooser : public RefCounted<FileChooser> {
@@ -81,6 +83,7 @@ public:
 
     WEBCORE_EXPORT void chooseFile(const String& path);
     WEBCORE_EXPORT void chooseFiles(const Vector<String>& paths, const Vector<String>& replacementPaths = { });
+    WEBCORE_EXPORT void cancelFileChoosing();
 #if PLATFORM(IOS_FAMILY)
     // FIXME: This function is almost identical to FileChooser::chooseFiles(). We should merge this
     // function with FileChooser::chooseFiles() and hence remove the PLATFORM(IOS_FAMILY)-guard.

--- a/Source/WebKit/WebProcess/WebPage/WebOpenPanelResultListener.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebOpenPanelResultListener.cpp
@@ -51,6 +51,11 @@ void WebOpenPanelResultListener::didChooseFiles(const Vector<String>& files, con
     m_fileChooser->chooseFiles(files, replacementFiles);
 }
 
+void WebOpenPanelResultListener::didCancelFileChoosing()
+{
+    m_fileChooser->cancelFileChoosing();
+}
+
 #if PLATFORM(IOS_FAMILY)
 void WebOpenPanelResultListener::didChooseFilesWithDisplayStringAndIcon(const Vector<String>& files, const String& displayString, WebCore::Icon* displayIcon)
 {

--- a/Source/WebKit/WebProcess/WebPage/WebOpenPanelResultListener.h
+++ b/Source/WebKit/WebProcess/WebPage/WebOpenPanelResultListener.h
@@ -45,6 +45,7 @@ public:
 
     void disconnectFromPage() { m_page = 0; }
     void didChooseFiles(const Vector<String>& files, const Vector<String>& replacementFiles);
+    void didCancelFileChoosing();
 #if PLATFORM(IOS_FAMILY)
     void didChooseFilesWithDisplayStringAndIcon(const Vector<String>&, const String& displayString, WebCore::Icon*);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5094,6 +5094,10 @@ void WebPage::didChooseFilesForOpenPanel(const Vector<String>& files, const Vect
 
 void WebPage::didCancelForOpenPanel()
 {
+    if (!m_activeOpenPanelResultListener)
+        return;
+
+    m_activeOpenPanelResultListener->didCancelFileChoosing();
     m_activeOpenPanelResultListener = nullptr;
 }
 


### PR DESCRIPTION
#### 059f8069cb4a83b08a89b8b2ae02d9b82d8c5fd1
<pre>
Implement cancel event on &lt;input type=file&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=227799">https://bugs.webkit.org/show_bug.cgi?id=227799</a>
rdar://80340803

Reviewed by Aditya Keerthi.

This PR implements the &quot;Add a &quot;cancel&quot; event for when file upload selection is unchanged&quot;
behavior.

The `cancel` event is now fired when:
- The file picker is dismissed
- The selected files are the same as those currently selected

Spec: <a href="https://html.spec.whatwg.org/multipage/input.html#show-the-picker">https://html.spec.whatwg.org/multipage/input.html#show-the-picker</a>,-if-applicable

* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::setFiles):
(WebCore::FileInputType::fileChoosingCancelled):
* Source/WebCore/html/FileInputType.h:
* Source/WebCore/platform/FileChooser.cpp:
(WebCore::FileChooser::cancelFileChoosing):
* Source/WebCore/platform/FileChooser.h:
* Source/WebKit/WebProcess/WebPage/WebOpenPanelResultListener.cpp:
(WebKit::WebOpenPanelResultListener::didCancelFileChoosing):
* Source/WebKit/WebProcess/WebPage/WebOpenPanelResultListener.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didCancelForOpenPanel):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RunOpenPanel.mm:
(-[FileInputTypeCancelEventUIDelegate webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:]):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/255394@main">https://commits.webkit.org/255394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4e6090fd81108588de31cf60dfc6da2e9125ced

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101874 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161929 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1310 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29711 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98050 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/820 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78606 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27766 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70809 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36137 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16355 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33889 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17457 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3737 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37760 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40166 "Found 2 new test failures: imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h264_annexb, imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_annexb (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36583 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->