### PR TITLE
Update API test after 255206@main

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/PageLoadState.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/PageLoadState.cpp
@@ -240,7 +240,7 @@ TEST(WebKit, PageLoadState)
     EXPECT_EQ(state.didChangeActiveURL, 1);
     EXPECT_EQ(state.didChangeCanGoBack, 0);
     EXPECT_EQ(state.didChangeCanGoForward, 0);
-    EXPECT_EQ(state.didChangeCertificateInfo, 1);
+    EXPECT_EQ(state.didChangeCertificateInfo, 0);
     EXPECT_GT(state.didChangeEstimatedProgress, 0);
     EXPECT_EQ(state.didChangeHasOnlySecureContent, 0);
     EXPECT_GT(state.didChangeIsLoading, 0);
@@ -251,7 +251,7 @@ TEST(WebKit, PageLoadState)
     EXPECT_EQ(state.willChangeActiveURL, 1);
     EXPECT_EQ(state.willChangeCanGoBack, 0);
     EXPECT_EQ(state.willChangeCanGoForward, 0);
-    EXPECT_EQ(state.willChangeCertificateInfo, 1);
+    EXPECT_EQ(state.willChangeCertificateInfo, 0);
     EXPECT_GT(state.willChangeEstimatedProgress, 0);
     EXPECT_EQ(state.willChangeHasOnlySecureContent, 0);
     EXPECT_GT(state.willChangeIsLoading, 0);


### PR DESCRIPTION
#### 116d2f9769a7d8cca0b7bb1decc1ca22c6cada18
<pre>
Update API test after 255206@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=246175">https://bugs.webkit.org/show_bug.cgi?id=246175</a>
rdar://100867880

Unreviewed.

* Tools/TestWebKitAPI/Tests/WebKit/PageLoadState.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/255241@main">https://commits.webkit.org/255241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7301b000482759fb84a563f7ee059154b6459fb4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1097 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/101533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1097 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/97852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97508 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/84182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/35959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/33706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37565 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1639 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/39459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->