### PR TITLE
Handle blob: PolicyContainer inheritance from the Network Process

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/history-iframe.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/history-iframe.sub-expected.txt
@@ -4,8 +4,8 @@ Harness Error (TIMEOUT), message = null
 
 PASS History navigation in iframe: "about:blank" document is navigated back from history same-origin.
 PASS History navigation in iframe: "about:blank" document is navigated back from history cross-origin.
-FAIL History navigation in iframe: blob URL document is navigated back from history same-origin. assert_equals: Image should be blocked by CSP reloaded from history. expected "img blocked" but got "img loaded"
-FAIL History navigation in iframe: blob URL document is navigated back from history cross-origin. assert_equals: Image should be blocked by CSP reloaded from history. expected "img blocked" but got "img loaded"
+PASS History navigation in iframe: blob URL document is navigated back from history same-origin.
+PASS History navigation in iframe: blob URL document is navigated back from history cross-origin.
 PASS History navigation in iframe: data URL document is navigated back from history same-origin.
 PASS History navigation in iframe: data URL document is navigated back from history cross-origin.
 TIMEOUT History navigation in iframe: srcdoc iframe is navigated back from history same-origin. Test timed out

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub-expected.txt
@@ -1,8 +1,8 @@
 
 PASS History navigation: "about:blank" document is navigated back from history same-origin.
 PASS History navigation: "about:blank" document is navigated back from history cross-origin.
-FAIL History navigation: blob URL document is navigated back from history same-origin. assert_equals: Image should be blocked by CSP reloaded from history. expected "img blocked" but got "img loaded"
-FAIL History navigation: blob URL document is navigated back from history cross-origin. assert_equals: Image should be blocked by CSP reloaded from history. expected "img blocked" but got "img loaded"
-FAIL History navigation: blob URL document is navigated back from history (without bfcache on Firefox) same-origin. assert_equals: Image should be blocked by CSP reloaded from history. expected "img blocked" but got "img loaded"
-FAIL History navigation: blob URL document is navigated back from history (without bfcache on Firefox) cross-origin. assert_equals: Image should be blocked by CSP reloaded from history. expected "img blocked" but got "img loaded"
+PASS History navigation: blob URL document is navigated back from history same-origin.
+PASS History navigation: blob URL document is navigated back from history cross-origin.
+PASS History navigation: blob URL document is navigated back from history (without bfcache on Firefox) same-origin.
+PASS History navigation: blob URL document is navigated back from history (without bfcache on Firefox) cross-origin.
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1698,6 +1698,7 @@ loader/NavigationScheduler.cpp
 loader/NetscapePlugInStreamLoader.cpp
 loader/PingLoader.cpp
 loader/PolicyChecker.cpp
+loader/PolicyContainer.cpp
 loader/PrivateClickMeasurement.cpp
 loader/ProgressTracker.cpp
 loader/ResourceCryptographicDigest.cpp

--- a/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
@@ -90,21 +90,21 @@ CrossOriginEmbedderPolicy CrossOriginEmbedderPolicy::isolatedCopy() &&
     };
 }
 
-void addCrossOriginEmbedderPolicyHeaders(ResourceResponse& response, const CrossOriginEmbedderPolicy& coep)
+void CrossOriginEmbedderPolicy::addPolicyHeadersTo(ResourceResponse& response) const
 {
-    if (coep.value != CrossOriginEmbedderPolicyValue::UnsafeNone) {
-        ASSERT(coep.value == CrossOriginEmbedderPolicyValue::RequireCORP);
-        if (coep.reportingEndpoint.isEmpty())
+    if (value != CrossOriginEmbedderPolicyValue::UnsafeNone) {
+        ASSERT(value == CrossOriginEmbedderPolicyValue::RequireCORP);
+        if (reportingEndpoint.isEmpty())
             response.setHTTPHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicy, "require-corp"_s);
         else
-            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicy, makeString("require-corp; report-to=\"", coep.reportingEndpoint, '\"'));
+            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicy, makeString("require-corp; report-to=\"", reportingEndpoint, '\"'));
     }
