### PR TITLE
AsyncScrolling: add ThreadedScrollingTreeScrollingNodeDelegate

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1919,6 +1919,7 @@ page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp
 page/scrolling/ScrollingTreeStickyNode.cpp
 page/scrolling/ThreadedScrollingCoordinator.cpp
 page/scrolling/ThreadedScrollingTree.cpp
+page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
 platform/CommonAtomStrings.cpp
 platform/ContentType.cpp
 platform/ContextMenu.cpp

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -285,10 +285,11 @@ void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScro
 
 FloatPoint ScrollingTreeScrollingNode::adjustedScrollPosition(const FloatPoint& scrollPosition, ScrollClamping clamping) const
 {
+    auto adjustedPosition = m_delegate ? m_delegate->adjustedScrollPosition(scrollPosition) : scrollPosition;
     if (clamping == ScrollClamping::Clamped)
-        return clampScrollPosition(scrollPosition);
+        return clampScrollPosition(adjustedPosition);
 
-    return scrollPosition;
+    return adjustedPosition;
 }
 
 void ScrollingTreeScrollingNode::scrollBy(const FloatSize& delta, ScrollClamping clamp)

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -50,8 +50,8 @@ class WEBCORE_EXPORT ScrollingTreeScrollingNode : public ScrollingTreeNode {
 #if PLATFORM(MAC)
     friend class ScrollingTreeScrollingNodeDelegateMac;
 #endif
-#if USE(NICOSIA)
-    friend class ScrollingTreeScrollingNodeDelegateNicosia;
+#if ENABLE(SCROLLING_THREAD)
+    friend class ThreadedScrollingTreeScrollingNodeDelegate;
 #endif
     friend class ScrollingTree;
     friend class ThreadedScrollingTree;
@@ -134,7 +134,7 @@ protected:
     
     virtual void willDoProgrammaticScroll(const FloatPoint&) { }
     
-    virtual FloatPoint adjustedScrollPosition(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped) const;
+    FloatPoint adjustedScrollPosition(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped) const;
     
     virtual bool startAnimatedScrollToPosition(FloatPoint);
     virtual void stopAnimatedScroll();

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -45,6 +45,10 @@ public:
 
     virtual void serviceScrollAnimation(MonotonicTime) = 0;
 
+    virtual void updateFromStateNode(const ScrollingStateScrollingNode&) { }
+
+    virtual FloatPoint adjustedScrollPosition(const FloatPoint& scrollPosition) const { return scrollPosition; }
+
 protected:
     WEBCORE_EXPORT ScrollingTree& scrollingTree() const;
     WEBCORE_EXPORT FloatPoint lastCommittedScrollPosition() const;

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2019 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ThreadedScrollingTreeScrollingNodeDelegate.h"
+
+#if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
+
+#include "ScrollExtents.h"
+#include "ScrollingStateScrollingNode.h"
+#include "ScrollingTree.h"
+#include "ScrollingTreeFrameScrollingNode.h"
+#include "ScrollingTreeScrollingNode.h"
+
+namespace WebCore {
+
+ThreadedScrollingTreeScrollingNodeDelegate::ThreadedScrollingTreeScrollingNodeDelegate(ScrollingTreeScrollingNode& scrollingNode)
+    : ScrollingTreeScrollingNodeDelegate(scrollingNode)
+    , m_scrollController(*this)
+{
+}
+
+ThreadedScrollingTreeScrollingNodeDelegate::~ThreadedScrollingTreeScrollingNodeDelegate() = default;
+
+void ThreadedScrollingTreeScrollingNodeDelegate::updateFromStateNode(const ScrollingStateScrollingNode& scrollingStateNode)
+{
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::SnapOffsetsInfo))
+        m_scrollController.setSnapOffsetsInfo(scrollingStateNode.snapOffsetsInfo().convertUnits<LayoutScrollSnapOffsetsInfo>());
+
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::CurrentHorizontalSnapOffsetIndex))
+        m_scrollController.setActiveScrollSnapIndexForAxis(ScrollEventAxis::Horizontal, scrollingStateNode.currentHorizontalSnapPointIndex());
+
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::CurrentVerticalSnapOffsetIndex))
+        m_scrollController.setActiveScrollSnapIndexForAxis(ScrollEventAxis::Vertical, scrollingStateNode.currentVerticalSnapPointIndex());
+}
+
+bool ThreadedScrollingTreeScrollingNodeDelegate::startAnimatedScrollToPosition(FloatPoint destinationPosition)
+{
+    auto currentOffset = ScrollableArea::scrollOffsetFromPosition(currentScrollPosition(), scrollOrigin());
+    auto destinationOffset = ScrollableArea::scrollOffsetFromPosition(destinationPosition, scrollOrigin());
+    return m_scrollController.startAnimatedScrollToDestination(currentOffset, destinationOffset);
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::stopAnimatedScroll()
+{
+    m_scrollController.stopAnimatedScroll();
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::serviceScrollAnimation(MonotonicTime currentTime)
+{
+    m_scrollController.animationCallback(currentTime);
+}
+
+std::unique_ptr<ScrollingEffectsControllerTimer> ThreadedScrollingTreeScrollingNodeDelegate::createTimer(Function<void()>&& function)
+{
+    // This is only used for a scroll snap timer.
+    return WTF::makeUnique<ScrollingEffectsControllerTimer>(RunLoop::current(), [function = WTFMove(function), protectedNode = Ref { scrollingNode() }] {
+        Locker locker { protectedNode->scrollingTree().treeLock() };
+        function();
+    });
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::startAnimationCallback(ScrollingEffectsController&)
+{
+    scrollingNode().setScrollAnimationInProgress(true);
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::stopAnimationCallback(ScrollingEffectsController&)
+{
+    scrollingNode().setScrollAnimationInProgress(false);
+}
+
+bool ThreadedScrollingTreeScrollingNodeDelegate::allowsHorizontalScrolling() const
+{
+    return ScrollingTreeScrollingNodeDelegate::allowsHorizontalScrolling();
+}
+
+bool ThreadedScrollingTreeScrollingNodeDelegate::allowsVerticalScrolling() const
+{
+    return ScrollingTreeScrollingNodeDelegate::allowsVerticalScrolling();
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::immediateScrollBy(const FloatSize& delta, ScrollClamping clamping)
+{
+    scrollingNode().scrollBy(delta, clamping);
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::adjustScrollPositionToBoundsIfNecessary()
+{
+    FloatPoint scrollPosition = currentScrollPosition();
+    FloatPoint constrainedPosition = scrollPosition.constrainedBetween(minimumScrollPosition(), maximumScrollPosition());
+    immediateScrollBy(constrainedPosition - scrollPosition);
+}
+
+FloatPoint ThreadedScrollingTreeScrollingNodeDelegate::scrollOffset() const
+{
+    return ScrollableArea::scrollOffsetFromPosition(currentScrollPosition(), scrollOrigin());
+}
+
+float ThreadedScrollingTreeScrollingNodeDelegate::pageScaleFactor() const
+{
+    // FIXME: What should this return for non-root frames, and overflow?
+    // Also, this should not have to access ScrollingTreeFrameScrollingNode.
+    if (is<ScrollingTreeFrameScrollingNode>(scrollingNode()))
+        return downcast<ScrollingTreeFrameScrollingNode>(scrollingNode()).frameScaleFactor();
+
+    return 1;
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::didStopAnimatedScroll()
+{
+    scrollingNode().didStopAnimatedScroll();
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::willStartScrollSnapAnimation()
+{
+    scrollingNode().setScrollSnapInProgress(true);
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::didStopScrollSnapAnimation()
+{
+    scrollingNode().setScrollSnapInProgress(false);
+}
+
+ScrollExtents ThreadedScrollingTreeScrollingNodeDelegate::scrollExtents() const
+{
+    return {
+        scrollingNode().totalContentsSize(),
+        scrollingNode().scrollableAreaSize()
+    };
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::deferWheelEventTestCompletionForReason(WheelEventTestMonitor::ScrollableAreaIdentifier identifier, WheelEventTestMonitor::DeferReason reason) const
+{
+    if (!scrollingTree().isMonitoringWheelEvents())
+        return;
+
+    scrollingTree().deferWheelEventTestCompletionForReason(identifier, reason);
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::removeWheelEventTestCompletionDeferralForReason(WheelEventTestMonitor::ScrollableAreaIdentifier identifier, WheelEventTestMonitor::DeferReason reason) const
+{
+    if (!scrollingTree().isMonitoringWheelEvents())
+        return;
+
+    scrollingTree().removeWheelEventTestCompletionDeferralForReason(identifier, reason);
+}
+
+FloatPoint ThreadedScrollingTreeScrollingNodeDelegate::adjustedScrollPosition(const FloatPoint& position) const
+{
+    return { roundf(position.x()), roundf(position.y()) };
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2019 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ScrollingTreeScrollingNodeDelegate.h"
+
+#if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
+
+#include "ScrollingEffectsController.h"
+
+namespace WebCore {
+
+class FloatPoint;
+class FloatSize;
+class IntPoint;
+class ScrollingStateScrollingNode;
+class ScrollingTreeScrollingNode;
+class ScrollingTree;
+
+class ThreadedScrollingTreeScrollingNodeDelegate : public ScrollingTreeScrollingNodeDelegate, private ScrollingEffectsControllerClient {
+protected:
+    explicit ThreadedScrollingTreeScrollingNodeDelegate(ScrollingTreeScrollingNode&);
+    virtual ~ThreadedScrollingTreeScrollingNodeDelegate();
+
+    void updateFromStateNode(const ScrollingStateScrollingNode&) override;
+
+    bool startAnimatedScrollToPosition(FloatPoint) override;
+    void stopAnimatedScroll() override;
+    void serviceScrollAnimation(MonotonicTime) override;
+
+    // ScrollingEffectsControllerClient.
+    std::unique_ptr<ScrollingEffectsControllerTimer> createTimer(Function<void()>&&) override;
+    void startAnimationCallback(ScrollingEffectsController&) override;
+    void stopAnimationCallback(ScrollingEffectsController&) override;
+
+    bool allowsHorizontalScrolling() const override;
+    bool allowsVerticalScrolling() const override;
+
+    void immediateScrollBy(const FloatSize&, ScrollClamping = ScrollClamping::Clamped) override;
+    void adjustScrollPositionToBoundsIfNecessary() override;
+
+    bool scrollPositionIsNotRubberbandingEdge(const FloatPoint&) const;
+
+    FloatPoint scrollOffset() const override;
+    float pageScaleFactor() const override;
+
+    void didStopAnimatedScroll() override;
+    void willStartScrollSnapAnimation() override;
+    void didStopScrollSnapAnimation() override;
+
+    ScrollExtents scrollExtents() const override;
+
+    void deferWheelEventTestCompletionForReason(WheelEventTestMonitor::ScrollableAreaIdentifier, WheelEventTestMonitor::DeferReason) const override;
+    void removeWheelEventTestCompletionDeferralForReason(WheelEventTestMonitor::ScrollableAreaIdentifier, WheelEventTestMonitor::DeferReason) const override;
+
+    FloatPoint adjustedScrollPosition(const FloatPoint&) const override;
+
+    ScrollingEffectsController m_scrollController;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
@@ -70,8 +70,6 @@ private:
     void willBeDestroyed() final;
     void willDoProgrammaticScroll(const FloatPoint&) final;
 
-    FloatPoint adjustedScrollPosition(const FloatPoint&, ScrollClamping) const final;
-
     void currentScrollPositionChanged(ScrollType, ScrollingLayerPositionAction) final;
     void repositionScrollingLayers() final WTF_REQUIRES_LOCK(scrollingTree().treeLock());
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
@@ -100,7 +100,7 @@ void ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren(const Scrolli
     if (logScrollingMode && isRootNode() && scrollingTree().scrollingPerformanceTestingEnabled())
         scrollingTree().reportSynchronousScrollingReasonsChanged(MonotonicTime::now(), synchronousScrollingReasons());
 
-    delegate().updateFromStateNode(scrollingStateNode);
+    m_delegate->updateFromStateNode(scrollingStateNode);
 
     m_hadFirstUpdate = true;
 }
@@ -135,12 +135,6 @@ WheelEventHandlingResult ScrollingTreeFrameScrollingNodeMac::handleWheelEvent(co
 void ScrollingTreeFrameScrollingNodeMac::willDoProgrammaticScroll(const FloatPoint& targetScrollPosition)
 {
     delegate().willDoProgrammaticScroll(targetScrollPosition);
-}
-
-FloatPoint ScrollingTreeFrameScrollingNodeMac::adjustedScrollPosition(const FloatPoint& position, ScrollClamping clamp) const
-{
-    FloatPoint scrollPosition(roundf(position.x()), roundf(position.y()));
-    return ScrollingTreeFrameScrollingNode::adjustedScrollPosition(scrollPosition, clamp);
 }
 
 void ScrollingTreeFrameScrollingNodeMac::currentScrollPositionChanged(ScrollType scrollType, ScrollingLayerPositionAction action)

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h
@@ -44,8 +44,6 @@ protected:
     ScrollingTreeOverflowScrollingNodeMac(ScrollingTree&, ScrollingNodeID);
 
     void commitStateBeforeChildren(const ScrollingStateNode&) override;
-    
-    FloatPoint adjustedScrollPosition(const FloatPoint&, ScrollClamping) const override;
 
     void currentScrollPositionChanged(ScrollType, ScrollingLayerPositionAction) final;
     void willDoProgrammaticScroll(const FloatPoint&) final;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm
@@ -64,7 +64,7 @@ void ScrollingTreeOverflowScrollingNodeMac::willBeDestroyed()
 void ScrollingTreeOverflowScrollingNodeMac::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
     ScrollingTreeOverflowScrollingNode::commitStateBeforeChildren(stateNode);
-    delegate().updateFromStateNode(downcast<ScrollingStateOverflowScrollingNode>(stateNode));
+    m_delegate->updateFromStateNode(downcast<ScrollingStateOverflowScrollingNode>(stateNode));
 }
 
 WheelEventHandlingResult ScrollingTreeOverflowScrollingNodeMac::handleWheelEvent(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting)
@@ -89,12 +89,6 @@ void ScrollingTreeOverflowScrollingNodeMac::currentScrollPositionChanged(ScrollT
 {
     ScrollingTreeOverflowScrollingNode::currentScrollPositionChanged(scrollType, action);
     delegate().currentScrollPositionChanged();
-}
-
-FloatPoint ScrollingTreeOverflowScrollingNodeMac::adjustedScrollPosition(const FloatPoint& position, ScrollClamping clamp) const
-{
-    FloatPoint scrollPosition(roundf(position.x()), roundf(position.y()));
-    return ScrollingTreeOverflowScrollingNode::adjustedScrollPosition(scrollPosition, clamp);
 }
 
 void ScrollingTreeOverflowScrollingNodeMac::repositionScrollingLayers()

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -25,11 +25,10 @@
 
 #pragma once
 
-#include "ScrollingTreeScrollingNodeDelegate.h"
-
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
 
 #include "ScrollingEffectsController.h"
+#include "ThreadedScrollingTreeScrollingNodeDelegate.h"
 #include <wtf/RunLoop.h>
 
 OBJC_CLASS NSScrollerImp;
@@ -43,7 +42,7 @@ class ScrollingStateScrollingNode;
 class ScrollingTreeScrollingNode;
 class ScrollingTree;
 
-class ScrollingTreeScrollingNodeDelegateMac : public ScrollingTreeScrollingNodeDelegate, private ScrollingEffectsControllerClient {
+class ScrollingTreeScrollingNodeDelegateMac : public ThreadedScrollingTreeScrollingNodeDelegate {
 public:
     explicit ScrollingTreeScrollingNodeDelegateMac(ScrollingTreeScrollingNode&);
     virtual ~ScrollingTreeScrollingNodeDelegateMac();
@@ -51,11 +50,6 @@ public:
     void nodeWillBeDestroyed();
 
     bool handleWheelEvent(const PlatformWheelEvent&);
-
-    bool startAnimatedScrollToPosition(FloatPoint) final;
-    void stopAnimatedScroll() final;
-
-    void serviceScrollAnimation(MonotonicTime) final;
 
     void willDoProgrammaticScroll(const FloatPoint&);
     void currentScrollPositionChanged();
@@ -66,48 +60,27 @@ public:
 
     bool isRubberBandInProgress() const;
 
-    void updateFromStateNode(const ScrollingStateScrollingNode&);
     void updateScrollbarPainters();
 
     void deferWheelEventTestCompletionForReason(WheelEventTestMonitor::ScrollableAreaIdentifier, WheelEventTestMonitor::DeferReason) const override;
     void removeWheelEventTestCompletionDeferralForReason(WheelEventTestMonitor::ScrollableAreaIdentifier, WheelEventTestMonitor::DeferReason) const override;
 
 private:
-    // ScrollingEffectsControllerClient.
-    std::unique_ptr<ScrollingEffectsControllerTimer> createTimer(Function<void()>&&) final;
-    void startAnimationCallback(ScrollingEffectsController&) final;
-    void stopAnimationCallback(ScrollingEffectsController&) final;
+    void updateFromStateNode(const ScrollingStateScrollingNode&) final;
 
+    // ScrollingEffectsControllerClient.
     bool allowsHorizontalStretching(const PlatformWheelEvent&) const final;
     bool allowsVerticalStretching(const PlatformWheelEvent&) const final;
     IntSize stretchAmount() const final;
     bool isPinnedOnSide(BoxSide) const final;
-
     RectEdges<bool> edgePinnedState() const final;
-    bool allowsHorizontalScrolling() const final;
-    bool allowsVerticalScrolling() const final;
 
     bool shouldRubberBandOnSide(BoxSide) const final;
-    void immediateScrollBy(const FloatSize&, ScrollClamping = ScrollClamping::Clamped) final;
     void didStopRubberBandAnimation() final;
     void rubberBandingStateChanged(bool) final;
-    void adjustScrollPositionToBoundsIfNecessary() final;
-
     bool scrollPositionIsNotRubberbandingEdge(const FloatPoint&) const;
 
-    FloatPoint scrollOffset() const final;
-    float pageScaleFactor() const final;
-
-    void didStopAnimatedScroll() final;
-
-    void willStartScrollSnapAnimation() final;
-    void didStopScrollSnapAnimation() final;
-
-    ScrollExtents scrollExtents() const final;
-
     void releaseReferencesToScrollerImpsOnTheMainThread();
-
-    ScrollingEffectsController m_scrollController;
 
     RetainPtr<NSScrollerImp> m_verticalScrollerImp;
     RetainPtr<NSScrollerImp> m_horizontalScrollerImp;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -41,8 +41,7 @@
 namespace WebCore {
 
 ScrollingTreeScrollingNodeDelegateMac::ScrollingTreeScrollingNodeDelegateMac(ScrollingTreeScrollingNode& scrollingNode)
-    : ScrollingTreeScrollingNodeDelegate(scrollingNode)
-    , m_scrollController(*this)
+    : ThreadedScrollingTreeScrollingNodeDelegate(scrollingNode)
 {
 }
 
@@ -64,14 +63,7 @@ void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingS
         m_horizontalScrollerImp = scrollingStateNode.horizontalScrollerImp();
     }
 
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::SnapOffsetsInfo))
-        m_scrollController.setSnapOffsetsInfo(scrollingStateNode.snapOffsetsInfo().convertUnits<LayoutScrollSnapOffsetsInfo>());
-
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::CurrentHorizontalSnapOffsetIndex))
-        m_scrollController.setActiveScrollSnapIndexForAxis(ScrollEventAxis::Horizontal, scrollingStateNode.currentHorizontalSnapPointIndex());
-
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::CurrentVerticalSnapOffsetIndex))
-        m_scrollController.setActiveScrollSnapIndexForAxis(ScrollEventAxis::Vertical, scrollingStateNode.currentVerticalSnapPointIndex());
+    ThreadedScrollingTreeScrollingNodeDelegate::updateFromStateNode(scrollingStateNode);
 }
 
 std::optional<unsigned> ScrollingTreeScrollingNodeDelegateMac::activeScrollSnapIndexForAxis(ScrollEventAxis axis) const
@@ -112,19 +104,6 @@ bool ScrollingTreeScrollingNodeDelegateMac::handleWheelEvent(const PlatformWheel
         return true;
 
     return m_scrollController.handleWheelEvent(wheelEvent);
-}
-
-bool ScrollingTreeScrollingNodeDelegateMac::startAnimatedScrollToPosition(FloatPoint destinationPosition)
-{
-    auto currentOffset = ScrollableArea::scrollOffsetFromPosition(currentScrollPosition(), scrollOrigin());
-    auto destinationOffset = ScrollableArea::scrollOffsetFromPosition(destinationPosition, scrollOrigin());
-    
-    return m_scrollController.startAnimatedScrollToDestination(currentOffset, destinationOffset);
-}
-
-void ScrollingTreeScrollingNodeDelegateMac::stopAnimatedScroll()
-{
-    m_scrollController.stopAnimatedScroll();
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::willDoProgrammaticScroll(const FloatPoint& targetPosition)
@@ -184,30 +163,6 @@ bool ScrollingTreeScrollingNodeDelegateMac::isRubberBandInProgress() const
 bool ScrollingTreeScrollingNodeDelegateMac::isScrollSnapInProgress() const
 {
     return m_scrollController.isScrollSnapInProgress();
-}
-
-std::unique_ptr<ScrollingEffectsControllerTimer> ScrollingTreeScrollingNodeDelegateMac::createTimer(Function<void()>&& function)
-{
-    // This is only used for a scroll snap timer.
-    return WTF::makeUnique<ScrollingEffectsControllerTimer>(RunLoop::current(), [function = WTFMove(function), protectedNode = Ref { scrollingNode() }] {
-        Locker locker { protectedNode->scrollingTree().treeLock() };
-        function();
-    });
-}
-
-void ScrollingTreeScrollingNodeDelegateMac::startAnimationCallback(ScrollingEffectsController&)
-{
-    scrollingNode().setScrollAnimationInProgress(true);
-}
-
-void ScrollingTreeScrollingNodeDelegateMac::stopAnimationCallback(ScrollingEffectsController&)
-{
-    scrollingNode().setScrollAnimationInProgress(false);
-}
-
-void ScrollingTreeScrollingNodeDelegateMac::serviceScrollAnimation(MonotonicTime currentTime)
-{
-    m_scrollController.animationCallback(currentTime);
 }
 
 bool ScrollingTreeScrollingNodeDelegateMac::allowsHorizontalStretching(const PlatformWheelEvent& wheelEvent) const
@@ -302,16 +257,6 @@ RectEdges<bool> ScrollingTreeScrollingNodeDelegateMac::edgePinnedState() const
     return scrollingNode().edgePinnedState();
 }
 
-bool ScrollingTreeScrollingNodeDelegateMac::allowsHorizontalScrolling() const
-{
-    return ScrollingTreeScrollingNodeDelegate::allowsHorizontalScrolling();
-}
-
-bool ScrollingTreeScrollingNodeDelegateMac::allowsVerticalScrolling() const
-{
-    return ScrollingTreeScrollingNodeDelegate::allowsVerticalScrolling();
-}
-
 bool ScrollingTreeScrollingNodeDelegateMac::shouldRubberBandOnSide(BoxSide side) const
 {
     if (scrollingNode().isRootNode())
@@ -328,11 +273,6 @@ bool ScrollingTreeScrollingNodeDelegateMac::shouldRubberBandOnSide(BoxSide side)
     return true;
 }
 
-void ScrollingTreeScrollingNodeDelegateMac::immediateScrollBy(const FloatSize& delta, ScrollClamping clamping)
-{
-    scrollingNode().scrollBy(delta, clamping);
-}
-
 void ScrollingTreeScrollingNodeDelegateMac::didStopRubberBandAnimation()
 {
     // Since the rubberband timer has stopped, totalContentsSizeForRubberBand can be synchronized with totalContentsSize.
@@ -342,51 +282,6 @@ void ScrollingTreeScrollingNodeDelegateMac::didStopRubberBandAnimation()
 void ScrollingTreeScrollingNodeDelegateMac::rubberBandingStateChanged(bool inRubberBand)
 {
     scrollingTree().setRubberBandingInProgressForNode(scrollingNode().scrollingNodeID(), inRubberBand);
-}
-
-void ScrollingTreeScrollingNodeDelegateMac::adjustScrollPositionToBoundsIfNecessary()
-{
-    FloatPoint scrollPosition = currentScrollPosition();
-    FloatPoint constrainedPosition = scrollPosition.constrainedBetween(minimumScrollPosition(), maximumScrollPosition());
-    immediateScrollBy(constrainedPosition - scrollPosition);
-}
-
-FloatPoint ScrollingTreeScrollingNodeDelegateMac::scrollOffset() const
-{
-    return ScrollableArea::scrollOffsetFromPosition(currentScrollPosition(), scrollOrigin());
-}
-
-float ScrollingTreeScrollingNodeDelegateMac::pageScaleFactor() const
-{
-    // FIXME: What should this return for non-root frames, and overflow?
-    // Also, this should not have to access ScrollingTreeFrameScrollingNode.
-    if (is<ScrollingTreeFrameScrollingNode>(scrollingNode()))
-        return downcast<ScrollingTreeFrameScrollingNode>(scrollingNode()).frameScaleFactor();
-
-    return 1;
-}
-
-void ScrollingTreeScrollingNodeDelegateMac::didStopAnimatedScroll()
-{
-    scrollingNode().didStopAnimatedScroll();
-}
-
-void ScrollingTreeScrollingNodeDelegateMac::willStartScrollSnapAnimation()
-{
-    scrollingNode().setScrollSnapInProgress(true);
-}
-
-void ScrollingTreeScrollingNodeDelegateMac::didStopScrollSnapAnimation()
-{
-    scrollingNode().setScrollSnapInProgress(false);
-}
-    
-ScrollExtents ScrollingTreeScrollingNodeDelegateMac::scrollExtents() const
-{
-    return {
-        scrollingNode().totalContentsSize(),
-        scrollingNode().scrollableAreaSize()
-    };
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::deferWheelEventTestCompletionForReason(WheelEventTestMonitor::ScrollableAreaIdentifier identifier, WheelEventTestMonitor::DeferReason reason) const

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp
@@ -89,18 +89,12 @@ void ScrollingTreeFrameScrollingNodeNicosia::commitStateBeforeChildren(const Scr
         m_footerLayer = downcast<Nicosia::CompositionLayer>(layer);
     }
 
-    delegate().updateFromStateNode(scrollingStateNode);
+    m_delegate->updateFromStateNode(scrollingStateNode);
 }
 
 WheelEventHandlingResult ScrollingTreeFrameScrollingNodeNicosia::handleWheelEvent(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting)
 {
     return delegate().handleWheelEvent(wheelEvent, eventTargeting);
-}
-
-FloatPoint ScrollingTreeFrameScrollingNodeNicosia::adjustedScrollPosition(const FloatPoint& position, ScrollClamping clamping) const
-{
-    FloatPoint scrollPosition(roundf(position.x()), roundf(position.y()));
-    return ScrollingTreeFrameScrollingNode::adjustedScrollPosition(scrollPosition, clamping);
 }
 
 void ScrollingTreeFrameScrollingNodeNicosia::currentScrollPositionChanged(ScrollType scrollType, ScrollingLayerPositionAction action)

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.h
@@ -56,7 +56,6 @@ private:
     void commitStateBeforeChildren(const ScrollingStateNode&) override;
 
     WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting) override;
-    FloatPoint adjustedScrollPosition(const FloatPoint&, ScrollClamping) const override;
     void currentScrollPositionChanged(ScrollType, ScrollingLayerPositionAction) override;
     void repositionScrollingLayers() override;
     void repositionRelatedLayers() override;

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp
@@ -33,6 +33,7 @@
 
 #include "NicosiaPlatformLayer.h"
 #include "ScrollingTreeScrollingNodeDelegateNicosia.h"
+#include "ThreadedScrollingTree.h"
 
 namespace WebCore {
 
@@ -54,10 +55,10 @@ ScrollingTreeScrollingNodeDelegateNicosia& ScrollingTreeOverflowScrollingNodeNic
     return *static_cast<ScrollingTreeScrollingNodeDelegateNicosia*>(m_delegate.get());
 }
 
-FloatPoint ScrollingTreeOverflowScrollingNodeNicosia::adjustedScrollPosition(const FloatPoint& position, ScrollClamping clamping) const
+void ScrollingTreeOverflowScrollingNodeNicosia::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    FloatPoint scrollPosition(roundf(position.x()), roundf(position.y()));
-    return ScrollingTreeOverflowScrollingNode::adjustedScrollPosition(scrollPosition, clamping);
+    ScrollingTreeOverflowScrollingNode::commitStateBeforeChildren(stateNode);
+    m_delegate->updateFromStateNode(downcast<ScrollingStateScrollingNode>(stateNode));
 }
 
 void ScrollingTreeOverflowScrollingNodeNicosia::repositionScrollingLayers()

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.h
@@ -46,7 +46,7 @@ private:
 
     ScrollingTreeScrollingNodeDelegateNicosia& delegate() const;
 
-    FloatPoint adjustedScrollPosition(const FloatPoint&, ScrollClamping) const override;
+    void commitStateBeforeChildren(const ScrollingStateNode&) override;
     void repositionScrollingLayers() override;
     WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting) override;
 };

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp
@@ -30,37 +30,17 @@
 #if ENABLE(ASYNC_SCROLLING) && USE(NICOSIA)
 
 #include "NicosiaPlatformLayer.h"
-#include "ScrollExtents.h"
 #include "ScrollingTreeFrameScrollingNode.h"
 
-#if USE(GLIB_EVENT_LOOP)
-#include <wtf/glib/RunLoopSourcePriority.h>
-#endif
-
 namespace WebCore {
-class ScrollAnimation;
-class ScrollAnimationKinetic;
 
 ScrollingTreeScrollingNodeDelegateNicosia::ScrollingTreeScrollingNodeDelegateNicosia(ScrollingTreeScrollingNode& scrollingNode, bool scrollAnimatorEnabled)
-    : ScrollingTreeScrollingNodeDelegate(scrollingNode)
-    , m_scrollController(*this)
+    : ThreadedScrollingTreeScrollingNodeDelegate(scrollingNode)
     , m_scrollAnimatorEnabled(scrollAnimatorEnabled)
 {
 }
 
 ScrollingTreeScrollingNodeDelegateNicosia::~ScrollingTreeScrollingNodeDelegateNicosia() = default;
-
-void ScrollingTreeScrollingNodeDelegateNicosia::updateFromStateNode(const ScrollingStateScrollingNode& scrollingStateNode)
-{
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::SnapOffsetsInfo))
-        m_scrollController.setSnapOffsetsInfo(scrollingStateNode.snapOffsetsInfo().convertUnits<LayoutScrollSnapOffsetsInfo>());
-
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::CurrentHorizontalSnapOffsetIndex))
-        m_scrollController.setActiveScrollSnapIndexForAxis(ScrollEventAxis::Horizontal, scrollingStateNode.currentHorizontalSnapPointIndex());
-
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::CurrentVerticalSnapOffsetIndex))
-        m_scrollController.setActiveScrollSnapIndexForAxis(ScrollEventAxis::Vertical, scrollingStateNode.currentVerticalSnapPointIndex());
-}
 
 std::unique_ptr<Nicosia::SceneIntegration::UpdateScope> ScrollingTreeScrollingNodeDelegateNicosia::createUpdateScope()
 {
@@ -90,99 +70,10 @@ WheelEventHandlingResult ScrollingTreeScrollingNodeDelegateNicosia::handleWheelE
     return handled ? WheelEventHandlingResult::handled() : WheelEventHandlingResult::unhandled();
 }
 
-std::unique_ptr<ScrollingEffectsControllerTimer> ScrollingTreeScrollingNodeDelegateNicosia::createTimer(Function<void()>&& function)
-{
-    return makeUnique<ScrollingEffectsControllerTimer>(RunLoop::current(), [function = WTFMove(function), protectedNode = Ref { scrollingNode() }] {
-        Locker locker { protectedNode->scrollingTree().treeLock() };
-        function();
-    });
-}
-
-void ScrollingTreeScrollingNodeDelegateNicosia::startAnimationCallback(ScrollingEffectsController&)
-{
-    scrollingNode().setScrollAnimationInProgress(true);
-}
-
-void ScrollingTreeScrollingNodeDelegateNicosia::stopAnimationCallback(ScrollingEffectsController&)
-{
-    scrollingNode().setScrollAnimationInProgress(false);
-}
-
-void ScrollingTreeScrollingNodeDelegateNicosia::serviceScrollAnimation(MonotonicTime currentTime)
-{
-    m_scrollController.animationCallback(currentTime);
-}
-
-bool ScrollingTreeScrollingNodeDelegateNicosia::allowsHorizontalScrolling() const
-{
-    return ScrollingTreeScrollingNodeDelegate::allowsHorizontalScrolling();
-}
-
-bool ScrollingTreeScrollingNodeDelegateNicosia::allowsVerticalScrolling() const
-{
-    return ScrollingTreeScrollingNodeDelegate::allowsVerticalScrolling();
-}
-
 void ScrollingTreeScrollingNodeDelegateNicosia::immediateScrollBy(const FloatSize& delta, ScrollClamping clamping)
 {
     auto updateScope = createUpdateScope();
-    scrollingNode().scrollBy(delta, clamping);
-}
-
-void ScrollingTreeScrollingNodeDelegateNicosia::adjustScrollPositionToBoundsIfNecessary()
-{
-    FloatPoint scrollPosition = currentScrollPosition();
-    FloatPoint constrainedPosition = scrollPosition.constrainedBetween(minimumScrollPosition(), maximumScrollPosition());
-    immediateScrollBy(constrainedPosition - scrollPosition);
-}
-
-FloatPoint ScrollingTreeScrollingNodeDelegateNicosia::scrollOffset() const
-{
-    return ScrollableArea::scrollOffsetFromPosition(currentScrollPosition(), scrollOrigin());
-}
-
-void ScrollingTreeScrollingNodeDelegateNicosia::willStartScrollSnapAnimation()
-{
-    scrollingNode().setScrollSnapInProgress(true);
-}
-
-void ScrollingTreeScrollingNodeDelegateNicosia::didStopScrollSnapAnimation()
-{
-    scrollingNode().setScrollSnapInProgress(false);
-}
-
-void ScrollingTreeScrollingNodeDelegateNicosia::didStopAnimatedScroll()
-{
-    scrollingNode().didStopAnimatedScroll();
-}
-
-float ScrollingTreeScrollingNodeDelegateNicosia::pageScaleFactor() const
-{
-    // FIXME: What should this return for non-root frames, and overflow?
-    // Also, this should not have to access ScrollingTreeFrameScrollingNode.
-    return is<ScrollingTreeFrameScrollingNode>(scrollingNode()) ?
-        downcast<ScrollingTreeFrameScrollingNode>(scrollingNode()).frameScaleFactor() : 1.;
-}
-
-ScrollExtents ScrollingTreeScrollingNodeDelegateNicosia::scrollExtents() const
-{
-    return {
-        scrollingNode().totalContentsSize(),
-        scrollingNode().scrollableAreaSize()
-    };
-}
-
-bool ScrollingTreeScrollingNodeDelegateNicosia::startAnimatedScrollToPosition(FloatPoint destinationPosition)
-{
-    auto currentOffset = ScrollableArea::scrollOffsetFromPosition(currentScrollPosition(), scrollOrigin());
-    auto destinationOffset = ScrollableArea::scrollOffsetFromPosition(destinationPosition, scrollOrigin());
-    
-    return m_scrollController.startAnimatedScrollToDestination(currentOffset, destinationOffset);
-}
-
-void ScrollingTreeScrollingNodeDelegateNicosia::stopAnimatedScroll()
-{
-    m_scrollController.stopAnimatedScroll();
+    ThreadedScrollingTreeScrollingNodeDelegate::immediateScrollBy(delta, clamping);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.h
@@ -30,57 +30,24 @@
 
 #if ENABLE(ASYNC_SCROLLING) && USE(NICOSIA)
 
-#include "NicosiaPlatformLayer.h"
-#include "ScrollingEffectsController.h"
-#include "ScrollingStateOverflowScrollingNode.h"
-#include "ThreadedScrollingTree.h"
-#include <wtf/RunLoop.h>
+#include "ThreadedScrollingTreeScrollingNodeDelegate.h"
 
 namespace WebCore {
 
-class ScrollingTreeScrollingNodeDelegateNicosia : public ScrollingTreeScrollingNodeDelegate, public ScrollingEffectsControllerClient {
+class ScrollingTreeScrollingNodeDelegateNicosia final : public ThreadedScrollingTreeScrollingNodeDelegate {
 public:
     explicit ScrollingTreeScrollingNodeDelegateNicosia(ScrollingTreeScrollingNode&, bool scrollAnimatorEnabled);
     virtual ~ScrollingTreeScrollingNodeDelegateNicosia();
 
-    void updateFromStateNode(const ScrollingStateScrollingNode&);
     std::unique_ptr<Nicosia::SceneIntegration::UpdateScope> createUpdateScope();
     void updateVisibleLengths();
     WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting);
 
-    // ScrollingTreeScrollingNodeDelegate
-    bool startAnimatedScrollToPosition(FloatPoint) final;
-    void stopAnimatedScroll() final;
-
-    void serviceScrollAnimation(MonotonicTime) final;
-
 private:
     // ScrollingEffectsControllerClient.
-    std::unique_ptr<ScrollingEffectsControllerTimer> createTimer(Function<void()>&&) final;
-
-    void startAnimationCallback(ScrollingEffectsController&) final;
-    void stopAnimationCallback(ScrollingEffectsController&) final;
-
-    bool allowsHorizontalScrolling() const final;
-    bool allowsVerticalScrolling() const final;
-
     void immediateScrollBy(const FloatSize&, ScrollClamping = ScrollClamping::Clamped) final;
 
-    void adjustScrollPositionToBoundsIfNecessary() final;
-
-    FloatPoint scrollOffset() const final;
-
-    void willStartScrollSnapAnimation() final;
-    void didStopScrollSnapAnimation() final;
-
-    void didStopAnimatedScroll() final;
-
-    float pageScaleFactor() const final;
-    ScrollExtents scrollExtents() const final;
-
     bool scrollAnimationEnabled() const final { return m_scrollAnimatorEnabled; }
-
-    ScrollingEffectsController m_scrollController;
 
     bool m_scrollAnimatorEnabled { false };
 };


### PR DESCRIPTION
#### fb5313470cebe40287dcdc72ce2664ad2c3f76ed
<pre>
AsyncScrolling: add ThreadedScrollingTreeScrollingNodeDelegate
<a href="https://bugs.webkit.org/show_bug.cgi?id=246212">https://bugs.webkit.org/show_bug.cgi?id=246212</a>

Reviewed by Simon Fraser.

Make mac and nicosia delegates inherit from
ThreadedScrollingTreeScrollingNodeDelegate and move the common code to
the base class.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::adjustedScrollPosition const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::updateFromStateNode):
(WebCore::ScrollingTreeScrollingNodeDelegate::adjustedScrollPosition const):
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp: Copied from Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp.
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::ThreadedScrollingTreeScrollingNodeDelegate):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::updateFromStateNode):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::startAnimatedScrollToPosition):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::stopAnimatedScroll):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::serviceScrollAnimation):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::createTimer):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::startAnimationCallback):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::stopAnimationCallback):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::allowsHorizontalScrolling const):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::allowsVerticalScrolling const):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::immediateScrollBy):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::adjustScrollPositionToBoundsIfNecessary):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::scrollOffset const):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::pageScaleFactor const):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::didStopAnimatedScroll):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::willStartScrollSnapAnimation):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::didStopScrollSnapAnimation):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::scrollExtents const):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::deferWheelEventTestCompletionForReason const):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::removeWheelEventTestCompletionDeferralForReason const):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::adjustedScrollPosition const):
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h: Added.
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
(WebCore::ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren):
(WebCore::ScrollingTreeFrameScrollingNodeMac::willDoProgrammaticScroll):
(WebCore::ScrollingTreeFrameScrollingNodeMac::adjustedScrollPosition const): Deleted.
* Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm:
(WebCore::ScrollingTreeOverflowScrollingNodeMac::commitStateBeforeChildren):
(WebCore::ScrollingTreeOverflowScrollingNodeMac::adjustedScrollPosition const): Deleted.
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::ScrollingTreeScrollingNodeDelegateMac):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::startAnimatedScrollToPosition): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::stopAnimatedScroll): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::createTimer): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::startAnimationCallback): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::stopAnimationCallback): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::serviceScrollAnimation): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::allowsHorizontalScrolling const): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::allowsVerticalScrolling const): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::immediateScrollBy): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::adjustScrollPositionToBoundsIfNecessary): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::scrollOffset const): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::pageScaleFactor const): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::didStopAnimatedScroll): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::willStartScrollSnapAnimation): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::didStopScrollSnapAnimation): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateMac::scrollExtents const): Deleted.
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp:
(WebCore::ScrollingTreeFrameScrollingNodeNicosia::commitStateBeforeChildren):
(WebCore::ScrollingTreeFrameScrollingNodeNicosia::adjustedScrollPosition const): Deleted.
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.h:
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp:
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::commitStateBeforeChildren):
(WebCore::ScrollingTreeOverflowScrollingNodeNicosia::adjustedScrollPosition const): Deleted.
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.h:
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp:
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::ScrollingTreeScrollingNodeDelegateNicosia):
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::immediateScrollBy):
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::updateFromStateNode): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::createTimer): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::startAnimationCallback): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::stopAnimationCallback): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::serviceScrollAnimation): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::allowsHorizontalScrolling const): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::allowsVerticalScrolling const): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::adjustScrollPositionToBoundsIfNecessary): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::scrollOffset const): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::willStartScrollSnapAnimation): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::didStopScrollSnapAnimation): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::didStopAnimatedScroll): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::pageScaleFactor const): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::scrollExtents const): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::startAnimatedScrollToPosition): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::stopAnimatedScroll): Deleted.
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.h:

Canonical link: <a href="https://commits.webkit.org/255379@main">https://commits.webkit.org/255379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd2b760e963a1767c305c00394d40cb04350522e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101991 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162275 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1429 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29828 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84644 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98157 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97859 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78726 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27877 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70915 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36250 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16469 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34006 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17632 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3729 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40268 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36767 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->