### PR TITLE
[JSC][32bit] Enable concurrent compilation 

### DIFF
--- a/JSTests/stress/dont-link-virtual-calls-on-compiler-thread.js
+++ b/JSTests/stress/dont-link-virtual-calls-on-compiler-thread.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture != "arm64" and $architecture != "x86_64"
+//@ skip if $memoryLimited
 
 let s = `
 for (let i = 0; i < 10000; i++) {

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -796,6 +796,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     heap/MutatorState.h
     heap/PackedCellPtr.h
     heap/PreciseAllocation.h
+    heap/PreciseAllocationSet.h
     heap/RegisterState.h
     heap/RootMarkReason.h
     heap/RunningScope.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2064,6 +2064,7 @@
 		E3FF75331D9CEA1800C7E16D /* DOMJITGetterSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FF752F1D9CEA1200C7E16D /* DOMJITGetterSetter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E49DC16C12EF294E00184A1F /* SourceProviderCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E49DC15112EF272200184A1F /* SourceProviderCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E49DC16D12EF295300184A1F /* SourceProviderCacheItem.h in Headers */ = {isa = PBXBuildFile; fileRef = E49DC14912EF261A00184A1F /* SourceProviderCacheItem.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F4B323192972213000F1DC82 /* PreciseAllocationSet.h in Headers */ = {isa = PBXBuildFile; fileRef = F4B323182972213000F1DC82 /* PreciseAllocationSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F6D67D4026F902E9006E0349 /* TemporalInstant.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D67D3A26F902E5006E0349 /* TemporalInstant.h */; };
 		F6D67D4226F902E9006E0349 /* TemporalInstantConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D67D3C26F902E7006E0349 /* TemporalInstantConstructor.h */; };
 		F6D67D4426F902E9006E0349 /* TemporalInstantPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D67D3E26F902E8006E0349 /* TemporalInstantPrototype.h */; };
@@ -5654,6 +5655,7 @@
 		E49DC15112EF272200184A1F /* SourceProviderCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SourceProviderCache.h; sourceTree = "<group>"; };
 		E49DC15512EF277200184A1F /* SourceProviderCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SourceProviderCache.cpp; sourceTree = "<group>"; };
 		F3459D7423973ABD00DCD27A /* InspectorTarget.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorTarget.cpp; sourceTree = "<group>"; };
+		F4B323182972213000F1DC82 /* PreciseAllocationSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PreciseAllocationSet.h; sourceTree = "<group>"; };
 		F5BB2BC5030F772101FCFE1D /* Completion.h */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = Completion.h; sourceTree = "<group>"; tabWidth = 8; };
 		F5C290E60284F98E018635CA /* JavaScriptCorePrefix.h */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = JavaScriptCorePrefix.h; sourceTree = "<group>"; tabWidth = 8; };
 		F68EBB8C0255D4C601FF60F7 /* config.h */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; tabWidth = 8; };
@@ -6934,6 +6936,7 @@
 				0F9DAA081FD1C3C80079C5B2 /* ParallelSourceAdapter.h */,
 				0F070A451D543A89006E7232 /* PreciseAllocation.cpp */,
 				0F070A461D543A89006E7232 /* PreciseAllocation.h */,
+				F4B323182972213000F1DC82 /* PreciseAllocationSet.h */,
 				0FBB73B61DEF3AAC002C009E /* PreventCollectionScope.h */,
 				0FD0E5EF1E46BF230006AB08 /* RegisterState.h */,
 				0F7CF94E1DBEEE860098CC12 /* ReleaseHeapAccessScope.h */,
@@ -11094,6 +11097,7 @@
 				0FE834181A6EF97B00D04847 /* PolymorphicCallStubRoutine.h in Headers */,
 				521131F71F82BF14007CCEEE /* PolyProtoAccessChain.h in Headers */,
 				0F070A4B1D543A98006E7232 /* PreciseAllocation.h in Headers */,
+				F4B323192972213000F1DC82 /* PreciseAllocationSet.h in Headers */,
 				0F98206116BFE38300240D02 /* PreciseJumpTargets.h in Headers */,
 				E3A421431D6F58930007C617 /* PreciseJumpTargetsInlines.h in Headers */,
 				CE20BD07237D3E480046E520 /* PredictionFileCreatingFuzzerAgent.h in Headers */,

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -2309,6 +2309,7 @@ void AccessCase::generateImpl(AccessGenerationState& state)
                 CCallHelpers::TrustedImm32(numberOfParameters),
                 calleeFrame.withOffset(CallFrameSlot::argumentCountIncludingThis * sizeof(Register) + PayloadOffset));
 
+            // FIXME: in 32bit platforms we spend an extra instruction to move the CellTag on the second storeCell unnecessarily
             jit.storeCell(
                 loadedValueGPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
 

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -538,6 +538,10 @@ SpeculatedType speculationFromClassInfoInheritance(const ClassInfo* classInfo)
 
 SpeculatedType speculationFromStructure(Structure* structure)
 {
+#if USE(JSVALUE32_64)
+    if (!isLiveConcurrently(structure))
+        return SpecNone;
+#endif
     SpeculatedType filteredResult = SpecNone;
     JSType type = structure->typeInfo().type();
     switch (type) {
@@ -631,6 +635,10 @@ SpeculatedType speculationFromCell(JSCell* cell)
         ASSERT_NOT_REACHED();
         return SpecNone;
     }
+#if USE(JSVALUE32_64)
+    if (!isLiveConcurrently(cell))
+        return SpecNone;
+#endif
     if (cell->isString()) {
         JSString* string = jsCast<JSString*>(cell);
         if (const StringImpl* impl = string->tryGetValueImpl()) {

--- a/Source/JavaScriptCore/bytecode/Watchpoint.h
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.h
@@ -38,6 +38,9 @@ namespace JSC {
 
 namespace DFG {
 struct ArrayBufferViewWatchpointAdaptor;
+#if USE(JSVALUE32_64)
+struct JSCellWatchpointAdaptor;
+#endif
 }
 
 class VM;
@@ -144,6 +147,9 @@ private:
     friend class WatchpointSet;
     // ArrayBufferViewWatchpointAdaptor can fire watchpoints if it tries to attach a watchpoint to a view but can't allocate the ArrayBuffer.
     friend struct DFG::ArrayBufferViewWatchpointAdaptor;
+#if USE(JSVALUE32_64)
+    friend struct DFG::JSCellWatchpointAdaptor;
+#endif
     void fire(VM&, const FireDetail&);
     template<typename Func>
     void runWithDowncast(const Func&);

--- a/Source/JavaScriptCore/dfg/DFGAbstractValue.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValue.h
@@ -405,16 +405,20 @@ struct AbstractValue {
         } else {
             if (!!m_value && m_value != value)
                 return false;
-        
-            if (mergeSpeculations(m_type, speculationFromValue(value)) != m_type)
+
+            SpeculatedType type = speculationFromValue(value);
+            if (!type)
                 return false;
-            
+
+            if (mergeSpeculations(m_type, type) != m_type)
+                return false;
+
             if (value.isEmpty()) {
                 ASSERT(m_type & SpecEmpty);
                 return true;
             }
         }
-        
+
         if (!!value && value.isCell()) {
             ASSERT(m_type & SpecCell);
             Structure* structure = value.asCell()->structure();

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1491,7 +1491,7 @@ FrozenValue* Graph::freeze(JSValue value)
     // part of the weak pointer set. For example, an optimized CodeBlock
     // having a weak pointer to itself will cause it to get collected.
     RELEASE_ASSERT(!jsDynamicCast<CodeBlock*>(value));
-    
+
     auto result = m_frozenValueMap.add(JSValue::encode(value), nullptr);
     if (LIKELY(!result.isNewEntry))
         return result.iterator->value;

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -256,7 +256,7 @@ public:
     // fix this when we can allocate on the Compiler thread.
     // https://bugs.webkit.org/show_bug.cgi?id=210627
     FrozenValue* bottomValueMatchingSpeculation(SpeculatedType);
-    
+
     RegisteredStructure registerStructure(Structure* structure)
     {
         StructureRegistrationResult ignored;

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -557,6 +557,13 @@ CompilationResult Plan::finalize()
             return CompilationFailed;
         }
 
+#if USE(JSVALUE32_64)
+        if (Options::useConcurrentJIT()) {
+            for (JSCell* cell : m_weakReferences.references())
+                watchpoints().addLazily(cell);
+        }
+#endif
+
         reallyAdd(m_codeBlock->jitCode()->dfgCommon());
         {
             ConcurrentJSLocker locker(m_codeBlock->m_lock);

--- a/Source/JavaScriptCore/heap/ConservativeRoots.cpp
+++ b/Source/JavaScriptCore/heap/ConservativeRoots.cpp
@@ -63,13 +63,13 @@ void ConservativeRoots::grow()
 }
 
 template<typename MarkHook>
-inline void ConservativeRoots::genericAddPointer(void* p, HeapVersion markingVersion, HeapVersion newlyAllocatedVersion, TinyBloomFilter<uintptr_t> filter, MarkHook& markHook)
+inline void ConservativeRoots::genericAddPointer(void* p, HeapVersion markingVersion, HeapVersion newlyAllocatedVersion, MarkHook& markHook)
 {
     p = removeArrayPtrTag(p);
     markHook.mark(p);
 
     HeapUtil::findGCObjectPointersForMarking(
-        m_heap, markingVersion, newlyAllocatedVersion, filter, p,
+        m_heap, markingVersion, newlyAllocatedVersion, p,
         [&] (void* p, HeapCell::Kind cellKind) {
             if (isJSCellKind(cellKind))
                 markHook.markKnownJSCell(static_cast<JSCell*>(p));
@@ -94,11 +94,10 @@ void ConservativeRoots::genericAddSpan(void* begin, void* end, MarkHook& markHoo
     RELEASE_ASSERT(isPointerAligned(begin));
     RELEASE_ASSERT(isPointerAligned(end));
 
-    TinyBloomFilter<uintptr_t> filter = m_heap.objectSpace().blocks().filter(); // Make a local copy of filter to show the compiler it won't alias, and can be register-allocated.
     HeapVersion markingVersion = m_heap.objectSpace().markingVersion();
     HeapVersion newlyAllocatedVersion = m_heap.objectSpace().newlyAllocatedVersion();
     for (char** it = static_cast<char**>(begin); it != static_cast<char**>(end); ++it)
-        genericAddPointer(*it, markingVersion, newlyAllocatedVersion, filter, markHook);
+        genericAddPointer(*it, markingVersion, newlyAllocatedVersion, markHook);
 }
 
 class DummyMarkHook {

--- a/Source/JavaScriptCore/heap/ConservativeRoots.h
+++ b/Source/JavaScriptCore/heap/ConservativeRoots.h
@@ -48,7 +48,7 @@ private:
     static constexpr size_t inlineCapacity = 2048;
     
     template<typename MarkHook>
-    void genericAddPointer(void*, HeapVersion markingVersion, HeapVersion newlyAllocatedVersion, TinyBloomFilter<uintptr_t>, MarkHook&);
+    void genericAddPointer(void*, HeapVersion markingVersion, HeapVersion newlyAllocatedVersion, MarkHook&);
 
     template<typename MarkHook>
     void genericAddSpan(void*, void* end, MarkHook&);

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -1191,4 +1191,24 @@ private:
 
 } // namespace GCClient
 
+#if USE(JSVALUE32_64)
+class CellAddressChecker {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(CellAddressChecker);
+    CellAddressChecker() = default;
+
+public:
+    static CellAddressChecker& instance();
+
+    void add(Heap*);
+    void remove(Heap*);
+
+    bool isValidCell(JSCell* candidate);
+
+private:
+    HashSet<Heap*> m_heaps;
+    Lock m_lock;
+};
+#endif
+
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -172,11 +172,14 @@ public:
         size_t backingStorageSize() { return bitwise_cast<uintptr_t>(end()) - bitwise_cast<uintptr_t>(pageStart()); }
         
         bool isAllocated();
-        
+
         bool isLive(HeapVersion markingVersion, HeapVersion newlyAllocatedVersion, bool isMarking, const HeapCell*);
+        bool isLiveConcurrently(HeapVersion markingVersion, HeapVersion newlyAllocatedVersion, bool isMarking, const HeapCell*);
+
         inline bool isLiveCell(HeapVersion markingVersion, HeapVersion newlyAllocatedVersion, bool isMarking, const void*);
 
         bool isLive(const HeapCell*);
+        bool isLiveConcurrently(const HeapCell*);
         bool isLiveCell(const void*);
 
         bool isFreeListedCell(const void* target) const;

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -185,7 +185,7 @@ MarkedSpace::MarkedSpace(Heap* heap)
 
 MarkedSpace::~MarkedSpace()
 {
-    ASSERT(!m_blocks.set().size());
+    ASSERT(!m_blocks.size());
 }
 
 void MarkedSpace::freeMemory()
@@ -268,7 +268,7 @@ void MarkedSpace::prepareForAllocation()
 
 void MarkedSpace::enablePreciseAllocationTracking()
 {
-    m_preciseAllocationSet = makeUnique<HashSet<HeapCell*>>();
+    m_preciseAllocationSet = makeUnique<PreciseAllocationSet>();
     for (auto* allocation : m_preciseAllocations)
         m_preciseAllocationSet->add(allocation->cell());
 }

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -25,6 +25,7 @@
 #include "MarkedBlock.h"
 #include "MarkedBlockSet.h"
 #include "PreciseAllocation.h"
+#include "PreciseAllocationSet.h"
 #include <array>
 #include <wtf/Bag.h>
 #include <wtf/HashSet.h>
@@ -156,7 +157,7 @@ public:
     const Vector<PreciseAllocation*>& preciseAllocations() const { return m_preciseAllocations; }
     unsigned preciseAllocationsNurseryOffset() const { return m_preciseAllocationsNurseryOffset; }
     unsigned preciseAllocationsOffsetForThisCollection() const { return m_preciseAllocationsOffsetForThisCollection; }
-    HashSet<HeapCell*>* preciseAllocationSet() const { return m_preciseAllocationSet.get(); }
+    PreciseAllocationSet* preciseAllocationSet() const { return m_preciseAllocationSet.get(); }
 
     void enablePreciseAllocationTracking();
     
@@ -200,7 +201,7 @@ private:
 
     Vector<Subspace*> m_subspaces;
 
-    std::unique_ptr<HashSet<HeapCell*>> m_preciseAllocationSet;
+    std::unique_ptr<PreciseAllocationSet> m_preciseAllocationSet;
     Vector<PreciseAllocation*> m_preciseAllocations;
     unsigned m_preciseAllocationsNurseryOffset { 0 };
     unsigned m_preciseAllocationsOffsetForThisCollection { 0 };

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -155,8 +155,8 @@ public:
 #endif
     }
 
-    template<typename U>
-    void storeCell(JSValueRegs regs, U address)
+    template<typename T>
+    void storeCell(JSValueRegs regs, T address)
     {
 #if USE(JSVALUE64)
         store64(regs.gpr(), address);
@@ -170,12 +170,7 @@ public:
 #if USE(JSVALUE32_64)
     void storeCell(const void* address)
     {
-#if ENABLE(CONCURRENT_JS)
-        if (Options::useConcurrentJIT()) {
-            store32Concurrently(AssemblyHelpers::TrustedImm32(JSValue::CellTag), address);
-            return;
-        }
-#endif
+        static_assert(!PayloadOffset && TagOffset == 4, "Assumes little-endian system");
         store32(AssemblyHelpers::TrustedImm32(JSValue::CellTag), address);
     }
 #endif

--- a/Source/JavaScriptCore/jit/JITPlan.cpp
+++ b/Source/JavaScriptCore/jit/JITPlan.cpp
@@ -151,6 +151,11 @@ bool JITPlan::reportCompileTimes() const
         || (Options::reportFTLCompileTimes() && isFTL());
 }
 
+inline bool verboseCompilationEnabled(JITCompilationMode mode = JITCompilationMode::DFG)
+{
+    return Options::verboseCompilation() || Options::dumpGraphAtEachPhase() || Options::logCompilationChanges() || (isFTL(mode) && Options::verboseFTLCompilation());
+}
+
 void JITPlan::compileInThread(JITWorklistThread* thread)
 {
     m_thread = thread;
@@ -164,10 +169,8 @@ void JITPlan::compileInThread(JITWorklistThread* thread)
 
     CompilationScope compilationScope;
 
-#if ENABLE(DFG_JIT)
-    if (DFG::logCompilationChanges(m_mode) || Options::logPhaseTimes())
-        dataLog("DFG(Plan) compiling ", *m_codeBlock, " with ", m_mode, ", instructions size = ", m_codeBlock->instructionsSize(), "\n");
-#endif // ENABLE(DFG_JIT)
+    if (verboseCompilationEnabled(m_mode) || Options::logPhaseTimes())
+        dataLog(m_mode, "(Plan) compiling ", *m_codeBlock, " with ", m_mode, ", instructions size = ", m_codeBlock->instructionsSize(), "\n");
 
     CompilationPath path = compileInThreadImpl();
 

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -127,7 +127,7 @@ public:
 
     // We use this abstraction to make it easier to grep for places where we lock cells.
     // to lock a cell you can just do:
-    // Locker locker { cell->cellLocker() };
+    // Locker locker { cell->cellLock() };
     JSCellLock& cellLock() { return *reinterpret_cast<JSCellLock*>(this); }
     
     JSType type() const;
@@ -299,6 +299,10 @@ inline auto subspaceForConcurrently(VM& vm)
 
 #if CPU(X86_64)
 JS_EXPORT_PRIVATE NEVER_INLINE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void reportZappedCellAndCrash(Heap&, const JSCell*);
+#endif
+
+#if USE(JSVALUE32_64)
+bool isLiveConcurrently(JSCell*);
 #endif
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -468,8 +468,6 @@ void SamplingProfiler::processUnverifiedStackTraces()
     // This function needs to be called from the JSC execution thread.
     RELEASE_ASSERT(m_lock.isLocked());
 
-    TinyBloomFilter<uintptr_t> filter = m_vm.heap.objectSpace().blocks().filter();
-
     for (UnprocessedStackTrace& unprocessedStackTrace : m_unprocessedStackTraces) {
         m_stackTraces.append(StackTrace());
         StackTrace& stackTrace = m_stackTraces.last();
@@ -533,7 +531,7 @@ void SamplingProfiler::processUnverifiedStackTraces()
 #endif
 
             JSValue callee = calleeBits.asCell();
-            if (!HeapUtil::isValueGCObject(m_vm.heap, filter, callee)) {
+            if (!HeapUtil::isValueGCObject(m_vm.heap, callee)) {
                 if (!alreadyHasExecutable)
                     stackFrame.frameType = FrameType::Unknown;
                 return;
@@ -577,7 +575,7 @@ void SamplingProfiler::processUnverifiedStackTraces()
                 return;
             }
 
-            RELEASE_ASSERT(HeapUtil::isPointerGCObjectJSCell(m_vm.heap, filter, executable));
+            RELEASE_ASSERT(HeapUtil::isPointerGCObjectJSCell(m_vm.heap, executable));
             stackFrame.frameType = FrameType::Executable;
             stackFrame.executable = executable;
             m_liveCellPointers.add(executable);

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -249,7 +249,7 @@ void VMInspector::edenGC(VM* vm)
 bool VMInspector::isInHeap(Heap* heap, void* ptr)
 {
     MarkedBlock* candidate = MarkedBlock::blockFor(ptr);
-    if (heap->objectSpace().blocks().set().contains(candidate))
+    if (heap->objectSpace().blocks().contains(candidate))
         return true;
     for (PreciseAllocation* allocation : heap->objectSpace().preciseAllocations()) {
         if (allocation->contains(ptr))

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -677,11 +677,7 @@
 
 #endif /* !defined(ENABLE_DFG_JIT) && ENABLE(JIT) */
 
-/* Concurrent JS only works on 64-bit platforms because it requires that
-   values get stored to atomically. This is trivially true on 64-bit platforms,
-   but not true at all on 32-bit platforms where values are composed of two
-   separate sub-values. */
-#if ENABLE(JIT) && USE(JSVALUE64)
+#if ENABLE(JIT)
 #define ENABLE_CONCURRENT_JS 1
 #endif
 


### PR DESCRIPTION
#### df50b57bbbf11f79296ed7298983d930bf787496
<pre>
[JSC][32bit] Enable concurrent compilation
<a href="https://bugs.webkit.org/show_bug.cgi?id=239821">https://bugs.webkit.org/show_bug.cgi?id=239821</a>

This enables concurrent compilation in 32-bit systems. The patch increases
JetStream2's score by 9.2%, compared to the sequential compilation version
(ToT on ARMv7).

The patch works by checking if a cell is live whenever we try to get a
cell's type from the payload, and adds a new watchpoint to DFG, that
jettisons the compiled code if a cell used during compilation is found to be dead.

The check if a cell is live is divided into two steps:
(1) We check if the cell pointer is valid, i.e., if it is part of the
precise allocation set, or if its markedBlock is part of the marked block set.
This required changes to make both sets thread-safe. There was a small regression
in performance in JetStream's score in 32bit systems using sequential compilation
(-0.4%) but no regression in intel 64bit linux.
(2) We check if the cell is live, similar to HeapCell:isLive. Special case for
when a cell's markedBlock is freelisted: the cell would be in a dead-but-not-destructed
state, so we check if it was zapped.

This patch also includes:
(1) Rewrite of MarkedBlockSet to be thread-safe and the creation of thread-safe
PreciseAllocationSet. This required a rewrite of some functions in HeapUtil and
its users.
(2) Creation of the singleton CellAddressChecker: it holds a set of heaps, used
to check if a pointer is actually a cell. I tried to use thread_local storage but
it caused JSC to run OOM in some tests.
(3) Some changes to DFG's abstract interpreter so it doesn't crash when it finds
a dead cell: a dead cell sets the abstract value to clear(), which
AbstractValue::checkConsistency() check that if the abstract value is a cell, it
should never be clear. The changes here check the cell type and clear the abstract
value, and don't call AbstractValue::checkConsistency() afterward.

JetStream2 results:

-----------------------------------------------------------------------------------------------------------------------
|          subtest          |    pts      |    pts      |  b / a   | pValue (significance using False Discovery Rate) |
-----------------------------------------------------------------------------------------------------------------------
| 3d-cube-SP                |166.842257   |191.651250   |1.148697  | 0.000000 (significant)                           |
| 3d-raytrace-SP            |121.830845   |137.467771   |1.128349  | 0.000000 (significant)                           |
| Air                       |94.564043    |113.849099   |1.203936  | 0.000000 (significant)                           |
| Babylon                   |136.550170   |197.096390   |1.443399  | 0.000000 (significant)                           |
| Basic                     |145.174218   |172.201772   |1.186173  | 0.000000 (significant)                           |
| Box2D                     |96.168053    |135.336668   |1.407293  | 0.000000 (significant)                           |
| FlightPlanner             |179.733139   |218.052388   |1.213201  | 0.000000 (significant)                           |
| ML                        |22.580790    |23.779379    |1.053080  | 0.000000 (significant)                           |
| UniPoker                  |77.069218    |76.944716    |0.998385  | 0.745485                                         |
| ai-astar                  |172.339827   |182.194075   |1.057179  | 0.000000 (significant)                           |
| async-fs                  |58.373134    |66.001618    |1.130685  | 0.000000 (significant)                           |
| base64-SP                 |163.675701   |164.258499   |1.003561  | 0.386329                                         |
| cdjs                      |64.786358    |68.880058    |1.063188  | 0.000000 (significant)                           |
| chai-wtb                  |30.723964    |35.512906    |1.155870  | 0.000000 (significant)                           |
| crypto                    |370.774651   |422.601554   |1.139780  | 0.000000 (significant)                           |
| crypto-aes-SP             |166.297273   |180.887002   |1.087733  | 0.000000 (significant)                           |
| crypto-md5-SP             |138.726334   |144.764783   |1.043528  | 0.000000 (significant)                           |
| crypto-sha1-SP            |148.701098   |154.401856   |1.038337  | 0.000000 (significant)                           |
| date-format-tofte-SP      |93.721970    |95.972233    |1.024010  | 0.000006 (significant)                           |
| date-format-xparb-SP      |84.335641    |84.399444    |1.000757  | 0.884345                                         |
| delta-blue                |203.552572   |250.170209   |1.229020  | 0.000000 (significant)                           |
| earley-boyer              |183.528931   |267.870222   |1.459553  | 0.000000 (significant)                           |
| first-inspector-code-load |130.165322   |125.707273   |0.965751  | 0.000000 (significant)                           |
| gaussian-blur             |105.136392   |102.088203   |0.971007  | 0.000000 (significant)                           |
| gbemu                     |29.254298    |34.314988    |1.172990  | 0.000000 (significant)                           |
| hash-map                  |128.335637   |125.664184   |0.979184  | 0.000003 (significant)                           |
| jshint-wtb                |13.149089    |14.809269    |1.126258  | 0.000000 (significant)                           |
| json-parse-inspector      |83.706580    |92.194498    |1.101401  | 0.000000 (significant)                           |
| json-stringify-inspector  |108.521622   |104.554735   |0.963446  | 0.000008 (significant)                           |
| multi-inspector-code-load |139.224604   |136.393483   |0.979665  | 0.000000 (significant)                           |
| n-body-SP                 |336.090961   |340.670871   |1.013627  | 0.000025 (significant)                           |
| navier-stokes             |425.875692   |406.026662   |0.953392  | 0.000000 (significant)                           |
| octane-code-load          |485.779704   |484.639128   |0.997652  | 0.708012                                         |
| pdfjs                     |51.953615    |59.042339    |1.136443  | 0.000000 (significant)                           |
| prepack-wtb               |12.559819    |16.765718    |1.334869  | 0.000000 (significant)                           |
| raytrace                  |184.737268   |214.173299   |1.159340  | 0.000000 (significant)                           |
| regex-dna-SP              |217.026089   |210.995824   |0.972214  | 0.000000 (significant)                           |
| regexp                    |120.429176   |122.785703   |1.019568  | 0.000459 (significant)                           |
| richards                  |231.044982   |248.550770   |1.075768  | 0.000000 (significant)                           |
| splay                     |94.720294    |115.778294   |1.222318  | 0.000000 (significant)                           |
| stanford-crypto-aes       |108.887712   |108.180925   |0.993509  | 0.205676                                         |
| stanford-crypto-pbkdf2    |210.891098   |225.484971   |1.069201  | 0.000000 (significant)                           |
| stanford-crypto-sha256    |190.608578   |190.512030   |0.999493  | 0.885449                                         |
| string-unpack-code-SP     |144.199974   |145.742765   |1.010699  | 0.001692 (significant)                           |
| tagcloud-SP               |117.106005   |119.112579   |1.017135  | 0.000080 (significant)                           |
-----------------------------------------------------------------------------------------------------------------------

a mean = 114.27907
b mean = 124.75480
pValue = 0.0000000000
(Bigger means are better.)
1.092 times better
Results ARE significant

* JSTests/stress/dont-link-virtual-calls-on-compiler-thread.js:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::generateImpl):
* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
(JSC::speculationFromCell):
* Source/JavaScriptCore/bytecode/Watchpoint.h:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter<AbstractStateType>::executeEffects):
* Source/JavaScriptCore/dfg/DFGAbstractValue.cpp:
(JSC::DFG::AbstractValue::set):
(JSC::DFG::AbstractValue::mergeOSREntryValue):
* Source/JavaScriptCore/dfg/DFGAbstractValue.h:
(JSC::DFG::AbstractValue::validateOSREntryValue const):
* Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp:
(JSC::DFG::JSCellWatchpointAdaptor::add):
(JSC::DFG::DesiredWatchpoints::addLazily):
(JSC::DFG::DesiredWatchpoints::reallyAdd):
(JSC::DFG::DesiredWatchpoints::areStillValid const):
(JSC::DFG::DesiredWatchpoints::dumpInContext const):
* Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.h:
(JSC::DFG::JSCellWatchpointAdaptor::hasBeenInvalidated):
(JSC::DFG::JSCellWatchpointAdaptor::dumpInContext):
(JSC::DFG::DesiredWatchpoints::dump const):
* Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.h:
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::freeze):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::finalize):
* Source/JavaScriptCore/heap/ConservativeRoots.cpp:
(JSC::ConservativeRoots::genericAddPointer):
(JSC::ConservativeRoots::genericAddSpan):
* Source/JavaScriptCore/heap/ConservativeRoots.h:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::Heap):
(JSC::Heap::~Heap):
(JSC::CellAddressChecker::instance):
(JSC::CellAddressChecker::add):
(JSC::CellAddressChecker::remove):
(JSC::CellAddressChecker::isValidCell):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/HeapUtil.h:
(JSC::HeapUtil::findGCObjectPointersForMarking):
(JSC::HeapUtil::isPointerGCObjectJSCell):
(JSC::HeapUtil::isValueGCObject):
* Source/JavaScriptCore/heap/MarkedBlockSet.h:
(JSC::MarkedBlockSet::add):
(JSC::MarkedBlockSet::remove):
(JSC::MarkedBlockSet::size):
(JSC::MarkedBlockSet::contains):
(JSC::MarkedBlockSet::forEachLiveCell):
(JSC::MarkedBlockSet::forEachDeadCell):
(JSC::MarkedBlockSet::filterRuleOut):
(JSC::MarkedBlockSet::filter const): Deleted.
(JSC:: const): Deleted.
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
(JSC::MarkedSpace::~MarkedSpace):
(JSC::MarkedSpace::enablePreciseAllocationTracking):
* Source/JavaScriptCore/heap/MarkedSpace.h:
(JSC::MarkedSpace::preciseAllocationSet const):
* Source/JavaScriptCore/heap/MarkedSpaceInlines.h:
(JSC::MarkedSpace::forEachLiveCell):
(JSC::MarkedSpace::forEachDeadCell):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::storeCell):
* Source/JavaScriptCore/jit/JITPlan.cpp:
(JSC::verboseCompilationEnabled):
(JSC::JITPlan::compileInThread):
* Source/JavaScriptCore/runtime/JSCell.cpp:
(JSC::isLiveConcurrently):
* Source/JavaScriptCore/runtime/JSCell.h:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::processUnverifiedStackTraces):
* Source/JavaScriptCore/tools/VMInspector.cpp:
(JSC::VMInspector::isInHeap):
* Source/WTF/wtf/PlatformEnable.h:
* </pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/356d1079ad3e8cba5879cc9158dfcaf0f716f7a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115044 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175173 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6215 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98079 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114817 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39977 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27045 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81636 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/editable (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95539 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8185 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28397 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/94824 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5982 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5058 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30448 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14294 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47945 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/103571 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10224 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25680 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->