### PR TITLE
Make use of crc32c to compute dcsctp checksum

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/net/dcsctp/packet/crc32c.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/net/dcsctp/packet/crc32c.cc
@@ -14,7 +14,7 @@
 #if !defined(WEBRTC_WEBKIT_BUILD)
 #include "third_party/crc32c/src/include/crc32c/crc32c.h"
 #else
-#include "rtc_base/crc32.h"
+#include "third_party/usrsctp/usrsctplib/usrsctplib/usrsctp.h"
 #endif
 
 namespace dcsctp {
@@ -23,7 +23,7 @@ uint32_t GenerateCrc32C(rtc::ArrayView<const uint8_t> data) {
 #if !defined(WEBRTC_WEBKIT_BUILD)
   uint32_t crc32c = crc32c_value(data.data(), data.size());
 #else
-  uint32_t crc32c = rtc::ComputeCrc32(data.data(), data.size());
+  uint32_t crc32c = usrsctp_crc32c(const_cast<uint8_t*>(data.data()), data.size());
 #endif
 
   // Byte swapping for little endian byte order:


### PR DESCRIPTION
#### 1838474d9060170ca0e497b82dacf5707b30fc90
<pre>
Make use of crc32c to compute dcsctp checksum
<a href="https://bugs.webkit.org/show_bug.cgi?id=246213">https://bugs.webkit.org/show_bug.cgi?id=246213</a>
rdar://100872064

Reviewed by Geoff Garen.

We were using the internal crc32 routine but crc32c should be used for SCTP,
as per <a href="https://www.rfc-editor.org/rfc/rfc4960#section-6.8.">https://www.rfc-editor.org/rfc/rfc4960#section-6.8.</a>
We therefore now use usrsctp crc32c routine.

Manually tested.

* Source/ThirdParty/libwebrtc/Source/webrtc/net/dcsctp/packet/crc32c.cc:

Canonical link: <a href="https://commits.webkit.org/255285@main">https://commits.webkit.org/255285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bce0865db1da668447633accaceb77a020846c99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/91991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101804 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1230 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84456 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97649 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78540 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27707 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82680 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36079 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33818 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3655 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37695 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36532 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->