### PR TITLE
[32bit] skip stress/verify-can-gc-node-index.js if it's memory limited

### DIFF
--- a/JSTests/stress/verify-can-gc-node-index.js
+++ b/JSTests/stress/verify-can-gc-node-index.js
@@ -1,5 +1,5 @@
 // Often hits JSCTEST_memoryLimit on ARM with --memory-limited.
-//@ skip if ($architecture == "arm") and $memoryLimited
+//@ skip if $memoryLimited
 //@ runDefault("--destroy-vm", "--maximumFunctionForCallInlineCandidateBytecodeCost=500", "--maximumInliningRecursion=5")
 
 function* gen() {


### PR DESCRIPTION
#### e046df1c0973fbe9063f9816db6670748506cfce
<pre>
[32bit] skip stress/verify-can-gc-node-index.js if it&apos;s memory limited

Unreviewed test gardening.

This patch removes the skip if only arm and skips the test on all memory
limited systems. I just ran the test on a MIPS system and got it to
randomly crash:

Running stress/verify-can-gc-node-index.js.default
Aborted
stress/verify-can-gc-node-index.js.default: Crashing because current footprint: 639549440 exceeds limit: 629145600
stress/verify-can-gc-node-index.js.default: ERROR: Unexpected exit code: 134
FAIL: stress/verify-can-gc-node-index.js.default

So it&apos;s not only an ARM issue.

* JSTests/stress/verify-can-gc-node-index.js:

Canonical link: <a href="https://commits.webkit.org/255447@main">https://commits.webkit.org/255447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7413729804ae1b2075a9501a57d1f5c0ebd4f546

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102143 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1600 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29985 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84807 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98303 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1058 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78889 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27999 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82667 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83776 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36402 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16610 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78786 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34168 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17780 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27290 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3776 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40399 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81408 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36928 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18413 "Passed tests") | 
<!--EWS-Status-Bubble-End-->