### PR TITLE
[css-typed-om] Implement CSSRotate::toMatrix()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix-expected.txt
@@ -1,6 +1,6 @@
 
 PASS CSSTranslate.toMatrix() returns correct matrix
-FAIL CSSRotate.toMatrix() returns correct matrix assert_array_approx_equals: property 0, expected 0.07142857142857148 +/- 0.000001, expected 0.07142857142857148 but got 1
+PASS CSSRotate.toMatrix() returns correct matrix
 PASS CSSScale.toMatrix() returns correct matrix
 PASS CSSSkew.toMatrix() returns correct matrix
 PASS CSSSkewX.toMatrix() returns correct matrix

--- a/Source/WebCore/css/typedom/transform/CSSRotate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSRotate.cpp
@@ -182,8 +182,21 @@ void CSSRotate::serialize(StringBuilder& builder) const
 
 ExceptionOr<Ref<DOMMatrix>> CSSRotate::toMatrix()
 {
-    // FIXME: Implement.
-    return DOMMatrix::fromMatrix(DOMMatrixInit { });
+    if (!is<CSSUnitValue>(m_angle) || !is<CSSUnitValue>(m_x) || !is<CSSUnitValue>(m_y) || !is<CSSUnitValue>(m_z))
+        return Exception { TypeError };
+
+    auto angle = downcast<CSSUnitValue>(m_angle.get()).convertTo(CSSUnitType::CSS_DEG);
+    if (!angle)
+        return Exception { TypeError };
+
+    auto x = downcast<CSSUnitValue>(m_x.get()).value();
+    auto y = downcast<CSSUnitValue>(m_y.get()).value();
+    auto z = downcast<CSSUnitValue>(m_z.get()).value();
+
+    TransformationMatrix matrix { };
+    matrix.rotate3d(x, y, z, angle->value());
+
+    return { DOMMatrix::create(WTFMove(matrix), is2D() ? DOMMatrixReadOnly::Is2D::Yes : DOMMatrixReadOnly::Is2D::No) };
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 81e612a951476739e55774492cf6a6c7ce3d1c33
<pre>
[css-typed-om] Implement CSSRotate::toMatrix()
<a href="https://bugs.webkit.org/show_bug.cgi?id=246082">https://bugs.webkit.org/show_bug.cgi?id=246082</a>

Reviewed by Antti Koivisto.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix-expected.txt:
* Source/WebCore/css/typedom/transform/CSSRotate.cpp:
(WebCore::CSSRotate::toMatrix):

Canonical link: <a href="https://commits.webkit.org/255187@main">https://commits.webkit.org/255187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b50f796b63d2f5689aaa302b53d9eb3dbd63eca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/905 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101370 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/904 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83989 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97333 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/27484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35795 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/33549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37393 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1611 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39298 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->