### PR TITLE
Add a log channel for IntersectionObserver

### DIFF
--- a/Source/WebCore/dom/DOMRectReadOnly.h
+++ b/Source/WebCore/dom/DOMRectReadOnly.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include "DOMRectInit.h"
+#include "FloatConversion.h"
+#include "FloatRect.h"
 #include "ScriptWrappable.h"
 #include <wtf/IsoMalloc.h>
 #include <wtf/MathExtras.h>
@@ -52,6 +54,8 @@ public:
     double right() const { return WTF::nanPropagatingMax(m_x, m_x + m_width); }
     double bottom() const { return WTF::nanPropagatingMax(m_y, m_y + m_height); }
     double left() const { return WTF::nanPropagatingMin(m_x, m_x + m_width); }
+
+    FloatRect toFloatRect() const { return FloatRect { narrowPrecisionToFloat(m_x), narrowPrecisionToFloat(m_y), narrowPrecisionToFloat(m_width), narrowPrecisionToFloat(m_height) }; }
 
 protected:
     DOMRectReadOnly(double x, double y, double width, double height)

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -260,7 +260,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
             }
             auto imageLoading = (m_lazyImageLoadState == LazyImageLoadState::Deferred) ? ImageLoading::DeferredUntilVisible : ImageLoading::Immediate;
             newImage = document.cachedResourceLoader().requestImage(WTFMove(request), imageLoading).value_or(nullptr);
-            LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " updateFromElement " << element() << " - state changed from " << oldState << " to " << m_lazyImageLoadState << ", loading is" << imageLoading << " new image " << newImage.get());
+            LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " updateFromElement " << element() << " - state changed from " << oldState << " to " << m_lazyImageLoadState << ", loading is " << imageLoading << " new image " << newImage.get());
         }
 
         // If we do not have an image here, it means that a cross-site

--- a/Source/WebCore/page/IntersectionObserverEntry.cpp
+++ b/Source/WebCore/page/IntersectionObserverEntry.cpp
@@ -43,4 +43,25 @@ IntersectionObserverEntry::IntersectionObserverEntry(const Init& init)
         m_rootBounds = DOMRectReadOnly::fromRect(*init.rootBounds);
 }
 
+TextStream& operator<<(TextStream& ts, const IntersectionObserverEntry& entry)
+{
+    TextStream::GroupScope scope(ts);
+    ts << "IntersectionObserverEntry " << &entry;
+    ts.dumpProperty("time", entry.time());
+    
+    if (entry.rootBounds())
+        ts.dumpProperty("rootBounds", entry.rootBounds()->toFloatRect());
+
+    if (entry.boundingClientRect())
+        ts.dumpProperty("boundingClientRect", entry.boundingClientRect()->toFloatRect());
+
+    if (entry.intersectionRect())
+        ts.dumpProperty("intersectionRect", entry.intersectionRect()->toFloatRect());
+
+    ts.dumpProperty("isIntersecting", entry.isIntersecting());
+    ts.dumpProperty("intersectionRatio", entry.intersectionRatio());
+
+    return ts;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/IntersectionObserverEntry.h
+++ b/Source/WebCore/page/IntersectionObserverEntry.h
@@ -31,6 +31,10 @@
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class Element;
@@ -75,5 +79,6 @@ private:
     bool m_isIntersecting { false };
 };
 
+TextStream& operator<<(TextStream&, const IntersectionObserverEntry&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -73,6 +73,7 @@ namespace WebCore {
     M(IndexedDB) \
     M(IndexedDBOperations) \
     M(Inspector) \
+    M(IntersectionObserver) \
     M(Layers) \
     M(Layout) \
     M(LazyLoading) \


### PR DESCRIPTION
#### 24ab2a368754d9133c2b3630a433358785dcb0f7
<pre>
Add a log channel for IntersectionObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=246028">https://bugs.webkit.org/show_bug.cgi?id=246028</a>
&lt;rdar://100770517&gt;

Reviewed by Wenson Hsieh.

Add the beginnings of a log channel for IntersectionObserver, which dumps the records (without collapsing them all onto a single line).

* Source/WebCore/dom/DOMRectReadOnly.h:
(WebCore::DOMRectReadOnly::toFloatRect const):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::IntersectionObserver):
(WebCore::IntersectionObserver::notify):
* Source/WebCore/page/IntersectionObserverEntry.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/IntersectionObserverEntry.h:
* Source/WebCore/platform/Logging.h:

Canonical link: <a href="https://commits.webkit.org/255197@main">https://commits.webkit.org/255197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21053b6f310370d2e523650bdba6c984938f4000

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101264 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161324 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/712 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83880 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97615 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/444 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78244 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27397 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82368 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70437 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35677 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16054 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33448 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17147 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3601 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39923 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36264 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->