### PR TITLE
[JSC] Update Intl.NumberFormat's useGrouping handling

### DIFF
--- a/JSTests/stress/intl-numberformat-usegrouping-v3.js
+++ b/JSTests/stress/intl-numberformat-usegrouping-v3.js
@@ -54,9 +54,12 @@ let validUseGrouping = [
 
 let nonListedUseGrouping = [
     "min-2",
+];
+
+let specialUseGrouping = [
     "true",
     "false",
-];
+]
 
 validUseGrouping.forEach(function(useGrouping) {
     let nf = new Intl.NumberFormat(undefined, {useGrouping});
@@ -64,8 +67,15 @@ validUseGrouping.forEach(function(useGrouping) {
 });
 
 nonListedUseGrouping.forEach(function(useGrouping) {
+    shouldThrow(() => {
+        let nf = new Intl.NumberFormat(undefined, {useGrouping});
+        nf.resolvedOptions().useGrouping
+    }, `RangeError: useGrouping must be either true, false, "min2", "auto", or "always"`);
+});
+
+specialUseGrouping.forEach(function(useGrouping) {
     let nf = new Intl.NumberFormat(undefined, {useGrouping});
-    shouldBe(nf.resolvedOptions().useGrouping, `auto`);
+    shouldBe("auto", nf.resolvedOptions().useGrouping);
 });
 
 // useGrouping: undefined get "auto"

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1233,9 +1233,6 @@ test/intl402/NumberFormat/prototype/formatRangeToParts/x-greater-than-y-not-thro
 test/intl402/NumberFormat/test-option-roundingPriority-mixed-options.js:
   default: 'Test262Error: Formatted value for 1, en-US-u-nu-arab and options {"minimumSignificantDigits":2,"minimumFractionDigits":2,"roundingPriority":"morePrecision","userGrouping":false} is ١٫٠٠; expected ١٫٠.'
   strict mode: 'Test262Error: Formatted value for 1, en-US-u-nu-arab and options {"minimumSignificantDigits":2,"minimumFractionDigits":2,"roundingPriority":"morePrecision","userGrouping":false} is ١٫٠٠; expected ١٫٠.'
-test/intl402/NumberFormat/test-option-useGrouping.js:
-  default: 'Test262Error: Throws RangeError when useGrouping value is not supported Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Throws RangeError when useGrouping value is not supported Expected a RangeError to be thrown but no exception was thrown at all'
 test/intl402/PluralRules/prototype/selectRange/default-en-us.js:
   default: "TypeError: pr.selectRange is not a function. (In 'pr.selectRange(102, 201)', 'pr.selectRange' is undefined)"
   strict mode: "TypeError: pr.selectRange is not a function. (In 'pr.selectRange(102, 201)', 'pr.selectRange' is undefined)"

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -414,7 +414,7 @@ void IntlNumberFormat::initializeNumberFormat(JSGlobalObject* globalObject, JSVa
     if (m_notation == IntlNotation::Compact)
         defaultUseGrouping = UseGrouping::Min2;
 
-    m_useGrouping = intlStringOrBooleanOption<UseGrouping>(globalObject, options, Identifier::fromString(vm, "useGrouping"_s), UseGrouping::Always, UseGrouping::False, { { "min2"_s, UseGrouping::Min2 }, { "auto"_s, UseGrouping::Auto }, { "always"_s, UseGrouping::Always } }, defaultUseGrouping);
+    m_useGrouping = intlStringOrBooleanOption<UseGrouping>(globalObject, options, Identifier::fromString(vm, "useGrouping"_s), UseGrouping::Always, UseGrouping::False, { { "min2"_s, UseGrouping::Min2 }, { "auto"_s, UseGrouping::Auto }, { "always"_s, UseGrouping::Always } }, "useGrouping must be either true, false, \"min2\", \"auto\", or \"always\""_s, defaultUseGrouping);
     RETURN_IF_EXCEPTION(scope, void());
 
     m_signDisplay = intlOption<SignDisplay>(globalObject, options, Identifier::fromString(vm, "signDisplay"_s), { { "auto"_s, SignDisplay::Auto }, { "never"_s, SignDisplay::Never }, { "always"_s, SignDisplay::Always }, { "exceptZero"_s, SignDisplay::ExceptZero }, { "negative"_s, SignDisplay::Negative } }, "signDisplay must be either \"auto\", \"never\", \"always\", \"exceptZero\", or \"negative\""_s, SignDisplay::Auto);

--- a/Source/JavaScriptCore/runtime/IntlObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlObjectInlines.h
@@ -152,7 +152,7 @@ ResultType intlOption(JSGlobalObject* globalObject, JSObject* options, PropertyN
 }
 
 template<typename ResultType>
-ResultType intlStringOrBooleanOption(JSGlobalObject* globalObject, JSObject* options, PropertyName property, ResultType trueValue, ResultType falsyValue, std::initializer_list<std::pair<ASCIILiteral, ResultType>> values, ResultType fallback)
+ResultType intlStringOrBooleanOption(JSGlobalObject* globalObject, JSObject* options, PropertyName property, ResultType trueValue, ResultType falsyValue, std::initializer_list<std::pair<ASCIILiteral, ResultType>> values, ASCIILiteral notFoundMessage, ResultType fallback)
 {
     // https://tc39.es/proposal-intl-numberformat-v3/out/negotiation/diff.html#sec-getstringorbooleanoption
 
@@ -182,12 +182,18 @@ ResultType intlStringOrBooleanOption(JSGlobalObject* globalObject, JSObject* opt
     String stringValue = value.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
+    // FIXME: We need to know whether this fallback is actually correct.
+    // https://github.com/tc39/proposal-intl-numberformat-v3/issues/111
+    if (stringValue == "true"_s || stringValue == "false"_s)
+        return fallback;
+
     for (const auto& entry : values) {
         if (entry.first == stringValue)
             return entry.second;
     }
 
-    return fallback;
+    throwRangeError(globalObject, scope, notFoundMessage);
+    return { };
 }
 
 ALWAYS_INLINE bool canUseASCIIUCADUCETComparison(UChar character)


### PR DESCRIPTION
#### 4a7ae871cccb5324e996699daf4c5d9e7a8f768e
<pre>
[JSC] Update Intl.NumberFormat&apos;s useGrouping handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=246196">https://bugs.webkit.org/show_bug.cgi?id=246196</a>
rdar://100877842

Reviewed by Ross Kirsling.

Update the implementation with the spec update[1], handling &quot;true&quot; and &quot;false&quot;
specially and throwing a range error for the other invalid cases.

[1]: <a href="https://github.com/tc39/proposal-intl-numberformat-v3/commit/4751da5c9c326f96a074b67ac5a8ecffe3440617">https://github.com/tc39/proposal-intl-numberformat-v3/commit/4751da5c9c326f96a074b67ac5a8ecffe3440617</a>

* JSTests/stress/intl-numberformat-usegrouping-v3.js:
(nonListedUseGrouping.forEach):
(specialUseGrouping.forEach):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::initializeNumberFormat):
* Source/JavaScriptCore/runtime/IntlObjectInlines.h:
(JSC::intlStringOrBooleanOption):

Canonical link: <a href="https://commits.webkit.org/255275@main">https://commits.webkit.org/255275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ac6bedb1219370b6864068dc6b56180136b2a40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101569 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161704 "Reverted pull request changes (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1148 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29614 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97958 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/696 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78463 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27656 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82618 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70692 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83279 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36005 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16239 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78330 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33740 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17339 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27033 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3654 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37617 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40054 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/80950 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36458 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17750 "Passed tests") | 
<!--EWS-Status-Bubble-End-->