### PR TITLE
Support for Curve 25519 - Algorithm Ed25519

### DIFF
--- a/LayoutTests/crypto/subtle/ed25519-generate-export-key-raw-expected.txt
+++ b/LayoutTests/crypto/subtle/ed25519-generate-export-key-raw-expected.txt
@@ -1,0 +1,12 @@
+Test exporting an Ed25519 public key with raw format.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Generating a key pair...
+Exporting the public key...
+PASS publicKey.byteLength is 32
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/ed25519-generate-export-key-raw.html
+++ b/LayoutTests/crypto/subtle/ed25519-generate-export-key-raw.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script type="text/javascript">
+description("Test exporting an Ed25519 public key with raw format.");
+
+jsTestIsAsync = true;
+
+var algorithmKeyGen = {
+    name: "Ed25519",
+};
+var extractable = true;
+
+var keyPair;
+debug("Generating a key pair...");
+crypto.subtle.generateKey(algorithmKeyGen, extractable, ["sign", "verify"]).then(function(result) {
+    keyPair = result;
+    debug("Exporting the public key...");
+    return crypto.subtle.exportKey("raw", keyPair.publicKey);
+}).then(function(result) {
+    publicKey = result;
+    shouldBe("publicKey.byteLength", "32");
+    finishJSTest();
+});
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>
+

