### PR TITLE
WTF::ThreadAssertion is not useful as most of the code is run with a WorkQueue

### DIFF
--- a/Source/WTF/wtf/MainThread.h
+++ b/Source/WTF/wtf/MainThread.h
@@ -32,6 +32,7 @@
 #include <stdint.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
+#include <wtf/ThreadAssertions.h>
 #include <wtf/ThreadingPrimitives.h>
 
 namespace WTF {
@@ -75,20 +76,32 @@ WTF_EXPORT_PRIVATE bool isMainThreadOrGCThread();
 // NOTE: these functions are internal to the callOnMainThread implementation.
 void initializeMainThreadPlatform();
 
+// To be used with WTF_REQUIRES_CAPABILITY(mainThread). Symbol is undefined.
+extern NamedAssertion& mainThread;
+inline void assertIsMainThread() WTF_ASSERTS_ACQUIRED_CAPABILITY(mainThread) { ASSERT(isMainThread()); }
+
+// To be used with WTF_REQUIRES_CAPABILITY(mainRunLoop). Symbol is undefined.
+extern NamedAssertion& mainRunLoop;
+inline void assertIsMainRunLoop() WTF_ASSERTS_ACQUIRED_CAPABILITY(mainRunLoop) { ASSERT(isMainRunLoop()); }
+
 } // namespace WTF
 
-using WTF::callOnMainThread;
-using WTF::callOnMainThreadAndWait;
+using WTF::assertIsMainRunLoop;
+using WTF::assertIsMainThread;
 using WTF::callOnMainRunLoop;
 using WTF::callOnMainRunLoopAndWait;
+using WTF::callOnMainThread;
+using WTF::callOnMainThreadAndWait;
+using WTF::canCurrentThreadAccessThreadLocalData;
 using WTF::ensureOnMainRunLoop;
 using WTF::ensureOnMainThread;
-using WTF::canCurrentThreadAccessThreadLocalData;
 using WTF::isMainRunLoop;
 using WTF::isMainThread;
 using WTF::isMainThreadOrGCThread;
 using WTF::isUIThread;
 using WTF::isWebThread;
+using WTF::mainRunLoop;
+using WTF::mainThread;
 
 #if PLATFORM(COCOA)
 using WTF::dispatchAsyncOnMainThreadWithWebThreadLockIfNeeded;

--- a/Source/WTF/wtf/ThreadAssertions.h
+++ b/Source/WTF/wtf/ThreadAssertions.h
@@ -25,12 +25,21 @@
 
 #pragma once
 
-#include <wtf/Compiler.h>
-#include <wtf/MainThread.h>
 #include <wtf/ThreadSafetyAnalysis.h>
