### PR TITLE
WebKitPrivate.h should be auto generated to include all headers from PrivateHeaders.

### DIFF
--- a/Source/WebKit/Scripts/generate-umbrella-header.py
+++ b/Source/WebKit/Scripts/generate-umbrella-header.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+
+import filecmp
+import os
+import re
+
+
+def generate_umbrella_header(input_filename, output_filename, tempoutput_filename, header_dirname, framework_name):
+    include_pattern = re.compile(r"\#(include|import)\s+\<" + framework_name + r"\/(.*)\>")
+
+    existing_framework_headers = set()
+    output_headers = []
+    blocklist = {
+        "%sPrivate.h" % framework_name,
+        "%s.h" % framework_name,
+    }
+
+    with open(tempoutput_filename or output_filename, "w+") as output_file:
+        with open(input_filename, "r") as input_file:
+            for line in input_file:
+                match = include_pattern.search(line)
+                if match:
+                    existing_framework_headers.add(match.group(2))
+
+                output_file.write(line)
+
+        for (dirpath, dirnames, filenames) in os.walk(header_dirname):
+            for file in filenames:
+                path = os.path.relpath(os.path.join(dirpath, file), start=header_dirname)
+
+                if path in blocklist or path in existing_framework_headers or not path.endswith(".h"):
+                    continue
+
+                output_headers.append(path)
+
+        output_headers.sort()
+        output_file.write("\n\n")
+
+        for output_header in output_headers:
+            output_file.write("#import <%s/%s>\n" % (framework_name, output_header))
+
+    if tempoutput_filename and (not os.path.exists(output_filename) or not filecmp.cmp(output_filename, tempoutput_filename)):
+        os.rename(tempoutput_filename, output_filename)
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=str, default=None, help="Input header file (ie. ${SRCROOT}/WebKitPrivate.h)")
+    parser.add_argument("--output", type=str, default=None, help="Output header file (ie. ${DSTROOT}/WebKit.framework/PrivateHeaders/WebKitPrivate.h)")
+    parser.add_argument("--tempoutput", type=str, default=None, help="Temporary output file (ie. ${TARGET_TEMP_DIR}/WebKitPrivate.h\nIf set, the header will be generated to this path, and the output path will only be touched if the file contents have changed.")
+    parser.add_argument("--headers", type=str, default=None, help="Header directory (ie. ${DSTROOT}/WebKit.framework/PrivateHeaders)")
+    parser.add_argument("--framework", type=str, default=None, help="Framework name (ie. WebKit)")
+    args = parser.parse_args()
+
+    if args.input is None or args.output is None or args.headers is None or args.framework is None:
+        parser.print_help()
+        sys.exit(1)
+
+    generate_umbrella_header(args.input, args.output, args.tempoutput, args.headers, args.framework)

--- a/Source/WebKit/Shared/API/Cocoa/WebKit.h
+++ b/Source/WebKit/Shared/API/Cocoa/WebKit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #import <WebKit/WKContentRuleListStore.h>
 #import <WebKit/WKContentWorld.h>
 #import <WebKit/WKContextMenuElementInfo.h>
+#import <WebKit/WKDataDetectorTypes.h>
 #import <WebKit/WKDownload.h>
 #import <WebKit/WKDownloadDelegate.h>
 #import <WebKit/WKError.h>

--- a/Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h
+++ b/Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,18 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKHistoryDelegatePrivate.h>
-#import <WebKit/WKNavigationPrivate.h>
-#import <WebKit/WKProcessPoolPrivate.h>
-#import <WebKit/WKUIDelegatePrivate.h>
-#import <WebKit/WKWebViewConfigurationPrivate.h>
-#import <WebKit/WKWebViewPrivate.h>
-#import <WebKit/_WKActivatedElementInfo.h>
-#import <WebKit/_WKAttachment.h>
-#import <WebKit/_WKElementAction.h>
-#import <WebKit/_WKFocusedElementInfo.h>
-#import <WebKit/_WKFormInputSession.h>
-#import <WebKit/_WKInputDelegate.h>
-#import <WebKit/_WKProcessPoolConfiguration.h>
-#import <WebKit/_WKThumbnailView.h>
-#import <WebKit/_WKVisitedLinkStore.h>
+#import <WebKit/WebKit.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoPrivate.h
@@ -25,6 +25,8 @@
 
 #import <WebKit/WKContextMenuElementInfo.h>
 
