### PR TITLE
Add SPI to create _WKWebsiteDataStoreConfiguration with identifier

### DIFF
--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -55,7 +55,7 @@ public:
         return UUID { generateWeakRandomUUIDVersion4() };
     }
 
-    static std::optional<UUID> parse(StringView);
+    WTF_EXPORT_PRIVATE static std::optional<UUID> parse(StringView);
     WTF_EXPORT_PRIVATE static std::optional<UUID> parseVersion4(StringView);
 
     explicit UUID(Span<const uint8_t, 16> span)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -33,6 +33,7 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 
 - (instancetype)init; // Creates a persistent configuration.
 - (instancetype)initNonPersistentConfiguration WK_API_AVAILABLE(macos(10.15), ios(13.0));
+- (instancetype)initWithIdentifier:(NSUUID *)identifier WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @property (nonatomic, readonly, getter=isPersistent) BOOL persistent WK_API_AVAILABLE(macos(10.15), ios(13.0));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -59,6 +59,21 @@ static void checkURLArgument(NSURL *url)
     return self;
 }
 
+- (instancetype)initWithIdentifier:(NSUUID *)identifier
+{
+    self = [super init];
+    if (!self)
+        return nil;
+
+    if (!identifier)
+        [NSException raise:NSInvalidArgumentException format:@"Identifier cannot be nil"];
+
+    auto uuid = UUID::parse(String([identifier UUIDString]));
+    API::Object::constructInWrapper<WebKit::WebsiteDataStoreConfiguration>(self, *uuid);
+
+    return self;
+}
+
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebsiteDataStoreConfiguration.class, self))
@@ -81,6 +96,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set _webStorageDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+    
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set _webStorageDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setLocalStorageDirectory(url.path);
 }
@@ -94,6 +113,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set _indexedDBDatabaseDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+    
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set _indexedDBDatabaseDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setIndexedDBDatabaseDirectory(url.path);
 }
@@ -107,6 +130,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set networkCacheDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set networkCacheDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setNetworkCacheDirectory(url.path);
 }
@@ -120,6 +147,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set deviceIdHashSaltsStorageDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set deviceIdHashSaltsStorageDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setDeviceIdHashSaltsStorageDirectory(url.path);
 }
@@ -133,6 +164,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set _webSQLDatabaseDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set _webSQLDatabaseDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setWebSQLDatabaseDirectory(url.path);
 }
@@ -166,6 +201,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set _cookieStorageFile on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set _cookieStorageFile on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     if ([url hasDirectoryPath])
         [NSException raise:NSInvalidArgumentException format:@"The cookie storage path must point to a file, not a directory."];
@@ -182,6 +221,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set _resourceLoadStatisticsDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set _resourceLoadStatisticsDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setResourceLoadStatisticsDirectory(url.path);
 }
@@ -195,6 +238,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set _cacheStorageDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set _cacheStorageDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setCacheStorageDirectory(url.path);
 }
@@ -208,6 +255,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set _serviceWorkerRegistrationDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set _serviceWorkerRegistrationDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setServiceWorkerRegistrationDirectory(url.path);
 }
@@ -251,6 +302,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set applicationCacheDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set applicationCacheDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setApplicationCacheDirectory(url.path);
 }
@@ -264,6 +319,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set applicationCacheFlatFileSubdirectoryName on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set applicationCacheFlatFileSubdirectoryName on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     _configuration->setApplicationCacheFlatFileSubdirectoryName(name);
 }
 
@@ -276,6 +335,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set mediaCacheDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set mediaCacheDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setMediaCacheDirectory(url.path);
 }
@@ -289,6 +352,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set mediaKeysStorageDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set mediaKeysStorageDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setMediaKeysStorageDirectory(url.path);
 }
@@ -302,6 +369,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set hstsStorageDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set hstsStorageDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setHSTSStorageDirectory(url.path);
 }
