### PR TITLE
[JSC] Optimize 3~ parameter Math.min / Math.max

### DIFF
--- a/JSTests/stress/arith-min-max-multiple-constant-fold.js
+++ b/JSTests/stress/arith-min-max-multiple-constant-fold.js
@@ -1,0 +1,49 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1()
+{
+    return Math.min(0, -1, -2, -3, -4);
+}
+noInline(test1);
+
+function test2()
+{
+    return Math.max(0, -1, -2, -3, -4, 20000);
+}
+noInline(test2);
+
+function test3()
+{
+    return Math.min(0.1, 0.2, 0.3, -1.3);
+}
+noInline(test3);
+
+function test4()
+{
+    return Math.max(0.1, 0.2, 0.3, -1.3, 2.5);
+}
+noInline(test4);
+
+function test5()
+{
+    return Math.min(0.1, 0.2, 0.3, -1.3, NaN);
+}
+noInline(test5);
+
+function test6()
+{
+    return Math.max(0.1, 0.2, 0.3, -1.3, 2.5, NaN);
+}
+noInline(test6);
+
+for (let i = 0; i < 1e5; ++i) {
+    shouldBe(test1(), -4);
+    shouldBe(test2(), 20000);
+    shouldBe(test3(), -1.3);
+    shouldBe(test4(), 2.5);
+    shouldBe(Number.isNaN(test5()), true);
+    shouldBe(Number.isNaN(test6()), true);
+}

--- a/JSTests/stress/arith-min-max-multiple.js
+++ b/JSTests/stress/arith-min-max-multiple.js
@@ -1,0 +1,53 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1(num)
+{
+    return Math.min(0, -1, -2, -3, -4, num);
+}
+noInline(test1);
+
+function test2(num)
+{
+    return Math.max(0, -1, -2, -3, -4, 20000, num);
+}
+noInline(test2);
+
+function test3(num)
+{
+    return Math.min(0.1, 0.2, 0.3, -1.3, num);
+}
+noInline(test3);
+
+function test4(num)
+{
+    return Math.max(0.1, 0.2, 0.3, -1.3, 2.5, num);
+}
+noInline(test4);
+
+function test5(num)
+{
+    return Math.min(0.1, 0.2, 0.3, -1.3, num, NaN);
+}
+noInline(test5);
+
+function test6(num)
+{
+    return Math.max(0.1, 0.2, 0.3, -1.3, 2.5, num, NaN);
+}
+noInline(test6);
+
+for (let i = 0; i < 1e5; ++i) {
+    shouldBe(test1(0), -4);
+    shouldBe(test1(-100), -100);
+    shouldBe(test2(0), 20000);
+    shouldBe(test2(10000000), 10000000);
+    shouldBe(test3(0), -1.3);
+    shouldBe(test3(-2222222200.1), -2222222200.1);
+    shouldBe(test4(0), 2.5);
+    shouldBe(test4(1e1000), 1e1000);
+    shouldBe(Number.isNaN(test5(0)), true);
+    shouldBe(Number.isNaN(test6(2000.1)), true);
+}

--- a/Source/JavaScriptCore/dfg/DFGArgumentsUtilities.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArgumentsUtilities.cpp
@@ -140,10 +140,14 @@ Node* emitCodeToGetArgumentsArrayLength(
 
     if (numberOfArgumentsToSkip) {
         // The above subtraction may produce a negative number if this number is non-zero. We correct that here.
+        unsigned firstChild = graph.m_varArgChildren.size();
+        graph.m_varArgChildren.append(Edge(result, Int32Use));
+        graph.m_varArgChildren.append(insertionSet.insertConstantForUse(nodeIndex, origin, jsNumber(static_cast<unsigned>(addThis)), Int32Use));
+
         result = insertionSet.insertNode(
-            nodeIndex, SpecInt32Only, ArithMax, origin, 
-            Edge(result, Int32Use), 
-            insertionSet.insertConstantForUse(nodeIndex, origin, jsNumber(static_cast<unsigned>(addThis)), Int32Use));
+            nodeIndex, SpecInt32Only, Node::VarArg, ArithMax, origin,
+            OpInfo(), OpInfo(), firstChild, graph.m_varArgChildren.size() - firstChild);
+
         result->setResult(NodeResultInt32);
     }
 

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -161,7 +161,7 @@ private:
 
     // Helper for min and max.
     template<typename ChecksFunctor>
