### PR TITLE
[JSC] Use "short" for "digital" style in Intl.DurationFormat

### DIFF
--- a/JSTests/stress/intl-durationformat-digital.js
+++ b/JSTests/stress/intl-durationformat-digital.js
@@ -16,8 +16,8 @@ if (Intl.DurationFormat) {
             style: 'digital'
         });
         shouldBeOneOf(fmt.format({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 }), [
-            `1y 2mo 3w 4d 10.34.33`,
-            `1y 2m 3w 4d 10.34.33`,
+            `1y, 2mo, 3w, 4d, 10.34.33`,
+            `1y, 2m, 3w, 4d, 10.34.33`,
         ]);
     }
     {
@@ -25,8 +25,8 @@ if (Intl.DurationFormat) {
             style: 'digital'
         });
         shouldBeOneOf(fmt.format({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 }), [
-            `1y 2mo 3w 4d 10.34.33`,
-            `1y 2m 3w 4d 10.34.33`,
+            `1y, 2mo, 3w, 4d, 10.34.33`,
+            `1y, 2m, 3w, 4d, 10.34.33`,
         ]);
     }
     {
@@ -34,8 +34,8 @@ if (Intl.DurationFormat) {
             style: 'digital'
         });
         shouldBeOneOf(fmt.format({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 }), [
-            `一y 二mo 三w 四d 一〇:三四:三三`,
-            `一y 二m 三w 四d 一〇:三四:三三`,
+            `一y, 二mo, 三w, 四d, 一〇:三四:三三`,
+            `一y, 二m, 三w, 四d, 一〇:三四:三三`,
         ]);
     }
     {
@@ -43,8 +43,8 @@ if (Intl.DurationFormat) {
             style: 'digital'
         });
         shouldBeOneOf(fmt.format({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 }), [
-            `1y 2mo 3w 4d 10:34:33`,
-            `1y 2m 3w 4d 10:34:33`,
+            `1y, 2mo, 3w, 4d, 10:34:33`,
+            `1y, 2m, 3w, 4d, 10:34:33`,
         ]);
     }
     {
@@ -52,8 +52,8 @@ if (Intl.DurationFormat) {
             style: 'digital'
         });
         shouldBeOneOf(fmt.format({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 }), [
-            `1y 2mo 3w 4d 10:34:33`,
-            `1y 2m 3w 4d 10:34:33`,
+            `1y, 2mo, 3w, 4d, 10:34:33`,
+            `1y, 2m, 3w, 4d, 10:34:33`,
         ]);
     }
     {
@@ -65,8 +65,8 @@ if (Intl.DurationFormat) {
         });
 
         shouldBeOneOf(fmt.format({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 }), [
-            `1y 2mo 3w 4d 10:34:33.032000000`,
-            `1y 2m 3w 4d 10:34:33.032000000`,
+            `1y, 2mo, 3w, 4d, 10:34:33.032000000`,
+            `1y, 2m, 3w, 4d, 10:34:33.032000000`,
         ]);
     }
     {
@@ -78,8 +78,8 @@ if (Intl.DurationFormat) {
         });
 
         shouldBeOneOf(fmt.format({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 }), [
-            `1y 2mo 3w 4d 10:34:33.03`,
-            `1y 2m 3w 4d 10:34:33.03`,
+            `1y, 2mo, 3w, 4d, 10:34:33.03`,
+            `1y, 2m, 3w, 4d, 10:34:33.03`,
         ]);
     }
     {
@@ -90,7 +90,7 @@ if (Intl.DurationFormat) {
         });
 
         shouldBeOneOf(fmt.format({ hours: 10, seconds: 33, milliseconds: 32 }), [
-            `10 33.032000000`,
+            `10, 33.032000000`,
         ]);
     }
     {

--- a/JSTests/stress/intl-durationformat-format-to-parts.js
+++ b/JSTests/stress/intl-durationformat-format-to-parts.js
@@ -54,8 +54,8 @@ if (Intl.DurationFormat) {
         });
 
         shouldBeOneOf(JSON.stringify(fmt.formatToParts({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 })), [
-            `[{"type":"years","value":"1y"},{"type":"literal","value":" "},{"type":"months","value":"2mo"},{"type":"literal","value":" "},{"type":"weeks","value":"3w"},{"type":"literal","value":" "},{"type":"days","value":"4d"},{"type":"literal","value":" "},{"type":"hours","value":"10"},{"type":"literal","value":":"},{"type":"minutes","value":"34"},{"type":"literal","value":":"},{"type":"seconds","value":"33.03"}]`,
-            `[{"type":"years","value":"1y"},{"type":"literal","value":" "},{"type":"months","value":"2m"},{"type":"literal","value":" "},{"type":"weeks","value":"3w"},{"type":"literal","value":" "},{"type":"days","value":"4d"},{"type":"literal","value":" "},{"type":"hours","value":"10"},{"type":"literal","value":":"},{"type":"minutes","value":"34"},{"type":"literal","value":":"},{"type":"seconds","value":"33.03"}]`,
+            `[{"type":"years","value":"1y"},{"type":"literal","value":", "},{"type":"months","value":"2mo"},{"type":"literal","value":", "},{"type":"weeks","value":"3w"},{"type":"literal","value":", "},{"type":"days","value":"4d"},{"type":"literal","value":", "},{"type":"hours","value":"10"},{"type":"literal","value":":"},{"type":"minutes","value":"34"},{"type":"literal","value":":"},{"type":"seconds","value":"33.03"}]`,
+            `[{"type":"years","value":"1y"},{"type":"literal","value":", "},{"type":"months","value":"2m"},{"type":"literal","value":", "},{"type":"weeks","value":"3w"},{"type":"literal","value":", "},{"type":"days","value":"4d"},{"type":"literal","value":", "},{"type":"hours","value":"10"},{"type":"literal","value":":"},{"type":"minutes","value":"34"},{"type":"literal","value":":"},{"type":"seconds","value":"33.03"}]`,
         ]);
     }
 }

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -249,15 +249,15 @@ void IntlDurationFormat::initializeDurationFormat(JSGlobalObject* globalObject, 
         auto toUListFormatterWidth = [](Style style) {
             // 6. Let listStyle be durationFormat.[[Style]].
             // 7. If listStyle is "digital", then
-            //     a. Set listStyle to "narrow".
+            //     a. Set listStyle to "short".
             // 8. Perform ! CreateDataPropertyOrThrow(lfOpts, "style", listStyle).
             switch (style) {
             case Style::Long:
                 return ULISTFMT_WIDTH_WIDE;
             case Style::Short:
+            case Style::Digital:
                 return ULISTFMT_WIDTH_SHORT;
             case Style::Narrow:
-            case Style::Digital:
                 return ULISTFMT_WIDTH_NARROW;
             }
             return ULISTFMT_WIDTH_WIDE;


### PR DESCRIPTION
#### 9bcd2c5685fd27553b1edf35846aa523c42b204e
<pre>
[JSC] Use &quot;short&quot; for &quot;digital&quot; style in Intl.DurationFormat
<a href="https://bugs.webkit.org/show_bug.cgi?id=246165">https://bugs.webkit.org/show_bug.cgi?id=246165</a>
rdar://100860476

Reviewed by Mark Lam.

In the last ECMA 402 meeting, we agreed that default style of Intl.DurationFormat should be &quot;short&quot;,
but the spec was not updated for &quot;digital&quot;. It was a spec bug[1]. We should fix our implementation.

[1]: <a href="https://github.com/tc39/proposal-intl-duration-format/pull/127">https://github.com/tc39/proposal-intl-duration-format/pull/127</a>

* JSTests/stress/intl-durationformat-digital.js:
(Intl.DurationFormat.shouldBeOneOf.fmt.format):
(Intl.DurationFormat.shouldBeOneOf):
* JSTests/stress/intl-durationformat-format-to-parts.js:
(Intl.DurationFormat.shouldBe.JSON.stringify.fmt.formatToParts):
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::IntlDurationFormat::initializeDurationFormat):

Canonical link: <a href="https://commits.webkit.org/255255@main">https://commits.webkit.org/255255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68223f8cdd6b15d2b4a0113f75f6bc05d15208c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101538 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161660 "Reverted pull request changes (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1102 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84187 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97889 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/676 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78436 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27638 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82597 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70677 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83250 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/35964 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16230 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/78300 "Build was cancelled. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33710 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17330 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/78300 "Build was cancelled. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3637 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37570 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80918 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36449 "Passed tests") | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/17739 "Build was cancelled. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; jscore-tests (cancelled)") | 
<!--EWS-Status-Bubble-End-->