@@ -315,6 +386,10 @@ static void checkURLArgument(NSURL *url)
 {
     if (!_configuration->isPersistent())
         [NSException raise:NSInvalidArgumentException format:@"Cannot set alternativeServicesDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set alternativeServicesStorageDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setAlternativeServicesDirectory(url.path);
 }
@@ -330,7 +405,11 @@ static void checkURLArgument(NSURL *url)
 - (void)setGeneralStorageDirectory:(NSURL *)url
 {
     if (!_configuration->isPersistent())
-        [NSException raise:NSInvalidArgumentException format:@"Cannot set storageDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+        [NSException raise:NSInvalidArgumentException format:@"Cannot set generalStorageDirectory on a non-persistent _WKWebsiteDataStoreConfiguration."];
+
+    if (_configuration->identifier())
+        [NSException raise:NSGenericException format:@"Cannot set generalStorageDirectory on a _WKWebsiteDataStoreConfiguration created with identifier"];
+
     checkURLArgument(url);
     _configuration->setGeneralStorageDirectory(url.path);
 }

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -231,13 +231,40 @@ void WebsiteDataStore::platformRemoveRecentSearches(WallTime oldestTimeToRemove)
     WebCore::removeRecentlyModifiedRecentSearches(oldestTimeToRemove);
 }
 
-NSString *WebDatabaseDirectoryDefaultsKey = @"WebDatabaseDirectory";
-NSString *WebStorageDirectoryDefaultsKey = @"WebKitLocalStorageDatabasePathPreferenceKey";
-NSString *WebKitMediaCacheDirectoryDefaultsKey = @"WebKitMediaCacheDirectory";
-NSString *WebKitMediaKeysStorageDirectoryDefaultsKey = @"WebKitMediaKeysStorageDirectory";
-
-String WebsiteDataStore::defaultApplicationCacheDirectory(const String&)
+String WebsiteDataStore::defaultWebsiteDataStoreDirectory(const String& identifier)
 {
+    static dispatch_once_t onceToken;
+    static NeverDestroyed<RetainPtr<NSURL>> websiteDataStoreDirectory;
+    dispatch_once(&onceToken, ^{
+        NSURL *libraryDirectory = [[NSFileManager defaultManager] URLForDirectory:NSLibraryDirectory inDomain:NSUserDomainMask appropriateForURL:nullptr create:NO error:nullptr];
+        RELEASE_ASSERT(libraryDirectory);
+        NSURL *webkitDirectory = [libraryDirectory URLByAppendingPathComponent:@"WebKit" isDirectory:YES];
+        if (!WebKit::processHasContainer()) {
+            NSString *applicationIdentifier = [NSBundle mainBundle].bundleIdentifier;
+            if (!applicationIdentifier)
+                applicationIdentifier = [NSProcessInfo processInfo].processName;
+            webkitDirectory = [webkitDirectory URLByAppendingPathComponent:applicationIdentifier isDirectory:YES];
+        }
+
+        websiteDataStoreDirectory.get() = [webkitDirectory URLByAppendingPathComponent:@"WebsiteDataStore" isDirectory:YES];
+    });
+
+    return [websiteDataStoreDirectory.get() URLByAppendingPathComponent:identifier isDirectory:YES].absoluteURL.path;
+}
+
+String WebsiteDataStore::defaultCookieStorageFile(const String& baseDirectory)
+{
+    if (baseDirectory.isEmpty())
+        return { };
+
+    return FileSystem::pathByAppendingComponents(baseDirectory, { "Cookies"_s, "Cookies.binarycookies"_s });
+}
+
+String WebsiteDataStore::defaultApplicationCacheDirectory(const String& baseDirectory)
+{
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "ApplicationCache"_s);
+
 #if PLATFORM(IOS_FAMILY)
     // This quirk used to make these apps share application cache storage, but doesn't accomplish that any more.
     // Preserving it avoids the need to migrate data when upgrading.
@@ -250,18 +277,23 @@ String WebsiteDataStore::defaultApplicationCacheDirectory(const String&)
     }
 #endif
 
-    return cacheDirectoryFileSystemRepresentation("OfflineWebApplicationCache"_s);
+    return cacheDirectoryFileSystemRepresentation("OfflineWebApplicationCache"_s, { }, ShouldCreateDirectory::No);
 }
 
-String WebsiteDataStore::defaultCacheStorageDirectory(const String&)
+String WebsiteDataStore::defaultCacheStorageDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "CacheStorage"_s);
+
     return cacheDirectoryFileSystemRepresentation("CacheStorage"_s);
 }
 
