### PR TITLE
REGRESSION(254760@main): mobile version of apple.com/iphone-14 doesn't display

### DIFF
--- a/LayoutTests/fast/css/transform-in-non-rendered-subtree-computed-style-expected.txt
+++ b/LayoutTests/fast/css/transform-in-non-rendered-subtree-computed-style-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Computed style of transform in non-rendered subtree should be none.
+

--- a/LayoutTests/fast/css/transform-in-non-rendered-subtree-computed-style.html
+++ b/LayoutTests/fast/css/transform-in-non-rendered-subtree-computed-style.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <title>Computed style of transform in non-rendered subtree should be none.</title>
+    <style>
+        .box {
+            width: 100px;
+            height: 100px;
+            background-color: blue;
+        }
+        .transformed {
+            transform: translate(50%, 50%);
+        }
+    </style>
+    <div class="box transformed" hidden></div>
+    <div class="box" hidden><div class="box transformed"></div></div>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script>
+    test(() => {
+        for (let box of document.querySelectorAll(".transformed")) {
+            assert_equals(window.getComputedStyle(box).transform, "none");
+        }
+    }, "Computed style of transform in non-rendered subtree should be none.");
+    </script>
+</html>

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -732,7 +732,7 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
 {
     auto& cssValuePool = CSSValuePool::singleton();
 
-    if (!style.hasTransform() || is<RenderInline>(renderer))
+    if (!style.hasTransform() || !rendererCanBeTransformed(renderer))
         return cssValuePool.createIdentifierValue(CSSValueNone);
 
     if (renderer) {


### PR DESCRIPTION
#### 99a2d4d46dc999ee35b42a0a3f2d1f8be1abdf3f
<pre>
REGRESSION(254760@main): mobile version of apple.com/iphone-14 doesn&apos;t display
<a href="https://bugs.webkit.org/show_bug.cgi?id=246122">https://bugs.webkit.org/show_bug.cgi?id=246122</a>
rdar://100814764

Reviewed by NOBODY (OOPS!).

The page doesn&apos;t work because it tries to initialize a DOMMatrix with a value of `translate(-50%, -50%)` which is invalid given it contains a percentage value.
Before 254760@main, the transform used to compute to `none` because it is on an element with no renderer, and `new DOMMatrix(&quot;none&quot;)` initializes fine, which gets the page working again.

Test: LayoutTests/fast/css/transform-in-non-rendered-subtree-computed-style.html

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::computedTransform):
* LayoutTests/fast/css/transform-in-non-rendered-subtree-computed-style.html: Added.
* LayoutTests/fast/css/transform-in-non-rendered-subtree-computed-style-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99a2d4d46dc999ee35b42a0a3f2d1f8be1abdf3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101410 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161485 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/945 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97721 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97373 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/562 "Found 7 new test failures: imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative.html, imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html, imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html, imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-computed-value.html, imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-inline-value.html, imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles.html, webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html (failure)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27515 "Found 7 new test failures: imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative.html, imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html, imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html, imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-computed-value.html, imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-inline-value.html, imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles.html, webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82486 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70554 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35834 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16143 "Found 7 new test failures: imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative.html, imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html, imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html, imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-computed-value.html, imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-inline-value.html, imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles.html, webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33588 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17241 "Found 7 new test failures: imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative.html, imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html, imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html, imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-computed-value.html, imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-inline-value.html, imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles.html, webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37433 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36358 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->