### PR TITLE
Move background-image document element painting to RenderView

### DIFF
--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -64,10 +64,14 @@ BackgroundPainter::BackgroundPainter(RenderBoxModelObject& renderer, const Paint
 
 void BackgroundPainter::paintBackground(const LayoutRect& paintRect, BackgroundBleedAvoidance bleedAvoidance)
 {
-    if (m_renderer.isDocumentElementRenderer()) {
+    if (m_renderer.isRenderView()) {
         paintRootBoxFillLayers();
         return;
     }
+
+    // RenderView paints the root background.
+    if (m_renderer.isDocumentElementRenderer())
+        return;
 
     if (!paintsOwnBackground(m_renderer))
         return;
@@ -83,7 +87,7 @@ void BackgroundPainter::paintBackground(const LayoutRect& paintRect, BackgroundB
 
 void BackgroundPainter::paintRootBoxFillLayers()
 {
-    ASSERT(m_renderer.isDocumentElementRenderer());
+    ASSERT(m_renderer.isRenderView());
     if (m_paintInfo.skipRootBackground())
         return;
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -883,7 +883,7 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
     bool newStyleSlowScroll = false;
     if (newStyle.hasAnyFixedBackground() && !settings().fixedBackgroundsPaintRelativeToDocument()) {
         newStyleSlowScroll = true;
-        bool drawsRootBackground = isDocumentElementRenderer() || (isBody() && !rendererHasBackground(document().documentElement()->renderer()));
+        bool drawsRootBackground = isRenderView() || (isBody() && !rendererHasBackground(document().documentElement()->renderer()));
         if (drawsRootBackground && newStyle.hasEntirelyFixedBackground() && view().compositor().supportsFixedRootBackgroundCompositing())
             newStyleSlowScroll = false;
     }
@@ -894,7 +894,7 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
     } else if (newStyleSlowScroll)
         view().frameView().addSlowRepaintObject(*this);
 
-    if (isDocumentElementRenderer() || isBody())
+    if (isRenderView() || isBody())
         view().frameView().updateExtendBackgroundIfNecessary();
 }
 


### PR DESCRIPTION
#### 14449106f71d959fdf0ce0a9b9e13b28456c9329
<pre>
Move background-image document element painting to RenderView
<a href="https://bugs.webkit.org/show_bug.cgi?id=245032">https://bugs.webkit.org/show_bug.cgi?id=245032</a>
rdar://99782177

Reviewed by NOBODY (OOPS!).

This has the side effect of stopping transforms from applying on the document element background, which is what we want according to: <a href="https://github.com/w3c/csswg-drafts/issues/6683#issuecomment-1269092125">https://github.com/w3c/csswg-drafts/issues/6683#issuecomment-1269092125</a>

* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintBackground):
(WebCore::BackgroundPainter::paintRootBoxFillLayers):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::paintBoxDecorations):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleWillChange):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14449106f71d959fdf0ce0a9b9e13b28456c9329

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102109 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162621 "Found 2 new test failures: fast/backgrounds/angled-background-repeating-gradient-rendering-vertical.html, fast/frames/frames-not-double-painted.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1564 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29951 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84764 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98272 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97999 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1032 "Found 30 new test failures: compositing/backgrounds/negative-z-index-behind-body.html, compositing/geometry/composited-frame-contents.html, compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html, compositing/sibling-layer-does-not-get-composited-transform-case.html, compositing/visibility/frameset-visibility-hidden.html, css3/blending/background-blend-mode-body-image.html, css3/blending/background-blend-mode-body-transparent-image.html, css3/blending/blend-mode-body-composited-child-background-color.html, css3/blending/blend-mode-body-composited-child.html, css3/flexbox/flex-percentage-height-in-table.html ... (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78853 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27963 "Found 205 new test failures: compositing/backgrounds/negative-z-index-behind-body.html, compositing/geometry/composited-frame-contents.html, compositing/iframes/border-radius-composited-frame.html, compositing/iframes/border-uneven-radius-composited-frame.html, compositing/images/positioned-image-content-rect.html, compositing/overlap-blending/nested-overlap.html, compositing/sibling-layer-does-not-get-composited-transform-case.html, compositing/visibility/frameset-visibility-hidden.html, css3/flexbox/flex-percentage-height-in-table.html, css3/viewport-percentage-lengths/viewport-percentage-vertical-align.html ... (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82951 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82625 "Found 7 new API test failures: TestWebKitAPI.SampledPageTopColor.HitTestBeforeCSSAnimation, TestWebKitAPI.SampledPageTopColor.DifferentColorsWithRightOutlierAboveMaxDifference, TestWebKitAPI.SampledPageTopColor.DifferentColorsCumulativelyAboveMaxDifference, TestWebKitAPI.SampledPageTopColor.VerticalGradientBelowMaxDifference, TestWebKitAPI.SampledPageTopColor.MainDocumentChange, TestWebKitAPI.SampledPageTopColor.HitTestBeforeCSSTransition, TestWebKitAPI.SampledPageTopColor.DifferentColorsWithLeftOutlierAboveMaxDifference (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71015 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36369 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16577 "Found 30 new test failures: animations/additive-transform-animations.html, compositing/background-color/background-color-alpha.html, compositing/background-color/background-color-change-to-text.html, compositing/background-color/background-color-container.html, compositing/background-color/background-color-content-clip.html, compositing/background-color/background-color-padding-change.html, compositing/background-color/background-color-padding-clip.html, compositing/background-color/background-color-simple.html, compositing/background-color/background-color-text-change.html, compositing/background-color/background-color-text-clip.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34132 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17745 "Found 30 new test failures: compositing/backgrounds/negative-z-index-behind-body.html, compositing/geometry/composited-frame-contents.html, compositing/iframes/border-uneven-radius-composited-frame.html, compositing/images/positioned-image-content-rect.html, compositing/sibling-layer-does-not-get-composited-transform-case.html, compositing/visibility/frameset-visibility-hidden.html, css3/blending/blend-mode-body-composited-child-background-color.html, css3/blending/blend-mode-body-composited-child.html, css3/flexbox/flex-percentage-height-in-table.html, css3/viewport-percentage-lengths/viewport-percentage-vertical-align.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38006 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40371 "Found 30 new test failures: compositing/backgrounds/negative-z-index-behind-body.html, compositing/geometry/composited-frame-contents.html, compositing/iframes/border-uneven-radius-composited-frame.html, compositing/images/positioned-image-content-rect.html, compositing/sibling-layer-does-not-get-composited-transform-case.html, compositing/visibility/frameset-visibility-hidden.html, css3/blending/blend-mode-body-composited-child-background-color.html, css3/blending/blend-mode-body-composited-child.html, css3/color/box-shadows.html, css3/color/text.html ... (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39906 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36889 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->