-String WebsiteDataStore::defaultGeneralStorageDirectory(const String&)
+String WebsiteDataStore::defaultGeneralStorageDirectory(const String& baseDirectory)
 {
-    auto directory = websiteDataDirectoryFileSystemRepresentation("Default"_s);
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "Origins"_s);
 
+    auto directory = websiteDataDirectoryFileSystemRepresentation("Default"_s);
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         // This is the old storage directory, and there might be files left here.
@@ -284,69 +316,108 @@ String WebsiteDataStore::defaultGeneralStorageDirectory(const String&)
     return directory;
 }
 
-String WebsiteDataStore::defaultNetworkCacheDirectory(const String&)
+String WebsiteDataStore::defaultNetworkCacheDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "NetworkCache"_s);
+
     return cacheDirectoryFileSystemRepresentation("NetworkCache"_s);
 }
 
-String WebsiteDataStore::defaultAlternativeServicesDirectory(const String&)
+String WebsiteDataStore::defaultAlternativeServicesDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "AlternativeServices"_s);
+
     return cacheDirectoryFileSystemRepresentation("AlternativeServices"_s, { }, ShouldCreateDirectory::No);
 }
 
-String WebsiteDataStore::defaultHSTSStorageDirectory(const String&)
+String WebsiteDataStore::defaultHSTSStorageDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "HSTS"_s);
+
     return cacheDirectoryFileSystemRepresentation("HSTS"_s);
 }
 
-String WebsiteDataStore::defaultMediaCacheDirectory(const String&)
+String WebsiteDataStore::defaultMediaCacheDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "MediaCache"_s);
+
     return tempDirectoryFileSystemRepresentation("MediaCache"_s);
 }
 
-String WebsiteDataStore::defaultIndexedDBDatabaseDirectory(const String&)
+String WebsiteDataStore::defaultIndexedDBDatabaseDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "IndexedDB"_s);
+
     return websiteDataDirectoryFileSystemRepresentation("IndexedDB"_s);
 }
 
-String WebsiteDataStore::defaultServiceWorkerRegistrationDirectory(const String&)
+String WebsiteDataStore::defaultServiceWorkerRegistrationDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "ServiceWorkers"_s);
+
     return cacheDirectoryFileSystemRepresentation("ServiceWorkers"_s);
 }
 
-String WebsiteDataStore::defaultLocalStorageDirectory(const String&)
+String WebsiteDataStore::defaultLocalStorageDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "LocalStorage"_s);
+
     return websiteDataDirectoryFileSystemRepresentation("LocalStorage"_s);
 }
 
-String WebsiteDataStore::defaultMediaKeysStorageDirectory(const String&)
+String WebsiteDataStore::defaultMediaKeysStorageDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "MediaKeys"_s);
+
     return websiteDataDirectoryFileSystemRepresentation("MediaKeys"_s);
 }
 
-String WebsiteDataStore::defaultDeviceIdHashSaltsStorageDirectory(const String&)
+String WebsiteDataStore::defaultDeviceIdHashSaltsStorageDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "DeviceIdHashSalts"_s);
+
     return websiteDataDirectoryFileSystemRepresentation("DeviceIdHashSalts"_s);
 }
 
-String WebsiteDataStore::defaultWebSQLDatabaseDirectory(const String&)
+String WebsiteDataStore::defaultWebSQLDatabaseDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "WebSQL"_s);
+
     return websiteDataDirectoryFileSystemRepresentation("WebSQL"_s, { }, ShouldCreateDirectory::No);
 }
 
-String WebsiteDataStore::defaultResourceLoadStatisticsDirectory(const String&)
+String WebsiteDataStore::defaultResourceLoadStatisticsDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "ResourceLoadStatistics"_s);
+
     return websiteDataDirectoryFileSystemRepresentation("ResourceLoadStatistics"_s);
 }
 
-String WebsiteDataStore::defaultJavaScriptConfigurationDirectory(const String&)
+String WebsiteDataStore::defaultJavaScriptConfigurationDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "JavaScriptCoreDebug"_s);
+
     return tempDirectoryFileSystemRepresentation("JavaScriptCoreDebug"_s, ShouldCreateDirectory::No);
 }
 
 #if ENABLE(ARKIT_INLINE_PREVIEW)
