### PR TITLE
Non-unified build fixes, early October 2022 edition

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.cpp
@@ -24,9 +24,11 @@
  */
 
 #include "config.h"
-#include "RTCEncodedAudioFrame.h"
 
 #if ENABLE(WEB_RTC)
+#include "RTCEncodedAudioFrame.h"
+
+#include <JavaScriptCore/ArrayBuffer.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.cpp
@@ -24,9 +24,11 @@
  */
 
 #include "config.h"
-#include "RTCEncodedVideoFrame.h"
 
 #if ENABLE(WEB_RTC)
+#include "RTCEncodedVideoFrame.h"
+
+#include <JavaScriptCore/ArrayBuffer.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -37,6 +37,7 @@
 #include "RenderBox.h"
 #include "RenderBoxModelObject.h"
 #include "RenderStyle.h"
+#include "StyleProperties.h"
 #include "StylePropertyShorthand.h"
 #include "StyleScope.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -46,6 +46,7 @@ class CSSFontSelector;
 class CSSSegmentedFontFace;
 class CSSValue;
 class CSSValueList;
+class Document;
 class Font;
 class FontCreationContext;
 class FontDescription;

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -37,6 +37,7 @@
 #include "ResourceLoadInfo.h"
 #include "RuleSet.h"
 #include "SecurityOrigin.h"
+#include "StyleProperties.h"
 #include "StyleRule.h"
 #include "StyleRuleImport.h"
 #include <wtf/Deque.h>

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -34,6 +34,7 @@
 #include "CSSParserContext.h"
 #include "CSSParserIdioms.h"
 #include "CSSPrimitiveValue.h"
+#include "CSSProperty.h"
 #include "CSSPropertyParser.h"
 #include "CSSPropertyParserHelpers.h"
 #include "CSSValueList.h"

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -31,6 +31,7 @@
 
 #include "CSSParser.h"
 #include "CSSParserTokenRange.h"
+#include "CSSProperty.h"
 #include "CSSPropertyNames.h"
 #include <memory>
 #include <wtf/Vector.h>
@@ -47,6 +48,7 @@ class StyleRuleKeyframe;
 class StyleRule;
 class StyleRuleBase;
 class StyleRuleCharset;
+class StyleRuleContainer;
 class StyleRuleFontFace;
 class StyleRuleFontPaletteValues;
 class StyleRuleImport;

--- a/Source/WebCore/css/parser/CSSParserObserverWrapper.h
+++ b/Source/WebCore/css/parser/CSSParserObserverWrapper.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "CSSParserObserver.h"
+#include <wtf/Vector.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -32,6 +32,7 @@
 
 #include "CSSParserImpl.h"
 #include "CSSSelectorParser.h"
+#include "StyleRule.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/display/css/DisplayBoxFactory.cpp
+++ b/Source/WebCore/display/css/DisplayBoxFactory.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "DisplayBoxFactory.h"
 
+#include "CachedImage.h"
 #include "DisplayBoxClip.h"
 #include "DisplayBoxDecorationData.h"
 #include "DisplayBoxDecorationPainter.h"

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -33,6 +33,10 @@
 #include <wtf/Vector.h>
 #include <wtf/text/AtomString.h>
 
+namespace JSC {
+class JSValue;
+}
+
 namespace WebCore {
 
 class CSSStyleSheet;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -129,6 +129,7 @@
 #include "ResourceUsageOverlay.h"
 #include "SVGDocumentExtensions.h"
 #include "SVGImage.h"
+#include "ScreenOrientationManager.h"
 #include "ScriptController.h"
 #include "ScriptDisallowedScope.h"
 #include "ScriptRunner.h"

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -29,7 +29,9 @@
 #include "Document.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "FrameDestructionObserverInlines.h"
 #include "JSDOMPromiseDeferred.h"
+#include "Page.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/ScreenOrientationType.h
+++ b/Source/WebCore/page/ScreenOrientationType.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/EnumTraits.h>
+
 namespace WebCore {
 
 enum class ScreenOrientationType : uint8_t {

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -33,6 +33,7 @@
 #include "GraphicsContext.h"
 #include "NinePieceImage.h"
 #include "PaintInfo.h"
+#include "RenderBox.h"
 #include "RenderTheme.h"
 
 namespace WebCore {

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -29,6 +29,7 @@
 #include "Logging.h"
 #include "ProcessThrottlerClient.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebKit {
     

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLTableSectionElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLTableSectionElement.cpp
@@ -26,6 +26,7 @@
 #include <WebCore/Document.h>
 #include <WebCore/ElementInlines.h>
 #include <WebCore/HTMLNames.h>
+#include <WebCore/HTMLTableRowElement.h>
 #include <WebCore/JSExecState.h>
 #include "GObjectEventListener.h"
 #include "WebKitDOMEventPrivate.h"

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebScreenOrientationManager.h"
 
+#include "WebPage.h"
 #include "WebProcess.h"
 #include "WebScreenOrientationManagerMessages.h"
 #include "WebScreenOrientationManagerProxyMessages.h"


### PR DESCRIPTION
#### 269b3d2cdb2f4e75088fbd49541ecd2319e9eb7d
<pre>
Non-unified build fixes, early October 2022 edition

Reviewed by Darin Adler.

* Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.cpp: Add
  missing JavaScriptCore/ArrayBuffer.h inclusion, move main header
  inclusion inside the ENABLE(WEB_RTC) guard to avoid it when WebRTC
  support is disabled.
* Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.cpp: Ditto.
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp: Add missing
  StyleProperties.h header inclusion.
* Source/WebCore/css/CSSFontFace.h: Add missing WebCore::Document
  forward declaration.
* Source/WebCore/css/StyleSheetContents.cpp: Add missing
  StyleProperties.h header inclusion.
* Source/WebCore/css/parser/CSSParserFastPaths.cpp: Add missing
  CSSProperty.h header inclusion.
* Source/WebCore/css/parser/CSSParserImpl.h: Add missing inclusion of
  the CSSProperty.h header and forward declaration for
  WebCore::StyleRuleContainer.
* Source/WebCore/css/parser/CSSParserObserverWrapper.h: Add missing
  wtf/Vector.h header inclusion.
* Source/WebCore/css/parser/CSSSupportsParser.cpp: Add missing
  StyleRule.h header inclusion.
* Source/WebCore/display/css/DisplayBoxFactory.cpp: Add missing
  CachedImage.h header inclusion.
* Source/WebCore/dom/TreeScope.h: Add missing JSC::JSValue forward
  declaration.
* Source/WebCore/page/Page.cpp: Add missing ScreenOrientationManager.h
  header inclusion.
* Source/WebCore/page/ScreenOrientation.cpp: Add missing Page.h and
  FrameDestructionObserverInlines.h header inclusions.
* Source/WebCore/page/ScreenOrientationType.h: Add missing
  wtf/EnumTraits.h heder inclusion.
* Source/WebCore/rendering/BorderPainter.cpp: Add missing RenderBox.h
  header inclusion.
* Source/WebKit/UIProcess/ProcessThrottler.cpp: Add missing
  wtf/text/TextStream.h header inclusion.
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLTableSectionElement.cpp:
  Add missing WebCore/HTMLTableRowElement.h header inclusion.
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp:
  Add missing WebPage.h header inclusion.

Canonical link: <a href="https://commits.webkit.org/255304@main">https://commits.webkit.org/255304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2895fefa4db43cc1563c3c623179fa330cf87ccc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101869 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161923 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1304 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84518 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97732 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78601 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/27760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36132 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33884 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17454 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3673 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37755 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36580 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->