### PR TITLE
[css-typed-om] css/css-typed-om/stylevalue-subclasses/cssSkew.tentative.html has failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssSkew.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssSkew.tentative-expected.txt
@@ -10,16 +10,16 @@ PASS Updating CSSSkew.ax with a keyword throws a TypeError
 PASS Updating CSSSkew.ax with a double throws a TypeError
 PASS Updating CSSSkew.ax with a unitless zero throws a TypeError
 PASS Updating CSSSkew.ax with a string angle throws a TypeError
-FAIL Updating CSSSkew.ax with a number CSSUnitValue throws a TypeError assert_throws_js: function "() => skew[attr] = value" did not throw
-FAIL Updating CSSSkew.ax with a time dimension CSSUnitValue throws a TypeError assert_throws_js: function "() => skew[attr] = value" did not throw
-FAIL Updating CSSSkew.ax with a CSSMathValue of length type throws a TypeError assert_throws_js: function "() => skew[attr] = value" did not throw
+PASS Updating CSSSkew.ax with a number CSSUnitValue throws a TypeError
+PASS Updating CSSSkew.ax with a time dimension CSSUnitValue throws a TypeError
+PASS Updating CSSSkew.ax with a CSSMathValue of length type throws a TypeError
 PASS Updating CSSSkew.ay with a keyword throws a TypeError
 PASS Updating CSSSkew.ay with a double throws a TypeError
 PASS Updating CSSSkew.ay with a unitless zero throws a TypeError
 PASS Updating CSSSkew.ay with a string angle throws a TypeError
-FAIL Updating CSSSkew.ay with a number CSSUnitValue throws a TypeError assert_throws_js: function "() => skew[attr] = value" did not throw
-FAIL Updating CSSSkew.ay with a time dimension CSSUnitValue throws a TypeError assert_throws_js: function "() => skew[attr] = value" did not throw
-FAIL Updating CSSSkew.ay with a CSSMathValue of length type throws a TypeError assert_throws_js: function "() => skew[attr] = value" did not throw
+PASS Updating CSSSkew.ay with a number CSSUnitValue throws a TypeError
+PASS Updating CSSSkew.ay with a time dimension CSSUnitValue throws a TypeError
+PASS Updating CSSSkew.ay with a CSSMathValue of length type throws a TypeError
 PASS CSSSkew can be constructed from an angle CSSUnitValue and an angle CSSUnitValue
 PASS CSSSkew can be constructed from an angle CSSUnitValue and a CSSMathValue of angle type
 PASS CSSSkew can be constructed from a CSSMathValue of angle type and an angle CSSUnitValue
@@ -28,5 +28,5 @@ PASS CSSSkew.ax can be updated to an angle CSSUnitValue
 PASS CSSSkew.ax can be updated to a CSSMathValue of angle type
 PASS CSSSkew.ay can be updated to an angle CSSUnitValue
 PASS CSSSkew.ay can be updated to a CSSMathValue of angle type
-FAIL Modifying CSSSkew.is2D is a no-op assert_true: expected true got false
+PASS Modifying CSSSkew.is2D is a no-op
 

--- a/Source/WebCore/css/typedom/transform/CSSSkew.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkew.cpp
@@ -88,6 +88,24 @@ CSSSkew::CSSSkew(Ref<CSSNumericValue> ax, Ref<CSSNumericValue> ay)
 {
 }
 
+ExceptionOr<void> CSSSkew::setAx(Ref<CSSNumericValue> ax)
+{
+    if (!ax->type().matches<CSSNumericBaseType::Angle>())
+        return Exception { TypeError };
+
+    m_ax = WTFMove(ax);
+    return { };
+}
+
+ExceptionOr<void> CSSSkew::setAy(Ref<CSSNumericValue> ay)
+{
+    if (!ay->type().matches<CSSNumericBaseType::Angle>())
+        return Exception { TypeError };
+
+    m_ay = WTFMove(ay);
+    return { };
+}
+
 void CSSSkew::serialize(StringBuilder& builder) const
 {
     // https://drafts.css-houdini.org/css-typed-om/#serialize-a-cssskew

--- a/Source/WebCore/css/typedom/transform/CSSSkew.h
+++ b/Source/WebCore/css/typedom/transform/CSSSkew.h
@@ -45,17 +45,18 @@ public:
     const CSSNumericValue& ax() const { return m_ax.get(); }
     const CSSNumericValue& ay() const { return m_ay.get(); }
     
-    void setAx(Ref<CSSNumericValue> ax) { m_ax = WTFMove(ax); }
-    void setAy(Ref<CSSNumericValue> ay) { m_ay = WTFMove(ay); }
+    ExceptionOr<void> setAx(Ref<CSSNumericValue>);
+    ExceptionOr<void> setAy(Ref<CSSNumericValue>);
 
     void serialize(StringBuilder&) const final;
     ExceptionOr<Ref<DOMMatrix>> toMatrix() final;
-    
+    void setIs2D(bool) final { };
+
     CSSTransformType getType() const final { return CSSTransformType::Skew; }
 
 private:
     CSSSkew(Ref<CSSNumericValue> ax, Ref<CSSNumericValue> ay);
-    
+
     Ref<CSSNumericValue> m_ax;
     Ref<CSSNumericValue> m_ay;
 };


### PR DESCRIPTION
#### 30e7a207ee9cd8acb13c3db229d602496a479096
<pre>
[css-typed-om] css/css-typed-om/stylevalue-subclasses/cssSkew.tentative.html has failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=246071">https://bugs.webkit.org/show_bug.cgi?id=246071</a>

Reviewed by Antti Koivisto.

We need to check that the x and y members are angles and raise exceptions otherwise.
Additionally, it should be impossible to make a CSSSKew a 3D operation so we override
setIs2D() to be a no-op.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssSkew.tentative-expected.txt:
* Source/WebCore/css/typedom/transform/CSSSkew.cpp:
(WebCore::CSSSkew::setAx):
(WebCore::CSSSkew::setAy):
* Source/WebCore/css/typedom/transform/CSSSkew.h:
(WebCore::CSSSkew::setAx): Deleted.
(WebCore::CSSSkew::setAy): Deleted.

Canonical link: <a href="https://commits.webkit.org/255167@main">https://commits.webkit.org/255167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a698aa1d20ecbe64c49a06d09f1b585394f4c968

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101311 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161380 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/804 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83929 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/477 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27438 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82401 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35734 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33489 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17171 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37329 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/75/builds/1603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36288 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->