-    if (coep.reportOnlyValue != CrossOriginEmbedderPolicyValue::UnsafeNone) {
-        ASSERT(coep.reportOnlyValue == CrossOriginEmbedderPolicyValue::RequireCORP);
-        if (coep.reportOnlyReportingEndpoint.isEmpty())
+    if (reportOnlyValue != CrossOriginEmbedderPolicyValue::UnsafeNone) {
+        ASSERT(reportOnlyValue == CrossOriginEmbedderPolicyValue::RequireCORP);
+        if (reportOnlyReportingEndpoint.isEmpty())
             response.setHTTPHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicyReportOnly, "require-corp"_s);
         else
-            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicyReportOnly, makeString("require-corp; report-to=\"", coep.reportOnlyReportingEndpoint, '\"'));
+            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicyReportOnly, makeString("require-corp; report-to=\"", reportOnlyReportingEndpoint, '\"'));
     }
 }
 

--- a/Source/WebCore/loader/CrossOriginEmbedderPolicy.h
+++ b/Source/WebCore/loader/CrossOriginEmbedderPolicy.h
@@ -54,6 +54,8 @@ struct CrossOriginEmbedderPolicy {
     CrossOriginEmbedderPolicy isolatedCopy() &&;
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<CrossOriginEmbedderPolicy> decode(Decoder&);
+
+    void addPolicyHeadersTo(ResourceResponse&) const;
 };
 
 inline bool operator==(const CrossOriginEmbedderPolicy& a, const CrossOriginEmbedderPolicy& b)
@@ -101,7 +103,6 @@ std::optional<CrossOriginEmbedderPolicy> CrossOriginEmbedderPolicy::decode(Decod
 enum class COEPDisposition : bool { Reporting , Enforce };
 
 WEBCORE_EXPORT CrossOriginEmbedderPolicy obtainCrossOriginEmbedderPolicy(const ResourceResponse&, const ScriptExecutionContext*);
-WEBCORE_EXPORT void addCrossOriginEmbedderPolicyHeaders(ResourceResponse&, const CrossOriginEmbedderPolicy&);
 WEBCORE_EXPORT void sendCOEPInheritenceViolation(ReportingClient&, const URL& embedderURL, const String& endpoint, COEPDisposition, const String& type, const URL& blockedURL);
 WEBCORE_EXPORT void sendCOEPCORPViolation(ReportingClient&, const URL& embedderURL, const String& endpoint, COEPDisposition, FetchOptions::Destination, const URL& blockedURL);
 

--- a/Source/WebCore/loader/CrossOriginOpenerPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginOpenerPolicy.cpp
@@ -233,19 +233,19 @@ CrossOriginOpenerPolicy CrossOriginOpenerPolicy::isolatedCopy() &&
     return { value, WTFMove(reportingEndpoint).isolatedCopy(), reportOnlyValue, WTFMove(reportOnlyReportingEndpoint).isolatedCopy() };
 }
 
-void addCrossOriginOpenerPolicyHeaders(ResourceResponse& response, const CrossOriginOpenerPolicy& coop)
+void CrossOriginOpenerPolicy::addPolicyHeadersTo(ResourceResponse& response) const
 {
-    if (coop.value != CrossOriginOpenerPolicyValue::UnsafeNone) {
-        if (coop.reportingEndpoint.isEmpty())
-            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginOpenerPolicy, crossOriginOpenerPolicyToString(coop.value));
+    if (value != CrossOriginOpenerPolicyValue::UnsafeNone) {
+        if (reportingEndpoint.isEmpty())
+            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginOpenerPolicy, crossOriginOpenerPolicyToString(value));
         else
-            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginOpenerPolicy, makeString(crossOriginOpenerPolicyToString(coop.value), "; report-to=\"", coop.reportingEndpoint, '\"'));
+            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginOpenerPolicy, makeString(crossOriginOpenerPolicyToString(value), "; report-to=\"", reportingEndpoint, '\"'));
     }
