### PR TITLE
Fixed the search icon color in the navigation header

### DIFF
--- a/Websites/webkit.org/wp-content/themes/webkit/header.php
+++ b/Websites/webkit.org/wp-content/themes/webkit/header.php
@@ -11,7 +11,7 @@
 
     <meta name="application-name" content="WebKit">
 
-    <link rel="stylesheet" type="text/css" href="<?php echo get_stylesheet_uri(); ?>?20200127" media="all">
+    <link rel="stylesheet" type="text/css" href="<?php echo get_stylesheet_uri(); ?>?20221005" media="all">
     <link rel="stylesheet" href="https://www.apple.com/wss/fonts?families=SF+Pro,v1" type="text/css">
     <link rel="stylesheet" href="https://www.apple.com/wss/fonts?families=SF+Mono,v2" type="text/css">
     <meta name="supported-color-schemes" content="light dark">

--- a/Websites/webkit.org/wp-content/themes/webkit/style.css
+++ b/Websites/webkit.org/wp-content/themes/webkit/style.css
@@ -42,6 +42,7 @@ Version: 1.0
     --submit-button-text-color: hsl(0, 0%, 100%);
     
     --search-glyph: url('images/search.svg#dark');
+    --search-glyph-light: url('images/search.svg#light');
     --search-term-text-color: hsl(0, 0%, 0%);
     --search-input-background: hsl(0, 100%, 100%);
 
@@ -2297,6 +2298,10 @@ header .menu-item { /* add bottom dimension to main menu items */
     transition: 200ms ease-out width, 200ms ease-in background-color;
 }
 
+#site-nav .search-input {
+    background-image: var(--search-glyph-light);
+}
+
 .search #site-nav ul.menu li:last-child {
     display: none;
 }
@@ -2549,6 +2554,7 @@ p .search-term {
         padding: 0 3rem 3rem 0;
     }
 
+    #site-nav .search-input,
     .search-input {
         width: 100%;
         


### PR DESCRIPTION
#### b770db0515fe568a19130be241b61b08359e9542
<pre>
Fixed the search icon color in the navigation header
<a href="https://bugs.webkit.org/show_bug.cgi?id=246105">https://bugs.webkit.org/show_bug.cgi?id=246105</a>

Reviewed by Devin Rousso.

* Websites/webkit.org/wp-content/themes/webkit/header.php:
* Websites/webkit.org/wp-content/themes/webkit/style.css:
(:root):
(#site-nav .search-input):
(@media only screen and (max-width: 1015px) #site-nav .search-input,):
(@media only screen and (max-width: 1015px) .search-input): Deleted.

Canonical link: <a href="https://commits.webkit.org/255199@main">https://commits.webkit.org/255199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbf5458dab633e406ab60c0f35e612a10cf47608

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101384 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/918 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84016 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97347 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/27500 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35809 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33563 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/17224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37407 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1618 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36341 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->