### PR TITLE
Automate deletion of temporary files on windows bots

### DIFF
--- a/Tools/CISupport/delete-stale-build-files
+++ b/Tools/CISupport/delete-stale-build-files
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2013-2020 Apple Inc.  All rights reserved.
+# Copyright (C) 2013-2022 Apple Inc.  All rights reserved.
 # Copyright (C) 2012 Google Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -25,6 +25,7 @@
 
 import optparse
 import os
+import shutil
 import subprocess
 import sys
 
@@ -38,15 +39,19 @@ def main():
 
     options, parameters = parser.parse_args()
     if not options.platform:
-        parser.error("Platform is required")
+        parser.error('Platform is required')
         return -1
+
+    if options.platform == 'win':
+        return deleteWindowsStaleFiles()
+
     if not options.configuration:
-        parser.error("Configuration is required")
+        parser.error('Configuration is required')
         return -2
 
     genericPlatform = options.platform.split('-', 1)[0]
     if genericPlatform not in ('mac', 'ios'):
-        print('Exited without removing any files.')
+        print('Exited without removing any files since platform {} is not supported by this script.'.format(genericPlatform))
         return 0
 
     if options.build_directory:
@@ -85,6 +90,20 @@ def webkitBuildDirectory(platform, fullPlatform, configuration):
         platform = 'device'
     return subprocess.Popen(['perl', os.path.join(os.path.dirname(__file__), "..", "Scripts", "webkit-build-directory"),
         "--" + platform, "--" + configuration, '--top-level'], stdout=subprocess.PIPE).communicate()[0].strip()
+
+def deleteWindowsStaleFiles():
+    directoriesToDelete = ['/cygdrive/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/sym/WebKit.pdb',
+                           '/cygdrive/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/sym/WTF.pdb',
+                           '/cygdrive/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/sym/JavaScriptCore.pdb',
+                           '/cygdrive/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/sym/DumpRenderTreeLib.pdb']
+    for directory in directoriesToDelete:
+        try:
+            print(f'Removing: {directory}')
+            shutil.rmtree(directory)
+        except OSError as e:
+            print(f'Failed to remove: {directory}, error: {e}')
+            continue
+        print('Done')
 
 
 if __name__ == '__main__':

--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -27,7 +27,7 @@ from buildbot.steps import trigger
 from steps import (AddReviewerToCommitMessage, ApplyPatch, ApplyWatchList, Canonicalize, CommitPatch,
                    CheckOutPullRequest, CheckOutSource, CheckOutSpecificRevision, CheckChangeRelevance,
                    CheckStatusOnEWSQueues, CheckStyle, CleanGitRepo, CompileJSC, CompileWebKit, ConfigureBuild,
-                   DownloadBuiltProduct, ExtractBuiltProduct, FetchBranches, FindModifiedLayoutTests,
+                   DeleteStaleBuildFiles, DownloadBuiltProduct, ExtractBuiltProduct, FetchBranches, FindModifiedLayoutTests,
                    InstallGtkDependencies, InstallWpeDependencies, KillOldProcesses, PrintConfiguration, PushCommitToWebKitRepo, PushPullRequestBranch,
                    RunAPITests, RunBindingsTests, RunBuildWebKitOrgUnitTests, RunBuildbotCheckConfigForBuildWebKit, RunBuildbotCheckConfigForEWS,
                    RunEWSUnitTests, RunResultsdbpyTests, RunJavaScriptCoreTests, RunWebKit1Tests, RunWebKitPerlTests, RunWebKitPyPython2Tests,
@@ -49,6 +49,8 @@ class Factory(factory.BuildFactory):
             self.addStep(FindModifiedLayoutTests())
         self.addStep(ValidateChange())
         self.addStep(PrintConfiguration())
+        if platform == 'win':
+            self.addStep(DeleteStaleBuildFiles())
         self.addStep(CleanGitRepo())
         self.addStep(CheckOutSource())
         self.addStep(FetchBranches())

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -350,6 +350,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'check-change-relevance',
             'validate-change',
             'configuration',
+            'delete-stale-build-files',
             'clean-up-git-repo',
             'checkout-source',
             'fetch-branch-references',

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5261,3 +5261,16 @@ class UpdatePullRequest(shell.ShellCommand, GitHubMixin, AddToLogMixin):
 
     def hideStepIf(self, results, step):
         return not self.doStepIf(step)
+
+
+class DeleteStaleBuildFiles(shell.ShellCommand):
+    name = 'delete-stale-build-files'
+    description = ['Deleting stale build files']
+    descriptionDone = ['Deleted stale build files']
+    command = ['python3', 'Tools/CISupport/delete-stale-build-files', WithProperties('--platform=%(fullPlatform)s')]
+    haltOnFailure = False
+    flunkOnFailure = False
+    warnOnFailure = False
+
+    def __init__(self, **kwargs):
+        super(DeleteStaleBuildFiles, self).__init__(logEnviron=False, timeout=600, **kwargs)


### PR DESCRIPTION
#### 9095b91f6ddaab1506f93fa0154f568cf2ebe6bf
<pre>
Automate deletion of temporary files on windows bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=245786">https://bugs.webkit.org/show_bug.cgi?id=245786</a>
&lt;rdar://100635624&gt;

Reviewed by Darin Adler.

* Tools/CISupport/delete-stale-build-files:
* Tools/CISupport/ews-build/factories.py:
* Tools/CISupport/ews-build/steps.py:
(DeleteStaleBuildFiles):
(DeleteStaleBuildFiles.__init__):
* Tools/CISupport/ews-build/steps_unittest.py:
* Tools/CISupport/ews-build/factories_unittest.py:

Canonical link: <a href="https://commits.webkit.org/255619@main">https://commits.webkit.org/255619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fd6d489710cca59c61c53d42b127aaf206022cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101349 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161438 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/878 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29486 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/83968 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97680 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/510 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78306 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27466 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82434 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70504 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35773 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16108 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/90716 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33528 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17204 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/39957 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1791 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36321 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->