### PR TITLE
AsyncScrolling: move ScrollingTreeScrollingNodeDelegate member to ScrollingTreeScrollingNode

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -36,6 +36,7 @@
 #include "ScrollingStateScrollingNode.h"
 #include "ScrollingStateTree.h"
 #include "ScrollingTree.h"
+#include "ScrollingTreeScrollingNodeDelegate.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -232,14 +233,27 @@ void ScrollingTreeScrollingNode::setScrollSnapInProgress(bool isSnapping)
     scrollingTree().setNodeScrollSnapInProgress(scrollingNodeID(), isSnapping);
 }
 
-void ScrollingTreeScrollingNode::willStartAnimatedScroll()
-{
-}
-
 void ScrollingTreeScrollingNode::didStopAnimatedScroll()
 {
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " didStopAnimatedScroll");
     scrollingTree().scrollingTreeNodeDidStopAnimatedScroll(*this);
+}
+
+bool ScrollingTreeScrollingNode::startAnimatedScrollToPosition(FloatPoint destinationPosition)
+{
+    return m_delegate ? m_delegate->startAnimatedScrollToPosition(destinationPosition) : false;
+}
+
+void ScrollingTreeScrollingNode::stopAnimatedScroll()
+{
+    if (m_delegate)
+        m_delegate->stopAnimatedScroll();
+}
+
+void ScrollingTreeScrollingNode::serviceScrollAnimation(MonotonicTime currentTime)
+{
+    if (m_delegate)
+        m_delegate->serviceScrollAnimation(currentTime);
 }
 
 void ScrollingTreeScrollingNode::setScrollAnimationInProgress(bool animationInProgress)

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class ScrollingTree;
 class ScrollingStateScrollingNode;