-    if (coop.reportOnlyValue != CrossOriginOpenerPolicyValue::UnsafeNone) {
-        if (coop.reportOnlyReportingEndpoint.isEmpty())
-            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginOpenerPolicyReportOnly, crossOriginOpenerPolicyToString(coop.reportOnlyValue));
+    if (reportOnlyValue != CrossOriginOpenerPolicyValue::UnsafeNone) {
+        if (reportOnlyReportingEndpoint.isEmpty())
+            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginOpenerPolicyReportOnly, crossOriginOpenerPolicyToString(reportOnlyValue));
         else
-            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginOpenerPolicyReportOnly, makeString(crossOriginOpenerPolicyToString(coop.reportOnlyValue), "; report-to=\"", coop.reportOnlyReportingEndpoint, '\"'));
+            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginOpenerPolicyReportOnly, makeString(crossOriginOpenerPolicyToString(reportOnlyValue), "; report-to=\"", reportOnlyReportingEndpoint, '\"'));
     }
 }
 

--- a/Source/WebCore/loader/CrossOriginOpenerPolicy.h
+++ b/Source/WebCore/loader/CrossOriginOpenerPolicy.h
@@ -65,6 +65,8 @@ struct CrossOriginOpenerPolicy {
     CrossOriginOpenerPolicy isolatedCopy() &&;
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<CrossOriginOpenerPolicy> decode(Decoder&);
+
+    void addPolicyHeadersTo(ResourceResponse&) const;
 };
 
 inline const String& CrossOriginOpenerPolicy::reportingEndpointForDisposition(COOPDisposition disposition) const
@@ -132,7 +134,6 @@ struct CrossOriginOpenerPolicyEnforcementResult {
 };
 
 CrossOriginOpenerPolicy obtainCrossOriginOpenerPolicy(const ResourceResponse&);
-WEBCORE_EXPORT void addCrossOriginOpenerPolicyHeaders(ResourceResponse&, const CrossOriginOpenerPolicy&);
 WEBCORE_EXPORT std::optional<CrossOriginOpenerPolicyEnforcementResult> doCrossOriginOpenerHandlingOfResponse(ReportingClient&, const ResourceResponse&, const std::optional<NavigationRequester>&, ContentSecurityPolicy* responseCSP, SandboxFlags effectiveSandboxFlags, const String& referrer, bool isDisplayingInitialEmptyDocument, const CrossOriginOpenerPolicyEnforcementResult& currentCoopEnforcementResult);
 
 } // namespace WebCore

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -193,11 +193,11 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
         document->setContentSecurityPolicy(makeUnique<ContentSecurityPolicy>(URL { url }, document));
         document->contentSecurityPolicy()->copyStateFrom(ownerDocument->contentSecurityPolicy());
         document->contentSecurityPolicy()->setInsecureNavigationRequestsToUpgrade(ownerDocument->contentSecurityPolicy()->takeNavigationRequestsToUpgrade());
