### PR TITLE
[GLib] D-Bus proxy quietly fails if host session bus address is an abstract socket

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
@@ -59,6 +59,12 @@ static int memfd_create(const char* name, unsigned flags)
 }
 #endif // #if !defined(MFD_ALLOW_SEALING) && HAVE(LINUX_MEMFD_H)
 
+#if PLATFORM(GTK)
+#define BASE_DIRECTORY "webkitgtk"
+#elif PLATFORM(WPE)
+#define BASE_DIRECTORY "wpe"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -195,13 +201,14 @@ static void bindIfExists(Vector<CString>& args, const char* path, BindFlags bind
 
 static void bindDBusSession(Vector<CString>& args, XDGDBusProxy& dbusProxy, bool allowPortals)
 {
-    auto dbusSessionProxy = dbusProxy.dbusSessionProxy(allowPortals ? XDGDBusProxy::AllowPortals::Yes : XDGDBusProxy::AllowPortals::No);
-    if (!dbusSessionProxy)
+    auto dbusSessionProxyPath = dbusProxy.dbusSessionProxy(allowPortals ? XDGDBusProxy::AllowPortals::Yes : XDGDBusProxy::AllowPortals::No);
+    if (!dbusSessionProxyPath)
         return;
 
-    GUniquePtr<char> proxyAddress(g_strdup_printf("unix:path=%s", dbusSessionProxy->second.data()));
+    GUniquePtr<char> sandboxedSessionBusPath(g_build_filename(g_get_user_runtime_dir(), BASE_DIRECTORY, "bus", nullptr));
+    GUniquePtr<char> proxyAddress(g_strdup_printf("unix:path=%s", sandboxedSessionBusPath.get()));
     args.appendVector(Vector<CString> {
-        "--ro-bind", WTFMove(dbusSessionProxy->first), WTFMove(dbusSessionProxy->second),
+        "--ro-bind", *dbusSessionProxyPath, sandboxedSessionBusPath.get(),
         "--setenv", "DBUS_SESSION_BUS_ADDRESS", proxyAddress.get()
     });
 }
@@ -340,13 +347,14 @@ static void bindGtkData(Vector<CString>& args)
 #if ENABLE(ACCESSIBILITY)
 static void bindA11y(Vector<CString>& args, XDGDBusProxy& dbusProxy)
 {
-    auto accessibilityProxy = dbusProxy.accessibilityProxy();
-    if (!accessibilityProxy)
+    GUniquePtr<char> sandboxedAccessibilityBusPath(g_build_filename(g_get_user_runtime_dir(), BASE_DIRECTORY, "at-spi-bus", nullptr));
+    auto accessibilityProxyPath = dbusProxy.accessibilityProxy(sandboxedAccessibilityBusPath.get());
+    if (!accessibilityProxyPath)
         return;
 
-    GUniquePtr<char> proxyAddress(g_strdup_printf("unix:path=%s", accessibilityProxy->second.data()));
+    GUniquePtr<char> proxyAddress(g_strdup_printf("unix:path=%s", sandboxedAccessibilityBusPath.get()));
     args.appendVector(Vector<CString> {
-        "--ro-bind", WTFMove(accessibilityProxy->first), WTFMove(accessibilityProxy->second),
+        "--ro-bind", *accessibilityProxyPath, sandboxedAccessibilityBusPath.get(),
         "--setenv", "AT_SPI_BUS_ADDRESS", proxyAddress.get()
     });
 }

--- a/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h
+++ b/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h
@@ -41,8 +41,8 @@ public:
     ~XDGDBusProxy() = default;
 
     enum class AllowPortals : bool { No, Yes };
-    std::optional<std::pair<CString, CString>> dbusSessionProxy(AllowPortals);
-    std::optional<std::pair<CString, CString>> accessibilityProxy();
+    std::optional<CString> dbusSessionProxy(AllowPortals);
+    std::optional<CString> accessibilityProxy(const char* sandboxedAccessibilityBusPath);
 
     bool launch();
 
@@ -52,9 +52,7 @@ private:
 
     Vector<CString> m_args;
     CString m_dbusSessionProxyPath;
-    CString m_dbusSessionPath;
     CString m_accessibilityProxyPath;
-    CString m_accessibilityPath;
     UnixFileDescriptor m_syncFD;
 };
 


### PR DESCRIPTION
#### 79f41316d99e6496904950be78a0015503385ec2
<pre>
[GLib] D-Bus proxy quietly fails if host session bus address is an abstract socket
<a href="https://bugs.webkit.org/show_bug.cgi?id=245843">https://bugs.webkit.org/show_bug.cgi?id=245843</a>

Reviewed by Carlos Garcia Campos.

Nowadays all major Linux distros run the D-Bus session bus using a
standard Unix socket created on the filesystem, but distros that do not
use systemd still wind up using dbus-daemon&apos;s default session bus
address, which up until now has used the abstract socket namespace.

Our code here is only compatible with filesystem sockets since it
attempts to create the proxy bus socket in the sandbox at exactly the
same location within the sandbox that the real session bus socket exists
on the host system. If the host session bus uses an abstract socket, our
code just fails. There&apos;s no particular reason to do things this way, so
let&apos;s not. Instead, we&apos;ll always create the proxy bus socket in a
well-known location within the sandbox, /run/webkitgtk/bus or
/run/wpe/bus. This matches flatpak&apos;s behavior and should allow things to
work regardless.

The accessibility bus requires the same changes.

Note there are major security problems if the host session bus uses an
abstract socket. See <a href="https://gitlab.freedesktop.org/dbus/dbus/-/issues/416">https://gitlab.freedesktop.org/dbus/dbus/-/issues/416</a>
for full details. While this configuration is not recommended, it&apos;s
usually safe for WebKit because our sandbox does not allow network access
(unless using a non-local X server, which is inherently insecure anyway).

* Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp:
(WebKit::bindDBusSession):
(WebKit::bindA11y):
* Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp:
(WebKit::XDGDBusProxy::dbusSessionPath):
(WebKit::XDGDBusProxy::accessibilityPath):
(WebKit::XDGDBusProxy::dbusSessionProxy):
(WebKit::XDGDBusProxy::accessibilityProxy):
(WebKit::XDGDBusProxy::makePath): Deleted.
* Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h:

Canonical link: <a href="https://commits.webkit.org/255218@main">https://commits.webkit.org/255218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c26298eec7436f5d085afa3a364db526f6d428fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101334 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/863 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29472 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83953 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97669 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97294 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/498 "Found 1 new test failure: fast/forms/ios/file-upload-panel-capture.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78295 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27457 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82422 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70494 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35758 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16097 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33513 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17193 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3618 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39952 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36310 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->