### PR TITLE
[GStreamer][MSE] High resolution video playback broken on Odysee.com due to unimplemented changeType operation

### DIFF
--- a/LayoutTests/media/media-source/media-source-changetype-second-init.html
+++ b/LayoutTests/media/media-source/media-source-changetype-second-init.html
@@ -25,6 +25,12 @@
 
         run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
         initSegment = makeAInit(8, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]);
+
+        if (sourceBuffer.changeType == undefined) {
+            consoleWrite("SourceBuffer.changeType is undefined");
+            endTest();
+        }
+
         run('sourceBuffer.appendBuffer(initSegment)');
         await waitFor(sourceBuffer, 'updateend');
 

--- a/LayoutTests/media/media-source/media-source-changetype-support-expected.txt
+++ b/LayoutTests/media/media-source/media-source-changetype-support-expected.txt
@@ -1,0 +1,7 @@
+
+EXPECTED (source.readyState == 'closed') OK
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+EXPECTED (sourceBuffer.changeType != 'undefined') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-changetype-support.html
+++ b/LayoutTests/media/media-source/media-source-changetype-support.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>mock-media-source</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    async function runTest() {
+        findMediaElement();
+
+        source = new MediaSource();
+        testExpected('source.readyState', 'closed');
+
+        video.srcObject = source;
+        await waitFor(source, 'sourceopen');
+
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+        testExpected('sourceBuffer.changeType', undefined, '!=');
+
+        endTest()
+    }
+
+    </script>
+</head>
+<body onload="runTest().catch(failTest)">
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-without-codecs-parameter-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-without-codecs-parameter-expected.txt
@@ -1,21 +1,21 @@
 
 PASS Check if browser supports enough test media types
-FAIL Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/webm; codecs="vorbis" (using types without codecs parameters) The operation is not supported.
-FAIL Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/mp4; codecs="mp4a.40.2" (using types without codecs parameters) The operation is not supported.
-FAIL Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/mpeg (using types without codecs parameters) The operation is not supported.
-FAIL Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/webm; codecs="vorbis" (using types without codecs parameters) The operation is not supported.
-FAIL Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/mp4; codecs="mp4a.40.2" (using types without codecs parameters) The operation is not supported.
-FAIL Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/mpeg (using types without codecs parameters) The operation is not supported.
-FAIL Test audio-only changeType for audio/mpeg <-> audio/webm; codecs="vorbis" (using types without codecs parameters) The operation is not supported.
-FAIL Test audio-only changeType for audio/mpeg <-> audio/mp4; codecs="mp4a.40.2" (using types without codecs parameters) The operation is not supported.
-FAIL Test audio-only changeType for audio/mpeg <-> audio/mpeg (using types without codecs parameters) The operation is not supported.
-FAIL Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp8" (using types without codecs parameters) The operation is not supported.
-FAIL Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp9" (using types without codecs parameters) The operation is not supported.
-FAIL Test video-only changeType for video/webm; codecs="vp8" <-> video/mp4; codecs="avc1.4D4001" (using types without codecs parameters) The operation is not supported.
-FAIL Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp8" (using types without codecs parameters) The operation is not supported.
-FAIL Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp9" (using types without codecs parameters) The operation is not supported.
-FAIL Test video-only changeType for video/webm; codecs="vp9" <-> video/mp4; codecs="avc1.4D4001" (using types without codecs parameters) The operation is not supported.
-FAIL Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/webm; codecs="vp8" (using types without codecs parameters) The operation is not supported.
-FAIL Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/webm; codecs="vp9" (using types without codecs parameters) The operation is not supported.
-FAIL Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/mp4; codecs="avc1.4D4001" (using types without codecs parameters) The operation is not supported.
+FAIL Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/webm; codecs="vorbis" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/mp4; codecs="mp4a.40.2" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/mpeg (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/webm; codecs="vorbis" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/mp4; codecs="mp4a.40.2" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/mpeg (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test audio-only changeType for audio/mpeg <-> audio/webm; codecs="vorbis" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test audio-only changeType for audio/mpeg <-> audio/mp4; codecs="mp4a.40.2" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test audio-only changeType for audio/mpeg <-> audio/mpeg (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp8" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp9" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test video-only changeType for video/webm; codecs="vp8" <-> video/mp4; codecs="avc1.4D4001" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp8" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp9" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test video-only changeType for video/webm; codecs="vp9" <-> video/mp4; codecs="avc1.4D4001" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/webm; codecs="vp8" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/webm; codecs="vp9" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
+FAIL Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/mp4; codecs="avc1.4D4001" (using types without codecs parameters) sourceBuffer.changeType is not a function. (In 'sourceBuffer.changeType(typeB)', 'sourceBuffer.changeType' is undefined)
 

--- a/LayoutTests/platform/glib/media/media-source/media-source-changetype-second-init-expected.txt
+++ b/LayoutTests/platform/glib/media/media-source/media-source-changetype-second-init-expected.txt
@@ -1,0 +1,7 @@
+
+EXPECTED (source.readyState == 'closed') OK
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+SourceBuffer.changeType is undefined
+END OF TEST
+

--- a/LayoutTests/platform/glib/media/media-source/media-source-changetype-support-expected.txt
+++ b/LayoutTests/platform/glib/media/media-source/media-source-changetype-support-expected.txt
@@ -1,0 +1,7 @@
+
+EXPECTED (source.readyState == 'closed') OK
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+EXPECTED (sourceBuffer.changeType != 'undefined'), OBSERVED 'undefined' FAIL
+END OF TEST
+

--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -2161,8 +2161,10 @@ SourceBufferChangeTypeEnabled:
     WebKitLegacy:
       default: true
     WebKit:
+      "USE(GSTREAMER)": false
       default: true
     WebCore:
+      "USE(GSTREAMER)": false
       default: true
 
 SpatialNavigationEnabled:


### PR DESCRIPTION
#### 90f34d7eabdf24606fbf34db6a24a1a3a116ec15
<pre>
[GStreamer][MSE] High resolution video playback broken on Odysee.com due to unimplemented changeType operation
<a href="https://bugs.webkit.org/show_bug.cgi?id=245851">https://bugs.webkit.org/show_bug.cgi?id=245851</a>

Reviewed by Philippe Normand and Alicia Boya Garcia.

Disable the SourceBuffer.changeType method by default in GLib based ports.

Test: LayoutTests/media/media-source/media-source-changetype-support.html.

* LayoutTests/media/media-source/media-source-changetype-second-init.html:
* LayoutTests/media/media-source/media-source-changetype-support-expected.txt: Added.
* LayoutTests/media/media-source/media-source-changetype-support.html: Copied from LayoutTests/media/media-source/media-source-changetype-second-init.html.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-without-codecs-parameter-expected.txt:
* LayoutTests/platform/glib/media/media-source/media-source-changetype-second-init-expected.txt: Added.
* LayoutTests/platform/glib/media/media-source/media-source-changetype-support-expected.txt: Added.
* Source/WTF/Scripts/Preferences/WebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/255345@main">https://commits.webkit.org/255345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59fd0eb8b64e97dd7de552d8bec13587155c6d7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102003 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1444 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29841 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84658 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98169 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/941 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78739 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27889 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82519 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70926 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/83641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36262 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78629 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34018 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17645 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/27203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3706 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37890 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81251 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36782 "Passed tests") | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/18077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->