### PR TITLE
[WebInspector] Display OpenGL object ids in canvas inspector

### DIFF
--- a/LayoutTests/inspector/canvas/recording-webgl-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-webgl-full-expected.txt
@@ -21,42 +21,42 @@ frames:
         3: performActions
         4: Global Code
   1: (duration)
-    0: attachShader(0, 0)
+    0: attachShader(1, 4)
       swizzleTypes: [WebGLProgram, WebGLShader]
       trace:
         0: attachShader
         1: (anonymous function)
         2: executeFrameFunction
   2: (duration)
-    0: bindAttribLocation(0, 1, "test")
+    0: bindAttribLocation(1, 1, "test")
       swizzleTypes: [WebGLProgram, Number, String]
       trace:
         0: bindAttribLocation
         1: (anonymous function)
         2: executeFrameFunction
   3: (duration)
-    0: bindBuffer(1, 0)
+    0: bindBuffer(1, 1)
       swizzleTypes: [Number, WebGLBuffer]
       trace:
         0: bindBuffer
         1: (anonymous function)
         2: executeFrameFunction
   4: (duration)
-    0: bindFramebuffer(1, 0)
+    0: bindFramebuffer(1, 3)
       swizzleTypes: [Number, WebGLFramebuffer]
       trace:
         0: bindFramebuffer
         1: (anonymous function)
         2: executeFrameFunction
   5: (duration)
-    0: bindRenderbuffer(1, 0)
+    0: bindRenderbuffer(1, 3)
       swizzleTypes: [Number, WebGLRenderbuffer]
       trace:
         0: bindRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   6: (duration)
-    0: bindTexture(1, 0)
+    0: bindTexture(1, 2)
       swizzleTypes: [Number, WebGLTexture]
       trace:
         0: bindTexture
@@ -161,7 +161,7 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   20: (duration)
-    0: compileShader(0)
+    0: compileShader(4)
       swizzleTypes: [WebGLShader]
       trace:
         0: compileShader
@@ -240,42 +240,42 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   32: (duration)
-    0: deleteBuffer(0)
+    0: deleteBuffer(1)
       swizzleTypes: [WebGLBuffer]
       trace:
         0: deleteBuffer
         1: (anonymous function)
         2: executeFrameFunction
   33: (duration)
-    0: deleteFramebuffer(0)
+    0: deleteFramebuffer(3)
       swizzleTypes: [WebGLFramebuffer]
       trace:
         0: deleteFramebuffer
         1: (anonymous function)
         2: executeFrameFunction
   34: (duration)
-    0: deleteProgram(0)
+    0: deleteProgram(1)
       swizzleTypes: [WebGLProgram]
       trace:
         0: deleteProgram
         1: (anonymous function)
         2: executeFrameFunction
   35: (duration)
-    0: deleteRenderbuffer(0)
+    0: deleteRenderbuffer(3)
       swizzleTypes: [WebGLRenderbuffer]
       trace:
         0: deleteRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   36: (duration)
-    0: deleteShader(0)
+    0: deleteShader(4)
       swizzleTypes: [WebGLShader]
       trace:
         0: deleteShader
         1: (anonymous function)
         2: executeFrameFunction
   37: (duration)
-    0: deleteTexture(0)
+    0: deleteTexture(2)
       swizzleTypes: [WebGLTexture]
       trace:
         0: deleteTexture

--- a/LayoutTests/inspector/canvas/recording-webgl-snapshots-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-webgl-snapshots-expected.txt
@@ -12,7 +12,7 @@ initialState:
   content: <filtered>
 frames:
   0: (duration)
-    0: useProgram(0)
+    0: useProgram(1)
       swizzleTypes: [WebGLProgram]
       trace:
         0: useProgram

--- a/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-full-expected.txt
+++ b/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-full-expected.txt
@@ -21,42 +21,42 @@ frames:
         3: performActions
         4: Global Code
   1: (duration)
-    0: attachShader(0, 0)
+    0: attachShader(1, 4)
       swizzleTypes: [WebGLProgram, WebGLShader]
       trace:
         0: attachShader
         1: (anonymous function)
         2: executeFrameFunction
   2: (duration)
-    0: bindAttribLocation(0, 1, "test")
+    0: bindAttribLocation(1, 1, "test")
       swizzleTypes: [WebGLProgram, Number, String]
       trace:
         0: bindAttribLocation
         1: (anonymous function)
         2: executeFrameFunction
   3: (duration)
-    0: bindBuffer(1, 0)
+    0: bindBuffer(1, 1)
       swizzleTypes: [Number, WebGLBuffer]
       trace:
         0: bindBuffer
         1: (anonymous function)
         2: executeFrameFunction
   4: (duration)
