### PR TITLE
Fix typo plartformAccessibilityBusAddress -> platformAccessibilityBusAddress

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -347,7 +347,7 @@ const String& PlatformDisplay::accessibilityBusAddress() const
         return m_accessibilityBusAddress.value();
     }
 
-    auto platformAddress = plartformAccessibilityBusAddress();
+    auto platformAddress = platformAccessibilityBusAddress();
     if (!platformAddress.isEmpty()) {
         m_accessibilityBusAddress = platformAddress;
         return m_accessibilityBusAddress.value();

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -138,7 +138,7 @@ protected:
 #endif
 
 #if USE(ATSPI)
-    virtual String plartformAccessibilityBusAddress() const { return { }; }
+    virtual String platformAccessibilityBusAddress() const { return { }; }
 
     mutable std::optional<String> m_accessibilityBusAddress;
 #endif

--- a/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp
+++ b/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp
@@ -264,7 +264,7 @@ cmsHPROFILE PlatformDisplayX11::colorProfile() const
 #endif
 
 #if USE(ATSPI)
-String PlatformDisplayX11::plartformAccessibilityBusAddress() const
+String PlatformDisplayX11::platformAccessibilityBusAddress() const
 {
     Atom atspiBusAtom = XInternAtom(m_display, "AT_SPI_BUS", False);
     Atom type;

--- a/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h
+++ b/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h
@@ -72,7 +72,7 @@ private:
 #endif
 
 #if USE(ATSPI)
-    String plartformAccessibilityBusAddress() const override;
+    String platformAccessibilityBusAddress() const override;
 #endif
 
     ::Display* m_display { nullptr };


### PR DESCRIPTION
#### 51c6953d8692801795c96458d78a0e074a351311
<pre>
Fix typo plartformAccessibilityBusAddress -&gt; platformAccessibilityBusAddress
<a href="https://bugs.webkit.org/show_bug.cgi?id=246086">https://bugs.webkit.org/show_bug.cgi?id=246086</a>

Reviewed by Tim Nguyen.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::accessibilityBusAddress const):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
(WebCore::PlatformDisplay::platformAccessibilityBusAddress const):
(WebCore::PlatformDisplay::plartformAccessibilityBusAddress const): Deleted.
* Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp:
(WebCore::PlatformDisplayX11::platformAccessibilityBusAddress const):
(WebCore::PlatformDisplayX11::plartformAccessibilityBusAddress const): Deleted.
* Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h:

Canonical link: <a href="https://commits.webkit.org/255177@main">https://commits.webkit.org/255177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaed07768af3cef1d623f0e4df15d22035800924

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/872 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101341 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/870 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83960 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/503 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27463 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35765 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33520 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3591 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37361 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39266 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->