### PR TITLE
Implement WebCodecsVideoEncoder with GPUProcess backend

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Error: assert_unreached: Not supported Reached unreachable code
 
 FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Error: assert_unreached: Not supported Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: H264 AVC format is not yet supported Reached unreachable code
 
 FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_h264_annexb-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Reconfiguring encoder promise_test: Unhandled rejection with value: object "InvalidStateError: VideoEncoder is not configured"
+FAIL Reconfiguring encoder promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_annexb-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Error: assert_unreached: Not supported Reached unreachable code
 
-FAIL Reconfiguring encoder promise_test: Unhandled rejection with value: object "InvalidStateError: VideoEncoder is not configured"
+FAIL Reconfiguring encoder promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_avc-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Error: assert_unreached: Not supported Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: H264 AVC format is not yet supported Reached unreachable code
 
 FAIL Reconfiguring encoder promise_test: Unhandled rejection with value: object "InvalidStateError: VideoEncoder is not configured"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any_h264-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any_h264-expected.txt
@@ -1,5 +1,3 @@
-CONSOLE MESSAGE: Error: assert_unreached: Not supported Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: Not supported Reached unreachable code
 
 FAIL SVC L1T2 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
 FAIL SVC L1T3 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -702,6 +702,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/webauthn/ResidentKeyRequirement.idl
     Modules/webauthn/UserVerificationRequirement.idl
 
+    Modules/webcodecs/AvcEncoderConfig.idl
     Modules/webcodecs/BitrateMode.idl
     Modules/webcodecs/LatencyMode.idl
     Modules/webcodecs/HardwareAcceleration.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -773,6 +773,7 @@ $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredentialType.idl
 $(PROJECT_DIR)/Modules/webauthn/ResidentKeyRequirement.idl
 $(PROJECT_DIR)/Modules/webauthn/UserVerificationRequirement.idl
+$(PROJECT_DIR)/Modules/webcodecs/AvcEncoderConfig.idl
 $(PROJECT_DIR)/Modules/webcodecs/BitrateMode.idl
 $(PROJECT_DIR)/Modules/webcodecs/HardwareAcceleration.idl
 $(PROJECT_DIR)/Modules/webcodecs/LatencyMode.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -278,6 +278,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAuthenticatorTransport.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAuthenticatorTransport.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAutomationRate.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAutomationRate.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAvcEncoderConfig.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAvcEncoderConfig.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBarProp.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBarProp.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBaseAudioContext.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -671,6 +671,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/webauthn/PublicKeyCredentialType.idl \
     $(WebCore)/Modules/webauthn/ResidentKeyRequirement.idl \
     $(WebCore)/Modules/webauthn/UserVerificationRequirement.idl \
+    $(WebCore)/Modules/webcodecs/AvcEncoderConfig.idl \
     $(WebCore)/Modules/webcodecs/BitrateMode.idl \
     $(WebCore)/Modules/webcodecs/LatencyMode.idl \
     $(WebCore)/Modules/webcodecs/HardwareAcceleration.idl \

--- a/Source/WebCore/Modules/webcodecs/AvcEncoderConfig.h
+++ b/Source/WebCore/Modules/webcodecs/AvcEncoderConfig.h
@@ -27,27 +27,16 @@
 
 #if ENABLE(WEB_CODECS)
 