-    0: bindFramebuffer(1, 0)
+    0: bindFramebuffer(1, 3)
       swizzleTypes: [Number, WebGLFramebuffer]
       trace:
         0: bindFramebuffer
         1: (anonymous function)
         2: executeFrameFunction
   5: (duration)
-    0: bindRenderbuffer(1, 0)
+    0: bindRenderbuffer(1, 3)
       swizzleTypes: [Number, WebGLRenderbuffer]
       trace:
         0: bindRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   6: (duration)
-    0: bindTexture(1, 0)
+    0: bindTexture(1, 2)
       swizzleTypes: [Number, WebGLTexture]
       trace:
         0: bindTexture
@@ -161,7 +161,7 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   20: (duration)
-    0: compileShader(0)
+    0: compileShader(4)
       swizzleTypes: [WebGLShader]
       trace:
         0: compileShader
@@ -240,42 +240,42 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   32: (duration)
-    0: deleteBuffer(0)
+    0: deleteBuffer(1)
       swizzleTypes: [WebGLBuffer]
       trace:
         0: deleteBuffer
         1: (anonymous function)
         2: executeFrameFunction
   33: (duration)
-    0: deleteFramebuffer(0)
+    0: deleteFramebuffer(3)
       swizzleTypes: [WebGLFramebuffer]
       trace:
         0: deleteFramebuffer
         1: (anonymous function)
         2: executeFrameFunction
   34: (duration)
-    0: deleteProgram(0)
+    0: deleteProgram(1)
       swizzleTypes: [WebGLProgram]
       trace:
         0: deleteProgram
         1: (anonymous function)
         2: executeFrameFunction
   35: (duration)
-    0: deleteRenderbuffer(0)
+    0: deleteRenderbuffer(3)
       swizzleTypes: [WebGLRenderbuffer]
       trace:
         0: deleteRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   36: (duration)
-    0: deleteShader(0)
+    0: deleteShader(4)
       swizzleTypes: [WebGLShader]
       trace:
         0: deleteShader
         1: (anonymous function)
         2: executeFrameFunction
   37: (duration)
-    0: deleteTexture(0)
+    0: deleteTexture(2)
       swizzleTypes: [WebGLTexture]
       trace:
         0: deleteTexture

--- a/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-snapshots-expected.txt
+++ b/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-snapshots-expected.txt
@@ -12,7 +12,7 @@ initialState:
   content: <filtered>
 frames:
   0: (duration)
-    0: useProgram(0)
+    0: useProgram(1)
       swizzleTypes: [WebGLProgram]
       trace:
         0: useProgram

--- a/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-full-expected.txt
+++ b/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-full-expected.txt
@@ -21,42 +21,42 @@ frames:
         3: performActions
         4: Global Code
   1: (duration)
-    0: attachShader(0, 0)
+    0: attachShader(1, 4)
       swizzleTypes: [WebGLProgram, WebGLShader]
       trace:
         0: attachShader
         1: (anonymous function)
         2: executeFrameFunction
   2: (duration)
-    0: bindAttribLocation(0, 1, "test")
+    0: bindAttribLocation(1, 1, "test")
       swizzleTypes: [WebGLProgram, Number, String]
       trace:
         0: bindAttribLocation
         1: (anonymous function)
         2: executeFrameFunction
   3: (duration)
-    0: bindBuffer(1, 0)
+    0: bindBuffer(1, 1)
       swizzleTypes: [Number, WebGLBuffer]
       trace:
         0: bindBuffer
         1: (anonymous function)
         2: executeFrameFunction
   4: (duration)
-    0: bindFramebuffer(1, 0)
+    0: bindFramebuffer(1, 3)
       swizzleTypes: [Number, WebGLFramebuffer]
       trace:
         0: bindFramebuffer
         1: (anonymous function)
         2: executeFrameFunction
   5: (duration)
-    0: bindRenderbuffer(1, 0)
+    0: bindRenderbuffer(1, 3)
       swizzleTypes: [Number, WebGLRenderbuffer]
       trace:
         0: bindRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   6: (duration)
-    0: bindTexture(1, 0)
+    0: bindTexture(1, 2)
       swizzleTypes: [Number, WebGLTexture]
       trace:
         0: bindTexture
@@ -161,7 +161,7 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   20: (duration)
-    0: compileShader(0)
+    0: compileShader(4)
       swizzleTypes: [WebGLShader]
       trace:
         0: compileShader
@@ -233,42 +233,42 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   31: (duration)
-    0: deleteBuffer(0)
+    0: deleteBuffer(1)
       swizzleTypes: [WebGLBuffer]
       trace:
         0: deleteBuffer
         1: (anonymous function)
         2: executeFrameFunction
   32: (duration)