-    } else if (url.hasLocalScheme()) {
+    } else if (url.protocolIsAbout() || url.protocolIsData()) {
         // https://html.spec.whatwg.org/multipage/origin.html#determining-navigation-params-policy-container
         auto* currentHistoryItem = m_frame->loader().history().currentItem();
 
-        if (!url.protocolIsBlob() && currentHistoryItem && currentHistoryItem->policyContainer()) {
+        if (currentHistoryItem && currentHistoryItem->policyContainer()) {
             const auto& policyContainerFromHistory = currentHistoryItem->policyContainer();
             ASSERT(policyContainerFromHistory);
             document->inheritPolicyContainerFrom(*policyContainerFromHistory);
@@ -213,7 +213,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
         }
 
         // https://html.spec.whatwg.org/multipage/origin.html#requires-storing-the-policy-container-in-history
-        if (triggeringAction && triggeringAction->type() != NavigationType::BackForward && !url.protocolIsBlob() && currentHistoryItem)
+        if (triggeringAction && triggeringAction->type() != NavigationType::BackForward && currentHistoryItem)
             currentHistoryItem->setPolicyContainer(document->policyContainer());
     }
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -763,6 +763,9 @@ void FrameLoader::didBeginDocument(bool dispatch)
         else
             m_frame.document()->contentSecurityPolicy()->didReceiveHeaders(ContentSecurityPolicyResponseHeaders(m_documentLoader->response()), referrer(), ContentSecurityPolicy::ReportParsingErrors::No);
 
+        if (m_frame.document()->url().protocolIsBlob())
+            m_frame.document()->contentSecurityPolicy()->updateSourceSelf(SecurityOrigin::create(m_frame.document()->url()));
+
         if (m_frame.document()->url().protocolIsInHTTPFamily() || m_frame.document()->url().protocolIsBlob())
             m_frame.document()->setCrossOriginEmbedderPolicy(obtainCrossOriginEmbedderPolicy(m_documentLoader->response(), m_frame.document()));
 

--- a/Source/WebCore/loader/PolicyContainer.cpp
+++ b/Source/WebCore/loader/PolicyContainer.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PolicyContainer.h"
+
+#include "ResourceResponse.h"
+
+namespace WebCore {
+
+void addPolicyContainerHeaders(ResourceResponse& response, const PolicyContainer& policyContainer)
+{
+    policyContainer.contentSecurityPolicyResponseHeaders.addPolicyHeadersTo(response);
+    policyContainer.crossOriginOpenerPolicy.addPolicyHeadersTo(response);
+    policyContainer.crossOriginEmbedderPolicy.addPolicyHeadersTo(response);
+    response.setHTTPHeaderField(HTTPHeaderName::ReferrerPolicy, referrerPolicyToString(policyContainer.referrerPolicy));
+}
+
+} // namespace WebCore

--- a/Source/WebCore/loader/PolicyContainer.h
+++ b/Source/WebCore/loader/PolicyContainer.h
@@ -90,4 +90,6 @@ std::optional<PolicyContainer> PolicyContainer::decode(Decoder& decoder)
     }};
 }
 
+WEBCORE_EXPORT void addPolicyContainerHeaders(ResourceResponse&, const PolicyContainer&);
+
 } // namespace WebCore

--- a/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.cpp
@@ -61,4 +61,18 @@ ContentSecurityPolicyResponseHeaders ContentSecurityPolicyResponseHeaders::isola
     return isolatedCopy;
 }
 
+void ContentSecurityPolicyResponseHeaders::addPolicyHeadersTo(ResourceResponse& response) const
+{
+    for (const auto& header : m_headers) {
+        switch (header.second) {
+        case ContentSecurityPolicyHeaderType::Enforce:
+            response.setHTTPHeaderField(HTTPHeaderName::ContentSecurityPolicy, header.first);
+            break;
+        case ContentSecurityPolicyHeaderType::Report:
+            response.setHTTPHeaderField(HTTPHeaderName::ContentSecurityPolicyReportOnly, header.first);
+            break;
+        }
+    }
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.h
@@ -62,6 +62,8 @@ public:
         }
     };
 
+    void addPolicyHeadersTo(ResourceResponse&) const;
+
 private:
     friend bool operator==(const ContentSecurityPolicyResponseHeaders&, const ContentSecurityPolicyResponseHeaders&);
     friend class ContentSecurityPolicy;

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -577,8 +577,7 @@ void BlobResourceHandle::notifyResponseOnSuccess()
     response.setHTTPHeaderField(HTTPHeaderName::ContentType, m_blobData->contentType());
     response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toAtomString());
     response.setHTTPHeaderField(HTTPHeaderName::ContentLength, String::number(m_totalRemainingSize));
