### PR TITLE
Implement last baseline alignment for CSS Grid.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1501,20 +1501,14 @@ webkit.org/b/231021 imported/w3c/web-platform-tests/css/css-grid/grid-within-fle
   
 imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-img-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-img-last-baseline-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-img-last-baseline-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-last-baseline-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-last-baseline-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-rtl-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-rtl-004.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-rtl-last-baseline-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-rtl-last-baseline-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-rtl-last-baseline-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-rtl-last-baseline-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-vertWM-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-vertWM-004.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-vertWM-last-baseline-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-vertWM-last-baseline-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-justify-self-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-justify-self-img-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-justify-self-img-last-baseline-001.html [ ImageOnlyFailure ]
@@ -1596,7 +1590,6 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-order-001
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-subgrid-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-subgrid-002.html [ ImageOnlyFailure ]
 
-webkit.org/b/236959 imported/w3c/web-platform-tests/css/css-grid/subgrid/baseline-001.html [ ImageOnlyFailure ]
 webkit.org/b/236958 imported/w3c/web-platform-tests/css/css-grid/subgrid/repeat-auto-fill-003.html [ ImageOnlyFailure ]
 
 # CSS Grid Baseline tests
@@ -4547,16 +4540,11 @@ webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-mixed-baseline-002.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-mixed-baseline-003.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-mixed-baseline-004.html [ ImageOnlyFailure ]
-webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-baseline-with-grid-001.html [ ImageOnlyFailure ]
-webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-baseline-with-grid-002.html [ ImageOnlyFailure ]
-webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-baseline-with-grid-003.html [ ImageOnlyFailure ]
-webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-self-alignment-baseline-with-grid-004.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-areas-overflowing-grid-container-001.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-areas-overflowing-grid-container-002.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-areas-overflowing-grid-container-003.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-overflow-padding-001.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-overflow-padding-002.html [ ImageOnlyFailure ]
-webkit.org/b/212267 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-self-baseline-001.html [ Skip ]
 
 # Only Cocoa ports support the -apple-system font keywords
 fast/text/text-styles/-apple-system [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-001-expected.txt
@@ -1,9 +1,7 @@
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-y="100"><span></span></div>
-offsetTop expected 100 but got 90
+PASS .target > * 3
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-y="55"><span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-002-expected.txt
@@ -3,7 +3,7 @@ PASS .target > * 1
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <div data-offset-x="48"><span></span></div>
-offsetLeft expected 48 but got 52
+offsetLeft expected 48 but got 47
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-x="90"><span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-003-expected.txt
@@ -3,7 +3,7 @@ PASS .target > * 1
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <div data-offset-x="93"><span></span></div>
-offsetLeft expected 93 but got 87
+offsetLeft expected 93 but got 92
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-x="50"><span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-001-expected.txt
@@ -16,17 +16,15 @@ FAIL #target > div 1 assert_equals:
 offsetLeft expected 120 but got 0
 FAIL #target > div 2 assert_equals:
 <div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 35
+offsetLeft expected 105 but got 140
 FAIL #target > div 3 assert_equals:
 <div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 42
-FAIL #target > div 4 assert_equals:
-<div data-offset-x="20">line1<br>line2</div>
-offsetLeft expected 20 but got 35
+offsetLeft expected 126 but got 161
+PASS #target > div 4
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 0
+offsetLeft expected 35 but got 140
 FAIL #target > div 6 assert_equals:
 <div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 21
+offsetLeft expected 42 but got 161
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-002-expected.txt
@@ -14,17 +14,17 @@ line2
 PASS #target > div 1
 FAIL #target > div 2 assert_equals:
 <div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 135
+offsetLeft expected 105 but got 0
 FAIL #target > div 3 assert_equals:
 <div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 142
+offsetLeft expected 126 but got 7
 FAIL #target > div 4 assert_equals:
 <div data-offset-x="20">line1<br>line2</div>
 offsetLeft expected 20 but got 140
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 125
+offsetLeft expected 35 but got 0
 FAIL #target > div 6 assert_equals:
 <div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 146
+offsetLeft expected 42 but got 7
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-003-expected.txt
@@ -2,13 +2,7 @@
 
 
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-y="40"><span></span><br><span></span></div>
-offsetTop expected 40 but got 10
-FAIL #target > div 2 assert_equals:
-<div data-offset-y="20"><span></span><br><span></span></div>
-offsetTop expected 20 but got 0
-FAIL #target > div 3 assert_equals:
-<div data-offset-y="70"><span></span><br><span></span></div>
-offsetTop expected 70 but got 20
+PASS #target > div 1
+PASS #target > div 2
+PASS #target > div 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-004-expected.txt
@@ -2,7 +2,5 @@
 
 
 PASS #target > div 1
-FAIL #target > div 2 assert_equals:
-<div style="grid-area: 1 / 2 / 4 / 2;" data-offset-y="100"><span></span><br><span></span></div>
-offsetTop expected 100 but got 0
+PASS #target > div 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-fieldset-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-fieldset-001-expected.txt
@@ -14,6 +14,12 @@ FAIL .target > * 2 assert_equals:
 offsetTop expected 0 but got 10
 FAIL .target > * 3 assert_equals:
 <div data-offset-y="40"><span></span></div>
-offsetTop expected 40 but got 20
-PASS .target > * 4
+offsetTop expected 40 but got 0
+FAIL .target > * 4 assert_equals:
+<fieldset data-offset-y="0">
+    <span></span><br><span></span>
+    <legend><span></span></legend>
+
+</fieldset>
+offsetTop expected 0 but got 10
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-fieldset-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-fieldset-002-expected.txt
@@ -8,6 +8,6 @@ offsetLeft expected 35 but got 65
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <div data-offset-x="15"><span></span></div>
-offsetLeft expected 15 but got 35
+offsetLeft expected 15 but got 65
 PASS .target > * 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-fieldset-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-fieldset-003-expected.txt
@@ -14,6 +14,12 @@ FAIL .target > * 2 assert_equals:
 offsetLeft expected 0 but got 5
 FAIL .target > * 3 assert_equals:
 <div data-offset-x="45"><span></span></div>
-offsetLeft expected 45 but got 25
-PASS .target > * 4
+offsetLeft expected 45 but got 0
+FAIL .target > * 4 assert_equals:
+<fieldset data-offset-x="0">
+    <span></span><br><span></span>
+    <legend><span></span></legend>
+
+</fieldset>
+offsetLeft expected 0 but got 5
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-001-expected.txt
@@ -1,33 +1,31 @@
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-y="35"><span></span></div>
-offsetTop expected 35 but got 15
+PASS .target > * 3
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-y="35"><span></span></div>
 offsetTop expected 35 but got 15
 PASS .target > * 6
-PASS .target > * 7
+FAIL .target > * 7 assert_equals:
+<div data-offset-y="15"><span></span></div>
+offsetTop expected 15 but got 35
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10
-FAIL .target > * 11 assert_equals:
-<div data-offset-y="45"><span></span></div>
-offsetTop expected 45 but got 15
+PASS .target > * 11
 PASS .target > * 12
 FAIL .target > * 13 assert_equals:
 <div data-offset-y="35"><span></span></div>
 offsetTop expected 35 but got 45
 PASS .target > * 14
-PASS .target > * 15
+FAIL .target > * 15 assert_equals:
+<div data-offset-y="45"><span></span></div>
+offsetTop expected 45 but got 35
 PASS .target > * 16
 PASS .target > * 17
 PASS .target > * 18
-FAIL .target > * 19 assert_equals:
-<div data-offset-y="70"><span></span></div>
-offsetTop expected 70 but got 25
+PASS .target > * 19
 PASS .target > * 20
 FAIL .target > * 21 assert_equals:
 <div data-offset-y="35"><span></span></div>
@@ -35,19 +33,19 @@ offsetTop expected 35 but got 25
 PASS .target > * 22
 FAIL .target > * 23 assert_equals:
 <div data-offset-y="45"><span></span></div>
-offsetTop expected 45 but got 25
+offsetTop expected 45 but got 70
 PASS .target > * 24
 PASS .target > * 25
 PASS .target > * 26
-FAIL .target > * 27 assert_equals:
-<div data-offset-y="50"><span></span></div>
-offsetTop expected 50 but got 25
+PASS .target > * 27
 PASS .target > * 28
 FAIL .target > * 29 assert_equals:
 <div data-offset-y="35"><span></span></div>
 offsetTop expected 35 but got 55
 PASS .target > * 30
-PASS .target > * 31
+FAIL .target > * 31 assert_equals:
+<div data-offset-y="55"><span></span></div>
+offsetTop expected 55 but got 45
 PASS .target > * 32
 FAIL .target > * 33 assert_equals:
 <div data-offset-y="15"><span></span></div>
@@ -55,13 +53,15 @@ offsetTop expected 15 but got 60
 PASS .target > * 34
 FAIL .target > * 35 assert_equals:
 <div data-offset-y="70"><span></span></div>
-offsetTop expected 70 but got 60
+offsetTop expected 70 but got 40
 PASS .target > * 36
 FAIL .target > * 37 assert_equals:
 <div data-offset-y="40"><span></span></div>
 offsetTop expected 40 but got 60
 PASS .target > * 38
-PASS .target > * 39
+FAIL .target > * 39 assert_equals:
+<div data-offset-y="60"><span></span></div>
+offsetTop expected 60 but got 40
 PASS .target > * 40
 FAIL .target > * 41 assert_equals:
 <div data-offset-y="15"><span></span></div>
@@ -69,12 +69,14 @@ offsetTop expected 15 but got 25
 PASS .target > * 42
 FAIL .target > * 43 assert_equals:
 <div data-offset-y="55"><span></span></div>
-offsetTop expected 55 but got 25
+offsetTop expected 55 but got 50
 PASS .target > * 44
 FAIL .target > * 45 assert_equals:
 <div data-offset-y="45"><span></span></div>
 offsetTop expected 45 but got 55
 PASS .target > * 46
-PASS .target > * 47
+FAIL .target > * 47 assert_equals:
+<div data-offset-y="55"><span></span></div>
+offsetTop expected 55 but got 45
 PASS .target > * 48
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-002-expected.txt
@@ -1,33 +1,33 @@
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-x="30"><span></span></div>
-offsetLeft expected 30 but got 40
+PASS .target > * 3
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-x="30"><span></span></div>
 offsetLeft expected 30 but got 40
 PASS .target > * 6
-PASS .target > * 7
+FAIL .target > * 7 assert_equals:
+<div data-offset-x="40"><span></span></div>
+offsetLeft expected 40 but got 30
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10
-FAIL .target > * 11 assert_equals:
-<div data-offset-x="30"><span></span></div>
-offsetLeft expected 30 but got 50
+PASS .target > * 11
 PASS .target > * 12
 FAIL .target > * 13 assert_equals:
 <div data-offset-x="40"><span></span></div>
 offsetLeft expected 40 but got 20
 PASS .target > * 14
-PASS .target > * 15
+FAIL .target > * 15 assert_equals:
+<div data-offset-x="20"><span></span></div>
+offsetLeft expected 20 but got 40
 PASS .target > * 16
 PASS .target > * 17
 PASS .target > * 18
 FAIL .target > * 19 assert_equals:
 <div data-offset-x="33"><span></span></div>
-offsetLeft expected 33 but got 70
+offsetLeft expected 33 but got 32
 PASS .target > * 20
 FAIL .target > * 21 assert_equals:
 <div data-offset-x="65"><span></span></div>
@@ -35,13 +35,13 @@ offsetLeft expected 65 but got 70
 PASS .target > * 22
 FAIL .target > * 23 assert_equals:
 <div data-offset-x="45"><span></span></div>
-offsetLeft expected 45 but got 70
+offsetLeft expected 45 but got 32
 PASS .target > * 24
 PASS .target > * 25
 PASS .target > * 26
 FAIL .target > * 27 assert_equals:
 <div data-offset-x="38"><span></span></div>
-offsetLeft expected 38 but got 55
+offsetLeft expected 38 but got 37
 PASS .target > * 28
 FAIL .target > * 29 assert_equals:
 <div data-offset-x="50"><span></span></div>
@@ -49,7 +49,7 @@ offsetLeft expected 50 but got 25
 PASS .target > * 30
 FAIL .target > * 31 assert_equals:
 <div data-offset-x="20"><span></span></div>
-offsetLeft expected 20 but got 25
+offsetLeft expected 20 but got 42
 PASS .target > * 32
 FAIL .target > * 33 assert_equals:
 <div data-offset-x="75"><span></span></div>
@@ -57,13 +57,15 @@ offsetLeft expected 75 but got 35
 PASS .target > * 34
 FAIL .target > * 35 assert_equals:
 <div data-offset-x="30"><span></span></div>
-offsetLeft expected 30 but got 35
+offsetLeft expected 30 but got 62
 PASS .target > * 36
 FAIL .target > * 37 assert_equals:
 <div data-offset-x="63"><span></span></div>
 offsetLeft expected 63 but got 35
 PASS .target > * 38
-PASS .target > * 39
+FAIL .target > * 39 assert_equals:
+<div data-offset-x="35"><span></span></div>
+offsetLeft expected 35 but got 62
 PASS .target > * 40
 FAIL .target > * 41 assert_equals:
 <div data-offset-x="60"><span></span></div>
@@ -71,12 +73,14 @@ offsetLeft expected 60 but got 55
 PASS .target > * 42
 FAIL .target > * 43 assert_equals:
 <div data-offset-x="30"><span></span></div>
-offsetLeft expected 30 but got 55
+offsetLeft expected 30 but got 37
 PASS .target > * 44
 FAIL .target > * 45 assert_equals:
 <div data-offset-x="43"><span></span></div>
 offsetLeft expected 43 but got 25
 PASS .target > * 46
-PASS .target > * 47
+FAIL .target > * 47 assert_equals:
+<div data-offset-x="25"><span></span></div>
+offsetLeft expected 25 but got 42
 PASS .target > * 48
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-003-expected.txt
@@ -15,16 +15,18 @@ offsetTop expected 55 but got 85
 PASS .target > * 8
 FAIL .target > * 9 assert_equals:
 <div data-offset-y="115"><span></span></div>
-offsetTop expected 115 but got 45
+offsetTop expected 115 but got 85
 PASS .target > * 10
 FAIL .target > * 11 assert_equals:
 <div data-offset-y="115"><span></span></div>
-offsetTop expected 115 but got 15
+offsetTop expected 115 but got 85
 PASS .target > * 12
-PASS .target > * 13
+FAIL .target > * 13 assert_equals:
+<div data-offset-y="115"><span></span></div>
+offsetTop expected 115 but got 25
 PASS .target > * 14
 FAIL .target > * 15 assert_equals:
 <div data-offset-y="115"><span></span></div>
-offsetTop expected 115 but got 85
+offsetTop expected 115 but got 25
 PASS .target > * 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-004-expected.txt
@@ -15,16 +15,18 @@ offsetLeft expected 105 but got 60
 PASS .target > * 8
 FAIL .target > * 9 assert_equals:
 <div data-offset-x="45"><span></span></div>
-offsetLeft expected 45 but got 110
+offsetLeft expected 45 but got 65
 PASS .target > * 10
 FAIL .target > * 11 assert_equals:
 <div data-offset-x="45"><span></span></div>
-offsetLeft expected 45 but got 130
+offsetLeft expected 45 but got 65
 PASS .target > * 12
-PASS .target > * 13
+FAIL .target > * 13 assert_equals:
+<div data-offset-x="40"><span></span></div>
+offsetLeft expected 40 but got 125
 PASS .target > * 14
 FAIL .target > * 15 assert_equals:
 <div data-offset-x="40"><span></span></div>
-offsetLeft expected 40 but got 60
+offsetLeft expected 40 but got 125
 PASS .target > * 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-001-expected.txt
@@ -1,9 +1,7 @@
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-y="100"><span></span></div>
-offsetTop expected 100 but got 35
+PASS .target > * 3
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-y="55"><span></span></div>
@@ -11,12 +9,10 @@ offsetTop expected 55 but got 25
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <div data-offset-y="115"><span></span></div>
-offsetTop expected 115 but got 25
+offsetTop expected 115 but got 90
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10
-FAIL .target > * 11 assert_equals:
-<div data-offset-y="90"><span></span></div>
-offsetTop expected 90 but got 25
+PASS .target > * 11
 PASS .target > * 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-002-expected.txt
@@ -3,7 +3,7 @@ PASS .target > * 1
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <div data-offset-x="48"><span></span></div>
-offsetLeft expected 48 but got 110
+offsetLeft expected 48 but got 47
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-x="90"><span></span></div>
@@ -11,12 +11,12 @@ offsetLeft expected 90 but got 115
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <div data-offset-x="33"><span></span></div>
-offsetLeft expected 33 but got 115
+offsetLeft expected 33 but got 52
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10
 FAIL .target > * 11 assert_equals:
 <div data-offset-x="53"><span></span></div>
-offsetLeft expected 53 but got 115
+offsetLeft expected 53 but got 52
 PASS .target > * 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-003-expected.txt
@@ -3,7 +3,7 @@ PASS .target > * 1
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <div data-offset-x="93"><span></span></div>
-offsetLeft expected 93 but got 30
+offsetLeft expected 93 but got 92
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-x="50"><span></span></div>
@@ -11,12 +11,12 @@ offsetLeft expected 50 but got 25
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <div data-offset-x="108"><span></span></div>
-offsetLeft expected 108 but got 25
+offsetLeft expected 108 but got 87
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10
 FAIL .target > * 11 assert_equals:
 <div data-offset-x="88"><span></span></div>
-offsetLeft expected 88 but got 25
+offsetLeft expected 88 but got 87
 PASS .target > * 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-line-clamp-001.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-line-clamp-001.tentative-expected.txt
@@ -37,36 +37,32 @@ PASS .target > * 1
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <div data-offset-y="110"><span></span></div>
-offsetTop expected 110 but got 30
+offsetTop expected 110 but got 190
 PASS .target > * 4
 PASS .target > * 5
 PASS .target > * 6
-FAIL .target > * 7 assert_equals:
-<div data-offset-y="70"><span></span></div>
-offsetTop expected 70 but got 30
+PASS .target > * 7
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10
-FAIL .target > * 11 assert_equals:
-<div data-offset-y="110"><span></span></div>
-offsetTop expected 110 but got 30
+PASS .target > * 11
 PASS .target > * 12
 PASS .target > * 13
 PASS .target > * 14
 FAIL .target > * 15 assert_equals:
 <div data-offset-y="110"><span></span></div>
-offsetTop expected 110 but got 30
+offsetTop expected 110 but got 190
 PASS .target > * 16
 PASS .target > * 17
 PASS .target > * 18
 FAIL .target > * 19 assert_equals:
 <div data-offset-y="110"><span></span></div>
-offsetTop expected 110 but got 30
+offsetTop expected 110 but got 190
 PASS .target > * 20
 PASS .target > * 21
 PASS .target > * 22
 FAIL .target > * 23 assert_equals:
 <div data-offset-y="110"><span></span></div>
-offsetTop expected 110 but got 30
+offsetTop expected 110 but got 190
 PASS .target > * 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-line-clamp-002.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-line-clamp-002.tentative-expected.txt
@@ -39,7 +39,7 @@ offsetLeft expected 105 but got 40
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <div data-offset-x="25"><span></span></div>
-offsetLeft expected 25 but got 40
+offsetLeft expected 25 but got 10
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-x="65"><span></span></div>
@@ -47,7 +47,7 @@ offsetLeft expected 65 but got 40
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <div data-offset-x="25"><span></span></div>
-offsetLeft expected 25 but got 40
+offsetLeft expected 25 but got 10
 PASS .target > * 8
 FAIL .target > * 9 assert_equals:
 <div data-offset-x="105"><span></span></div>
@@ -55,7 +55,7 @@ offsetLeft expected 105 but got 40
 PASS .target > * 10
 FAIL .target > * 11 assert_equals:
 <div data-offset-x="25"><span></span></div>
-offsetLeft expected 25 but got 40
+offsetLeft expected 25 but got 10
 PASS .target > * 12
 FAIL .target > * 13 assert_equals:
 <div data-offset-x="105"><span></span></div>
@@ -63,7 +63,7 @@ offsetLeft expected 105 but got 40
 PASS .target > * 14
 FAIL .target > * 15 assert_equals:
 <div data-offset-x="25"><span></span></div>
-offsetLeft expected 25 but got 40
+offsetLeft expected 25 but got 10
 PASS .target > * 16
 FAIL .target > * 17 assert_equals:
 <div data-offset-x="105"><span></span></div>
@@ -71,7 +71,7 @@ offsetLeft expected 105 but got 40
 PASS .target > * 18
 FAIL .target > * 19 assert_equals:
 <div data-offset-x="25"><span></span></div>
-offsetLeft expected 25 but got 40
+offsetLeft expected 25 but got 10
 PASS .target > * 20
 FAIL .target > * 21 assert_equals:
 <div data-offset-x="105"><span></span></div>
@@ -79,6 +79,6 @@ offsetLeft expected 105 but got 40
 PASS .target > * 22
 FAIL .target > * 23 assert_equals:
 <div data-offset-x="25"><span></span></div>
-offsetLeft expected 25 but got 40
+offsetLeft expected 25 but got 10
 PASS .target > * 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-line-clamp-003.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-line-clamp-003.tentative-expected.txt
@@ -39,7 +39,7 @@ offsetLeft expected 25 but got 10
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <div data-offset-x="105"><span></span></div>
-offsetLeft expected 105 but got 10
+offsetLeft expected 105 but got 40
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-x="25"><span></span></div>
@@ -47,7 +47,7 @@ offsetLeft expected 25 but got 10
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <div data-offset-x="65"><span></span></div>
-offsetLeft expected 65 but got 10
+offsetLeft expected 65 but got 40
 PASS .target > * 8
 FAIL .target > * 9 assert_equals:
 <div data-offset-x="25"><span></span></div>
@@ -55,7 +55,7 @@ offsetLeft expected 25 but got 10
 PASS .target > * 10
 FAIL .target > * 11 assert_equals:
 <div data-offset-x="105"><span></span></div>
-offsetLeft expected 105 but got 10
+offsetLeft expected 105 but got 40
 PASS .target > * 12
 FAIL .target > * 13 assert_equals:
 <div data-offset-x="25"><span></span></div>
@@ -63,7 +63,7 @@ offsetLeft expected 25 but got 10
 PASS .target > * 14
 FAIL .target > * 15 assert_equals:
 <div data-offset-x="105"><span></span></div>
-offsetLeft expected 105 but got 10
+offsetLeft expected 105 but got 40
 PASS .target > * 16
 FAIL .target > * 17 assert_equals:
 <div data-offset-x="25"><span></span></div>
@@ -71,7 +71,7 @@ offsetLeft expected 25 but got 10
 PASS .target > * 18
 FAIL .target > * 19 assert_equals:
 <div data-offset-x="105"><span></span></div>
-offsetLeft expected 105 but got 10
+offsetLeft expected 105 but got 40
 PASS .target > * 20
 FAIL .target > * 21 assert_equals:
 <div data-offset-x="25"><span></span></div>
@@ -79,6 +79,6 @@ offsetLeft expected 25 but got 10
 PASS .target > * 22
 FAIL .target > * 23 assert_equals:
 <div data-offset-x="105"><span></span></div>
-offsetLeft expected 105 but got 10
+offsetLeft expected 105 but got 40
 PASS .target > * 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-overflow-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-overflow-001-expected.txt
@@ -13,9 +13,7 @@
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-y="55"><span></span><br><span></span></div>
-offsetTop expected 55 but got 45
+PASS .target > * 3
 PASS .target > * 4
 PASS .target > * 5
 FAIL .target > * 6 assert_equals:
@@ -32,13 +30,13 @@ FAIL .target > * 8 assert_equals:
       <span></span><br><span></span>
     </div>
   </div>
-offsetTop expected 50 but got 185
+offsetTop expected 50 but got 175
 FAIL .target > * 9 assert_equals:
 <div data-offset-y="110"><span></span><br><span></span></div>
 offsetTop expected 110 but got 245
 PASS .target > * 10
 FAIL .target > * 11 assert_equals:
 <div data-offset-y="90"><span></span><br><span></span></div>
-offsetTop expected 90 but got 245
+offsetTop expected 90 but got 255
 PASS .target > * 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-overflow-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-overflow-002-expected.txt
@@ -13,9 +13,7 @@
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-x="60"><span></span><br><span></span></div>
-offsetLeft expected 60 but got 70
+PASS .target > * 3
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-x="100"><span></span><br><span></span></div>
@@ -23,7 +21,7 @@ offsetLeft expected 100 but got 270
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <div data-offset-x="120"><span></span><br><span></span></div>
-offsetLeft expected 120 but got 270
+offsetLeft expected 120 but got 260
 PASS .target > * 8
 PASS .target > * 9
 FAIL .target > * 10 assert_equals:
@@ -40,5 +38,5 @@ FAIL .target > * 12 assert_equals:
       <span></span><br><span></span>
     </div>
   </div>
-offsetLeft expected 20 but got 160
+offsetLeft expected 20 but got 170
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-overflow-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-overflow-003-expected.txt
@@ -13,9 +13,7 @@
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-x="50"><span></span><br><span></span></div>
-offsetLeft expected 50 but got 40
+PASS .target > * 3
 PASS .target > * 4
 PASS .target > * 5
 FAIL .target > * 6 assert_equals:
@@ -32,13 +30,13 @@ FAIL .target > * 8 assert_equals:
       <span></span><br><span></span>
     </div>
   </div>
-offsetLeft expected 40 but got 190
+offsetLeft expected 40 but got 180
 FAIL .target > * 9 assert_equals:
 <div data-offset-x="120"><span></span><br><span></span></div>
 offsetLeft expected 120 but got 240
 PASS .target > * 10
 FAIL .target > * 11 assert_equals:
 <div data-offset-x="100"><span></span><br><span></span></div>
-offsetLeft expected 100 but got 240
+offsetLeft expected 100 but got 250
 PASS .target > * 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-003-expected.txt
@@ -15,6 +15,6 @@ PASS .target > * 1
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <div data-offset-x="95"><span></span></div>
-offsetLeft expected 95 but got 45
+offsetLeft expected 95 but got 149
 PASS .target > * 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
@@ -16,17 +16,15 @@ FAIL #target > div 1 assert_equals:
 offsetLeft expected 120 but got 0
 FAIL #target > div 2 assert_equals:
 <div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 35
+offsetLeft expected 105 but got 0
 FAIL #target > div 3 assert_equals:
 <div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 42
-FAIL #target > div 4 assert_equals:
-<div data-offset-x="20">line1<br>line2</div>
-offsetLeft expected 20 but got 35
+offsetLeft expected 126 but got 7
+PASS #target > div 4
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="35">line1<br>line2</div>
 offsetLeft expected 35 but got 0
 FAIL #target > div 6 assert_equals:
 <div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 21
+offsetLeft expected 42 but got 7
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt
@@ -4,11 +4,11 @@
 
 FAIL #target > div 1 assert_equals:
 <div data-offset-y="40"><span></span><br><span></span></div>
-offsetTop expected 40 but got 10
+offsetTop expected 40 but got 0
 FAIL #target > div 2 assert_equals:
 <div data-offset-y="20"><span></span><br><span></span></div>
-offsetTop expected 20 but got 0
+offsetTop expected 20 but got 40
 FAIL #target > div 3 assert_equals:
 <div data-offset-y="75"><span></span><br><span></span></div>
-offsetTop expected 75 but got 20
+offsetTop expected 75 but got 40
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt
@@ -4,11 +4,11 @@
 
 FAIL #target > div 1 assert_equals:
 <div data-offset-y="40"><span></span><br><span></span></div>
-offsetTop expected 40 but got 10
+offsetTop expected 40 but got 0
 FAIL #target > div 2 assert_equals:
 <div data-offset-y="20"><span></span><br><span></span></div>
-offsetTop expected 20 but got 0
+offsetTop expected 20 but got 40
 FAIL #target > div 3 assert_equals:
 <div data-offset-y="75"><span></span><br><span></span></div>
-offsetTop expected 75 but got 20
+offsetTop expected 75 but got 40
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-001-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-001-expected.txt
@@ -15,7 +15,7 @@ PASS .target > * 1
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <div data-offset-y="95"><span></span></div>
-offsetTop expected 95 but got 144
+offsetTop expected 95 but got 145
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-y="20"><span></span></div>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-002-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-002-expected.txt
@@ -15,6 +15,6 @@ PASS .target > * 1
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <div data-offset-x="65"><span></span></div>
-offsetLeft expected 65 but got 11
+offsetLeft expected 65 but got 10
 PASS .target > * 4
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-003-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-003-expected.txt
@@ -14,7 +14,7 @@ bottom
 PASS .target > * 1
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
-<div data-offset-x="65"><span></span></div>
-offsetLeft expected 65 but got 11
+<div data-offset-x="95"><span></span></div>
+offsetLeft expected 95 but got 150
 PASS .target > * 4
 

--- a/Source/WebCore/rendering/GridBaselineAlignment.h
+++ b/Source/WebCore/rendering/GridBaselineAlignment.h
@@ -160,8 +160,8 @@ private:
     const BaselineGroup& baselineGroupForChild(ItemPosition, unsigned sharedContext, const RenderBox&, GridAxis) const;
     LayoutUnit marginOverForChild(const RenderBox&, GridAxis) const;
     LayoutUnit marginUnderForChild(const RenderBox&, GridAxis) const;
-    LayoutUnit logicalAscentForChild(const RenderBox&, GridAxis) const;
-    LayoutUnit ascentForChild(const RenderBox&, GridAxis) const;
+    LayoutUnit logicalAscentForChild(const RenderBox&, GridAxis, ItemPosition) const;
+    LayoutUnit ascentForChild(const RenderBox&, GridAxis, ItemPosition) const;
     LayoutUnit descentForChild(const RenderBox&, LayoutUnit, GridAxis) const;
     bool isDescentBaselineForChild(const RenderBox&, GridAxis) const;
     bool isHorizontalBaselineAxis(GridAxis) const;

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -30,6 +30,7 @@
 #include "GridArea.h"
 #include "GridLayoutFunctions.h"
 #include "RenderGrid.h"
+#include "rendering/style/RenderStyleConstants.h"
 
 namespace WebCore {
 
@@ -936,7 +937,8 @@ void GridTrackSizingAlgorithm::updateBaselineAlignmentContext(const RenderBox& c
 
     ItemPosition align = m_renderGrid->selfAlignmentForChild(baselineAxis, child).position();
     const auto& span = m_renderGrid->gridSpanForChild(child, gridDirectionForAxis(baselineAxis));
-    m_baselineAlignment.updateBaselineAlignmentContext(align, span.startLine(), child, baselineAxis);
+    auto spanForBaselineAlignment = align == ItemPosition::Baseline ? span.startLine() : span.endLine();
+    m_baselineAlignment.updateBaselineAlignmentContext(align, spanForBaselineAlignment, child, baselineAxis);
 }
 
 LayoutUnit GridTrackSizingAlgorithm::baselineOffsetForChild(const RenderBox& child, GridAxis baselineAxis) const
@@ -951,7 +953,8 @@ LayoutUnit GridTrackSizingAlgorithm::baselineOffsetForChild(const RenderBox& chi
 
     ItemPosition align = m_renderGrid->selfAlignmentForChild(baselineAxis, child).position();
     const auto& span = m_renderGrid->gridSpanForChild(child, gridDirectionForAxis(baselineAxis));
-    return m_baselineAlignment.baselineOffsetForChild(align, span.startLine(), child, baselineAxis);
+    auto spanForBaselineAlignment = align == ItemPosition::Baseline ? span.startLine() : span.endLine();
+    return m_baselineAlignment.baselineOffsetForChild(align, spanForBaselineAlignment, child, baselineAxis);
 }
 
 void GridTrackSizingAlgorithm::clearBaselineItemsCache()

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -206,6 +206,8 @@ private:
 
     LayoutUnit baselinePosition(FontBaseline, bool firstLine, LineDirectionMode, LinePositionMode = PositionOnContainingLine) const final;
     std::optional<LayoutUnit> firstLineBaseline() const final;
+    std::optional<LayoutUnit> lastLineBaseline() const final;
+    WeakPtr<RenderBox> getBaselineChild(ItemPosition alignment) const;
     std::optional<LayoutUnit> inlineBlockBaseline(LineDirectionMode) const final;
     bool isInlineBaselineAlignedChild(const RenderBox&) const;
 


### PR DESCRIPTION
#### 7545fa38ae640521e6ab05ffc5cf73031c8aa521
<pre>
Implement last baseline alignment for CSS Grid.
<a href="https://bugs.webkit.org/show_bug.cgi?id=243524">https://bugs.webkit.org/show_bug.cgi?id=243524</a>
rdar://98089709

Reviewed by Brent Fulgham.

In order to implement last baseline alignment for grid, there are a
couple of extra pieces of information we need to keep track of:
1.) The grid items that are participating in last baseline alignment
2.) The descent values of each of those items

