### PR TITLE
[Wasm-GC] Fix handling of recursive types using shorthand encoding

### DIFF
--- a/JSTests/wasm/gc/rec.js
+++ b/JSTests/wasm/gc/rec.js
@@ -13,6 +13,61 @@ function module(bytes, valid = true) {
 }
 
 function testRecDeclaration() {
+  /*
+   * This test needs to be in binary format, as it tests the specific encoding
+   * of the recursion group. This one omits the explicit `rec`.
+   *
+   *  (module
+   *    (rec (type (array (ref 0))))
+   *    (func (result (ref null 0)) (ref.null 0)))
+   */
+  new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x8a\x80\x80\x80\x00\x02\x5e\x6b\x00\x00\x60\x00\x01\x6c\x00\x03\x82\x80\x80\x80\x00\x01\x01\x0a\x8a\x80\x80\x80\x00\x01\x84\x80\x80\x80\x00\x00\xd0\x00\x0b"))
+
+  // Same test as above but using a non-shorthand encoding.
+  new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x8c\x80\x80\x80\x00\x02\x4f\x01\x5e\x6b\x00\x00\x60\x00\x01\x6c\x00\x03\x82\x80\x80\x80\x00\x01\x01\x0a\x8a\x80\x80\x80\x00\x01\x84\x80\x80\x80\x00\x00\xd0\x00\x0b"))
+
+  // Test invalid reference type index in a recursion group.
+  assert.throws(
+    () => module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x8a\x80\x80\x80\x00\x02\x5e\x6b\x01\x00\x60\x00\x01\x6c\x00\x03\x82\x80\x80\x80\x00\x01\x01\x0a\x8a\x80\x80\x80\x00\x01\x84\x80\x80\x80\x00\x00\xd0\x00\x0b"),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 18: can't get array's element Type"
+  );
+
+  assert.throws(
+    () => module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x8c\x80\x80\x80\x00\x02\x4f\x01\x5e\x6b\x01\x00\x60\x00\x01\x6c\x00\x03\x82\x80\x80\x80\x00\x01\x01\x0a\x8a\x80\x80\x80\x00\x01\x84\x80\x80\x80\x00\x00\xd0\x00\x0b"),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 20: can't get array's element Type"
+  );
+
+  /*
+   *  Test invalid index in a recursion group with more than one type.
+   *
+   *  (module (rec (type (array (ref 2))) (type (array (ref 1)))))
+   */
+  assert.throws(
+    () => module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x8b\x80\x80\x80\x00\x01\x4f\x02\x5e\x6b\x02\x00\x5e\x6b\x01\x00"),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 20: can't get array's element Type"
+  );
+
+  instantiate(`
+     (module
+       (type (struct (field (ref 0))))
+       (func (result (ref null 0)) (ref.null 0)))
+  `);
+
+  instantiate(`
+     (module
+       (type (array (ref 0)))
+       (func (result (ref null array)) (ref.null 0)))
+  `);
+
+  instantiate(`
+     (module
+       (type (func (param (ref 0))))
+       (func (result (ref null func)) (ref.null 0)))
+  `);
+
   instantiate(`
     (module
       (rec (type (func)) (type (struct)))

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -53,11 +53,14 @@ public:
         : m_payload(payload)
         , m_argCount(argumentCount)
         , m_retCount(returnCount)
+        , m_hasRecursiveReference(false)
     {
     }
 
     FunctionArgCount argumentCount() const { return m_argCount; }
     FunctionArgCount returnCount() const { return m_retCount; }
+    bool hasRecursiveReference() const { return m_hasRecursiveReference; }
+    void setHasRecursiveReference(bool value) { m_hasRecursiveReference = value; }
     Type returnType(FunctionArgCount i) const { ASSERT(i < returnCount()); return const_cast<FunctionSignature*>(this)->getReturnType(i); }
     bool returnsVoid() const { return !returnCount(); }
     Type argumentType(FunctionArgCount i) const { return const_cast<FunctionSignature*>(this)->getArgumentType(i); }
@@ -86,6 +89,7 @@ private:
     Type* m_payload;
     FunctionArgCount m_argCount;
     FunctionArgCount m_retCount;
+    bool m_hasRecursiveReference;
 };
 
 // FIXME auto-generate this. https://bugs.webkit.org/show_bug.cgi?id=165231
@@ -107,10 +111,13 @@ public:
     StructType(FieldType* payload, StructFieldCount fieldCount)
         : m_payload(payload)
         , m_fieldCount(fieldCount)
+        , m_hasRecursiveReference(false)
     {
     }
 
     StructFieldCount fieldCount() const { return m_fieldCount; }
+    bool hasRecursiveReference() const { return m_hasRecursiveReference; }
+    void setHasRecursiveReference(bool value) { m_hasRecursiveReference = value; }
     FieldType field(StructFieldCount i) const { return const_cast<StructType*>(this)->getField(i); }
 
     WTF::String toString() const;
@@ -123,16 +130,20 @@ public:
 private:
     FieldType* m_payload;
     StructFieldCount m_fieldCount;
+    bool m_hasRecursiveReference;
 };
 
 class ArrayType {
 public:
     ArrayType(FieldType* payload)
         : m_payload(payload)
+        , m_hasRecursiveReference(false)
     {
     }
 
     FieldType elementType() const { return const_cast<ArrayType*>(this)->getElementType(); }
+    bool hasRecursiveReference() const { return m_hasRecursiveReference; }
+    void setHasRecursiveReference(bool value) { m_hasRecursiveReference = value; }
 
     WTF::String toString() const;
     void dump(WTF::PrintStream& out) const;
@@ -143,6 +154,7 @@ public:
 
 private:
     FieldType* m_payload;
+    bool m_hasRecursiveReference;
 };
 
 class RecursionGroup {
@@ -177,6 +189,9 @@ private:
 // We store projections rather than the implied unfolding because the actual type being
 // represented may be recursive and infinite. Projections are unfolded into a concrete type
 // when operations on the type require a specific concrete type.
+//
+// A projection with an invalid PlaceholderGroup index represents a recursive reference
+// that has not yet been resolved. The expand() function on type definitions resolves it.
 class Projection {
 public:
     Projection(TypeIndex* payload)
@@ -194,6 +209,9 @@ public:
     ProjectionIndex& getIndex() { return *reinterpret_cast<ProjectionIndex*>(storage(1)); }
     TypeIndex* storage(uint32_t i) { ASSERT(i <= 1); return i + m_payload; }
     const TypeIndex* storage(uint32_t i) const { return const_cast<Projection*>(this)->storage(i); }
+
+    static constexpr TypeIndex PlaceholderGroup = 0;
+    bool isPlaceholder() const { return recursionGroup() == PlaceholderGroup; }
 
 private:
     TypeIndex* m_payload;


### PR DESCRIPTION
#### cc59ec0dd950292d1b23faf10bae59b03ae20967
<pre>
[Wasm-GC] Fix handling of recursive types using shorthand encoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=246049">https://bugs.webkit.org/show_bug.cgi?id=246049</a>

Reviewed by Justin Michaud.

In the Wasm GC proposal, recursive types can be encoded in different
ways. For example, an explicit `rec` operator may appear in the binary
format (required for recursion groups with multiple types).

A single type (e.g., a struct type) is treated implicitly as a recursion
group (the `rec` is implicit and elided in the binary format).

This patch adds support for the latter shorthand, and includes the
following additional fixes/changes:

  - Removes the hacky use of the `rec` type opcode to encode an
    unresolved recursive reference. Instead, it is now a standard `ref`
    type where the type index points to a Projection with an invalid
    recursion group type index. These are resolved in `expand()`.
  - Fixes bounds checking for recursive references into a recursion
    group.
  - Adds missing `expand()` calls in subtyping checks.
  - Adds a boolean field indicating if a type definition has any type
    fields with a recursive reference. This is used to detect if a
    single-type recursion group should be constructed for a structural
    type. The intent is to also use this in a follow-up patch to
    optimize `expand()` to avoid expansion steps for types known to be
    non-recursive.

* JSTests/wasm/gc/rec.js:
(testRecDeclaration):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::isValueType):
(JSC::Wasm::isRefWithRecursiveReference):
(JSC::Wasm::isSubtype):
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::Parser&lt;SuccessType&gt;::parseHeapType):
(JSC::Wasm::Parser&lt;SuccessType&gt;::parseValueType):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseType):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeDefinition::substitute):
(JSC::Wasm::FunctionParameterTypes::translate):
(JSC::Wasm::StructParameterTypes::translate):
(JSC::Wasm::ArrayParameterTypes::translate):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::FunctionSignature::FunctionSignature):
(JSC::Wasm::FunctionSignature::hasRecursiveReference const):
(JSC::Wasm::FunctionSignature::setHasRecursiveReference):
(JSC::Wasm::StructType::StructType):
(JSC::Wasm::StructType::hasRecursiveReference const):
(JSC::Wasm::StructType::setHasRecursiveReference):
(JSC::Wasm::ArrayType::ArrayType):
(JSC::Wasm::ArrayType::hasRecursiveReference const):
(JSC::Wasm::ArrayType::setHasRecursiveReference):
(JSC::Wasm::Projection::isPlaceholder const):

Canonical link: <a href="https://commits.webkit.org/255460@main">https://commits.webkit.org/255460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb359b1606d58595af7652cf039f409666bfcbf3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102288 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1756 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30126 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98457 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1180 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79039 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28116 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83913 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36537 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16726 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78949 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34317 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17905 "Found 1 new test failure: compositing/backing/backing-store-attachment-animating-outside-viewport.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27363 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3784 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40516 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81568 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37062 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18448 "Passed tests") | 
<!--EWS-Status-Bubble-End-->