### PR TITLE
[LBSE] Unreviewed gardening -- update text baseline if needed

### DIFF
--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations
@@ -74,6 +74,7 @@ svg/filters/feDiffuseLighting-fePointLight-primitiveUnits-objectBoundingBox.svg 
 svg/filters/feDiffuseLighting-feSpotLight-dynamic-update.svg                           [ ImageOnlyFailure ]
 svg/filters/feDiffuseLighting-feSpotLight-primitiveUnits-objectBoundingBox.svg         [ ImageOnlyFailure ]
 svg/filters/feDisplacementMap-color-interpolation-filters.svg                          [ ImageOnlyFailure ]
+svg/filters/feDisplacementMap-filterUnits.svg                                          [ ImageOnlyFailure ]
 svg/filters/feDisplacementMap.svg                                                      [ ImageOnlyFailure ]
 svg/filters/feDropShadow-blur-radius.html                                              [ ImageOnlyFailure ]
 svg/filters/feDropShadow-subregion.svg                                                 [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/color-prop-01-b-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/color-prop-01-b-expected.txt
@@ -19,7 +19,7 @@ layer at (60,215) size 360x80
 layer at (60,215) size 360x80
   RenderSVGTransformableContainer {g} at (0,0) size 360x80
 layer at (60,215) size 360x80
-  RenderSVGRect {rect} at (0,0) size 360x80 [fill={[type=SOLID] [color=#00000000]}] [x=60.00] [y=215.00] [width=360.00] [height=80.00]
+  RenderSVGRect {rect} at (0,0) size 360x80 [fill={[type=SOLID] [color=#0000FF]}] [x=60.00] [y=215.00] [width=360.00] [height=80.00]
 layer at (120,142.50) size 264x71
   RenderSVGTransformableContainer {g} at (60,122.50) size 263.33x70
 layer at (120,142.50) size 35x35

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-13-b-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-13-b-expected.txt
@@ -53,7 +53,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -75,7 +75,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -97,7 +97,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -119,7 +119,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -141,7 +141,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -163,7 +163,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -185,7 +185,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -207,7 +207,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -229,7 +229,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -251,7 +251,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -273,7 +273,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -295,7 +295,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -317,7 +317,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -339,7 +339,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -361,7 +361,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (0,0) size 100x60
   RenderSVGTransformableContainer {use} at (0,0) size 100x60
 layer at (0,0) size 100x60
@@ -383,7 +383,7 @@ layer at (75,0) size 10x60
 layer at (90,0) size 10x60
   RenderSVGRect {rect} at (90,0) size 10x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#FFD700]}] [x=90.00] [y=0.00] [width=10.00] [height=60.00]
 layer at (0,0) size 100x60
-  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
+  RenderSVGRect {rect} at (0,0) size 100x60 [stroke={[type=SOLID] [color=#000000] [stroke width=0.50]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=60.00]
 layer at (10,312.50) size 198x35
   RenderSVGText {text} at (10,312) size 198x36 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 198x35

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-background-image/background-image-preserveaspectRatio-support-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-background-image/background-image-preserveaspectRatio-support-expected.txt
@@ -3,92 +3,92 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x504
   RenderBlock {HTML} at (0,0) size 800x504
     RenderBody {BODY} at (8,8) size 784x488
-      RenderTable {TABLE} at (0,0) size 668.77x488
-        RenderTableSection {TBODY} at (0,0) size 668.77x488
-          RenderTableRow {TR} at (0,2) size 668.77x20
-            RenderTableCell {TH} at (2,2) size 92.69x20 [bgcolor=#DDDD99] [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (0,0) size 669x488
+        RenderTableSection {TBODY} at (0,0) size 669x488
+          RenderTableRow {TR} at (0,2) size 669x20
+            RenderTableCell {TH} at (2,2) size 93x20 [bgcolor=#DDDD99] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (9,1) size 75x18
                 text run at (9,1) width 75: "viewBox?"
-            RenderTableCell {TH} at (96.69,2) size 162.08x20 [bgcolor=#DDDD99] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TH} at (96,2) size 163x20 [bgcolor=#DDDD99] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 161x18
                 text run at (1,1) width 161: "preserve\x{AD}Aspect\x{AD}Ratio"
-            RenderTableCell {TH} at (260.77,2) size 202x20 [bgcolor=#DDDD99] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TH} at (260,2) size 203x20 [bgcolor=#DDDD99] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (77,1) size 48x18
                 text run at (77,1) width 48: "<img>"
-            RenderTableCell {TH} at (464.77,2) size 202x20 [bgcolor=#DDDD99] [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TH} at (464,2) size 203x20 [bgcolor=#DDDD99] [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (80,1) size 42x18
                 text run at (80,1) width 42: "<div>"
-          RenderTableRow {TR} at (0,24) size 668.77x56
-            RenderTableCell {TH} at (2,129) size 92.69x20 [bgcolor=#DDDD99] [r=1 c=0 rs=4 cs=1]
+          RenderTableRow {TR} at (0,24) size 669x56
+            RenderTableCell {TH} at (2,129) size 93x20 [bgcolor=#DDDD99] [r=1 c=0 rs=4 cs=1]
               RenderText {#text} at (1,1) size 91x18
                 text run at (1,1) width 91: "No viewBox"
-            RenderTableCell {TH} at (96.69,51) size 162.08x2 [bgcolor=#DDDD99] [r=1 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (260.77,24) size 202x56 [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TH} at (96,51) size 163x2 [bgcolor=#DDDD99] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (260,24) size 203x56 [r=1 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,26) size 202x52 [r=1 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,26) size 203x52 [r=1 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 200x50 [border: (2px dashed #800000)]
-          RenderTableRow {TR} at (0,82) size 668.77x56
-            RenderTableCell {TH} at (96.69,100) size 162.08x20 [bgcolor=#DDDD99] [r=2 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,82) size 669x56
+            RenderTableCell {TH} at (96,100) size 163x20 [bgcolor=#DDDD99] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (61,1) size 40x18
                 text run at (61,1) width 40: "none"
-            RenderTableCell {TD} at (260.77,82) size 202x56 [r=2 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (260,82) size 203x56 [r=2 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,84) size 202x52 [r=2 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,84) size 203x52 [r=2 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 200x50 [border: (2px dashed #800000)]
-          RenderTableRow {TR} at (0,140) size 668.77x56
-            RenderTableCell {TH} at (96.69,158) size 162.08x20 [bgcolor=#DDDD99] [r=3 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,140) size 669x56
+            RenderTableCell {TH} at (96,158) size 163x20 [bgcolor=#DDDD99] [r=3 c=1 rs=1 cs=1]
               RenderText {#text} at (62,1) size 38x18
                 text run at (62,1) width 38: "meet"
-            RenderTableCell {TD} at (260.77,140) size 202x56 [r=3 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (260,140) size 203x56 [r=3 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,142) size 202x52 [r=3 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,142) size 203x52 [r=3 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 200x50 [border: (2px dashed #800000)]
-          RenderTableRow {TR} at (0,198) size 668.77x56
-            RenderTableCell {TH} at (96.69,216) size 162.08x20 [bgcolor=#DDDD99] [r=4 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,198) size 669x56
+            RenderTableCell {TH} at (96,216) size 163x20 [bgcolor=#DDDD99] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (63,1) size 36x18
                 text run at (63,1) width 36: "slice"
-            RenderTableCell {TD} at (260.77,198) size 202x56 [r=4 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (260,198) size 203x56 [r=4 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,200) size 202x52 [r=4 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,200) size 203x52 [r=4 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 200x50 [border: (2px dashed #800000)]
-          RenderTableRow {TR} at (0,256) size 668.77x56
-            RenderTableCell {TH} at (2,361) size 92.69x20 [bgcolor=#DDDD99] [r=5 c=0 rs=4 cs=1]
+          RenderTableRow {TR} at (0,256) size 669x56
+            RenderTableCell {TH} at (2,361) size 93x20 [bgcolor=#DDDD99] [r=5 c=0 rs=4 cs=1]
               RenderText {#text} at (13,1) size 66x18
                 text run at (13,1) width 66: "viewBox"
-            RenderTableCell {TH} at (96.69,283) size 162.08x2 [bgcolor=#DDDD99] [r=5 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (260.77,256) size 202x56 [r=5 c=2 rs=1 cs=1]
+            RenderTableCell {TH} at (96,283) size 163x2 [bgcolor=#DDDD99] [r=5 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (260,256) size 203x56 [r=5 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,258) size 202x52 [r=5 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,258) size 203x52 [r=5 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 200x50 [border: (2px dashed #800000)]
-          RenderTableRow {TR} at (0,314) size 668.77x56
-            RenderTableCell {TH} at (96.69,332) size 162.08x20 [bgcolor=#DDDD99] [r=6 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,314) size 669x56
+            RenderTableCell {TH} at (96,332) size 163x20 [bgcolor=#DDDD99] [r=6 c=1 rs=1 cs=1]
               RenderText {#text} at (61,1) size 40x18
                 text run at (61,1) width 40: "none"
-            RenderTableCell {TD} at (260.77,314) size 202x56 [r=6 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (260,314) size 203x56 [r=6 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,316) size 202x52 [r=6 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,316) size 203x52 [r=6 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 200x50 [border: (2px dashed #800000)]
-          RenderTableRow {TR} at (0,372) size 668.77x56
-            RenderTableCell {TH} at (96.69,390) size 162.08x20 [bgcolor=#DDDD99] [r=7 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,372) size 669x56
+            RenderTableCell {TH} at (96,390) size 163x20 [bgcolor=#DDDD99] [r=7 c=1 rs=1 cs=1]
               RenderText {#text} at (62,1) size 38x18
                 text run at (62,1) width 38: "meet"
-            RenderTableCell {TD} at (260.77,372) size 202x56 [r=7 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (260,372) size 203x56 [r=7 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,374) size 202x52 [r=7 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,374) size 203x52 [r=7 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 200x50 [border: (2px dashed #800000)]
-          RenderTableRow {TR} at (0,430) size 668.77x56
-            RenderTableCell {TH} at (96.69,448) size 162.08x20 [bgcolor=#DDDD99] [r=8 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,430) size 669x56
+            RenderTableCell {TH} at (96,448) size 163x20 [bgcolor=#DDDD99] [r=8 c=1 rs=1 cs=1]
               RenderText {#text} at (63,1) size 36x18
                 text run at (63,1) width 36: "slice"
-            RenderTableCell {TD} at (260.77,430) size 202x56 [r=8 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (260,430) size 203x56 [r=8 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,432) size 202x52 [r=8 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,432) size 203x52 [r=8 c=3 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 200x50 [border: (2px dashed #800000)]

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-border-image/svg-as-border-image-2-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-border-image/svg-as-border-image-2-expected.txt
@@ -3,11 +3,11 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DIV} at (0,0) size 366x437.81 [border: (1px solid #000000)]
-        RenderBlock {H2} at (1,20.91) size 364x28
+      RenderBlock {DIV} at (0,0) size 366x438 [border: (1px solid #000000)]
+        RenderBlock {H2} at (1,20) size 364x29
           RenderText {#text} at (0,0) size 195x28
             text run at (0,0) width 195: "SVG border-image"
-        RenderBlock (anonymous) at (1,68.81) size 364x368
+        RenderBlock (anonymous) at (1,68) size 364x369
           RenderBlock {DIV} at (10,10) size 160x160 [border: (30px solid #000000)]
           RenderText {#text} at (180,166) size 4x18
             text run at (180,166) width 4: " "
@@ -20,11 +20,11 @@ layer at (0,0) size 800x600
           RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (366,418) size 4x18
         text run at (366,418) width 4: " "
-      RenderBlock {DIV} at (370,0) size 366x437.81 [border: (1px solid #000000)]
-        RenderBlock {H2} at (1,20.91) size 364x28
+      RenderBlock {DIV} at (370,0) size 366x438 [border: (1px solid #000000)]
+        RenderBlock {H2} at (1,20) size 364x29
           RenderText {#text} at (0,0) size 196x28
             text run at (0,0) width 196: "PNG border-image"
-        RenderBlock (anonymous) at (1,68.81) size 364x368
+        RenderBlock (anonymous) at (1,68) size 364x369
           RenderBlock {DIV} at (10,10) size 160x160 [border: (30px solid #000000)]
           RenderText {#text} at (180,166) size 4x18
             text run at (180,166) width 4: " "

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-border-image/svg-as-border-image-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-border-image/svg-as-border-image-expected.txt
@@ -3,11 +3,11 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DIV} at (0,0) size 366x437.81 [border: (1px solid #000000)]
-        RenderBlock {H2} at (1,20.91) size 364x28
+      RenderBlock {DIV} at (0,0) size 366x438 [border: (1px solid #000000)]
+        RenderBlock {H2} at (1,20) size 364x29
           RenderText {#text} at (0,0) size 195x28
             text run at (0,0) width 195: "SVG border-image"
-        RenderBlock (anonymous) at (1,68.81) size 364x368
+        RenderBlock (anonymous) at (1,68) size 364x369
           RenderBlock {DIV} at (10,10) size 160x160 [border: (30px solid #000000)]
           RenderText {#text} at (180,166) size 4x18
             text run at (180,166) width 4: " "
@@ -20,11 +20,11 @@ layer at (0,0) size 800x600
           RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (366,418) size 4x18
         text run at (366,418) width 4: " "
-      RenderBlock {DIV} at (370,0) size 366x437.81 [border: (1px solid #000000)]
-        RenderBlock {H2} at (1,20.91) size 364x28
+      RenderBlock {DIV} at (370,0) size 366x438 [border: (1px solid #000000)]
+        RenderBlock {H2} at (1,20) size 364x29
           RenderText {#text} at (0,0) size 196x28
             text run at (0,0) width 196: "PNG border-image"
-        RenderBlock (anonymous) at (1,68.81) size 364x368
+        RenderBlock (anonymous) at (1,68) size 364x369
           RenderBlock {DIV} at (10,10) size 160x160 [border: (30px solid #000000)]
           RenderText {#text} at (180,166) size 4x18
             text run at (180,166) width 4: " "

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-image/img-preserveAspectRatio-support-1-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-image/img-preserveAspectRatio-support-1-expected.txt
@@ -3,30 +3,30 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x504
   RenderBlock {HTML} at (0,0) size 800x504
     RenderBody {BODY} at (8,8) size 784x488
-      RenderTable {TABLE} at (0,0) size 668.77x488
-        RenderTableSection {TBODY} at (0,0) size 668.77x488
-          RenderTableRow {TR} at (0,2) size 668.77x20
-            RenderTableCell {TH} at (2,2) size 92.69x20 [bgcolor=#DDDD99] [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (0,0) size 669x488
+        RenderTableSection {TBODY} at (0,0) size 669x488
+          RenderTableRow {TR} at (0,2) size 669x20
+            RenderTableCell {TH} at (2,2) size 93x20 [bgcolor=#DDDD99] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (9,1) size 75x18
                 text run at (9,1) width 75: "viewBox?"
-            RenderTableCell {TH} at (96.69,2) size 162.08x20 [bgcolor=#DDDD99] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TH} at (96,2) size 163x20 [bgcolor=#DDDD99] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 161x18
                 text run at (1,1) width 161: "preserve\x{AD}Aspect\x{AD}Ratio"
-            RenderTableCell {TH} at (260.77,2) size 202x20 [bgcolor=#DDDD99] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TH} at (260,2) size 203x20 [bgcolor=#DDDD99] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (77,1) size 48x18
                 text run at (77,1) width 48: "<img>"
-            RenderTableCell {TH} at (464.77,2) size 202x20 [bgcolor=#DDDD99] [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TH} at (464,2) size 203x20 [bgcolor=#DDDD99] [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (68,1) size 66x18
                 text run at (68,1) width 66: "<object>"
-          RenderTableRow {TR} at (0,24) size 668.77x56
-            RenderTableCell {TH} at (2,129) size 92.69x20 [bgcolor=#DDDD99] [r=1 c=0 rs=4 cs=1]
+          RenderTableRow {TR} at (0,24) size 669x56
+            RenderTableCell {TH} at (2,129) size 93x20 [bgcolor=#DDDD99] [r=1 c=0 rs=4 cs=1]
               RenderText {#text} at (1,1) size 91x18
                 text run at (1,1) width 91: "No viewBox"
-            RenderTableCell {TH} at (96.69,51) size 162.08x2 [bgcolor=#DDDD99] [r=1 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (260.77,24) size 202x56 [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TH} at (96,51) size 163x2 [bgcolor=#DDDD99] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (260,24) size 203x56 [r=1 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,24) size 202x56 [r=1 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,24) size 203x56 [r=1 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (1,1) size 200x50 [border: (1px dashed #008000)]
                 layer at (0,0) size 192x42
                   RenderView at (0,0) size 192x42
@@ -37,14 +37,14 @@ layer at (0,0) size 800x504
                 layer at (0,0) size 220x220 backgroundClip at (0,0) size 192x42 clip at (0,0) size 192x42
                   RenderSVGEllipse {circle} at (0,0) size 220x220 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [cx=110.00] [cy=110.00] [r=110.00]
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,82) size 668.77x56
-            RenderTableCell {TH} at (96.69,100) size 162.08x20 [bgcolor=#DDDD99] [r=2 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,82) size 669x56
+            RenderTableCell {TH} at (96,100) size 163x20 [bgcolor=#DDDD99] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (61,1) size 40x18
                 text run at (61,1) width 40: "none"
-            RenderTableCell {TD} at (260.77,82) size 202x56 [r=2 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (260,82) size 203x56 [r=2 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,82) size 202x56 [r=2 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,82) size 203x56 [r=2 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (1,1) size 200x50 [border: (1px dashed #008000)]
                 layer at (0,0) size 192x42
                   RenderView at (0,0) size 192x42
@@ -53,14 +53,14 @@ layer at (0,0) size 800x504
                 layer at (0,0) size 192x42
                   RenderSVGViewportContainer at (0,0) size 192x42
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,140) size 668.77x56
-            RenderTableCell {TH} at (96.69,158) size 162.08x20 [bgcolor=#DDDD99] [r=3 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,140) size 669x56
+            RenderTableCell {TH} at (96,158) size 163x20 [bgcolor=#DDDD99] [r=3 c=1 rs=1 cs=1]
               RenderText {#text} at (62,1) size 38x18
                 text run at (62,1) width 38: "meet"
-            RenderTableCell {TD} at (260.77,140) size 202x56 [r=3 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (260,140) size 203x56 [r=3 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,140) size 202x56 [r=3 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,140) size 203x56 [r=3 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (1,1) size 200x50 [border: (1px dashed #008000)]
                 layer at (0,0) size 192x42
                   RenderView at (0,0) size 192x42
@@ -69,14 +69,14 @@ layer at (0,0) size 800x504
                 layer at (0,0) size 192x42
                   RenderSVGViewportContainer at (0,0) size 192x42
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,198) size 668.77x56
-            RenderTableCell {TH} at (96.69,216) size 162.08x20 [bgcolor=#DDDD99] [r=4 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,198) size 669x56
+            RenderTableCell {TH} at (96,216) size 163x20 [bgcolor=#DDDD99] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (63,1) size 36x18
                 text run at (63,1) width 36: "slice"
-            RenderTableCell {TD} at (260.77,198) size 202x56 [r=4 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (260,198) size 203x56 [r=4 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,198) size 202x56 [r=4 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,198) size 203x56 [r=4 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (1,1) size 200x50 [border: (1px dashed #008000)]
                 layer at (0,0) size 192x42
                   RenderView at (0,0) size 192x42
@@ -85,15 +85,15 @@ layer at (0,0) size 800x504
                 layer at (0,0) size 192x42
                   RenderSVGViewportContainer at (0,0) size 192x42
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,256) size 668.77x56
-            RenderTableCell {TH} at (2,361) size 92.69x20 [bgcolor=#DDDD99] [r=5 c=0 rs=4 cs=1]
+          RenderTableRow {TR} at (0,256) size 669x56
+            RenderTableCell {TH} at (2,361) size 93x20 [bgcolor=#DDDD99] [r=5 c=0 rs=4 cs=1]
               RenderText {#text} at (13,1) size 66x18
                 text run at (13,1) width 66: "viewBox"
-            RenderTableCell {TH} at (96.69,283) size 162.08x2 [bgcolor=#DDDD99] [r=5 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (260.77,256) size 202x56 [r=5 c=2 rs=1 cs=1]
+            RenderTableCell {TH} at (96,283) size 163x2 [bgcolor=#DDDD99] [r=5 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (260,256) size 203x56 [r=5 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,256) size 202x56 [r=5 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,256) size 203x56 [r=5 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (1,1) size 200x50 [border: (1px dashed #008000)]
                 layer at (0,0) size 192x42
                   RenderView at (0,0) size 192x42
@@ -102,14 +102,14 @@ layer at (0,0) size 800x504
                 layer at (0,0) size 192x42
                   RenderSVGViewportContainer at (0,0) size 192x42
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,314) size 668.77x56
-            RenderTableCell {TH} at (96.69,332) size 162.08x20 [bgcolor=#DDDD99] [r=6 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,314) size 669x56
+            RenderTableCell {TH} at (96,332) size 163x20 [bgcolor=#DDDD99] [r=6 c=1 rs=1 cs=1]
               RenderText {#text} at (61,1) size 40x18
                 text run at (61,1) width 40: "none"
-            RenderTableCell {TD} at (260.77,314) size 202x56 [r=6 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (260,314) size 203x56 [r=6 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,314) size 202x56 [r=6 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,314) size 203x56 [r=6 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (1,1) size 200x50 [border: (1px dashed #008000)]
                 layer at (0,0) size 192x42
                   RenderView at (0,0) size 192x42
@@ -118,14 +118,14 @@ layer at (0,0) size 800x504
                 layer at (0,0) size 192x42
                   RenderSVGViewportContainer at (0,0) size 192x42
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,372) size 668.77x56
-            RenderTableCell {TH} at (96.69,390) size 162.08x20 [bgcolor=#DDDD99] [r=7 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,372) size 669x56
+            RenderTableCell {TH} at (96,390) size 163x20 [bgcolor=#DDDD99] [r=7 c=1 rs=1 cs=1]
               RenderText {#text} at (62,1) size 38x18
                 text run at (62,1) width 38: "meet"
-            RenderTableCell {TD} at (260.77,372) size 202x56 [r=7 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (260,372) size 203x56 [r=7 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,372) size 202x56 [r=7 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,372) size 203x56 [r=7 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (1,1) size 200x50 [border: (1px dashed #008000)]
                 layer at (0,0) size 192x42
                   RenderView at (0,0) size 192x42
@@ -134,14 +134,14 @@ layer at (0,0) size 800x504
                 layer at (0,0) size 192x42
                   RenderSVGViewportContainer at (0,0) size 192x42
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,430) size 668.77x56
-            RenderTableCell {TH} at (96.69,448) size 162.08x20 [bgcolor=#DDDD99] [r=8 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,430) size 669x56
+            RenderTableCell {TH} at (96,448) size 163x20 [bgcolor=#DDDD99] [r=8 c=1 rs=1 cs=1]
               RenderText {#text} at (63,1) size 36x18
                 text run at (63,1) width 36: "slice"
-            RenderTableCell {TD} at (260.77,430) size 202x56 [r=8 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (260,430) size 203x56 [r=8 c=2 rs=1 cs=1]
               RenderImage {IMG} at (1,1) size 200x50 [border: (2px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (464.77,430) size 202x56 [r=8 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (464,430) size 203x56 [r=8 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (1,1) size 200x50 [border: (1px dashed #008000)]
                 layer at (0,0) size 192x42
                   RenderView at (0,0) size 192x42

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-image/img-preserveAspectRatio-support-2-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-image/img-preserveAspectRatio-support-2-expected.txt
@@ -1,12 +1,12 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x322
-  RenderBlock {HTML} at (0,0) size 800x321.88
-    RenderBody {BODY} at (8,21.44) size 784x292.44
+  RenderBlock {HTML} at (0,0) size 800x322
+    RenderBody {BODY} at (8,21) size 784x293
       RenderBlock {H1} at (0,0) size 784x37
         RenderText {#text} at (0,0) size 223x37
           text run at (0,0) width 223: "No size specified"
-      RenderBlock (anonymous) at (0,58.44) size 784x234
+      RenderBlock (anonymous) at (0,58) size 784x235
         RenderImage {IMG} at (0,0) size 230x230 [border: (2px dashed #800000)]
         RenderText {#text} at (230,216) size 4x18
           text run at (230,216) width 4: " "

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-image/svg-non-integer-scaled-image-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-image/svg-non-integer-scaled-image-expected.txt
@@ -3,5 +3,5 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderImage {IMG} at (0,0) size 99.98x100.98
+      RenderImage {IMG} at (0,0) size 100x101
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/batik/paints/patternPreserveAspectRatioA-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/batik/paints/patternPreserveAspectRatioA-expected.txt
@@ -401,141 +401,141 @@ layer at (0,0) size 91x30
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {g} at (0,0) size 90x30
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {g} at (0,0) size 90x30
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 91x30
   RenderSVGTransformableContainer {g} at (3.67,20) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {g} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {g} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 91x30
   RenderSVGTransformableContainer {g} at (3.67,20) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {g} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {g} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 91x30
   RenderSVGTransformableContainer {g} at (3.67,20) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (0,0) size 90x30
   RenderSVGTransformableContainer {use} at (0,0) size 90x30 [start marker=startEndMarker] [end marker=startEndMarker]
 layer at (0,0) size 90x30
-  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#00000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
+  RenderSVGRect {rect} at (0,0) size 90x30 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [start marker=startEndMarker] [end marker=startEndMarker] [x=0.00] [y=0.00] [width=90.00] [height=30.00]
 layer at (-0.05,-0.36) size 540x565 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
   RenderSVGTransformableContainer {use} at (-0.05,-0.36) size 539x563.77
 layer at (-0.05,-0.36) size 539x564 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/bug45331-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/bug45331-expected.txt
@@ -3,14 +3,14 @@ layer at (0,0) size 785x616
 layer at (0,0) size 785x600
   RenderBlock {html} at (0,0) size 785x600
     RenderBody {body} at (8,16) size 769x600
-      RenderBlock {parsererror} at (16,0) size 737x136.88 [bgcolor=#FFDDDD] [border: (2px solid #CC7777)]
-        RenderBlock {h3} at (18,20.72) size 701x22
+      RenderBlock {parsererror} at (16,0) size 737x137 [bgcolor=#FFDDDD] [border: (2px solid #CC7777)]
+        RenderBlock {h3} at (18,20) size 701x23
           RenderText {#text} at (0,0) size 323x22
             text run at (0,0) width 323: "This page contains the following errors:"
-        RenderBlock {div} at (18,61.44) size 701x14
+        RenderBlock {div} at (18,61) size 701x15
           RenderText {#text} at (0,0) size 497x14
             text run at (0,0) width 497: "error on line 3 at column 1: Extra content at the end of the document"
             text run at (496,0) width 1: " "
-        RenderBlock {h3} at (18,94.16) size 701x22
+        RenderBlock {h3} at (18,94) size 701x23
           RenderText {#text} at (0,0) size 424x22
             text run at (0,0) width 424: "Below is a rendering of the page up to the first error."

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/scrolling-embedded-svg-file-image-repaint-problem-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/scrolling-embedded-svg-file-image-repaint-problem-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 1026x1016 backgroundClip at (0,0) size 1026x1015.63 clip at (0,0) size 1026x1015.63
+layer at (0,0) size 1026x1016
   RenderView at (0,0) size 785x585
-layer at (0,0) size 785x1016 backgroundClip at (0,0) size 1026x1015.63 clip at (0,0) size 1026x1015.63
-  RenderBlock {HTML} at (0,0) size 785x1015.63
-    RenderBody {BODY} at (8,16) size 769x995.63
+layer at (0,0) size 785x1016
+  RenderBlock {HTML} at (0,0) size 785x1016
+    RenderBody {BODY} at (8,16) size 769x996
       RenderBlock {DIV} at (16,0) size 737x60
         RenderBlock {P} at (0,0) size 737x20
           RenderInline {A} at (0,0) size 90x18 [color=#0000EE]
@@ -34,26 +34,26 @@ layer at (0,0) size 785x1016 backgroundClip at (0,0) size 1026x1015.63 clip at (
             RenderText {#text} at (408,1) size 176x18
               text run at (408,1) width 176: "\x{2192} script-handle-01-b"
           RenderText {#text} at (0,0) size 0x0
-      RenderTable {TABLE} at (0,64) size 1018x550.88
-        RenderTableSection {TBODY} at (0,0) size 1018x550.88
-          RenderTableRow {TR} at (0,0) size 1018x550.88
-            RenderTableCell {TD} at (0,0) size 1018x550.88 [r=0 c=0 rs=1 cs=3]
-              RenderTable {TABLE} at (10,10) size 998x530.88
-                RenderTableSection {TBODY} at (0,0) size 998x530.88
-                  RenderTableRow {TR} at (0,2) size 998x106.88
-                    RenderTableCell {TD} at (2,2) size 994x106.88 [r=0 c=0 rs=1 cs=2]
-                      RenderBlock {H1} at (8,29.44) size 978x48
+      RenderTable {TABLE} at (0,64) size 1018x551
+        RenderTableSection {TBODY} at (0,0) size 1018x551
+          RenderTableRow {TR} at (0,0) size 1018x551
+            RenderTableCell {TD} at (0,0) size 1018x551 [r=0 c=0 rs=1 cs=3]
+              RenderTable {TABLE} at (10,10) size 998x531
+                RenderTableSection {TBODY} at (0,0) size 998x531
+                  RenderTableRow {TR} at (0,2) size 998x107
+                    RenderTableCell {TD} at (2,2) size 994x107 [r=0 c=0 rs=1 cs=2]
+                      RenderBlock {H1} at (8,29) size 978x49
                         RenderText {#text} at (314,5) size 350x38
                           text run at (314,5) width 350: "render-groups-01-b"
-                  RenderTableRow {TR} at (0,110.88) size 998x36 [color=#FFFFFF] [bgcolor=#000000]
-                    RenderTableCell {TD} at (2,110.88) size 496x36 [r=1 c=0 rs=1 cs=1]
+                  RenderTableRow {TR} at (0,110) size 998x37 [color=#FFFFFF] [bgcolor=#000000]
+                    RenderTableCell {TD} at (2,110) size 496x37 [r=1 c=0 rs=1 cs=1]
                       RenderText {#text} at (204,9) size 88x18
                         text run at (204,9) width 88: "SVG Image"
-                    RenderTableCell {TD} at (500,110.88) size 496x36 [r=1 c=1 rs=1 cs=1]
+                    RenderTableCell {TD} at (500,110) size 496x37 [r=1 c=1 rs=1 cs=1]
                       RenderText {#text} at (203,9) size 90x18
                         text run at (203,9) width 90: "PNG Image"
-                  RenderTableRow {TR} at (0,148.88) size 998x380
-                    RenderTableCell {TD} at (2,148.88) size 496x380 [r=2 c=0 rs=1 cs=1]
+                  RenderTableRow {TR} at (0,148) size 998x381
+                    RenderTableCell {TD} at (2,148) size 496x381 [r=2 c=0 rs=1 cs=1]
                       RenderEmbeddedObject {EMBED} at (8,8) size 480x360
                         layer at (0,0) size 480x360
                           RenderView at (0,0) size 480x360
@@ -61,40 +61,40 @@ layer at (0,0) size 785x1016 backgroundClip at (0,0) size 1026x1015.63 clip at (
                           RenderSVGRoot {svg} at (0,0) size 480x360
                         layer at (0,0) size 480x360
                           RenderSVGViewportContainer at (0,0) size 480x360
-                        layer at (20,5.63) size 230x160
-                          RenderSVGTransformableContainer {g} at (20,5.63) size 230x159.38
-                        layer at (20,5.63) size 230x160
-                          RenderSVGTransformableContainer {g} at (0,0) size 230x159.38
+                        layer at (20,6) size 230x160
+                          RenderSVGTransformableContainer {g} at (20,6) size 230x159
+                        layer at (20,6) size 230x160
+                          RenderSVGTransformableContainer {g} at (0,0) size 230x159
                         layer at (20,10) size 230x156
-                          RenderSVGRect {rect} at (0,4.38) size 230x155 [fill={[type=SOLID] [color=#C0C0C0]}] [x=20.00] [y=10.00] [width=230.00] [height=155.00]
+                          RenderSVGRect {rect} at (0,4) size 230x155 [fill={[type=SOLID] [color=#C0C0C0]}] [x=20.00] [y=10.00] [width=230.00] [height=155.00]
                         layer at (40,10) size 0x166
-                          RenderSVGPath {line} at (20,4.38) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=40.00] [y1=10.00] [x2=40.00] [y2=175.00]
+                          RenderSVGPath {line} at (20,4) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=40.00] [y1=10.00] [x2=40.00] [y2=175.00]
                         layer at (70,10) size 0x166
-                          RenderSVGPath {line} at (50,4.38) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=70.00] [y1=10.00] [x2=70.00] [y2=175.00]
+                          RenderSVGPath {line} at (50,4) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=70.00] [y1=10.00] [x2=70.00] [y2=175.00]
                         layer at (100,10) size 0x166
-                          RenderSVGPath {line} at (80,4.38) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=100.00] [y1=10.00] [x2=100.00] [y2=175.00]
+                          RenderSVGPath {line} at (80,4) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=100.00] [y1=10.00] [x2=100.00] [y2=175.00]
                         layer at (130,10) size 0x166
-                          RenderSVGPath {line} at (110,4.38) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=130.00] [y1=10.00] [x2=130.00] [y2=175.00]
+                          RenderSVGPath {line} at (110,4) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=130.00] [y1=10.00] [x2=130.00] [y2=175.00]
                         layer at (160,10) size 0x166
-                          RenderSVGPath {line} at (140,4.38) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=160.00] [y1=10.00] [x2=160.00] [y2=175.00]
+                          RenderSVGPath {line} at (140,4) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=160.00] [y1=10.00] [x2=160.00] [y2=175.00]
                         layer at (190,10) size 0x166
-                          RenderSVGPath {line} at (170,4.38) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=190.00] [y1=10.00] [x2=190.00] [y2=175.00]
+                          RenderSVGPath {line} at (170,4) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=190.00] [y1=10.00] [x2=190.00] [y2=175.00]
                         layer at (220,10) size 0x166
-                          RenderSVGPath {line} at (200,4.38) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=220.00] [y1=10.00] [x2=220.00] [y2=175.00]
+                          RenderSVGPath {line} at (200,4) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=220.00] [y1=10.00] [x2=220.00] [y2=175.00]
                         layer at (250,10) size 0x166
-                          RenderSVGPath {line} at (230,4.38) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=250.00] [y1=10.00] [x2=250.00] [y2=175.00]
+                          RenderSVGPath {line} at (230,4) size 0x165 [stroke={[type=SOLID] [color=#FFFFFF] [stroke width=15.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=250.00] [y1=10.00] [x2=250.00] [y2=175.00]
                         layer at (20,10) size 230x156
-                          RenderSVGRect {rect} at (0,4.38) size 230x155 [stroke={[type=SOLID] [color=#000000]}] [x=20.00] [y=10.00] [width=230.00] [height=155.00]
-                        layer at (30,5.63) size 212x150
-                          RenderSVGTransformableContainer {g} at (10,0) size 212x149.38 [opacity=0.50]
-                        layer at (30,5.63) size 132x120
+                          RenderSVGRect {rect} at (0,4) size 230x155 [stroke={[type=SOLID] [color=#000000]}] [x=20.00] [y=10.00] [width=230.00] [height=155.00]
+                        layer at (30,6) size 212x150
+                          RenderSVGTransformableContainer {g} at (10,0) size 212x149 [opacity=0.50]
+                        layer at (30,6) size 132x120
                           RenderSVGText {text} at (0,0) size 133x121 contains 1 chunk(s)
                             RenderSVGInlineText {#text} at (0,0) size 133x121
                               chunk 1 text run 1 at (30.00,90.00) startOffset 0 endOffset 3 width 132.36: "SVG"
                         layer at (70,55) size 130x71
-                          RenderSVGRect {rect} at (40,49.38) size 130x70 [fill={[type=SOLID] [color=#820032]}] [x=70.00] [y=55.00] [width=130.00] [height=70.00]
+                          RenderSVGRect {rect} at (40,49) size 130x70 [fill={[type=SOLID] [color=#820032]}] [x=70.00] [y=55.00] [width=130.00] [height=70.00]
                         layer at (162,75) size 80x81
-                          RenderSVGImage {image} at (132,69.38) size 80x80
+                          RenderSVGImage {image} at (132,69) size 80x80
                         layer at (10,304) size 263x46
                           RenderSVGText {text} at (10,304) size 264x46 contains 1 chunk(s)
                             RenderSVGInlineText {#text} at (0,0) size 264x46
@@ -102,15 +102,15 @@ layer at (0,0) size 785x1016 backgroundClip at (0,0) size 1026x1015.63 clip at (
                         layer at (1,1) size 478x358
                           RenderSVGRect {rect} at (1,1) size 478x358 [stroke={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=478.00] [height=358.00]
                       RenderText {#text} at (0,0) size 0x0
-                    RenderTableCell {TD} at (500,148.88) size 496x380 [r=2 c=1 rs=1 cs=1]
+                    RenderTableCell {TD} at (500,148) size 496x381 [r=2 c=1 rs=1 cs=1]
                       RenderImage {IMG} at (8,8) size 480x360
                       RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (23.06,626.06) size 722.88x333.56
-        RenderBlock {P} at (0,0) size 722.88x40
+      RenderBlock {DIV} at (23,626) size 723x334
+        RenderBlock {P} at (0,0) size 723x40
           RenderText {#text} at (0,1) size 716x38
             text run at (0,1) width 716: "Verifies implicit rendering order (paragraph 3.3) and grouping mechanism (paragraphs 3.4)."
             text run at (0,21) width 430: "It also validates basic Shape, Image and text rendering."
-        RenderBlock {P} at (0,51.19) size 722.88x160
+        RenderBlock {P} at (0,51) size 723x161
           RenderText {#text} at (0,1) size 709x158
             text run at (0,1) width 152: "This test renders 3 "
             text run at (151,1) width 274: "elements: a text string \"SVG\", then "
@@ -128,7 +128,7 @@ layer at (0,0) size 785x1016 backgroundClip at (0,0) size 1026x1015.63 clip at (
             text run at (0,121) width 200: "should show through the "
             text run at (199,121) width 479: "rectangle and none of the rectangle should show through the"
             text run at (0,141) width 53: "image."
-        RenderBlock {P} at (0,222.38) size 722.88x80
+        RenderBlock {P} at (0,222) size 723x81
           RenderText {#text} at (0,1) size 712x78
             text run at (0,1) width 622: "Prerequisites: the test assumes proper handling of the fill stroke, stroke-width, "
             text run at (621,1) width 62: "opacity,"
@@ -137,10 +137,10 @@ layer at (0,0) size 785x1016 backgroundClip at (0,0) size 1026x1015.63 clip at (
             text run at (0,41) width 598: "the elements required for the test template. To ensure that the text string is "
             text run at (597,41) width 111: "overlapped by"
             text run at (0,61) width 656: "the other elements and to avoid a dependency on system fonts, an SVG font is used."
-        RenderBlock {P} at (0,313.56) size 722.88x20
+        RenderBlock {P} at (0,313) size 723x21
           RenderText {#text} at (0,1) size 492x18
             text run at (0,1) width 492: "The rendered image should match the reference image exactly."
-      RenderBlock {DIV} at (16,975.63) size 737x20
+      RenderBlock {DIV} at (16,975) size 737x21
         RenderBlock {P} at (0,0) size 737x20
           RenderInline {A} at (0,0) size 202x18 [color=#0000EE]
             RenderText {#text} at (153,1) size 202x18

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/svg-fonts-in-html-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/svg-fonts-in-html-expected.txt
@@ -1,33 +1,33 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x518
-  RenderBlock {HTML} at (0,0) size 800x517.53 [bgcolor=#FFFFFF]
-layer at (173.23,32) size 454x454
-  RenderBody {BODY} at (173.23,32) size 453.53x453.53 [color=#FFFFFF] [bgcolor=#DD6600]
-    RenderBlock {DIV} at (0,0) size 453.53x0
-      RenderBlock {DIV} at (0,0) size 453.53x0
-        RenderBlock {DIV} at (0,0) size 453.53x0
-    RenderBlock {DIV} at (0,0) size 453.53x0
+  RenderBlock {HTML} at (0,0) size 800x518 [bgcolor=#FFFFFF]
+layer at (173,32) size 454x454
+  RenderBody {BODY} at (173,32) size 454x454 [color=#FFFFFF] [bgcolor=#DD6600]
+    RenderBlock {DIV} at (0,0) size 454x0
+      RenderBlock {DIV} at (0,0) size 454x0
+        RenderBlock {DIV} at (0,0) size 454x0
+    RenderBlock {DIV} at (0,0) size 454x0
       RenderInline {SPAN} at (0,0) size 0x0
-    RenderBlock {DIV} at (0,0) size 453.53x0
+    RenderBlock {DIV} at (0,0) size 454x0
       RenderInline {SPAN} at (0,0) size 0x0
-    RenderBlock {DIV} at (0,0) size 453.53x0
+    RenderBlock {DIV} at (0,0) size 454x0
       RenderInline {SPAN} at (0,0) size 0x0
-    RenderBlock {DIV} at (0,0) size 453.53x0
+    RenderBlock {DIV} at (0,0) size 454x0
       RenderInline {SPAN} at (0,0) size 0x0
-    RenderBlock {DIV} at (0,0) size 453.53x0
+    RenderBlock {DIV} at (0,0) size 454x0
       RenderInline {SPAN} at (0,0) size 0x0
-    RenderBlock {DIV} at (0,0) size 453.53x0
+    RenderBlock {DIV} at (0,0) size 454x0
       RenderInline {SPAN} at (0,0) size 0x0
-layer at (173.23,47.11) size 454x188
-  RenderBlock (positioned) {H1} at (0,15.11) size 453.53x188 [color=#DD9955]
+layer at (173,47) size 454x188
+  RenderBlock (positioned) {H1} at (0,15) size 454x189 [color=#DD9955]
     RenderInline {SPAN} at (0,0) size 341x190
       RenderText {#text} at (64,-1) size 341x190
         text run at (64,-1) width 163: "CSS"
         text run at (198,-1) width 192: " ZEN"
         text run at (56,93) width 341: "GARDEN"
-layer at (173.23,119.47) size 454x21
-  RenderBlock (positioned) {H2} at (0,87.47) size 453.53x21 [color=#EEFF00]
+layer at (173,119) size 454x21
+  RenderBlock (positioned) {H2} at (0,87) size 454x22 [color=#EEFF00]
     RenderInline {SPAN} at (0,0) size 149x19
       RenderText {#text} at (152,1) size 88x19
         text run at (152,1) width 88: "The Beauty of "
@@ -36,8 +36,8 @@ layer at (173.23,119.47) size 454x21
           text run at (239,1) width 22: "CSS"
       RenderText {#text} at (260,1) size 41x19
         text run at (260,1) width 41: " Design"
-layer at (173.23,351.34) size 454x135
-  RenderBlock (positioned) {DIV} at (0,319.34) size 453.53x134.19
+layer at (173,351) size 454x135
+  RenderBlock (positioned) {DIV} at (0,319) size 454x135
     RenderInline {P} at (0,0) size 431x29
       RenderInline {SPAN} at (0,0) size 431x29
         RenderText {#text} at (11,-1) size 431x29
@@ -79,8 +79,8 @@ layer at (173.23,351.34) size 454x135
           text run at (11,97) width 431: "Learn to use the (yet to be) time-honored techniques in new"
           text run at (11,111) width 353: "and invigorating fashion. Become one with the web."
     RenderText {#text} at (0,0) size 0x0
-layer at (321.42,235.47) size 306x80
-  RenderBlock (positioned) {H3} at (148.19,-115.88) size 305.34x80 [color=#CCCC77] [bgcolor=#888811] [border: (3px solid #888811) none (3px solid #888811)]
+layer at (321,235) size 306x80
+  RenderBlock (positioned) {H3} at (148,-116) size 306x81 [color=#CCCC77] [bgcolor=#888811] [border: (3px solid #888811) none (3px solid #888811)]
     RenderInline {SPAN} at (0,0) size 277x83
       RenderText {#text} at (44,-2) size 277x83
         text run at (44,-2) width 232: "The Road to"

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/svg-fonts-with-no-element-reference-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/svg-fonts-with-no-element-reference-expected.txt
@@ -1,11 +1,11 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x99
-  RenderBlock {HTML} at (0,0) size 800x98.67
-    RenderBody {BODY} at (8,18.89) size 784x60.89
+  RenderBlock {HTML} at (0,0) size 800x99
+    RenderBody {BODY} at (8,18) size 784x62
       RenderBlock {P} at (0,0) size 784x21
         RenderText {#text} at (0,1) size 277x19
           text run at (0,1) width 277: "This text should be rendered with a first font."
-      RenderBlock {P} at (0,39.89) size 784x21
+      RenderBlock {P} at (0,39) size 784x22
         RenderText {#text} at (0,1) size 285x19
           text run at (0,1) width 285: "This text should be rendered with a second font."

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/svg-fonts-without-missing-glyph-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/svg-fonts-without-missing-glyph-expected.txt
@@ -1,29 +1,29 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x284
-  RenderBlock {html} at (0,0) size 800x283.88
-    RenderBody {body} at (8,21.44) size 784x246.44
+  RenderBlock {html} at (0,0) size 800x284
+    RenderBody {body} at (8,21) size 784x247
       RenderBlock {h1} at (0,0) size 784x37
         RenderText {#text} at (0,0) size 113x37
           text run at (0,0) width 113: "Test for "
         RenderInline {a} at (0,0) size 144x37 [color=#0000EE]
           RenderText {#text} at (112,0) size 144x37
             text run at (112,0) width 144: "Bug 42352"
-      RenderBlock {p} at (0,58.44) size 784x18
+      RenderBlock {p} at (0,58) size 784x19
         RenderText {#text} at (0,0) size 510x18
           text run at (0,0) width 510: "Following text should be rendered as usual. Only \"A\" has a glyph in SVG Font."
-      RenderBlock {p} at (0,92.44) size 784x18
+      RenderBlock {p} at (0,92) size 784x19
         RenderText {#text} at (0,1) size 35x16
           text run at (0,1) width 35: "XXA"
-      RenderBlock {p} at (0,126.44) size 784x18
+      RenderBlock {p} at (0,126) size 784x19
         RenderText {#text} at (0,1) size 35x16
           text run at (0,1) width 35: "XAX"
-      RenderBlock {p} at (0,160.44) size 784x18
+      RenderBlock {p} at (0,160) size 784x19
         RenderText {#text} at (0,1) size 35x16
           text run at (0,1) width 35: "AXX"
-      RenderBlock {p} at (0,194.44) size 784x18
+      RenderBlock {p} at (0,194) size 784x19
         RenderText {#text} at (0,1) size 33x16
           text run at (0,1) width 33: "XXX"
-      RenderBlock {p} at (0,228.44) size 784x18
+      RenderBlock {p} at (0,228) size 784x19
         RenderText {#text} at (0,1) size 39x16
           text run at (0,1) width 39: "AAA"

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/use-on-symbol-inside-pattern-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/use-on-symbol-inside-pattern-expected.txt
@@ -31,7 +31,7 @@ layer at (0,-4) size 68x18 backgroundClip at (0,0) size 225x425 clip at (0,0) si
 layer at (0,0) size 200x90
   RenderSVGTransformableContainer {use} at (0,4) size 200x90
 layer at (0,0) size 200x90
-  RenderSVGPath {path} at (0,0) size 200x90 [stroke={[type=SOLID] [color=#B42D25] [stroke width=2.00]}] [fill={[type=SOLID] [color=#00000000]}] [data="M 0 50 L 100 0 L 200 20 L 150 70 L 50 90 Z"]
+  RenderSVGPath {path} at (0,0) size 200x90 [stroke={[type=SOLID] [color=#B42D25] [stroke width=2.00]}] [fill={[type=SOLID] [color=#000000]}] [data="M 0 50 L 100 0 L 200 20 L 150 70 L 50 90 Z"]
 layer at (0,-4) size 200x94 backgroundClip at (0,0) size 225x425 clip at (0,0) size 225x425
   RenderSVGTransformableContainer {g} at (0,-4) size 200x94
 layer at (0,-4) size 76x18 backgroundClip at (0,0) size 225x425 clip at (0,0) size 225x425
@@ -41,4 +41,4 @@ layer at (0,-4) size 76x18 backgroundClip at (0,0) size 225x425 clip at (0,0) si
 layer at (0,0) size 200x90
   RenderSVGTransformableContainer {use} at (0,4) size 200x90
 layer at (0,0) size 200x90
-  RenderSVGPath {path} at (0,0) size 200x90 [stroke={[type=SOLID] [color=#B42D25] [stroke width=2.00]}] [fill={[type=SOLID] [color=#00000000]}] [data="M 0 50 L 100 0 L 200 20 L 150 70 L 50 90 Z"]
+  RenderSVGPath {path} at (0,0) size 200x90 [stroke={[type=SOLID] [color=#B42D25] [stroke width=2.00]}] [fill={[type=SOLID] [color=#000000]}] [data="M 0 50 L 100 0 L 200 20 L 150 70 L 50 90 Z"]

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/hixie/text/003-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/hixie/text/003-expected.txt
@@ -14,7 +14,7 @@ layer at (0,0) size 800x402
             RenderSVGRoot {svg} at (0,0) size 300x150
           layer at (0,0) size 300x150
             RenderSVGViewportContainer at (0,0) size 300x150
-          layer at (0,-0.11) size 2x1 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
+          layer at (0,0) size 2x1 backgroundClip at (0,0) size 300x150 clip at (0,0) size 300x150
             RenderSVGText {text} at (0,-1) size 3x3 contains 1 chunk(s)
               RenderSVGInlineText {#text} at (0,0) size 3x2
                 chunk 1 text run 1 at (0.00,0.80) startOffset 0 endOffset 4 width 2.39: "PASS"

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/sizing-flakiness-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/sizing-flakiness-expected.txt
@@ -13,7 +13,7 @@ layer at (0,0) size 800x410
             RenderSVGViewportContainer at (0,0) size 200x150
           layer at (1,1) size 118x38
             RenderSVGRect {rect} at (1,1) size 118x38 [stroke={[type=SOLID] [color=#FFCC33] [stroke width=2.00]}] [fill={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=118.00] [height=38.00]
-          layer at (54.48,9.14) size 12x23
+          layer at (54,9) size 12x23
             RenderSVGText {text} at (54,9) size 12x23 contains 1 chunk(s)
               RenderSVGInlineText {#text} at (0,0) size 12x23
                 chunk 1 (middle anchor) text run 1 at (54.49,27.00) startOffset 0 endOffset 1 width 11.01: "F"

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/test-rightsizing-b-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/test-rightsizing-b-expected.txt
@@ -1,17 +1,17 @@
 layer at (0,0) size 785x703
   RenderView at (0,0) size 785x600
 layer at (0,0) size 785x703
-  RenderBlock {html} at (0,0) size 785x703.11
-    RenderBody {body} at (47.09,30.72) size 737.89x664.39
-      RenderBlock {div} at (0,0) size 737.89x664.39
-        RenderBlock {h1} at (0,0) size 678.86x31
+  RenderBlock {html} at (0,0) size 785x704
+    RenderBody {body} at (47,30) size 738x666
+      RenderBlock {div} at (0,0) size 738x665
+        RenderBlock {h1} at (0,0) size 679x31
           RenderText {#text} at (0,0) size 385x30
             text run at (0,0) width 385: "rightsizing to percentage width"
-        RenderBlock {h4} at (0,31) size 737.89x16
+        RenderBlock {h4} at (0,31) size 738x16
           RenderText {#text} at (0,0) size 137x16
             text run at (0,0) width 137: "WICD Core 1.0 #20-2"
-        RenderBlock (anonymous) at (0,66.14) size 737.89x154
-          RenderEmbeddedObject {object} at (0,0) size 295.16x150 [bgcolor=#FF0000]
+        RenderBlock (anonymous) at (0,66) size 738x155
+          RenderEmbeddedObject {object} at (0,0) size 296x150 [bgcolor=#FF0000]
             layer at (0,0) size 295x150
               RenderView at (0,0) size 295x150
             layer at (0,0) size 295x150
@@ -22,15 +22,15 @@ layer at (0,0) size 785x703
               RenderSVGRect {rect} at (-3000,-1000) size 6200x2200 [fill={[type=SOLID] [color=#5588FF]}] [x=-3000.00] [y=-1000.00] [width=6200.00] [height=2200.00]
             layer at (0,0) size 200x200 backgroundClip at (0,0) size 295x150 clip at (0,0) size 295x150
               RenderSVGEllipse {circle} at (0,0) size 200x200 [fill={[type=SOLID] [color=#0000FF]}] [cx=100.00] [cy=100.00] [r=100.00]
-            layer at (26.08,59.41) size 148x83
-              RenderSVGTransformableContainer {g} at (26.08,59.41) size 147.84x82.20
-            layer at (26.08,59.41) size 148x82
+            layer at (26,59) size 148x83
+              RenderSVGTransformableContainer {g} at (26,59) size 148x83
+            layer at (26,59) size 148x82
               RenderSVGText {text} at (0,0) size 148x83 contains 1 chunk(s)
                 RenderSVGInlineText {#text} at (0,0) size 148x83
                   chunk 1 (middle anchor) text run 1 at (26.08,125.00) startOffset 0 endOffset 3 width 147.83: "SVG"
           RenderText {#text} at (295,136) size 5x17
             text run at (295,136) width 5: " "
-          RenderEmbeddedObject {object} at (299.59,0) size 147.58x150 [bgcolor=#FF0000]
+          RenderEmbeddedObject {object} at (299,0) size 149x150 [bgcolor=#FF0000]
             layer at (0,0) size 148x150
               RenderView at (0,0) size 148x150
             layer at (0,0) size 148x150
@@ -41,15 +41,15 @@ layer at (0,0) size 785x703
               RenderSVGRect {rect} at (-3000,-1000) size 6200x2200 [fill={[type=SOLID] [color=#5588FF]}] [x=-3000.00] [y=-1000.00] [width=6200.00] [height=2200.00]
             layer at (0,0) size 200x200 backgroundClip at (0,0) size 148x150 clip at (0,0) size 148x150
               RenderSVGEllipse {circle} at (0,0) size 200x200 [fill={[type=SOLID] [color=#0000FF]}] [cx=100.00] [cy=100.00] [r=100.00]
-            layer at (26.48,59.78) size 148x83 backgroundClip at (0,0) size 148x150 clip at (0,0) size 148x150
-              RenderSVGTransformableContainer {g} at (26.48,59.78) size 147.03x81.73
-            layer at (26.48,59.78) size 147x82 backgroundClip at (0,0) size 148x150 clip at (0,0) size 148x150
+            layer at (26,60) size 148x83 backgroundClip at (0,0) size 148x150 clip at (0,0) size 148x150
+              RenderSVGTransformableContainer {g} at (26,60) size 148x82
+            layer at (26,60) size 147x82 backgroundClip at (0,0) size 148x150 clip at (0,0) size 148x150
               RenderSVGText {text} at (0,0) size 148x82 contains 1 chunk(s)
                 RenderSVGInlineText {#text} at (0,0) size 148x82
                   chunk 1 (middle anchor) text run 1 at (26.50,125.00) startOffset 0 endOffset 3 width 147.01: "SVG"
           RenderText {#text} at (447,136) size 5x17
             text run at (447,136) width 5: " "
-          RenderEmbeddedObject {object} at (451.63,0) size 73.78x150 [bgcolor=#FF0000]
+          RenderEmbeddedObject {object} at (451,0) size 75x150 [bgcolor=#FF0000]
             layer at (0,0) size 74x150
               RenderView at (0,0) size 74x150
             layer at (0,0) size 74x150
@@ -60,15 +60,15 @@ layer at (0,0) size 785x703
               RenderSVGRect {rect} at (-3000,-1000) size 6200x2200 [fill={[type=SOLID] [color=#5588FF]}] [x=-3000.00] [y=-1000.00] [width=6200.00] [height=2200.00]
             layer at (0,0) size 200x200 backgroundClip at (0,0) size 74x150 clip at (0,0) size 74x150
               RenderSVGEllipse {circle} at (0,0) size 200x200 [fill={[type=SOLID] [color=#0000FF]}] [cx=100.00] [cy=100.00] [r=100.00]
-            layer at (26.48,59.78) size 148x83 backgroundClip at (0,0) size 74x150 clip at (0,0) size 74x150
-              RenderSVGTransformableContainer {g} at (26.48,59.78) size 147.03x81.73
-            layer at (26.48,59.78) size 147x82 backgroundClip at (0,0) size 74x150 clip at (0,0) size 74x150
+            layer at (26,60) size 148x83 backgroundClip at (0,0) size 74x150 clip at (0,0) size 74x150
+              RenderSVGTransformableContainer {g} at (26,60) size 148x82
+            layer at (26,60) size 147x82 backgroundClip at (0,0) size 74x150 clip at (0,0) size 74x150
               RenderSVGText {text} at (0,0) size 148x82 contains 1 chunk(s)
                 RenderSVGInlineText {#text} at (0,0) size 148x82
                   chunk 1 (middle anchor) text run 1 at (26.50,125.00) startOffset 0 endOffset 3 width 147.01: "SVG"
           RenderText {#text} at (525,136) size 5x17
             text run at (525,136) width 5: " "
-          RenderEmbeddedObject {object} at (529.84,0) size 36.89x150 [bgcolor=#FF0000]
+          RenderEmbeddedObject {object} at (529,0) size 38x150 [bgcolor=#FF0000]
             layer at (0,0) size 37x150
               RenderView at (0,0) size 37x150
             layer at (0,0) size 37x150
@@ -79,14 +79,14 @@ layer at (0,0) size 785x703
               RenderSVGRect {rect} at (-3000,-1000) size 6200x2200 [fill={[type=SOLID] [color=#5588FF]}] [x=-3000.00] [y=-1000.00] [width=6200.00] [height=2200.00]
             layer at (0,0) size 200x200 backgroundClip at (0,0) size 37x150 clip at (0,0) size 37x150
               RenderSVGEllipse {circle} at (0,0) size 200x200 [fill={[type=SOLID] [color=#0000FF]}] [cx=100.00] [cy=100.00] [r=100.00]
-            layer at (26.48,59.78) size 148x83 backgroundClip at (0,0) size 37x150 clip at (0,0) size 37x150
-              RenderSVGTransformableContainer {g} at (26.48,59.78) size 147.03x81.73
-            layer at (26.48,59.78) size 147x82 backgroundClip at (0,0) size 37x150 clip at (0,0) size 37x150
+            layer at (26,60) size 148x83 backgroundClip at (0,0) size 37x150 clip at (0,0) size 37x150
+              RenderSVGTransformableContainer {g} at (26,60) size 148x82
+            layer at (26,60) size 147x82 backgroundClip at (0,0) size 37x150 clip at (0,0) size 37x150
               RenderSVGText {text} at (0,0) size 148x82 contains 1 chunk(s)
                 RenderSVGInlineText {#text} at (0,0) size 148x82
                   chunk 1 (middle anchor) text run 1 at (26.50,125.00) startOffset 0 endOffset 3 width 147.01: "SVG"
           RenderText {#text} at (0,0) size 0x0
-        RenderBlock {p} at (0,223.02) size 678.86x64
+        RenderBlock {p} at (0,223) size 679x65
           RenderText {#text} at (0,0) size 675x32
             text run at (0,0) width 675: "Above there must be four times the same, square SVG child visible, each referenced by an object element with"
             text run at (0,16) width 377: "different widths (40%, 20%, 10%, 5%) and no height defined."
@@ -94,23 +94,23 @@ layer at (0,0) size 785x703
           RenderBR {br} at (0,32) size 0x16
           RenderText {#text} at (0,48) size 398x16
             text run at (0,48) width 398: "Beyond there is the same, only with PNG images instead of SVG."
-        RenderBlock (anonymous) at (0,292.77) size 737.89x299
-          RenderImage {object} at (0,0) size 295.16x295.16 [bgcolor=#FF0000]
+        RenderBlock (anonymous) at (0,292) size 738x300
+          RenderImage {object} at (0,0) size 296x296 [bgcolor=#FF0000]
           RenderText {#text} at (295,281) size 5x17
             text run at (295,281) width 5: " "
-          RenderImage {object} at (299.59,147) size 147.58x147.58 [bgcolor=#FF0000]
+          RenderImage {object} at (299,147) size 149x148 [bgcolor=#FF0000]
           RenderText {#text} at (447,281) size 5x17
             text run at (447,281) width 5: " "
-          RenderImage {object} at (451.63,221) size 73.78x73.78 [bgcolor=#FF0000]
+          RenderImage {object} at (451,221) size 75x74 [bgcolor=#FF0000]
           RenderText {#text} at (525,281) size 5x17
             text run at (525,281) width 5: " "
-          RenderImage {object} at (529.84,258) size 36.89x36.89 [bgcolor=#FF0000]
+          RenderImage {object} at (529,258) size 38x37 [bgcolor=#FF0000]
           RenderText {#text} at (0,0) size 0x0
-        RenderBlock {p} at (0,594.64) size 678.86x32
+        RenderBlock {p} at (0,594) size 679x33
           RenderText {#text} at (0,0) size 656x32
             text run at (0,0) width 656: "This test has succeeded, if both rows look exactly the same (SVGs must be square!) and no red background"
             text run at (0,16) width 92: "color is visible."
-        RenderBlock {p} at (0,632.39) size 678.86x32
+        RenderBlock {p} at (0,632) size 679x33
           RenderBR {br} at (0,0) size 0x16
           RenderInline {a} at (0,0) size 31x16 [color=#000066]
             RenderText {#text} at (0,16) size 31x16

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/test-scalable-background-image1-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/test-scalable-background-image1-expected.txt
@@ -1,25 +1,25 @@
 layer at (0,0) size 820x585
   RenderView at (0,0) size 800x585
 layer at (0,0) size 800x316
-  RenderBlock {html} at (0,0) size 800x315.86
-    RenderBody {body} at (48,8) size 772x299.86
-      RenderBlock {h1} at (10,40.72) size 691.83x31
+  RenderBlock {html} at (0,0) size 800x316
+    RenderBody {body} at (48,8) size 772x300
+      RenderBlock {h1} at (10,40) size 692x32
         RenderText {#text} at (0,0) size 320x30
           text run at (0,0) width 320: "scalable CSS background"
-      RenderBlock {h4} at (10,71.72) size 752x16
+      RenderBlock {h4} at (10,71) size 752x17
         RenderText {#text} at (0,0) size 123x16
           text run at (0,0) width 123: "WICD Core 1.0 #11"
-      RenderBlock {p} at (10,106.86) size 711.83x36
+      RenderBlock {p} at (10,106) size 712x37
         RenderText {#text} at (10,10) size 499x16
           text run at (10,10) width 499: "This text paragraph, as well as all following, must have a SVG background image."
-      RenderBlock {p} at (10,148.61) size 711.83x36
+      RenderBlock {p} at (10,148) size 712x37
         RenderText {#text} at (10,10) size 673x16
           text run at (10,10) width 673: "This background image (grey color-gradient and rounded corners) must always exactly fit the text paragraph."
-      RenderBlock {p} at (10,190.36) size 711.83x52
+      RenderBlock {p} at (10,190) size 712x53
         RenderText {#text} at (10,10) size 679x32
           text run at (10,10) width 679: "This test has failed, if you don't see any graphics on the background. (your user agent does not support SVG as"
           text run at (10,26) width 124: "background image)."
-      RenderBlock {p} at (10,248.11) size 711.83x36
+      RenderBlock {p} at (10,248) size 712x37
         RenderInline {a} at (0,0) size 31x16 [color=#000066]
           RenderText {#text} at (10,10) size 31x16
             text run at (10,10) width 31: "Back"

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/test-scalable-background-image2-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/test-scalable-background-image2-expected.txt
@@ -2,23 +2,23 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {html} at (0,0) size 800x600
-    RenderBody {body} at (48,30.72) size 752x157.64
-      RenderBlock {h1} at (0,0) size 691.83x31
+    RenderBody {body} at (48,30) size 752x159
+      RenderBlock {h1} at (0,0) size 692x31
         RenderText {#text} at (0,0) size 389x30
           text run at (0,0) width 389: "scalable fullscreen background"
       RenderBlock {h4} at (0,31) size 752x16
         RenderText {#text} at (0,0) size 124x16
           text run at (0,0) width 124: "WICD Core 1.0 #12"
-      RenderBlock {p} at (0,66.14) size 691.83x32
+      RenderBlock {p} at (0,66) size 692x33
         RenderText {#text} at (0,0) size 685x32
           text run at (0,0) width 622: "This text is XHTML main layer content, which must overlay a lightblue SVG-background image with "
           text run at (621,0) width 64: "text ('SVG"
           text run at (0,16) width 624: "background image'). The SVG background image must cover the complete XHTML-background area."
-      RenderBlock {p} at (0,103.89) size 691.83x32
+      RenderBlock {p} at (0,103) size 692x33
         RenderText {#text} at (0,0) size 679x32
           text run at (0,0) width 679: "This test has failed, if you don't see any graphics on the background. (your user agent does not support SVG as"
           text run at (0,16) width 124: "background image)."
-      RenderBlock {p} at (0,141.64) size 691.83x16
+      RenderBlock {p} at (0,141) size 692x17
         RenderInline {a} at (0,0) size 31x16 [color=#000066]
           RenderText {#text} at (0,0) size 31x16
             text run at (0,0) width 31: "Back"

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-background-image-tiled-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-background-image-tiled-expected.txt
@@ -1,6 +1,6 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x245
-  RenderBlock {HTML} at (0,0) size 800x244.52
-    RenderBody {BODY} at (16.58,16.58) size 766.84x211.36
-      RenderBlock {DIV} at (0,0) size 770.84x211.36 [border: (2px solid #CCCCCC)]
+  RenderBlock {HTML} at (0,0) size 800x245
+    RenderBody {BODY} at (16,16) size 768x212
+      RenderBlock {DIV} at (0,0) size 771x212 [border: (2px solid #CCCCCC)]

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-background-images-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-background-images-expected.txt
@@ -1,18 +1,18 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x163
-  RenderBlock {HTML} at (0,0) size 800x163.25
-    RenderBody {BODY} at (4.63,4.63) size 790.75x154
-      RenderBlock {DIV} at (11.56,11.56) size 129.31x129.31 [border: (1px solid #000000)]
+  RenderBlock {HTML} at (0,0) size 800x164
+    RenderBody {BODY} at (4,4) size 792x155
+      RenderBlock {DIV} at (11,11) size 130x130 [border: (1px solid #000000)]
       RenderText {#text} at (152,144) size 3x10
         text run at (152,144) width 3: " "
-      RenderBlock {DIV} at (166.25,11.56) size 129.31x129.31 [border: (1px solid #000000)]
+      RenderBlock {DIV} at (166,11) size 130x130 [border: (1px solid #000000)]
       RenderText {#text} at (307,144) size 3x10
         text run at (307,144) width 3: " "
-      RenderBlock {DIV} at (320.94,11.56) size 129.31x129.31 [border: (1px solid #000000)]
+      RenderBlock {DIV} at (320,11) size 131x130 [border: (1px solid #000000)]
       RenderText {#text} at (461,144) size 4x10
         text run at (461,144) width 4: " "
-      RenderImage {IMG} at (475.63,11.56) size 129.31x129.31 [border: (1px solid #000000)]
+      RenderImage {IMG} at (475,11) size 130x130 [border: (1px solid #000000)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-as-background-with-relative-size-and-viewBox-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-as-background-with-relative-size-and-viewBox-expected.txt
@@ -3,6 +3,6 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DIV} at (0,0) size 666.66x500 [bgcolor=#008000]
+      RenderBlock {DIV} at (0,0) size 667x500 [bgcolor=#008000]
         RenderText {#text} at (0,0) size 4x15
           text run at (0,0) width 4: " "

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-as-background-with-relative-size-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-as-background-with-relative-size-expected.txt
@@ -3,6 +3,6 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DIV} at (0,0) size 289.34x289.34 [bgcolor=#008000]
+      RenderBlock {DIV} at (0,0) size 290x290 [bgcolor=#008000]
         RenderText {#text} at (0,0) size 3x10
           text run at (0,0) width 3: " "

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-as-image-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-as-image-expected.txt
@@ -3,6 +3,6 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DIV} at (0,0) size 207.36x207.36 [bgcolor=#FF0000]
-        RenderImage {IMG} at (0,0) size 207.36x207.36
+      RenderBlock {DIV} at (0,0) size 208x208 [bgcolor=#FF0000]
+        RenderImage {IMG} at (0,0) size 208x208
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-as-relative-image-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-as-relative-image-expected.txt
@@ -3,6 +3,6 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
-      RenderBlock {DIV} at (0,0) size 83.33x83.33 [bgcolor=#FF0000]
-        RenderImage {IMG} at (0,0) size 83.33x83.33
+      RenderBlock {DIV} at (0,0) size 84x84 [bgcolor=#FF0000]
+        RenderImage {IMG} at (0,0) size 84x84
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-through-object-with-absolute-size-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-through-object-with-absolute-size-expected.txt
@@ -1,29 +1,29 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x205
-  RenderBlock {html} at (0,0) size 800x204.50
-    RenderBody {body} at (5.55,5.55) size 788.91x193.41
-      RenderTable {table} at (143.38,0) size 502.16x193.41
-        RenderTableSection (anonymous) at (0,0) size 502.16x193.41
-          RenderTableRow {tr} at (0,0) size 502.16x193.41
-            RenderTableCell {td} at (0,0) size 502.16x193.41 [r=0 c=0 rs=1 cs=3]
-              RenderTable {table} at (6.94,6.94) size 488.28x179.53
-                RenderTableSection (anonymous) at (0,0) size 488.28x179.53
-                  RenderTableRow {tr} at (0,1.38) size 488.28x66.84
-                    RenderTableCell {td} at (1.38,1.38) size 485.55x66.84 [r=0 c=0 rs=1 cs=2]
-                      RenderBlock {h1} at (5.55,20.42) size 474.45x26
+  RenderBlock {html} at (0,0) size 800x205
+    RenderBody {body} at (5,5) size 790x194
+      RenderTable {table} at (143,0) size 503x194
+        RenderTableSection (anonymous) at (0,0) size 503x194
+          RenderTableRow {tr} at (0,0) size 503x194
+            RenderTableCell {td} at (0,0) size 503x194 [r=0 c=0 rs=1 cs=3]
+              RenderTable {table} at (6,6) size 490x181
+                RenderTableSection (anonymous) at (0,0) size 489x180
+                  RenderTableRow {tr} at (0,1) size 489x68
+                    RenderTableCell {td} at (1,1) size 486x68 [r=0 c=0 rs=1 cs=2]
+                      RenderBlock {h1} at (5,20) size 475x27
                         RenderText {#text} at (0,0) size 475x26
                           text run at (0,0) width 475: "Both sides should have identical size after zooming"
-                  RenderTableRow {tr} at (0,69.59) size 488.28x24.09
-                    RenderTableCell {td} at (1.38,69.59) size 242.08x24.09 [r=1 c=0 rs=1 cs=1]
+                  RenderTableRow {tr} at (0,69) size 489x25
+                    RenderTableCell {td} at (1,69) size 243x25 [r=1 c=0 rs=1 cs=1]
                       RenderText {#text} at (94,5) size 54x14
                         text run at (94,5) width 54: "SVG Image"
-                    RenderTableCell {td} at (244.83,69.59) size 242.09x24.09 [r=1 c=1 rs=1 cs=1]
+                    RenderTableCell {td} at (244,69) size 243x25 [r=1 c=1 rs=1 cs=1]
                       RenderText {#text} at (94,5) size 54x14
                         text run at (94,5) width 54: "PNG Image"
-                  RenderTableRow {tr} at (0,95.06) size 488.28x83.09
-                    RenderTableCell {td} at (1.38,95.06) size 242.08x83.09 [r=2 c=0 rs=1 cs=1]
-                      RenderEmbeddedObject {object} at (97.66,5.55) size 138.88x69.44
+                  RenderTableRow {tr} at (0,95) size 489x84
+                    RenderTableCell {td} at (1,95) size 243x84 [r=2 c=0 rs=1 cs=1]
+                      RenderEmbeddedObject {object} at (97,5) size 140x70
                         layer at (0,0) size 139x69
                           RenderView at (0,0) size 139x69
                         layer at (0,0) size 139x69 scrollWidth 200 scrollHeight 100
@@ -39,6 +39,6 @@ layer at (0,0) size 800x205
                         layer at (1,1) size 478x358 backgroundClip at (0,0) size 139x69 clip at (0,0) size 139x69
                           RenderSVGRect {rect} at (1,1) size 478x358 [stroke={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=478.00] [height=358.00]
                       RenderText {#text} at (0,0) size 0x0
-                    RenderTableCell {td} at (244.83,95.06) size 242.09x83.09 [r=2 c=1 rs=1 cs=1]
-                      RenderImage {img} at (5.55,5.55) size 138.88x69.44
+                    RenderTableCell {td} at (244,95) size 243x84 [r=2 c=1 rs=1 cs=1]
+                      RenderImage {img} at (5,5) size 140x70
                       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-through-object-with-huge-size-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-through-object-with-huge-size-expected.txt
@@ -1,13 +1,13 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x351
-  RenderBlock {html} at (0,0) size 800x351.44
-    RenderBody {body} at (5.55,11.11) size 788.91x329.22
-      RenderBlock {p} at (0,0) size 788.91x13
+  RenderBlock {html} at (0,0) size 800x352
+    RenderBody {body} at (5,11) size 790x330
+      RenderBlock {p} at (0,0) size 789x13
         RenderText {#text} at (0,0) size 84x13
           text run at (0,0) width 84: "Text above the rect"
-      RenderBlock (anonymous) at (0,24.11) size 788.91x281
-        RenderEmbeddedObject {object} at (0,0) size 277.77x277.77
+      RenderBlock (anonymous) at (0,24) size 789x282
+        RenderEmbeddedObject {object} at (0,0) size 278x278
           layer at (0,0) size 278x278
             RenderView at (0,0) size 278x278
           layer at (0,0) size 278x278 scrollWidth 400 scrollHeight 400
@@ -17,6 +17,6 @@ layer at (0,0) size 800x351
           layer at (0,0) size 100x100
             RenderSVGRect {rect} at (0,0) size 100x100 [stroke={[type=SOLID] [color=#008000] [stroke width=5.00]}] [fill={[type=SOLID] [color=#0000FF]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {p} at (0,316.22) size 788.91x13
+      RenderBlock {p} at (0,316) size 789x14
         RenderText {#text} at (0,0) size 85x13
           text run at (0,0) width 85: "Text below the rect"

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-through-object-with-percentage-size-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-through-object-with-percentage-size-expected.txt
@@ -1,29 +1,29 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x386
-  RenderBlock {html} at (0,0) size 800x385.50
-    RenderBody {body} at (5.55,5.55) size 788.91x374.41
-      RenderTable {table} at (41.03,0) size 706.84x374.41
-        RenderTableSection (anonymous) at (0,0) size 706.84x374.41
-          RenderTableRow {tr} at (0,0) size 706.84x374.41
-            RenderTableCell {td} at (0,0) size 706.84x374.41 [r=0 c=0 rs=1 cs=3]
-              RenderTable {table} at (6.94,6.94) size 692.97x360.53
-                RenderTableSection (anonymous) at (0,0) size 692.97x360.53
-                  RenderTableRow {tr} at (0,1.38) size 692.97x66.84
-                    RenderTableCell {td} at (1.38,1.38) size 690.22x66.84 [r=0 c=0 rs=1 cs=2]
-                      RenderBlock {h1} at (5.55,20.42) size 679.13x26
+  RenderBlock {html} at (0,0) size 800x386
+    RenderBody {body} at (5,5) size 790x375
+      RenderTable {table} at (41,0) size 707x375
+        RenderTableSection (anonymous) at (0,0) size 707x375
+          RenderTableRow {tr} at (0,0) size 707x375
+            RenderTableCell {td} at (0,0) size 707x375 [r=0 c=0 rs=1 cs=3]
+              RenderTable {table} at (6,6) size 694x362
+                RenderTableSection (anonymous) at (0,0) size 693x361
+                  RenderTableRow {tr} at (0,1) size 693x68
+                    RenderTableCell {td} at (1,1) size 691x68 [r=0 c=0 rs=1 cs=2]
+                      RenderBlock {h1} at (5,20) size 680x27
                         RenderText {#text} at (102,0) size 475x26
                           text run at (102,0) width 475: "Both sides should have identical size after zooming"
-                  RenderTableRow {tr} at (0,69.59) size 692.97x24.09
-                    RenderTableCell {td} at (1.38,69.59) size 344.42x24.09 [r=1 c=0 rs=1 cs=1]
+                  RenderTableRow {tr} at (0,69) size 693x25
+                    RenderTableCell {td} at (1,69) size 345x25 [r=1 c=0 rs=1 cs=1]
                       RenderText {#text} at (146,5) size 53x14
                         text run at (146,5) width 53: "SVG Image"
-                    RenderTableCell {td} at (347.17,69.59) size 344.42x24.09 [r=1 c=1 rs=1 cs=1]
+                    RenderTableCell {td} at (347,69) size 345x25 [r=1 c=1 rs=1 cs=1]
                       RenderText {#text} at (146,5) size 53x14
                         text run at (146,5) width 53: "PNG Image"
-                  RenderTableRow {tr} at (0,95.06) size 692.97x264.09
-                    RenderTableCell {td} at (1.38,95.06) size 344.42x264.09 [r=2 c=0 rs=1 cs=1]
-                      RenderEmbeddedObject {object} at (5.55,5.55) size 333.33x249.98
+                  RenderTableRow {tr} at (0,95) size 693x265
+                    RenderTableCell {td} at (1,95) size 345x265 [r=2 c=0 rs=1 cs=1]
+                      RenderEmbeddedObject {object} at (5,5) size 334x251
                         layer at (0,0) size 333x250
                           RenderView at (0,0) size 333x250
                         layer at (0,0) size 333x250 scrollWidth 480 scrollHeight 360
@@ -47,6 +47,6 @@ layer at (0,0) size 800x386
                         layer at (1,1) size 478x358 backgroundClip at (0,0) size 333x250 clip at (0,0) size 333x250
                           RenderSVGRect {rect} at (1,1) size 478x358 [stroke={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=478.00] [height=358.00]
                       RenderText {#text} at (0,0) size 0x0
-                    RenderTableCell {td} at (347.17,95.06) size 344.42x264.09 [r=2 c=1 rs=1 cs=1]
-                      RenderImage {img} at (5.55,5.55) size 333.33x249.97
+                    RenderTableCell {td} at (347,95) size 345x265 [r=2 c=1 rs=1 cs=1]
+                      RenderImage {img} at (5,5) size 334x251
                       RenderText {#text} at (0,0) size 0x0


### PR DESCRIPTION
#### d81392512c75d7f33552810ffae579a2152a9282
<pre>
[LBSE] Unreviewed gardening -- update text baseline if needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=246038">https://bugs.webkit.org/show_bug.cgi?id=246038</a>

Unreviewed, update LBSE text results.

I forgot to rebaseline a few tests when subpixel precision for LBSE
render tree dumps was activated, fix that. A few tests have changed
results due to recent upstream color serialization changes.

Add a new filter test to exclusion list, that was recently activated
to run on macOS (svg/filters/feDisplacementMap-filterUnits.svg) since
filter support in LBSE is not upstreamed yet.

* LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/color-prop-01-b-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-13-b-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-background-image/background-image-preserveaspectRatio-support-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-border-image/svg-as-border-image-2-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-border-image/svg-as-border-image-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-image/img-preserveAspectRatio-support-1-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-image/img-preserveAspectRatio-support-2-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/as-image/svg-non-integer-scaled-image-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/batik/paints/patternPreserveAspectRatioA-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/bug45331-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/scrolling-embedded-svg-file-image-repaint-problem-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/svg-fonts-in-html-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/svg-fonts-with-no-element-reference-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/svg-fonts-without-missing-glyph-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/use-on-symbol-inside-pattern-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/hixie/text/003-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/sizing-flakiness-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/test-rightsizing-b-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/test-scalable-background-image1-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/wicd/test-scalable-background-image2-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-background-image-tiled-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-background-images-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-as-background-with-relative-size-and-viewBox-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-as-background-with-relative-size-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-as-image-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-as-relative-image-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-through-object-with-absolute-size-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-through-object-with-huge-size-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/page/zoom-svg-through-object-with-percentage-size-expected.txt:

Canonical link: <a href="https://commits.webkit.org/255145@main">https://commits.webkit.org/255145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fab83bc4157a0e25fb2d63efef55be9bf9453d0c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91517 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/101240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97175 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/83856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/35646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/33424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/37236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1593 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/39151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->