--- a/LayoutTests/crypto/subtle/ed25519-generate-key-sing-verify-Curve25519-expected.txt
+++ b/LayoutTests/crypto/subtle/ed25519-generate-key-sing-verify-Curve25519-expected.txt
@@ -1,0 +1,12 @@
+Test Ed25519 signing/verifying operations with generated Curve25519 keys
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Generating keys
+PASS signature.byteLength is 64
+PASS verified is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/ed25519-generate-key-sing-verify-Curve25519.html
+++ b/LayoutTests/crypto/subtle/ed25519-generate-key-sing-verify-Curve25519.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script type="text/javascript">
+description("Test Ed25519 signing/verifying operations with generated Curve25519 keys");
+
+jsTestIsAsync = true;
+
+var extractable = true;
+var ed25519Params = {
+    name: "Ed25519",
+}
+var data = asciiToUint8Array("Hello, World!");
+
+debug("Generating keys");
+crypto.subtle.generateKey({ name: "Ed25519"}, extractable, ["sign", "verify"]).then(function(result) {
+    keyPair = result;
+    return crypto.subtle.sign(ed25519Params, keyPair.privateKey, data);
+}).then(function(result) {
+    signature = result;
+    shouldBe("signature.byteLength", "64");
+    return crypto.subtle.verify(ed25519Params, keyPair.publicKey, signature, data);
+}).then(function(result) {
+    verified = result;
+    shouldBeTrue("verified");
+    finishJSTest();
+}, failAndFinishJSTest);
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/ed25519-import-raw-key-expected.txt
+++ b/LayoutTests/crypto/subtle/ed25519-import-raw-key-expected.txt
@@ -1,0 +1,15 @@
+Test importing an Ed25519 raw key
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Importing a key...
+PASS publicKey.toString() is '[object CryptoKey]'
+PASS publicKey.type is 'public'
+PASS publicKey.extractable is true
+PASS publicKey.algorithm.name is 'Ed25519'
+PASS publicKey.usages is ['verify']
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/ed25519-import-raw-key.html
+++ b/LayoutTests/crypto/subtle/ed25519-import-raw-key.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script type="text/javascript">
+description("Test importing an Ed25519 raw key");
+
+jsTestIsAsync = true;
+
+var rawKey = new Uint8Array([233, 47, 177, 106, 82, 224, 122, 208, 149, 79, 30, 251, 246, 35, 88, 194, 200, 75, 31, 47, 233, 93, 241, 52, 51, 218, 46, 210, 51, 54, 156, 4]);
+var extractable = true;
+
+debug("Importing a key...");
+crypto.subtle.importKey("raw", rawKey, { name: "Ed25519"}, extractable, ['verify']).then(function(result) {
+    publicKey = result;
+
+    shouldBe("publicKey.toString()", "'[object CryptoKey]'");
+    shouldBe("publicKey.type", "'public'");
+    shouldBe("publicKey.extractable", "true");
+    shouldBe("publicKey.algorithm.name", "'Ed25519'");
+    shouldBe("publicKey.usages", "['verify']");
+
+    finishJSTest();
+});
+
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/ed25519-serialize-expected.txt
+++ b/LayoutTests/crypto/subtle/ed25519-serialize-expected.txt
@@ -1,0 +1,12 @@
+Test importing an Ed25519 raw key
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Importing a key...
+First imported key 6S+xalLgetCVTx779iNYwshLHy/pXfE0M9ou0jM2nAQ=
+Second exported key 6S+xalLgetCVTx779iNYwshLHy/pXfE0M9ou0jM2nAQ=
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/ed25519-serialize.html
+++ b/LayoutTests/crypto/subtle/ed25519-serialize.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script type="text/javascript">
+description("Test importing an Ed25519 raw key");
+
+jsTestIsAsync = true;
+
+var rawKey = new Uint8Array([233, 47, 177, 106, 82, 224, 122, 208, 149, 79, 30, 251, 246, 35, 88, 194, 200, 75, 31, 47, 233, 93, 241, 52, 51, 218, 46, 210, 51, 54, 156, 4]);
+var extractable = true;
+
+debug("Importing a key...");
+crypto.subtle.importKey("raw", rawKey, { name: "Ed25519"}, extractable, []).then(function(result) {
+    publicKey = result;
+    return crypto.subtle.exportKey("raw", publicKey);
+}).then(function(result) {
+    publicKey_exported = result;
+    var hex_exported = btoa(String.fromCharCode.apply(null, new Uint8Array(result)));
+    var hex_rawKey = btoa(String.fromCharCode.apply(null, rawKey));
+    debug("First imported key " + hex_rawKey);
+    debug("Second exported key " + hex_exported);
+    finishJSTest();
+});
+
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>
+
+

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -570,6 +570,12 @@ webkit.org/b/175199 crypto/subtle/ecdsa-import-jwk-public-key-alg-521.html [ Ski
 webkit.org/b/175199 crypto/subtle/ecdsa-import-key-sign-p521.html [ Skip ]
 webkit.org/b/175199 crypto/subtle/ecdsa-import-key-verify-p521.html [ Skip ]
 webkit.org/b/175199 crypto/subtle/ecdsa-import-pkcs8-key-p521-validate-ecprivatekey-parameters-publickey.html [ Skip ]
+ 
+#No support of ed25519 algorithm
+webkit.org/b/248980 crypto/subtle/ed25519-generate-export-key-raw.html [ Skip ]
+webkit.org/b/248980 crypto/subtle/ed25519-generate-key-sing-verify-Curve25519.html [ Skip ]
+webkit.org/b/248980 crypto/subtle/ed25519-import-raw-key.html [ Skip ]
+webkit.org/b/248980 crypto/subtle/ed25519-serialize.html [ Skip ]
 
 # GTK does not implement setAutomaticLinkDetectionEnabled
 editing/inserting/typing-space-to-trigger-smart-link.html [ Skip ]

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -810,6 +810,7 @@ set(WebCore_NON_SVG_IDL_FILES
     crypto/parameters/EcKeyParams.idl
     crypto/parameters/EcdhKeyDeriveParams.idl
     crypto/parameters/EcdsaParams.idl
+    crypto/parameters/Ed25519Params.idl
     crypto/parameters/HkdfParams.idl
     crypto/parameters/HmacKeyParams.idl
     crypto/parameters/Pbkdf2Params.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -932,6 +932,7 @@ $(PROJECT_DIR)/crypto/parameters/AesKeyParams.idl
 $(PROJECT_DIR)/crypto/parameters/EcKeyParams.idl
 $(PROJECT_DIR)/crypto/parameters/EcdhKeyDeriveParams.idl
 $(PROJECT_DIR)/crypto/parameters/EcdsaParams.idl
+$(PROJECT_DIR)/crypto/parameters/Ed25519Params.idl
 $(PROJECT_DIR)/crypto/parameters/HkdfParams.idl
 $(PROJECT_DIR)/crypto/parameters/HmacKeyParams.idl
 $(PROJECT_DIR)/crypto/parameters/Pbkdf2Params.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -839,6 +839,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEcdhKeyDeriveParams.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEcdhKeyDeriveParams.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEcdsaParams.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEcdsaParams.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEd25519Params.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEd25519Params.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEffectTiming.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEffectTiming.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElement+CSSOMView.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -811,6 +811,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/crypto/parameters/EcKeyParams.idl \
     $(WebCore)/crypto/parameters/EcdhKeyDeriveParams.idl \
     $(WebCore)/crypto/parameters/EcdsaParams.idl \
+    $(WebCore)/crypto/parameters/Ed25519Params.idl \
     $(WebCore)/crypto/parameters/HkdfParams.idl \
     $(WebCore)/crypto/parameters/HmacKeyParams.idl \
     $(WebCore)/crypto/parameters/Pbkdf2Params.idl \

--- a/Source/WebCore/PAL/pal/spi/cocoa/CoreCryptoSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/CoreCryptoSPI.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+WTF_EXTERN_C_BEGIN
+
+#if USE(APPLE_INTERNAL_SDK)
+#include <corecrypto/ccec25519.h>
+#include <corecrypto/ccec25519_priv.h>
+#include <corecrypto/ccsha2.h>
+#else
+
+#define CC_SPTR(_sn_, _n_) _n_
+
+#define CC_WIDE_NULL nullptr
+
+#define CCRNG_STATE_COMMON \
+int(*CC_SPTR(ccrng_state, generate))(struct ccrng_state *rng, size_t outlen, void *out);
+
+struct ccrng_state {
+    CCRNG_STATE_COMMON
+};
+struct ccrng_state *ccrng(int *error);
+
+#define ccrng_generate(rng, outlen, out) \
+((rng)->generate((struct ccrng_state *)(rng), (outlen), (out)))
+
+typedef uint8_t ccec25519key[32];
+typedef ccec25519key ccec25519secretkey;
+typedef ccec25519key ccec25519pubkey;
+typedef ccec25519key ccec25519base;
+typedef uint8_t ccec25519signature[64];
+
+const struct ccdigest_info *ccsha512_di(void);
+void cccurve25519(ccec25519key out, const ccec25519secretkey sk, const ccec25519base);
+
+inline void cccurve25519_make_priv(struct ccrng_state *rng, ccec25519secretkey sk)
+{
+    ccrng_generate(rng, 32, sk);
+    sk[0] &= 248;
+    sk[31] &= 127;
+    sk[31] |= 64;
+}
+
+inline void cccurve25519_make_pub(ccec25519pubkey pk, const ccec25519secretkey sk)
+{
+    cccurve25519(pk, sk, CC_WIDE_NULL);
+}
+
+inline void cccurve25519_make_key_pair(const struct ccdigest_info *, struct ccrng_state *rng, ccec25519pubkey pk, ccec25519secretkey sk)
+{
+    cccurve25519_make_priv(rng, sk);
+    cccurve25519_make_pub(pk, sk);
+}
+
+int cced25519_make_pub(const struct ccdigest_info *, ccec25519pubkey pk, const ccec25519secretkey sk);
+
+void cced25519_make_key_pair(const struct ccdigest_info *, struct ccrng_state *, ccec25519pubkey pk, ccec25519secretkey sk);
+#if __has_feature(bounds_attributes)
+#define cc_sized_by(x)                __attribute__((sized_by(x)))
+#else
+#define cc_sized_by(x)
+#endif // __has_feature(bounds_attributes)
+
+void cced25519_sign(const struct ccdigest_info *, ccec25519signature, size_t len, const void *cc_sized_by(len) msg, const ccec25519pubkey pk, const ccec25519secretkey sk);
+int cced25519_verify(const struct ccdigest_info *, size_t len, const void *cc_sized_by(len) msg, const ccec25519signature, const ccec25519pubkey pk);
+
+#endif // USE(APPLE_INTERNAL_SDK)
+
+WTF_EXTERN_C_END

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -709,6 +709,7 @@ crypto/algorithms/CryptoAlgorithmAES_GCM.cpp
 crypto/algorithms/CryptoAlgorithmAES_KW.cpp
 crypto/algorithms/CryptoAlgorithmECDH.cpp
 crypto/algorithms/CryptoAlgorithmECDSA.cpp
+crypto/algorithms/CryptoAlgorithmEd25519.cpp
 crypto/algorithms/CryptoAlgorithmHKDF.cpp
 crypto/algorithms/CryptoAlgorithmHMAC.cpp
 crypto/algorithms/CryptoAlgorithmPBKDF2.cpp
@@ -4119,6 +4120,7 @@ JSCSSStyleValue.cpp
 JSCSSUnitValue.cpp
 JSCSSUnparsedValue.cpp
 JSFullscreenOptions.cpp
+JSEd25519Params.cpp
 JSUIEvent.cpp
 JSUIEventInit.cpp
 JSURLSearchParams.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -151,6 +151,7 @@ crypto/mac/CryptoAlgorithmAES_GCMMac.cpp
 crypto/mac/CryptoAlgorithmAES_KWMac.cpp
 crypto/mac/CryptoAlgorithmECDHMac.cpp
 crypto/mac/CryptoAlgorithmECDSAMac.cpp
+crypto/mac/CryptoAlgorithmEd25519Mac.cpp
 crypto/mac/CryptoAlgorithmHKDFMac.cpp
 crypto/mac/CryptoAlgorithmHMACMac.cpp
 crypto/mac/CryptoAlgorithmPBKDF2Mac.cpp

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -336,8 +336,9 @@ enum class CryptoAlgorithmIdentifierTag {
     SHA_512 = 18,
     HKDF = 20,
     PBKDF2 = 21,
+    Ed25519 = 22,
 };
-const uint8_t cryptoAlgorithmIdentifierTagMaximumValue = 21;
+const uint8_t cryptoAlgorithmIdentifierTagMaximumValue = 22;
 
 static unsigned countUsages(CryptoKeyUsageBitmap usages)
 {
@@ -1831,6 +1832,9 @@ private:
         case CryptoAlgorithmIdentifier::ECDH:
             write(CryptoAlgorithmIdentifierTag::ECDH);
             break;
+        case CryptoAlgorithmIdentifier::Ed25519:
+            write(CryptoAlgorithmIdentifierTag::SHA_256);
+            break;
         case CryptoAlgorithmIdentifier::AES_CTR:
             write(CryptoAlgorithmIdentifierTag::AES_CTR);
             break;
@@ -2999,6 +3003,9 @@ private:
             break;
         case CryptoAlgorithmIdentifierTag::ECDH:
             result = CryptoAlgorithmIdentifier::ECDH;
+            break;
+        case CryptoAlgorithmIdentifierTag::Ed25519:
+            result  = CryptoAlgorithmIdentifier::Ed25519;
             break;
         case CryptoAlgorithmIdentifierTag::AES_CTR:
             result = CryptoAlgorithmIdentifier::AES_CTR;

--- a/Source/WebCore/crypto/CryptoAlgorithmIdentifier.h
+++ b/Source/WebCore/crypto/CryptoAlgorithmIdentifier.h
@@ -36,6 +36,7 @@ enum class CryptoAlgorithmIdentifier {
     RSA_OAEP,
     ECDSA,
     ECDH,
+    Ed25519,
     AES_CTR,
     AES_CBC,
     AES_GCM,

--- a/Source/WebCore/crypto/CryptoAlgorithmParameters.h
+++ b/Source/WebCore/crypto/CryptoAlgorithmParameters.h
@@ -44,6 +44,7 @@ public:
         AesKeyParams,
         EcKeyParams,
         EcdhKeyDeriveParams,
+        Ed25519Params,
         EcdsaParams,
         HkdfParams,
         HmacKeyParams,

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEB_CRYPTO)
 
 #include "CryptoAlgorithm.h"
+#include "CryptoAlgorithmEd25519Params.h"
 #include "CryptoAlgorithmRegistry.h"
 #include "JSAesCbcCfbParams.h"
 #include "JSAesCtrParams.h"
@@ -42,6 +43,7 @@
 #include "JSEcKeyParams.h"
 #include "JSEcdhKeyDeriveParams.h"
 #include "JSEcdsaParams.h"
+#include "JSEd25519Params.h"
 #include "JSHkdfParams.h"
 #include "JSHmacKeyParams.h"
 #include "JSJsonWebKey.h"
@@ -163,6 +165,12 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
             result = makeUnique<CryptoAlgorithmEcdsaParams>(params);
             break;
         }
+        case CryptoAlgorithmIdentifier::Ed25519: {
+            auto params = convertDictionary<CryptoAlgorithmEd25519Params>(state, value.get());
+            RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
+            result = makeUnique<CryptoAlgorithmEd25519Params>(params);
+            break;
+        }
         case CryptoAlgorithmIdentifier::RSA_PSS: {
             auto params = convertDictionary<CryptoAlgorithmRsaPssParams>(state, value.get());
             RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
@@ -232,6 +240,11 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
             RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
             result = makeUnique<CryptoAlgorithmEcKeyParams>(params);
             break;
+        }
+        case CryptoAlgorithmIdentifier::Ed25519: {
+            auto result = makeUnique<CryptoAlgorithmParameters>();
+            result->identifier = identifier.value();
+            return result;
         }
         default:
             return Exception { NotSupportedError };
@@ -316,6 +329,11 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
             RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
             result = makeUnique<CryptoAlgorithmEcKeyParams>(params);
             break;
+        }
+        case CryptoAlgorithmIdentifier::Ed25519: {
+            auto result = makeUnique<CryptoAlgorithmParameters>();
+            result->identifier = identifier.value();
+            return result;
         }
         case CryptoAlgorithmIdentifier::HKDF:
         case CryptoAlgorithmIdentifier::PBKDF2:
@@ -497,6 +515,7 @@ static bool isSupportedExportKey(CryptoAlgorithmIdentifier identifier)
     case CryptoAlgorithmIdentifier::HMAC:
     case CryptoAlgorithmIdentifier::ECDSA:
     case CryptoAlgorithmIdentifier::ECDH:
+    case CryptoAlgorithmIdentifier::Ed25519:
         return true;
     default:
         return false;

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
@@ -54,6 +54,11 @@ void CryptoAlgorithmECDH::generateKey(const CryptoAlgorithmParameters& parameter
         return;
     }
 
+    if (ecParameters.namedCurve != "P-256"_s && ecParameters.namedCurve != "P-384"_s && ecParameters.namedCurve != "P-521"_s) {
+        exceptionCallback(NotSupportedError);
+        return;
+    }
+
     auto result = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, ecParameters.namedCurve, extractable, usages);
     if (result.hasException()) {
         exceptionCallback(result.releaseException().code());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp
@@ -90,6 +90,11 @@ void CryptoAlgorithmECDSA::generateKey(const CryptoAlgorithmParameters& paramete
         return;
     }
 
+    if (ecParameters.namedCurve != "P-256"_s && ecParameters.namedCurve != "P-384"_s && ecParameters.namedCurve != "P-521"_s) {
+        exceptionCallback(NotSupportedError);
+        return;
+    }
+
     auto result = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDSA, ecParameters.namedCurve, extractable, usages);
     if (result.hasException()) {
         exceptionCallback(result.releaseException().code());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+#include "CryptoAlgorithmEd25519.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CryptoAlgorithmECDSA.h"
+#include "CryptoAlgorithmEcKeyParams.h"
+#include "CryptoAlgorithmEd25519Params.h"
+#include "CryptoKeyEC.h"
+#include "NotImplemented.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+#include <stdio.h>
+#include <string.h>
+#include <wtf/Assertions.h>
+#include <wtf/CrossThreadCopier.h>
+
+namespace WebCore {
+
+#if !PLATFORM(COCOA)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyEC&, const Vector<uint8_t>&)
+{
+    ASSERT_NOT_REACHED();
+    notImplemented();
+    return Exception { NotSupportedError };
+}
+
+ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyEC&, const Vector<uint8_t>&, const Vector<uint8_t>&)
+{
+    ASSERT_NOT_REACHED();
+    notImplemented();
+    return Exception { NotSupportedError };
+}
+
+#endif // PLATFORM(COCOA)
+
+Ref<CryptoAlgorithm> CryptoAlgorithmEd25519::create()
+{
+    return adoptRef(*new CryptoAlgorithmEd25519);
+}
+
+CryptoAlgorithmIdentifier CryptoAlgorithmEd25519::identifier() const
+{
+    return s_identifier;
+}
+
+void CryptoAlgorithmEd25519::generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext&)
+{
+    if (usages & (CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt | CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits | CryptoKeyUsageWrapKey | CryptoKeyUsageUnwrapKey)) {
+        exceptionCallback(SyntaxError);
+        return;
+    }
+    
+    auto result = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::Ed25519, "Curve25519"_s, extractable, usages);
+    if (result.hasException()) {
+        exceptionCallback(result.releaseException().code());
+        return;
+    }
+
+    auto pair = result.releaseReturnValue();
+    pair.publicKey->setUsagesBitmap(pair.publicKey->usagesBitmap() & CryptoKeyUsageVerify);
+    pair.privateKey->setUsagesBitmap(pair.privateKey->usagesBitmap() & CryptoKeyUsageSign);
+    callback(WTFMove(pair));
+}
+
+void CryptoAlgorithmEd25519::sign(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& key, Vector<uint8_t>&& data, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+{
+    if (key->type() != CryptoKeyType::Private) {
+        exceptionCallback(InvalidAccessError);
+        return;
+    }
+    dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
+        [parameters = crossThreadCopy(downcast<CryptoAlgorithmEd25519Params>(parameters)), key = WTFMove(key), data = WTFMove(data)] {
+            return platformSign( downcast<CryptoKeyEC>(key.get()), data);
+        });
+}
+
+void CryptoAlgorithmEd25519::verify(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& key, Vector<uint8_t>&& signature, Vector<uint8_t>&& data, BoolCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+{
+    if (key->type() != CryptoKeyType::Public) {
+        exceptionCallback(InvalidAccessError);
+        return;
+    }
+    dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
+        [parameters = crossThreadCopy(downcast<CryptoAlgorithmEd25519Params>(parameters)), key = WTFMove(key), signature = WTFMove(signature), data = WTFMove(data)] {
+            return platformVerify(downcast<CryptoKeyEC>(key.get()), signature, data);
+        });
+}
+void CryptoAlgorithmEd25519::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+{
+    RefPtr<CryptoKeyEC> result;
+    switch (format) {
+    case CryptoKeyFormat::Jwk: {
+        JsonWebKey key = WTFMove(std::get<JsonWebKey>(data));
+        if (usages && ((!key.d.isNull() && (usages ^ CryptoKeyUsageSign)) || (key.d.isNull() && (usages ^ CryptoKeyUsageVerify)))) {
+            exceptionCallback(SyntaxError);
+            return;
+        }
+        if (usages && !key.use.isNull() && key.use != "sig"_s) {
+            exceptionCallback(DataError);
+            return;
+        }
+        result = CryptoKeyEC::importJwk(CryptoAlgorithmIdentifier::Ed25519, "Curve25519"_s, WTFMove(key), extractable, usages);
+        break;
+    }
+    case CryptoKeyFormat::Raw:
+        if (usages && (usages ^ CryptoKeyUsageVerify)) {
+            exceptionCallback(SyntaxError);
+            return;
+        }
+        result = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::Ed25519, "Curve25519"_s, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
+        break;
+    case CryptoKeyFormat::Spki:
+        if (usages && (usages ^ CryptoKeyUsageVerify)) {
+            exceptionCallback(SyntaxError);
+            return;
+        }
+        result = CryptoKeyEC::importSpki(CryptoAlgorithmIdentifier::Ed25519, "Curve25519"_s, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
+        break;
+    case CryptoKeyFormat::Pkcs8:
+        if (usages && (usages ^ CryptoKeyUsageSign)) {
+            exceptionCallback(SyntaxError);
+            return;
+        }
+        result = CryptoKeyEC::importPkcs8(CryptoAlgorithmIdentifier::Ed25519, "Curve25519"_s, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
+        break;
+    }
+    if (!result) {
+        exceptionCallback(DataError);
+        return;
+    }
+    callback(*result);
+}
+void CryptoAlgorithmEd25519::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+{
+    const auto& ecKey = downcast<CryptoKeyEC>(key.get());
+    if (!ecKey.keySizeInBits()) {
+        exceptionCallback(OperationError);
+        return;
+    }
+    KeyData result;
+    switch (format) {
+    case CryptoKeyFormat::Jwk: {
+        auto jwk = ecKey.exportJwk();
+        if (jwk.hasException()) {
+            exceptionCallback(jwk.releaseException().code());
+            return;
+        }
+        result = jwk.releaseReturnValue();
+        break;
+    }
+    case CryptoKeyFormat::Raw: {
+        auto raw = ecKey.exportRaw();
+        if (raw.hasException()) {
+            exceptionCallback(raw.releaseException().code());
+            return;
+        }
+        result = raw.releaseReturnValue();
+        break;
+    }
+    case CryptoKeyFormat::Spki: {
+        auto spki = ecKey.exportSpki();
+        if (spki.hasException()) {
+            exceptionCallback(spki.releaseException().code());
+            return;
+        }
+        result = spki.releaseReturnValue();
+        break;
+    }
+    case CryptoKeyFormat::Pkcs8: {
+        auto pkcs8 = ecKey.exportPkcs8();
+        if (pkcs8.hasException()) {
+            exceptionCallback(pkcs8.releaseException().code());
+            return;
+        }
+        result = pkcs8.releaseReturnValue();
+        break;
+    }
+    }
+    callback(format, WTFMove(result));
+}
+
+} // namespace WebCore
+#endif // ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include "CryptoAlgorithm.h"
+
+#if ENABLE(WEB_CRYPTO)
+namespace WebCore {
+
+struct CryptoAlgorithmEd25519Params;
+class CryptoKeyEC;
+
+class CryptoAlgorithmEd25519 final : public CryptoAlgorithm {
+public:
+    static constexpr ASCIILiteral s_name = "Ed25519"_s;
+    static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::Ed25519;
+    static Ref<CryptoAlgorithm> create();
+    
+private:
+    CryptoAlgorithmEd25519() = default;
+    CryptoAlgorithmIdentifier identifier() const final;
+    
+    void generateKey(const CryptoAlgorithmParameters& , bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& , ExceptionCallback&& , ScriptExecutionContext&);
+    void sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    
+    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyEC&, const Vector<uint8_t>&);
+    static ExceptionOr<bool> platformVerify(const CryptoKeyEC&, const Vector<uint8_t>&, const Vector<uint8_t>&);
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Metrological Group B.V.
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CryptoAlgorithmEd25519.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CryptoAlgorithmEd25519Params.h"
+#include "CryptoKeyEC.h"
+#include "GCryptUtilities.h"
+#include "NotImplemented.h"
+#include <pal/crypto/CryptoDigest.h>
+
+namespace WebCore {
+
+static std::optional<Vector<uint8_t>> gcryptSign(gcry_sexp_t keySexp, const Vector<uint8_t>& data, CryptoAlgorithmIdentifier hashAlgorithmIdentifier, size_t keySizeInBytes)
+{
+    notImplemented();
+    return std::nullopt;
+}
+
+static std::optional<bool> gcryptVerify(gcry_sexp_t keySexp, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, CryptoAlgorithmIdentifier hashAlgorithmIdentifier, size_t keySizeInBytes)
+{
+    notImplemented();
+    return std::nullopt;
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoAlgorithmEd25519Params& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data)
+{
+    notImplemented();
+    return std::nullopt;
+}
+
+ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoAlgorithmEd25519Params& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+{
+    notImplemented();
+    return std::nullopt;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CRYPTO)
+

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRegistryGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRegistryGCrypt.cpp
@@ -34,6 +34,7 @@
 #include "CryptoAlgorithmAES_KW.h"
 #include "CryptoAlgorithmECDH.h"
 #include "CryptoAlgorithmECDSA.h"
+#include "CryptoAlgorithmEd25519.h"
 #include "CryptoAlgorithmHKDF.h"
 #include "CryptoAlgorithmHMAC.h"
 #include "CryptoAlgorithmPBKDF2.h"
@@ -57,6 +58,7 @@ void CryptoAlgorithmRegistry::platformRegisterAlgorithms()
     registerAlgorithm<CryptoAlgorithmAES_KW>();
     registerAlgorithm<CryptoAlgorithmECDH>();
     registerAlgorithm<CryptoAlgorithmECDSA>();
+    registerAlgorithm<CryptoAlgorithmEd25519>();
     registerAlgorithm<CryptoAlgorithmHKDF>();
     registerAlgorithm<CryptoAlgorithmHMAC>();
     registerAlgorithm<CryptoAlgorithmPBKDF2>();

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
@@ -46,6 +46,9 @@ static const char* curveName(CryptoKeyEC::NamedCurve curve)
         return "NIST P-384";
     case CryptoKeyEC::NamedCurve::P521:
         return "NIST P-521";
+    case CryptoKeyEC::NamedCurve::Curve25519:
+        ASSERT_NOT_REACHED();
+        break;
     }
 
     ASSERT_NOT_REACHED();
@@ -61,6 +64,9 @@ static const uint8_t* curveIdentifier(CryptoKeyEC::NamedCurve curve)
         return CryptoConstants::s_secp384r1Identifier.data();
     case CryptoKeyEC::NamedCurve::P521:
         return CryptoConstants::s_secp521r1Identifier.data();
+    case CryptoKeyEC::NamedCurve::Curve25519:
+        ASSERT_NOT_REACHED();
+        break;
     }
 
     ASSERT_NOT_REACHED();
@@ -76,6 +82,9 @@ static size_t curveSize(CryptoKeyEC::NamedCurve curve)
         return 384;
     case CryptoKeyEC::NamedCurve::P521:
         return 521;
+    case CryptoKeyEC::NamedCurve::Curve25519:
+        ASSERT_NOT_REACHED();
+        break;
     }
 
     ASSERT_NOT_REACHED();
