### PR TITLE
[WTF] Implement "reduce" function for Vector

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <functional>
 #include <initializer_list>
 #include <limits>
 #include <optional>
@@ -902,6 +903,19 @@ public:
 
     template<typename ResultVector, typename MapFunction>
     auto map(MapFunction&&) const -> std::enable_if_t<std::is_invocable_v<MapFunction, const T&>, ResultVector>;
+
+    template <typename BinaryOperation> T reduce(const BinaryOperation& binaryOperation, std::optional<T> initial = { }) const
+    {
+        if (isEmpty())
+            return initial ? *initial : T { };
+
+        auto accumulator = initial ? *initial : at(0);
+        auto start = initial ? 0 : 1;
+        for (size_t i = start ; i < size() ; i++)
+            accumulator = binaryOperation(accumulator, at(i));
+
+        return accumulator;
+    }
 
     template<typename MapFunction>
     auto map(MapFunction&&) const -> std::enable_if_t<std::is_invocable_v<MapFunction, const T&>, Vector<typename std::invoke_result_t<MapFunction, const T&>>>;

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -1810,4 +1810,26 @@ TEST(WTF_Vector, MoveAssignmentOperator)
     }
 }
 
+TEST(WTF_Vector, Reduce)
+{
+    {
+        Vector<String> strings({ "a"_str, "b"_str, "c"_str, "d"_str, "e"_str });
+        auto concat = [] (auto& a, auto& b) {
+            return a + "-" + b;
+        };
+        auto without_initial = strings.reduce(concat);
+        EXPECT_EQ(without_initial.length(), 9U);
+        EXPECT_STREQ(without_initial.utf8().data(), "a-b-c-d-e");
+        auto with_initial = strings.reduce(concat, "hello"_str);
+        EXPECT_EQ(with_initial.length(), 15U);
+        EXPECT_STREQ(with_initial.utf8().data(), "hello-a-b-c-d-e");
+
+        Vector<int> empty;
+        auto add = [] (int a, int b) {
+            return a + b;
+        };
+        EXPECT_EQ(empty.reduce(add), 0);
+    }
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 934ab5ee72c37c5c40e9b07274f538c5ec89c01a
<pre>
[WTF] Implement &quot;reduce&quot; function for Vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=246140">https://bugs.webkit.org/show_bug.cgi?id=246140</a>

Reviewed by NOBODY (OOPS!).

This is a very basic implementation of a reduce/accumulate function
in a fold-left fashion.

* Source/WTF/wtf/Vector.h:
(WTF::Vector::reduce):
* Source/WebCore/platform/text/TextFlags.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::reduce): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/934ab5ee72c37c5c40e9b07274f538c5ec89c01a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101785 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161854 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1204 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29650 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84436 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97991 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/739 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78514 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27691 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70727 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83324 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36055 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16281 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78380 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33793 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17383 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27051 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37670 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40097 "Found 2 new test failures: imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h264_annexb, imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_annexb (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81002 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36507 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17797 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode (failure)") | 
<!--EWS-Status-Bubble-End-->