### PR TITLE
[WK2] constexpr-ify IPC encoding, decoding of std::tuple<> objects

### DIFF
--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -436,8 +436,7 @@ template<typename T> struct ArgumentCoder<Ref<T>> {
     }
 };
 
-template<typename... Elements>
-struct TupleEncoder {
+template<typename... Elements> struct ArgumentCoder<std::tuple<Elements...>> {
     template<typename Encoder>
     static void encode(Encoder& encoder, const std::tuple<Elements...>& tuple)
     {
@@ -450,48 +449,29 @@ struct TupleEncoder {
         if constexpr (sizeof...(Indices) > 0)
             (encoder << ... << std::get<Indices>(tuple));
     }
-};
-
-template<typename... Elements> struct TupleDecoder;
-
-template<typename Type, typename... Types>
-struct TupleDecoder<Type, Types...> {
-    template<typename Decoder>
-    static std::optional<std::tuple<Type, Types...>> decode(Decoder& decoder)
-    {
-        std::optional<Type> optional;
-        decoder >> optional;
-        if (!optional)
-            return std::nullopt;
-
-        std::optional<std::tuple<Types...>> remainder = TupleDecoder<Types...>::decode(decoder);
-        if (!remainder)
-            return std::nullopt;
-
-        return std::tuple_cat(std::make_tuple(WTFMove(*optional)), WTFMove(*remainder));
-    }
-};
-
-template<>
-struct TupleDecoder<> {
-    template<typename Decoder>
-    static std::optional<std::tuple<>> decode(Decoder&)
-    {
-        return std::make_tuple();
-    }
-};
-
-template<typename... Elements> struct ArgumentCoder<std::tuple<Elements...>> {
-    template<typename Encoder>
-    static void encode(Encoder& encoder, const std::tuple<Elements...>& tuple)
-    {
-        TupleEncoder<Elements...>::encode(encoder, tuple);
-    }
 
     template<typename Decoder>
     static std::optional<std::tuple<Elements...>> decode(Decoder& decoder)
     {
-        return TupleDecoder<Elements...>::decode(decoder);
+        return decode(decoder, std::tuple<> { }, std::index_sequence_for<> { });
+    }
+
+    template<typename Decoder, typename OptionalTuple, size_t... Indices>
+    static std::optional<std::tuple<Elements...>> decode(Decoder& decoder, OptionalTuple&& optionalTuple, std::index_sequence<Indices...>)
+    {
+        constexpr size_t Index = sizeof...(Indices);
+        static_assert(Index == std::tuple_size_v<OptionalTuple>);
+
+        if constexpr (Index < sizeof...(Elements)) {
+            std::optional<std::tuple_element_t<Index, std::tuple<Elements...>>> optional;
+            decoder >> optional;
+            if (!optional)
+                return std::nullopt;
+            return decode(decoder, std::forward_as_tuple(std::get<Indices>(WTFMove(optionalTuple))..., WTFMove(optional)), std::make_index_sequence<Index + 1> { });
+        } else {
+            static_assert(Index == sizeof...(Elements));
+            return std::make_tuple(*std::get<Indices>(WTFMove(optionalTuple))...);
+        }
     }
 };
 


### PR DESCRIPTION
#### b807bfd9ce0a83f31884a9b093d37a127cca7d5a
<pre>
[WK2] constexpr-ify IPC encoding, decoding of std::tuple&lt;&gt; objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=246149">https://bugs.webkit.org/show_bug.cgi?id=246149</a>

Reviewed by Kimmo Kinnunen.

Simplify the ArgumentCoder&lt;std::tuple&lt;&gt;&gt; specialization, removing helper structs
and leaning into constexpr for a finer implementation.

The encoding remains the same, just the helper struct&apos;s methods inlined into the
ArgumentCoder specialization.

The decoding methods are reworked to use constexpr to make compile-time codepaths.
For each desired element, decoding is done into std::optional&lt;&gt; values that are
then passed through tuples of rvalue references into recursive calls, with the
index sequence adjusted each time to address the next element. Once all elements
are successfully decoded, the final tuple is constructed, with the decoded objects
all moved into that tuple. If decoding was unsuccessful at any point, a nullopt
value is returned immediately, as before.

This avoids concatenating tuples that was occurring for each decoded element, and
was ending up moving each contained element into the concatenation result for each
such concatenation.

* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::TupleEncoder::encode): Deleted.
(IPC::TupleDecoder&lt;&gt;::decode): Deleted.

Canonical link: <a href="https://commits.webkit.org/255496@main">https://commits.webkit.org/255496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2ed65ac62afd15bdd6e323f422685af39f2d056

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102253 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1720 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30090 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84912 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98437 "Hash e2ed65ac for PR 5083 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1155 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79001 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28082 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82762 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71178 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36501 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16698 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34281 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17874 "Found 1 new test failure: compositing/backing/backing-store-attachment-animating-outside-viewport.html (failure)") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3808 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40488 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37028 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->