### PR TITLE
[css-typed-om] Implement CSSPerspective::toMatrix()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix-expected.txt
@@ -5,6 +5,6 @@ PASS CSSScale.toMatrix() returns correct matrix
 PASS CSSSkew.toMatrix() returns correct matrix
 PASS CSSSkewX.toMatrix() returns correct matrix
 PASS CSSSkewY.toMatrix() returns correct matrix
-FAIL CSSPerspective.toMatrix() returns correct matrix assert_array_approx_equals: property 11, expected -0.1 +/- 0.000001, expected -0.1 but got 0
+PASS CSSPerspective.toMatrix() returns correct matrix
 FAIL CSSMatrixComponent.toMatrix() returns correct matrix assert_array_approx_equals: property 1, expected 2 +/- 0.000001, expected 2 but got 0
 

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
@@ -143,8 +143,17 @@ void CSSPerspective::serialize(StringBuilder& builder) const
 
 ExceptionOr<Ref<DOMMatrix>> CSSPerspective::toMatrix()
 {
-    // FIXME: Implement.
-    return DOMMatrix::fromMatrix(DOMMatrixInit { });
+    if (!std::holds_alternative<RefPtr<CSSNumericValue>>(m_length))
+        return { DOMMatrix::create({ }, DOMMatrixReadOnly::Is2D::Yes) };
+
+    auto length = std::get<RefPtr<CSSNumericValue>>(m_length);
+    if (!is<CSSUnitValue>(length))
+        return Exception { TypeError };
+
+    TransformationMatrix matrix { };
+    matrix.applyPerspective(downcast<CSSUnitValue>(*length).value());
+
+    return { DOMMatrix::create(WTFMove(matrix), DOMMatrixReadOnly::Is2D::No) };
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 7e2adfec75953584a79f290edb645e4191559c91
<pre>
[css-typed-om] Implement CSSPerspective::toMatrix()
<a href="https://bugs.webkit.org/show_bug.cgi?id=246081">https://bugs.webkit.org/show_bug.cgi?id=246081</a>

Reviewed by Antti Koivisto.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix-expected.txt:
* Source/WebCore/css/typedom/transform/CSSPerspective.cpp:
(WebCore::CSSPerspective::toMatrix):

Canonical link: <a href="https://commits.webkit.org/255189@main">https://commits.webkit.org/255189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/541e7a7f9ff1b82b395f9c99bcc6d649775aadb8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/908 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/101373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/907 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97336 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/83992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35798 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/33552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37396 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1613 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/39301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->