### PR TITLE
Port TextFlags encoders/decoders over to the new serialization format

### DIFF
--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -341,9 +341,6 @@ struct FontVariantSettings {
 
     bool operator!=(const FontVariantSettings& other) const { return !(*this == other); }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<FontVariantSettings> decode(Decoder&);
-
     FontVariantLigatures commonLigatures;
     FontVariantLigatures discretionaryLigatures;
     FontVariantLigatures historicalLigatures;
@@ -361,123 +358,6 @@ struct FontVariantSettings {
     FontVariantEastAsianRuby eastAsianRuby;
 };
 
-template<class Encoder>
-void FontVariantSettings::encode(Encoder& encoder) const
-{
-    encoder << commonLigatures;
-    encoder << discretionaryLigatures;
-    encoder << historicalLigatures;
-    encoder << contextualAlternates;
-    encoder << position;
-    encoder << caps;
-    encoder << numericFigure;
-    encoder << numericSpacing;
-    encoder << numericFraction;
-    encoder << numericOrdinal;
-    encoder << numericSlashedZero;
-    encoder << alternates;
-    encoder << eastAsianVariant;
-    encoder << eastAsianWidth;
-    encoder << eastAsianRuby;
-}
-
-template<class Decoder>
-std::optional<FontVariantSettings> FontVariantSettings::decode(Decoder& decoder)
-{
-    std::optional<FontVariantLigatures> commonLigatures;
-    decoder >> commonLigatures;
-    if (!commonLigatures)
-        return std::nullopt;
-
-    std::optional<FontVariantLigatures> discretionaryLigatures;
-    decoder >> discretionaryLigatures;
-    if (!discretionaryLigatures)
-        return std::nullopt;
-
-    std::optional<FontVariantLigatures> historicalLigatures;
-    decoder >> historicalLigatures;
-    if (!historicalLigatures)
-        return std::nullopt;
-
-    std::optional<FontVariantLigatures> contextualAlternates;
-    decoder >> contextualAlternates;
-    if (!contextualAlternates)
-        return std::nullopt;
-
-    std::optional<FontVariantPosition> position;
-    decoder >> position;
-    if (!position)
-        return std::nullopt;
-
-    std::optional<FontVariantCaps> caps;
-    decoder >> caps;
-    if (!caps)
-        return std::nullopt;
-
-    std::optional<FontVariantNumericFigure> numericFigure;
-    decoder >> numericFigure;
-    if (!numericFigure)
-        return std::nullopt;
-
-    std::optional<FontVariantNumericSpacing> numericSpacing;
-    decoder >> numericSpacing;
-    if (!numericSpacing)
-        return std::nullopt;
-
-    std::optional<FontVariantNumericFraction> numericFraction;
-    decoder >> numericFraction;
-    if (!numericFraction)
-        return std::nullopt;
-
-    std::optional<FontVariantNumericOrdinal> numericOrdinal;
-    decoder >> numericOrdinal;
-    if (!numericOrdinal)
-        return std::nullopt;
-
-    std::optional<FontVariantNumericSlashedZero> numericSlashedZero;
-    decoder >> numericSlashedZero;
-    if (!numericSlashedZero)
-        return std::nullopt;
-
-    std::optional<FontVariantAlternates> alternates;
-    decoder >> alternates;
-    if (!alternates)
-        return std::nullopt;
-
-    std::optional<FontVariantEastAsianVariant> eastAsianVariant;
-    decoder >> eastAsianVariant;
-    if (!eastAsianVariant)
-        return std::nullopt;
-
-    std::optional<FontVariantEastAsianWidth> eastAsianWidth;
-    decoder >> eastAsianWidth;
-    if (!eastAsianWidth)
-        return std::nullopt;
-
-    std::optional<FontVariantEastAsianRuby> eastAsianRuby;
-    decoder >> eastAsianRuby;
-    if (!eastAsianRuby)
-        return std::nullopt;
-
-    return {{
-        *commonLigatures,
-        *discretionaryLigatures,
-        *historicalLigatures,
-        *contextualAlternates,
-        *position,
-        *caps,
-        *numericFigure,
-        *numericSpacing,
-        *numericFraction,
-        *numericOrdinal,
-        *numericSlashedZero,
-        *alternates,
-        *eastAsianVariant,
-        *eastAsianWidth,
-        *eastAsianRuby
-    }};
-}
-
 struct FontVariantLigaturesValues {
     FontVariantLigaturesValues(
         FontVariantLigatures commonLigatures,
@@ -491,49 +371,11 @@ struct FontVariantLigaturesValues {
     {
     }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<FontVariantLigaturesValues> decode(Decoder&);
-
     FontVariantLigatures commonLigatures;
     FontVariantLigatures discretionaryLigatures;
     FontVariantLigatures historicalLigatures;
     FontVariantLigatures contextualAlternates;
 };
-
-template<class Encoder>
-void FontVariantLigaturesValues::encode(Encoder& encoder) const
-{
-    encoder << commonLigatures;
-    encoder << discretionaryLigatures;
-    encoder << historicalLigatures;
-    encoder << contextualAlternates;
-}
-
-template<class Decoder>
-std::optional<FontVariantLigaturesValues> FontVariantLigaturesValues::decode(Decoder& decoder)
-{
-    std::optional<FontVariantLigatures> commonLigatures;
-    decoder >> commonLigatures;
-    if (!commonLigatures)
-        return std::nullopt;
-
-    std::optional<FontVariantLigatures> discretionaryLigatures;
-    decoder >> discretionaryLigatures;
-    if (!discretionaryLigatures)
-        return std::nullopt;
-
-    std::optional<FontVariantLigatures> historicalLigatures;
-    decoder >> historicalLigatures;
-    if (!historicalLigatures)
-        return std::nullopt;
-
-    std::optional<FontVariantLigatures> contextualAlternates;
-    decoder >> contextualAlternates;
-    if (!contextualAlternates)
-        return std::nullopt;
-
-    return {{ *commonLigatures, *discretionaryLigatures, *historicalLigatures, *contextualAlternates }};
-}
 
 struct FontVariantNumericValues {
     FontVariantNumericValues(
@@ -550,56 +392,12 @@ struct FontVariantNumericValues {
     {
     }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<FontVariantNumericValues> decode(Decoder&);
-
     FontVariantNumericFigure figure;
     FontVariantNumericSpacing spacing;
     FontVariantNumericFraction fraction;
     FontVariantNumericOrdinal ordinal;
     FontVariantNumericSlashedZero slashedZero;
 };
-
-template<class Encoder>
-void FontVariantNumericValues::encode(Encoder& encoder) const
-{
-    encoder << figure;
-    encoder << spacing;
-    encoder << fraction;
-    encoder << ordinal;
-    encoder << slashedZero;
-}
-
-template<class Decoder>
-std::optional<FontVariantNumericValues> FontVariantNumericValues::decode(Decoder& decoder)
-{
-    std::optional<FontVariantNumericFigure> figure;
-    decoder >> figure;
-    if (!figure)
-        return std::nullopt;
-
-    std::optional<FontVariantNumericSpacing> spacing;
-    decoder >> spacing;
-    if (!spacing)
-        return std::nullopt;
-
-    std::optional<FontVariantNumericFraction> fraction;
-    decoder >> fraction;
-    if (!fraction)
-        return std::nullopt;
-
-    std::optional<FontVariantNumericOrdinal> ordinal;
-    decoder >> ordinal;
-    if (!ordinal)
-        return std::nullopt;
-
-    std::optional<FontVariantNumericSlashedZero> slashedZero;
-    decoder >> slashedZero;
-    if (!slashedZero)
-        return std::nullopt;
-
-    return {{ *figure, *spacing, *fraction, *ordinal, *slashedZero }};
-}
 
 struct FontVariantEastAsianValues {
     FontVariantEastAsianValues(
@@ -612,42 +410,11 @@ struct FontVariantEastAsianValues {
     {
     }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<FontVariantEastAsianValues> decode(Decoder&);
-
     FontVariantEastAsianVariant variant;
     FontVariantEastAsianWidth width;
     FontVariantEastAsianRuby ruby;
 };
 
-template<class Encoder>
-void FontVariantEastAsianValues::encode(Encoder& encoder) const
-{
-    encoder << variant;
-    encoder << width;
-    encoder << ruby;
-}
-
-template<class Decoder>
-std::optional<FontVariantEastAsianValues> FontVariantEastAsianValues::decode(Decoder& decoder)
-{
-    std::optional<FontVariantEastAsianVariant> variant;
-    decoder >> variant;
-    if (!variant)
-        return std::nullopt;
-
-    std::optional<FontVariantEastAsianWidth> width;
-    decoder >> width;
-    if (!width)
-        return std::nullopt;
-
-    std::optional<FontVariantEastAsianRuby> ruby;
-    decoder >> ruby;
-    if (!ruby)
-        return std::nullopt;
-
-    return {{ *variant, *width, *ruby }};
-}
 
 enum class FontWidthVariant : uint8_t {
     RegularWidth,
@@ -661,9 +428,9 @@ const unsigned FontWidthVariantWidth = 2;
 
 static_assert(!(static_cast<unsigned>(FontWidthVariant::LastFontWidthVariant) >> FontWidthVariantWidth), "FontWidthVariantWidth is correct");
 
-enum class FontSmallCaps : uint8_t {
-    Off = 0,
-    On = 1
+enum class FontSmallCaps : bool {
+    Off,
+    On
 };
 
 enum class Kerning : uint8_t {
@@ -691,200 +458,3 @@ enum class AllowUserInstalledFonts : uint8_t {
 };
 
 }
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::TextRenderingMode> {
-    using values = EnumValues<
-    WebCore::TextRenderingMode,
-    WebCore::TextRenderingMode::AutoTextRendering,
-    WebCore::TextRenderingMode::OptimizeSpeed,
-    WebCore::TextRenderingMode::OptimizeLegibility,
-    WebCore::TextRenderingMode::GeometricPrecision
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontSmoothingMode> {
-    using values = EnumValues<
-    WebCore::FontSmoothingMode,
-    WebCore::FontSmoothingMode::AutoSmoothing,
-    WebCore::FontSmoothingMode::NoSmoothing,
-    WebCore::FontSmoothingMode::Antialiased,
-    WebCore::FontSmoothingMode::SubpixelAntialiased,
-    WebCore::FontSmoothingMode::AutoSmoothing
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontOrientation> {
-    using values = EnumValues<
-    WebCore::FontOrientation,
-    WebCore::FontOrientation::Horizontal,
-    WebCore::FontOrientation::Vertical
-    >;
-};
-
-template<> struct EnumTraits<WebCore::NonCJKGlyphOrientation> {
-    using values = EnumValues<
-    WebCore::NonCJKGlyphOrientation,
-    WebCore::NonCJKGlyphOrientation::Mixed,
-    WebCore::NonCJKGlyphOrientation::Upright
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontVariantLigatures> {
-    using values = EnumValues<
-    WebCore::FontVariantLigatures,
-    WebCore::FontVariantLigatures::Normal,
-    WebCore::FontVariantLigatures::Yes,
-    WebCore::FontVariantLigatures::No
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontVariantPosition> {
-    using values = EnumValues<
-    WebCore::FontVariantPosition,
-    WebCore::FontVariantPosition::Normal,
-    WebCore::FontVariantPosition::Subscript,
-    WebCore::FontVariantPosition::Superscript
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontVariantCaps> {
-    using values = EnumValues<
-    WebCore::FontVariantCaps,
-    WebCore::FontVariantCaps::Normal,
-    WebCore::FontVariantCaps::Small,
-    WebCore::FontVariantCaps::AllSmall,
-    WebCore::FontVariantCaps::Petite,
-    WebCore::FontVariantCaps::AllPetite,
-    WebCore::FontVariantCaps::Unicase,
-    WebCore::FontVariantCaps::Titling
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontVariantNumericFigure> {
-    using values = EnumValues<
-    WebCore::FontVariantNumericFigure,
-    WebCore::FontVariantNumericFigure::Normal,
-    WebCore::FontVariantNumericFigure::LiningNumbers,
-    WebCore::FontVariantNumericFigure::OldStyleNumbers
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontVariantNumericSpacing> {
-    using values = EnumValues<
-    WebCore::FontVariantNumericSpacing,
-    WebCore::FontVariantNumericSpacing::Normal,
-    WebCore::FontVariantNumericSpacing::ProportionalNumbers,
-    WebCore::FontVariantNumericSpacing::TabularNumbers
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontVariantNumericFraction> {
-    using values = EnumValues<
-    WebCore::FontVariantNumericFraction,
-    WebCore::FontVariantNumericFraction::Normal,
-    WebCore::FontVariantNumericFraction::DiagonalFractions,
-    WebCore::FontVariantNumericFraction::StackedFractions
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontVariantNumericOrdinal> {
-    using values = EnumValues<
-    WebCore::FontVariantNumericOrdinal,
-    WebCore::FontVariantNumericOrdinal::Normal,
-    WebCore::FontVariantNumericOrdinal::Yes
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontVariantNumericSlashedZero> {
-    using values = EnumValues<
-    WebCore::FontVariantNumericSlashedZero,
-    WebCore::FontVariantNumericSlashedZero::Normal,
-    WebCore::FontVariantNumericSlashedZero::Yes
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontVariantEastAsianVariant> {
-    using values = EnumValues<
-    WebCore::FontVariantEastAsianVariant,
-    WebCore::FontVariantEastAsianVariant::Normal,
-    WebCore::FontVariantEastAsianVariant::Jis78,
-    WebCore::FontVariantEastAsianVariant::Jis83,
-    WebCore::FontVariantEastAsianVariant::Jis90,
-    WebCore::FontVariantEastAsianVariant::Jis04,
-    WebCore::FontVariantEastAsianVariant::Simplified,
-    WebCore::FontVariantEastAsianVariant::Traditional,
-    WebCore::FontVariantEastAsianVariant::Normal
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontVariantEastAsianWidth> {
-    using values = EnumValues<
-    WebCore::FontVariantEastAsianWidth,
-    WebCore::FontVariantEastAsianWidth::Normal,
-    WebCore::FontVariantEastAsianWidth::Full,
-    WebCore::FontVariantEastAsianWidth::Proportional
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontVariantEastAsianRuby> {
-    using values = EnumValues<
-    WebCore::FontVariantEastAsianRuby,
-    WebCore::FontVariantEastAsianRuby::Normal,
-    WebCore::FontVariantEastAsianRuby::Yes
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontWidthVariant> {
-    using values = EnumValues<
-    WebCore::FontWidthVariant,
-    WebCore::FontWidthVariant::RegularWidth,
-    WebCore::FontWidthVariant::HalfWidth,
-    WebCore::FontWidthVariant::ThirdWidth,
-    WebCore::FontWidthVariant::QuarterWidth
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontSmallCaps> {
-    using values = EnumValues<
-    WebCore::FontSmallCaps,
-    WebCore::FontSmallCaps::Off,
-    WebCore::FontSmallCaps::On
-    >;
-};
-
-template<> struct EnumTraits<WebCore::Kerning> {
-    using values = EnumValues<
-    WebCore::Kerning,
-    WebCore::Kerning::Auto,
-    WebCore::Kerning::Normal,
-    WebCore::Kerning::NoShift
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontOpticalSizing> {
-    using values = EnumValues<
-    WebCore::FontOpticalSizing,
-    WebCore::FontOpticalSizing::Enabled,
-    WebCore::FontOpticalSizing::Disabled
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontStyleAxis> {
-    using values = EnumValues<
-    WebCore::FontStyleAxis,
-    WebCore::FontStyleAxis::slnt,
-    WebCore::FontStyleAxis::ital
-    >;
-};
-
-template<> struct EnumTraits<WebCore::AllowUserInstalledFonts> {
-    using values = EnumValues<
-    WebCore::AllowUserInstalledFonts,
-    WebCore::AllowUserInstalledFonts::No,
-    WebCore::AllowUserInstalledFonts::Yes
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -521,6 +521,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/FrameTreeNodeData.serialization.in
     Shared/LayerTreeContext.serialization.in
     Shared/ShareableBitmap.serialization.in
+    Shared/TextFlags.serialization.in
     Shared/WebCoreArgumentCoders.serialization.in
     Shared/WebsiteDataStoreParameters.serialization.in
 

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -145,6 +145,7 @@ $(PROJECT_DIR)/Shared/Notifications/NotificationManagerMessageHandler.messages.i
 $(PROJECT_DIR)/Shared/Notifications/NotificationManagerProxy.messages.in
 $(PROJECT_DIR)/Shared/Plugins/NPObjectMessageReceiver.messages.in
 $(PROJECT_DIR)/Shared/ShareableBitmap.serialization.in
+$(PROJECT_DIR)/Shared/TextFlags.serialization.in
 $(PROJECT_DIR)/Shared/WebConnection.messages.in
 $(PROJECT_DIR)/Shared/WebCoreArgumentCoders.serialization.in
 $(PROJECT_DIR)/Shared/WebExtensionControllerParameters.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -460,6 +460,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/FrameInfoData.serialization.in \
 	Shared/FrameTreeNodeData.serialization.in \
 	Shared/LayerTreeContext.serialization.in \
+	Shared/TextFlags.serialization.in \
 	Shared/WebCoreArgumentCoders.serialization.in \
 	Shared/WebExtensionControllerParameters.serialization.in \
 	Shared/mac/SecItemResponseData.serialization.in \

--- a/Source/WebKit/Shared/TextFlags.serialization.in
+++ b/Source/WebKit/Shared/TextFlags.serialization.in
@@ -1,0 +1,139 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+enum class WebCore::FontWidthVariant : uint8_t {
+    RegularWidth,
+    HalfWidth,
+    ThirdWidth,
+    QuarterWidth,
+};
+
+enum class WebCore::Kerning : uint8_t {
+    Auto,
+    Normal,
+    NoShift
+};
+
+enum class WebCore::FontOpticalSizing : uint8_t {
+    Enabled,
+    Disabled
+};
+
+enum class WebCore::FontStyleAxis : uint8_t {
+    slnt,
+    ital
+};
+
+enum class WebCore::AllowUserInstalledFonts : uint8_t {
+    No,
+    Yes
+};
+
+enum class WebCore::FontVariantEastAsianVariant : uint8_t {
+    Normal,
+    Jis78,
+    Jis83,
+    Jis90,
+    Jis04,
+    Simplified,
+    Traditional
+};
+
+enum class WebCore::FontVariantEastAsianWidth : uint8_t {
+    Normal,
+    Full,
+    Proportional
+};
+
+enum class WebCore::FontVariantEastAsianRuby : uint8_t {
+    Normal,
+    Yes
+};
+
+enum class WebCore::FontVariantLigatures : uint8_t {
+    Normal,
+    Yes,
+    No
+};
+
+enum class WebCore::FontVariantPosition : uint8_t {
+    Normal,
+    Subscript,
+    Superscript
+};
+
+enum class WebCore::FontVariantCaps : uint8_t {
+    Normal,
+    Small,
+    AllSmall,
+    Petite,
+    AllPetite,
+    Unicase,
+    Titling
+};
+
+enum class WebCore::FontVariantNumericFigure : uint8_t {
+    Normal,
+    LiningNumbers,
+    OldStyleNumbers
+};
+
+enum class WebCore::FontVariantNumericSpacing : uint8_t {
+    Normal,
+    ProportionalNumbers,
+    TabularNumbers
+};
+
+enum class WebCore::FontVariantNumericFraction : uint8_t {
+    Normal,
+    DiagonalFractions,
+    StackedFractions
+};
+
+enum class WebCore::TextRenderingMode : uint8_t {
+    AutoTextRendering,
+    OptimizeSpeed,
+    OptimizeLegibility,
+    GeometricPrecision
+};
+
+enum class WebCore::FontSmoothingMode : uint8_t {
+    AutoSmoothing,
+    NoSmoothing,
+    Antialiased,
+    SubpixelAntialiased
+};
+
+enum class WebCore::FontOrientation : uint8_t {
+    Horizontal,
+    Vertical
+};
+
+enum class WebCore::NonCJKGlyphOrientation : uint8_t {
+    Mixed,
+    Upright
+};
+
+enum class FontVariantNumericOrdinal : bool
+enum class FontVariantNumericSlashedZero : bool
+enum class WebCore::FontSynthesisLonghandValue : bool
+enum class WebCore::FontSmallCaps : bool

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5826,6 +5826,7 @@
 		868160CF187645370021E79D /* WindowServerConnection.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WindowServerConnection.mm; sourceTree = "<group>"; };
 		86AE2A9628D61EDD007F5A1C /* WebCoreArgumentCodersCocoa.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebCoreArgumentCodersCocoa.serialization.in; sourceTree = "<group>"; };
 		86DA60C628EAE9C00044FE4D /* FocusedElementInformation.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = FocusedElementInformation.serialization.in; sourceTree = "<group>"; };
+		86DD518B28EF028500DF2A58 /* TextFlags.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = TextFlags.serialization.in; sourceTree = "<group>"; };
 		86E67A21190F411800004AB7 /* ProcessThrottler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessThrottler.h; sourceTree = "<group>"; };
 		86E67A22190F411800004AB7 /* ProcessThrottler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProcessThrottler.cpp; sourceTree = "<group>"; };
 		86F9536018FF4FD4001DB2EF /* ProcessAssertion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessAssertion.h; sourceTree = "<group>"; };
@@ -8149,6 +8150,7 @@
 				83F9644C1FA0F76300C47750 /* SharedStringHashTableReadOnly.h */,
 				932CA81B283C35EB00C20BEB /* StorageAreaIdentifier.h */,
 				1A5E4DA312D3BD3D0099A2BB /* TextCheckerState.h */,
+				86DD518B28EF028500DF2A58 /* TextFlags.serialization.in */,
 				F4A7CE842667EB4E00228685 /* TextRecognitionUpdateResult.h */,
 				7BE37F6F27B1475F007A6CD3 /* ThreadSafeObjectHeap.h */,
 				2FD43B921FA006A30083F51C /* TouchBarMenuData.cpp */,


### PR DESCRIPTION
#### 124e37f038913ae4088a9855106553a5f02a242a
<pre>
Port TextFlags encoders/decoders over to the new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=246154">https://bugs.webkit.org/show_bug.cgi?id=246154</a>
rdar://100852252

Reviewed by Alex Christensen.

Port the encoders/decoders/enums supporting TextFlags over to the new format.
Also remove the ones no-longer needed.

* Source/WebCore/platform/text/TextFlags.h:
(WebCore::FontVariantSettings::encode const): Deleted.
(WebCore::FontVariantSettings::decode): Deleted.
(WebCore::FontVariantLigaturesValues::encode const): Deleted.
(WebCore::FontVariantLigaturesValues::decode): Deleted.
(WebCore::FontVariantNumericValues::encode const): Deleted.
(WebCore::FontVariantNumericValues::decode): Deleted.
(WebCore::FontVariantEastAsianValues::encode const): Deleted.
(WebCore::FontVariantEastAsianValues::decode): Deleted.
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/255249@main">https://commits.webkit.org/255249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4674c0951dfcd9344c339c5de045eb70edc1ef2a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101484 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161606 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1033 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84125 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97810 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/621 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78391 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27598 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82546 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35899 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16194 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33653 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17295 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3634 "Build was cancelled. Recent messages:Cleaned up git repository; Checked out pull request; Running validate-remote; Verified commit is squashed; Reviewed by Alex Christensen; Validated commit message; Compiled WebKit (cancelled)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37501 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36415 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->