### PR TITLE
Support GitHub Release Asset Downloads

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitcorepy',
-    version='0.13.15',
+    version='0.13.16',
     description='Library containing various Python support classes and functions.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -44,7 +44,7 @@ from webkitcorepy.call_by_need import CallByNeed
 from webkitcorepy.editor import Editor
 from webkitcorepy.file_lock import FileLock
 
-version = Version(0, 13, 15)
+version = Version(0, 13, 16)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/requests_.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/requests_.py
@@ -33,14 +33,14 @@ class Response(object):
         return Response(text=data, url=url, headers=headers)
 
     @staticmethod
-    def fromJson(data, url=None, headers=None):
+    def fromJson(data, url=None, headers=None, status_code=None):
         assert isinstance(data, list) or isinstance(data, dict)
 
         headers = headers or {}
         if 'Content-Type' not in headers:
             headers['Content-Type'] = 'text/json'
 
-        return Response(text=json.dumps(data), url=url, headers=headers)
+        return Response(text=json.dumps(data), url=url, headers=headers, status_code=status_code)
 
     @staticmethod
     def create404(url=None, headers=None):

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.6.14',
+    version='5.6.15',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 6, 14)
+version = Version(5, 6, 15)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
@@ -146,10 +146,10 @@ class GitHub(bmocks.GitHub):
 
         base = self.commit(ref)
         if not base:
-            return mocks.Response(
-                status_code=404,
+            return mocks.Response.fromJson(
+                dict(message='No commit found for SHA: {}'.format(ref)),
                 url=url,
-                text=jsonlib.dumps(dict(message='No commit found for SHA: {}'.format(ref))),
+                status_code=404,
             )
 
         response = []
@@ -192,10 +192,10 @@ class GitHub(bmocks.GitHub):
 
         commit = self.commit(ref)
         if not commit:
-            return mocks.Response(
-                status_code=404,
+            return mocks.Response.fromJson(
+                dict(message='No commit found for SHA: {}'.format(ref)),
                 url=url,
-                text=jsonlib.dumps(dict(message='No commit found for SHA: {}'.format(ref))),
+                status_code=404,
             )
         return mocks.Response.fromJson({
             'sha': commit.hash,
@@ -222,10 +222,10 @@ class GitHub(bmocks.GitHub):
         commit_a = self.commit(ref_a)
         commit_b = self.commit(ref_b)
         if not commit_a or not commit_b:
-            return mocks.Response(
-                status_code=404,
+            return mocks.Response.fromJson(
+                dict(message='Not found'),
                 url=url,
-                text=jsonlib.dumps(dict(message='Not found')),
+                status_code=404,
             )
 
         if commit_a.branch != self.default_branch or commit_b.branch == self.default_branch:
@@ -435,10 +435,11 @@ class GitHub(bmocks.GitHub):
                     return mocks.Response.fromJson({
                         key: value for key, value in candidate.items() if key not in ('requested_reviews', 'reviews')
                     }, url=url)
-            return mocks.Response(
-                status_code=404,
-                text=jsonlib.dumps(dict(message='Not found')),
+
+            return mocks.Response.fromJson(
+                dict(message='Not found'),
                 url=url,
+                status_code=404,
             )
 
         # Create/update pull-request


### PR DESCRIPTION
#### 755130ccaa69538d9cd7cc69f5d55d934a4f08e6
<pre>
Support GitHub Release Asset Downloads
<a href="https://bugs.webkit.org/show_bug.cgi?id=246162">https://bugs.webkit.org/show_bug.cgi?id=246162</a>
rdar://100859270

Reviewed by Jonathan Bedard.

* Tools/Scripts/libraries/webkitcorepy/setup.py: version bump
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: version bump
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/requests_.py:
(Response.fromJson): expose `status_code` optional argument
* Tools/Scripts/libraries/webkitscmpy/setup.py: version bump
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: version bump
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub._commits_response): Use Response.fromJson when mocking 404 response with JSON text
(GitHub._commit_response): Use Response.fromJson when mocking 404 response with JSON text
(GitHub._compare_response): Use Response.fromJson when mocking 404 response with JSON text
(GitHub.request):Use Response.fromJson when mocking 404 response with JSON text
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
Added optional `stream` argument to `GitHub.request()`. Implemented `GitHub.download_release_assets()`

Canonical link: <a href="https://commits.webkit.org/255283@main">https://commits.webkit.org/255283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ef90842b95ea99879e9d9dd8abc3510135158d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101760 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161766 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1175 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29628 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84414 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97972 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/716 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78486 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27681 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/95509 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82638 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70716 "Found 2 new API test failures: /TestWTF:WTF_WordLock.ManyContendedLongSections, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/children-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36027 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16254 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/90993 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33764 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17354 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3659 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37641 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36474 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->