-    addCrossOriginOpenerPolicyHeaders(response, m_blobData->policyContainer().crossOriginOpenerPolicy);
-    addCrossOriginEmbedderPolicyHeaders(response, m_blobData->policyContainer().crossOriginEmbedderPolicy);
+    addPolicyContainerHeaders(response, m_blobData->policyContainer());
 
     if (isRangeRequest) {
         auto rangeEnd = m_rangeEnd;

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -42,10 +42,9 @@
 #include "WebErrors.h"
 #include <WebCore/AsyncFileStream.h>
 #include <WebCore/BlobRegistryImpl.h>
-#include <WebCore/CrossOriginEmbedderPolicy.h>
-#include <WebCore/CrossOriginOpenerPolicy.h>
 #include <WebCore/HTTPParsers.h>
 #include <WebCore/ParsedContentRange.h>
+#include <WebCore/PolicyContainer.h>
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/SharedBuffer.h>
@@ -268,8 +267,7 @@ void NetworkDataTaskBlob::dispatchDidReceiveResponse(Error errorCode)
         response.setHTTPHeaderField(HTTPHeaderName::ContentType, m_blobData->contentType());
         response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toAtomString());
         response.setHTTPHeaderField(HTTPHeaderName::ContentLength, String::number(m_totalRemainingSize));
-        addCrossOriginOpenerPolicyHeaders(response, m_blobData->policyContainer().crossOriginOpenerPolicy);
-        addCrossOriginEmbedderPolicyHeaders(response, m_blobData->policyContainer().crossOriginEmbedderPolicy);
+        addPolicyContainerHeaders(response, m_blobData->policyContainer());
 
         if (isRangeRequest) {
             auto rangeEnd = m_rangeEnd;


### PR DESCRIPTION
#### 73a8787f1d069ff502146c0588eddf245a185999
<pre>
Handle blob: PolicyContainer inheritance from the Network Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=246093">https://bugs.webkit.org/show_bug.cgi?id=246093</a>
&lt;rdar://100813396&gt;

Reviewed by Chris Dumez.

The blob store in the Network process holds the appropriate PolicyContainer to inherit from.
This patch solves blob URL PolicyContainer inheritance by crafting an HTTP response with the
policy headers generated from that PolicyContainer.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/history-iframe.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub-expected.txt:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp:
(WebCore::CrossOriginEmbedderPolicy::addPolicyHeadersTo const):
(WebCore::addCrossOriginEmbedderPolicyHeaders): Deleted.
* Source/WebCore/loader/CrossOriginEmbedderPolicy.h:
* Source/WebCore/loader/CrossOriginOpenerPolicy.cpp:
(WebCore::CrossOriginOpenerPolicy::addPolicyHeadersTo const):
(WebCore::addCrossOriginOpenerPolicyHeaders): Deleted.
* Source/WebCore/loader/CrossOriginOpenerPolicy.h:
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::begin):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didBeginDocument):
    Blob inheritance effectively happens here. We parse the HTTP headers returned from the Network process
    and update our security origin to the origin of the blob URL. The SO that CSP needs for &apos;self&apos; in
    the case of the document having an opaque origin should be the blob&apos;s origin [0].
* Source/WebCore/loader/PolicyContainer.cpp: Copied from Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.cpp.
(WebCore::addPolicyContainerHeaders):
* Source/WebCore/loader/PolicyContainer.h:
* Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.cpp:
(WebCore::ContentSecurityPolicyResponseHeaders::addPolicyHeadersTo const):
* Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.h:
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::notifyResponseOnSuccess):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::dispatchDidReceiveResponse):

[0] <a href="https://w3c.github.io/webappsec-csp/#framework-policy">https://w3c.github.io/webappsec-csp/#framework-policy</a>

Canonical link: <a href="https://commits.webkit.org/255352@main">https://commits.webkit.org/255352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a95d79158de83fcd6ab3d3e2d1e84865dcedcdcf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102029 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1471 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29867 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98194 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97901 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78764 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/84686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36287 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34043 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/17667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3708 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37916 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39815 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/36808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->