### PR TITLE
[MSE] Improved coded frame eviction algorithm

### DIFF
--- a/LayoutTests/media/media-source/media-source-append-before-last-range-no-quota-exceeded-expected.txt
+++ b/LayoutTests/media/media-source/media-source-append-before-last-range-no-quota-exceeded-expected.txt
@@ -127,6 +127,6 @@ EVENT(updateend)
 Appending PTS=118
 EVENT(updateend)
 EXPECTED (exception != 'QuotaExceededError: The quota has been exceeded.') OK
-EXPECTED (bufferedRanges() == '[ 115...119, 120...170 ]') OK
+EXPECTED (bufferedRanges() == '[ 115...119, 120...146 ]') OK
 END OF TEST
 

--- a/LayoutTests/media/media-source/media-source-append-before-last-range-no-quota-exceeded.html
+++ b/LayoutTests/media/media-source/media-source-append-before-last-range-no-quota-exceeded.html
@@ -76,7 +76,7 @@
         exception = await appendPtsRange(115, 118);
 
         testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '!=');
-        testExpected('bufferedRanges()', '[ 115...119, 120...170 ]', '==');
+        testExpected('bufferedRanges()', '[ 115...119, 120...146 ]', '==');
 
         endTest();
     });

--- a/LayoutTests/media/media-source/media-source-append-buffer-full-quota-exceeded-error-expected.txt
+++ b/LayoutTests/media/media-source/media-source-append-buffer-full-quota-exceeded-error-expected.txt
@@ -117,7 +117,7 @@ Appending PTS=41
 EVENT(updateend)
 Appending PTS=42
 EXPECTED (exception == 'QuotaExceededError: The quota has been exceeded.') OK
-EXPECTED (1 == '1') OK
+EXPECTED (sourceBuffer.buffered.length == '1') OK
 EVENT(updateend)
 Appending PTS=0.002
 EVENT(updateend)
@@ -141,70 +141,10 @@ Appending PTS=9.002
 EVENT(updateend)
 Appending PTS=10.002
 EVENT(updateend)
-Appending PTS=11.002
-EVENT(updateend)
-Appending PTS=12.002
-EVENT(updateend)
-Appending PTS=13.002
-EVENT(updateend)
-Appending PTS=14.002
-EVENT(updateend)
-Appending PTS=15.002
-EVENT(updateend)
-Appending PTS=16.002
-EVENT(updateend)
-Appending PTS=17.002
-EVENT(updateend)
-Appending PTS=18.002
-EVENT(updateend)
-Appending PTS=19.002
-EVENT(updateend)
-Appending PTS=20.002
-EVENT(updateend)
-Appending PTS=21.002
-EVENT(updateend)
-Appending PTS=22.002
-EVENT(updateend)
-Appending PTS=23.002
-EVENT(updateend)
-Appending PTS=24.002
-EVENT(updateend)
-Appending PTS=25.002
-EVENT(updateend)
-Appending PTS=26.002
-EVENT(updateend)
-Appending PTS=27.002
-EVENT(updateend)
-Appending PTS=28.002
-EVENT(updateend)
-Appending PTS=29.002
-EVENT(updateend)
-Appending PTS=30.002
-EVENT(updateend)
-Appending PTS=31.002
-EVENT(updateend)
-Appending PTS=32.002
-EVENT(updateend)
-Appending PTS=33.002
-EVENT(updateend)
-Appending PTS=34.002
-EVENT(updateend)
-Appending PTS=35.002
-EVENT(updateend)
-Appending PTS=36.002
-EVENT(updateend)
-Appending PTS=37.002
-EVENT(updateend)
-Appending PTS=38.002
-EVENT(updateend)
-Appending PTS=39.002
-EVENT(updateend)
-Appending PTS=40.002
-EVENT(updateend)
-Appending PTS=41.002
-EVENT(updateend)
-Appending PTS=42.002
+EXPECTED (exception != 'QuotaExceededError: The quota has been exceeded.') OK
+Appending PTS=11002-60002
 EXPECTED (exception == 'QuotaExceededError: The quota has been exceeded.') OK
+EXPECTED (sourceBuffer.buffered.length == '1') OK
 EVENT(updateend)
 Appending PTS=0
 EVENT(updateend)
