### PR TITLE
WIP for modify headers

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionActions.h
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.h
@@ -101,17 +101,19 @@ struct WEBCORE_EXPORT ModifyHeadersAction {
         void serialize(Vector<uint8_t>&) const;
         static ModifyHeaderInfo deserialize(Span<const uint8_t>);
         static size_t serializedLength(Span<const uint8_t>);
-        void applyToRequest(ResourceRequest&);
+        void applyToRequest(ResourceRequest&, HashMap<String, String>&);
     };
 
     enum class HashTableType : uint8_t { Empty, Deleted, Full } hashTableType;
     Vector<ModifyHeaderInfo> requestHeaders;
     Vector<ModifyHeaderInfo> responseHeaders;
+    uint32_t priority;
 
-    ModifyHeadersAction(Vector<ModifyHeaderInfo>&& requestHeaders, Vector<ModifyHeaderInfo>&& responseHeaders)
+    ModifyHeadersAction(Vector<ModifyHeaderInfo>&& requestHeaders, Vector<ModifyHeaderInfo>&& responseHeaders, uint32_t priority)
         : hashTableType(HashTableType::Full)
         , requestHeaders(WTFMove(requestHeaders))
-        , responseHeaders(WTFMove(responseHeaders)) { }
+        , responseHeaders(WTFMove(responseHeaders))
+        , priority(priority) { }
 
     enum EmptyValueTag { EmptyValue };
     enum DeletedValueTag { DeletedValue };
@@ -126,7 +128,7 @@ struct WEBCORE_EXPORT ModifyHeadersAction {
     void serialize(Vector<uint8_t>&) const;
     static ModifyHeadersAction deserialize(Span<const uint8_t>);
     static size_t serializedLength(Span<const uint8_t>);
-    void applyToRequest(ResourceRequest&);
+    void applyToRequest(ResourceRequest&, HashMap<String, String>&);
 };
 
 struct WEBCORE_EXPORT RedirectAction {

--- a/Source/WebCore/contentextensions/ContentExtensionError.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionError.cpp
@@ -126,6 +126,8 @@ const std::error_category& contentExtensionErrorCategory()
                 return "A modify-headers operation of \"set\" or \"append\" must have a value";
             case ContentExtensionError::JSONModifyHeadersNotArray:
                 return "A headers member must be an array";
+            case ContentExtensionError::JSONModifyHeadersInvalidPriority:
+                return "A priority cannot be an empty string";
             }
 
             return std::string();

--- a/Source/WebCore/contentextensions/ContentExtensionError.h
+++ b/Source/WebCore/contentextensions/ContentExtensionError.h
@@ -82,6 +82,7 @@ enum class ContentExtensionError {
     JSONModifyHeadersInvalidOperation,
     JSONModifyHeadersMissingHeader,
     JSONModifyHeadersMissingValue,
+    JSONModifyHeadersInvalidPriority,
 
     ErrorWritingSerializedNFA,
 };

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -347,8 +347,19 @@ void applyResultsToRequest(ContentRuleListResults&& results, Page* page, Resourc
         request.setURL(newURL);
     }
 
+    // ELLIE the changes need to be made at this level
+    /*
+    1. Sort [✅]
+    2. Pass around a hash table of <header, action type {set, append, remove}> [✅]
+    3. Use hash table in the same place as it is done currently [✅]
+    */
+    fprintf(stderr, "sorting the headers");
+    std::sort(results.summary.modifyHeadersActions.begin(), results.summary.modifyHeadersActions.end(),
+        [] (const ModifyHeadersAction& a, const ModifyHeadersAction& b) { return a.priority < b.priority; });
+
+    HashMap<String, String> headerNameToFirstOperationApplied;
     for (auto& action : results.summary.modifyHeadersActions)
