### PR TITLE
Blob support for the private browsing backing store

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -347,17 +347,6 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::putOrAdd(JSGlobalObject& state, JSV
     if (UNLIKELY(scope.exception()))
         return Exception { DataCloneError, "Failed to store record in an IDBObjectStore: An object could not be cloned."_s };
 
-    bool privateBrowsingEnabled = false;
-    if (is<Document>(*context)) {
-        if (auto* page = downcast<Document>(*context).page())
-            privateBrowsingEnabled = page->sessionID().isEphemeral();
-    }
-
-    if (serializedValue->hasBlobURLs() && privateBrowsingEnabled) {
-        // https://bugs.webkit.org/show_bug.cgi?id=156347 - Support Blobs in private browsing.
-        return Exception { DataCloneError, "Failed to store record in an IDBObjectStore: BlobURLs are not yet supported."_s };
-    }
-
     if (key && !key->isValid())
         return Exception { DataError, "Failed to store record in an IDBObjectStore: The parameter is not a valid key."_s };
 

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -94,8 +94,13 @@ public:
 
     Vector<String> blobURLs() const;
     Vector<URLKeepingBlobAlive> blobHandles() const { return crossThreadCopy(m_blobHandles); }
+
     void writeBlobsToDiskForIndexedDB(CompletionHandler<void(IDBValue&&)>&&);
     IDBValue writeBlobsToDiskForIndexedDBSynchronously();
+
+    void writeBlobsToMemoryForPrivateBrowsingIndexedDB(CompletionHandler<void(bool)>&& completionHandler);
+    bool writeBlobsToMemoryForPrivateBrowsingIndexedDBSynchronously();
+    
     static Ref<SerializedScriptValue> createFromWireBytes(Vector<uint8_t>&& data)
     {
         return adoptRef(*new SerializedScriptValue(WTFMove(data)));

--- a/Source/WebCore/platform/network/BlobRegistry.h
+++ b/Source/WebCore/platform/network/BlobRegistry.h
@@ -71,6 +71,7 @@ public:
 
     virtual unsigned long long blobSize(const URL&) = 0;
 
+    virtual void writeBlobsToMemoryForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(bool)>&&) = 0;
     virtual void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&&) = 0;
 
     virtual BlobRegistryImpl* blobRegistryImpl() { return nullptr; }

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -40,6 +40,8 @@
 #include "ResourceHandle.h"
 #include "ResourceRequest.h"
 #include "ResourceResponse.h"
+#include "wtf/Compiler.h"
+#include "wtf/Forward.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
@@ -343,6 +345,17 @@ static bool writeFilePathsOrDataBuffersToFile(const Vector<std::pair<String, Ref
     }
     return true;
 }
+
+void BlobRegistryImpl::writeBlobsToMemoryForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(bool result)>&& completionHandler)
+{
+    UNUSED_PARAM(completionHandler);
+    Vector<BlobForFileWriting> blobs;
+    if (!populateBlobsForFileWriting(blobURLs, blobs)) {
+                return;
+    }
+
+}
+
 
 void BlobRegistryImpl::writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&& completionHandler)
 {

--- a/Source/WebCore/platform/network/BlobRegistryImpl.h
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.h
@@ -33,6 +33,7 @@
 
 #include "BlobData.h"
 #include "BlobRegistry.h"
+#include "wtf/CrossThreadCopier.h"
 #include <wtf/HashCountedSet.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/URLHash.h>
@@ -72,11 +73,13 @@ public:
 
     unsigned long long blobSize(const URL&);
 
+    void writeBlobsToMemoryForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(bool result)>&&);
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&&);
 
     struct BlobForFileWriting {
         String blobURL;
         Vector<std::pair<String, RefPtr<DataSegment>>> filePathsOrDataBuffers;
+        BlobForFileWriting isolatedCopy() const { return { blobURL.isolatedCopy(), crossThreadCopy(filePathsOrDataBuffers) }; }
     };
 
     bool populateBlobsForFileWriting(const Vector<String>& blobURLs, Vector<BlobForFileWriting>&);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -73,6 +73,7 @@
 #include "WebSharedWorkerServerToContextConnection.h"
 #include "WebSharedWorkerServerToContextConnectionMessages.h"
 #include "WebsiteDataStoreParameters.h"