-    bool handleMinMax(Operand result, NodeType op, int registerOffset, int argumentCountIncludingThis, const ChecksFunctor& insertChecks);
+    void handleMinMax(Operand result, NodeType op, int registerOffset, int argumentCountIncludingThis, const ChecksFunctor& insertChecks);
     
     void refineStatically(CallLinkStatus&, Node* callTarget);
     // Blocks can either be targetable (i.e. in the m_blockLinkingTargets of one InlineStackEntry) with a well-defined bytecodeBegin,
@@ -2300,7 +2300,7 @@ ByteCodeParser::CallOptimizationResult ByteCodeParser::handleInlining(
 }
 
 template<typename ChecksFunctor>
-bool ByteCodeParser::handleMinMax(Operand result, NodeType op, int registerOffset, int argumentCountIncludingThis, const ChecksFunctor& insertChecks)
+void ByteCodeParser::handleMinMax(Operand result, NodeType op, int registerOffset, int argumentCountIncludingThis, const ChecksFunctor& insertChecks)
 {
     ASSERT(op == ArithMin || op == ArithMax);
 
@@ -2308,7 +2308,7 @@ bool ByteCodeParser::handleMinMax(Operand result, NodeType op, int registerOffse
         insertChecks();
         double limit = op == ArithMax ? -std::numeric_limits<double>::infinity() : +std::numeric_limits<double>::infinity();
         set(result, addToGraph(JSConstant, OpInfo(m_graph.freeze(jsDoubleNumber(limit)))));
-        return true;
+        return;
     }
      
     if (argumentCountIncludingThis == 2) {
@@ -2316,17 +2316,14 @@ bool ByteCodeParser::handleMinMax(Operand result, NodeType op, int registerOffse
         Node* resultNode = get(VirtualRegister(virtualRegisterForArgumentIncludingThis(1, registerOffset)));
         addToGraph(Phantom, Edge(resultNode, NumberUse));
         set(result, resultNode);
-        return true;
+        return;
     }
     
-    if (argumentCountIncludingThis == 3) {
-        insertChecks();
-        set(result, addToGraph(op, get(virtualRegisterForArgumentIncludingThis(1, registerOffset)), get(virtualRegisterForArgumentIncludingThis(2, registerOffset))));
-        return true;
-    }
-    
-    // Don't handle >=3 arguments for now.
-    return false;
+    insertChecks();
+    for (int index = 1; index < argumentCountIncludingThis; ++index)
+        addVarArgChild(get(virtualRegisterForArgumentIncludingThis(index, registerOffset)));
+    set(result, addToGraph(Node::VarArg, op, OpInfo(), OpInfo()));
+    return;
 }
 
 template<typename ChecksFunctor>
@@ -2378,11 +2375,9 @@ bool ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, Intrinsic
 
         case MinIntrinsic:
         case MaxIntrinsic:
-            if (handleMinMax(result, intrinsic == MinIntrinsic ? ArithMin : ArithMax, registerOffset, argumentCountIncludingThis, insertChecks)) {
-                didSetResult = true;
-                return true;
-            }
-            return false;
+            handleMinMax(result, intrinsic == MinIntrinsic ? ArithMin : ArithMax, registerOffset, argumentCountIncludingThis, insertChecks);
+            didSetResult = true;
+            return true;
 
 #define DFG_ARITH_UNARY(capitalizedName, lowerName) \
         case capitalizedName##Intrinsic:

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -219,8 +219,6 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
         
     case ArithIMul:
-    case ArithMin:
-    case ArithMax:
     case ArithPow:
     case GetScope:
     case SkipScope:
@@ -254,6 +252,11 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case BottomValue:
     case TypeOf:
         def(PureValue(node));
+        return;
+
+    case ArithMin:
+    case ArithMax:
+        def(PureValue(graph, node));
         return;
 
     case GetGlobalThis:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -720,13 +720,15 @@ private:
             
         case ArithMin:
         case ArithMax: {
-            if (m_graph.binaryArithShouldSpeculateInt32(node, FixupPass)) {
-                fixIntOrBooleanEdge(node->child1());
-                fixIntOrBooleanEdge(node->child2());
+            if (m_graph.variadicArithShouldSpeculateInt32(node, FixupPass)) {
+                m_graph.doToChildren(node, [&](Edge& child) {
+                    fixIntOrBooleanEdge(child);
+                });
                 break;
             }
-            fixDoubleOrBooleanEdge(node->child1());
-            fixDoubleOrBooleanEdge(node->child2());
+            m_graph.doToChildren(node, [&](Edge& child) {
+                fixDoubleOrBooleanEdge(child);
+            });
             node->setResult(NodeResultDouble);
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -431,6 +431,23 @@ public:
     }
 #endif
 
+    bool variadicArithShouldSpeculateInt32(Node* node, PredictionPass pass)
+    {
+        bool result = true;
+        RareCaseProfilingSource source = AllRareCases;
+        if (pass == PrimaryPass)
+            source = DFGRareCase;
+
+        doToChildren(node, [&](Edge& child) {
+            if (!child->shouldSpeculateInt32OrBooleanForArithmetic())
+                result = false;
+            if (child->sawBooleans())
+                source = DFGRareCase;
+        });
+
+        return result && node->canSpeculateInt32(source);
+    }
+
     bool canOptimizeStringObjectAccess(const CodeOrigin&);
 
     bool getRegExpPrototypeProperty(JSObject* regExpPrototype, Structure* regExpPrototypeStructure, UniquedStringImpl* uid, JSValue& returnJSValue);

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -165,8 +165,8 @@ namespace JSC { namespace DFG {
     macro(ArithDiv, NodeResultNumber | NodeMustGenerate) \
     macro(ArithMod, NodeResultNumber | NodeMustGenerate) \
     macro(ArithAbs, NodeResultNumber | NodeMustGenerate) \
-    macro(ArithMin, NodeResultNumber) \
-    macro(ArithMax, NodeResultNumber) \
+    macro(ArithMin, NodeResultNumber | NodeHasVarArgs) \
+    macro(ArithMax, NodeResultNumber | NodeHasVarArgs) \
     macro(ArithFRound, NodeResultDouble | NodeMustGenerate) \
     macro(ArithPow, NodeResultDouble) \
     macro(ArithRandom, NodeResultDouble | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -756,6 +756,32 @@ JSC_DEFINE_JIT_OPERATION(operationArithTrunc, EncodedJSValue, (JSGlobalObject* g
     return JSValue::encode(jsNumber(truncatedValueOfArgument));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationArithMinMultipleDouble, double, (const double* buffer, unsigned elementCount))
+{
+    double result = +std::numeric_limits<double>::infinity();
+    for (unsigned index = 0; index < elementCount; ++index) {
+        double val = buffer[index];
+        if (std::isnan(val))
+            return PNaN;
+        if (val < result || (!val && !result && std::signbit(val)))
+            result = val;
+    }
+    return result;
+}
+
+JSC_DEFINE_JIT_OPERATION(operationArithMaxMultipleDouble, double, (const double* buffer, unsigned elementCount))
+{
+    double result = -std::numeric_limits<double>::infinity();
+    for (unsigned index = 0; index < elementCount; ++index) {
+        double val = buffer[index];
+        if (std::isnan(val))
+            return PNaN;
+        if (val > result || (!val && !result && !std::signbit(val)))
+            result = val;
+    }
+    return result;
+}
+
 ALWAYS_INLINE EncodedJSValue getByValCellInt(JSGlobalObject* globalObject, VM& vm, JSCell* base, int32_t index)
 {
     if (index < 0) {

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -96,6 +96,8 @@ JSC_DECLARE_JIT_OPERATION(operationArithRound, EncodedJSValue, (JSGlobalObject*,
 JSC_DECLARE_JIT_OPERATION(operationArithFloor, EncodedJSValue, (JSGlobalObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationArithCeil, EncodedJSValue, (JSGlobalObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationArithTrunc, EncodedJSValue, (JSGlobalObject*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationArithMinMultipleDouble, double, (const double* buffer, unsigned elementCount));
+JSC_DECLARE_JIT_OPERATION(operationArithMaxMultipleDouble, double, (const double* buffer, unsigned elementCount));
 JSC_DECLARE_JIT_OPERATION(operationGetByValObjectInt, EncodedJSValue, (JSGlobalObject*, JSObject*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationGetByValStringInt, EncodedJSValue, (JSGlobalObject*, JSString*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationGetByValObjectString, EncodedJSValue, (JSGlobalObject*, JSCell*, JSCell* string));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -7151,74 +7151,99 @@ void SpeculativeJIT::compileArithSqrt(Node* node)
 
 void SpeculativeJIT::compileArithMinMax(Node* node)
 {
-    switch (node->binaryUseKind()) {
+    switch (m_graph.child(node, 0).useKind()) {
     case Int32Use: {
-        SpeculateStrictInt32Operand op1(this, node->child1());
-        SpeculateStrictInt32Operand op2(this, node->child2());
+        SpeculateStrictInt32Operand op1(this, m_graph.child(node, 0));
         GPRTemporary result(this, Reuse, op1);
 
         GPRReg op1GPR = op1.gpr();
-        GPRReg op2GPR = op2.gpr();
         GPRReg resultGPR = result.gpr();
 
-        MacroAssembler::Jump op1Less = m_jit.branch32(node->op() == ArithMin ? MacroAssembler::LessThan : MacroAssembler::GreaterThan, op1GPR, op2GPR);
-        m_jit.move(op2GPR, resultGPR);
-        if (op1GPR != resultGPR) {
-            MacroAssembler::Jump done = m_jit.jump();
-            op1Less.link(&m_jit);
-            m_jit.move(op1GPR, resultGPR);
-            done.link(&m_jit);
-        } else
-            op1Less.link(&m_jit);
+        m_jit.move(op1GPR, resultGPR);
+
+        for (unsigned index = 1; index < node->numChildren(); ++index) {
+            SpeculateStrictInt32Operand op2(this, m_graph.child(node, index));
+            GPRReg op2GPR = op2.gpr();
+#if CPU(ARM64) || CPU(X86_64)
+            m_jit.moveConditionally32(node->op() == ArithMin ? MacroAssembler::GreaterThan : MacroAssembler::LessThan, resultGPR, op2GPR, op2GPR, resultGPR);
+#else
+            auto resultLess = m_jit.branch32(node->op() == ArithMin ? MacroAssembler::LessThan : MacroAssembler::GreaterThan, resultGPR, op2GPR);
+            m_jit.move(op2GPR, resultGPR);
+            resultLess.link(&m_jit);
+#endif
+        }
 
         strictInt32Result(resultGPR, node);
         break;
     }
 
     case DoubleRepUse: {
-        SpeculateDoubleOperand op1(this, node->child1());
-        SpeculateDoubleOperand op2(this, node->child2());
-        FPRTemporary result(this, op1);
+        if (node->numChildren() == 2) {
+            SpeculateDoubleOperand op1(this, m_graph.child(node, 0));
+            SpeculateDoubleOperand op2(this, m_graph.child(node, 1));
+            FPRTemporary result(this, op1);
 
-        FPRReg op1FPR = op1.fpr();
-        FPRReg op2FPR = op2.fpr();
-        FPRReg resultFPR = result.fpr();
+            FPRReg op1FPR = op1.fpr();
+            FPRReg op2FPR = op2.fpr();
+            FPRReg resultFPR = result.fpr();
 
-        MacroAssembler::JumpList done;
+            MacroAssembler::JumpList done;
 
-        MacroAssembler::Jump op1Less = m_jit.branchDouble(node->op() == ArithMin ? MacroAssembler::DoubleLessThanAndOrdered : MacroAssembler::DoubleGreaterThanAndOrdered, op1FPR, op2FPR);
-        MacroAssembler::Jump opNotEqualOrUnordered = m_jit.branchDouble(MacroAssembler::DoubleNotEqualOrUnordered, op1FPR, op2FPR);
+            MacroAssembler::Jump op1Less = m_jit.branchDouble(node->op() == ArithMin ? MacroAssembler::DoubleLessThanAndOrdered : MacroAssembler::DoubleGreaterThanAndOrdered, op1FPR, op2FPR);
+            MacroAssembler::Jump opNotEqualOrUnordered = m_jit.branchDouble(MacroAssembler::DoubleNotEqualOrUnordered, op1FPR, op2FPR);
 
-        // The spec for Math.min and Math.max states that +0 is considered to be larger than -0.
-        if (node->op() == ArithMin)
-            m_jit.orDouble(op1FPR, op2FPR, resultFPR);
-        else
-            m_jit.andDouble(op1FPR, op2FPR, resultFPR);
+            // The spec for Math.min and Math.max states that +0 is considered to be larger than -0.
+            if (node->op() == ArithMin)
+                m_jit.orDouble(op1FPR, op2FPR, resultFPR);
+            else
+                m_jit.andDouble(op1FPR, op2FPR, resultFPR);
 
-        done.append(m_jit.jump());
-
-        opNotEqualOrUnordered.link(&m_jit);
-        // op2 is either the lesser one or one of then is NaN
-        MacroAssembler::Jump op2Less = m_jit.branchDouble(node->op() == ArithMin ? MacroAssembler::DoubleGreaterThanAndOrdered : MacroAssembler::DoubleLessThanAndOrdered, op1FPR, op2FPR);
-
-        // Unordered case. We don't know which of op1, op2 is NaN. Manufacture NaN by adding
-        // op1 + op2 and putting it into result.
-        m_jit.addDouble(op1FPR, op2FPR, resultFPR);
-        done.append(m_jit.jump());
-
-        op2Less.link(&m_jit);
-        m_jit.moveDouble(op2FPR, resultFPR);
-
-        if (op1FPR != resultFPR) {
             done.append(m_jit.jump());
 
-            op1Less.link(&m_jit);
-            m_jit.moveDouble(op1FPR, resultFPR);
-        } else
-            op1Less.link(&m_jit);
+            opNotEqualOrUnordered.link(&m_jit);
+            // op2 is either the lesser one or one of then is NaN
+            MacroAssembler::Jump op2Less = m_jit.branchDouble(node->op() == ArithMin ? MacroAssembler::DoubleGreaterThanAndOrdered : MacroAssembler::DoubleLessThanAndOrdered, op1FPR, op2FPR);
 
-        done.link(&m_jit);
+            // Unordered case. We don't know which of op1, op2 is NaN. Manufacture NaN by adding
+            // op1 + op2 and putting it into result.
+            m_jit.addDouble(op1FPR, op2FPR, resultFPR);
+            done.append(m_jit.jump());
 
+            op2Less.link(&m_jit);
+            m_jit.moveDouble(op2FPR, resultFPR);
+
+            if (op1FPR != resultFPR) {
+                done.append(m_jit.jump());
+
+                op1Less.link(&m_jit);
+                m_jit.moveDouble(op1FPR, resultFPR);
+            } else
+                op1Less.link(&m_jit);
+
+            done.link(&m_jit);
+
+            doubleResult(resultFPR, node);
+            break;
+        }
+
+        GPRTemporary buffer(this);
+
+        GPRReg bufferGPR = buffer.gpr();
+
+        size_t scratchSize = sizeof(double) * node->numChildren();
+        ScratchBuffer* scratchBuffer = vm().scratchBufferForSize(scratchSize);
+        m_jit.move(TrustedImmPtr(bitwise_cast<const double*>(scratchBuffer->dataBuffer())), bufferGPR);
+
+        for (unsigned index = 0; index < node->numChildren(); ++index) {
+            SpeculateDoubleOperand op(this, m_graph.child(node, index));
+            FPRReg opFPR = op.fpr();
+            m_jit.storeDouble(opFPR, CCallHelpers::Address(bufferGPR, sizeof(double) * index));
+        }
+
+        flushRegisters();
+        FPRResult result(this);
+        FPRReg resultFPR = result.fpr();
+        callOperation(node->op() == ArithMin ? operationArithMinMultipleDouble : operationArithMaxMultipleDouble, resultFPR, bufferGPR, TrustedImm32(node->numChildren()));
         doubleResult(resultFPR, node);
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -279,8 +279,6 @@ public:
                 case ArithIMul:
                 case ArithDiv:
                 case ArithMod:
-                case ArithMin:
-                case ArithMax:
                 case ArithPow:
                 case CompareLess:
                 case CompareLessEq:
@@ -292,8 +290,16 @@ public:
                 case CompareStrictEq:
                 case SameValue:
                 case StrCat:
-                    VALIDATE((node), !!node->child1());
-                    VALIDATE((node), !!node->child2());
+                    m_graph.doToChildren(node, [&](Edge& edge) {
+                        VALIDATE((node), !!edge);
+                    });
+                    break;
+                case ArithMin:
+                case ArithMax:
+                    m_graph.doToChildren(node, [&](Edge& edge) {
+                        VALIDATE((node), !!edge);
+                    });
+                    VALIDATE((node), node->numChildren());
                     break;
                 case CompareEqPtr:
                     VALIDATE((node), !!node->child1());


### PR DESCRIPTION
#### 70f665155e30119d679eaca988e5e26ad70832d1
<pre>
[JSC] Optimize 3~ parameter Math.min / Math.max
<a href="https://bugs.webkit.org/show_bug.cgi?id=246202">https://bugs.webkit.org/show_bug.cgi?id=246202</a>
rdar://100884179

Reviewed by Mark Lam.

We found that JetStream2/chai-wtb is using Math.min(a, b, c) with three parameters,
and DFG / FTL gave up optimization for that right now. This patch changes ArithMin / ArithMax
to take variadic parameters so that we can emit code efficiently.

For Int32, we emit sequence of cmp and cmov, which should be compact and fast. For Double,
if the # of parameters are 3~, we call a runtime function which does max / min efficiently,
since double min/max are more complicated and this avoids bloating code.

This change offers 5-10% improvement in JetStream2/chai-wtb.

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleMinMax):
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGValidate.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArithMinOrMax):

Canonical link: <a href="https://commits.webkit.org/255288@main">https://commits.webkit.org/255288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/377317c00a7e30db44864dc757ea51d2d2800a5e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91989 "29 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101802 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161875 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1228 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84454 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/757 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78538 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27706 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82679 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83342 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36077 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16303 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78404 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33816 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17405 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27071 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37693 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81026 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1654 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36530 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17810 "Passed tests") | 
<!--EWS-Status-Bubble-End-->