@@ -91,6 +100,9 @@ static unsigned curveUncompressedFieldElementSize(CryptoKeyEC::NamedCurve curve)
         return 48;
     case CryptoKeyEC::NamedCurve::P521:
         return 66;
+    case CryptoKeyEC::NamedCurve::Curve25519:
+        ASSERT_NOT_REACHED();
+        break;
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
@@ -30,13 +30,18 @@
 
 #include "CryptoAlgorithmRegistry.h"
 #include "JsonWebKey.h"
+#include "NotImplemented.h"
+#include <wtf/CommaPrinter.h>
+#include <wtf/HexNumber.h>
 #include <wtf/text/Base64.h>
+#include <wtf/text/UniquedStringImpl.h>
 
 namespace WebCore {
 
 static const ASCIILiteral P256 { "P-256"_s };
 static const ASCIILiteral P384 { "P-384"_s };
 static const ASCIILiteral P521 { "P-521"_s };
+static const ASCIILiteral Curve25519 { "Curve25519"_s };
 
 static std::optional<CryptoKeyEC::NamedCurve> toNamedCurve(const String& curve)
 {
@@ -46,6 +51,8 @@ static std::optional<CryptoKeyEC::NamedCurve> toNamedCurve(const String& curve)
         return CryptoKeyEC::NamedCurve::P384;
     if (curve == P521)
         return CryptoKeyEC::NamedCurve::P521;
+    if (curve ==  Curve25519)
+        return CryptoKeyEC::NamedCurve:: Curve25519;
 
     return std::nullopt;
 }
@@ -159,6 +166,9 @@ ExceptionOr<JsonWebKey> CryptoKeyEC::exportJwk() const
     case NamedCurve::P521:
         result.crv = P521;
         break;
+    case NamedCurve::Curve25519:
+        result.crv = Curve25519;
+        break;
     }
     result.key_ops = usages();
     result.ext = extractable();
