### PR TITLE
[css-typed-om] Implement CSSScale::toMatrix()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix-expected.txt
@@ -1,7 +1,7 @@
 
 PASS CSSTranslate.toMatrix() returns correct matrix
 FAIL CSSRotate.toMatrix() returns correct matrix assert_array_approx_equals: property 0, expected 0.07142857142857148 +/- 0.000001, expected 0.07142857142857148 but got 1
-FAIL CSSScale.toMatrix() returns correct matrix assert_array_approx_equals: property 5, expected 2 +/- 0.000001, expected 2 but got 1
+PASS CSSScale.toMatrix() returns correct matrix
 PASS CSSSkew.toMatrix() returns correct matrix
 FAIL CSSSkewX.toMatrix() returns correct matrix assert_array_approx_equals: property 4, expected 0.17632698070846498 +/- 0.000001, expected 0.17632698070846498 but got 0
 FAIL CSSSkewY.toMatrix() returns correct matrix assert_array_approx_equals: property 1, expected 0.17632698070846498 +/- 0.000001, expected 0.17632698070846498 but got 0

--- a/Source/WebCore/css/typedom/transform/CSSScale.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSScale.cpp
@@ -149,8 +149,17 @@ void CSSScale::serialize(StringBuilder& builder) const
 
 ExceptionOr<Ref<DOMMatrix>> CSSScale::toMatrix()
 {
-    // FIXME: Implement.
-    return DOMMatrix::fromMatrix(DOMMatrixInit { });
+    if (!is<CSSUnitValue>(m_x) || !is<CSSUnitValue>(m_y) || !is<CSSUnitValue>(m_z))
+        return Exception { TypeError };
+
+    auto x = downcast<CSSUnitValue>(m_x.get()).value();
+    auto y = downcast<CSSUnitValue>(m_y.get()).value();
+    auto z = downcast<CSSUnitValue>(m_z.get()).value();
+
+    TransformationMatrix matrix { };
+    matrix.scale3d(x, y, z);
+
+    return { DOMMatrix::create(WTFMove(matrix), is2D() ? DOMMatrixReadOnly::Is2D::Yes : DOMMatrixReadOnly::Is2D::No) };
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 3087e2f0938e1537e6d5258752897a145ed745f5
<pre>
[css-typed-om] Implement CSSScale::toMatrix()
<a href="https://bugs.webkit.org/show_bug.cgi?id=246085">https://bugs.webkit.org/show_bug.cgi?id=246085</a>

Reviewed by Antti Koivisto.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix-expected.txt:
* Source/WebCore/css/typedom/transform/CSSScale.cpp:
(WebCore::CSSScale::toMatrix):

Canonical link: <a href="https://commits.webkit.org/255184@main">https://commits.webkit.org/255184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5999b46473e34aa276431751751045515b163aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101335 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161425 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/864 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83954 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/499 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27455 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82423 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35759 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33514 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17192 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37355 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1608 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36309 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->