### PR TITLE
Address search input and search result layout issues

### DIFF
--- a/Websites/webkit.org/wp-content/themes/webkit/404.php
+++ b/Websites/webkit.org/wp-content/themes/webkit/404.php
@@ -1,9 +1,9 @@
 <?php get_header(); ?>
 <style>
-h1 {
+main h1 {
     font-size: 6rem;
-    font-weight: 100;
     padding-top: 9rem;
+    text-align: left;
 }
 h1, p, form {
     margin-bottom: 3rem;
@@ -15,39 +15,10 @@ img {
     max-width: 800px;
 }
 input {
-    display: inline-block;
-    box-sizing: border-box;
-    vertical-align: top;
-    height: 32px;
+    height: 3.2rem;
     padding-top: 3px;
-    margin-bottom: 16px;
-    padding-left: 15px;
-    padding-right: 15px;
-    font-size: 15px;
-    color: #333333;
-    text-align: left;
-    border: 1px solid #d6d6d6;
-    border-radius: 4px;
-    background: white;
-    background-clip: padding-box;
-    font-family: "Myriad Set Pro", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
-    font-size: 15px;
-    line-height: 1.33333;
-    font-weight: 400;
-    letter-spacing: normal;
-    font-size: 2rem;
-}
-
-input[type=submit] {
-    background-color: #1d9bd9;
-    background: linear-gradient(#3baee7, #0088cc);
-    border-radius: 4px;
-    color: white;
-    cursor: pointer;
-    font-size: 1.5rem;
-    font-weight: 500;
-    text-align: center;
-    border: 0;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
 }
 </style>
 
@@ -59,6 +30,5 @@ input[type=submit] {
 <p>You can try a search or return to the <a href="<?php bloginfo('siteurl'); ?>">home page</a>.</p>
 
 <?php echo get_search_form(); ?>
-
 
 <?php get_footer(); ?>

--- a/Websites/webkit.org/wp-content/themes/webkit/header.php
+++ b/Websites/webkit.org/wp-content/themes/webkit/header.php
@@ -11,7 +11,7 @@
 
     <meta name="application-name" content="WebKit">
 
-    <link rel="stylesheet" type="text/css" href="<?php echo get_stylesheet_uri(); ?>?20221005" media="all">
+    <link rel="stylesheet" type="text/css" href="<?php echo get_stylesheet_uri(); ?>?2022100501" media="all">
     <link rel="stylesheet" href="https://www.apple.com/wss/fonts?families=SF+Pro,v1" type="text/css">
     <link rel="stylesheet" href="https://www.apple.com/wss/fonts?families=SF+Mono,v2" type="text/css">
     <meta name="supported-color-schemes" content="light dark">

--- a/Websites/webkit.org/wp-content/themes/webkit/style.css
+++ b/Websites/webkit.org/wp-content/themes/webkit/style.css
@@ -2285,7 +2285,7 @@ header .menu-item { /* add bottom dimension to main menu items */
     background-color: transparent;
     background-repeat: no-repeat;
     background-size: 1.8rem;
-    background-position: 6px 5px;
+    background-position: 6px 5.5px;
 
     padding: 3px 3px 3px 30px;
 
@@ -2298,18 +2298,12 @@ header .menu-item { /* add bottom dimension to main menu items */
     transition: 200ms ease-out width, 200ms ease-in background-color;
 }
 
-#site-nav .search-input {
+header .search-input {
     background-image: var(--search-glyph-light);
 }
 
 .search #site-nav ul.menu li:last-child {
     display: none;
-}
-
-.search-input:focus,
-.search-input:not([value=""]) {
-    width: 18rem;
-    background-color: rgba(0,0,0,0.3);
 }
 
 .search-results main {
@@ -2371,6 +2365,12 @@ header .menu-item { /* add bottom dimension to main menu items */
 
 p .search-term {
     color: var(--search-term-text-color);
+}
+
+header .search-input:focus,
+header .search-input:not([value=""]) {
+    width: 18rem;
+    background-color: rgba(0,0,0,0.3);
 }
 
 /** Accessibility **/
@@ -2554,7 +2554,7 @@ p .search-term {
         padding: 0 3rem 3rem 0;
     }
 
-    #site-nav .search-input,
+    header .search-input,
     .search-input {
         width: 100%;
         
@@ -2569,18 +2569,11 @@ p .search-term {
         color: var(--text-color);
     }
     
-    .search-input:focus,
-    .search-input:not([value=""]) {
+    header .search-input:focus,
+    header .search-input:not([value=""]) {
         width: 100%;
         background-color: rgba(255,255,255,0.1);
     }
-    
-    .search-results h1,
-    .search-results main ul {
-        width: 100%;
-        margin: 0 auto;
-    }
-
 }
 
 @media only screen and (max-width: 690px) {
@@ -2673,6 +2666,17 @@ p .search-term {
     .scrollable .scrollable-padding {
         display: inline-block;
         padding: 0 3rem;
+    }
+    
+    .search-results h1 {
+        font-size: 5.4rem;
+    }
+
+    .search-results h1,
+    .search-results main form,
+    .search-results main .results-list {
+        width: 100%;
+        margin: 0 auto;
     }
 }
 


### PR DESCRIPTION
#### 6de86cf915b187b9df0fd8102b9d833d2d665959
<pre>
Address search input and search result layout issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=246126">https://bugs.webkit.org/show_bug.cgi?id=246126</a>

Reviewed by Devin Rousso.

* Websites/webkit.org/wp-content/themes/webkit/404.php:
* Websites/webkit.org/wp-content/themes/webkit/header.php:
* Websites/webkit.org/wp-content/themes/webkit/style.css:
(.search-input):
(header .search-input):
(header .search-input:focus,):
(@media only screen and (max-width: 1015px) header .search-input,):
(@media only screen and (max-width: 1015px) header .search-input:focus,):
(@media only screen and (max-width: 690px) .search-results h1):
(@media only screen and (max-width: 690px) .search-results h1,):
(#site-nav .search-input): Deleted.
(.search-input:focus,): Deleted.
(@media only screen and (max-width: 1015px) #site-nav .search-input,): Deleted.
(@media only screen and (max-width: 1015px) .search-input:focus,): Deleted.
(@media only screen and (max-width: 1015px) .search-results h1,): Deleted.

Canonical link: <a href="https://commits.webkit.org/255225@main">https://commits.webkit.org/255225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4744884802be47345132c1ffa3a0ab83bbe5aef0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101422 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/955 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84041 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97729 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/564 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78349 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27517 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82488 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70556 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35842 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16147 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33596 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17245 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37442 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/39985 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1632 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36362 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->