### PR TITLE
[LBSE] Assure <foreignObject> HTML descendants create a new formatting context

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1285,9 +1285,10 @@ webkit.org/b/240934 imported/w3c/web-platform-tests/css/filter-effects/root-elem
 
 imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-opacity.html [ ImageOnlyFailure ]
 
-# Compositing/z-index needs LBSE enabled builds, which is off by default for this port.
+# The following tests need LBSE enabled builds, which is off by default for this port.
 svg/compositing [ Skip ]
 svg/z-index [ Skip ]
+svg/foreignObject/respect-block-margin.html [ Skip ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of SVG-related bugs

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations
@@ -242,7 +242,6 @@ svg/zoom/page/zoom-svg-through-object-with-absolute-size-2.xhtml [ Failure ]
 svg/zoom/page/zoom-svg-through-object-with-auto-size.html        [ Failure ]
 svg/zoom/page/zoom-svg-through-object-with-override-size.html    [ Failure ]
 svg/zoom/text/zoom-hixie-mixed-008.xml                           [ ImageOnlyFailure ]
-svg/zoom/text/zoom-hixie-mixed-009.xml                           [ ImageOnlyFailure ]
 
 # No gradients
 svg/W3C-SVG-1.1-SE/pservers-grad-17-b.svg                         [ ImageOnlyFailure ]
@@ -670,7 +669,6 @@ svg/custom/multiple-view-elements.html          [ ImageOnlyFailure ]
 svg/dom/complex-svgView-specification.html      [ ImageOnlyFailure ]
 
 # SVG <foreignObject> issues
-svg/hixie/mixed/009.xml                      [ ImageOnlyFailure ]
 svg/overflow/overflow-on-foreignObject.svg   [ ImageOnlyFailure ]
 svg/text/foreignObject-text-clipping-bug.xml [ ImageOnlyFailure ]
 
@@ -680,19 +678,8 @@ svg/repaint/buffered-rendering-static-image.html [ ImageOnlyFailure ]
 ###############
 # Buggy tests #
 ###############
-# 1) no width/height specified for <foreignObject> (disabled rendering in LBSE, ignored by legacy)
-svg/custom/display-table-caption-foreignObject.svg           [ Failure ]
-svg/custom/display-table-caption-inherit-foreignObject.xhtml [ Failure ]
-svg/custom/use-on-use-with-child.svg                         [ Failure ]
-svg/dom/SVGScriptElement/script-async-attr.svg               [ Failure ]
-svg/dom/SVGScriptElement/script-load-and-error-events.svg    [ Failure ]
-svg/dom/SVGScriptElement/script-onerror-bubbling.svg         [ Failure ]
-svg/dom/SVGScriptElement/script-reexecution.svg              [ Failure ]
-svg/dom/SVGScriptElement/script-type-attribute.svg           [ Failure ]
-svg/dom/smil-methods.svg                                     [ Failure ]
-svg/hittest/svg-standalone-tooltip.svg                       [ Failure ]
 
-# 2) Parses render tree output, therefore not adapted to LBSE.
+# Parses render tree output, therefore not adapted to LBSE.
 svg/outermost-svg-root.html [ Failure ]
 
 ###############

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/hixie/mixed/009-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/hixie/mixed/009-expected.txt
@@ -17,8 +17,8 @@ layer at (8,38) size 400x120
   RenderSVGViewportContainer at (0,0) size 400x120
 layer at (8,38) size 60x12
   RenderSVGRect {rect} at (0,0) size 60x12 [fill={[type=SOLID] [color=#EEEEEE]}] [x=0.00] [y=0.00] [width=60.00] [height=12.00]
-layer at (8,38) size 60x10 scrollHeight 33
+layer at (8,38) size 60x10 scrollHeight 13
   RenderSVGForeignObject {foreignObject} at (0,0) size 60x10
-    RenderBlock {div} at (0,10) size 60x13 [color=#000080]
+    RenderBlock {div} at (0,0) size 60x13 [color=#000080]
       RenderText {#text} at (0,0) size 24x13
         text run at (0,0) width 24: "TEST"

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/text/zoom-hixie-mixed-009-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/text/zoom-hixie-mixed-009-expected.txt
@@ -17,8 +17,8 @@ layer at (8,46) size 400x120
   RenderSVGViewportContainer at (0,0) size 400x120
 layer at (8,46) size 60x12
   RenderSVGRect {rect} at (0,0) size 60x12 [fill={[type=SOLID] [color=#EEEEEE]}] [x=0.00] [y=0.00] [width=60.00] [height=12.00]
-layer at (8,46) size 60x10 scrollHeight 33
+layer at (8,46) size 60x10 scrollHeight 13
   RenderSVGForeignObject {foreignObject} at (0,0) size 60x10
-    RenderBlock {div} at (0,10) size 60x13 [color=#000080]
+    RenderBlock {div} at (0,0) size 60x13 [color=#000080]
       RenderText {#text} at (0,0) size 24x13
         text run at (0,0) width 24: "TEST"

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -2243,9 +2243,10 @@ svg/filters/feImage-self-and-other-referencing.html
 # GCController.collect() issues.
 svg/animations/svglength-element-removed-crash.svg [ Failure ]
 
-# Compositing/z-index needs LBSE enabled builds, which is off by default for this port.
+# The following tests need LBSE enabled builds, which is off by default for this port.
 svg/compositing [ Skip ]
 svg/z-index [ Skip ]
+svg/foreignObject/respect-block-margin.html [ Skip ]
 
 ################################################################################
 ###################          End SVG Issues              #######################

--- a/LayoutTests/svg/custom/display-table-caption-foreignObject.svg
+++ b/LayoutTests/svg/custom/display-table-caption-foreignObject.svg
@@ -3,5 +3,5 @@
   if (window.testRunner)
     testRunner.dumpAsText();
   </script>
-  <foreignObject display="table-caption"><xhtml:div>This test PASSED if we don't crash when the display value is table-caption</xhtml:div></foreignObject>
+  <foreignObject width="1" height="1" display="table-caption"><xhtml:div>This test PASSED if we don't crash when the display value is table-caption</xhtml:div></foreignObject>
 </svg>

--- a/LayoutTests/svg/custom/display-table-caption-inherit-foreignObject.xhtml
+++ b/LayoutTests/svg/custom/display-table-caption-inherit-foreignObject.xhtml
@@ -4,6 +4,6 @@
     if (window.testRunner)
       testRunner.dumpAsText();
     </script>
-    <foreignObject display="inherit"><xhtml:div>This test PASSED if we don't crash when the display value is table-caption by using inherit</xhtml:div></foreignObject>
+    <foreignObject width="1" height="1" display="inherit"><xhtml:div>This test PASSED if we don't crash when the display value is table-caption by using inherit</xhtml:div></foreignObject>
   </svg>
 </div>

--- a/LayoutTests/svg/custom/use-on-use-with-child.svg
+++ b/LayoutTests/svg/custom/use-on-use-with-child.svg
@@ -12,7 +12,7 @@
 
     <use id="zoomplus" xlink:href="#loupePlus" x="300" y="300" >
     </use> 
-    <foreignObject><pre id="console" xmlns="http://www.w3.org/1999/xhtml"/></foreignObject>
+    <foreignObject width="300" height="50"><pre id="console" xmlns="http://www.w3.org/1999/xhtml"/></foreignObject>
     <script>
         if (window.eventSender) {
             eventSender.dragMode = false;

--- a/LayoutTests/svg/dom/SVGScriptElement/script-async-attr.svg
+++ b/LayoutTests/svg/dom/SVGScriptElement/script-async-attr.svg
@@ -13,7 +13,7 @@ function test() {
 </script>
 <script type="text/javascript" id="s0" xlink:href="resources/thisShouldNotExist.null" async="async"></script>
 </defs>
-<foreignObject>
+<foreignObject width="100%" height="100">
 <xhtml:p>Tests that the async attribute is not supported for SVG scripts.</xhtml:p>
 <xhtml:span id="p0">FAIL</xhtml:span>
 </foreignObject>

--- a/LayoutTests/svg/dom/SVGScriptElement/script-load-and-error-events.svg
+++ b/LayoutTests/svg/dom/SVGScriptElement/script-load-and-error-events.svg
@@ -118,7 +118,7 @@ function continueDynamicTest2() {
 <script id="2" type="text/javascript" onerror="errorEventHandler(evt)" onload="loadEventHandler(evt)" xlink:href="resources/script-load.js"></script>
 <script id="3" type="text/javascript" onerror="errorEventHandler(evt)" onload="loadEventHandler(evt); lastTestBeforeRootElementLoaded();" xlink:href="resources/script-load.js"/>
 </defs>
-<foreignObject>
+<foreignObject width="100%" height="100">
 Test load and error event handling with SVGScriptElement
 <xhtml:hr/>
 <xhtml:p id="results">FAIL: Test never finished.</xhtml:p>

--- a/LayoutTests/svg/dom/SVGScriptElement/script-onerror-bubbling.svg
+++ b/LayoutTests/svg/dom/SVGScriptElement/script-onerror-bubbling.svg
@@ -55,7 +55,7 @@ function endTest() {
 <script id="1" type="text/javascript" onerror="scriptOnErrorHandler(1)" xlink:href="resources/certainlydoesnotexisttoo.js"/>
 <script id="2" type="text/javascript" onload="testOnErrorInDynamicScript()" xlink:href="resources/script-load.js"></script>
 </defs>
-<foreignObject>
+<foreignObject width="100%" height="100">
 Test that "error" event is dispatched to SVGScriptElement onerror handler and doesn't bubble.
 <xhtml:hr/>
 <xhtml:p id="results"></xhtml:p>

--- a/LayoutTests/svg/dom/SVGScriptElement/script-reexecution.svg
+++ b/LayoutTests/svg/dom/SVGScriptElement/script-reexecution.svg
@@ -50,7 +50,7 @@ function finish() {
 }
 </script>
 </defs>
-<foreignObject>
+<foreignObject width="100%" height="100">
 <xhtml:p>Created script element, script data passed as text content, appended: <xhtml:span id="p1">FAIL</xhtml:span></xhtml:p>
 <xhtml:p>Removed element, readd element, remove again, script shouldn't have executed:<xhtml:span id="p2">PASS</xhtml:span></xhtml:p>
 <xhtml:p>Created script element, loading external script content, appended: <xhtml:span id="p3">FAIL</xhtml:span></xhtml:p>

--- a/LayoutTests/svg/dom/SVGScriptElement/script-type-attribute.svg
+++ b/LayoutTests/svg/dom/SVGScriptElement/script-type-attribute.svg
@@ -17,7 +17,7 @@ function test() {
         document.getElementById("p0").innerHTML = "FAIL";
 }
 </script>
-<foreignObject>
+<foreignObject width="100%" height="100">
 <xhtml:p>Test that getting/setting the type JS property on SVGScriptElement keeps sync with the type content attribute.</xhtml:p>
 <xhtml:span id="p0">PASS</xhtml:span>
 </foreignObject>

--- a/LayoutTests/svg/dom/smil-methods.svg
+++ b/LayoutTests/svg/dom/smil-methods.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg">
   <animate id="animate" attributeName="visibility" value="visible; visible" dur="10s"/>
-  <foreignObject><pre id="console" xmlns="http://www.w3.org/1999/xhtml"/></foreignObject>
+  <foreignObject width="100%" height="400"><pre id="console" xmlns="http://www.w3.org/1999/xhtml"/></foreignObject>
   <script>
 var console = document.getElementById("console");
 var animate = document.getElementById("animate");

--- a/LayoutTests/svg/foreignObject/respect-block-margin-expected.html
+++ b/LayoutTests/svg/foreignObject/respect-block-margin-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+ <head>
+ <body style="margin: 0">
+  <div style="width: 400px; height: 120px;">
+    <div style="margin: 100px 0">Margin should be respected</div>
+  </div>
+ </body>
+</html>

--- a/LayoutTests/svg/foreignObject/respect-block-margin.html
+++ b/LayoutTests/svg/foreignObject/respect-block-margin.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+ <head>
+ <body style="margin: 0">
+  <svg xmlns="http://www.w3.org/2000/svg" width="400" height="120">
+   <foreignObject width="400" height="120" overflow="visible">
+    <div style="margin: 100px 0">Margin should be respected</div>
+   </foreignObject>
+  </svg>
+ </body>
+</html>

--- a/LayoutTests/svg/hittest/svg-standalone-tooltip.svg
+++ b/LayoutTests/svg/hittest/svg-standalone-tooltip.svg
@@ -67,7 +67,7 @@
   <use id="use_without_title" xlink:href="#shape" x="0" y="240"/>
 
   <!-- For logging the test results -->
-  <foreignObject>
+  <foreignObject width="100%" height="100">
     <pre id="log" xmlns="http://www.w3.org/1999/xhtml"></pre>
   </foreignObject>
   

--- a/LayoutTests/svg/hixie/mixed/009.xml
+++ b/LayoutTests/svg/hixie/mixed/009.xml
@@ -12,7 +12,7 @@
   <svg xmlns="http://www.w3.org/2000/svg" width="400" height="120" class="test">
    <rect x="0" y="0" width="60" height="12" transform="scale(10)"/>
    <foreignObject x="0" y="0" width="60" height="10" transform="scale(10)">
-    <div xmlns="http://www.w3.org/1999/xhtml"> TEST </div>
+    <div xmlns="http://www.w3.org/1999/xhtml" style="margin: 0;"> TEST </div>
    </foreignObject>
   </svg>
   <div class="control">TEST</div>

--- a/LayoutTests/svg/zoom/page/zoom-hixie-mixed-009.xml
+++ b/LayoutTests/svg/zoom/page/zoom-hixie-mixed-009.xml
@@ -12,7 +12,7 @@
   <svg xmlns="http://www.w3.org/2000/svg" width="400" height="120" class="test">
    <rect x="0" y="0" width="60" height="12" transform="scale(10)"/>
    <foreignObject x="0" y="0" width="60" height="10" transform="scale(10)">
-    <div xmlns="http://www.w3.org/1999/xhtml"> TEST </div>
+    <div xmlns="http://www.w3.org/1999/xhtml" style="margin: 0;"> TEST </div>
    </foreignObject>
   </svg>
   <div class="control">TEST</div>

--- a/LayoutTests/svg/zoom/text/zoom-hixie-mixed-009.xml
+++ b/LayoutTests/svg/zoom/text/zoom-hixie-mixed-009.xml
@@ -12,7 +12,7 @@
   <svg xmlns="http://www.w3.org/2000/svg" width="400" height="120" class="test">
    <rect x="0" y="0" width="60" height="12" transform="scale(10)"/>
    <foreignObject x="0" y="0" width="60" height="10" transform="scale(10)">
-    <div xmlns="http://www.w3.org/1999/xhtml"> TEST </div>
+    <div xmlns="http://www.w3.org/1999/xhtml" style="margin: 0;"> TEST </div>
    </foreignObject>
   </svg>
   <div class="control">TEST</div>

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2133,7 +2133,7 @@ bool RenderElement::createsNewFormattingContext() const
     if (isWritingModeRoot() && isBlockContainer())
         return true;
     return isInlineBlockOrInlineTable() || isFlexItemIncludingDeprecated()
-        || isTableCell() || isTableCaption() || isFieldset() || isDocumentElementRenderer() || isRenderFragmentedFlow()
+        || isTableCell() || isTableCaption() || isFieldset() || isDocumentElementRenderer() || isRenderFragmentedFlow() || isSVGForeignObject()
         || style().specifiesColumns() || style().columnSpan() == ColumnSpan::All || style().display() == DisplayType::FlowRoot || establishesIndependentFormattingContext();
 }
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -105,6 +105,7 @@
 #include "RenderMarquee.h"
 #include "RenderMultiColumnFlow.h"
 #include "RenderReplica.h"
+#include "RenderSVGForeignObject.h"
 #include "RenderSVGHiddenContainer.h"
 #include "RenderSVGInline.h"
 #include "RenderSVGModelObject.h"
@@ -1560,7 +1561,16 @@ void RenderLayer::setAncestorChainHasVisibleDescendant()
 
 void RenderLayer::updateAncestorDependentState()
 {
-    bool insideSVGForeignObject = renderer().document().mayHaveRenderedSVGForeignObjects() && ancestorsOfType<LegacyRenderSVGForeignObject>(renderer()).first();
+    bool insideSVGForeignObject = false;
+    if (renderer().document().mayHaveRenderedSVGForeignObjects()) {
+        if (ancestorsOfType<LegacyRenderSVGForeignObject>(renderer()).first())
+            insideSVGForeignObject = true;
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+        else if (renderer().document().settings().layerBasedSVGEngineEnabled() && ancestorsOfType<RenderSVGForeignObject>(renderer()).first())
+            insideSVGForeignObject = true;
+#endif
+    }
+
     if (insideSVGForeignObject == m_insideSVGForeignObject)
         return;
 
@@ -4413,7 +4423,7 @@ void RenderLayer::calculateClipRects(const ClipRectsContext& clipRectsContext, C
         clipRects.setFixed(true);
     } else if (renderer().isInFlowPositioned())
         clipRects.setPosClipRect(clipRects.overflowClipRect());
-    else if (renderer().isAbsolutelyPositioned())
+    else if (renderer().isAbsolutelyPositioned() || renderer().isSVGForeignObject())
         clipRects.setOverflowClipRect(clipRects.posClipRect());
     
     // Update the clip rects that will be passed to child layers.


### PR DESCRIPTION
#### 912165516f6affad851ae15b53e5f350d5490b64
<pre>
[LBSE] Assure &lt;foreignObject&gt; HTML descendants create a new formatting context
<a href="https://bugs.webkit.org/show_bug.cgi?id=245908">https://bugs.webkit.org/show_bug.cgi?id=245908</a>

Reviewed by Rob Buis.

Fix mistake in svg/hixie/mixed/009.xml and its copies. A style sheet
applied a certain &apos;margin&apos; value to all &lt;div&gt; elements, including the
one inside the &lt;foreignObject&gt;, which was unintentional. Now the testcase
behaves as expected in Firefox/Chrome, but is broken in Safari. With LBSE
the test works correctly: &apos;margin&apos; is respected as intended on block-level
children that are direct children of &lt;foreignObject&gt;.

-&gt; &lt;foreignObject&gt; needs to create a new formatting context for its descendants.
This finally fixes margin handling for block-children of &lt;foreignObject&gt; which
was broken since forever (at least 15 years) in WebKit.

Some further fixes are necessary to correctly compute clip rects for &lt;foreignObject&gt;.
&lt;fO&gt; should behaves like an absolutely positioned object -- but we failed
to honor that SVG2 requirement, when comuting clip rects in RenderLayer - fix that.

Enable some tests that were skipped because of bugs in the testcases themselves,
such as missing width/height attributes on &lt;foreignObject&gt; elements.

Covered by existing tests -- some tests will be fully fixed once zooming works, too.

* LayoutTests/platform/glib/TestExpectations: Skip new test (needs LBSE).
* LayoutTests/platform/win/TestExpectations: Ditto.
* LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/hixie/mixed/009-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/zoom/text/zoom-hixie-mixed-009-expected.txt:
* LayoutTests/svg/custom/display-table-caption-foreignObject.svg:
* LayoutTests/svg/custom/display-table-caption-inherit-foreignObject.xhtml:
* LayoutTests/svg/custom/use-on-use-with-child.svg:
* LayoutTests/svg/dom/SVGScriptElement/script-async-attr.svg:
* LayoutTests/svg/dom/SVGScriptElement/script-load-and-error-events.svg:
* LayoutTests/svg/dom/SVGScriptElement/script-onerror-bubbling.svg:
* LayoutTests/svg/dom/SVGScriptElement/script-reexecution.svg:
* LayoutTests/svg/dom/SVGScriptElement/script-type-attribute.svg:
* LayoutTests/svg/dom/smil-methods.svg:
* LayoutTests/svg/foreignObject/respect-block-margin-expected.html: Added.
* LayoutTests/svg/foreignObject/respect-block-margin.html: Added. Always run this test with LBSE, broken in legacy.
* LayoutTests/svg/hittest/svg-standalone-tooltip.svg:
* LayoutTests/svg/hixie/mixed/009.xml:
* LayoutTests/svg/zoom/page/zoom-hixie-mixed-009.xml:
* LayoutTests/svg/zoom/text/zoom-hixie-mixed-009.xml:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::createsNewFormattingContext const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateAncestorDependentState):
(WebCore::RenderLayer::calculateClipRects const):

Canonical link: <a href="https://commits.webkit.org/255626@main">https://commits.webkit.org/255626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7911c10e94b6dbb4b0d31f78f86779f7a02a050b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102809 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2310 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30630 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98927 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1594 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79576 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28516 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71624 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37023 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17156 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34835 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18390 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3898 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38706 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40932 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37598 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->