### PR TITLE
[cssom] Serialize the 'all' shorthand in cssText

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-all-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-all-shorthand-expected.txt
@@ -1,0 +1,7 @@
+
+PASS 'all' shorthand alone
+PASS 'all' shorthand with 'width' and 'height'
+PASS 'all' shorthand with 'direction' and 'unicode-bidi'
+PASS 'all' shorthand with 'width', 'height' and custom properties
+PASS 'all' shorthand with all longhands
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-all-shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-all-shorthand.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<title>CSSOM test: serialization of the 'all' shorthand in cssText</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-1/#dom-cssstyledeclaration-csstext">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const style = document.createElement("div").style;
+
+test(function() {
+  style.cssText = "all: inherit";
+  assert_equals(style.cssText, "all: inherit;");
+}, "'all' shorthand alone");
+
+test(function() {
+  style.cssText = "width: 100px; all: inherit; height: inherit";
+  assert_equals(style.cssText, "all: inherit;");
+}, "'all' shorthand with 'width' and 'height'");
+
+test(function() {
+  style.cssText = "direction: ltr; all: inherit; unicode-bidi: plaintext";
+  assert_equals(style.cssText, "direction: ltr; all: inherit; unicode-bidi: plaintext;");
+}, "'all' shorthand with 'direction' and 'unicode-bidi'");
+
+test(function() {
+  style.cssText = "width: 100px; --a: a; all: inherit; --b: b; height: inherit";
+  assert_equals(style.cssText, "--a: a; all: inherit; --b: b;");
+}, "'all' shorthand with 'width', 'height' and custom properties");
+
+test(function() {
+  let cssText = "all: inherit; ";
+  for (let longhand of getComputedStyle(document.documentElement)) {
+    cssText += longhand + ": inherit; ";
+  }
+  style.cssText = cssText;
+  assert_equals(style.cssText, "all: inherit; direction: inherit; unicode-bidi: inherit;");
+}, "'all' shorthand with all longhands");
+</script>

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -1680,6 +1680,19 @@ StringBuilder StyleProperties::asTextInternal() const
             shorthands.append(substitutionValue.shorthandPropertyId());
             value = substitutionValue.shorthandValue().cssText();
         } else {
+            // FIXME: could probably use matchingShorthandsForLonghand() instead of populating 'shorthands' manually.
+            switch (propertyID) {
+            case CSSPropertyCustom:
+            case CSSPropertyDirection:
+            case CSSPropertyUnicodeBidi:
+                // These are the only longhands not included in the 'all' shorthand.
+                break;
+            default:
+                ASSERT(propertyID >= firstCSSProperty);
+                ASSERT(propertyID < firstShorthandProperty);
+                shorthands.append(CSSPropertyAll);
+            }
+
             switch (propertyID) {
             case CSSPropertyAnimationName:
             case CSSPropertyAnimationDuration:
@@ -1968,6 +1981,8 @@ StringBuilder StyleProperties::asTextInternal() const
     // In 2007 we decided this was required because background-position-x/y are non-standard properties and WebKit generated output would not work in Firefox (<rdar://problem/5143183>).
     // FIXME: This can probably be cleaned up now that background-position-x/y are standardized.
     auto appendPositionOrProperty = [&] (int xIndex, int yIndex, const char* name, const StylePropertyShorthand& shorthand) {
+        if (shorthandPropertyUsed[CSSPropertyAll - firstShorthandProperty])
+            return;
         if (xIndex != -1 && yIndex != -1 && propertyAt(xIndex).isImportant() == propertyAt(yIndex).isImportant()) {
             String value;
             auto xProperty = propertyAt(xIndex);


### PR DESCRIPTION
#### 4481e38af645d3bac270241c50053345a9962d8a
<pre>
[cssom] Serialize the &apos;all&apos; shorthand in cssText
<a href="https://bugs.webkit.org/show_bug.cgi?id=190753">https://bugs.webkit.org/show_bug.cgi?id=190753</a>

Reviewed by Darin Adler.

Test: imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-all-shorthand.html

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-all-shorthand-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-all-shorthand.html: Added.
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::asTextInternal const):

Canonical link: <a href="https://commits.webkit.org/255329@main">https://commits.webkit.org/255329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed06b6c5bef9541fda88e7822bf45f1f0f54c5ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1386 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101943 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162121 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1384 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29777 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84598 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98110 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/890 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78679 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27830 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70868 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36204 "Built successfully") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33961 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17538 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3695 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40225 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36665 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->