-String WebsiteDataStore::defaultModelElementCacheDirectory(const String&)
+String WebsiteDataStore::defaultModelElementCacheDirectory(const String& baseDirectory)
 {
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "ModelElement"_s);
+
     return tempDirectoryFileSystemRepresentation("ModelElement"_s, ShouldCreateDirectory::No);
 }
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -343,6 +343,10 @@ public:
     SOAuthorizationCoordinator& soAuthorizationCoordinator(const WebPageProxy&);
 #endif
 
+#if PLATFORM(COCOA)
+    static String defaultWebsiteDataStoreDirectory(const String& identifier);
+    static String defaultCookieStorageFile(const String& baseDataDirectory = nullString());
+#endif
     static String defaultServiceWorkerRegistrationDirectory(const String& baseDataDirectory = nullString());
     static String defaultLocalStorageDirectory(const String& baseDataDirectory = nullString());
     static String defaultResourceLoadStatisticsDirectory(const String& baseDataDirectory = nullString());

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -52,6 +52,24 @@ WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration(IsPersistent isPers
     }
 }
 
+#if PLATFORM(COCOA)
+
+WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration(const UUID& identifier)
+    : m_isPersistent(IsPersistent::Yes)
+    , m_shouldUseCustomStoragePaths(WebsiteDataStore::defaultShouldUseCustomStoragePaths())
+    , m_identifier(identifier)
+    , m_baseCacheDirectory(WebsiteDataStore::defaultWebsiteDataStoreDirectory(identifier.toString()))
+    , m_baseDataDirectory(WebsiteDataStore::defaultWebsiteDataStoreDirectory(identifier.toString()))
+    , m_perOriginStorageQuota(WebsiteDataStore::defaultPerOriginQuota())
+#if PLATFORM(IOS)
+    , m_pcmMachServiceName("com.apple.webkit.adattributiond.service"_s)
+#endif
+{
+    initializePaths();
+}
+
+#endif
+
 #if !PLATFORM(COCOA)
 WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration(const String& baseCacheDirectory, const String& baseDataDirectory)
     : m_isPersistent(IsPersistent::Yes)
@@ -87,6 +105,9 @@ void WebsiteDataStoreConfiguration::initializePaths()
     setResourceLoadStatisticsDirectory(WebsiteDataStore::defaultResourceLoadStatisticsDirectory(m_baseDataDirectory));
     setDeviceIdHashSaltsStorageDirectory(WebsiteDataStore::defaultDeviceIdHashSaltsStorageDirectory(m_baseDataDirectory));
     setJavaScriptConfigurationDirectory(WebsiteDataStore::defaultJavaScriptConfigurationDirectory(m_baseDataDirectory));
+#if PLATFORM(COCOA)
+    setCookieStorageFile(WebsiteDataStore::defaultCookieStorageFile(m_baseDataDirectory));
+#endif
 }
 
 Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -27,6 +27,7 @@
 
 #include "APIObject.h"
 #include <wtf/URL.h>
+#include <wtf/UUID.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -43,6 +44,10 @@ public:
     static Ref<WebsiteDataStoreConfiguration> create(IsPersistent isPersistent) { return adoptRef(*new WebsiteDataStoreConfiguration(isPersistent, ShouldInitializePaths::Yes)); }
     WebsiteDataStoreConfiguration(IsPersistent, ShouldInitializePaths = ShouldInitializePaths::Yes);
 
+#if PLATFORM(COCOA)
+    WebsiteDataStoreConfiguration(const UUID&);
+#endif
+
 #if !PLATFORM(COCOA)
     // All cache and data directories are initialized relative to baseCacheDirectory and
     // baseDataDirectory, respectively, if provided. On Cocoa ports, these are always null.
@@ -52,6 +57,7 @@ public:
     Ref<WebsiteDataStoreConfiguration> copy() const;
 
     bool isPersistent() const { return m_isPersistent == IsPersistent::Yes; }
+    std::optional<UUID> identifier() const { return m_identifier; }
 
     uint64_t perOriginStorageQuota() const { return m_perOriginStorageQuota; }
     void setPerOriginStorageQuota(uint64_t quota) { m_perOriginStorageQuota = quota; }
@@ -227,6 +233,7 @@ private:
     IsPersistent m_isPersistent { IsPersistent::No };
 
     bool m_shouldUseCustomStoragePaths;