+class ScrollingTreeScrollingNodeDelegate;
 struct WheelEventHandlingResult;
 
 struct ScrollPropagationInfo {
@@ -80,7 +81,7 @@ public:
     bool isScrollSnapInProgress() const;
     void setScrollSnapInProgress(bool);
 
-    virtual void serviceScrollAnimation(MonotonicTime) { }
+    virtual void serviceScrollAnimation(MonotonicTime);
 
     // These are imperative; they adjust the scrolling layers.
     void scrollTo(const FloatPoint&, ScrollType = ScrollType::User, ScrollClamping = ScrollClamping::Clamped);
@@ -135,10 +136,9 @@ protected:
     
     virtual FloatPoint adjustedScrollPosition(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped) const;
     
-    virtual bool startAnimatedScrollToPosition(FloatPoint) { return false; }
-    virtual void stopAnimatedScroll() { }
+    virtual bool startAnimatedScrollToPosition(FloatPoint);
+    virtual void stopAnimatedScroll();
 
-    void willStartAnimatedScroll();
     void didStopAnimatedScroll();
 
     void setScrollAnimationInProgress(bool);
@@ -174,6 +174,8 @@ protected:
     bool overscrollBehaviorAllowsRubberBand() const { return m_scrollableAreaParameters.horizontalOverscrollBehavior != OverscrollBehavior::None ||  m_scrollableAreaParameters.verticalOverscrollBehavior != OverscrollBehavior::None; }
     bool shouldRubberBand(const PlatformWheelEvent&, EventTargeting) const;
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
+
+    std::unique_ptr<ScrollingTreeScrollingNodeDelegate> m_delegate;
 
 private:
     FloatSize m_scrollableAreaSize;

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -32,6 +32,7 @@
 namespace WebCore {
 
 class ScrollingTreeScrollingNodeDelegate {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT explicit ScrollingTreeScrollingNodeDelegate(ScrollingTreeScrollingNode&);
     WEBCORE_EXPORT virtual ~ScrollingTreeScrollingNodeDelegate();

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
@@ -37,6 +37,8 @@ OBJC_CLASS CALayer;
 
 namespace WebCore {
 
+class ScrollingTreeScrollingNodeDelegateMac;
+
 class WEBCORE_EXPORT ScrollingTreeFrameScrollingNodeMac : public ScrollingTreeFrameScrollingNode {
 public:
     static Ref<ScrollingTreeFrameScrollingNode> create(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
@@ -63,19 +65,15 @@ protected:
     unsigned exposedUnfilledArea() const;
 
 private:
+    ScrollingTreeScrollingNodeDelegateMac& delegate() const;
+
     void willBeDestroyed() final;
     void willDoProgrammaticScroll(const FloatPoint&) final;
-
-    bool startAnimatedScrollToPosition(FloatPoint) final;
-    void stopAnimatedScroll() final;
-    void serviceScrollAnimation(MonotonicTime) final;
 
     FloatPoint adjustedScrollPosition(const FloatPoint&, ScrollClamping) const final;
 
     void currentScrollPositionChanged(ScrollType, ScrollingLayerPositionAction) final;
     void repositionScrollingLayers() final;
-
-    ScrollingTreeScrollingNodeDelegateMac m_delegate;
 
     RetainPtr<CALayer> m_rootContentsLayer;
     RetainPtr<CALayer> m_counterScrollingLayer;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h
@@ -28,11 +28,12 @@
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
 
 #include "ScrollingTreeOverflowScrollingNode.h"
-#include "ScrollingTreeScrollingNodeDelegateMac.h"
 
 OBJC_CLASS CALayer;
 
 namespace WebCore {
+
+class ScrollingTreeScrollingNodeDelegateMac;
 
 class WEBCORE_EXPORT ScrollingTreeOverflowScrollingNodeMac : public ScrollingTreeOverflowScrollingNode {
 public:
@@ -46,22 +47,18 @@ protected:
     
     FloatPoint adjustedScrollPosition(const FloatPoint&, ScrollClamping) const override;
 
-    bool startAnimatedScrollToPosition(FloatPoint destinationPosition) override;
-    void stopAnimatedScroll() override;
-
     void currentScrollPositionChanged(ScrollType, ScrollingLayerPositionAction) final;
     void willDoProgrammaticScroll(const FloatPoint&) final;
 
     void repositionScrollingLayers() override;
     void repositionRelatedLayers() override;
-    void serviceScrollAnimation(MonotonicTime) override;
 
     WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting) override;
 
 private:
-    void willBeDestroyed() final;
+    ScrollingTreeScrollingNodeDelegateMac& delegate() const;
 
-    ScrollingTreeScrollingNodeDelegateMac m_delegate;
+    void willBeDestroyed() final;
 };
 
 } // namespace WebKit

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.h
@@ -31,7 +31,6 @@
 #if ENABLE(ASYNC_SCROLLING) && USE(NICOSIA)
 
 #include "ScrollingTreeFrameScrollingNode.h"
-#include "ScrollingTreeScrollingNodeDelegateNicosia.h"
 #include <wtf/RefPtr.h>
 
 namespace Nicosia {
@@ -39,8 +38,8 @@ class CompositionLayer;
 }
 
 namespace WebCore {
-class ScrollAnimation;
-class ScrollAnimationKinetic;
+
+class ScrollingTreeScrollingNodeDelegateNicosia;
 
 class ScrollingTreeFrameScrollingNodeNicosia final : public ScrollingTreeFrameScrollingNode {
 public:
@@ -52,11 +51,9 @@ public:
 private:
     ScrollingTreeFrameScrollingNodeNicosia(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    ScrollingTreeScrollingNodeDelegateNicosia& delegate() const;
 
-    bool startAnimatedScrollToPosition(FloatPoint) override;
-    void stopAnimatedScroll() override;
-    void serviceScrollAnimation(MonotonicTime) final;
+    void commitStateBeforeChildren(const ScrollingStateNode&) override;
 
     WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting) override;
     FloatPoint adjustedScrollPosition(const FloatPoint&, ScrollClamping) const override;
@@ -70,8 +67,6 @@ private:
     RefPtr<Nicosia::CompositionLayer> m_contentShadowLayer;
     RefPtr<Nicosia::CompositionLayer> m_headerLayer;
     RefPtr<Nicosia::CompositionLayer> m_footerLayer;
-
-    ScrollingTreeScrollingNodeDelegateNicosia m_delegate;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.h
@@ -31,11 +31,10 @@
 #if ENABLE(ASYNC_SCROLLING) && USE(NICOSIA)
 
 #include "ScrollingTreeOverflowScrollingNode.h"
-#include "ScrollingTreeScrollingNodeDelegateNicosia.h"
 
 namespace WebCore {
-class ScrollAnimation;
-class ScrollAnimationKinetic;
+
+class ScrollingTreeScrollingNodeDelegateNicosia;
 
 class ScrollingTreeOverflowScrollingNodeNicosia final : public ScrollingTreeOverflowScrollingNode {
 public:
@@ -45,15 +44,11 @@ public:
 private:
     ScrollingTreeOverflowScrollingNodeNicosia(ScrollingTree&, ScrollingNodeID);
 
+    ScrollingTreeScrollingNodeDelegateNicosia& delegate() const;
+
     FloatPoint adjustedScrollPosition(const FloatPoint&, ScrollClamping) const override;
     void repositionScrollingLayers() override;
     WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting) override;
-
-    bool startAnimatedScrollToPosition(FloatPoint) override;
-    void stopAnimatedScroll() override;
-    void serviceScrollAnimation(MonotonicTime) final;
-
-    ScrollingTreeScrollingNodeDelegateNicosia m_delegate;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
@@ -45,6 +45,8 @@ public:
 private:
     ScrollingTreeFrameScrollingNodeRemoteIOS(WebCore::ScrollingTree&, WebCore::ScrollingNodeType, WebCore::ScrollingNodeID);
 
+    ScrollingTreeScrollingNodeDelegateIOS* delegate() const;
+
     void commitStateBeforeChildren(const WebCore::ScrollingStateNode&) override;
     void commitStateAfterChildren(const WebCore::ScrollingStateNode&) override;
 
@@ -53,11 +55,6 @@ private:
 
     void repositionScrollingLayers() override;
     void repositionRelatedLayers() override;
-
-    bool startAnimatedScrollToPosition(WebCore::FloatPoint) final;
-    void stopAnimatedScroll() final;
-
-    std::unique_ptr<ScrollingTreeScrollingNodeDelegateIOS> m_scrollingNodeDelegate;
 
     RetainPtr<CALayer> m_counterScrollingLayer;
     RetainPtr<CALayer> m_headerLayer;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
@@ -45,16 +45,12 @@ public:
 private:
     ScrollingTreeOverflowScrollingNodeIOS(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
 
+    ScrollingTreeScrollingNodeDelegateIOS& delegate() const;
+
     void commitStateBeforeChildren(const WebCore::ScrollingStateNode&) final;
     void commitStateAfterChildren(const WebCore::ScrollingStateNode&) final;
     
     void repositionScrollingLayers() final;
-
-    bool startAnimatedScrollToPosition(WebCore::FloatPoint) final;
-    void stopAnimatedScroll() final;
-
-    // The delegate is non-null for subframes.
-    std::unique_ptr<ScrollingTreeScrollingNodeDelegateIOS> m_scrollingNodeDelegate;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
@@ -43,52 +43,44 @@ Ref<ScrollingTreeOverflowScrollingNodeIOS> ScrollingTreeOverflowScrollingNodeIOS
 
 ScrollingTreeOverflowScrollingNodeIOS::ScrollingTreeOverflowScrollingNodeIOS(WebCore::ScrollingTree& scrollingTree, WebCore::ScrollingNodeID nodeID)
     : ScrollingTreeOverflowScrollingNode(scrollingTree, nodeID)
-    , m_scrollingNodeDelegate(makeUnique<ScrollingTreeScrollingNodeDelegateIOS>(*this))
 {
+    m_delegate = makeUnique<ScrollingTreeScrollingNodeDelegateIOS>(*this);
 }
 
 ScrollingTreeOverflowScrollingNodeIOS::~ScrollingTreeOverflowScrollingNodeIOS()
 {
 }
 
+ScrollingTreeScrollingNodeDelegateIOS& ScrollingTreeOverflowScrollingNodeIOS::delegate() const
+{
+    return *static_cast<ScrollingTreeScrollingNodeDelegateIOS*>(m_delegate.get());
+}
+
 UIScrollView* ScrollingTreeOverflowScrollingNodeIOS::scrollView() const
 {
-    return m_scrollingNodeDelegate->scrollView();
+    return delegate().scrollView();
 }
 
 void ScrollingTreeOverflowScrollingNodeIOS::commitStateBeforeChildren(const WebCore::ScrollingStateNode& stateNode)
 {
     if (stateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
-        m_scrollingNodeDelegate->resetScrollViewDelegate();
+        delegate().resetScrollViewDelegate();
 
     ScrollingTreeOverflowScrollingNode::commitStateBeforeChildren(stateNode);
-    m_scrollingNodeDelegate->commitStateBeforeChildren(downcast<ScrollingStateScrollingNode>(stateNode));
+    delegate().commitStateBeforeChildren(downcast<ScrollingStateScrollingNode>(stateNode));
 }
 
 void ScrollingTreeOverflowScrollingNodeIOS::commitStateAfterChildren(const ScrollingStateNode& stateNode)
 {
     const auto& scrollingStateNode = downcast<ScrollingStateScrollingNode>(stateNode);
-    m_scrollingNodeDelegate->commitStateAfterChildren(scrollingStateNode);
+    delegate().commitStateAfterChildren(scrollingStateNode);
 
     ScrollingTreeOverflowScrollingNode::commitStateAfterChildren(stateNode);
 }
 
 void ScrollingTreeOverflowScrollingNodeIOS::repositionScrollingLayers()
 {
-    m_scrollingNodeDelegate->repositionScrollingLayers();
-}
-
-bool ScrollingTreeOverflowScrollingNodeIOS::startAnimatedScrollToPosition(FloatPoint destinationPosition)
-{
-    bool started = m_scrollingNodeDelegate->startAnimatedScrollToPosition(destinationPosition);
-    if (started)
-        willStartAnimatedScroll();
-    return started;
-}
-
-void ScrollingTreeOverflowScrollingNodeIOS::stopAnimatedScroll()
-{
-    m_scrollingNodeDelegate->stopAnimatedScroll();
+    delegate().repositionScrollingLayers();
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 743a5cdc9032e321d4dd6336484c5bb63d801dab
<pre>
AsyncScrolling: move ScrollingTreeScrollingNodeDelegate member to ScrollingTreeScrollingNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=246211">https://bugs.webkit.org/show_bug.cgi?id=246211</a>

Reviewed by Simon Fraser.

This allows us to remove some duplicated code in classes derived from ScrollingTreeScrollingNode.

* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::startAnimatedScrollToPosition):
(WebCore::ScrollingTreeScrollingNode::stopAnimatedScroll):
(WebCore::ScrollingTreeScrollingNode::serviceScrollAnimation):
(WebCore::ScrollingTreeScrollingNode::willStartAnimatedScroll): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
(WebCore::ScrollingTreeFrameScrollingNodeMac::ScrollingTreeFrameScrollingNodeMac):
(WebCore::ScrollingTreeFrameScrollingNodeMac::delegate const):
(WebCore::ScrollingTreeFrameScrollingNodeMac::willBeDestroyed):
(WebCore::ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren):
(WebCore::ScrollingTreeFrameScrollingNodeMac::handleWheelEvent):
(WebCore::ScrollingTreeFrameScrollingNodeMac::willDoProgrammaticScroll):
(WebCore::ScrollingTreeFrameScrollingNodeMac::currentScrollPositionChanged):
(WebCore::ScrollingTreeFrameScrollingNodeMac::repositionRelatedLayers):
(WebCore::ScrollingTreeFrameScrollingNodeMac::startAnimatedScrollToPosition): Deleted.
(WebCore::ScrollingTreeFrameScrollingNodeMac::stopAnimatedScroll): Deleted.
(WebCore::ScrollingTreeFrameScrollingNodeMac::serviceScrollAnimation): Deleted.
* Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm:
(WebCore::ScrollingTreeOverflowScrollingNodeMac::ScrollingTreeOverflowScrollingNodeMac):
(WebCore::ScrollingTreeOverflowScrollingNodeMac::delegate const):
(WebCore::ScrollingTreeOverflowScrollingNodeMac::willBeDestroyed):
(WebCore::ScrollingTreeOverflowScrollingNodeMac::commitStateBeforeChildren):
(WebCore::ScrollingTreeOverflowScrollingNodeMac::handleWheelEvent):
(WebCore::ScrollingTreeOverflowScrollingNodeMac::willDoProgrammaticScroll):
(WebCore::ScrollingTreeOverflowScrollingNodeMac::currentScrollPositionChanged):
(WebCore::ScrollingTreeOverflowScrollingNodeMac::repositionRelatedLayers):
(WebCore::ScrollingTreeOverflowScrollingNodeMac::startAnimatedScrollToPosition): Deleted.
(WebCore::ScrollingTreeOverflowScrollingNodeMac::stopAnimatedScroll): Deleted.
(WebCore::ScrollingTreeOverflowScrollingNodeMac::serviceScrollAnimation): Deleted.
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp:
(WebCore::ScrollingTreeFrameScrollingNodeNicosia::ScrollingTreeFrameScrollingNodeNicosia):
(WebCore::ScrollingTreeFrameScrollingNodeNicosia::delegate const):
(WebCore::ScrollingTreeFrameScrollingNodeNicosia::commitStateBeforeChildren):
(WebCore::ScrollingTreeFrameScrollingNodeNicosia::handleWheelEvent):
(WebCore::ScrollingTreeFrameScrollingNodeNicosia::repositionRelatedLayers):
(WebCore::ScrollingTreeFrameScrollingNodeNicosia::startAnimatedScrollToPosition): Deleted.
(WebCore::ScrollingTreeFrameScrollingNodeNicosia::stopAnimatedScroll): Deleted.
(WebCore::ScrollingTreeFrameScrollingNodeNicosia::serviceScrollAnimation): Deleted.
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.h:
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp:
(WebCore::ScrollingTreeOverflowScrollingNodeNicosia::ScrollingTreeOverflowScrollingNodeNicosia):
(WebCore::ScrollingTreeOverflowScrollingNodeNicosia::delegate const):
(WebCore::ScrollingTreeOverflowScrollingNodeNicosia::repositionScrollingLayers):
(WebCore::ScrollingTreeOverflowScrollingNodeNicosia::handleWheelEvent):
(WebCore::ScrollingTreeOverflowScrollingNodeNicosia::startAnimatedScrollToPosition): Deleted.
(WebCore::ScrollingTreeOverflowScrollingNodeNicosia::stopAnimatedScroll): Deleted.
(WebCore::ScrollingTreeOverflowScrollingNodeNicosia::serviceScrollAnimation): Deleted.
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm:
(WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::delegate const):
(WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::scrollView const):
(WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::commitStateBeforeChildren):
(WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::commitStateAfterChildren):
(WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::repositionScrollingLayers):
(WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::startAnimatedScrollToPosition): Deleted.
(WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::stopAnimatedScroll): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm:
(WebKit::ScrollingTreeOverflowScrollingNodeIOS::ScrollingTreeOverflowScrollingNodeIOS):
(WebKit::ScrollingTreeOverflowScrollingNodeIOS::delegate const):
(WebKit::ScrollingTreeOverflowScrollingNodeIOS::scrollView const):
(WebKit::ScrollingTreeOverflowScrollingNodeIOS::commitStateBeforeChildren):
(WebKit::ScrollingTreeOverflowScrollingNodeIOS::commitStateAfterChildren):
(WebKit::ScrollingTreeOverflowScrollingNodeIOS::repositionScrollingLayers):
(WebKit::ScrollingTreeOverflowScrollingNodeIOS::startAnimatedScrollToPosition): Deleted.
(WebKit::ScrollingTreeOverflowScrollingNodeIOS::stopAnimatedScroll): Deleted.

Canonical link: <a href="https://commits.webkit.org/255323@main">https://commits.webkit.org/255323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03e5a935ca6a553f21133c9586a96ad0597846a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101790 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161871 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/95976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1213 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29655 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/97996 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/748 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78523 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27694 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82274 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70730 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36064 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16291 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33802 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17393 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3691 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37679 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40106 "Found 2 new test failures: imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h264_annexb, imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_annexb (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36518 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->