### PR TITLE
[PlayStation][gpup] Add platform specific entry for gpu process on playstation port.

### DIFF
--- a/Source/WebKit/GPUProcess/EntryPoint/playstation/GPUProcessMain.cpp
+++ b/Source/WebKit/GPUProcess/EntryPoint/playstation/GPUProcessMain.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GPUProcessMain.h"
+
+#include <EnvVarUtils.h>
+#include <dlfcn.h>
+#include <process-initialization/nk-gpuprocess.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static void loadLibraryOrExit(const char* name)
+{
+    if (!dlopen(name, RTLD_NOW)) {
+        fprintf(stderr, "Failed to load %s.\n", name);
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main(int argc, char** argv)
+{
+    loadLibraryOrExit("libWebKit");
+    loadLibraryOrExit(WebKitRequirements_LOAD_AT);
+    // load backend libraries as needed here
+
+    char* coreProcessIdentifier = argv[1];
+    WebKit::parseAndSetEnvVars(argv[2]);
+
+    char connectionIdentifier[16];
+    snprintf(connectionIdentifier, sizeof(connectionIdentifier), "%d", PlayStation::getConnectionIdentifier());
+
+    char program[] = "dummy";
+    char* internalArgv[] = {
+        program,
+        coreProcessIdentifier,
+        connectionIdentifier,
+        0
+    };
+    return WebKit::GPUProcessMain(sizeof(internalArgv) / sizeof(char*), internalArgv);
+}

--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -20,7 +20,7 @@ list(APPEND NetworkProcess_PRIVATE_LIBRARIES
 )
 
 list(APPEND GPUProcess_SOURCES
-    GPUProcess/EntryPoint/unix/GPUProcessMain.cpp
+    GPUProcess/EntryPoint/playstation/GPUProcessMain.cpp
 )
 list(APPEND GPUProcess_PRIVATE_LIBRARIES
     ${ProcessLauncher_LIBRARY}


### PR DESCRIPTION
[PlayStation][gpup] Add platform specific entry for gpu process on playstation port.
https://bugs.webkit.org/show_bug.cgi?id=246024

Reviewed by NOBODY (OOPS!).

Adds support for entrypoint to launch GPU Process on playstation port. Current model uses the linux entry point which cannot execute on PlayStation

* Source/WebKit/GPUProcess/EntryPoint/playstation/GPUProcessMain.cpp Added
* Source/WebKit/GPUProcess/EntryPoint/playstation/GPUProcessMain.cpp:
* (main) Added
* (loadLibraryOrExit) Added<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b99adcc1af789deec79599c58086561f021d97f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102235 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1700 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30074 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84896 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98385 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1139 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78982 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28067 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71164 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36485 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16684 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34263 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17859 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3820 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40475 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40040 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37011 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->