+    std::optional<UUID> m_identifier;
     String m_baseCacheDirectory;
     String m_baseDataDirectory;
     String m_cacheStorageDirectory;


### PR DESCRIPTION
#### 9ad8d1f0e69645ce2837750ca339ab055a0dd13b
<pre>
Add SPI to create _WKWebsiteDataStoreConfiguration with identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=246125">https://bugs.webkit.org/show_bug.cgi?id=246125</a>
rdar://100579003

Reviewed by Alex Christensen.

* Source/WTF/wtf/UUID.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration initWithIdentifier:]):
(-[_WKWebsiteDataStoreConfiguration _setWebStorageDirectory:]):
(-[_WKWebsiteDataStoreConfiguration _setIndexedDBDatabaseDirectory:]):
(-[_WKWebsiteDataStoreConfiguration setNetworkCacheDirectory:]):
(-[_WKWebsiteDataStoreConfiguration setDeviceIdHashSaltsStorageDirectory:]):
(-[_WKWebsiteDataStoreConfiguration _setWebSQLDatabaseDirectory:]):
(-[_WKWebsiteDataStoreConfiguration _setCookieStorageFile:]):
(-[_WKWebsiteDataStoreConfiguration _setResourceLoadStatisticsDirectory:]):
(-[_WKWebsiteDataStoreConfiguration _setCacheStorageDirectory:]):
(-[_WKWebsiteDataStoreConfiguration _setServiceWorkerRegistrationDirectory:]):
(-[_WKWebsiteDataStoreConfiguration setApplicationCacheDirectory:]):
(-[_WKWebsiteDataStoreConfiguration setApplicationCacheFlatFileSubdirectoryName:]):
(-[_WKWebsiteDataStoreConfiguration setMediaCacheDirectory:]):
(-[_WKWebsiteDataStoreConfiguration setMediaKeysStorageDirectory:]):
(-[_WKWebsiteDataStoreConfiguration setHSTSStorageDirectory:]):
(-[_WKWebsiteDataStoreConfiguration setAlternativeServicesStorageDirectory:]):
(-[_WKWebsiteDataStoreConfiguration setGeneralStorageDirectory:]):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::defaultWebsiteDataStoreDirectory):
(WebKit::WebsiteDataStore::defaultCookieStorageFile):
(WebKit::WebsiteDataStore::defaultApplicationCacheDirectory):
(WebKit::WebsiteDataStore::defaultCacheStorageDirectory):
(WebKit::WebsiteDataStore::defaultGeneralStorageDirectory):
(WebKit::WebsiteDataStore::defaultNetworkCacheDirectory):
(WebKit::WebsiteDataStore::defaultAlternativeServicesDirectory):
(WebKit::WebsiteDataStore::defaultHSTSStorageDirectory):
(WebKit::WebsiteDataStore::defaultMediaCacheDirectory):
(WebKit::WebsiteDataStore::defaultIndexedDBDatabaseDirectory):
(WebKit::WebsiteDataStore::defaultServiceWorkerRegistrationDirectory):
(WebKit::WebsiteDataStore::defaultLocalStorageDirectory):
(WebKit::WebsiteDataStore::defaultMediaKeysStorageDirectory):
(WebKit::WebsiteDataStore::defaultDeviceIdHashSaltsStorageDirectory):
(WebKit::WebsiteDataStore::defaultWebSQLDatabaseDirectory):
(WebKit::WebsiteDataStore::defaultResourceLoadStatisticsDirectory):
(WebKit::WebsiteDataStore::defaultJavaScriptConfigurationDirectory):
(WebKit::WebsiteDataStore::defaultModelElementCacheDirectory):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration):
(WebKit::WebsiteDataStoreConfiguration::initializePaths):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::identifier const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/255271@main">https://commits.webkit.org/255271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e39ffa1ab984fdf819e744ea2ee4359bbaf17d99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91948 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101771 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161818 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1188 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84422 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97606 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78499 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27684 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82649 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70719 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83309 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36040 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16268 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78365 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33777 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17369 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27045 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3649 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37654 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80987 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39538 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36490 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17778 "Passed tests") | 
<!--EWS-Status-Bubble-End-->