### PR TITLE
[GLib] Implement FileSystem::fileID()

### DIFF
--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -77,7 +77,7 @@ const PlatformFileHandle invalidPlatformFileHandle = -1;
 
 // PlatformFileID
 #if USE(GLIB) && !OS(WINDOWS)
-typedef uint64_t PlatformFileID;
+typedef CString PlatformFileID;
 #elif OS(WINDOWS)
 typedef FILE_ID_128 PlatformFileID;
 #else

--- a/Source/WTF/wtf/glib/FileSystemGlib.cpp
+++ b/Source/WTF/wtf/glib/FileSystemGlib.cpp
@@ -136,14 +136,16 @@ std::optional<uint64_t> fileSize(PlatformFileHandle handle)
 
 std::optional<PlatformFileID> fileID(PlatformFileHandle handle)
 {
-    // FIXME (246118): Implement this function properly.
+    GRefPtr<GFileInfo> info = adoptGRef(g_file_io_stream_query_info(handle, G_FILE_ATTRIBUTE_ID_FILE, nullptr, nullptr));
+    if (info && g_file_info_has_attribute(info.get(), G_FILE_ATTRIBUTE_ID_FILE))
+        return { g_file_info_get_attribute_string(info.get(), G_FILE_ATTRIBUTE_ID_FILE) };
+
     return std::nullopt;
 }
 
 bool fileIDsAreEqual(std::optional<PlatformFileID> a, std::optional<PlatformFileID> b)
 {
-    // FIXME (246118): Implement this function properly.
-    return true;
+    return a == b;
 }
 
 std::optional<WallTime> fileCreationTime(const String& path)


### PR DESCRIPTION
#### 023badc05a9788e17a62e8be51b5973067f22e6f
<pre>
[GLib] Implement FileSystem::fileID()
<a href="https://bugs.webkit.org/show_bug.cgi?id=246143">https://bugs.webkit.org/show_bug.cgi?id=246143</a>

Reviewed by Carlos Garcia Campos.

Implement WTF::FileSystem::fileID() in terms of GFileInfo, using the
G_FILE_ATTRIBUTE_ID_FILE. GLib represents this attribute as a string in
order to be able to support the variety of systems it supports, so this
also changes the PlatformFileID type accordingly.

* Source/WTF/wtf/FileSystem.h: Switch to CString as the representation
  of the PlatformFileID type.
* Source/WTF/wtf/glib/FileSystemGlib.cpp:
(WTF::FileSystemImpl::fileID): Implement.
(WTF::FileSystemImpl::fileIDsAreEqual): Implement.

Canonical link: <a href="https://commits.webkit.org/255324@main">https://commits.webkit.org/255324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdda48d47b6fad020b0f0f6583c3c2c9cc36b410

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101938 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1380 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29772 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84592 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98105 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/886 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78674 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27825 "Found 12 new test failures: fast/dom/FileList-iterator-using-open-panel.html, fast/files/file-reader-directory-crash-using-open-panel.html, fast/forms/file/file-input-reset-using-open-panel.html, fast/forms/file/file-input-type-detached-on-change.html, fast/forms/file/file-input-user-selection-events.html, fast/forms/file/file-input-webkitdirectory-icon.html, fast/forms/file/file-reset-in-change-using-open-panel-with-icon.html, fast/forms/file/file-reset-in-change-using-open-panel.html, fast/forms/file/input-file-value-using-open-panel.html, fast/forms/file/input-file-write-files-using-open-panel.html ... (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82400 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70863 "Found 1 new API test failure: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83490 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36200 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16410 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78561 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33956 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17531 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27120 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3692 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40222 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81185 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36658 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17852 "Passed tests") | 
<!--EWS-Status-Bubble-End-->