+#include "wtf/Compiler.h"
 #include <WebCore/DocumentStorageAccess.h>
 #include <WebCore/HTTPCookieAcceptPolicy.h>
 #include <WebCore/NetworkStorageSession.h>
@@ -979,6 +980,21 @@ void NetworkConnectionToWebProcess::blobSize(const URL& url, CompletionHandler<v
 {
     auto* session = networkSession();
     completionHandler(session ? session->blobRegistry().blobSize(url) : 0);
+}
+
+void NetworkConnectionToWebProcess::writeBlobsToMemoryForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(bool)>&& completionHandler)
+{
+    auto* session = networkSession();
+    if(!session)
+        return completionHandler(false);
+
+    
+    // session->blobRegistry().writeBlobsToMemoryForIndexedDB(blobURLs, [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](bool success) mutable {
+    // // if (auto* session = networkSession())
+    // //   session->storageManager().registerTemporaryBlobFilePaths(m_connection, &success);
+    //      completionHandler(success);
+    // });
+    
 }
 
 void NetworkConnectionToWebProcess::writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&&)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -254,6 +254,8 @@ private:
     void registerBlobURLForSlice(const URL&, const URL& srcURL, int64_t start, int64_t end, const String& contentType);
     void blobSize(const URL&, CompletionHandler<void(uint64_t)>&&);
     void unregisterBlobURL(const URL&);
+
+    void writeBlobsToMemoryForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(bool)>&&);
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&&)>&&);
 
     void registerBlobURLHandle(const URL&);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -55,7 +55,10 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
     RegisterBlobURLForSlice(URL url, URL srcURL, int64_t start, int64_t end, String contentType)
     UnregisterBlobURL(URL url)
     BlobSize(URL url) -> (uint64_t resultSize) Synchronous
+
+    WriteBlobsToMemoryForIndexedDB(Vector<String> blobURLs) -> (bool result)
     WriteBlobsToTemporaryFilesForIndexedDB(Vector<String> blobURLs) -> (Vector<String> fileNames)
+
     RegisterBlobURLHandle(URL url);
     UnregisterBlobURLHandle(URL url);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.cpp
@@ -64,7 +64,10 @@ BlobRegistry* NetworkProcessPlatformStrategies::createBlobRegistry()
         void registerBlobURLForSlice(const URL&, const URL& srcURL, long long start, long long end, const String& contentType) final { ASSERT_NOT_REACHED(); }
         void unregisterBlobURL(const URL&) final { ASSERT_NOT_REACHED(); }
         unsigned long long blobSize(const URL&) final { ASSERT_NOT_REACHED(); return 0; }
+
+        void writeBlobsToMemoryForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(bool result)>&&) final { RELEASE_ASSERT_NOT_REACHED(); }
         void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&&) final { ASSERT_NOT_REACHED(); }
+
         void registerBlobURLHandle(const URL&) final { ASSERT_NOT_REACHED(); }
         void unregisterBlobURLHandle(const URL&) final { ASSERT_NOT_REACHED(); }
     };

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -35,7 +35,9 @@
 #include "WebPageProxyIdentifier.h"
 #include "WebsiteData.h"
 #include "WorkQueueMessageReceiver.h"
+#include "wtf/ThreadSafetyAnalysis.h"
 #include <WebCore/ClientOrigin.h>
+#include <WebCore/BlobRegistryImpl.h>
 #include <WebCore/FileSystemHandleIdentifier.h>
 #include <WebCore/FileSystemSyncAccessHandleIdentifier.h>
 #include <WebCore/IDBResourceIdentifier.h>
@@ -95,7 +97,10 @@ public:
     void resume();
     void handleLowMemoryWarning();
     void syncLocalStorage(CompletionHandler<void()>&&);
