### PR TITLE
[css-typed-om] css/css-typed-om/stylevalue-subclasses/cssSkewX.tentative.html has failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssSkewX.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssSkewX.tentative-expected.txt
@@ -10,12 +10,12 @@ PASS Updating CSSSkewX.ax with a keyword throws a TypeError
 PASS Updating CSSSkewX.ax with a double throws a TypeError
 PASS Updating CSSSkewX.ax with a unitless zero throws a TypeError
 PASS Updating CSSSkewX.ax with a string angle throws a TypeError
-FAIL Updating CSSSkewX.ax with a number CSSUnitValue throws a TypeError assert_throws_js: function "() => skewX.ax = value" did not throw
-FAIL Updating CSSSkewX.ax with a time dimension CSSUnitValue throws a TypeError assert_throws_js: function "() => skewX.ax = value" did not throw
-FAIL Updating CSSSkewX.ax with a CSSMathValue of length type throws a TypeError assert_throws_js: function "() => skewX.ax = value" did not throw
+PASS Updating CSSSkewX.ax with a number CSSUnitValue throws a TypeError
+PASS Updating CSSSkewX.ax with a time dimension CSSUnitValue throws a TypeError
+PASS Updating CSSSkewX.ax with a CSSMathValue of length type throws a TypeError
 PASS CSSSkewX can be constructed from an angle CSSUnitValue
 PASS CSSSkewX can be constructed from a CSSMathValue of angle type
 PASS CSSSkew.ax can be updated to an angle CSSUnitValue
 PASS CSSSkew.ax can be updated to a CSSMathValue of angle type
-FAIL Modifying skewX.is2D is a no-op assert_true: expected true got false
+PASS Modifying skewX.is2D is a no-op
 

--- a/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
@@ -77,6 +77,15 @@ CSSSkewX::CSSSkewX(Ref<CSSNumericValue> ax)
 {
 }
 
+ExceptionOr<void> CSSSkewX::setAx(Ref<CSSNumericValue> ax)
+{
+    if (!ax->type().matches<CSSNumericBaseType::Angle>())
+        return Exception { TypeError };
+
+    m_ax = WTFMove(ax);
+    return { };
+}
+
 void CSSSkewX::serialize(StringBuilder& builder) const
 {
     // https://drafts.css-houdini.org/css-typed-om/#serialize-a-cssskewx

--- a/Source/WebCore/css/typedom/transform/CSSSkewX.h
+++ b/Source/WebCore/css/typedom/transform/CSSSkewX.h
@@ -43,11 +43,12 @@ public:
     static ExceptionOr<Ref<CSSSkewX>> create(CSSFunctionValue&);
 
     const CSSNumericValue& ax() const { return m_ax.get(); }
-    void setAx(Ref<CSSNumericValue> ax) { m_ax = WTFMove(ax); }
+    ExceptionOr<void> setAx(Ref<CSSNumericValue>);
 
     void serialize(StringBuilder&) const final;
     ExceptionOr<Ref<DOMMatrix>> toMatrix() final;
-    
+    void setIs2D(bool) final { };
+
     CSSTransformType getType() const final { return CSSTransformType::SkewX; }
 
 private:


### PR DESCRIPTION
#### 6b024ebfa782de48a8092aff7cbfb8f5852d8b46
<pre>
[css-typed-om] css/css-typed-om/stylevalue-subclasses/cssSkewX.tentative.html has failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=246072">https://bugs.webkit.org/show_bug.cgi?id=246072</a>

Reviewed by Antti Koivisto.

We need to check that the x member is an angle and raise an exception otherwise.
Additionally, it should be impossible to make a CSSSKewX a 3D operation so we override
setIs2D() to be a no-op.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssSkewX.tentative-expected.txt:
* Source/WebCore/css/typedom/transform/CSSSkewX.cpp:
(WebCore::CSSSkewX::setAx):
* Source/WebCore/css/typedom/transform/CSSSkewX.h:
(WebCore::CSSSkewX::setAx): Deleted.

Canonical link: <a href="https://commits.webkit.org/255169@main">https://commits.webkit.org/255169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fa20c79732a84947f50832e3436d0fe08a4e6ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101312 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161381 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/805 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83930 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/479 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27440 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82403 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35735 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33490 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17172 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37330 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1602 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36289 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->