### PR TITLE
REGRESSION(253790@main): Fullscreen animation on NHL.com looks weird

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6109,3 +6109,6 @@ imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.
 
 # WPT meta name="variant" is not supported. And iframe 'load' event has a bug.
 imported/w3c/web-platform-tests/import-maps/data-driven/resolving.html [ Skip ]
+
+# WebKit2 Only
+fullscreen/fullscreen-enter-bottom-padding-animation.html [ Skip ]

--- a/LayoutTests/fullscreen/full-screen-test.js
+++ b/LayoutTests/fullscreen/full-screen-test.js
@@ -159,6 +159,12 @@ function waitForEventTestAndEnd(element, eventName, testFuncString)
     waitForEventAndTest(element, eventName, testFuncString, true);
 }
 
+function sleepFor(duration) {
+    return new Promise(resolve => {
+        setTimeout(resolve, duration);
+    });
+}
+
 var testEnded = false;
 
 function endTest()

--- a/LayoutTests/fullscreen/fullscreen-enter-bottom-padding-animation-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-enter-bottom-padding-animation-expected.txt
@@ -1,0 +1,12 @@
+supportsFullScreen() == true
+enterFullScreenForElement()
+beganEnterFullScreen() - initialRect.size: {100, 600}, finalRect.size: {800, 600}
+exitFullScreenForElement()
+beganExitFullScreen() - initialRect.size: {800, 600}, finalRect.size: {100, 600}
+RUN(testRunner.dumpFullScreenCallbacks())
+RUN(target.webkitRequestFullScreen())
+EVENT(webkitfullscreenchange)
+RUN(document.webkitExitFullscreen())
+EVENT(webkitfullscreenchange)
+END OF TEST
+

--- a/LayoutTests/fullscreen/fullscreen-enter-bottom-padding-animation.html
+++ b/LayoutTests/fullscreen/fullscreen-enter-bottom-padding-animation.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>fullscreen-enter-bottom-padding-animation</title>
+    <style>
+        #target { 
+            padding-bottom: 500px;
+            width: 100px;
+            height: 100px;
+        }
+    </style>
+    <script src="full-screen-test.js"></script>
+    <script>
+
+    window.addEventListener('load', async event => {
+        run("testRunner.dumpFullScreenCallbacks()");
+
+        internals.withUserGesture(() => { run('target.webkitRequestFullScreen()'); });
+
+        await waitFor(target, 'webkitfullscreenchange');
+
+        await sleepFor(10);
+
+        run('document.webkitExitFullscreen()');
+
+        await waitFor(target, 'webkitfullscreenchange');
+
+        await sleepFor(10);
+
+        endTest();
+    });
+</script>
+</head>
+<body>
+<div id="target">
+</div>
+</body>
+</html>

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -825,6 +825,9 @@ http/tests/security/contentSecurityPolicy/extensions/manifest-v3/script-src/mani
 # Flaky CSP console logging
 http/tests/security/contentSecurityPolicy/extensions/manifest-v3/script-src/manifest-v3-script-src-block-partial-wildcard.html [ DumpJSConsoleLogInStdErr ]
 
+# Fullscreen callback dumps are WK2 only
+fullscreen/fullscreen-enter-bottom-padding-animation.html [ Pass ]
+
 ### END OF (5) Progressions, expected successes that are expected failures in WebKit1.
 ########################################
 

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -192,7 +192,7 @@ public:
     void suspendAnimations(MonotonicTime = MonotonicTime());
     void resumeAnimations();
 
