### PR TITLE
Generate more IPC serialization code from WebCore/Modules

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -261,6 +261,21 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/mediarecorder/MediaRecorderProvider.h
 
+    Modules/mediasession/NavigatorMediaSession.h
+    Modules/mediasession/MediaSession.h
+    Modules/mediasession/MediaImage.h
+    Modules/mediasession/MediaMetadata.h
+    Modules/mediasession/MediaSessionActionDetails.h
+    Modules/mediasession/MediaPositionState.h
+    Modules/mediasession/MediaSessionActionHandler.h
+    Modules/mediasession/MediaSessionPlaybackState.h
+    Modules/mediasession/MediaSessionCoordinatorPrivate.h
+    Modules/mediasession/MediaSessionCoordinatorState.h
+    Modules/mediasession/MediaSessionReadyState.h
+    Modules/mediasession/MediaSessionCoordinator.h
+    Modules/mediasession/MediaMetadataInit.h
+    Modules/mediasession/MediaSessionAction.h
+
     Modules/mediasource/SampleMap.h
 
     Modules/mediastream/DetachedRTCDataChannel.h

--- a/Source/WebCore/Modules/cache/RetrieveRecordsOptions.h
+++ b/Source/WebCore/Modules/cache/RetrieveRecordsOptions.h
@@ -36,9 +36,6 @@ struct RetrieveRecordsOptions {
     RetrieveRecordsOptions isolatedCopy() const & { return { request.isolatedCopy(), crossOriginEmbedderPolicy.isolatedCopy(), sourceOrigin->isolatedCopy(), ignoreSearch, ignoreMethod, ignoreVary, shouldProvideResponse }; }
     RetrieveRecordsOptions isolatedCopy() && { return { WTFMove(request).isolatedCopy(), WTFMove(crossOriginEmbedderPolicy).isolatedCopy(), sourceOrigin->isolatedCopy(), ignoreSearch, ignoreMethod, ignoreVary, shouldProvideResponse }; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<RetrieveRecordsOptions> decode(Decoder&);
-
     ResourceRequest request;
     CrossOriginEmbedderPolicy crossOriginEmbedderPolicy;
     Ref<SecurityOrigin> sourceOrigin;
@@ -47,49 +44,5 @@ struct RetrieveRecordsOptions {
     bool ignoreVary { false };
     bool shouldProvideResponse { true };
 };
-
-template<class Encoder> inline void RetrieveRecordsOptions::encode(Encoder& encoder) const
-{
-    encoder << request << crossOriginEmbedderPolicy << sourceOrigin.get() << ignoreSearch << ignoreMethod << ignoreVary << shouldProvideResponse;
-}
-
-template<class Decoder> inline std::optional<RetrieveRecordsOptions> RetrieveRecordsOptions::decode(Decoder& decoder)
-{
-    std::optional<ResourceRequest> request;
-    decoder >> request;
-    if (!request)
-        return std::nullopt;
-
-    std::optional<CrossOriginEmbedderPolicy> crossOriginEmbedderPolicy;
-    decoder >> crossOriginEmbedderPolicy;
-    if (!crossOriginEmbedderPolicy)
-        return std::nullopt;
-
-    auto sourceOrigin = SecurityOrigin::decode(decoder);
-    if (!sourceOrigin)
-        return std::nullopt;
-
-    std::optional<bool> ignoreSearch;
-    decoder >> ignoreSearch;
-    if (!ignoreSearch)
-        return std::nullopt;
-
-    std::optional<bool> ignoreMethod;
-    decoder >> ignoreMethod;
-    if (!ignoreMethod)
-        return std::nullopt;
-
-    std::optional<bool> ignoreVary;
-    decoder >> ignoreVary;
-    if (!ignoreVary)
-        return std::nullopt;
-
-    std::optional<bool> shouldProvideResponse;
-    decoder >> shouldProvideResponse;
-    if (!shouldProvideResponse)
-        return std::nullopt;
-
-    return { { WTFMove(*request), WTFMove(*crossOriginEmbedderPolicy), sourceOrigin.releaseNonNull(), WTFMove(*ignoreSearch), WTFMove(*ignoreMethod), WTFMove(*ignoreVary), WTFMove(*shouldProvideResponse) } };
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/contact-picker/ContactInfo.h
+++ b/Source/WebCore/Modules/contact-picker/ContactInfo.h
@@ -34,38 +34,6 @@ struct ContactInfo {
     Vector<String> name;
     Vector<String> email;
     Vector<String> tel;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ContactInfo> decode(Decoder&);
 };
-
-template<class Encoder>
-void ContactInfo::encode(Encoder& encoder) const
-{
-    encoder << name;
-    encoder << email;
-    encoder << tel;
-}
-
-template<class Decoder>
-std::optional<ContactInfo> ContactInfo::decode(Decoder& decoder)
-{
-    std::optional<Vector<String>> name;
-    decoder >> name;
-    if (!name)
-        return std::nullopt;
-
-    std::optional<Vector<String>> email;
-    decoder >> email;
-    if (!email)
-        return std::nullopt;
-
-    std::optional<Vector<String>> tel;
-    decoder >> tel;
-    if (!tel)
-        return std::nullopt;
-
-    return {{ *name, *email, *tel }};
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/contact-picker/ContactsRequestData.h
+++ b/Source/WebCore/Modules/contact-picker/ContactsRequestData.h
@@ -36,38 +36,6 @@ struct ContactsRequestData {
     Vector<ContactProperty> properties;
     bool multiple { false };
     String url;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ContactsRequestData> decode(Decoder&);
 };
-
-template<class Encoder>
-void ContactsRequestData::encode(Encoder& encoder) const
-{
-    encoder << properties;
-    encoder << multiple;
-    encoder << url;
-}
-
-template<class Decoder>
-std::optional<ContactsRequestData> ContactsRequestData::decode(Decoder& decoder)
-{
-    std::optional<Vector<ContactProperty>> properties;
-    decoder >> properties;
-    if (!properties)
-        return std::nullopt;
-
-    std::optional<bool> multiple;
-    decoder >> multiple;
-    if (!multiple)
-        return std::nullopt;
-
-    std::optional<String> url;
-    decoder >> url;
-    if (!url)
-        return std::nullopt;
-
-    return {{ *properties, *multiple, *url }};
-}
 
 }

--- a/Source/WebCore/Modules/mediasession/MediaImage.h
+++ b/Source/WebCore/Modules/mediasession/MediaImage.h
@@ -36,32 +36,7 @@ struct MediaImage {
     String src;
     String sizes;
     String type;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<MediaImage> decode(Decoder&);
 };
-
-template<class Encoder> inline void MediaImage::encode(Encoder& encoder) const
-{
-    encoder << src << sizes << type;
-}
-
-template<class Decoder> inline std::optional<MediaImage> MediaImage::decode(Decoder& decoder)
-{
-    String src;
-    if (!decoder.decode(src))
-        return { };
-
-    String sizes;
-    if (!decoder.decode(sizes))
-        return { };
-
-    String type;
-    if (!decoder.decode(type))
-        return { };
-
-    return MediaImage { WTFMove(src), WTFMove(sizes), WTFMove(type) };
-}
 
 }
 

--- a/Source/WebCore/Modules/mediasession/MediaMetadataInit.h
+++ b/Source/WebCore/Modules/mediasession/MediaMetadataInit.h
@@ -39,59 +39,7 @@ struct MediaMetadataInit {
     String trackIdentifier;
 #endif
     Vector<MediaImage> artwork;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<MediaMetadataInit> decode(Decoder&);
 };
-
-template<class Encoder> inline void MediaMetadataInit::encode(Encoder& encoder) const
-{
-    encoder << title << artist << album
-#if ENABLE(MEDIA_SESSION_PLAYLIST)
-    << trackIdentifier
-#endif
-    << artwork;
-}
-
-template<class Decoder> inline std::optional<MediaMetadataInit> MediaMetadataInit::decode(Decoder& decoder)
-{
-    std::optional<String> title;
-    decoder >> title;
-    if (!title)
-        return { };
-
-    std::optional<String> artist;
-    decoder >> artist;
-    if (!artist)
-        return { };
-
-    std::optional<String> album;
-    decoder >> album;
-    if (!album)
-        return { };
-
-#if ENABLE(MEDIA_SESSION_PLAYLIST)
-    std::optional<String> trackIdentifier;
-    decoder >> trackIdentifier;
-    if (!trackIdentifier)
-        return { };
-#endif
-
-    std::optional<Vector<MediaImage>> artwork;
-    decoder >> artwork;
-    if (!artwork)
-        return { };
-
-    return { {
-        WTFMove(*title),
-        WTFMove(*artist),
-        WTFMove(*album),
-#if ENABLE(MEDIA_SESSION_PLAYLIST)
-        WTFMove(*trackIdentifier),
-#endif
-        WTFMove(*artwork)
-    } };
-}
 
 }
 

--- a/Source/WebCore/Modules/mediasession/MediaPositionState.h
+++ b/Source/WebCore/Modules/mediasession/MediaPositionState.h
@@ -36,33 +36,8 @@ struct MediaPositionState {
 
     String toJSONString() const;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<MediaPositionState> decode(Decoder&);
-
     bool operator==(const MediaPositionState& other) const { return duration == other.duration && playbackRate == other.playbackRate && position == other.position; }
 };
-
-template<class Encoder> inline void MediaPositionState::encode(Encoder& encoder) const
-{
-    encoder << duration << playbackRate << position;
-}
-
-template<class Decoder> inline std::optional<MediaPositionState> MediaPositionState::decode(Decoder& decoder)
-{
-    double duration;
-    if (!decoder.decode(duration))
-        return { };
-
-    double playbackRate;
-    if (!decoder.decode(playbackRate))
-        return { };
-
-    double position;
-    if (!decoder.decode(position))
-        return { };
-
-    return MediaPositionState { WTFMove(duration), WTFMove(playbackRate), WTFMove(position) };
-}
 
 }
 