-#include "AvcEncoderConfig.h"
-#include "BitrateMode.h"
-#include "HardwareAcceleration.h"
-#include "LatencyMode.h"
-#include <optional>
-
 namespace WebCore {
 
-struct WebCodecsVideoEncoderConfig {
-    String codec;
-    size_t width;
-    size_t height;
-    std::optional<size_t> displayWidth;
-    std::optional<size_t> displayHeight;
-    std::optional<uint64_t> bitrate;
-    std::optional<double> framerate;
-    HardwareAcceleration hardwareAcceleration { HardwareAcceleration::NoPreference };
-    String scalabilityMode;
-    BitrateMode bitrateMode { BitrateMode::Variable };
-    LatencyMode latencyMode { LatencyMode::Quality };
-    std::optional<AvcEncoderConfig> avc;
+enum class AvcBitstreamFormat {
+    Annexb,
+    Avc
+};
+
+struct AvcEncoderConfig {
+    using BitstreamFormat = AvcBitstreamFormat;
+    AvcBitstreamFormat format;
 };
 
 }

--- a/Source/WebCore/Modules/webcodecs/AvcEncoderConfig.idl
+++ b/Source/WebCore/Modules/webcodecs/AvcEncoderConfig.idl
@@ -23,33 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#if ENABLE(WEB_CODECS)
-
-#include "AvcEncoderConfig.h"
-#include "BitrateMode.h"
-#include "HardwareAcceleration.h"
-#include "LatencyMode.h"
-#include <optional>
-
-namespace WebCore {
-
-struct WebCodecsVideoEncoderConfig {
-    String codec;
-    size_t width;
-    size_t height;
-    std::optional<size_t> displayWidth;
-    std::optional<size_t> displayHeight;
-    std::optional<uint64_t> bitrate;
-    std::optional<double> framerate;
-    HardwareAcceleration hardwareAcceleration { HardwareAcceleration::NoPreference };
-    String scalabilityMode;
-    BitrateMode bitrateMode { BitrateMode::Variable };
-    LatencyMode latencyMode { LatencyMode::Quality };
-    std::optional<AvcEncoderConfig> avc;
+[
+    Conditional=WEB_CODECS
+] enum AvcBitstreamFormat {
+  "annexb",
+  "avc",
 };
 
-}
-
-#endif // ENABLE(WEB_CODECS)
+[
+    Conditional=WEB_CODECS,
+    JSGenerateToJSObject,
+] dictionary AvcEncoderConfig {
+    AvcBitstreamFormat format = "avc";
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -100,7 +100,8 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(WebCodecsVideoEncoderConfig&&
                 });
             };
         }