-#include <wtf/Threading.h>
 
 namespace WTF {
+
+class ThreadLikeAssertion;
+
+class ThreadLike {
+public:
+    // Never returns 0.
+    WTF_EXPORT_PRIVATE static uint32_t currentSequence();
+
+protected:
+    static std::atomic<uint32_t> s_uid;
+    static ThreadLikeAssertion createThreadLikeAssertion(uint32_t);
+};
 
 // A type to use for asserting that private member functions or private member variables
 // of a class are accessed from correct threads.
@@ -43,30 +52,44 @@ namespace WTF {
 // private:
 //     void doTaskImpl() WTF_REQUIRES_CAPABILITY(m_ownerThread);
 //     int m_value WTF_GUARDED_BY_CAPABILITY(m_ownerThread) { 0 };
-//     NO_UNIQUE_ADDRESS ThreadAssertion m_ownerThread;
+//     NO_UNIQUE_ADDRESS ThreadLikeAssertion m_ownerThread;
 // };
-class WTF_CAPABILITY("is current") ThreadAssertion {
+class WTF_CAPABILITY("is current") ThreadLikeAssertion {
 public:
-    ThreadAssertion() = default;
+    ThreadLikeAssertion() = default;
     enum UninitializedTag { Uninitialized };
-    constexpr ThreadAssertion(UninitializedTag)
+    constexpr ThreadLikeAssertion(UninitializedTag)
 #if ASSERT_ENABLED
-        : m_uid(0) // Thread::uid() does not return this.
+        : m_uid(0)
 #endif
     {
     }
-    ~ThreadAssertion() { assertIsCurrent(*this); }
-    void reset() { *this = ThreadAssertion { }; }
+    ~ThreadLikeAssertion() { assertIsCurrent(*this); }
+    void reset() { *this = ThreadLikeAssertion { }; }
 private:
 #if ASSERT_ENABLED
-    uint32_t m_uid { Thread::current().uid() };
+    constexpr ThreadLikeAssertion(uint32_t uid)
+        : m_uid(uid)
+    {
+    }
+    uint32_t m_uid { ThreadLike::currentSequence() };
+#else
+    constexpr ThreadLikeAssertion(uint32_t)
+    {
+    }
 #endif
-    friend void assertIsCurrent(const ThreadAssertion&);
+    friend void assertIsCurrent(const ThreadLikeAssertion&);
+    friend class ThreadLike;
 };
 
-inline void assertIsCurrent(const ThreadAssertion& threadAssertion) WTF_ASSERTS_ACQUIRED_CAPABILITY(threadAssertion)
+inline void assertIsCurrent(const ThreadLikeAssertion& threadLikeAssertion) WTF_ASSERTS_ACQUIRED_CAPABILITY(threadLikeAssertion)
 {
-    ASSERT_UNUSED(threadAssertion, Thread::current().uid() == threadAssertion.m_uid);
+    ASSERT_UNUSED(threadLikeAssertion, ThreadLike::currentSequence() == threadLikeAssertion.m_uid);
+}
+
+inline ThreadLikeAssertion ThreadLike::createThreadLikeAssertion(uint32_t uid)
+{
+    return ThreadLikeAssertion { uid };
 }
 
 // Type for globally named assertions for describing access requirements.
@@ -85,20 +108,9 @@ inline void assertIsCurrent(const ThreadAssertion& threadAssertion) WTF_ASSERTS_
 // }
 class WTF_CAPABILITY("is current") NamedAssertion { };
 
-// To be used with WTF_REQUIRES_CAPABILITY(mainThread). Symbol is undefined.
-extern NamedAssertion& mainThread;
-inline void assertIsMainThread() WTF_ASSERTS_ACQUIRED_CAPABILITY(mainThread) { ASSERT(isMainThread()); }
-
-// To be used with WTF_REQUIRES_CAPABILITY(mainRunLoop). Symbol is undefined.
-extern NamedAssertion& mainRunLoop;
-inline void assertIsMainRunLoop() WTF_ASSERTS_ACQUIRED_CAPABILITY(mainRunLoop) { ASSERT(isMainRunLoop()); }
-
 }
 
-using WTF::ThreadAssertion;
+using WTF::ThreadLike;
+using WTF::ThreadLikeAssertion;
 using WTF::assertIsCurrent;
 using WTF::NamedAssertion;
-using WTF::assertIsMainThread;
-using WTF::assertIsMainRunLoop;
-using WTF::mainThread;
-using WTF::mainRunLoop;

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -124,7 +124,16 @@ static std::optional<size_t> stackSize(ThreadType threadType)
 #endif
 }
 
-std::atomic<uint32_t> Thread::s_uid { 0 };
+std::atomic<uint32_t> ThreadLike::s_uid;
+
+uint32_t ThreadLike::currentSequence()
+{
+#if PLATFORM(COCOA)
+    if (uint32_t uid = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(dispatch_get_specific(&s_uid))))
+        return uid;
+#endif
+    return Thread::current().uid();
+}
 
 struct Thread::NewThreadContext : public ThreadSafeRefCounted<NewThreadContext> {
 public:

--- a/Source/WTF/wtf/generic/MainThreadGeneric.cpp
+++ b/Source/WTF/wtf/generic/MainThreadGeneric.cpp
@@ -37,7 +37,7 @@
 
 namespace WTF {
 
-static pthread_t mainThread;
+static pthread_t s_mainThread;
 
 void initializeMainThreadPlatform()
 {
@@ -46,12 +46,12 @@ void initializeMainThreadPlatform()
     // The WebKit main thread need not be the application's actual OS-level main thread, which might be
     // controlled by a language runtime or virtual machine; for example, in Eclipse, the OS main thread is
     // controlled by the JVM, while the separate WebKit main thread runs all the GUI and WebKit stuff.
-    mainThread = pthread_self();
+    s_mainThread = pthread_self();
 }
 
 bool isMainThread()
 {
-    return pthread_equal(pthread_self(), mainThread);
+    return pthread_equal(pthread_self(), s_mainThread);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
+++ b/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
@@ -88,9 +88,9 @@ Ref<WorkQueue> WorkQueue::constructMainWorkQueue()
 }
 
 #if ASSERT_ENABLED
-void WorkQueue::assertIsCurrent() const
+ThreadLikeAssertion WorkQueueBase::threadLikeAssertion() const
 {
-    ASSERT(m_threadID == Thread::current().uid());
+    return createThreadLikeAssertion(m_threadID);
 }
 #endif
 

--- a/Source/WTF/wtf/win/MainThreadWin.cpp
+++ b/Source/WTF/wtf/win/MainThreadWin.cpp
@@ -37,17 +37,17 @@
 
 namespace WTF {
 
-static ThreadIdentifier mainThread { 0 };
+static ThreadIdentifier s_mainThread { 0 };
 
 void initializeMainThreadPlatform()
 {
-    mainThread = Thread::currentID();
+    s_mainThread = Thread::currentID();
     Thread::initializeCurrentThreadInternal("Main Thread");
 }
 
 bool isMainThread()
 {
-    return mainThread == Thread::currentID();
+    return s_mainThread == Thread::currentID();
 }
 
 } // namespace WTF

--- a/Source/WebCore/platform/graphics/mac/DisplayConfigurationMonitor.cpp
+++ b/Source/WebCore/platform/graphics/mac/DisplayConfigurationMonitor.cpp
@@ -28,7 +28,7 @@
 
 #if PLATFORM(MAC)
 
-#include <wtf/ThreadAssertions.h>
+#include <wtf/MainThread.h>
 
 namespace WebCore {
 

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
@@ -31,6 +31,7 @@
 #include "RemoteVideoFrameObjectHeapMessages.h"
 #include "RemoteVideoFrameObjectHeapProxyProcessorMessages.h"
 #include "RemoteVideoFrameProxy.h"
+#include <wtf/MainThread.h>
 #include <wtf/Scope.h>
 #include <wtf/WorkQueue.h>
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -95,7 +95,7 @@ private:
     std::unique_ptr<WebCore::LocalSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
     std::unique_ptr<LayerHostingContext> m_layerHostingContext;
     SharedVideoFrameReader m_sharedVideoFrameReader;
-    ThreadAssertion m_consumeThread NO_UNIQUE_ADDRESS;
+    ThreadLikeAssertion m_consumeThread NO_UNIQUE_ADDRESS;
 
 };
 

--- a/Tools/TestWebKitAPI/Tests/WTF/ThreadAssertionsTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/ThreadAssertionsTest.cpp
@@ -24,10 +24,11 @@
  */
 
 #include "config.h"
+#include <wtf/ThreadAssertions.h>
 
 #include "Utilities.h"
+#include <wtf/MainThread.h>
 #include <wtf/RunLoop.h>
-#include <wtf/ThreadAssertions.h> // NOLINT: check-webkit-style has problems with files that do not have primary header.
 
 namespace TestWebKitAPI {
 namespace {
@@ -48,7 +49,7 @@ public:
 private:
     int doTaskImpl(int n) WTF_REQUIRES_CAPABILITY(m_ownerThread) { return n + 1; }
     int m_value WTF_GUARDED_BY_CAPABILITY(m_ownerThread) { 0 };
-    NO_UNIQUE_ADDRESS ThreadAssertion m_ownerThread;
+    NO_UNIQUE_ADDRESS ThreadLikeAssertion m_ownerThread;
 };
 }
 


### PR DESCRIPTION
#### 8ed46d3dd638db662ea8093cec940b1b00992ecf
<pre>
WTF::ThreadAssertion is not useful as most of the code is run with a WorkQueue
<a href="https://bugs.webkit.org/show_bug.cgi?id=237026">https://bugs.webkit.org/show_bug.cgi?id=237026</a>
rdar://problem/89608226

Reviewed by Chris Dumez.

Rename ThreadAssertion to ThreadlikeAssertion, and assert that if the assertion is created in a WorkQueue,
the assertion checks for the work queue. If it is created on a Thread, it checks for that.

Implement for non-Cocoa by just using thread id for the sequence id. All WorkQueues have unique threads
and all Threads have unique ids. This means WorkQueues can be distinquished from Threads without WorkQueues.

Implement for Cocoa by using the same uid id namespace for WorkQueues as Threads have. Store the uid
in a Dispatch dispatch queue specific field. If the code is not running in Dispatch, return the current
thread uid. Since the uid namespace is the same, WorkQueues can be distinuished from Threads without WorkQueues.

In both cases, non-WebKit platform threads get also a Thread, so they&apos;re distinquished from WorkQueues.

Currently it is common in WebKit code to use a pattern of:
ASSERT(RunLoop::isMain()) -- This is not run in a work queue or a specific thread
ASSERT(!RunLoop::isMain()) -- This is run in a specific thread, but because we use WorkQueues,
we cannot actually assert the specific thread.

This pattern could be for example used to assert that object is created and destroyed in
correct thread.

After this commit, that can be expressed more exactly as:
 NO_UNIQUE_ADDRESS ThreadlikeAssertion m_owner;

* Source/WTF/wtf/MainThread.h:
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):
* Source/WTF/wtf/ThreadAssertions.h:
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):
(WTF::Threadlike::createThreadlikeAssertion):
* Source/WTF/wtf/Threading.cpp:
(WTF::Threadlike::currentSequence):
* Source/WTF/wtf/Threading.h:
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):
(WTF::Thread::Thread): Deleted.
* Source/WTF/wtf/WorkQueue.h:
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):
* Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp:
(WTF::WorkQueueBase::platformInitialize):
(WTF::WorkQueue::WorkQueue):
(WTF::WorkQueue::threadlikeAssertion const):
(WTF::WorkQueue::assertIsCurrent const): Deleted.
* Source/WTF/wtf/generic/WorkQueueGeneric.cpp:
(WTF::WorkQueueBase::threadlikeAssertion const):
(WTF::WorkQueue::assertIsCurrent const): Deleted.
* Source/WebCore/platform/graphics/mac/DisplayConfigurationMonitor.cpp:
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp:
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h:
* Tools/TestWebKitAPI/Tests/WTF/ThreadAssertionsTest.cpp:
* Tools/TestWebKitAPI/Tests/WTF/WorkQueue.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/255274@main">https://commits.webkit.org/255274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d40a78d5a2e85ac07c316fa338becec18f76d3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101774 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161833 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1191 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29638 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84425 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97609 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/729 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78502 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27690 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82651 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83312 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36043 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78368 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33780 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17372 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27047 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3653 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37657 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80990 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36494 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17781 "Passed tests") | 
<!--EWS-Status-Bubble-End-->