### PR TITLE
Allow generated serialization of nested classes

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
@@ -35,7 +35,7 @@
 namespace WebCore {
 
 struct ApplicationManifest {
-    enum class Display {
+    enum class Display : uint8_t {
         Browser,
         MinimalUI,
         Standalone,
@@ -43,7 +43,7 @@ struct ApplicationManifest {
     };
 
     struct Icon {
-        enum class Purpose : uint8_t  {
+        enum class Purpose : uint8_t {
             Any = 1 << 0,
             Monochrome = 1 << 1,
             Maskable = 1 << 2,
@@ -53,9 +53,6 @@ struct ApplicationManifest {
         Vector<String> sizes;
         String type;
         OptionSet<Purpose> purposes;
-
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<ApplicationManifest::Icon> decode(Decoder&);
     };
 
     String name;
@@ -66,88 +63,9 @@ struct ApplicationManifest {
     URL startURL;
     Color themeColor;
     Vector<Icon> icons;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ApplicationManifest> decode(Decoder&);
 };
-
-template<class Encoder>
-void ApplicationManifest::encode(Encoder& encoder) const
-{
-    encoder << name << shortName << description << scope << display << startURL << themeColor << icons;
-}
-
-template<class Decoder>
-std::optional<ApplicationManifest> ApplicationManifest::decode(Decoder& decoder)
-{
-    ApplicationManifest result;
-
-    if (!decoder.decode(result.name))
-        return std::nullopt;
-    if (!decoder.decode(result.shortName))
-        return std::nullopt;
-    if (!decoder.decode(result.description))
-        return std::nullopt;
-    if (!decoder.decode(result.scope))
-        return std::nullopt;
-    if (!decoder.decode(result.display))
-        return std::nullopt;
-    if (!decoder.decode(result.startURL))
-        return std::nullopt;
-    if (!decoder.decode(result.themeColor))
-        return std::nullopt;
-    if (!decoder.decode(result.icons))
-        return std::nullopt;
-
-    return result;
-}
-
-template<class Encoder>
-void ApplicationManifest::Icon::encode(Encoder& encoder) const
-{
-    encoder << src << sizes << type << purposes;
-}
-
-template<class Decoder>
-std::optional<ApplicationManifest::Icon> ApplicationManifest::Icon::decode(Decoder& decoder)
-{
-    ApplicationManifest::Icon result;
-    if (!decoder.decode(result.src))
-        return std::nullopt;
-    if (!decoder.decode(result.sizes))
-        return std::nullopt;
-    if (!decoder.decode(result.type))
-        return std::nullopt;
-    if (!decoder.decode(result.purposes))
-        return std::nullopt;
-
-    return result;
-}
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ApplicationManifest::Display> {
-    using values = EnumValues<
-        WebCore::ApplicationManifest::Display,
-        WebCore::ApplicationManifest::Display::Browser,
-        WebCore::ApplicationManifest::Display::MinimalUI,
-        WebCore::ApplicationManifest::Display::Standalone,
-        WebCore::ApplicationManifest::Display::Fullscreen
-    >;
-};
-
-template<> struct EnumTraits<WebCore::ApplicationManifest::Icon::Purpose> {
-    using values = EnumValues<
-        WebCore::ApplicationManifest::Icon::Purpose,
-        WebCore::ApplicationManifest::Icon::Purpose::Any,
-        WebCore::ApplicationManifest::Icon::Purpose::Monochrome,
-        WebCore::ApplicationManifest::Icon::Purpose::Maskable
-    >;
-};
-
-} // namespace WTF;
 
 #endif // ENABLE(APPLICATION_MANIFEST)
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -37,11 +37,17 @@
 #endif
 #include <Namespace/EmptyConstructorNullable.h>
 #include <Namespace/EmptyConstructorStruct.h>
-#include <Namespace/OtherClass.h>
 #include <Namespace/ReturnRefClass.h>
 #include <WebCore/InheritsFrom.h>
 
 namespace IPC {
+
+
+template<> struct ArgumentCoder<Namespace::OtherClass> {
+    static void encode(Encoder&, const Namespace::OtherClass&);
+    static std::optional<Namespace::OtherClass> decode(Decoder&);
+};
+
 
 #if ENABLE(TEST_FEATURE)
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -34,11 +34,9 @@ namespace EnumNamespace { enum class BoolEnumType : bool; }
 #if ENABLE(UINT16_ENUM)
 namespace EnumNamespace { enum class EnumType : uint16_t; }
 #endif
-namespace EnumNamespace2 { enum class OptionSetEnumType : uint8_t; }
 #if ENABLE(TEST_FEATURE)
 namespace Namespace::Subnamespace { struct StructName; }
 #endif
-namespace Namespace { class OtherClass; }
 namespace Namespace { class ReturnRefClass; }
 namespace Namespace { struct EmptyConstructorStruct; }
 namespace Namespace { class EmptyConstructorNullable; }
@@ -59,11 +57,6 @@ template<> struct ArgumentCoder<Namespace::Subnamespace::StructName> {
     static std::optional<Namespace::Subnamespace::StructName> decode(Decoder&);
 };
 #endif
-
-template<> struct ArgumentCoder<Namespace::OtherClass> {
-    static void encode(Encoder&, const Namespace::OtherClass&);
-    static std::optional<Namespace::OtherClass> decode(Decoder&);
-};
 
 template<> struct ArgumentCoder<Namespace::ReturnRefClass> {
     static void encode(Encoder&, const Namespace::ReturnRefClass&);
@@ -104,6 +97,5 @@ namespace WTF {
 #if ENABLE(UINT16_ENUM)
 template<> bool isValidEnum<EnumNamespace::EnumType, void>(uint16_t);
 #endif
-template<> bool isValidOptionSet<EnumNamespace2::OptionSetEnumType>(OptionSet<EnumNamespace2::OptionSetEnumType>);
 
 } // namespace WTF

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -37,7 +37,6 @@
 #endif
 #include <Namespace/EmptyConstructorNullable.h>
 #include <Namespace/EmptyConstructorStruct.h>
-#include <Namespace/OtherClass.h>
 #include <Namespace/ReturnRefClass.h>
 #include <WebCore/InheritsFrom.h>
 

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -13,7 +13,7 @@ headers: "StructHeader.h" "FirstMemberType.h" "SecondMemberType.h"
 }
 #endif
 
-class Namespace::OtherClass {
+[Nested] class Namespace::OtherClass {
     [ReturnEarlyIfTrue] bool isNull
     int a
     bool b
@@ -63,7 +63,7 @@ enum class EnumNamespace::EnumType : uint16_t {
 }
 #endif
 
-[OptionSet] enum class EnumNamespace2::OptionSetEnumType : uint8_t {
+[OptionSet, Nested] enum class EnumNamespace2::OptionSetEnumType : uint8_t {
     OptionSetFirstValue,
 #if ENABLE(OPTION_SET_SECOND_VALUE)
     OptionSetSecondValue,

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -682,3 +682,36 @@ struct WebCore::ApplePayCouponCodeUpdate : WebCore::ApplePayDetailsUpdateBase {
     Vector<WebCore::ApplePayShippingMethod> newShippingMethods;
 };
 #endif
+
+#if ENABLE(APPLICATION_MANIFEST)
+[Nested] enum class WebCore::ApplicationManifest::Display : uint8_t {
+    Browser
+    MinimalUI
+    Standalone
+    Fullscreen
+};
+
+[Nested, OptionSet] enum class WebCore::ApplicationManifest::Icon::Purpose : uint8_t {
+    Any
+    Monochrome
+    Maskable
+}
+
+[Nested] struct WebCore::ApplicationManifest::Icon {
+    URL src
+    Vector<String> sizes
+    String type
+    OptionSet<WebCore::ApplicationManifest::Icon::Purpose> purposes
+}
+
+struct WebCore::ApplicationManifest {
+    String name
+    String shortName
+    String description
+    URL scope
+    WebCore::ApplicationManifest::Display display
+    URL startURL
+    WebCore::Color themeColor
+    Vector<WebCore::ApplicationManifest::Icon> icons
+}
+#endif // ENABLE(APPLICATION_MANIFEST)


### PR DESCRIPTION
#### 58c21888e82152b62f34646163e412dd00a21a4c
<pre>
Allow generated serialization of nested classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=246057">https://bugs.webkit.org/show_bug.cgi?id=246057</a>
rdar://100788834

Reviewed by Tim Horton.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h:
(WebCore::ApplicationManifest::encode const): Deleted.
(WebCore::ApplicationManifest::decode): Deleted.
(WebCore::ApplicationManifest::Icon::encode const): Deleted.
(WebCore::ApplicationManifest::Icon::decode): Deleted.
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(SerializedEnum.is_option_set):
(SerializedEnum):
(SerializedEnum.is_nested):
(argument_coder_declarations):
(generate_header):
(generate_impl):
(parse_serialized_types):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/255154@main">https://commits.webkit.org/255154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ba902e43fc6f20866b5bf36b421e8e05f532294

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/738 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101279 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/736 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83894 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97228 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27407 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/95150 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35694 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33461 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3580 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37288 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39195 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->