### PR TITLE
Fix WebCodecsVideoDecoder isValidDecoderConfig

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt
@@ -4,20 +4,10 @@ PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Unrecogni
 PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Audio codec
 PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Ambiguous codec
 PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Codec with MIME type
-FAIL Test that VideoDecoder.configure() rejects invalid config:Empty codec assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoDecoder.configure() rejects invalid config:Unrecognized codec assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoDecoder.configure() rejects invalid config:Audio codec assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoDecoder.configure() rejects invalid config:Ambiguous codec assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoDecoder.configure() rejects invalid config:Codec with MIME type assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+PASS Test that VideoDecoder.configure() rejects invalid config:Empty codec
+PASS Test that VideoDecoder.configure() rejects invalid config:Unrecognized codec
+PASS Test that VideoDecoder.configure() rejects invalid config:Audio codec
+PASS Test that VideoDecoder.configure() rejects invalid config:Ambiguous codec
+PASS Test that VideoDecoder.configure() rejects invalid config:Codec with MIME type
 PASS Test VideoDecoder construction
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt
@@ -4,20 +4,10 @@ PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Unrecogni
 PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Audio codec
 PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Ambiguous codec
 PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Codec with MIME type
-FAIL Test that VideoDecoder.configure() rejects invalid config:Empty codec assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoDecoder.configure() rejects invalid config:Unrecognized codec assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoDecoder.configure() rejects invalid config:Audio codec assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoDecoder.configure() rejects invalid config:Ambiguous codec assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoDecoder.configure() rejects invalid config:Codec with MIME type assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+PASS Test that VideoDecoder.configure() rejects invalid config:Empty codec
+PASS Test that VideoDecoder.configure() rejects invalid config:Unrecognized codec
+PASS Test that VideoDecoder.configure() rejects invalid config:Audio codec
+PASS Test that VideoDecoder.configure() rejects invalid config:Ambiguous codec
+PASS Test that VideoDecoder.configure() rejects invalid config:Codec with MIME type
 PASS Test VideoDecoder construction
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_annexb-expected.txt
@@ -2,7 +2,7 @@
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
 PASS Test that isConfigSupported() returns a parsed configuration
-FAIL Test invalid configs assert_unreached: Should have rejected: invalid codedWidth Reached unreachable code
+PASS Test invalid configs
 PASS Test configure()
 FAIL Decode a key frame assert_equals: outputs expected 1 but got 0
 PASS Decode a non key frame first fails

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_avc-expected.txt
@@ -2,7 +2,7 @@
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
 PASS Test that isConfigSupported() returns a parsed configuration
-FAIL Test invalid configs assert_unreached: Should have rejected: invalid codedWidth Reached unreachable code
+PASS Test invalid configs
 FAIL Test configure() assert_equals: state expected "configured" but got "closed"
 FAIL Decode a key frame promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
 FAIL Decode a non key frame first fails assert_throws_dom: function "() => decoder.decode(CHUNKS[1], 'decode')" threw object "InvalidStateError: VideoDecoder is not configured" that is not a DOMException DataError: property "code" is equal to 11, expected 0

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp8-expected.txt
@@ -2,7 +2,7 @@
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
 PASS Test that isConfigSupported() returns a parsed configuration
-FAIL Test invalid configs assert_unreached: Should have rejected: invalid codedWidth Reached unreachable code
+PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame
 PASS Decode a non key frame first fails

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp9-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp9-expected.txt
@@ -2,7 +2,7 @@
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
 PASS Test that isConfigSupported() returns a parsed configuration
-FAIL Test invalid configs assert_unreached: Should have rejected: invalid codedWidth Reached unreachable code
+PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame
 PASS Decode a non key frame first fails

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_annexb-expected.txt
@@ -2,7 +2,7 @@
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
 PASS Test that isConfigSupported() returns a parsed configuration
-FAIL Test invalid configs assert_unreached: Should have rejected: invalid codedWidth Reached unreachable code
+PASS Test invalid configs
 PASS Test configure()
 FAIL Decode a key frame assert_equals: outputs expected 1 but got 0
 PASS Decode a non key frame first fails

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_avc-expected.txt
@@ -2,7 +2,7 @@
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
 PASS Test that isConfigSupported() returns a parsed configuration
-FAIL Test invalid configs assert_unreached: Should have rejected: invalid codedWidth Reached unreachable code
+PASS Test invalid configs
 FAIL Test configure() assert_equals: state expected "configured" but got "closed"
 FAIL Decode a key frame promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
 FAIL Decode a non key frame first fails assert_throws_dom: function "() => decoder.decode(CHUNKS[1], 'decode')" threw object "InvalidStateError: VideoDecoder is not configured" that is not a DOMException DataError: property "code" is equal to 11, expected 0

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp8-expected.txt
@@ -2,7 +2,7 @@
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
 PASS Test that isConfigSupported() returns a parsed configuration
