### PR TITLE
Fix build with stricter C warnings

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/crypto/kernel/crypto_kernel.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/crypto/kernel/crypto_kernel.c
@@ -69,7 +69,7 @@ srtp_crypto_kernel_t crypto_kernel = {
 
 #define MAX_RNG_TRIALS 25
 
-srtp_err_status_t srtp_crypto_kernel_init()
+srtp_err_status_t srtp_crypto_kernel_init(void)
 {
     srtp_err_status_t status;
 
@@ -172,7 +172,7 @@ srtp_err_status_t srtp_crypto_kernel_init()
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_crypto_kernel_status()
+srtp_err_status_t srtp_crypto_kernel_status(void)
 {
     srtp_err_status_t status;
     srtp_kernel_cipher_type_t *ctype = crypto_kernel.cipher_type_list;
@@ -213,7 +213,7 @@ srtp_err_status_t srtp_crypto_kernel_status()
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_crypto_kernel_list_debug_modules()
+srtp_err_status_t srtp_crypto_kernel_list_debug_modules(void)
 {
     srtp_kernel_debug_module_t *dm = crypto_kernel.debug_module_list;
 
@@ -232,7 +232,7 @@ srtp_err_status_t srtp_crypto_kernel_list_debug_modules()
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_crypto_kernel_shutdown()
+srtp_err_status_t srtp_crypto_kernel_shutdown(void)
 {
     /*
      * free dynamic memory used in crypto_kernel at present

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/crypto/kernel/err.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/crypto/kernel/err.c
@@ -54,7 +54,7 @@
 
 static FILE *srtp_err_file = NULL;
 
-srtp_err_status_t srtp_err_reporting_init()
+srtp_err_status_t srtp_err_reporting_init(void)
 {
 #ifdef ERR_REPORTING_STDOUT
     srtp_err_file = stdout;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/srtp/srtp.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/srtp/srtp.c
@@ -110,7 +110,7 @@ static srtp_err_status_t srtp_validate_rtp_header(void *rtp_hdr,
     return srtp_err_status_ok;
 }
 
-const char *srtp_get_version_string()
+const char *srtp_get_version_string(void)
 {
     /*
      * Simply return the autotools generated string
@@ -118,7 +118,7 @@ const char *srtp_get_version_string()
     return SRTP_VER_STRING;
 }
 
-unsigned int srtp_get_version()
+unsigned int srtp_get_version(void)
 {
     unsigned int major = 0, minor = 0, micro = 0;
     unsigned int rv = 0;
@@ -2723,7 +2723,7 @@ srtp_err_status_t srtp_unprotect_mki(srtp_ctx_t *ctx,
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_init()
+srtp_err_status_t srtp_init(void)
 {
     srtp_err_status_t status;
 
@@ -2740,7 +2740,7 @@ srtp_err_status_t srtp_init()
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_shutdown()
+srtp_err_status_t srtp_shutdown(void)
 {
     srtp_err_status_t status;
 

--- a/Source/ThirdParty/libwebrtc/Source/third_party/pffft/src/pffft.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/pffft/src/pffft.c
@@ -213,7 +213,7 @@ typedef union v4sf_union {
 #define assertv4(v,f0,f1,f2,f3) assert(v.f[0] == (f0) && v.f[1] == (f1) && v.f[2] == (f2) && v.f[3] == (f3))
 
 /* detect bugs with the vector support macros */
-void validate_pffft_simd() {
+void validate_pffft_simd(void) {
   float f[16] = { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 };
   v4sf_union a0, a1, a2, a3, t, u; 
   memcpy(a0.f, f, 4*sizeof(float));
@@ -258,7 +258,7 @@ void pffft_aligned_free(void *p) {
   if (p) free(*((void **) p - 1));
 }
 
-int pffft_simd_size() { return SIMD_SZ; }
+int pffft_simd_size(void) { return SIMD_SZ; }
 
 /*
   passf2 and passb2 has been merged here, fsign = -1 for passf2, +1 for passb2

--- a/Source/ThirdParty/libwebrtc/Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_pcb.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_pcb.c
@@ -7952,7 +7952,7 @@ sctp_drain_mbufs(struct sctp_tcb *stcb)
 }
 
 void
-sctp_drain()
+sctp_drain(void)
 {
 	/*
 	 * We must walk the PCB lists for ALL associations here. The system

--- a/Source/ThirdParty/libwebrtc/Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_sysctl.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_sysctl.c
@@ -61,7 +61,7 @@ FEATURE(sctp, "Stream Control Transmission Protocol");
  */
 
 void
-sctp_init_sysctls()
+sctp_init_sysctls(void)
 {
 	SCTP_BASE_SYSCTL(sctp_sendspace) = SCTPCTL_MAXDGRAM_DEFAULT;
 	SCTP_BASE_SYSCTL(sctp_recvspace) = SCTPCTL_RECVSPACE_DEFAULT;

--- a/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
@@ -214,7 +214,7 @@ static pas_large_sharing_node* create_and_insert(
     return result;
 }
 
-static void boot_tree()
+static void boot_tree(void)
 {
     pas_range range;
     

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -201,13 +201,13 @@ bool pas_probabilistic_guard_malloc_check_exists(uintptr_t mem)
 #pragma mark Helper Functions
 #endif
 
-size_t pas_probabilistic_guard_malloc_get_free_virtual_memory()
+size_t pas_probabilistic_guard_malloc_get_free_virtual_memory(void)
 {
     pas_heap_lock_assert_held();
     return free_virtual_mem;
 }
 
-size_t pas_probabilistic_guard_malloc_get_free_wasted_memory()
+size_t pas_probabilistic_guard_malloc_get_free_wasted_memory(void)
 {
     pas_heap_lock_assert_held();
     return free_wasted_mem;

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
@@ -801,7 +801,7 @@ typedef struct scavenger_thread_suspend_data {
 #endif
 } scavenger_thread_suspend_data;
 
-static scavenger_thread_suspend_data scavenger_thread_suspend_data_create()
+static scavenger_thread_suspend_data scavenger_thread_suspend_data_create(void)
 {
     scavenger_thread_suspend_data thread_suspend_data;
     thread_suspend_data.did_suspend = false;

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout.c
@@ -166,7 +166,7 @@ pas_thread_local_cache_layout_node pas_thread_local_cache_layout_get_node_for_in
     return pas_compact_thread_local_cache_layout_node_load(&compact_node);
 }
 
-pas_thread_local_cache_layout_node pas_thread_local_cache_layout_get_last_node()
+pas_thread_local_cache_layout_node pas_thread_local_cache_layout_get_last_node(void)
 {
     pas_heap_lock_assert_held();
     if (!pas_thread_local_cache_layout_last_segment)

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.c
@@ -189,7 +189,7 @@ void pas_assertion_failed_no_inline_with_extra_detail(const char* filename, int 
     pas_crash_with_info_impl((uint64_t)filename, (uint64_t)line, (uint64_t)function, (uint64_t)expression, extra, 1337, 0xbeef0bff);
 }
 
-void pas_panic_on_out_of_memory_error()
+void pas_panic_on_out_of_memory_error(void)
 {
     __builtin_trap();
 }


### PR DESCRIPTION
#### deaa47fe6ecc1573fb4801446bb932b836a9d350
<pre>
Fix build with stricter C warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=246133">https://bugs.webkit.org/show_bug.cgi?id=246133</a>
rdar://100835228

Unreviewed build fixes.

* Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/crypto/kernel/crypto_kernel.c:
(srtp_crypto_kernel_status):
(srtp_crypto_kernel_list_debug_modules):
(srtp_crypto_kernel_shutdown):
* Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/crypto/kernel/err.c:
(srtp_err_reporting_init):
* Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/srtp/srtp.c:
(srtp_get_version_string):
(srtp_get_version):
(srtp_init):
(srtp_shutdown):
* Source/ThirdParty/libwebrtc/Source/third_party/pffft/src/pffft.c:
(validate_pffft_simd):
(pffft_simd_size):
* Source/ThirdParty/libwebrtc/Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_pcb.c:
* Source/ThirdParty/libwebrtc/Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_sysctl.c:
(sctp_init_sysctls):
* Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c:
(boot_tree):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_get_free_virtual_memory):
(pas_probabilistic_guard_malloc_get_free_wasted_memory):
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:
(scavenger_thread_suspend_data_create):
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout.c:
(pas_thread_local_cache_layout_get_last_node):
* Source/bmalloc/libpas/src/libpas/pas_utils.c:
(pas_panic_on_out_of_memory_error):

Canonical link: <a href="https://commits.webkit.org/255208@main">https://commits.webkit.org/255208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6ee9ca386fb44a0580bf8ec8a61427d02761aed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91737 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22327 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/101436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/985 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97395 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27530 "layout-tests (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83162 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35855 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78207 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33609 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/17256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/26999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3607 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37455 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80819 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39357 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/36373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17704 "Passed tests") | 
<!--EWS-Status-Bubble-End-->