@@ -198,6 +208,8 @@ String CryptoKeyEC::namedCurveString() const
         return String(P384);
     case NamedCurve::P521:
         return String(P521);
+    case NamedCurve::Curve25519:
+        return String(Curve25519);
     }
 
     ASSERT_NOT_REACHED();
@@ -206,7 +218,7 @@ String CryptoKeyEC::namedCurveString() const
 
 bool CryptoKeyEC::isValidECAlgorithm(CryptoAlgorithmIdentifier algorithm)
 {
-    return algorithm == CryptoAlgorithmIdentifier::ECDSA || algorithm == CryptoAlgorithmIdentifier::ECDH;
+    return algorithm == CryptoAlgorithmIdentifier::ECDSA || algorithm == CryptoAlgorithmIdentifier::ECDH || algorithm == CryptoAlgorithmIdentifier:: Ed25519;
 }
 
 auto CryptoKeyEC::algorithm() const -> KeyAlgorithm
@@ -223,6 +235,9 @@ auto CryptoKeyEC::algorithm() const -> KeyAlgorithm
         break;
     case NamedCurve::P521:
         result.namedCurve = P521;
+        break;
+    case NamedCurve::Curve25519:
+        result.namedCurve = Curve25519;
         break;
     }
 

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmECDHMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmECDHMac.cpp
@@ -38,7 +38,9 @@ std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const Cry
     std::optional<Vector<uint8_t>> result = std::nullopt;
     Vector<uint8_t> derivedKey(baseKey.keySizeInBytes()); // Per https://tools.ietf.org/html/rfc6090#section-4.
     size_t size = derivedKey.size();