-FAIL Test invalid configs assert_unreached: Should have rejected: invalid codedWidth Reached unreachable code
+PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame
 PASS Decode a non key frame first fails

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp9-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp9-expected.txt
@@ -2,7 +2,7 @@
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
 PASS Test that isConfigSupported() returns a parsed configuration
-FAIL Test invalid configs assert_unreached: Should have rejected: invalid codedWidth Reached unreachable code
+PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame
 PASS Decode a non key frame first fails

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -49,7 +49,6 @@ Ref<WebCodecsVideoDecoder> WebCodecsVideoDecoder::create(ScriptExecutionContext&
     return decoder;
 }
 
-
 WebCodecsVideoDecoder::WebCodecsVideoDecoder(ScriptExecutionContext& context, Init&& init)
     : ActiveDOMObject(&context)
     , m_output(init.output.releaseNonNull())
@@ -61,8 +60,34 @@ WebCodecsVideoDecoder::~WebCodecsVideoDecoder()
 {
 }
 
+static bool isValidDecoderConfig(const WebCodecsVideoDecoderConfig& config)
+{
+    // FIXME: Check codec more accurately.
+    if (!config.codec.startsWith("vp8"_s) && !config.codec.startsWith("vp09."_s) && !config.codec.startsWith("avc1."_s))
+        return false;
+
+    if (!!config.codedWidth != !!config.codedHeight)
+        return false;
+    if (config.codedWidth && !*config.codedWidth)
+        return false;
+    if (config.codedHeight && !*config.codedHeight)
+        return false;
+
+    if (!!config.displayAspectWidth != !!config.displayAspectHeight)
+        return false;
+    if (config.displayAspectWidth && !*config.displayAspectWidth)
+        return false;
+    if (config.displayAspectHeight && !*config.displayAspectHeight)
+        return false;
+
+    return true;
+}
+
 ExceptionOr<void> WebCodecsVideoDecoder::configure(WebCodecsVideoDecoderConfig&& config)
 {
+    if (!isValidDecoderConfig(config))
+        return Exception { TypeError, "Config is not valid"_s };
+
     if (m_state == WebCodecsCodecState::Closed || !scriptExecutionContext())
         return Exception { InvalidStateError, "VideoDecoder is closed"_s };
 
@@ -176,29 +201,6 @@ ExceptionOr<void> WebCodecsVideoDecoder::reset()
 ExceptionOr<void> WebCodecsVideoDecoder::close()
 {
     return closeDecoder(Exception { AbortError, "Close called"_s });
-}
-
-static bool isValidDecoderConfig(const WebCodecsVideoDecoderConfig& config)
-{
-    // FIXME: Check codec more accurately.
-    if (!config.codec.startsWith("vp8"_s) && !config.codec.startsWith("vp09.00"_s) && !config.codec.startsWith("avc1."_s) && !config.codec.startsWith("hev1."_s))
-        return false;
-
-    if (!!config.codedWidth != !!config.codedHeight)
-        return false;
-    if (config.codedWidth && !config.codedWidth)
-        return false;
-    if (config.codedWidth && !config.codedHeight)
-        return false;
-
-    if (!!config.displayAspectWidth != !!config.displayAspectHeight)
-        return false;
-    if (config.displayAspectWidth && !config.displayAspectWidth)
-        return false;
-    if (config.displayAspectHeight && !config.displayAspectHeight)
-        return false;
-
-    return true;
 }
 
 void WebCodecsVideoDecoder::isConfigSupported(WebCodecsVideoDecoderConfig&& config, Ref<DeferredPromise>&& promise)


### PR DESCRIPTION
#### b02ab78bd7bb5e79ac9dadef16b3f8231523609d
<pre>
Fix WebCodecsVideoDecoder isValidDecoderConfig
<a href="https://bugs.webkit.org/show_bug.cgi?id=246079">https://bugs.webkit.org/show_bug.cgi?id=246079</a>
rdar://problem/100805259

Reviewed by Eric Carlson.

Add a check to validate decoder config in WebCodecsVideoDecoder::configure.
Also fix the actual checks so that they are inline with <a href="https://w3c.github.io/webcodecs/#valid-videodecoderconfig.">https://w3c.github.io/webcodecs/#valid-videodecoderconfig.</a>

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp9-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp9-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::isValidDecoderConfig):
(WebCore::WebCodecsVideoDecoder::configure):

Canonical link: <a href="https://commits.webkit.org/255260@main">https://commits.webkit.org/255260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5dfc958201d5b464b0efce8a6fd536c43f76257

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22494 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/101779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1198 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97616 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78508 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/84430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82656 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36049 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33787 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/17377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3643 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37664 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39548 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36501 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->