+
+    void registerTemporaryBlobDataByConnection(IPC::Connection& connection, Vector<WebCore::BlobRegistryImpl::BlobForFileWriting>& blobs);
     void registerTemporaryBlobFilePaths(IPC::Connection&, const Vector<String>&);
+
     void requestSpace(const WebCore::ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&&);
     void resetQuotaForTesting(CompletionHandler<void()>&&);
     void resetQuotaUpdatedBasedOnUsageForTesting(WebCore::ClientOrigin&&);
@@ -199,6 +204,8 @@ private:
     bool m_shouldUseCustomPaths;
     IPC::Connection::UniqueID m_parentConnection;
     HashMap<IPC::Connection::UniqueID, HashSet<String>> m_temporaryBlobPathsByConnection WTF_GUARDED_BY_CAPABILITY(workQueue());
+    HashMap<IPC::Connection::UniqueID, Vector<WebCore::BlobRegistryImpl::BlobForFileWriting>> m_temporaryBlobDataByConnection WTF_GUARDED_BY_CAPABILITY(workQueue());
+
 #if PLATFORM(IOS_FAMILY)
     Seconds m_backupExclusionPeriod;
 #endif

--- a/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp
+++ b/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp
@@ -94,6 +94,11 @@ unsigned long long BlobRegistryProxy::blobSize(const URL& url)
     return resultSize;
 }
 
+void BlobRegistryProxy::writeBlobsToMemoryForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(bool)>&& completionHandler)
+{
+    WebProcess::singleton().ensureNetworkProcessConnection().writeBlobsToMemoryForIndexedDB(blobURLs, WTFMove(completionHandler));
+}
+
 void BlobRegistryProxy::writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&& completionHandler)
 {
     WebProcess::singleton().ensureNetworkProcessConnection().writeBlobsToTemporaryFilesForIndexedDB(blobURLs, WTFMove(completionHandler));

--- a/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.h
+++ b/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.h
@@ -38,7 +38,10 @@ public:
     void unregisterBlobURL(const URL&) final;
     void registerBlobURLForSlice(const URL&, const URL& srcURL, long long start, long long end, const String& contentType) final;
     unsigned long long blobSize(const URL&) final;
+
+    void writeBlobsToMemoryForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(bool result)>&&) final;
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&&) final;
+
     void registerBlobURLHandle(const URL&) final;
     void unregisterBlobURLHandle(const URL&) final;
 };

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -241,6 +241,12 @@ void NetworkProcessConnection::didReceiveInvalidMessage(IPC::Connection&, IPC::M
 {
 }
 
+
+void NetworkProcessConnection::writeBlobsToMemoryForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(bool result)>&& completionHandler)
+{
+    connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::WriteBlobsToMemoryForIndexedDB(blobURLs), WTFMove(completionHandler));
+}
+
 void NetworkProcessConnection::writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&& completionHandler)
 {
     connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::WriteBlobsToTemporaryFilesForIndexedDB(blobURLs), WTFMove(completionHandler));

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -67,6 +67,8 @@ public:
 
     void didReceiveNetworkProcessConnectionMessage(IPC::Connection&, IPC::Decoder&);
 
+
+    void writeBlobsToMemoryForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(bool result)>&&);
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&&);
 
     WebIDBConnectionToServer* existingIDBConnectionToServer() const { return m_webIDBConnection.get(); };

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
@@ -90,6 +90,8 @@ private:
     void registerBlobURLForSlice(const URL& url, const URL& srcURL, long long start, long long end, const String& contentType) final { m_blobRegistry.registerBlobURLForSlice(url, srcURL, start, end, contentType); }
     void unregisterBlobURL(const URL& url) final { m_blobRegistry.unregisterBlobURL(url); }
     unsigned long long blobSize(const URL& url) final { return m_blobRegistry.blobSize(url); }
+
+    void writeBlobsToMemoryForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(bool result)>&& completionHandler) final { m_blobRegistry.writeBlobsToMemoryForIndexedDB(blobURLs, WTFMove(completionHandler)); }
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&& completionHandler) final { m_blobRegistry.writeBlobsToTemporaryFilesForIndexedDB(blobURLs, WTFMove(completionHandler)); }
     void registerBlobURLHandle(const URL& url) final { m_blobRegistry.registerBlobURLHandle(url); }
     void unregisterBlobURLHandle(const URL& url) final { m_blobRegistry.unregisterBlobURLHandle(url); }

