### PR TITLE
[LBSE] Enable size negotiation logic for <object> + RenderSVGRoot in LBSE

### DIFF
--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations
@@ -586,7 +586,6 @@ svg/foreignObject/text-tref-02-b.svg       [ ImageOnlyFailure ]
 svg/hittest/text-multiple-dx-values.svg    [ ImageOnlyFailure ]
 svg/hittest/text-with-multiple-tspans.svg  [ ImageOnlyFailure ]
 svg/hittest/text-with-text-path.svg        [ ImageOnlyFailure ]
-svg/hixie/text/003.html                    [ ImageOnlyFailure ]
 svg/text/font-size-below-point-five-2.svg  [ ImageOnlyFailure ]
 svg/text/monospace-text-size-in-img.html   [ ImageOnlyFailure ]
 svg/text/text-repaint-rects.xhtml          [ ImageOnlyFailure ]
@@ -602,29 +601,11 @@ svg/in-html/overflow-svg-root-style.html [ ImageOnlyFailure ]
 # General transform issues
 svg/custom/small-rect-scale.svg [ Failure ]
 
-# SVG sizing/repainting broken for SVGs embedded via HTML <img>
-svg/as-image/img-preserveAspectRatio-support-2.html [ ImageOnlyFailure ]
-svg/as-image/svg-object-intrinsic-size.html         [ ImageOnlyFailure ]
-
 # SVG sizing/repainting broken for SVGs embedded via HTML <object>
-svg/as-object/deep-nested-embedded-svg-size-changes-no-layout-triggers-1.html [ ImageOnlyFailure ]
-svg/as-object/deep-nested-embedded-svg-size-changes-no-layout-triggers-2.html [ ImageOnlyFailure ]
-svg/as-object/embedded-svg-immediate-offsetWidth-query.html                   [ ImageOnlyFailure ]
-svg/as-object/embedded-svg-size-changes-no-layout-triggers.html               [ ImageOnlyFailure ]
-svg/as-object/embedded-svg-size-changes.html                                  [ ImageOnlyFailure ]
-svg/as-object/mutate-on-load.html                                             [ ImageOnlyFailure ]
-svg/as-object/nested-embedded-svg-size-changes-no-layout-triggers-1.html      [ ImageOnlyFailure ]
-svg/as-object/nested-embedded-svg-size-changes-no-layout-triggers-2.html      [ ImageOnlyFailure ]
-svg/as-object/nested-embedded-svg-size-changes.html                           [ ImageOnlyFailure ]
-svg/as-object/sizing/svg-in-object-placeholder-height-auto.html               [ Failure ]
-svg/as-object/sizing/svg-in-object-placeholder-height-fixed.html              [ Failure ]
-svg/as-object/sizing/svg-in-object-placeholder-height-percentage.html         [ Failure ]
 svg/custom/object-no-size-attributes.xhtml                                    [ Failure ]
 svg/custom/object-sizing-no-width-height.xhtml                                [ Failure ]
 svg/custom/object-sizing.xhtml                                                [ Failure ]
-svg/hixie/intrinsic/003.html                                                  [ ImageOnlyFailure ]
 svg/wicd/sizing-flakiness.html                                                [ ImageOnlyFailure ]