-    if (!CCECCryptorComputeSharedSecret(baseKey.platformKey(), publicKey.platformKey(), derivedKey.data(), &size))
+    CCECCryptorRef cceccbasekey = std::get<CCECCryptorRef>(baseKey.platformKey());
+    CCECCryptorRef cceccpublickey = std::get<CCECCryptorRef>(publicKey.platformKey());
+    if (!CCECCryptorComputeSharedSecret(cceccbasekey, cceccpublickey, derivedKey.data(), &size))
         result = WTFMove(derivedKey);
     return result;
 }

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmECDSAMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmECDSAMac.cpp
@@ -55,8 +55,8 @@ static ExceptionOr<Vector<uint8_t>> signECDSA(CryptoAlgorithmIdentifier hash, co
     // tag + length(1) + tag + length(1) + InitialOctet(?) + keyLength in bytes + tag + length(1) + InitialOctet(?) + keyLength in bytes
     Vector<uint8_t> signature(8 + keyLengthInBytes * 2);
     size_t signatureSize = signature.size();
-
-    CCCryptorStatus status = CCECCryptorSignHash(key, digestData.data(), digestData.size(), signature.data(), &signatureSize);
+    CCECCryptorRef ccecckey = std::get<CCECCryptorRef>(key);
+    CCCryptorStatus status = CCECCryptorSignHash(ccecckey, digestData.data(), digestData.size(), signature.data(), &signatureSize);
     if (status)
         return Exception { OperationError };
 
@@ -149,7 +149,8 @@ static ExceptionOr<bool> verifyECDSA(CryptoAlgorithmIdentifier hash, const Platf
     newSignature.append(signature.data() + sStart, keyLengthInBytes * 2 - sStart);
 
     uint32_t valid;
-    CCCryptorStatus status = CCECCryptorVerifyHash(key, digestData.data(), digestData.size(), newSignature.data(), newSignature.size(), &valid);
+    CCECCryptorRef ccecckey = std::get<CCECCryptorRef>(key);
+    CCCryptorStatus status = CCECCryptorVerifyHash(ccecckey, digestData.data(), digestData.size(), newSignature.data(), newSignature.size(), &valid);
     if (status) {
         WTFLogAlways("ERROR: CCECCryptorVerifyHash() returns error=%d", status);
         return false;

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmEd25519Mac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmEd25519Mac.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+#include "CryptoAlgorithmEd25519.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CommonCryptoDERUtilities.h"
+#include "CommonCryptoUtilities.h"
+#include "CryptoAlgorithmEd25519Params.h"
+#include "CryptoDigestAlgorithm.h"
+#include "CryptoKeyEC.h"
+#include <pal/spi/cocoa/CoreCryptoSPI.h>
+#include <stdio.h>
+#include <string.h>
+#include <wtf/Assertions.h>
+#include <wtf/text/Base64.h>
+
+namespace WebCore {
+
+static ExceptionOr<Vector<uint8_t>> signEd25519(const PlatformECKey key, size_t, const Vector<uint8_t>& data)
+{   
+    auto& sk = std::get<Vector<uint8_t>>(key);
+    ccec25519pubkey pk;
+    const struct ccdigest_info* di = ccsha512_di();
+    cced25519_make_pub(di, pk, sk.data());
+    ccec25519signature newSignature;
+    cced25519_sign(di, newSignature, data.size(), data.data(), pk, sk.data());
+    return Vector<uint8_t>(newSignature, 64);
+}
+
+static ExceptionOr<bool> verifyEd25519(const PlatformECKey key, size_t keyLengthInBytes, const Vector<uint8_t>& signature, const Vector<uint8_t> data)
+{
+    if (signature.size() != keyLengthInBytes * 2)
+        return false;
+    const struct ccdigest_info* di = ccsha512_di();
+    return !cced25519_verify(di, data.size(), data.data(), signature.data(), std::get<Vector<uint8_t>>(key).data());
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyEC& key, const Vector<uint8_t>& data)
+{
+    return signEd25519(key.platformKey(), key.keySizeInBytes(), data);
+}
+
+ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+{
+    return verifyEd25519(key.platformKey(), key.keySizeInBytes(), signature, data);
+}
+
+}
+
+#endif

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmHKDFMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmHKDFMac.cpp
@@ -27,7 +27,7 @@
 #include "CryptoAlgorithmHKDF.h"
 
 #if ENABLE(WEB_CRYPTO)
-
+#include "CommonCryptoUtilities.h"
 #include "CryptoAlgorithmHkdfParams.h"
 #include "CryptoKeyRaw.h"
 #include "CryptoUtilitiesCocoa.h"

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmRegistryMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmRegistryMac.cpp
@@ -35,6 +35,7 @@
 #include "CryptoAlgorithmAES_KW.h"
 #include "CryptoAlgorithmECDH.h"
 #include "CryptoAlgorithmECDSA.h"
+#include "CryptoAlgorithmEd25519.h"
 #include "CryptoAlgorithmHKDF.h"
 #include "CryptoAlgorithmHMAC.h"
 #include "CryptoAlgorithmPBKDF2.h"
@@ -59,6 +60,7 @@ void CryptoAlgorithmRegistry::platformRegisterAlgorithms()
     registerAlgorithm<CryptoAlgorithmAES_KW>();
     registerAlgorithm<CryptoAlgorithmECDH>();
     registerAlgorithm<CryptoAlgorithmECDSA>();
+    registerAlgorithm<CryptoAlgorithmEd25519>();
     registerAlgorithm<CryptoAlgorithmHKDF>();
     registerAlgorithm<CryptoAlgorithmHMAC>();
     registerAlgorithm<CryptoAlgorithmPBKDF2>();

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmEd25519OpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmEd25519OpenSSL.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CryptoAlgorithmEd25519.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CryptoAlgorithmEd25519Params.h"
+#include "CryptoKeyEC.h"
+#include "NotImplemented.h"
+#include "OpenSSLUtilities.h"
+
+namespace WebCore {
+
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoAlgorithmEd25519Params& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data)
+{
+    notImplemented();
+    return std::nullopt;
+}
+
+ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoAlgorithmEd25519Params&, const CryptoKeyEC&, const Vector<uint8_t>&, const Vector<uint8_t>&)
+{
+    notImplemented();
+    return std::nullopt;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CRYPTO)
+

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmRegistryOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmRegistryOpenSSL.cpp
@@ -35,6 +35,7 @@
 #include "CryptoAlgorithmAES_KW.h"
 #include "CryptoAlgorithmECDH.h"
 #include "CryptoAlgorithmECDSA.h"
+#include "CryptoAlgorithmEd25519.h"
 #include "CryptoAlgorithmHKDF.h"
 #include "CryptoAlgorithmHMAC.h"
 #include "CryptoAlgorithmPBKDF2.h"
@@ -59,6 +60,7 @@ void CryptoAlgorithmRegistry::platformRegisterAlgorithms()
     registerAlgorithm<CryptoAlgorithmAES_KW>();
     registerAlgorithm<CryptoAlgorithmECDH>();
     registerAlgorithm<CryptoAlgorithmECDSA>();
+    registerAlgorithm<CryptoAlgorithmEd25519>();
     registerAlgorithm<CryptoAlgorithmHKDF>();
     registerAlgorithm<CryptoAlgorithmHMAC>();
     registerAlgorithm<CryptoAlgorithmPBKDF2>();

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEd25519Params.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEd25519Params.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CryptoAlgorithmParameters.h"
+#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/Strong.h>
+#include <variant>
+
+#if ENABLE(WEB_CRYPTO)
+
+namespace WebCore {
+
+struct CryptoAlgorithmEd25519Params final : CryptoAlgorithmParameters {
+    
+    Class parametersClass() const final { return Class::Ed25519Params; }
+
+    CryptoAlgorithmEd25519Params isolatedCopy() const
+    {
+        CryptoAlgorithmEd25519Params result;
+        result.identifier = identifier;
+        return result;
+    }
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CRYPTO_ALGORITHM_PARAMETERS(Ed25519Params)
+
+#endif // ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/crypto/parameters/Ed25519Params.idl
+++ b/Source/WebCore/crypto/parameters/Ed25519Params.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+ typedef (object or DOMString) HashAlgorithmIdentifier;
+[
+    Conditional=WEB_CRYPTO,
+    ImplementedAs=CryptoAlgorithmEd25519Params,
+] dictionary Ed25519Params : CryptoAlgorithmParameters {
+};

--- a/Source/WebCore/css/StylePropertyShorthand.h
+++ b/Source/WebCore/css/StylePropertyShorthand.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "CSSPropertyNames.h"
+#include "CSSValueKeywords.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {


### PR DESCRIPTION
#### 49d4ef6da92f266244e072be6be48f29c4043dca
<pre>
Support for Curve 25519 - Algorithm Ed25519
https://bugs.webkit.org/show_bug.cgi?id=246145
rdar://100401588

Reviewed by NOBODY (OOPS!).

Adding support for the Curve 25519 (doing the necessary modifications to be able to work with such type  of curve), specifically the implementation of the Ed25519 algorithm, as in https://www.rfc-editor.org/rfc/rfc7748. The current patch adds support  to generate keys, import, export (in raw format for now), sign and verify and tests that make use of such operations. Following the specs in https://wicg.github.io/webcrypto-secure-curves/#ed25519.

* LayoutTests/crypto/subtle/ed25519-generate-export-key-raw-expected.txt: Added.
* LayoutTests/crypto/subtle/ed25519-generate-export-key-raw.html: Added.
* LayoutTests/crypto/subtle/ed25519-generate-key-sing-verify-Curve25519-expected.txt: Added.
* LayoutTests/crypto/subtle/ed25519-generate-key-sing-verify-Curve25519.html: Added.
* LayoutTests/crypto/subtle/ed25519-import-raw-key-expected.txt: Added.
* LayoutTests/crypto/subtle/ed25519-import-raw-key.html: Added.
* LayoutTests/crypto/subtle/ed25519-serialize-expected.txt: Added.
* LayoutTests/crypto/subtle/ed25519-serialize.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/PAL/pal/spi/cocoa/CoreCryptoSPI.h: Added.
(cccurve25519_make_priv):
(cccurve25519_make_pub):
(cccurve25519_make_key_pair):
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::write):
(WebCore::CloneDeserializer::read):
* Source/WebCore/crypto/CryptoAlgorithmIdentifier.h:
* Source/WebCore/crypto/CryptoAlgorithmParameters.h:
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::normalizeCryptoAlgorithmParameters):
(WebCore::isSupportedExportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp:
(WebCore::CryptoAlgorithmECDH::generateKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp:
(WebCore::CryptoAlgorithmECDSA::generateKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp: Copied from Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp.
(WebCore::CryptoAlgorithmEd25519::platformSign):
(WebCore::CryptoAlgorithmEd25519::platformVerify):
(WebCore::CryptoAlgorithmEd25519::create):
(WebCore::CryptoAlgorithmEd25519::identifier const):
(WebCore::CryptoAlgorithmEd25519::generateKey):
(WebCore::CryptoAlgorithmEd25519::sign):
(WebCore::CryptoAlgorithmEd25519::verify):
(WebCore::CryptoAlgorithmEd25519::importKey):
(WebCore::CryptoAlgorithmEd25519::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h: Added.
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp: Copied from Source/WebCore/crypto/mac/CryptoAlgorithmECDHMac.cpp.
(WebCore::gcryptSign):
(WebCore::gcryptVerify):
(WebCore::CryptoAlgorithmEd25519::platformSign):
(WebCore::CryptoAlgorithmEd25519::platformVerify):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmRegistryGCrypt.cpp:
(WebCore::CryptoAlgorithmRegistry::platformRegisterAlgorithms):
* Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp:
(WebCore::curveName):
(WebCore::curveIdentifier):
(WebCore::curveSize):
(WebCore::curveUncompressedFieldElementSize):
* Source/WebCore/crypto/keys/CryptoKeyEC.cpp:
(WebCore::toNamedCurve):
(WebCore::CryptoKeyEC::exportJwk const):
(WebCore::CryptoKeyEC::namedCurveString const):
(WebCore::CryptoKeyEC::isValidECAlgorithm):
(WebCore::CryptoKeyEC::algorithm const):
* Source/WebCore/crypto/keys/CryptoKeyEC.h:
* Source/WebCore/crypto/mac/CryptoAlgorithmECDHMac.cpp:
(WebCore::CryptoAlgorithmECDH::platformDeriveBits):
* Source/WebCore/crypto/mac/CryptoAlgorithmECDSAMac.cpp:
(WebCore::signECDSA):
(WebCore::verifyECDSA):
* Source/WebCore/crypto/mac/CryptoAlgorithmEd25519Mac.cpp: Added.
(WebCore::signEd25519):
(WebCore::verifyEd25519):
(WebCore::CryptoAlgorithmEd25519::platformSign):
(WebCore::CryptoAlgorithmEd25519::platformVerify):
* Source/WebCore/crypto/mac/CryptoAlgorithmHKDFMac.cpp:
* Source/WebCore/crypto/mac/CryptoAlgorithmRegistryMac.cpp:
(WebCore::CryptoAlgorithmRegistry::platformRegisterAlgorithms):
* Source/WebCore/crypto/mac/CryptoKeyECMac.cpp:
(WebCore::keySizeInBitsFromNamedCurve):
(WebCore::CryptoKeyEC::keySizeInBits const):
(WebCore::CryptoKeyEC::platformSupportedCurve):
(WebCore::CryptoKeyEC::platformGeneratePair):
(WebCore::CryptoKeyEC::platformImportRaw):
(WebCore::CryptoKeyEC::platformExportRaw const):
(WebCore::CryptoKeyEC::platformImportJWKPublic):
(WebCore::CryptoKeyEC::platformImportJWKPrivate):
(WebCore::CryptoKeyEC::platformAddFieldElements const):
(WebCore::getOID):
(WebCore::CryptoKeyEC::platformImportSpki):
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformImportPkcs8):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):
* Source/WebCore/crypto/openssl/CryptoAlgorithmEd25519OpenSSL.cpp: Copied from Source/WebCore/crypto/mac/CryptoAlgorithmECDHMac.cpp.
(WebCore::CryptoAlgorithmEd25519::platformSign):
(WebCore::CryptoAlgorithmEd25519::platformVerify):
* Source/WebCore/crypto/openssl/CryptoAlgorithmRegistryOpenSSL.cpp:
(WebCore::CryptoAlgorithmRegistry::platformRegisterAlgorithms):
* Source/WebCore/crypto/parameters/CryptoAlgorithmEd25519Params.h: Copied from Source/WebCore/crypto/CryptoAlgorithmIdentifier.h.
* Source/WebCore/crypto/parameters/Ed25519Params.idl: Copied from Source/WebCore/crypto/CryptoAlgorithmIdentifier.h.
* Source/WebCore/css/StylePropertyShorthand.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cfb9135493dd76c002bbb5f608c5d077fe25198

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109632 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169849 "Failed to checkout and rebase branch from PR 5026") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/15 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92717 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107512 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34519 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89895 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77474 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3220 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24035 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3209 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/147 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/source-list-parsing-05.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9331 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43525 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5029 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->