-    0: deleteFramebuffer(0)
+    0: deleteFramebuffer(3)
       swizzleTypes: [WebGLFramebuffer]
       trace:
         0: deleteFramebuffer
         1: (anonymous function)
         2: executeFrameFunction
   33: (duration)
-    0: deleteProgram(0)
+    0: deleteProgram(1)
       swizzleTypes: [WebGLProgram]
       trace:
         0: deleteProgram
         1: (anonymous function)
         2: executeFrameFunction
   34: (duration)
-    0: deleteRenderbuffer(0)
+    0: deleteRenderbuffer(3)
       swizzleTypes: [WebGLRenderbuffer]
       trace:
         0: deleteRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   35: (duration)
-    0: deleteShader(0)
+    0: deleteShader(4)
       swizzleTypes: [WebGLShader]
       trace:
         0: deleteShader
         1: (anonymous function)
         2: executeFrameFunction
   36: (duration)
-    0: deleteTexture(0)
+    0: deleteTexture(2)
       swizzleTypes: [WebGLTexture]
       trace:
         0: deleteTexture

--- a/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-snapshots-expected.txt
+++ b/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-snapshots-expected.txt
@@ -12,7 +12,7 @@ initialState:
   content: <filtered>
 frames:
   0: (duration)
-    0: useProgram(0)
+    0: useProgram(1)
       swizzleTypes: [WebGLProgram]
       trace:
         0: useProgram

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -610,35 +610,35 @@ std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::pro
 {
     if (!argument)
         return std::nullopt;
-    return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLBuffer }};
+    return {{ JSON::Value::create(static_cast<int>(argument->object())), RecordingSwizzleType::WebGLBuffer }};
 }
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(WebGLFramebuffer* argument)
 {
     if (!argument)
         return std::nullopt;
-    return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLFramebuffer }};
+    return {{ JSON::Value::create(static_cast<int>(argument->object())), RecordingSwizzleType::WebGLFramebuffer }};
 }
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(WebGLProgram* argument)
 {
     if (!argument)
         return std::nullopt;
-    return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLProgram }};
+    return {{ JSON::Value::create(static_cast<int>(argument->object())), RecordingSwizzleType::WebGLProgram }};
 }
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(WebGLQuery* argument)
 {
     if (!argument)
         return std::nullopt;
-    return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLQuery }};
+    return {{ JSON::Value::create(static_cast<int>(argument->object())), RecordingSwizzleType::WebGLQuery }};
 }
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(WebGLRenderbuffer* argument)
 {
     if (!argument)
         return std::nullopt;
-    return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLRenderbuffer }};
+    return {{ JSON::Value::create(static_cast<int>(argument->object())), RecordingSwizzleType::WebGLRenderbuffer }};
 }
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(WebGLRenderingContextBase::BufferDataSource& argument)
@@ -673,42 +673,42 @@ std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::pro
 {
     if (!argument)
         return std::nullopt;
-    return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLSampler }};
+    return {{ JSON::Value::create(static_cast<int>(argument->object())), RecordingSwizzleType::WebGLSampler }};
 }
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(WebGLShader* argument)
 {
     if (!argument)
         return std::nullopt;
-    return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLShader }};
+    return {{ JSON::Value::create(static_cast<int>(argument->object())), RecordingSwizzleType::WebGLShader }};
 }
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(WebGLSync* argument)
 {
     if (!argument)
         return std::nullopt;
-    return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLSync }};
+    return {{ JSON::Value::create(static_cast<int>(argument->object())), RecordingSwizzleType::WebGLSync }};
 }
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(WebGLTexture* argument)
 {
     if (!argument)
         return std::nullopt;
-    return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLTexture }};
+    return {{ JSON::Value::create(static_cast<int>(argument->object())), RecordingSwizzleType::WebGLTexture }};
 }
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(WebGLUniformLocation* argument)
 {
     if (!argument)
         return std::nullopt;
-    return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLUniformLocation }};
+    return {{ JSON::Value::create(argument->location()), RecordingSwizzleType::WebGLUniformLocation }};
 }
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(WebGLVertexArrayObject* argument)
 {
     if (!argument)
         return std::nullopt;
-    return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLVertexArrayObject }};
+    return {{ JSON::Value::create(static_cast<int>(argument->object())), RecordingSwizzleType::WebGLVertexArrayObject }};
 }
 
 #endif // ENABLE(WEBGL)
@@ -719,7 +719,7 @@ std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::pro
 {
     if (!argument)
         return std::nullopt;
-    return {{ JSON::Value::create(0), RecordingSwizzleType::WebGLTransformFeedback }};
+    return {{ JSON::Value::create(static_cast<int>(argument->object())), RecordingSwizzleType::WebGLTransformFeedback }};
 }
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(WebGL2RenderingContext::Uint32List::VariantType& argument)