--- a/Source/WebKitLegacy/win/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKitLegacy/win/WebCoreSupport/WebPlatformStrategies.cpp
@@ -86,7 +86,10 @@ private:
     void registerBlobURLForSlice(const URL& url, const URL& srcURL, long long start, long long end, const String& contentType) final { m_blobRegistry.registerBlobURLForSlice(url, srcURL, start, end, contentType); }
     void unregisterBlobURL(const URL& url) final { m_blobRegistry.unregisterBlobURL(url); }
     unsigned long long blobSize(const URL& url) final { return m_blobRegistry.blobSize(url); }
+
+    void writeBlobsToMemoryForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(bool result)>&& completionHandler) final { m_blobRegistry.writeBlobsToMemoryForIndexedDB(blobURLs, WTFMove(completionHandler)); }
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&& completionHandler) final { m_blobRegistry.writeBlobsToTemporaryFilesForIndexedDB(blobURLs, WTFMove(completionHandler)); }
+
     void registerBlobURLHandle(const URL& url) final { m_blobRegistry.registerBlobURLHandle(url); }
     void unregisterBlobURLHandle(const URL& url) final { m_blobRegistry.unregisterBlobURLHandle(url); }
 


### PR DESCRIPTION
#### 5a6601f7638bdda5db482e5637d453b620521c50
<pre>
Blob support for the private browsing backing store
<a href="https://bugs.webkit.org/show_bug.cgi?id=156347">https://bugs.webkit.org/show_bug.cgi?id=156347</a>

Reviewed by NOBODY (OOPS!).

    Adding suppport for blobs in private browsing mode with IndexedDB.
    Currently IndexedDB writes to a file in regular browsing, which is not
    desired in a private browsing mode. Instead we will keep all blob data
    in memory.

    * Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
    (WebCore::IDBObjectStore::putOrAdd):
    * Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
    (WebCore::IDBTransaction::putOrAddOnServer):
    * Source/WebCore/bindings/js/SerializedScriptValue.cpp:
    (WebCore::SerializedScriptValue::writeBlobsToDiskForIndexedDBSynchronously):
    (WebCore::SerializedScriptValue::writeBlobsToMemoryForPrivateBrowsingIndexedDB):
    (WebCore::SerializedScriptValue::writeBlobsToMemoryForPrivateBrowsingIndexedDBSynchronously):
    * Source/WebCore/bindings/js/SerializedScriptValue.h:
    * Source/WebCore/platform/network/BlobRegistry.h:
    * Source/WebCore/platform/network/BlobRegistryImpl.cpp:
    (WebCore::BlobRegistryImpl::writeBlobsToMemoryForIndexedDB):
    * Source/WebCore/platform/network/BlobRegistryImpl.h:
    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
    (WebKit::NetworkConnectionToWebProcess::writeBlobsToMemoryForIndexedDB):
    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
    * Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.cpp:
    (WebKit::NetworkProcessPlatformStrategies::createBlobRegistry):
    * Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
    (WebKit::NetworkStorageManager::registerTemporaryBlobDataByConnection):
    * Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
    * Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp:
    (WebKit::BlobRegistryProxy::writeBlobsToMemoryForIndexedDB):
    * Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.h:
    * Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
    (WebKit::NetworkProcessConnection::writeBlobsToMemoryForIndexedDB):
    * Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
    * Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm:
    * Source/WebKitLegacy/win/WebCoreSupport/WebPlatformStrategies.cpp:

</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1097726772578ab30bc06477ac94cff3cc460a97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92813 "20 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102541 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162840 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2027 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30367 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85212 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98706 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1380 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79301 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28294 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83004 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71412 "Found 2 new API test failures: /TestWTF:WTF_WordLock.ManyContendedLongSections, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36771 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16917 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34572 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18106 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40712 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37277 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->