### PR TITLE
Assorted style cleanups

### DIFF
--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
@@ -51,7 +51,7 @@ struct ClientState {
     {
     }
 
-    bool operator == (ClientState const& other) const
+    bool operator==(const ClientState& other) const
     {
         return contextId == other.contextId && &client == &other.client;
     }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -963,7 +963,7 @@ Vector<SimpleRange> AccessibilityObject::findTextRanges(const AccessibilitySearc
     return result;
 }
 
-Vector<String> AccessibilityObject::performTextOperation(AccessibilityTextOperation const& operation)
+Vector<String> AccessibilityObject::performTextOperation(const AccessibilityTextOperation& operation)
 {
     Vector<String> result;
 
@@ -4012,7 +4012,7 @@ static bool isRadioButtonInDifferentAdhocGroup(RefPtr<AXCoreObject> axObject, AX
     return axObject->attributeValue("name"_s) != referenceObject->attributeValue("name"_s);
 }
 
-static bool isAccessibilityObjectSearchMatchAtIndex(RefPtr<AXCoreObject> axObject, AccessibilitySearchCriteria const& criteria, size_t index)
+static bool isAccessibilityObjectSearchMatchAtIndex(RefPtr<AXCoreObject> axObject, const AccessibilitySearchCriteria& criteria, size_t index)
 {
     switch (criteria.searchKeys[index]) {
     case AccessibilitySearchKey::AnyType:
@@ -4120,7 +4120,7 @@ static bool isAccessibilityObjectSearchMatchAtIndex(RefPtr<AXCoreObject> axObjec
     }
 }
 
-static bool isAccessibilityObjectSearchMatch(RefPtr<AXCoreObject> axObject, AccessibilitySearchCriteria const& criteria)
+static bool isAccessibilityObjectSearchMatch(RefPtr<AXCoreObject> axObject, const AccessibilitySearchCriteria& criteria)
 {
     if (!axObject)
         return false;
@@ -4136,7 +4136,7 @@ static bool isAccessibilityObjectSearchMatch(RefPtr<AXCoreObject> axObject, Acce
     return false;
 }
 
-static bool isAccessibilityTextSearchMatch(RefPtr<AXCoreObject> axObject, AccessibilitySearchCriteria const& criteria)
+static bool isAccessibilityTextSearchMatch(RefPtr<AXCoreObject> axObject, const AccessibilitySearchCriteria& criteria)
 {
     if (!axObject)
         return false;
@@ -4150,7 +4150,7 @@ static bool isAccessibilityTextSearchMatch(RefPtr<AXCoreObject> axObject, Access
         || containsPlainText(axObject->stringValue(), criteria.searchText, CaseInsensitive);
 }
 
-static bool objectMatchesSearchCriteriaWithResultLimit(RefPtr<AXCoreObject> object, AccessibilitySearchCriteria const& criteria, AXCoreObject::AccessibilityChildrenVector& results)
+static bool objectMatchesSearchCriteriaWithResultLimit(RefPtr<AXCoreObject> object, const AccessibilitySearchCriteria& criteria, AXCoreObject::AccessibilityChildrenVector& results)
 {
     if (isAccessibilityObjectSearchMatch(object, criteria) && isAccessibilityTextSearchMatch(object, criteria)) {
         results.append(object);
@@ -4214,7 +4214,7 @@ static void appendChildrenToArray(RefPtr<AXCoreObject> object, bool isForward, R
     }
 }
 
-void findMatchingObjects(AccessibilitySearchCriteria const& criteria, AXCoreObject::AccessibilityChildrenVector& results)
+void findMatchingObjects(const AccessibilitySearchCriteria& criteria, AXCoreObject::AccessibilityChildrenVector& results)
 {
     AXTRACE("Accessibility::findMatchingObjects"_s);
     AXLOG(criteria);

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -369,7 +369,7 @@ public:
 
     // Text selection
     Vector<SimpleRange> findTextRanges(const AccessibilitySearchTextCriteria&) const override;
-    Vector<String> performTextOperation(AccessibilityTextOperation const&) override;
+    Vector<String> performTextOperation(const AccessibilityTextOperation&) override;
 
     AccessibilityObject* observableObject() const override { return nullptr; }
     AccessibilityChildrenVector linkedObjects() const override { return { }; }

--- a/Source/WebCore/accessibility/AccessibilityObjectInterface.h
+++ b/Source/WebCore/accessibility/AccessibilityObjectInterface.h
@@ -1123,7 +1123,7 @@ public:
 
     // Text selection
     virtual Vector<SimpleRange> findTextRanges(const AccessibilitySearchTextCriteria&) const = 0;
-    virtual Vector<String> performTextOperation(AccessibilityTextOperation const&) = 0;
+    virtual Vector<String> performTextOperation(const AccessibilityTextOperation&) = 0;
 
     virtual AXCoreObject* observableObject() const = 0;
     virtual AccessibilityChildrenVector linkedObjects() const = 0;
@@ -1560,7 +1560,7 @@ T* findRelatedObjectInAncestry(const T& object, AXRelationType relationType, con
     return nullptr;
 }
 
-void findMatchingObjects(AccessibilitySearchCriteria const&, AXCoreObject::AccessibilityChildrenVector&);
+void findMatchingObjects(const AccessibilitySearchCriteria&, AXCoreObject::AccessibilityChildrenVector&);
 
 template<typename T, typename F>
 void enumerateAncestors(const T& object, bool includeSelf, const F& lambda)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -1080,7 +1080,7 @@ Vector<SimpleRange> AXIsolatedObject::findTextRanges(const AccessibilitySearchTe
     });
 }
 
-Vector<String> AXIsolatedObject::performTextOperation(AccessibilityTextOperation const& textOperation)
+Vector<String> AXIsolatedObject::performTextOperation(const AccessibilityTextOperation& textOperation)
 {
     return Accessibility::retrieveValueFromMainThread<Vector<String>>([&textOperation, this] () -> Vector<String> {
         if (auto* object = associatedAXObject())

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -349,7 +349,7 @@ private:
 
     // Parameterized attribute retrieval.
     Vector<SimpleRange> findTextRanges(const AccessibilitySearchTextCriteria&) const override;
-    Vector<String> performTextOperation(AccessibilityTextOperation const&) override;
+    Vector<String> performTextOperation(const AccessibilityTextOperation&) override;
     void findMatchingObjects(AccessibilitySearchCriteria*, AccessibilityChildrenVector&) override;
 
     // Attributes retrieved from the root node only so that the data isn't duplicated on each node.

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -592,7 +592,7 @@ JSC::JSGlobalObject* JSDOMGlobalObject::deriveShadowRealmGlobalObject(JSC::JSGlo
         // with a given wrapper world should outlive other objects in that
         // world)
         auto document = &downcast<Document>(*context);
-        auto const& originalOrigin = document->securityOrigin();
+        const auto& originalOrigin = document->securityOrigin();
         auto& originalWorld = domGlobalObject->world();
 
         while (!document->isTopDocument()) {

--- a/Source/WebCore/css/StyleColor.cpp
+++ b/Source/WebCore/css/StyleColor.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 Google Inc. All rights reserved.
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016, 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -38,11 +38,6 @@
 #include "RenderTheme.h"
 
 namespace WebCore {
-
-StyleColor StyleColor::currentColor()
-{
-    return { CurrentColor { } };
-}
 
 String serializationForRenderTreeAsText(const StyleColor& color)
 {
@@ -169,32 +164,10 @@ bool StyleColor::isAbsoluteColor() const
     return std::holds_alternative<Color>(m_color);
 }
 
-Color const& StyleColor::absoluteColor() const
+const Color& StyleColor::absoluteColor() const
 {
     ASSERT(isAbsoluteColor());
     return std::get<Color>(m_color);
-}
-
-// The default constructor initializes to currentcolor to preserve old behavior,
-// we might want to change it to invalid color at some point.
-StyleColor::StyleColor()
-: m_color { CurrentColor { } } 
-{
-}
-
-StyleColor::StyleColor(const ColorKind& color)
-: m_color { color }
-{
-}
-
-StyleColor::StyleColor(const Color& color)
-: m_color { Color { color } }
-{
-}
-
-StyleColor::StyleColor(const SRGBA<uint8_t>& color)
-: m_color { Color { color } }
-{
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
@@ -119,7 +119,7 @@ bool WebGLVertexArrayObjectBase::areAllEnabledAttribBuffersBound()
 {
     if (!m_allEnabledAttribBuffersBoundCache) {
         m_allEnabledAttribBuffersBoundCache = [&] {
-            for (auto const& state : m_vertexAttribState) {
+            for (const auto& state : m_vertexAttribState) {
                 if (!state.validateBinding())
                     return false;
             }

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1508,7 +1508,7 @@ void DragController::insertDroppedImagePlaceholdersAtCaret(const Vector<IntSize>
         image->setAttributeWithoutSynchronization(HTMLNames::widthAttr, AtomString::number(size.width()));
         image->setAttributeWithoutSynchronization(HTMLNames::heightAttr, AtomString::number(size.height()));
         image->setInlineStyleProperty(CSSPropertyMaxWidth, 100, CSSUnitType::CSS_PERCENTAGE);
-        image->setInlineStyleProperty(CSSPropertyBackgroundColor, serializationForCSS(static_cast<Color>(Color::black.colorWithAlphaByte(13))));
+        image->setInlineStyleProperty(CSSPropertyBackgroundColor, serializationForCSS(Color { Color::black.colorWithAlphaByte(13) }));
         image->setIsDroppedImagePlaceholder();
         fragment->appendChild(WTFMove(image));
     }

--- a/Source/WebCore/platform/network/ParsedContentType.h
+++ b/Source/WebCore/platform/network/ParsedContentType.h
@@ -61,7 +61,7 @@ public:
 private:
     ParsedContentType(const String&);
     ParsedContentType(const ParsedContentType&) = delete;
-    ParsedContentType& operator=(ParsedContentType const&) = delete;
+    ParsedContentType& operator=(const ParsedContentType&) = delete;
     bool parseContentType(Mode);
     void setContentType(String&&, Mode);
     void setContentTypeParameter(const String&, const String&, Mode);

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -380,7 +380,7 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
         if (borderTop || borderRight || borderBottom || borderLeft) {
             ts << " [border:";
 
-            auto printBorder = [&ts, &o] (LayoutUnit const& width, BorderStyle const& style, StyleColor const& color) {
+            auto printBorder = [&ts, &o] (const LayoutUnit& width, const BorderStyle& style, const StyleColor& color) {
                 if (!width)
                     ts << " none";
                 else {

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2247,10 +2247,6 @@ StyleColor RenderStyle::unresolvedColorForProperty(CSSPropertyID colorProperty, 
     return { };
 }
 
-StyleColor RenderStyle::currentColor() { return StyleColor::currentColor(); }
-
-bool RenderStyle::isCurrentColor(const StyleColor& color) { return color.isCurrentColor();  }
-
 Color RenderStyle::colorResolvingCurrentColor(CSSPropertyID colorProperty, bool visitedLink) const
 {
     auto result = unresolvedColorForProperty(colorProperty, visitedLink);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -91,7 +91,6 @@
 #include "StyleColorScheme.h"
 #endif
 
-
 #define SET_VAR(group, variable, value) do { \
         if (!compareEqual(group->variable, value)) \
             group.access().variable = value; \
@@ -1908,8 +1907,8 @@ public:
     void getShadowInlineDirectionExtent(const ShadowData*, LayoutUnit& logicalLeft, LayoutUnit& logicalRight) const;
     void getShadowBlockDirectionExtent(const ShadowData*, LayoutUnit& logicalTop, LayoutUnit& logicalBottom) const;
 
-    static StyleColor currentColor();
-    static bool isCurrentColor(const StyleColor&);
+    static StyleColor currentColor() { return StyleColor::currentColor(); }
+    static bool isCurrentColor(const StyleColor& color) { return color.isCurrentColor(); }
 
     const StyleColor& borderLeftColor() const { return m_surroundData->border.left().color(); }
     const StyleColor& borderRightColor() const { return m_surroundData->border.right().color(); }

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -162,7 +162,6 @@ public:
 
     static void applyValueColor(BuilderState&, CSSValue&);
 
-
 private:
     static void resetEffectiveZoom(BuilderState&);
 
@@ -233,16 +232,19 @@ inline void BuilderCustom::applyValueZoom(BuilderState& builderState, CSSValue& 
             builderState.setZoom(number);
     }
 }
+
 inline Length BuilderCustom::mmLength(double mm)
 {
     Ref<CSSPrimitiveValue> value(CSSPrimitiveValue::create(mm, CSSUnitType::CSS_MM));
     return value.get().computeLength<Length>({ });
 }
+
 inline Length BuilderCustom::inchLength(double inch)
 {
     Ref<CSSPrimitiveValue> value(CSSPrimitiveValue::create(inch, CSSUnitType::CSS_IN));
     return value.get().computeLength<Length>({ });
 }
+
 bool BuilderCustom::getPageSizeFromName(CSSPrimitiveValue* pageSizeName, CSSPrimitiveValue* pageOrientation, Length& width, Length& height)
 {
     static NeverDestroyed<Length> a5Width(mmLength(148));
@@ -369,9 +371,13 @@ inline void BuilderCustom::applyValueImageResolution(BuilderState& builderState,
 
 #endif // ENABLE(CSS_IMAGE_RESOLUTION)
 
-inline void BuilderCustom::applyInheritSize(BuilderState&) { }
+inline void BuilderCustom::applyInheritSize(BuilderState&)
+{
+}
 
-inline void BuilderCustom::applyInitialSize(BuilderState&) { }
+inline void BuilderCustom::applyInitialSize(BuilderState&)
+{
+}
 
 inline void BuilderCustom::applyValueSize(BuilderState& builderState, CSSValue& value)
 {
@@ -488,7 +494,7 @@ inline void BuilderCustom::applyValueTextIndent(BuilderState& builderState, CSSV
 
 enum BorderImageType { BorderImage, WebkitMaskBoxImage };
 enum BorderImageModifierType { Outset, Repeat, Slice, Width };
-template <BorderImageType type, BorderImageModifierType modifier>
+template<BorderImageType type, BorderImageModifierType modifier>
 class ApplyPropertyBorderImageModifier {
 public:
     static void applyInheritValue(BuilderState& builderState)
@@ -1385,7 +1391,9 @@ inline void BuilderCustom::applyValueCounter(BuilderState& builderState, CSSValu
     }
 }
 
-inline void BuilderCustom::applyInitialCounterIncrement(BuilderState&) { }
+inline void BuilderCustom::applyInitialCounterIncrement(BuilderState&)
+{
+}
 
 inline void BuilderCustom::applyInheritCounterIncrement(BuilderState& builderState)
 {
@@ -1397,7 +1405,9 @@ inline void BuilderCustom::applyValueCounterIncrement(BuilderState& builderState
     applyValueCounter<Increment>(builderState, value);
 }
 
-inline void BuilderCustom::applyInitialCounterReset(BuilderState&) { }
+inline void BuilderCustom::applyInitialCounterReset(BuilderState&)
+{
+}
 
 inline void BuilderCustom::applyInheritCounterReset(BuilderState& builderState)
 {
@@ -1478,7 +1488,6 @@ inline void BuilderCustom::applyInheritFill(BuilderState& builderState)
     auto& svgStyle = builderState.style().accessSVGStyle();
     auto& svgParentStyle = builderState.parentStyle().svgStyle();
     svgStyle.setFillPaint(svgParentStyle.fillPaintType(), svgParentStyle.fillPaintColor(), svgParentStyle.fillPaintUri(), builderState.applyPropertyToRegularStyle(), builderState.applyPropertyToVisitedLinkStyle());
-
 }
 
 inline void BuilderCustom::applyValueFill(BuilderState& builderState, CSSValue& value)


### PR DESCRIPTION
#### c5bd323a7d366696ac2e218461813541c1a5efa4
<pre>
Assorted style cleanups
<a href="https://bugs.webkit.org/show_bug.cgi?id=246046">https://bugs.webkit.org/show_bug.cgi?id=246046</a>
&lt;rdar://100785096&gt;

Reviewed by Tim Nguyen.

Address a few style issues I noticed:
- Foo const&amp; -&gt; const Foo&amp;
- Move some trivial constructors to the header when no additional includes are needed.
- Whitespace / brace placement issues

* Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp:
(WebCore::ClientState::operator== const):
(WebCore::ClientState::operator ==  const): Deleted.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::performTextOperation):
(WebCore::Accessibility::isAccessibilityObjectSearchMatchAtIndex):
(WebCore::Accessibility::isAccessibilityObjectSearchMatch):
(WebCore::Accessibility::isAccessibilityTextSearchMatch):
(WebCore::Accessibility::objectMatchesSearchCriteriaWithResultLimit):
(WebCore::Accessibility::findMatchingObjects):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityObjectInterface.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::performTextOperation):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::deriveShadowRealmGlobalObject):
* Source/WebCore/css/StyleColor.cpp:
(WebCore::StyleColor::absoluteColor const):
(WebCore::StyleColor::currentColor): Deleted.
(WebCore::StyleColor::StyleColor): Deleted.
* Source/WebCore/css/StyleColor.h:
(WebCore::StyleColor::StyleColor):
(WebCore::StyleColor::currentColor):
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp:
(WebCore::WebGLVertexArrayObjectBase::areAllEnabledAttribBuffersBound):
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::insertDroppedImagePlaceholdersAtCaret):
* Source/WebCore/platform/network/ParsedContentType.h:
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::RenderTreeAsText::writeRenderObject):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::currentColor): Deleted.
(WebCore::RenderStyle::isCurrentColor): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::currentColor):
(WebCore::RenderStyle::isCurrentColor):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyInheritSize):
(WebCore::Style::BuilderCustom::applyInitialSize):
(WebCore::Style::BuilderCustom::applyInitialCounterIncrement):
(WebCore::Style::BuilderCustom::applyInitialCounterReset):
(WebCore::Style::BuilderCustom::applyInheritFill):

Canonical link: <a href="https://commits.webkit.org/255178@main">https://commits.webkit.org/255178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03333ac60b608cd8cf20a5f4e293f26607716d49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101255 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161313 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/700 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83871 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97606 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/438 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78236 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27391 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82362 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70431 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35667 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16050 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33439 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17143 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3593 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37259 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36260 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->