-    LayoutRect compositedBounds() const;
+    WEBCORE_EXPORT LayoutRect compositedBounds() const;
     // Returns true if changed.
     bool setCompositedBounds(const LayoutRect&);
     // Returns true if changed.

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -62,7 +62,7 @@ static WebCore::IntRect screenRectOfContents(WebCore::Element* element)
         return { };
 
     if (element->renderer() && element->renderer()->hasLayer() && element->renderer()->enclosingLayer()->isComposited()) {
-        WebCore::FloatQuad contentsBox = static_cast<WebCore::FloatRect>(element->renderer()->enclosingLayer()->backing()->contentsBox());
+        WebCore::FloatQuad contentsBox = static_cast<WebCore::FloatRect>(element->renderer()->enclosingLayer()->backing()->compositedBounds());
         contentsBox = element->renderer()->localToAbsoluteQuad(contentsBox);
         return element->renderer()->view().frameView().contentsToScreen(contentsBox.enclosingBoundingBox());
     }

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -1720,18 +1720,34 @@ void InjectedBundlePage::exitFullScreenForElement(WKBundleNodeHandleRef elementR
     m_fullscreenState = NotInFullscreen;
 }
 
-void InjectedBundlePage::beganEnterFullScreen(WKBundlePageRef, WKRect, WKRect)
+void InjectedBundlePage::beganEnterFullScreen(WKBundlePageRef, WKRect initialRect, WKRect finalRect)
 {
     auto& injectedBundle = InjectedBundle::singleton();
-    if (injectedBundle.testRunner()->shouldDumpFullScreenCallbacks())
-        injectedBundle.outputText("beganEnterFullScreen()\n"_s);
+    if (!injectedBundle.testRunner()->shouldDumpFullScreenCallbacks())
+        return;
+
+    injectedBundle.outputText(makeString("beganEnterFullScreen() - initialRect.size: {",
+        initialRect.size.width, ", ",
+        initialRect.size.height,
+        "}, finalRect.size: {",
+        finalRect.size.width, ", ",
+        finalRect.size.height,
+        "}\n"));
 }
 
-void InjectedBundlePage::beganExitFullScreen(WKBundlePageRef, WKRect, WKRect)
+void InjectedBundlePage::beganExitFullScreen(WKBundlePageRef, WKRect initialRect, WKRect finalRect)
 {
     auto& injectedBundle = InjectedBundle::singleton();
-    if (injectedBundle.testRunner()->shouldDumpFullScreenCallbacks())
-        injectedBundle.outputText("beganExitFullScreen()\n"_s);
+    if (!injectedBundle.testRunner()->shouldDumpFullScreenCallbacks())
+        return;
+
+    injectedBundle.outputText(makeString("beganExitFullScreen() - initialRect.size: {",
+        initialRect.size.width, ", ",
+        initialRect.size.height,
+        "}, finalRect.size: {",
+        finalRect.size.width, ", ",
+        finalRect.size.height,
+        "}\n"));
 }
 
 void InjectedBundlePage::closeFullScreen(WKBundlePageRef pageRef)


### PR DESCRIPTION
#### f66eadee1b7ac5f0901e1912322b9cf4893a20bb
<pre>
REGRESSION(253790@main): Fullscreen animation on NHL.com looks weird
<a href="https://bugs.webkit.org/show_bug.cgi?id=246023">https://bugs.webkit.org/show_bug.cgi?id=246023</a>
&lt;rdar://100463264&gt;

Reviewed by Eric Carlson.

NHL.com vertically centers its video content with a `padding-bottom:56%` rule. This, when combined
with an absolutely positioned child element, causes the RenderLayerBacking::contentsBox() to return
a very small rect, which is used by screenRectOfContents() in WebFullScreenManager in the case
where the fullscreen element is layer-backed to calculate the starting and ending screen location
for the fullscreen animation.

In this layer-backed case, use compositedBounds() rather than contentsBox(), as this more correctly
represents the visual bounds of the element.

* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::screenRectOfContents):

Canonical link: <a href="https://commits.webkit.org/255391@main">https://commits.webkit.org/255391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a34592ec71cff70765cb4481a54d3247461701ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101815 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161883 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1242 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29669 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84466 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98010 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/765 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78550 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27716 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82301 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70753 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36088 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16318 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33829 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17420 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3736 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37705 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40126 "Found 2 new test failures: imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h264_annexb, imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_annexb (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36545 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->