-svg/wicd/test-rightsizing-b.xhtml                                             [ ImageOnlyFailure ]
 svg/zoom/page/zoom-img-preserveAspectRatio-support-1.html                     [ Failure ]
 
 # CSS 'mix-blend-mode' broken

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-image/img-preserveAspectRatio-support-2-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-image/img-preserveAspectRatio-support-2-expected.txt
@@ -10,13 +10,13 @@ layer at (0,0) size 800x322
         RenderImage {IMG} at (0,0) size 230x230 [border: (2px dashed #800000)]
         RenderText {#text} at (230,216) size 4x18
           text run at (230,216) width 4: " "
-        RenderEmbeddedObject {OBJECT} at (234,72) size 308x158 [border: (1px dashed #008000)]
-          layer at (0,0) size 300x150
-            RenderView at (0,0) size 300x150
-          layer at (0,0) size 300x150
-            RenderSVGRoot {svg} at (0,0) size 300x150
-          layer at (0,0) size 300x150
-            RenderSVGViewportContainer at (0,0) size 300x150
-          layer at (0,0) size 220x220 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
+        RenderEmbeddedObject {OBJECT} at (234,2) size 228x228 [border: (1px dashed #008000)]
+          layer at (0,0) size 220x220
+            RenderView at (0,0) size 220x220
+          layer at (0,0) size 220x220
+            RenderSVGRoot {svg} at (0,0) size 220x220
+          layer at (0,0) size 220x220
+            RenderSVGViewportContainer at (0,0) size 220x220
+          layer at (0,0) size 220x220
             RenderSVGEllipse {circle} at (0,0) size 220x220 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [cx=110.00] [cy=110.00] [r=110.00]
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/deep-nested-embedded-svg-size-changes-no-layout-triggers-1-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/deep-nested-embedded-svg-size-changes-no-layout-triggers-1-expected.txt
@@ -15,16 +15,16 @@ layer at (0,0) size 800x600
                 layer at (0,0) size 400x200
                   RenderBlock {HTML} at (0,0) size 400x200
                     RenderBody {BODY} at (0,0) size 400x200
-                      RenderEmbeddedObject {OBJECT} at (0,0) size 300x150
-                        layer at (0,0) size 300x150
-                          RenderView at (0,0) size 300x150
-                        layer at (0,0) size 300x150
-                          RenderSVGRoot {svg} at (0,0) size 300x150
-                        layer at (0,0) size 300x150
-                          RenderSVGViewportContainer at (0,0) size 300x150
-                        layer at (10,10) size 180x180 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
+                      RenderEmbeddedObject {OBJECT} at (0,0) size 400x200
+                        layer at (0,0) size 400x200
+                          RenderView at (0,0) size 400x200
+                        layer at (0,0) size 400x200
+                          RenderSVGRoot {svg} at (0,0) size 400x200
+                        layer at (0,0) size 400x200
+                          RenderSVGViewportContainer at (0,0) size 400x200
+                        layer at (10,10) size 180x180
                           RenderSVGRect {rect} at (10,10) size 180x180 [fill={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=180.00] [height=180.00]
-                        layer at (10,10) size 180x180 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
+                        layer at (10,10) size 180x180
                           RenderSVGRect {rect} at (10,10) size 180x180 [fill={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=180.00] [height=180.00]
                       RenderText {#text} at (0,0) size 0x0
               RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/deep-nested-embedded-svg-size-changes-no-layout-triggers-2-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/deep-nested-embedded-svg-size-changes-no-layout-triggers-2-expected.txt
@@ -15,16 +15,16 @@ layer at (0,0) size 800x600
                 layer at (0,0) size 400x200
                   RenderBlock {HTML} at (0,0) size 400x200
                     RenderBody {BODY} at (0,0) size 400x200
-                      RenderEmbeddedObject {OBJECT} at (0,0) size 300x150
-                        layer at (0,0) size 300x150
-                          RenderView at (0,0) size 300x150
-                        layer at (0,0) size 300x150
-                          RenderSVGRoot {svg} at (0,0) size 300x150
-                        layer at (0,0) size 300x150
-                          RenderSVGViewportContainer at (0,0) size 300x150
-                        layer at (10,10) size 180x180 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
+                      RenderEmbeddedObject {OBJECT} at (0,0) size 400x200
+                        layer at (0,0) size 400x200
+                          RenderView at (0,0) size 400x200
+                        layer at (0,0) size 400x200
+                          RenderSVGRoot {svg} at (0,0) size 400x200
+                        layer at (0,0) size 400x200
+                          RenderSVGViewportContainer at (0,0) size 400x200
+                        layer at (10,10) size 180x180
                           RenderSVGRect {rect} at (10,10) size 180x180 [fill={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=180.00] [height=180.00]
-                        layer at (10,10) size 180x180 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
+                        layer at (10,10) size 180x180
                           RenderSVGRect {rect} at (10,10) size 180x180 [fill={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=180.00] [height=180.00]
                       RenderText {#text} at (0,0) size 0x0
               RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/embedded-svg-size-changes-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/embedded-svg-size-changes-expected.txt
@@ -9,12 +9,12 @@ PASS document.defaultView.getComputedStyle(object1).width is "300px"
 PASS document.defaultView.getComputedStyle(object1).height is "150px"
 
 Check initial <object> size, after external resource loaded
-FAIL document.defaultView.getComputedStyle(object1).width should be 200px. Was 300px.
-FAIL document.defaultView.getComputedStyle(object1).height should be 200px. Was 150px.
+PASS document.defaultView.getComputedStyle(object1).width is "200px"
+PASS document.defaultView.getComputedStyle(object1).height is "200px"
 
 Check final <object> size, after resizing finished
-FAIL document.defaultView.getComputedStyle(object1).width should be 400px. Was 300px.
-FAIL document.defaultView.getComputedStyle(object1).height should be 200px. Was 150px.
+PASS document.defaultView.getComputedStyle(object1).width is "400px"
+PASS document.defaultView.getComputedStyle(object1).height is "200px"
 
 Test passed if you see two green rectangles
 PASS successfullyParsed is true

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/embedded-svg-size-changes-no-layout-triggers-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/embedded-svg-size-changes-no-layout-triggers-expected.txt
@@ -3,15 +3,15 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderEmbeddedObject {OBJECT} at (0,0) size 302x152 [border: (1px solid #FF0000)]
-        layer at (0,0) size 300x150
-          RenderView at (0,0) size 300x150
-        layer at (0,0) size 300x150
-          RenderSVGRoot {svg} at (0,0) size 300x150
-        layer at (0,0) size 300x150
-          RenderSVGViewportContainer at (0,0) size 300x150
-        layer at (10,10) size 180x180 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
+      RenderEmbeddedObject {OBJECT} at (0,0) size 402x202 [border: (1px solid #FF0000)]
+        layer at (0,0) size 400x200
+          RenderView at (0,0) size 400x200
+        layer at (0,0) size 400x200
+          RenderSVGRoot {svg} at (0,0) size 400x200
+        layer at (0,0) size 400x200
+          RenderSVGViewportContainer at (0,0) size 400x200
+        layer at (10,10) size 180x180
           RenderSVGRect {rect} at (10,10) size 180x180 [fill={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=180.00] [height=180.00]
-        layer at (10,10) size 180x180 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
+        layer at (10,10) size 180x180
           RenderSVGRect {rect} at (10,10) size 180x180 [fill={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=180.00] [height=180.00]
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/nested-embedded-svg-size-changes-no-layout-triggers-1-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/nested-embedded-svg-size-changes-no-layout-triggers-1-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
         layer at (0,0) size 400x200
           RenderBlock {HTML} at (0,0) size 400x200
             RenderBody {BODY} at (0,0) size 400x200
-              RenderEmbeddedObject {OBJECT} at (0,0) size 300x150
-                layer at (0,0) size 300x150
-                  RenderView at (0,0) size 300x150
-                layer at (0,0) size 300x150
-                  RenderSVGRoot {svg} at (0,0) size 300x150
-                layer at (0,0) size 300x150
-                  RenderSVGViewportContainer at (0,0) size 300x150
-                layer at (10,10) size 180x180 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
+              RenderEmbeddedObject {OBJECT} at (0,0) size 400x200
+                layer at (0,0) size 400x200
+                  RenderView at (0,0) size 400x200
+                layer at (0,0) size 400x200
+                  RenderSVGRoot {svg} at (0,0) size 400x200
+                layer at (0,0) size 400x200
+                  RenderSVGViewportContainer at (0,0) size 400x200
+                layer at (10,10) size 180x180
                   RenderSVGRect {rect} at (10,10) size 180x180 [fill={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=180.00] [height=180.00]
-                layer at (10,10) size 180x180 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
+                layer at (10,10) size 180x180
                   RenderSVGRect {rect} at (10,10) size 180x180 [fill={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=180.00] [height=180.00]
               RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/nested-embedded-svg-size-changes-no-layout-triggers-2-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/nested-embedded-svg-size-changes-no-layout-triggers-2-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
         layer at (0,0) size 400x200
           RenderBlock {HTML} at (0,0) size 400x200
             RenderBody {BODY} at (0,0) size 400x200
-              RenderEmbeddedObject {OBJECT} at (0,0) size 300x150
-                layer at (0,0) size 300x150
-                  RenderView at (0,0) size 300x150
-                layer at (0,0) size 300x150
-                  RenderSVGRoot {svg} at (0,0) size 300x150
-                layer at (0,0) size 300x150
-                  RenderSVGViewportContainer at (0,0) size 300x150
-                layer at (10,10) size 180x180 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
+              RenderEmbeddedObject {OBJECT} at (0,0) size 400x200
+                layer at (0,0) size 400x200
+                  RenderView at (0,0) size 400x200
+                layer at (0,0) size 400x200
+                  RenderSVGRoot {svg} at (0,0) size 400x200
+                layer at (0,0) size 400x200
+                  RenderSVGViewportContainer at (0,0) size 400x200
+                layer at (10,10) size 180x180
                   RenderSVGRect {rect} at (10,10) size 180x180 [fill={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=180.00] [height=180.00]
-                layer at (10,10) size 180x180 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
+                layer at (10,10) size 180x180
                   RenderSVGRect {rect} at (10,10) size 180x180 [fill={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=180.00] [height=180.00]
               RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/hixie/intrinsic/003-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/hixie/intrinsic/003-expected.txt
@@ -1,15 +1,15 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x217
-  RenderBlock {HTML} at (0,0) size 800x217 [color=#000080] [bgcolor=#FFFFFF]
-    RenderBody {BODY} at (8,16) size 784x185
-      RenderBlock {DIV} at (0,0) size 100x150
-        RenderBlock {P} at (0,0) size 100x150
-          RenderEmbeddedObject {OBJECT} at (0,0) size 400x150
-            layer at (0,0) size 300x150
-              RenderView at (0,0) size 300x150
-            layer at (0,0) size 300x150
-              RenderSVGRoot {svg} at (0,0) size 300x150
-      RenderBlock {P} at (0,166) size 784x19
+layer at (0,0) size 800x267
+  RenderBlock {HTML} at (0,0) size 800x267 [color=#000080] [bgcolor=#FFFFFF]
+    RenderBody {BODY} at (8,16) size 784x235
+      RenderBlock {DIV} at (0,0) size 100x200
+        RenderBlock {P} at (0,0) size 100x200
+          RenderEmbeddedObject {OBJECT} at (0,0) size 200x200
+            layer at (0,0) size 100x200
+              RenderView at (0,0) size 100x200
+            layer at (0,0) size 100x200
+              RenderSVGRoot {svg} at (0,0) size 100x200
+      RenderBlock {P} at (0,216) size 784x19
         RenderText {#text} at (0,0) size 431x18
           text run at (0,0) width 431: "There should be a complete unbroken yin-yang symbol (\x{262F}) above."

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/hixie/text/003-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/hixie/text/003-expected.txt
@@ -1,32 +1,32 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x402
-  RenderBlock {HTML} at (0,0) size 800x402
-    RenderBody {BODY} at (8,16) size 784x370
+layer at (0,0) size 800x414
+  RenderBlock {HTML} at (0,0) size 800x414
+    RenderBody {BODY} at (8,16) size 784x382
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 616x18
           text run at (0,0) width 616: "The following two blocks should look identical (to the pixel), and they should both say \"PASS\":"
-      RenderBlock {P} at (0,34) size 784x160
-        RenderEmbeddedObject {OBJECT} at (0,0) size 306x156 [border: (3px inset #000080)]
-          layer at (0,0) size 300x150
-            RenderView at (0,0) size 300x150
-          layer at (0,0) size 300x150
-            RenderSVGRoot {svg} at (0,0) size 300x150
-          layer at (0,0) size 300x150
-            RenderSVGViewportContainer at (0,0) size 300x150
-          layer at (0,0) size 2x1 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
+      RenderBlock {P} at (0,34) size 784x166
+        RenderEmbeddedObject {OBJECT} at (0,0) size 784x162 [border: (3px inset #000080)]
+          layer at (0,0) size 778x156
+            RenderView at (0,0) size 778x156
+          layer at (0,0) size 778x156
+            RenderSVGRoot {svg} at (0,0) size 778x156
+          layer at (0,0) size 778x156
+            RenderSVGViewportContainer at (0,0) size 778x156
+          layer at (0,0) size 2x1 backgroundClip at (0,0) size 778x156 clip at (0,0) size 778x156
             RenderSVGText {text} at (0,-1) size 3x3 contains 1 chunk(s)
               RenderSVGInlineText {#text} at (0,0) size 3x2
-                chunk 1 text run 1 at (0.00,0.80) startOffset 0 endOffset 4 width 2.39: "PASS"
-      RenderBlock {P} at (0,210) size 784x160
-        RenderEmbeddedObject {OBJECT} at (0,0) size 306x156 [border: (3px inset #000080)]
-          layer at (0,0) size 300x150
-            RenderView at (0,0) size 300x150
-          layer at (0,0) size 300x150
-            RenderSVGRoot {svg} at (0,0) size 300x150
-          layer at (0,0) size 300x150
-            RenderSVGViewportContainer at (0,0) size 300x150
-          layer at (0,-100) size 2391x1150 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
-            RenderSVGText {text} at (0,-100) size 2391x1150 contains 1 chunk(s)
-              RenderSVGInlineText {#text} at (0,0) size 2391x1150
-                chunk 1 text run 1 at (0.00,800.00) startOffset 0 endOffset 4 width 2390.63: "PASS"
+                chunk 1 text run 1 at (0.00,0.80) startOffset 0 endOffset 4 width 2.40: "PASS"
+      RenderBlock {P} at (0,216) size 784x166
+        RenderEmbeddedObject {OBJECT} at (0,0) size 784x162 [border: (3px inset #000080)]
+          layer at (0,0) size 778x156
+            RenderView at (0,0) size 778x156
+          layer at (0,0) size 778x156
+            RenderSVGRoot {svg} at (0,0) size 778x156
+          layer at (0,0) size 778x156
+            RenderSVGViewportContainer at (0,0) size 778x156
+          layer at (0,-100) size 2397x1151 backgroundClip at (0,0) size 778x156 clip at (0,0) size 778x156
+            RenderSVGText {text} at (0,-100) size 2397x1151 contains 1 chunk(s)
+              RenderSVGInlineText {#text} at (0,0) size 2397x1151
+                chunk 1 text run 1 at (0.00,800.00) startOffset 0 endOffset 4 width 2396.77: "PASS"

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/sizing-flakiness-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/sizing-flakiness-expected.txt
@@ -4,13 +4,13 @@ layer at (0,0) size 800x410
   RenderBlock {HTML} at (0,0) size 800x410
     RenderBody {BODY} at (8,8) size 784x0
       RenderBlock (floating) {DIV} at (0,0) size 402x402 [border: (1px solid #FF0000)]
-        RenderEmbeddedObject {OBJECT} at (1,1) size 200x150
-          layer at (0,0) size 200x150
-            RenderView at (0,0) size 200x150
-          layer at (0,0) size 200x150
-            RenderSVGRoot {svg} at (0,0) size 200x150
-          layer at (0,0) size 200x150
-            RenderSVGViewportContainer at (0,0) size 200x150
+        RenderEmbeddedObject {OBJECT} at (1,1) size 200x67
+          layer at (0,0) size 200x67
+            RenderView at (0,0) size 200x67
+          layer at (0,0) size 200x67
+            RenderSVGRoot {svg} at (0,0) size 200x67
+          layer at (0,0) size 200x67
+            RenderSVGViewportContainer at (0,0) size 200x67
           layer at (1,1) size 118x38
             RenderSVGRect {rect} at (1,1) size 118x38 [stroke={[type=SOLID] [color=#FFCC33] [stroke width=2.00]}] [fill={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=118.00] [height=38.00]
           layer at (54,9) size 12x23

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/test-rightsizing-b-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/test-rightsizing-b-expected.txt
@@ -1,92 +1,86 @@
-layer at (0,0) size 785x703
+layer at (0,0) size 785x848
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x703
-  RenderBlock {html} at (0,0) size 785x704
-    RenderBody {body} at (47,30) size 738x666
-      RenderBlock {div} at (0,0) size 738x665
+layer at (0,0) size 785x848
+  RenderBlock {html} at (0,0) size 785x849
+    RenderBody {body} at (47,30) size 738x811
+      RenderBlock {div} at (0,0) size 738x810
         RenderBlock {h1} at (0,0) size 679x31
           RenderText {#text} at (0,0) size 385x30
             text run at (0,0) width 385: "rightsizing to percentage width"
         RenderBlock {h4} at (0,31) size 738x16
           RenderText {#text} at (0,0) size 137x16
             text run at (0,0) width 137: "WICD Core 1.0 #20-2"
-        RenderBlock (anonymous) at (0,66) size 738x155
-          RenderEmbeddedObject {object} at (0,0) size 296x150 [bgcolor=#FF0000]
-            layer at (0,0) size 295x150
-              RenderView at (0,0) size 295x150
-            layer at (0,0) size 295x150
-              RenderSVGRoot {svg} at (0,0) size 295x150
-            layer at (0,0) size 295x150
-              RenderSVGViewportContainer at (0,0) size 295x150
-            layer at (-3000,-1000) size 6200x2200 backgroundClip at (0,0) size 295x150 clip at (0,0) size 295x150
+        RenderBlock (anonymous) at (0,66) size 738x300
+          RenderEmbeddedObject {object} at (0,0) size 296x296 [bgcolor=#FF0000]
+            layer at (0,0) size 295x295
+              RenderView at (0,0) size 295x295
+            layer at (0,0) size 295x295
+              RenderSVGRoot {svg} at (0,0) size 295x295
+            layer at (0,0) size 295x295
+              RenderSVGViewportContainer at (0,0) size 295x295
+            layer at (-3000,-1000) size 6200x2200 backgroundClip at (0,0) size 295x295 clip at (0,0) size 295x295
               RenderSVGRect {rect} at (-3000,-1000) size 6200x2200 [fill={[type=SOLID] [color=#5588FF]}] [x=-3000.00] [y=-1000.00] [width=6200.00] [height=2200.00]
-            layer at (0,0) size 200x200 backgroundClip at (0,0) size 295x150 clip at (0,0) size 295x150
+            layer at (0,0) size 200x200
               RenderSVGEllipse {circle} at (0,0) size 200x200 [fill={[type=SOLID] [color=#0000FF]}] [cx=100.00] [cy=100.00] [r=100.00]
-            layer at (26,59) size 148x83
-              RenderSVGTransformableContainer {g} at (26,59) size 148x83
-            layer at (26,59) size 148x82
-              RenderSVGText {text} at (0,0) size 148x83 contains 1 chunk(s)
-                RenderSVGInlineText {#text} at (0,0) size 148x83
-                  chunk 1 (middle anchor) text run 1 at (26.08,125.00) startOffset 0 endOffset 3 width 147.83: "SVG"
-          RenderText {#text} at (295,136) size 5x17
-            text run at (295,136) width 5: " "
-          RenderEmbeddedObject {object} at (299,0) size 149x150 [bgcolor=#FF0000]
-            layer at (0,0) size 148x150
-              RenderView at (0,0) size 148x150
-            layer at (0,0) size 148x150
-              RenderSVGRoot {svg} at (0,0) size 148x150
-            layer at (0,0) size 148x150
-              RenderSVGViewportContainer at (0,0) size 148x150
-            layer at (-3000,-1000) size 6200x2200 backgroundClip at (0,0) size 148x150 clip at (0,0) size 148x150
+            layer at (27,60) size 148x82
+              RenderSVGTransformableContainer {g} at (27,60) size 146x81
+            layer at (27,60) size 146x81
+              RenderSVGText {text} at (0,0) size 147x82 contains 1 chunk(s)
+                RenderSVGInlineText {#text} at (0,0) size 147x82
+                  chunk 1 (middle anchor) text run 1 at (26.96,125.00) startOffset 0 endOffset 3 width 146.09: "SVG"
+          RenderText {#text} at (295,281) size 5x17
+            text run at (295,281) width 5: " "
+          RenderEmbeddedObject {object} at (299,147) size 149x148 [bgcolor=#FF0000]
+            layer at (0,0) size 148x148
+              RenderView at (0,0) size 148x148
+            layer at (0,0) size 148x148
+              RenderSVGRoot {svg} at (0,0) size 148x148
+            layer at (0,0) size 148x148
+              RenderSVGViewportContainer at (0,0) size 148x148
+            layer at (-3000,-1000) size 6200x2200 backgroundClip at (0,0) size 148x148 clip at (0,0) size 148x148
               RenderSVGRect {rect} at (-3000,-1000) size 6200x2200 [fill={[type=SOLID] [color=#5588FF]}] [x=-3000.00] [y=-1000.00] [width=6200.00] [height=2200.00]
-            layer at (0,0) size 200x200 backgroundClip at (0,0) size 148x150 clip at (0,0) size 148x150
+            layer at (0,0) size 200x200 backgroundClip at (0,0) size 148x148 clip at (0,0) size 148x148
               RenderSVGEllipse {circle} at (0,0) size 200x200 [fill={[type=SOLID] [color=#0000FF]}] [cx=100.00] [cy=100.00] [r=100.00]
-            layer at (26,60) size 148x83 backgroundClip at (0,0) size 148x150 clip at (0,0) size 148x150
+            layer at (26,60) size 148x83 backgroundClip at (0,0) size 148x148 clip at (0,0) size 148x148
               RenderSVGTransformableContainer {g} at (26,60) size 148x82
-            layer at (26,60) size 147x82 backgroundClip at (0,0) size 148x150 clip at (0,0) size 148x150
+            layer at (26,60) size 147x82 backgroundClip at (0,0) size 148x148 clip at (0,0) size 148x148
               RenderSVGText {text} at (0,0) size 148x82 contains 1 chunk(s)
                 RenderSVGInlineText {#text} at (0,0) size 148x82
                   chunk 1 (middle anchor) text run 1 at (26.50,125.00) startOffset 0 endOffset 3 width 147.01: "SVG"
-          RenderText {#text} at (447,136) size 5x17
-            text run at (447,136) width 5: " "
-          RenderEmbeddedObject {object} at (451,0) size 75x150 [bgcolor=#FF0000]
-            layer at (0,0) size 74x150
-              RenderView at (0,0) size 74x150
-            layer at (0,0) size 74x150
-              RenderSVGRoot {svg} at (0,0) size 74x150
-            layer at (0,0) size 74x150
-              RenderSVGViewportContainer at (0,0) size 74x150
-            layer at (-3000,-1000) size 6200x2200 backgroundClip at (0,0) size 74x150 clip at (0,0) size 74x150
+          RenderText {#text} at (447,281) size 5x17
+            text run at (447,281) width 5: " "
+          RenderEmbeddedObject {object} at (451,221) size 75x74 [bgcolor=#FF0000]
+            layer at (0,0) size 74x74
+              RenderView at (0,0) size 74x74
+            layer at (0,0) size 74x74
+              RenderSVGRoot {svg} at (0,0) size 74x74
+            layer at (0,0) size 74x74
+              RenderSVGViewportContainer at (0,0) size 74x74
+            layer at (-3000,-1000) size 6200x2200 backgroundClip at (0,0) size 74x74 clip at (0,0) size 74x74
               RenderSVGRect {rect} at (-3000,-1000) size 6200x2200 [fill={[type=SOLID] [color=#5588FF]}] [x=-3000.00] [y=-1000.00] [width=6200.00] [height=2200.00]
-            layer at (0,0) size 200x200 backgroundClip at (0,0) size 74x150 clip at (0,0) size 74x150
+            layer at (0,0) size 200x200 backgroundClip at (0,0) size 74x74 clip at (0,0) size 74x74
               RenderSVGEllipse {circle} at (0,0) size 200x200 [fill={[type=SOLID] [color=#0000FF]}] [cx=100.00] [cy=100.00] [r=100.00]
-            layer at (26,60) size 148x83 backgroundClip at (0,0) size 74x150 clip at (0,0) size 74x150
+            layer at (26,60) size 148x83 backgroundClip at (0,0) size 74x74 clip at (0,0) size 74x74
               RenderSVGTransformableContainer {g} at (26,60) size 148x82
-            layer at (26,60) size 147x82 backgroundClip at (0,0) size 74x150 clip at (0,0) size 74x150
+            layer at (26,60) size 147x82 backgroundClip at (0,0) size 74x74 clip at (0,0) size 74x74
               RenderSVGText {text} at (0,0) size 148x82 contains 1 chunk(s)
                 RenderSVGInlineText {#text} at (0,0) size 148x82
                   chunk 1 (middle anchor) text run 1 at (26.50,125.00) startOffset 0 endOffset 3 width 147.01: "SVG"
-          RenderText {#text} at (525,136) size 5x17
-            text run at (525,136) width 5: " "
-          RenderEmbeddedObject {object} at (529,0) size 38x150 [bgcolor=#FF0000]
-            layer at (0,0) size 37x150
-              RenderView at (0,0) size 37x150
-            layer at (0,0) size 37x150
-              RenderSVGRoot {svg} at (0,0) size 37x150
-            layer at (0,0) size 37x150
-              RenderSVGViewportContainer at (0,0) size 37x150
-            layer at (-3000,-1000) size 6200x2200 backgroundClip at (0,0) size 37x150 clip at (0,0) size 37x150
+          RenderText {#text} at (525,281) size 5x17
+            text run at (525,281) width 5: " "
+          RenderEmbeddedObject {object} at (529,258) size 38x37 [bgcolor=#FF0000]
+            layer at (0,0) size 37x37
+              RenderView at (0,0) size 37x37
+            layer at (0,0) size 37x37
+              RenderSVGRoot {svg} at (0,0) size 37x37
+            layer at (0,0) size 37x37
+              RenderSVGViewportContainer at (0,0) size 37x37
+            layer at (-3000,-1000) size 6200x2200 backgroundClip at (0,0) size 37x37 clip at (0,0) size 37x37
               RenderSVGRect {rect} at (-3000,-1000) size 6200x2200 [fill={[type=SOLID] [color=#5588FF]}] [x=-3000.00] [y=-1000.00] [width=6200.00] [height=2200.00]
-            layer at (0,0) size 200x200 backgroundClip at (0,0) size 37x150 clip at (0,0) size 37x150
+            layer at (0,0) size 200x200 backgroundClip at (0,0) size 37x37 clip at (0,0) size 37x37
               RenderSVGEllipse {circle} at (0,0) size 200x200 [fill={[type=SOLID] [color=#0000FF]}] [cx=100.00] [cy=100.00] [r=100.00]
-            layer at (26,60) size 148x83 backgroundClip at (0,0) size 37x150 clip at (0,0) size 37x150
-              RenderSVGTransformableContainer {g} at (26,60) size 148x82
-            layer at (26,60) size 147x82 backgroundClip at (0,0) size 37x150 clip at (0,0) size 37x150
-              RenderSVGText {text} at (0,0) size 148x82 contains 1 chunk(s)
-                RenderSVGInlineText {#text} at (0,0) size 148x82
-                  chunk 1 (middle anchor) text run 1 at (26.50,125.00) startOffset 0 endOffset 3 width 147.01: "SVG"
           RenderText {#text} at (0,0) size 0x0
-        RenderBlock {p} at (0,223) size 679x65
+        RenderBlock {p} at (0,368) size 679x65
           RenderText {#text} at (0,0) size 675x32
             text run at (0,0) width 675: "Above there must be four times the same, square SVG child visible, each referenced by an object element with"
             text run at (0,16) width 377: "different widths (40%, 20%, 10%, 5%) and no height defined."
@@ -94,7 +88,7 @@ layer at (0,0) size 785x703
           RenderBR {br} at (0,32) size 0x16
           RenderText {#text} at (0,48) size 398x16
             text run at (0,48) width 398: "Beyond there is the same, only with PNG images instead of SVG."
-        RenderBlock (anonymous) at (0,292) size 738x300
+        RenderBlock (anonymous) at (0,437) size 738x300
           RenderImage {object} at (0,0) size 296x296 [bgcolor=#FF0000]
           RenderText {#text} at (295,281) size 5x17
             text run at (295,281) width 5: " "
@@ -106,11 +100,11 @@ layer at (0,0) size 785x703
             text run at (525,281) width 5: " "
           RenderImage {object} at (529,258) size 38x37 [bgcolor=#FF0000]
           RenderText {#text} at (0,0) size 0x0
-        RenderBlock {p} at (0,594) size 679x33
+        RenderBlock {p} at (0,739) size 679x33
           RenderText {#text} at (0,0) size 656x32
             text run at (0,0) width 656: "This test has succeeded, if both rows look exactly the same (SVGs must be square!) and no red background"
             text run at (0,16) width 92: "color is visible."
-        RenderBlock {p} at (0,632) size 679x33
+        RenderBlock {p} at (0,777) size 679x33
           RenderBR {br} at (0,0) size 0x16
           RenderInline {a} at (0,0) size 31x16 [color=#000066]
             RenderText {#text} at (0,16) size 31x16


### PR DESCRIPTION
#### f02cb2246d5b4b081cc8d127fb1aadfdfa2bedac
<pre>
[LBSE] Enable size negotiation logic for &lt;object&gt; + RenderSVGRoot in LBSE
<a href="https://bugs.webkit.org/show_bug.cgi?id=245907">https://bugs.webkit.org/show_bug.cgi?id=245907</a>

Reviewed by Adrian Perez de Castro.

The &lt;object&gt; size negotiation logic is only activated for the legacy engine.
Fix that --&gt; mark 17 more tests as passing in LBSE.

* LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-image/img-preserveAspectRatio-support-2-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/deep-nested-embedded-svg-size-changes-no-layout-triggers-1-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/deep-nested-embedded-svg-size-changes-no-layout-triggers-2-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/embedded-svg-size-changes-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/embedded-svg-size-changes-no-layout-triggers-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/nested-embedded-svg-size-changes-no-layout-triggers-1-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-object/nested-embedded-svg-size-changes-no-layout-triggers-2-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/hixie/intrinsic/003-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/hixie/text/003-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/sizing-flakiness-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/test-rightsizing-b-expected.txt:
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::forceLayoutParentViewIfNeeded):
(WebCore::FrameView::embeddedContentBox const):

Canonical link: <a href="https://commits.webkit.org/255291@main">https://commits.webkit.org/255291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bb04357e93e66b9f004df1a950cb1d7ef4a0818

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101788 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161864 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1209 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29653 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84439 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97994 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/742 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78519 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27692 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82664 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70728 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36060 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16288 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33798 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17390 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3665 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37675 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36514 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->