Once we have this, then the rest is similar to how first baseline
alignment is done.

When determining which items are participating in last baseline
alignment, we need to know if any of those items also span into other
tracks. This is because if an item spans into multiple tracks, then
it will participate in last baseline alignment with the items in the
last track it spans. Any calls to updateBaselineAlignmentContext must
now take this into consideration to provide the correct span to update
the baseline sharing groups.

Computing the descent values for last baseline items is the same idea
as computing the ascent for baseline items. This allows us to figure
out the &quot;shim&quot; value that is used to add an artificial margin to items
so that all of the last baseline items align. From the spec:

For the items in each baseline-sharing group, add a “shim”
(effectively, additional margin) on the start/end side
(for first/last-baseline alignment) of each item so that,
when start/end-aligned together their baselines align as specified.

Spec reference:
<a href="https://www.w3.org/TR/css-grid-1/#algo-baseline-shims">https://www.w3.org/TR/css-grid-1/#algo-baseline-shims</a>
<a href="https://www.w3.org/TR/css-grid-1/#grid-baselines">https://www.w3.org/TR/css-grid-1/#grid-baselines</a>
<a href="https://www.w3.org/TR/css-align-3/#baseline-sharing-group">https://www.w3.org/TR/css-align-3/#baseline-sharing-group</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-fieldset-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-fieldset-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-fieldset-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-flex-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-line-clamp-001.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-line-clamp-002.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-line-clamp-003.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-overflow-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-overflow-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-overflow-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-001-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-002-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-003-expected.txt:

* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::logicalAscentForChild const):
We need to take into consideration if the item is being last baseline
aligned here. If it is, then we need to compute its descent value
instead.

(WebCore::GridBaselineAlignment::ascentForChild const):
Similarly, depending on the alignment we will need to call into the
child&apos;s firstLineBaseline or lastLineBaseline method to get the first
line&apos;s baseline value or the last line&apos;s baseline value, respectively.

(WebCore::GridBaselineAlignment::updateBaselineAlignmentContext):
A little bit of cleanup was done here. Instead of calling
ascentForChild and then checking if we need to compute the descent, we
can instead call logicalAscentForChild which does the same for us.
Also, instead of polluting the contextsMap with nullptrs, we can first
try to get the item from the map and decide whether we need to insert
it into the map of update the baseline sharing group instead.

(WebCore::GridBaselineAlignment::baselineOffsetForChild const):
* Source/WebCore/rendering/GridBaselineAlignment.h:

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::updateBaselineAlignmentContext):
(WebCore::GridTrackSizingAlgorithm::baselineOffsetForChild const):
In both of the cases above, we need to check if the item is being first
or last baseline aligned. If it is being last baseline aligned, then it
needs to be in the baseline sharing group for the last track it spans.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::lastLineBaseline const):
Implementation to get the last line baseline for grid items. Definition
of the baseline is in the spec reference above.

(WebCore::RenderGrid::getBaselineChild const):
(WebCore::RenderGrid::columnAxisPositionForChild const):
(WebCore::RenderGrid::columnAxisOffsetForChild const):
A little bit of cleanup to separate the GridAxisEnd (used for last
baseline alignment) from the GridAxisCenter code. This required pulling
out some of the local variables so that they could be used in both
scopes. (startPosition + offsetFromStartPosition) should move the item
to the end of the axis and columnAxisOffsetForChild should provide the
baseline shim to align the item to the other last baselines. If an item
needs to be moved to GridAxisEnd but is not participating in last
baseline alignment, then the shim should be 0.

* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/255455@main">https://commits.webkit.org/255455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9242fdc3c28ac70bb8500bfcfa15abfb511e9685

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102307 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1776 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30145 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84994 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98472 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1195 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79058 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36555 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34337 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17918 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3779 "Found 1 new test failure: compositing/backing/backing-store-attachment-animating-outside-viewport.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38206 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40531 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1720 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37075 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->