--- a/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.css
@@ -54,6 +54,10 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .
     opacity: 1;
 }
 
+.item.recording-action > .titles .parameter.object-handle {
+    color: var(--text-color-gray-medium);
+}
+
 .item.recording-action > .titles .parameter.swizzled {
     color: var(--text-color-gray-medium);
 }

--- a/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.js
@@ -49,6 +49,7 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
         let parameterCount = recordingAction.parameters.length;
 
         function createParameterElement(parameter, swizzleType, index) {
+            let parameterCopyText = "";
             let parameterElement = document.createElement("span");
             parameterElement.classList.add("parameter");
 
@@ -87,6 +88,10 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
             case WI.Recording.Swizzle.Path2D:
             case WI.Recording.Swizzle.CanvasGradient:
             case WI.Recording.Swizzle.CanvasPattern:
+                    parameterElement.classList.add("swizzled");
+                    parameterElement.textContent = WI.Recording.displayNameForSwizzleType(swizzleType);
+                    break;
+
             case WI.Recording.Swizzle.WebGLBuffer:
             case WI.Recording.Swizzle.WebGLFramebuffer:
             case WI.Recording.Swizzle.WebGLRenderbuffer:
@@ -99,8 +104,17 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
             case WI.Recording.Swizzle.WebGLSync:
             case WI.Recording.Swizzle.WebGLTransformFeedback:
             case WI.Recording.Swizzle.WebGLVertexArrayObject:
-                parameterElement.classList.add("swizzled");
-                parameterElement.textContent = WI.Recording.displayNameForSwizzleType(swizzleType);
+                parameterCopyText = WI.Recording.displayNameForSwizzleType(swizzleType);
+
+                parameterElement.textContent = parameterCopyText;
+                if (parameter) {
+                    let objectHandleElement = document.createElement("span");
+                    objectHandleElement.classList.add("parameter");
+                    objectHandleElement.classList.add("object-handle");
+                    objectHandleElement.textContent = `@${parameter}`;
+                    parameterElement.append(" ", objectHandleElement);
+                } else
+                    parameterElement.classList.add("swizzled");
                 break;
             }
 
@@ -109,7 +123,10 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
                 parameterElement.textContent = swizzleType === WI.Recording.Swizzle.None ? parameter : WI.Recording.displayNameForSwizzleType(swizzleType);
             }
 
-            return parameterElement;
+            if (!parameterCopyText.length)
+                   parameterCopyText = parameterElement.textContent;
+
+            return {parameterElement, parameterCopyText};
         }
 
         let titleFragment = document.createDocumentFragment();
@@ -142,13 +159,13 @@ WI.RecordingActionTreeElement = class RecordingActionTreeElement extends WI.Gene
         for (let i = 0; i < parameterCount; ++i) {
             let parameter = recordingAction.parameters[i];
             let swizzleType = recordingAction.swizzleTypes[i];
-            let parameterElement = createParameterElement(parameter, swizzleType, i);
+            let {parameterElement, parameterCopyText} = createParameterElement(parameter, swizzleType, i);
             parametersContainer.appendChild(parameterElement);
 
             if (i)
                 copyText += ", ";
 
-            copyText += parameterElement.textContent;
+            copyText += parameterCopyText;
         }
 
         if (recordingAction.isFunction)


### PR DESCRIPTION
#### 8574b90773edf4ffb2bd7f9c5fd1b361cef52360
<pre>
[WebInspector] Display OpenGL object ids in canvas inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=246186">https://bugs.webkit.org/show_bug.cgi?id=246186</a>
rdar://problem/100875691
Reviewed by Devin Rousso and Dean Jackson.

Record the underlying OpenGL object id associated with each WebGL object and
display these ids along with the WebGL object type in WebInspector canvas
inspector mode to aid determining which objects are being referred to in the
call trace.

* LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-full-expected.txt:
* LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-snapshots-expected.txt:
* LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-full-expected.txt:
* LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-snapshots-expected.txt:
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::processArgument):
* Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.js:
(WI.RecordingActionTreeElement._generateDOM.createParameterElement):
(WI.RecordingActionTreeElement._generateDOM):

Canonical link: <a href="https://commits.webkit.org/255565@main">https://commits.webkit.org/255565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/694a296ee8cf0bd31baa6f513b75f8d9f73fdede

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92650 "24 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102367 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1865 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30216 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85035 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98528 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1255 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79140 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28177 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71267 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36624 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16803 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34415 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17986 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3852 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40592 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37146 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->