@@ -316,16 +256,11 @@ EVENT(updateend)
 Appending PTS=31.916666666666668
 EVENT(updateend)
 EXPECTED (exception != 'QuotaExceededError: The quota has been exceeded.') OK
-EXPECTED (1 == '1') OK
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+Create a small 2000/24000 gap in the data at 31s.
 EVENT(updateend)
-EXPECTED (2 == '2') OK
-Appending PTS=32
-EVENT(updateend)
-Appending PTS=33
-EVENT(updateend)
-Appending PTS=34
-EVENT(updateend)
-Appending PTS=35
+EXPECTED (sourceBuffer.buffered.length == '2') OK
+Appending PTS=32-100
 EXPECTED (exception == 'QuotaExceededError: The quota has been exceeded.') OK
 END OF TEST
 

--- a/LayoutTests/media/media-source/media-source-append-buffer-full-quota-exceeded-error.html
+++ b/LayoutTests/media/media-source/media-source-append-buffer-full-quota-exceeded-error.html
@@ -28,11 +28,13 @@
         return resultException;
     }
 
-    async function appendConcatenateSamples(start, end) {
+    async function appendConcatenateSamples(start, end, timescale = 1, gap = 0, step = null) {
         var resultException = null;
+        if (step == null)
+            step = timescale;
         const samples = [];
-        for (let time = start; time <= end; time++)
-            samples.push(makeASample(time, time, 1, 1, 1, time === start ? SAMPLE_FLAG.SYNC : SAMPLE_FLAG.NONE));
+        for (let time = start; time <= end; time += step)
+            samples.push(makeASample(time, time, step - gap, timescale, 1, time === start ? SAMPLE_FLAG.SYNC : SAMPLE_FLAG.NONE, 1));
 
         try {
             consoleWrite('Appending PTS='+start+'-'+end );
@@ -82,13 +84,17 @@
         exception = await appendPtsRange(0, 60000, 1000, 2);
         testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '==');
         // Check that appendBuffer removed all the small gaps in the data less than the threshold.
-        testExpected(sourceBuffer.buffered.length, '1', '==');
+        testExpected('sourceBuffer.buffered.length', '1', '==');
 
+        internals.settings.setMaximumSourceBufferSize(1500);
         // Ensure that if current time is close enough to the buffered data that the nearest range isn't evicted.
         sourceBuffer.remove(0, Infinity);
         await waitFor(sourceBuffer, 'updateend');
-        exception = await appendPtsRange(2, 60002, 1000);
+        exception = await appendPtsRange(2, 10002, 1000);
+        testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '!=');
+        exception = await appendConcatenateSamples(11002, 60002, 1000);
         testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '==');
+        testExpected('sourceBuffer.buffered.length', '1', '==');
 
         internals.settings.setMaximumSourceBufferSize(4000);
         // Ensure that small gaps that would be ignored during playback are also ignored by eviction.
@@ -101,12 +107,12 @@
         // Add 30 to 32s in smaller granularity.
         exception = await appendPtsRange(720000, 768000 - 1, 24000, 0, 2000);
         testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '!=');
-        testExpected(sourceBuffer.buffered.length, '1', '==');
-        // Create a small 2000/24000 gap in the data at 31s.
+        testExpected('sourceBuffer.buffered.length', '1', '==');
+        consoleWrite("Create a small 2000/24000 gap in the data at 31s.");
         sourceBuffer.remove(744000 / 24000, (744000 + 2000) / 24000);
         await waitFor(sourceBuffer, 'updateend');
-        testExpected(sourceBuffer.buffered.length, '2', '==');
-        exception = await appendPtsRange(32, 60);
+        testExpected('sourceBuffer.buffered.length', '2', '==');
+        exception = await appendConcatenateSamples(32, 100);
         testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '==');
 
         endTest();

--- a/LayoutTests/media/media-source/media-source-evict-codedframe-after-seek-expected.txt
+++ b/LayoutTests/media/media-source/media-source-evict-codedframe-after-seek-expected.txt
@@ -102,6 +102,6 @@ EVENT(updateend)
 Appending PTS=45
 EVENT(updateend)
 EXPECTED (exception != 'QuotaExceededError: The quota has been exceeded.') OK