-        action.applyToRequest(request);
+        action.applyToRequest(request, headerNameToFirstOperationApplied); // don't think this is right
 
     for (auto& pair : results.summary.redirectActions)
         pair.first.applyToRequest(request, pair.second);

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -1586,12 +1586,15 @@ TEST_F(ContentExtensionTest, InvalidJSON)
     checkCompilerError("[{\"action\":{\"type\":\"redirect\",\"redirect\":{\"transform\":{\"scheme\":\"!@#$%\"}}},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONRedirectURLSchemeInvalid);
     checkCompilerError("[{\"action\":{\"type\":\"redirect\",\"redirect\":{\"transform\":{\"scheme\":\"JaVaScRiPt\"}}},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONRedirectToJavaScriptURL);
     checkCompilerError("[{\"action\":{\"type\":\"redirect\",\"redirect\":{\"transform\":{\"scheme\":\"About\"}}},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, { });
-    checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"request-headers\":5},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersNotArray);
-    checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"request-headers\":[5]},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersInfoNotADictionary);
-    checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"request-headers\":[{}]},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersMissingOperation);
-    checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"request-headers\":[{\"operation\":\"remove\"}]},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersMissingHeader);
-    checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"request-headers\":[{\"operation\":\"set\",\"header\":\"testheader\"}]},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersMissingValue);
-    checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"request-headers\":[{\"operation\":\"invalid\",\"header\":\"testheader\"}]},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersInvalidOperation);
+
+    // ELLIE Run these tests
+    // ELLIE add test for JSONModifyHeadersInvalidPriority?
+    checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"priority\":2,\"request-headers\":5},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersNotArray);
+    checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"priority\":2,\"request-headers\":[5]},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersInfoNotADictionary);
+    checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"priority\":2,\"request-headers\":[{}]},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersMissingOperation);
+    checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"priority\":2,\"request-headers\":[{\"operation\":\"remove\"}]},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersMissingHeader);
+    checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"priority\":2,\"request-headers\":[{\"operation\":\"set\",\"header\":\"testheader\"}]},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersMissingValue);
+    checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"priority\":2,\"request-headers\":[{\"operation\":\"invalid\",\"header\":\"testheader\"}]},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersInvalidOperation);
 }
 
 TEST_F(ContentExtensionTest, StrictPrefixSeparatedMachines1)
@@ -3058,13 +3061,13 @@ TEST_F(ContentExtensionTest, Serialization)
 
     ModifyHeadersAction modifyHeaders { {
         { { ModifyHeadersAction::ModifyHeaderInfo::AppendOperation { "key1"_s, "value1"_s } } },
-        { { ModifyHeadersAction::ModifyHeaderInfo::SetOperation { "key2"_s, "value2"_s } } }
+        { { ModifyHeadersAction::ModifyHeaderInfo::SetOperation { "key2"_s, "value2"_s } } },
     }, {
         { { ModifyHeadersAction::ModifyHeaderInfo::RemoveOperation { String::fromUTF8("💩") } } }
-    } };
+    }, 2 };
     Vector<uint8_t> modifyHeadersBuffer;
     modifyHeaders.serialize(modifyHeadersBuffer);
-    EXPECT_EQ(modifyHeadersBuffer.size(), 55u);
+    EXPECT_EQ(modifyHeadersBuffer.size(), 59u);
     auto deserializedModifyHeaders = ModifyHeadersAction::deserialize({ modifyHeadersBuffer.data(), modifyHeadersBuffer.size() });
     EXPECT_EQ(modifyHeaders, deserializedModifyHeaders);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
@@ -562,24 +562,25 @@ static void checkURLs(const Vector<String>& actual, const Vector<String>& expect
         EXPECT_WK_STREQ(actual[i], expected[i]);
 }
 
+// ELLIE run these tests
 TEST_F(WKContentRuleListStoreTest, ModifyHeaders)
 {
     auto list = compileContentRuleList(R"JSON(
         [ {
-            "action": { "type": "modify-headers", "request-headers": [ {
+            "action": { "type": "modify-headers", "priority": 2, "request-headers": [ {
                 "operation": "set",
                 "header": "testkey",
                 "value": "testvalue"
             } ] },
             "trigger": { "url-filter": "testscheme" }
         }, {
-            "action": { "type": "modify-headers", "request-headers": [ {
+            "action": { "type": "modify-headers", "priority": 3, "request-headers": [ {
                 "operation": "remove",
                 "header": "Accept"
             } ] },
             "trigger": { "url-filter": "testscheme" }
         }, {
-            "action": { "type": "modify-headers", "request-headers": [ {
+            "action": { "type": "modify-headers", "priority": 4, "request-headers": [ {
                 "operation": "append",
                 "header": "Content-Type",
                 "value": "Modified-by-test"


### PR DESCRIPTION
#### 12fd91d7f127ec68567f9abfa0c9e4826f2f6c13
<pre>
WIP for modify headers

Reviewed by NOBODY (OOPS!).

* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::ModifyHeadersAction::parse):
(WebCore::ContentExtensions::ModifyHeadersAction::isolatedCopy const):
(WebCore::ContentExtensions::ModifyHeadersAction::isolatedCopy):
(WebCore::ContentExtensions::ModifyHeadersAction::operator== const):
(WebCore::ContentExtensions::ModifyHeadersAction::serialize const):
(WebCore::ContentExtensions::ModifyHeadersAction::deserialize):
(WebCore::ContentExtensions::ModifyHeadersAction::applyToRequest):
(WebCore::ContentExtensions::ModifyHeadersAction::ModifyHeaderInfo::applyToRequest):
(WebCore::ContentExtensions::ModifyHeadersAction::ModifyHeaderInfo::serialize const):
* Source/WebCore/contentextensions/ContentExtensionActions.h:
* Source/WebCore/contentextensions/ContentExtensionCompiler.cpp:
(WebCore::ContentExtensions::serializeActions):
(WebCore::ContentExtensions::compileRuleList):
* Source/WebCore/contentextensions/ContentExtensionError.cpp:
(WebCore::ContentExtensions::contentExtensionErrorCategory):
* Source/WebCore/contentextensions/ContentExtensionError.h:
* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::loadAction):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
(WebCore::ContentExtensions::applyResultsToRequest):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::compiledToFile):
(API::ContentRuleListStore::compileContentRuleList):
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm:
(-[WKContentRuleListStore compileContentRuleListForIdentifier:encodedContentRuleList:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(compileContentRuleList):
(TEST_F):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12fd91d7f127ec68567f9abfa0c9e4826f2f6c13

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91683 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/913 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/101378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/912 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97341 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/83997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/83997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/35803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/33557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/37401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/39306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->