+#if TARGET_OS_IPHONE
+
 @class _WKActivatedElementInfo;
 
 @interface WKContextMenuElementInfo (WKPrivate)
@@ -32,3 +34,5 @@
 @property (nonatomic, copy, readonly) _WKActivatedElementInfo *_activatedElementInfo;
 
 @end
+
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -236,7 +236,6 @@
 		1A60224C18C16B9F00C3E8C9 /* VisitedLinkStoreMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A60224A18C16B9F00C3E8C9 /* VisitedLinkStoreMessageReceiver.cpp */; };
 		1A60224D18C16B9F00C3E8C9 /* VisitedLinkStoreMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A60224B18C16B9F00C3E8C9 /* VisitedLinkStoreMessages.h */; };
 		1A6280C51919949F006AD9F9 /* WebKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A6280C41919949F006AD9F9 /* WebKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1A6280C71919950C006AD9F9 /* WebKitPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A6280C61919950C006AD9F9 /* WebKitPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A6280F31919982A006AD9F9 /* WebKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A6280F21919982A006AD9F9 /* WebKit.m */; };
 		1A6420E512DCE2FF00CAAE2C /* ShareableBitmap.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A6420E312DCE2FF00CAAE2C /* ShareableBitmap.h */; };
 		1A64229912DD029200CAAE2C /* DrawingAreaMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A64229712DD029200CAAE2C /* DrawingAreaMessageReceiver.cpp */; };
@@ -3523,6 +3522,7 @@
 		1C627477288A1DDE00CED3A2 /* WebExtensionCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionCocoa.mm; sourceTree = "<group>"; };
 		1C62747B288B4C3E00CED3A2 /* CocoaHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocoaHelpers.h; sourceTree = "<group>"; };
 		1C62747C288B4C3E00CED3A2 /* CocoaHelpers.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaHelpers.mm; sourceTree = "<group>"; };
+		1C628FFE28EC98B900C26B60 /* generate-umbrella-header.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = "generate-umbrella-header.py"; sourceTree = "<group>"; };
 		1C739E852347BCF600C621EC /* CoreTextHelpers.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreTextHelpers.mm; sourceTree = "<group>"; };
 		1C739E872347BD0F00C621EC /* CoreTextHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreTextHelpers.h; sourceTree = "<group>"; };
 		1C77C1951288A872006A742F /* WebInspectorUIProxy.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebInspectorUIProxy.messages.in; sourceTree = "<group>"; };
@@ -13337,6 +13337,7 @@
 				4157853021276B6F00DD3800 /* copy-webcontent-resources-to-private-headers.sh */,
 				C0CE73361247F70E00BC0EC4 /* generate-message-receiver.py */,
 				5CD4F01C28B6ADDB00F9ECEA /* generate-serializers.py */,
+				1C628FFE28EC98B900C26B60 /* generate-umbrella-header.py */,
 				0FC0856F187CE0A900780D86 /* messages.py */,
 				0FC08570187CE0A900780D86 /* model.py */,
 				0FC08571187CE0A900780D86 /* parser.py */,
@@ -15096,7 +15097,6 @@
 				DDA0A29D27E55E4E005E086E /* WebKitErrorsPrivate.h in Headers */,
 				DDA0A41E27E94644005E086E /* WebKitLegacy.h in Headers */,
 				DDA0A37527E55E4F005E086E /* WebKitNSStringExtras.h in Headers */,