-bufferedRanges()=[ 0...12, 13...46 ]
+bufferedRanges()=[ 6...12, 13...48 ]
 END OF TEST
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -501,7 +501,7 @@ ExceptionOr<void> SourceBuffer::appendBufferInternal(const unsigned char* data, 
     m_source->openIfInEndedState();
 
     // 4. Run the coded frame eviction algorithm.
-    m_private->evictCodedFrames(size, maximumBufferSize(), m_source->currentTime(), m_source->duration(), m_source->isEnded());
+    m_private->evictCodedFrames(size, maximumBufferSize(), m_source->currentTime(), m_source->isEnded());
 
     // 5. If the buffer full flag equals true, then throw a QuotaExceededError exception and abort these step.
     if (m_private->isBufferFullFor(size, maximumBufferSize())) {

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -138,6 +138,14 @@ MediaTime PlatformTimeRanges::maximumBufferedTime() const
     return m_ranges[length() - 1].m_end;
 }
 
+MediaTime PlatformTimeRanges::minimumBufferedTime() const
+{
+    if (!length())
+        return MediaTime::invalidTime();
+
+    return m_ranges[0].m_start;
+}
+
 void PlatformTimeRanges::add(const MediaTime& start, const MediaTime& end)
 {
 #if !PLATFORM(MAC) // https://bugs.webkit.org/show_bug.cgi?id=180253

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.h
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.h
@@ -50,6 +50,7 @@ public:
     MediaTime end(unsigned index, bool& valid) const;
     MediaTime duration(unsigned index) const;
     MediaTime maximumBufferedTime() const;
+    MediaTime minimumBufferedTime() const;
 
     void invert();
     void intersectWith(const PlatformTimeRanges&);

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -92,7 +92,7 @@ public:
     virtual void setShouldGenerateTimestamps(bool flag) { m_shouldGenerateTimestamps = flag; }
     WEBCORE_EXPORT virtual void updateBufferedFromTrackBuffers(bool sourceIsEnded);
     WEBCORE_EXPORT virtual void removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentMediaTime, bool isEnded, CompletionHandler<void()>&& = [] { });
-    WEBCORE_EXPORT virtual void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, const MediaTime& duration, bool isEnded);
+    WEBCORE_EXPORT virtual void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded);
     WEBCORE_EXPORT virtual uint64_t totalTrackBufferSizeInBytes() const;
     WEBCORE_EXPORT virtual void resetTimestampOffsetInTrackBuffers();
     virtual void startChangingType() { m_pendingInitializationSegmentForChangeType = true; }

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -270,9 +270,9 @@ void RemoteSourceBufferProxy::removeCodedFrames(const MediaTime& start, const Me
     });
 }
 
-void RemoteSourceBufferProxy::evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, const MediaTime& duration, bool isEnded, EvictCodedFramesDelayedReply&& completionHandler)
+void RemoteSourceBufferProxy::evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded, EvictCodedFramesDelayedReply&& completionHandler)
 {
-    m_sourceBufferPrivate->evictCodedFrames(newDataSize, maximumBufferSize, currentTime, duration, isEnded);
+    m_sourceBufferPrivate->evictCodedFrames(newDataSize, maximumBufferSize, currentTime, isEnded);
     completionHandler(m_sourceBufferPrivate->totalTrackBufferSizeInBytes());
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -100,7 +100,7 @@ private:
     using RemoveCodedFramesAsyncReply = Messages::RemoteSourceBufferProxy::RemoveCodedFramesAsyncReply;
     using EvictCodedFramesDelayedReply= Messages::RemoteSourceBufferProxy::EvictCodedFramesDelayedReply;
     void removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime, bool isEnded, RemoveCodedFramesAsyncReply&&);