--- a/Source/WebCore/Modules/mediastream/DetachedRTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/DetachedRTCDataChannel.h
@@ -45,6 +45,8 @@ public:
         , state(state)
     {
     }
+    DetachedRTCDataChannel(DetachedRTCDataChannel&&) = default;
+    DetachedRTCDataChannel& operator=(DetachedRTCDataChannel&&) = default;
 
     size_t memoryCost() const { return label.sizeInBytes(); }
 
@@ -52,39 +54,7 @@ public:
     String label;
     RTCDataChannelInit options;
     RTCDataChannelState state { RTCDataChannelState::Closed };
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::unique_ptr<DetachedRTCDataChannel> decode(Decoder&);
 };
-
-template<class Encoder> void DetachedRTCDataChannel::encode(Encoder& encoder) const
-{
-    encoder << identifier << label << options << state;
-}
-
-template<class Decoder> std::unique_ptr<DetachedRTCDataChannel> DetachedRTCDataChannel::decode(Decoder& decoder)
-{
-    std::optional<RTCDataChannelIdentifier> identifier;
-    decoder >> identifier;
-    if (!identifier)
-        return { };
-
-    String label;
-    if (!decoder.decode(label))
-        return { };
-
-    std::optional<RTCDataChannelInit> options;
-    decoder >> options;
-    if (!options)
-        return { };
-
-    std::optional<RTCDataChannelState> state;
-    decoder >> state;
-    if (!state)
-        return { };
-
-    return makeUnique<DetachedRTCDataChannel>(*identifier, WTFMove(label), WTFMove(options).value(), *state);
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElementCamera.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElementCamera.h
@@ -33,37 +33,7 @@ struct HTMLModelElementCamera {
     double pitch { 0 };
     double yaw { 0 };
     double scale { 1 };
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<HTMLModelElementCamera> decode(Decoder&);
 };
-
-template<class Encoder> void HTMLModelElementCamera::encode(Encoder& encoder) const
-{
-    encoder << pitch;
-    encoder << yaw;
-    encoder << scale;
-}
-
-template<class Decoder> std::optional<HTMLModelElementCamera> HTMLModelElementCamera::decode(Decoder& decoder)
-{
-    std::optional<double> pitch;
-    decoder >> pitch;
-    if (!pitch)
-        return std::nullopt;
-
-    std::optional<double> yaw;
-    decoder >> yaw;
-    if (!yaw)
-        return std::nullopt;
-
-    std::optional<double> scale;
-    decoder >> scale;
-    if (!scale)
-        return std::nullopt;
-
-    return { { *pitch, *yaw, *scale } };
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/notifications/NotificationData.h
+++ b/Source/WebCore/Modules/notifications/NotificationData.h
@@ -40,9 +40,6 @@ namespace WebCore {
 enum class NotificationDirection : uint8_t;
 
 struct NotificationData {
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<NotificationData> decode(Decoder&);
-
     WEBCORE_EXPORT NotificationData isolatedCopy() const &;
     WEBCORE_EXPORT NotificationData isolatedCopy() &&;
 
@@ -67,96 +64,5 @@ struct NotificationData {
     MonotonicTime creationTime;
     Vector<uint8_t> data;
 };
-
-template<class Encoder>
-void NotificationData::encode(Encoder& encoder) const
-{
-    encoder << title << body << iconURL << tag << language << direction << originString << serviceWorkerRegistrationURL << notificationID << contextIdentifier << sourceSession << creationTime << data;
-}
-
-template<class Decoder>
-std::optional<NotificationData> NotificationData::decode(Decoder& decoder)
-{
-    std::optional<String> title;
-    decoder >> title;
-    if (!title)
-        return std::nullopt;
-
-    std::optional<String> body;
-    decoder >> body;
-    if (!body)
-        return std::nullopt;
-
-    std::optional<String> iconURL;
-    decoder >> iconURL;
-    if (!iconURL)
-        return std::nullopt;
-
-    std::optional<String> tag;
-    decoder >> tag;
-    if (!tag)
-        return std::nullopt;
-
-    std::optional<String> language;
-    decoder >> language;
-    if (!language)
-        return std::nullopt;
-
-    std::optional<WebCore::NotificationDirection> direction;
-    decoder >> direction;
-    if (!direction)
-        return std::nullopt;
-
-    std::optional<String> originString;
-    decoder >> originString;
-    if (!originString)
-        return std::nullopt;
-
-    std::optional<URL> serviceWorkerRegistrationURL;
-    decoder >> serviceWorkerRegistrationURL;
-    if (!serviceWorkerRegistrationURL)
-        return std::nullopt;
-
-    std::optional<UUID> notificationID;
-    decoder >> notificationID;
-    if (!notificationID)
-        return std::nullopt;
-
-    std::optional<ScriptExecutionContextIdentifier> scriptExecutionContextIdentifier;
-    decoder >> scriptExecutionContextIdentifier;
-    if (!scriptExecutionContextIdentifier)
-        return std::nullopt;
-
-    std::optional<PAL::SessionID> sourceSession;
-    decoder >> sourceSession;
-    if (!sourceSession)
-        return std::nullopt;
-
-    std::optional<MonotonicTime> creationTime;
-    decoder >> creationTime;
-    if (!creationTime)
-        return std::nullopt;
-
-    std::optional<Vector<uint8_t>> data;
-    decoder >> data;
-    if (!data)
-        return std::nullopt;
-
-    return { {
-        WTFMove(*title),
-        WTFMove(*body),
-        WTFMove(*iconURL),
-        WTFMove(*tag),
-        WTFMove(*language),
-        WTFMove(*direction),
-        WTFMove(*originString),
-        WTFMove(*serviceWorkerRegistrationURL),
-        WTFMove(*notificationID),
-        *scriptExecutionContextIdentifier,
-        WTFMove(*sourceSession),
-        WTFMove(*creationTime),
-        WTFMove(*data)
-    } };
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/permissions/PermissionDescriptor.h
+++ b/Source/WebCore/Modules/permissions/PermissionDescriptor.h
@@ -34,22 +34,6 @@ struct PermissionDescriptor {
     PermissionName name;
 
     bool operator==(const PermissionDescriptor& descriptor) const { return name == descriptor.name; }
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<PermissionDescriptor> decode(Decoder&);
 };
-
-template<class Encoder> inline void PermissionDescriptor::encode(Encoder& encoder) const
-{
-    encoder << name;
-}
-
-template<class Decoder> std::optional<PermissionDescriptor> PermissionDescriptor::decode(Decoder& decoder)
-{
-    PermissionDescriptor result;
-    if (!decoder.decode(result.name))
-        return std::nullopt;
-
-    return result;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/push-api/PushSubscriptionData.h
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionData.h
@@ -44,57 +44,7 @@ struct PushSubscriptionData {
 
     WEBCORE_EXPORT PushSubscriptionData isolatedCopy() const &;
     WEBCORE_EXPORT PushSubscriptionData isolatedCopy() &&;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<PushSubscriptionData> decode(Decoder&);
 };
-
-template<class Encoder>
-void PushSubscriptionData::encode(Encoder& encoder) const
-{
-    encoder << identifier;
-    encoder << endpoint;
-    encoder << expirationTime;
-    encoder << serverVAPIDPublicKey;
-    encoder << clientECDHPublicKey;
-    encoder << sharedAuthenticationSecret;
-}
-
-template<class Decoder>
-std::optional<PushSubscriptionData> PushSubscriptionData::decode(Decoder& decoder)
-{
-    std::optional<PushSubscriptionIdentifier> identifier;
-    decoder >> identifier;
-    if (!identifier)
-        return std::nullopt;
-
-    std::optional<String> endpoint;
-    decoder >> endpoint;
-    if (!endpoint)
-        return std::nullopt;
-
-    std::optional<std::optional<WebCore::EpochTimeStamp>> expirationTime;
-    decoder >> expirationTime;
-    if (!expirationTime)
-        return std::nullopt;
-
-    std::optional<Vector<uint8_t>> serverVAPIDPublicKey;
-    decoder >> serverVAPIDPublicKey;
-    if (!serverVAPIDPublicKey)
-        return std::nullopt;
-
-    std::optional<Vector<uint8_t>> clientECDHPublicKey;
-    decoder >> clientECDHPublicKey;
-    if (!clientECDHPublicKey)
-        return std::nullopt;
-
-    std::optional<Vector<uint8_t>> sharedAuthenticationSecret;
-    decoder >> sharedAuthenticationSecret;
-    if (!sharedAuthenticationSecret)
-        return std::nullopt;
-
-    return PushSubscriptionData { WTFMove(*identifier), WTFMove(*endpoint), WTFMove(*expirationTime), WTFMove(*serverVAPIDPublicKey), WTFMove(*clientECDHPublicKey), WTFMove(*sharedAuthenticationSecret) };
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/reporting/DeprecationReportBody.h
+++ b/Source/WebCore/Modules/reporting/DeprecationReportBody.h
@@ -50,9 +50,6 @@ public:
 
     WEBCORE_EXPORT Ref<FormData> createReportFormDataForViolation() const;
 
-    template<typename Encoder> void encode(Encoder&) const;
-    template<typename Decoder> static std::optional<RefPtr<WebCore::DeprecationReportBody>> decode(Decoder&);
-
 private:
     DeprecationReportBody(String&& id, WallTime anticipatedRemoval, String&& message, String&& sourceFile, std::optional<unsigned> lineNumber, std::optional<unsigned> columnNumber);
 
@@ -63,48 +60,6 @@ private:
     const std::optional<unsigned> m_lineNumber;
     const std::optional<unsigned> m_columnNumber;
 };
-
-template<typename Encoder>
-void DeprecationReportBody::encode(Encoder& encoder) const
-{
-    encoder << m_id << m_anticipatedRemoval << m_message << m_sourceFile << m_lineNumber << m_columnNumber;
-}
-
-template<typename Decoder>
-std::optional<RefPtr<DeprecationReportBody>> DeprecationReportBody::decode(Decoder& decoder)
-{
-    std::optional<String> reportId;
-    decoder >> reportId;
-    if (!reportId)
-        return std::nullopt;
-
-    std::optional<WallTime> anticipatedRemoval;
-    decoder >> anticipatedRemoval;
-    if (!anticipatedRemoval)
-        return std::nullopt;
-
-    std::optional<String> message;
-    decoder >> message;
-    if (!message)
-        return std::nullopt;
-
-    std::optional<String> sourceFile;
-    decoder >> sourceFile;
-    if (!sourceFile)
-        return std::nullopt;
-
-    std::optional<std::optional<unsigned>> lineNumber;
-    decoder >> lineNumber;
-    if (!lineNumber)
-        return std::nullopt;
-
-    std::optional<std::optional<unsigned>> columnNumber;
-    decoder >> columnNumber;
-    if (!columnNumber)
-        return std::nullopt;
-
-    return DeprecationReportBody::create(WTFMove(*reportId), *anticipatedRemoval, WTFMove(*message), WTFMove(*sourceFile), WTFMove(*lineNumber), WTFMove(*columnNumber));
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/reporting/Report.cpp
+++ b/Source/WebCore/Modules/reporting/Report.cpp
@@ -59,7 +59,7 @@ const String& Report::url() const
     return m_url;
 }
 
-const RefPtr<ReportBody>& Report::body()
+const RefPtr<ReportBody>& Report::body() const
 {
     return m_body;
 }

--- a/Source/WebCore/Modules/reporting/Report.h
+++ b/Source/WebCore/Modules/reporting/Report.h
@@ -43,12 +43,9 @@ public:
 
     const String& type() const;
     const String& url() const;
-    const RefPtr<ReportBody>& body();
+    const RefPtr<ReportBody>& body() const;
 
     static Ref<FormData> createReportFormDataForViolation(const String& type, const URL&, const String& userAgent, const Function<void(JSON::Object&)>& populateBody);
-
-    template<typename Encoder> void WEBCORE_EXPORT encode(Encoder&) const;
-    template<typename Decoder> static WEBCORE_EXPORT std::optional<Ref<WebCore::Report>> decode(Decoder&);
 
 private:
     explicit Report(const String& type, const String& url, RefPtr<ReportBody>&&);
@@ -57,32 +54,5 @@ private:
     String m_url;
     RefPtr<ReportBody> m_body;
 };
-
-template<typename Encoder>
-void Report::encode(Encoder& encoder) const
-{
-    encoder << m_type << m_url << m_body;
-}
-
-template<typename Decoder>
-std::optional<Ref<WebCore::Report>> Report::decode(Decoder& decoder)
-{
-    std::optional<String> type;
-    decoder >> type;
-    if (!type)
-        return std::nullopt;
-
-    std::optional<String> url;
-    decoder >> url;
-    if (!url)
-        return std::nullopt;
-
-    std::optional<RefPtr<ReportBody>> body;
-    decoder >> body;
-    if (!body)
-        return std::nullopt;
-
-    return Report::create(WTFMove(*type), WTFMove(*url), WTFMove(*body));
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/reporting/TestReportBody.h
+++ b/Source/WebCore/Modules/reporting/TestReportBody.h
@@ -39,36 +39,16 @@ class TestReportBody final : public ReportBody {
 public:
     WEBCORE_EXPORT static Ref<TestReportBody> create(String&& message);
 
-    const String& type() const final;
-    const String& message() const;
+    WEBCORE_EXPORT const String& type() const final;
+    WEBCORE_EXPORT const String& message() const;
 
     WEBCORE_EXPORT Ref<FormData> createReportFormDataForViolation() const;
-
-    template<typename Encoder> void encode(Encoder&) const;
-    template<typename Decoder> static std::optional<RefPtr<WebCore::TestReportBody>> decode(Decoder&);
 
 private:
     TestReportBody(String&& message);
 
     const String m_bodyMessage;
 };
-
-template<typename Encoder>
-void TestReportBody::encode(Encoder& encoder) const
-{
-    encoder << m_bodyMessage;
-}
-
-template<typename Decoder>
-std::optional<RefPtr<TestReportBody>> TestReportBody::decode(Decoder& decoder)
-{
-    std::optional<String> bodymessage;
-    decoder >> bodymessage;
-    if (!bodymessage)
-        return std::nullopt;
-
-    return TestReportBody::create(WTFMove(*bodymessage));
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/speech/SpeechRecognitionError.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionError.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -43,49 +43,6 @@ enum class SpeechRecognitionErrorType : uint8_t {
 struct SpeechRecognitionError {
     SpeechRecognitionErrorType type;
     String message;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<SpeechRecognitionError> decode(Decoder&);
 };
-
-template<class Encoder>
-void SpeechRecognitionError::encode(Encoder& encoder) const
-{
-    encoder << type << message;
-}
-
-template<class Decoder>
-std::optional<SpeechRecognitionError> SpeechRecognitionError::decode(Decoder& decoder)
-{
-    std::optional<SpeechRecognitionErrorType> type;
-    decoder >> type;
-    if (!type)
-        return std::nullopt;
-
-    std::optional<String> message;
-    decoder >> message;
-    if (!message)
-        return std::nullopt;
-    
-    return SpeechRecognitionError { WTFMove(*type), WTFMove(*message) };
-}
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::SpeechRecognitionErrorType> {
-    using values = EnumValues<
-        WebCore::SpeechRecognitionErrorType,
-        WebCore::SpeechRecognitionErrorType::NoSpeech,
-        WebCore::SpeechRecognitionErrorType::Aborted,
-        WebCore::SpeechRecognitionErrorType::AudioCapture,
-        WebCore::SpeechRecognitionErrorType::Network,
-        WebCore::SpeechRecognitionErrorType::NotAllowed,
-        WebCore::SpeechRecognitionErrorType::ServiceNotAllowed,
-        WebCore::SpeechRecognitionErrorType::BadGrammar,
-        WebCore::SpeechRecognitionErrorType::LanguageNotSupported
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/speech/SpeechRecognitionRequestInfo.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionRequestInfo.h
@@ -39,64 +39,6 @@ struct SpeechRecognitionRequestInfo {
     uint64_t maxAlternatives { 1 };
     ClientOrigin clientOrigin;
     FrameIdentifier frameIdentifier;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<SpeechRecognitionRequestInfo> decode(Decoder&);
 };
-
-template<class Encoder>
-void SpeechRecognitionRequestInfo::encode(Encoder& encoder) const
-{
-    encoder << clientIdentifier << lang << continuous << interimResults << maxAlternatives << clientOrigin << frameIdentifier;
-}
-
-template<class Decoder>
-std::optional<SpeechRecognitionRequestInfo> SpeechRecognitionRequestInfo::decode(Decoder& decoder)
-{
-    std::optional<SpeechRecognitionConnectionClientIdentifier> clientIdentifier;
-    decoder >> clientIdentifier;
-    if (!clientIdentifier)
-        return std::nullopt;
-
-    std::optional<String> lang;
-    decoder >> lang;
-    if (!lang)
-        return std::nullopt;
-
-    std::optional<bool> continuous;
-    decoder >> continuous;
-    if (!continuous)
-        return std::nullopt;
-
-    std::optional<bool> interimResults;
-    decoder >> interimResults;
-    if (!interimResults)
-        return std::nullopt;
-
-    std::optional<uint64_t> maxAlternatives;
-    decoder >> maxAlternatives;
-    if (!maxAlternatives)
-        return std::nullopt;
-
-    std::optional<ClientOrigin> clientOrigin;
-    decoder >> clientOrigin;
-    if (!clientOrigin)
-        return std::nullopt;
-
-    std::optional<FrameIdentifier> frameIdentifier;
-    decoder >> frameIdentifier;
-    if (!frameIdentifier)
-        return std::nullopt;
-
-    return {{
-        WTFMove(*clientIdentifier),
-        WTFMove(*lang),
-        WTFMove(*continuous),
-        WTFMove(*interimResults),
-        WTFMove(*maxAlternatives),
-        WTFMove(*clientOrigin),
-        WTFMove(*frameIdentifier)
-    }};
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechRecognitionResultData.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionResultData.h
@@ -30,55 +30,11 @@ namespace WebCore {
 struct SpeechRecognitionAlternativeData {
     String transcript;
     double confidence { 0.0 };
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<SpeechRecognitionAlternativeData> decode(Decoder&);
 };
-
-template<class Encoder>
-void SpeechRecognitionAlternativeData::encode(Encoder& encoder) const
-{
-    encoder << transcript << confidence;
-}
-
-template<class Decoder>
-std::optional<SpeechRecognitionAlternativeData> SpeechRecognitionAlternativeData::decode(Decoder& decoder)
-{
-    SpeechRecognitionAlternativeData result;
-    if (!decoder.decode(result.transcript))
-        return std::nullopt;
-
-    if (!decoder.decode(result.confidence))
-        return std::nullopt;
-
-    return result;
-}
 
 struct SpeechRecognitionResultData {
     Vector<SpeechRecognitionAlternativeData> alternatives;
     bool isFinal { false };
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<SpeechRecognitionResultData> decode(Decoder&);
 };
-
-template<class Encoder>
-void SpeechRecognitionResultData::encode(Encoder& encoder) const
-{
-    encoder << alternatives << isFinal;
-}
-
-template<class Decoder>
-std::optional<SpeechRecognitionResultData> SpeechRecognitionResultData::decode(Decoder& decoder)
-{
-    SpeechRecognitionResultData result;
-    if (!decoder.decode(result.alternatives))
-        return std::nullopt;
-
-    if (!decoder.decode(result.isFinal))
-        return std::nullopt;
-
-    return result;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/web-locks/WebLockManagerSnapshot.h
+++ b/Source/WebCore/Modules/web-locks/WebLockManagerSnapshot.h
@@ -39,9 +39,6 @@ struct WebLockManagerSnapshot {
 
         Info isolatedCopy() const & { return { name.isolatedCopy(), mode, clientId.isolatedCopy() }; }
         Info isolatedCopy() && { return { WTFMove(name).isolatedCopy(), mode, WTFMove(clientId).isolatedCopy() }; }
-
-        template<class Encoder> void encode(Encoder& encoder) const { encoder << name << mode << clientId; }
-        template<class Decoder> static std::optional<Info> decode(Decoder&);
     };
 
     Vector<Info> held;
@@ -49,46 +46,6 @@ struct WebLockManagerSnapshot {
 
     WebLockManagerSnapshot isolatedCopy() const & { return { crossThreadCopy(held), crossThreadCopy(pending) }; }
     WebLockManagerSnapshot isolatedCopy() && { return { crossThreadCopy(WTFMove(held)), crossThreadCopy(WTFMove(pending)) }; }
-
-    template<class Encoder> void encode(Encoder& encoder) const { encoder << held << pending; }
-    template<class Decoder> static std::optional<WebLockManagerSnapshot> decode(Decoder&);
 };
-
-template<class Decoder>
-std::optional<WebLockManagerSnapshot::Info> WebLockManagerSnapshot::Info::decode(Decoder& decoder)
-{
-    std::optional<String> name;
-    decoder >> name;
-    if (!name)
-        return std::nullopt;
-
-    std::optional<WebLockMode> mode;
-    decoder >> mode;
-    if (!mode)
-        return std::nullopt;
-
-    std::optional<String> clientId;
-    decoder >> clientId;
-    if (!clientId)
-        return std::nullopt;
-
-    return { { WTFMove(*name), *mode, WTFMove(*clientId) } };
-}
-
-template<class Decoder>
-std::optional<WebLockManagerSnapshot> WebLockManagerSnapshot::decode(Decoder& decoder)
-{
-    std::optional<Vector<Info>> held;
-    decoder >> held;
-    if (!held)
-        return std::nullopt;
-
-    std::optional<Vector<Info>> pending;
-    decoder >> pending;
-    if (!pending)
-        return std::nullopt;
-
-    return { { WTFMove(*held), WTFMove(*pending) } };
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h
@@ -36,38 +36,9 @@ struct AuthenticationExtensionsClientInputs {
     bool googleLegacyAppidSupport;
     bool credProps;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<AuthenticationExtensionsClientInputs> decode(Decoder&);
-
     WEBCORE_EXPORT Vector<uint8_t> toCBOR() const;
     WEBCORE_EXPORT static std::optional<AuthenticationExtensionsClientInputs> fromCBOR(Span<const uint8_t>);
 };
-
-template<class Encoder>
-void AuthenticationExtensionsClientInputs::encode(Encoder& encoder) const
-{
-    encoder << appid << googleLegacyAppidSupport;
-}
-
-template<class Decoder>
-std::optional<AuthenticationExtensionsClientInputs> AuthenticationExtensionsClientInputs::decode(Decoder& decoder)
-{
-    AuthenticationExtensionsClientInputs result;
-
-    std::optional<String> appid;
-    decoder >> appid;
-    if (!appid)
-        return std::nullopt;
-    result.appid = WTFMove(*appid);
-
-    std::optional<bool> googleLegacyAppidSupport;
-    decoder >> googleLegacyAppidSupport;
-    if (!googleLegacyAppidSupport)
-        return std::nullopt;
-    result.googleLegacyAppidSupport = WTFMove(*googleLegacyAppidSupport);
-
-    return result;
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.h
@@ -36,64 +36,13 @@ namespace WebCore {
 struct AuthenticationExtensionsClientOutputs {
     struct CredentialPropertiesOutput {
         bool rk;
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<CredentialPropertiesOutput> decode(Decoder&);
     };
     std::optional<bool> appid;
     std::optional<CredentialPropertiesOutput> credProps;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<AuthenticationExtensionsClientOutputs> decode(Decoder&);
-
     WEBCORE_EXPORT Vector<uint8_t> toCBOR() const;
     WEBCORE_EXPORT static std::optional<AuthenticationExtensionsClientOutputs> fromCBOR(const Vector<uint8_t>&);
 };
-
-template<class Encoder>
-void AuthenticationExtensionsClientOutputs::encode(Encoder& encoder) const
-{
-    encoder << appid << credProps;
-}
-
-template<class Decoder>
-std::optional<AuthenticationExtensionsClientOutputs> AuthenticationExtensionsClientOutputs::decode(Decoder& decoder)
-{
-    AuthenticationExtensionsClientOutputs result;
-
-    std::optional<std::optional<bool>> appid;
-    decoder >> appid;
-    if (!appid)
-        return std::nullopt;
-    result.appid = WTFMove(*appid);
-
-    std::optional<std::optional<CredentialPropertiesOutput>> credProps;
-    decoder >> credProps;
-    if (!credProps)
-        return std::nullopt;
-    result.credProps = WTFMove(*credProps);
-
-    return result;
-}
-
-template<class Encoder>
-void AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput::encode(Encoder& encoder) const
-{
-    encoder << rk;
-}
-
-template<class Decoder>
-std::optional<AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput> AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput::decode(Decoder& decoder)
-{
-    CredentialPropertiesOutput result;
-
-    std::optional<bool> rk;
-    decoder >> rk;
-    if (!rk)
-        return std::nullopt;
-    result.rk = *rk;
-
-    return result;
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.h
@@ -59,9 +59,6 @@ struct PublicKeyCredentialCreationOptions {
     struct Parameters {
         PublicKeyCredentialType type;
         int64_t alg;
-
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<Parameters> decode(Decoder&);
     };
 
     struct AuthenticatorSelectionCriteria {
@@ -70,9 +67,6 @@ struct PublicKeyCredentialCreationOptions {
         std::optional<ResidentKeyRequirement> residentKey;
         bool requireResidentKey { false };
         UserVerificationRequirement userVerification { UserVerificationRequirement::Preferred };
-
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<AuthenticatorSelectionCriteria> decode(Decoder&);
     };
 
     RpEntity rp;
@@ -86,129 +80,7 @@ struct PublicKeyCredentialCreationOptions {
     std::optional<AuthenticatorSelectionCriteria> authenticatorSelection;
     AttestationConveyancePreference attestation;
     mutable std::optional<AuthenticationExtensionsClientInputs> extensions;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<PublicKeyCredentialCreationOptions> decode(Decoder&);
 #endif // ENABLE(WEB_AUTHN)
 };
-
-#if ENABLE(WEB_AUTHN)
-template<class Encoder>
-void PublicKeyCredentialCreationOptions::Parameters::encode(Encoder& encoder) const
-{
-    encoder << type << alg;
-}
-
-template<class Decoder>
-std::optional<PublicKeyCredentialCreationOptions::Parameters> PublicKeyCredentialCreationOptions::Parameters::decode(Decoder& decoder)
-{
-    PublicKeyCredentialCreationOptions::Parameters result;
-    if (!decoder.decode(result.type))
-        return std::nullopt;
-    if (!decoder.decode(result.alg))
-        return std::nullopt;
-    return result;
-}
-
-template<class Encoder>
-void PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::encode(Encoder& encoder) const
-{
-    encoder << authenticatorAttachment << requireResidentKey << userVerification << residentKey;
-}
-
-template<class Decoder>
-std::optional<PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria> PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::decode(Decoder& decoder)
-{
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria result;
-
-    std::optional<std::optional<AuthenticatorAttachment>> authenticatorAttachment;
-    decoder >> authenticatorAttachment;
-    if (!authenticatorAttachment)
-        return std::nullopt;
-    result.authenticatorAttachment = WTFMove(*authenticatorAttachment);
-
-    std::optional<bool> requireResidentKey;
-    decoder >> requireResidentKey;
-    if (!requireResidentKey)
-        return std::nullopt;
-    result.requireResidentKey = *requireResidentKey;
-
-    if (!decoder.decode(result.userVerification))
-        return std::nullopt;
-
-    std::optional<std::optional<ResidentKeyRequirement>> residentKey;
-    decoder >> residentKey;
-    if (!residentKey)
-        return std::nullopt;
-    result.residentKey = *residentKey;
-
-    return result;
-}
-
-// Not every member is encoded.
-template<class Encoder>
-void PublicKeyCredentialCreationOptions::encode(Encoder& encoder) const
-{
-    encoder << rp.id << rp.name << rp.icon;
-    encoder << user.id;
-    encoder << user.displayName << user.name << user.icon << pubKeyCredParams << timeout << excludeCredentials << authenticatorSelection << attestation << extensions;
-    encoder << static_cast<uint64_t>(challenge.length());
-    encoder.encodeFixedLengthData(challenge.data(), challenge.length(), 1);
-}
-
-template<class Decoder>
-std::optional<PublicKeyCredentialCreationOptions> PublicKeyCredentialCreationOptions::decode(Decoder& decoder)
-{
-    PublicKeyCredentialCreationOptions result;
-    if (!decoder.decode(result.rp.id))
-        return std::nullopt;
-    if (!decoder.decode(result.rp.name))
-        return std::nullopt;
-    if (!decoder.decode(result.rp.icon))
-        return std::nullopt;
-    if (!decoder.decode(result.user.id))
-        return std::nullopt;
-    if (!decoder.decode(result.user.displayName))
-        return std::nullopt;
-    if (!decoder.decode(result.user.name))
-        return std::nullopt;
-    if (!decoder.decode(result.user.icon))
-        return std::nullopt;
-    if (!decoder.decode(result.pubKeyCredParams))
-        return std::nullopt;
-
-    std::optional<std::optional<unsigned>> timeout;
-    decoder >> timeout;
-    if (!timeout)
-        return std::nullopt;
-    result.timeout = WTFMove(*timeout);
-
-    if (!decoder.decode(result.excludeCredentials))
-        return std::nullopt;
-
-    std::optional<std::optional<AuthenticatorSelectionCriteria>> authenticatorSelection;
-    decoder >> authenticatorSelection;
-    if (!authenticatorSelection)
-        return std::nullopt;
-    result.authenticatorSelection = WTFMove(*authenticatorSelection);
-
-    std::optional<AttestationConveyancePreference> attestation;
-    decoder >> attestation;
-    if (!attestation)
-        return std::nullopt;
-    result.attestation = WTFMove(*attestation);
-
-    std::optional<std::optional<AuthenticationExtensionsClientInputs>> extensions;
-    decoder >> extensions;
-    if (!extensions)
-        return std::nullopt;
-    result.extensions = WTFMove(*extensions);
-
-    if (!decoder.decode(result.challenge))
-        return std::nullopt;
-
-    return result;
-}
-#endif // ENABLE(WEB_AUTHN)
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h
@@ -37,31 +37,7 @@ struct PublicKeyCredentialDescriptor {
     PublicKeyCredentialType type;
     BufferSource id;
     Vector<AuthenticatorTransport> transports;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<PublicKeyCredentialDescriptor> decode(Decoder&);
 };
-
-template<class Encoder>
-void PublicKeyCredentialDescriptor::encode(Encoder& encoder) const
-{
-    encoder << type;
-    encoder << id;
-    encoder << transports;
-}
-
-template<class Decoder>
-std::optional<PublicKeyCredentialDescriptor> PublicKeyCredentialDescriptor::decode(Decoder& decoder)
-{
-    PublicKeyCredentialDescriptor result;
-    if (!decoder.decode(result.type))
-        return std::nullopt;
-    if (!decoder.decode(result.id))
-        return std::nullopt;
-    if (!decoder.decode(result.transports))
-        return std::nullopt;
-    return result;
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h
@@ -45,55 +45,7 @@ struct PublicKeyCredentialRequestOptions {
     UserVerificationRequirement userVerification { UserVerificationRequirement::Preferred };
     std::optional<AuthenticatorAttachment> authenticatorAttachment;
     mutable std::optional<AuthenticationExtensionsClientInputs> extensions;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<PublicKeyCredentialRequestOptions> decode(Decoder&);
 #endif // ENABLE(WEB_AUTHN)
 };
-
-#if ENABLE(WEB_AUTHN)
-// Not every member is encoded.
-template<class Encoder>
-void PublicKeyCredentialRequestOptions::encode(Encoder& encoder) const
-{
-    encoder << timeout << rpId << allowCredentials << userVerification << extensions;
-    encoder << static_cast<uint64_t>(challenge.length());
-    encoder.encodeFixedLengthData(challenge.data(), challenge.length(), 1);
-}
-
-template<class Decoder>
-std::optional<PublicKeyCredentialRequestOptions> PublicKeyCredentialRequestOptions::decode(Decoder& decoder)
-{
-    PublicKeyCredentialRequestOptions result;
-
-    std::optional<std::optional<unsigned>> timeout;
-    decoder >> timeout;
-    if (!timeout)
-        return std::nullopt;
-    result.timeout = WTFMove(*timeout);
-
-    if (!decoder.decode(result.rpId))
-        return std::nullopt;
-    if (!decoder.decode(result.allowCredentials))
-        return std::nullopt;
-
-    std::optional<UserVerificationRequirement> userVerification;
-    decoder >> userVerification;
-    if (!userVerification)
-        return std::nullopt;
-    result.userVerification = WTFMove(*userVerification);
-
-    std::optional<std::optional<AuthenticationExtensionsClientInputs>> extensions;
-    decoder >> extensions;
-    if (!extensions)
-        return std::nullopt;
-    result.extensions = WTFMove(*extensions);
-
-    if (!decoder.decode(result.challenge))
-        return std::nullopt;
-
-    return result;
-}
-#endif // ENABLE(WEB_AUTHN)
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -220,10 +220,11 @@ RefPtr<SerializedScriptValue> SerializedScriptValue::decode(Decoder& decoder)
 
     Vector<std::unique_ptr<DetachedRTCDataChannel>> detachedRTCDataChannels;
     while (detachedRTCDataChannelsSize--) {
-        auto detachedRTCDataChannel = DetachedRTCDataChannel::decode(decoder);
+        std::optional<DetachedRTCDataChannel> detachedRTCDataChannel;
+        decoder >> detachedRTCDataChannel;
         if (!detachedRTCDataChannel)
             return nullptr;
-        detachedRTCDataChannels.append(WTFMove(detachedRTCDataChannel));
+        detachedRTCDataChannels.append(makeUnique<DetachedRTCDataChannel>(WTFMove(*detachedRTCDataChannel)));
     }
 #endif
 

--- a/Source/WebKit/Platform/IPC/DaemonCoders.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.cpp
@@ -50,9 +50,6 @@ void Coder<class>::encode(Encoder& encoder, const class& instance) { instance.en
 std::optional<class> Coder<class>::decode(Decoder& decoder) { return class::decode(decoder); }
 
 IMPLEMENT_CODER(WebCore::ExceptionData);
-#if ENABLE(SERVICE_WORKER)
-IMPLEMENT_CODER(WebCore::PushSubscriptionData);
-#endif
 IMPLEMENT_CODER(WebCore::PushSubscriptionIdentifier);
 IMPLEMENT_CODER(WebCore::RegistrableDomain);
 IMPLEMENT_CODER(WebCore::SecurityOriginData);
@@ -60,6 +57,60 @@ IMPLEMENT_CODER(WebKit::WebPushMessage);
 IMPLEMENT_CODER(WebPushD::WebPushDaemonConnectionConfiguration);
 
 #undef IMPLEMENT_CODER
+
+#if ENABLE(SERVICE_WORKER)
+void Coder<WebCore::PushSubscriptionData>::encode(Encoder& encoder, const WebCore::PushSubscriptionData& instance)
+{
+    encoder << instance.identifier;
+    encoder << instance.endpoint;
+    encoder << instance.expirationTime;
+    encoder << instance.serverVAPIDPublicKey;
+    encoder << instance.clientECDHPublicKey;
+    encoder << instance.sharedAuthenticationSecret;
+}
+
+std::optional<WebCore::PushSubscriptionData> Coder<WebCore::PushSubscriptionData>::decode(Decoder& decoder)
+{
+    std::optional<WebCore::PushSubscriptionIdentifier> identifier;
+    decoder >> identifier;
+    if (!identifier)
+        return std::nullopt;
+
+    std::optional<String> endpoint;
+    decoder >> endpoint;
+    if (!endpoint)
+        return std::nullopt;
+
+    std::optional<std::optional<WebCore::EpochTimeStamp>> expirationTime;
+    decoder >> expirationTime;
+    if (!expirationTime)
+        return std::nullopt;
+
+    std::optional<Vector<uint8_t>> serverVAPIDPublicKey;
+    decoder >> serverVAPIDPublicKey;
+    if (!serverVAPIDPublicKey)
+        return std::nullopt;
+
+    std::optional<Vector<uint8_t>> clientECDHPublicKey;
+    decoder >> clientECDHPublicKey;
+    if (!clientECDHPublicKey)
+        return std::nullopt;
+
+    std::optional<Vector<uint8_t>> sharedAuthenticationSecret;
+    decoder >> sharedAuthenticationSecret;
+    if (!sharedAuthenticationSecret)
+        return std::nullopt;
+
+    return { {
+        WTFMove(*identifier),
+        WTFMove(*endpoint),
+        WTFMove(*expirationTime),
+        WTFMove(*serverVAPIDPublicKey),
+        WTFMove(*clientECDHPublicKey),
+        WTFMove(*sharedAuthenticationSecret),
+    } };
+}
+#endif
 
 void Coder<WTF::WallTime>::encode(Encoder& encoder, const WTF::WallTime& instance)
 {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -605,6 +605,11 @@ template<> struct ArgumentCoder<RefPtr<WebCore::SecurityOrigin>> {
     static std::optional<RefPtr<WebCore::SecurityOrigin>> decode(Decoder&);
 };
 
+template<> struct ArgumentCoder<Ref<WebCore::SecurityOrigin>> {
+    static void encode(Encoder&, const Ref<WebCore::SecurityOrigin>&);
+    static std::optional<Ref<WebCore::SecurityOrigin>> decode(Decoder&);
+};
+
 template<> struct ArgumentCoder<WebCore::FontAttributes> {
     static void encode(Encoder&, const WebCore::FontAttributes&);
     static std::optional<WebCore::FontAttributes> decode(Decoder&);
@@ -719,11 +724,6 @@ template<> struct ArgumentCoder<UnixFileDescriptor> {
 template<> struct ArgumentCoder<WebCore::PixelBuffer> {
     template<class Encoder> static void encode(Encoder&, const WebCore::PixelBuffer&);
     static std::optional<Ref<WebCore::PixelBuffer>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<Ref<WebCore::Report>> {
-    static void encode(Encoder&, const Ref<WebCore::Report>&);
-    static std::optional<Ref<WebCore::Report>> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<RefPtr<WebCore::ReportBody>> {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -21,10 +21,20 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 header: <WebCore/DOMCacheEngine.h>
-[CustomHeader=True] struct WebCore::DOMCacheEngine::CacheInfo {
+[CustomHeader] struct WebCore::DOMCacheEngine::CacheInfo {
     WebCore::DOMCacheIdentifier identifier
     String name
 }
+
+[CustomHeader] struct WebCore::DOMCacheEngine::CacheInfos {
+    Vector<WebCore::DOMCacheEngine::CacheInfo> infos;
+    uint64_t updateCounter;
+};
+
+[CustomHeader] struct WebCore::DOMCacheEngine::CacheIdentifierOperationResult {
+    WebCore::DOMCacheIdentifier identifier;
+    bool hadStorageError;
+};
 
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::TransformationMatrix {
     double m11()
@@ -715,3 +725,232 @@ struct WebCore::ApplicationManifest {
     Vector<WebCore::ApplicationManifest::Icon> icons
 }
 #endif // ENABLE(APPLICATION_MANIFEST)
+
+enum class WebCore::DOMCacheEngine::Error : uint8_t {
+    NotImplemented,
+    ReadDisk,
+    WriteDisk,
+    QuotaExceeded,
+    Internal,
+    Stopped,
+    CORP
+};
+
+struct WebCore::RetrieveRecordsOptions {
+    WebCore::ResourceRequest request;
+    WebCore::CrossOriginEmbedderPolicy crossOriginEmbedderPolicy;
+    Ref<WebCore::SecurityOrigin> sourceOrigin;
+    bool ignoreSearch;
+    bool ignoreMethod;
+    bool ignoreVary;
+    bool shouldProvideResponse;
+};
+
+struct WebCore::ContactInfo {
+    Vector<String> name;
+    Vector<String> email;
+    Vector<String> tel;
+};
+
+struct WebCore::ContactsRequestData {
+    Vector<WebCore::ContactProperty> properties;
+    bool multiple;
+    String url;
+};
+
+#if ENABLE(MEDIA_SESSION)
+struct WebCore::MediaPositionState {
+    double duration;
+    double playbackRate;
+    double position;
+};
+#endif // ENABLE(MEDIA_SESSION)
+
+#if ENABLE(WEB_RTC)
+struct WebCore::DetachedRTCDataChannel {
+    WebCore::RTCDataChannelIdentifier identifier;
+    String label;
+    WebCore::RTCDataChannelInit options;
+    WebCore::RTCDataChannelState state;
+};
+#endif
+
+struct WebCore::HTMLModelElementCamera {
+    double pitch;
+    double yaw;
+    double scale;
+};
+
+struct WebCore::NotificationData {
+    String title;
+    String body;
+    String iconURL;
+    String tag;
+    String language;
+    WebCore::NotificationDirection direction;
+    String originString;
+    URL serviceWorkerRegistrationURL;
+    UUID notificationID;
+    WebCore::ScriptExecutionContextIdentifier contextIdentifier;
+    PAL::SessionID sourceSession;
+    MonotonicTime creationTime;
+    Vector<uint8_t> data;
+};
+
+struct WebCore::PermissionDescriptor {
+    WebCore::PermissionName name;
+}
+
+#if ENABLE(SERVICE_WORKER)
+struct WebCore::PushSubscriptionData {
+    WebCore::PushSubscriptionIdentifier identifier;
+    String endpoint;
+    std::optional<WebCore::EpochTimeStamp> expirationTime;
+    Vector<uint8_t> serverVAPIDPublicKey;
+    Vector<uint8_t> clientECDHPublicKey;
+    Vector<uint8_t> sharedAuthenticationSecret;
+};
+#endif
+
+[Return=Ref] class WebCore::DeprecationReportBody {
+    String id()
+    WallTime anticipatedRemoval()
+    String message()
+    String sourceFile()
+    std::optional<unsigned> lineNumber()
+    std::optional<unsigned> columnNumber()
+};
+
+[Return=Ref] class WebCore::Report {
+    String type()
+    String url()
+    RefPtr<WebCore::ReportBody> body()
+};
+
+[Return=Ref] class WebCore::TestReportBody {
+    String message()
+}
+
+enum class WebCore::SpeechRecognitionErrorType : uint8_t {
+    NoSpeech,
+    Aborted,
+    AudioCapture,
+    Network,
+    NotAllowed,
+    ServiceNotAllowed,
+    BadGrammar,
+    LanguageNotSupported
+};
+
+struct WebCore::SpeechRecognitionError {
+    WebCore::SpeechRecognitionErrorType type;
+    String message;
+};
+
+struct WebCore::SpeechRecognitionRequestInfo {
+    WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier;
+    String lang;
+    bool continuous;
+    bool interimResults;
+    uint64_t maxAlternatives;
+    WebCore::ClientOrigin clientOrigin;
+    WebCore::FrameIdentifier frameIdentifier;
+};
+
+[CustomHeader] struct WebCore::SpeechRecognitionAlternativeData {
+    String transcript;
+    double confidence;
+};
+
+struct WebCore::SpeechRecognitionResultData {
+    Vector<WebCore::SpeechRecognitionAlternativeData> alternatives;
+    bool isFinal;
+};
+
+struct WebCore::WebLockManagerSnapshot {
+    Vector<WebCore::WebLockManagerSnapshot::Info> held;
+    Vector<WebCore::WebLockManagerSnapshot::Info> pending;
+};
+
+[Nested] struct WebCore::WebLockManagerSnapshot::Info {
+    String name;
+    WebCore::WebLockMode mode;
+    String clientId;
+};
+
+#if ENABLE(WEB_AUTHN)
+struct WebCore::AuthenticationExtensionsClientInputs {
+    String appid;
+    bool googleLegacyAppidSupport;
+    bool credProps;
+}
+
+[Nested] struct WebCore::AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput {
+    bool rk;
+};
+
+struct WebCore::AuthenticationExtensionsClientOutputs {
+    std::optional<bool> appid;
+    std::optional<WebCore::AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput> credProps;
+}
+
+[Nested] struct WebCore::PublicKeyCredentialCreationOptions::Parameters {
+    WebCore::PublicKeyCredentialType type;
+    int64_t alg;
+};
+
+[Nested] struct WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria {
+    std::optional<WebCore::AuthenticatorAttachment> authenticatorAttachment;
+    std::optional<WebCore::ResidentKeyRequirement> residentKey;
+    bool requireResidentKey;
+    WebCore::UserVerificationRequirement userVerification;
+};
+
+[Nested] struct WebCore::PublicKeyCredentialCreationOptions::Entity {
+    String name;
+    String icon;
+};
+
+[Nested] struct WebCore::PublicKeyCredentialCreationOptions::RpEntity : WebCore::PublicKeyCredentialCreationOptions::Entity {
+    std::optional<String> id;
+};
+
+[Nested] struct WebCore::PublicKeyCredentialCreationOptions::UserEntity : WebCore::PublicKeyCredentialCreationOptions::Entity {
+    WebCore::BufferSource id;
+    String displayName;
+};
+
+struct WebCore::PublicKeyCredentialDescriptor {
+    WebCore::PublicKeyCredentialType type;
+    WebCore::BufferSource id;
+    Vector<WebCore::AuthenticatorTransport> transports;
+};
+#endif // ENABLE(WEB_AUTHN)
+
+struct WebCore::PublicKeyCredentialCreationOptions {
+#if ENABLE(WEB_AUTHN)
+    WebCore::PublicKeyCredentialCreationOptions::RpEntity rp;
+    WebCore::PublicKeyCredentialCreationOptions::UserEntity user;
+
+    WebCore::BufferSource challenge;
+    Vector<WebCore::PublicKeyCredentialCreationOptions::Parameters> pubKeyCredParams;
+
+    std::optional<unsigned> timeout;
+    Vector<WebCore::PublicKeyCredentialDescriptor> excludeCredentials;
+    std::optional<WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria> authenticatorSelection;
+    WebCore::AttestationConveyancePreference attestation;
+    std::optional<WebCore::AuthenticationExtensionsClientInputs> extensions;
+#endif // ENABLE(WEB_AUTHN)
+};
+
+struct WebCore::PublicKeyCredentialRequestOptions {
+#if ENABLE(WEB_AUTHN)
+    WebCore::BufferSource challenge;
+    std::optional<unsigned> timeout;
+    String rpId;
+    Vector<WebCore::PublicKeyCredentialDescriptor> allowCredentials;
+    WebCore::UserVerificationRequirement userVerification;
+    std::optional<WebCore::AuthenticatorAttachment> authenticatorAttachment;
+    std::optional<WebCore::AuthenticationExtensionsClientInputs> extensions;
+#endif // ENABLE(WEB_AUTHN)
+};


### PR DESCRIPTION
#### 9bf02c2618ef6d1cfa1969e9836217b30f9081fa
<pre>
Generate more IPC serialization code from WebCore/Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=246119">https://bugs.webkit.org/show_bug.cgi?id=246119</a>

Reviewed by Tim Horton.

* Source/WebCore/Modules/cache/DOMCacheEngine.h:
(WebCore::DOMCacheEngine::CacheInfos::encode const): Deleted.
(WebCore::DOMCacheEngine::CacheInfos::decode): Deleted.
(WebCore::DOMCacheEngine::CacheIdentifierOperationResult::encode const): Deleted.
(WebCore::DOMCacheEngine::CacheIdentifierOperationResult::decode): Deleted.
* Source/WebCore/Modules/cache/RetrieveRecordsOptions.h:
(WebCore::RetrieveRecordsOptions::encode const): Deleted.
(WebCore::RetrieveRecordsOptions::decode): Deleted.
* Source/WebCore/Modules/contact-picker/ContactInfo.h:
(WebCore::ContactInfo::encode const): Deleted.
(WebCore::ContactInfo::decode): Deleted.
* Source/WebCore/Modules/contact-picker/ContactsRequestData.h:
(WebCore::ContactsRequestData::encode const): Deleted.
(WebCore::ContactsRequestData::decode): Deleted.
* Source/WebCore/Modules/mediasession/MediaImage.h:
(WebCore::MediaImage::encode const): Deleted.
(WebCore::MediaImage::decode): Deleted.
* Source/WebCore/Modules/mediasession/MediaMetadataInit.h:
(WebCore::MediaMetadataInit::encode const): Deleted.
(WebCore::MediaMetadataInit::decode): Deleted.
* Source/WebCore/Modules/mediasession/MediaPositionState.h:
(WebCore::MediaPositionState::encode const): Deleted.
(WebCore::MediaPositionState::decode): Deleted.
* Source/WebCore/Modules/mediastream/DetachedRTCDataChannel.h:
(WebCore::DetachedRTCDataChannel::encode const): Deleted.
(WebCore::DetachedRTCDataChannel::decode): Deleted.
* Source/WebCore/Modules/model-element/HTMLModelElementCamera.h:
(WebCore::HTMLModelElementCamera::encode const): Deleted.
(WebCore::HTMLModelElementCamera::decode): Deleted.
* Source/WebCore/Modules/notifications/NotificationData.h:
(WebCore::NotificationData::encode const): Deleted.
(WebCore::NotificationData::decode): Deleted.
* Source/WebCore/Modules/permissions/PermissionDescriptor.h:
(WebCore::PermissionDescriptor::operator== const):
(WebCore::PermissionDescriptor::encode const): Deleted.
(WebCore::PermissionDescriptor::decode): Deleted.
* Source/WebCore/Modules/push-api/PushSubscriptionData.h:
(WebCore::PushSubscriptionData::encode const): Deleted.
(WebCore::PushSubscriptionData::decode): Deleted.
* Source/WebCore/Modules/reporting/DeprecationReportBody.h:
(WebCore::DeprecationReportBody::encode const): Deleted.
(WebCore::DeprecationReportBody::decode): Deleted.
* Source/WebCore/Modules/reporting/Report.cpp:
(WebCore::Report::body const):
(WebCore::Report::body): Deleted.
* Source/WebCore/Modules/reporting/Report.h:
(WebCore::Report::encode const): Deleted.
(WebCore::Report::decode): Deleted.
* Source/WebCore/Modules/reporting/TestReportBody.h:
(WebCore::TestReportBody::encode const): Deleted.
(WebCore::TestReportBody::decode): Deleted.
* Source/WebCore/Modules/speech/SpeechRecognitionError.h:
(WebCore::SpeechRecognitionError::encode const): Deleted.
(WebCore::SpeechRecognitionError::decode): Deleted.
* Source/WebCore/Modules/speech/SpeechRecognitionRequestInfo.h:
(WebCore::SpeechRecognitionRequestInfo::encode const): Deleted.
(WebCore::SpeechRecognitionRequestInfo::decode): Deleted.
* Source/WebCore/Modules/speech/SpeechRecognitionResultData.h:
(WebCore::SpeechRecognitionAlternativeData::encode const): Deleted.
(WebCore::SpeechRecognitionAlternativeData::decode): Deleted.
(WebCore::SpeechRecognitionResultData::encode const): Deleted.
(WebCore::SpeechRecognitionResultData::decode): Deleted.
* Source/WebCore/Modules/web-locks/WebLockManagerSnapshot.h:
(WebCore::WebLockManagerSnapshot::Info::isolatedCopy):
(WebCore::WebLockManagerSnapshot::isolatedCopy):
(WebCore::WebLockManagerSnapshot::Info::encode const): Deleted.
(WebCore::WebLockManagerSnapshot::encode const): Deleted.
(WebCore::WebLockManagerSnapshot::Info::decode): Deleted.
(WebCore::WebLockManagerSnapshot::decode): Deleted.
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h:
(WebCore::AuthenticationExtensionsClientInputs::encode const): Deleted.
(WebCore::AuthenticationExtensionsClientInputs::decode): Deleted.
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.h:
(WebCore::AuthenticationExtensionsClientOutputs::encode const): Deleted.
(WebCore::AuthenticationExtensionsClientOutputs::decode): Deleted.
(WebCore::AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput::encode const): Deleted.
(WebCore::AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput::decode): Deleted.
* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.h:
(WebCore::PublicKeyCredentialCreationOptions::Parameters::encode const): Deleted.
(WebCore::PublicKeyCredentialCreationOptions::Parameters::decode): Deleted.
(WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::encode const): Deleted.
(WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::decode): Deleted.
(WebCore::PublicKeyCredentialCreationOptions::encode const): Deleted.
(WebCore::PublicKeyCredentialCreationOptions::decode): Deleted.
* Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h:
(WebCore::PublicKeyCredentialDescriptor::encode const): Deleted.
(WebCore::PublicKeyCredentialDescriptor::decode): Deleted.
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h:
(WebCore::PublicKeyCredentialRequestOptions::encode const): Deleted.
(WebCore::PublicKeyCredentialRequestOptions::decode): Deleted.
* Source/WebCore/bindings/js/SerializedScriptValue.h:
(WebCore::SerializedScriptValue::decode):
* Source/WebKit/Platform/IPC/DaemonCoders.cpp:
(WebKit::Daemon::Coder&lt;WebCore::PushSubscriptionData&gt;::encode):
(WebKit::Daemon::Coder&lt;WebCore::PushSubscriptionData&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;Ref&lt;SecurityOrigin&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;Ref&lt;SecurityOrigin&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ReportBody&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ReportBody&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;Ref&lt;WebCore::Report&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;Ref&lt;WebCore::Report&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/255205@main">https://commits.webkit.org/255205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bfbb3154dc7dfc94fd9e44bcb907162c3c4ba2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91708 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101404 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161479 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/938 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84026 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97366 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27507 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82479 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35827 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33582 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/17235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37426 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1621 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36352 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->