-        VideoEncoder::create(config.codec, { config.width, config.height }, [this, weakedThis = WeakPtr { *this }](auto&& result) {
+        bool useAnnexB = config.avc && config.avc->format == AvcBitstreamFormat::Annexb;
+        VideoEncoder::create(config.codec, { config.width, config.height, useAnnexB }, [this, weakedThis = WeakPtr { *this }](auto&& result) {
             if (!weakedThis)
                 return;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.idl
@@ -43,4 +43,5 @@ typedef [EnforceRange] unsigned long long WebCodecsVideoEncoderConfigBitrate;
     DOMString scalabilityMode;
     BitrateMode bitrateMode = "variable";
     LatencyMode latencyMode = "quality";
+    AvcEncoderConfig avc;
 };

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3027,6 +3027,7 @@ JSBeforeUnloadEvent.cpp
 JSBiquadFilterNode.cpp
 JSBiquadFilterOptions.cpp
 JSBiquadFilterType.cpp
+JSAvcEncoderConfig.cpp
 JSBitrateMode.cpp
 JSBlob.cpp
 JSBlobCallback.cpp

--- a/Source/WebCore/platform/VideoEncoder.h
+++ b/Source/WebCore/platform/VideoEncoder.h
@@ -41,6 +41,7 @@ public:
     struct Config {
         uint64_t width { 0 };
         uint64_t height { 0 };
+        bool useAnnexB { false };
     };
     struct EncodedFrame {
         Vector<uint8_t> data;
@@ -58,7 +59,12 @@ public:
     using PostTaskCallback = Function<void(Function<void()>&&)>;
     using OutputCallback = Function<void(EncodedFrame&&)>;
     using CreateCallback = CompletionHandler<void(CreateResult&&)>;
+
+    using CreatorFunction = void(*)(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+    WEBCORE_EXPORT static void setCreatorCallback(CreatorFunction&&);
+
     static void create(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+    WEBCORE_EXPORT static void createLocalEncoder(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
 
     using EncodeCallback = Function<void(String&&)>;
     virtual void encode(RawFrame&&, bool shouldGenerateKeyFrame, EncodeCallback&&) = 0;
@@ -66,6 +72,8 @@ public:
     virtual void flush(Function<void()>&&) = 0;
     virtual void reset() = 0;
     virtual void close() = 0;
+
+    static CreatorFunction s_customCreator;
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.h
@@ -28,6 +28,7 @@
 #if USE(LIBWEBRTC) && PLATFORM(COCOA) && ENABLE(GPU_PROCESS) && ENABLE(WEB_CODECS)
 
 #include <WebCore/VideoDecoder.h>
+#include <WebCore/VideoEncoder.h>
 
 namespace WebKit {
 
@@ -41,7 +42,7 @@ public:
 
 private:
     static void createDecoder(const String&, const WebCore::VideoDecoder::Config&, WebCore::VideoDecoder::CreateCallback&&, WebCore::VideoDecoder::OutputCallback&&, WebCore::VideoDecoder::PostTaskCallback&&);
-
+    static void createEncoder(const String&, const WebCore::VideoEncoder::Config&, WebCore::VideoEncoder::CreateCallback&&, WebCore::VideoEncoder::OutputCallback&&, WebCore::VideoEncoder::PostTaskCallback&&);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
@@ -73,6 +73,8 @@ public:
 #if USE(LIBWEBRTC)
     std::optional<SharedVideoFrame::Buffer> writeBuffer(const webrtc::VideoFrame&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::Handle&)>&);
 #endif
+    std::optional<SharedVideoFrame::Buffer> writeBuffer(const WebCore::VideoFrame&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::Handle&)>&);
+
     void disable();
     bool isDisabled() const { return m_isDisabled; }
 
@@ -83,7 +85,6 @@ private:
     bool allocateStorage(size_t, const Function<void(const SharedMemory::Handle&)>&);
     bool prepareWriting(const WebCore::SharedVideoFrameInfo&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::Handle&)>&);
 
-    std::optional<SharedVideoFrame::Buffer> writeBuffer(const WebCore::VideoFrame&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::Handle&)>&);
 #if USE(LIBWEBRTC)
     std::optional<SharedVideoFrame::Buffer> writeBuffer(webrtc::VideoFrameBuffer&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::Handle&)>&);
 #endif


### PR DESCRIPTION
#### c946458d447464be29d85328c0173468fdcb00f7
<pre>
Implement WebCodecsVideoEncoder with GPUProcess backend
<a href="https://bugs.webkit.org/show_bug.cgi?id=246068">https://bugs.webkit.org/show_bug.cgi?id=246068</a>
rdar://problem/100798062

Reviewed by Eric Carlson.

Complement RemoteVideoCodecFactory with remote encoder support.
Add support for AvcEncoderConfig to make sure we only support AnnexB for now.
Make use of libwebrtc remote encoders through RemoteVideoCodecFactory/RemoteVideoEncoder like done for decoders.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker_h264-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any_h264-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/webcodecs/AvcEncoderConfig.h: Added.
* Source/WebCore/Modules/webcodecs/AvcEncoderConfig.idl: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::isValidEncoderConfig):
(WebCore::WebCodecsVideoEncoder::configure):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/VideoEncoder.cpp:
(WebCore::VideoEncoder::setCreatorCallback):
(WebCore::VideoEncoder::create):
(WebCore::VideoEncoder::createLocalEncoder):
* Source/WebCore/platform/VideoEncoder.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoEncoderCallbacks::create):
(WebKit::RemoteVideoEncoderCallbacks::postTask):
(WebKit::RemoteVideoEncoderCallbacks::close):
(WebKit::RemoteVideoEncoderCallbacks::addDuration):
(WebKit::RemoteVideoCodecFactory::RemoteVideoCodecFactory):
(WebKit::RemoteVideoCodecFactory::createDecoder):
(WebKit::RemoteVideoCodecFactory::createEncoder):
(WebKit::RemoteVideoEncoder::RemoteVideoEncoder):
(WebKit::RemoteVideoEncoder::~RemoteVideoEncoder):
(WebKit::RemoteVideoEncoder::encode):
(WebKit::RemoteVideoEncoder::flush):
(WebKit::RemoteVideoEncoder::reset):
(WebKit::RemoteVideoEncoder::close):
(WebKit::RemoteVideoEncoderCallbacks::RemoteVideoEncoderCallbacks):
(WebKit::RemoteVideoEncoderCallbacks::notifyEncodedChunk):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::createEncoder):
(WebKit::LibWebRTCCodecs::createEncoderAndWaitUntilReady):
(WebKit::LibWebRTCCodecs::createEncoderInternal):
(WebKit::LibWebRTCCodecs::releaseEncoder):
(WebKit::LibWebRTCCodecs::encodeFrameInternal):
(WebKit::LibWebRTCCodecs::encodeFrame):
(WebKit::LibWebRTCCodecs::registerEncodeFrameCallback):
(WebKit::LibWebRTCCodecs::registerEncodedVideoFrameCallback):
(WebKit::LibWebRTCCodecs::completedEncoding):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
(WebKit::LibWebRTCCodecs::createDecoderInternal): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h:

Canonical link: <a href="https://commits.webkit.org/255316@main">https://commits.webkit.org/255316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e5a35b52635b44eba4236fd33a24cceb538de6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101786 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161859 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1205 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29651 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84437 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97992 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/741 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78515 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27697 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70733 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36056 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16283 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33794 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17385 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3685 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37671 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40098 "Found 2 new test failures: imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h264_annexb, imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_annexb (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36509 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->