-    void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, const MediaTime& duration, bool isEnded, EvictCodedFramesDelayedReply&&);
+    void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded, EvictCodedFramesDelayedReply&&);
     void addTrackBuffer(TrackPrivateRemoteIdentifier);
     void resetTrackBuffers();
     void clearTrackBuffers();

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
@@ -42,7 +42,7 @@ messages -> RemoteSourceBufferProxy NotRefCounted {
     ClearTrackBuffers()
     SetAllTrackBuffersNeedRandomAccess()
     RemoveCodedFrames(MediaTime start, MediaTime end, MediaTime currentTime, bool isEnded) -> (WebCore::PlatformTimeRanges buffered, uint64_t totalTrackBufferSizeInBytes)
-    EvictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, MediaTime currentTime, MediaTime duration, bool isEnded) -> (uint64_t totalTrackBufferSizeInBytes) Synchronous
+    EvictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, MediaTime currentTime, bool isEnded) -> (uint64_t totalTrackBufferSizeInBytes) Synchronous
     ReenqueueMediaIfNeeded(MediaTime currentMediaTime)
     SetGroupStartTimestamp(MediaTime timestamp)
     SetGroupStartTimestampToEndTimestamp()

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -205,12 +205,12 @@ void SourceBufferPrivateRemote::removeCodedFrames(const MediaTime& start, const 
         m_remoteSourceBufferIdentifier);
 }
 
-void SourceBufferPrivateRemote::evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, const MediaTime& duration, bool isEnded)
+void SourceBufferPrivateRemote::evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded)
 {
     if (!m_gpuProcessConnection)
         return;
 
-    auto sendResult = m_gpuProcessConnection->connection().sendSync(Messages::RemoteSourceBufferProxy::EvictCodedFrames(newDataSize, maximumBufferSize, currentTime, duration, isEnded), m_remoteSourceBufferIdentifier);
+    auto sendResult = m_gpuProcessConnection->connection().sendSync(Messages::RemoteSourceBufferProxy::EvictCodedFrames(newDataSize, maximumBufferSize, currentTime, isEnded), m_remoteSourceBufferIdentifier);
     if (sendResult)
         std::tie(m_totalTrackBufferSizeInBytes) = sendResult.takeReply();
 }

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -91,7 +91,7 @@ private:
     void setShouldGenerateTimestamps(bool) final;
     void updateBufferedFromTrackBuffers(bool sourceIsEnded) final;
     void removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentMediaTime, bool isEnded, CompletionHandler<void()>&&) final;
-    void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, const MediaTime& duration, bool isEnded) final;
+    void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded) final;
     void resetTimestampOffsetInTrackBuffers() final;
     void startChangingType() final;
     void setTimestampOffset(const MediaTime&) final;


### PR DESCRIPTION
#### 48b51f0536c90a12e3acd596d36ef82324acd3a5
<pre>
[MSE] Improved coded frame eviction algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=246144">https://bugs.webkit.org/show_bug.cgi?id=246144</a>

Reviewed by Alicia Boya Garcia.

I made it in two aspects, first is that now it does not begin at 0, it
begins at the first buffered range.

A fix would be that sometimes you need to evict frames but a window of
30s is too much and it can easily happen it does not evict anything,
so we need to reduce the partition to be able to effectively evict
something. We do it in windows from 30 to 3s.

This is tested by several tests that needed a rebase line or small tweaks.

* LayoutTests/media/media-source/media-source-append-before-last-range-no-quota-exceeded-expected.txt:
* LayoutTests/media/media-source/media-source-append-before-last-range-no-quota-exceeded.html:
* LayoutTests/media/media-source/media-source-append-buffer-full-quota-exceeded-error-expected.txt:
* LayoutTests/media/media-source/media-source-append-buffer-full-quota-exceeded-error.html:
* LayoutTests/media/media-source/media-source-evict-codedframe-after-seek-expected.txt:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::appendBufferInternal):
* Source/WebCore/platform/graphics/PlatformTimeRanges.cpp:
(WebCore::PlatformTimeRanges::minimumBufferedTime const):
* Source/WebCore/platform/graphics/PlatformTimeRanges.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::evictCodedFrames):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::evictCodedFrames):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::evictCodedFrames):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/256441@main">https://commits.webkit.org/256441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46145ed7a23b56cb00a702a102c50c5f7c58bfe2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105348 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5104 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33780 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88153 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101179 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101431 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82382 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30810 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87526 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73643 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39515 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37205 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20385 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4452 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41267 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43310 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39637 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->