-				1A6280C71919950C006AD9F9 /* WebKitPrivate.h in Headers */,
 				DDA0A2EF27E55E4E005E086E /* WebKitStatistics.h in Headers */,
 				DDA0A2CD27E55E4E005E086E /* WebLocalizableStrings.h in Headers */,
 				465FA7262757D93D0072362B /* WebLockRegistryProxy.h in Headers */,
@@ -15907,6 +15907,7 @@
 				1A07D2F51919AA8A00ECDA16 /* Make Frameworks Symbolic Link */,
 				8DC2EF500486A6940098B216 /* Headers */,
 				DDA0A42827EA3435005E086E /* (Legacy) Install Headers */,
+				1C628FFF28EC99E700C26B60 /* Generate Private Umbrella Header */,
 				2E16B6F42019BC25008996D6 /* Copy Additional Resources */,
 				8DC2EF520486A6940098B216 /* Resources */,
 				372589431C1E496800C92CA9 /* Copy Shims */,
@@ -16211,6 +16212,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Touch Info.plist to let Xcode know it needs to copy it into the built product\nif [[ \"${CONFIGURATION}\" != \"Production\" ]]; then\ntouch \"${SRCROOT}/Info.plist\";\nfi;\n";
+		};
+		1C628FFF28EC99E700C26B60 /* Generate Private Umbrella Header */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Scripts/generate-umbrella-headers.py",
+				"$(SRCROOT)/Shared/API/Cocoa/WebKitPrivate.h",
+			);
+			name = "Generate Private Umbrella Header";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(PRIVATE_HEADERS_FOLDER_PATH)/WebKitPrivate.h",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Scripts/generate-umbrella-header.py\" --input \"${SRCROOT}/Shared/API/Cocoa/WebKitPrivate.h\" --output \"${TARGET_BUILD_DIR}/${PRIVATE_HEADERS_FOLDER_PATH}/WebKitPrivate.h\" --tempoutput \"${TARGET_TEMP_DIR}/WebKitPrivate.h\" --headers \"${TARGET_BUILD_DIR}/${PRIVATE_HEADERS_FOLDER_PATH}\" --framework \"${PRODUCT_MODULE_NAME}\"\n";
 		};
 		2D7DEBDF21269C9F00B9F73C /* Generate Unified Sources */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
#### 9dfe72096db5bba3461b8706cf1a7a921e8ef925
<pre>
WebKitPrivate.h should be auto generated to include all headers from PrivateHeaders.
<a href="https://bugs.webkit.org/show_bug.cgi?id=246030">https://bugs.webkit.org/show_bug.cgi?id=246030</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/Scripts/generate-umbrella-header.py: Added.
* Source/WebKit/Shared/API/Cocoa/WebKit.h: Added WKDataDetectorTypes.h, which is public.
* Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h: Remove headers and just include &lt;WebKit/WebKit.h&gt;.
* Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoPrivate.h: Add missing #if TARGET_OS_IPHONE.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
Added new Generate Private Umbrella Header script build phase that calls generate-umbrella-header.py.
Removed WebKitPrivate.h from the target as a Private header, since the script places it now.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dfe72096db5bba3461b8706cf1a7a921e8ef925

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/688 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22169 "Hash 9dfe7209 for PR 4991 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101252 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/695 "Built successfully") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29407 "Hash 9dfe7209 for PR 4991 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83868 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97603 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/434 "Passed tests") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78233 "Hash 9dfe7209 for PR 4991 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27388 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/95113 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82358 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/22169 "Hash 9dfe7209 for PR 4991 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70428 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35661 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/22169 "Hash 9dfe7209 for PR 4991 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33436 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/22169 "Hash 9dfe7209 for PR 4991 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37252 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/78233 "Hash 9dfe7209 for PR 4991 does not build (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39166 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/22169 "Hash 9dfe7209 for PR 4991 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->