### PR TITLE
[GTK] D-Bus proxy quietly fails if host bus address is not mounted in xdg-dbus-proxy's sandbox

### DIFF
--- a/Source/WTF/wtf/glib/Sandbox.cpp
+++ b/Source/WTF/wtf/glib/Sandbox.cpp
@@ -60,4 +60,15 @@ bool shouldUsePortal()
     return returnValue;
 }
 
+String& sandboxedAccessibilityBusAddress()
+{
+    static String accessibilityBusAddress;
+    return accessibilityBusAddress;
+}
+
+void setSandboxedAccessibilityBusAddress(String&& address)
+{
+    sandboxedAccessibilityBusAddress() = address;
+}
+
 } // namespace WTF

--- a/Source/WTF/wtf/glib/Sandbox.h
+++ b/Source/WTF/wtf/glib/Sandbox.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <wtf/text/WTFString.h>
+
 namespace WTF {
 
 WTF_EXPORT_PRIVATE bool isInsideFlatpak();
@@ -26,9 +28,15 @@ WTF_EXPORT_PRIVATE bool isInsideDocker();
 WTF_EXPORT_PRIVATE bool isInsideSnap();
 WTF_EXPORT_PRIVATE bool shouldUsePortal();
 
+WTF_EXPORT_PRIVATE String& sandboxedAccessibilityBusAddress();
+WTF_EXPORT_PRIVATE void setSandboxedAccessibilityBusAddress(String&&);
+
 } // namespace WTF
 
 using WTF::isInsideFlatpak;
 using WTF::isInsideDocker;
 using WTF::isInsideSnap;
 using WTF::shouldUsePortal;
+
+using WTF::sandboxedAccessibilityBusAddress;
+using WTF::setSandboxedAccessibilityBusAddress;

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -105,7 +105,6 @@ public:
 #endif
 
 #if USE(ATSPI)
-    void setAccessibilityBusAddress(String&& address) { m_accessibilityBusAddress = WTFMove(address); }
     const String& accessibilityBusAddress() const;
 #endif
 

--- a/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h
+++ b/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.h
@@ -41,14 +41,13 @@ public:
     ~XDGDBusProxy() = default;
 
     enum class AllowPortals : bool { No, Yes };
-    std::optional<CString> dbusSessionProxy(AllowPortals);
-    std::optional<CString> accessibilityProxy(const char* sandboxedAccessibilityBusPath);
+    std::optional<CString> dbusSessionProxy(const char* baseDirectory, AllowPortals);
+    std::optional<CString> accessibilityProxy(const char* baseDirectory, const char* sandboxedAccessibilityBusPath);
 
     bool launch();
 
 private:
-    static CString makePath(const char* dbusAddress);
-    static CString makeProxy(const char* proxyTemplate);
+    static CString makeProxy(const char* baseDirectory, const char* proxyTemplate);
 
     Vector<CString> m_args;
     CString m_dbusSessionProxyPath;

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -34,6 +34,7 @@
 #include "WebProcessCreationParameters.h"
 #include <WebCore/PlatformDisplay.h>
 #include <wtf/FileSystem.h>
+#include <wtf/glib/Sandbox.h>
 
 #if ENABLE(REMOTE_INSPECTOR)
 #include <JavaScriptCore/RemoteInspector.h>
@@ -119,8 +120,18 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 #endif
 
 #if USE(ATSPI)
-    static const char* accessibilityBusAddress = getenv("WEBKIT_A11Y_BUS_ADDRESS");
-    parameters.accessibilityBusAddress = accessibilityBusAddress ? String::fromUTF8(accessibilityBusAddress) : WebCore::PlatformDisplay::sharedDisplay().accessibilityBusAddress();
+    parameters.accessibilityBusAddress = [this] {
+        if (auto* address = getenv("WEBKIT_A11Y_BUS_ADDRESS"))
+            return String::fromUTF8(address);
+
+        if (m_sandboxEnabled) {
+            String& address = sandboxedAccessibilityBusAddress();
+            if (!address.isNull())
+                return address;
+        }
+
+        return WebCore::PlatformDisplay::sharedDisplay().accessibilityBusAddress();
+    }();
 #endif
 
 #if PLATFORM(GTK)


### PR DESCRIPTION
#### 67cda4acff9b343c48a2b24c326a2be08642ccee
<pre>
[GTK] D-Bus proxy quietly fails if host bus address is not mounted in xdg-dbus-proxy&apos;s sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=246159">https://bugs.webkit.org/show_bug.cgi?id=246159</a>

Reviewed by Carlos Garcia Campos.

D-Bus 1.15.2 has changed the default session bus address to a filesystem
socket that lives under /tmp. However, our xdg-dbus-proxy cannot access
this location because we assume the session bus socket will always be
mounted under /run, since that&apos;s where all major distros put it. It&apos;s OK
to be flexible and mount absolutely any directory, whatever it may be,
since we&apos;re not actually trying to create a sandbox that the
xdg-dbus-proxy cannot break out of. It&apos;s a trusted process, and the
sandbox exists solely so that portals can verify the app ID of the
process that is using the proxy, which is done by inspecting
/.flatpak-info in its mount namespace&apos;s filesystem root. So let&apos;s mount
whatever directory is in use and move on. Credit to oreo639 for
investigating the problem and proposing a fix in WebKit#5011.

The a11y bus has the same theoretical problem, although it&apos;s not an
issue today because currently it will always be under /run in
practice. Still, we should fix it. There is one complication:
PlatformDisplay currently uses just one variable for both the host a11y
bus address and the proxy bus address, relying on XDGDBusProxy to change
it from the host address to the proxy address. This is fragile and it&apos;s
easier to fix it than to work around it by caching the value before it
changes, so at Carlos&apos;s suggestion, I have removed the ability to
overwrite the value in PlatformDisplay, and added a separate variable to
track the proxy address in WTF&apos;s Sandbox helpers.

I have snuck in a drive-by cleanup to avoid duplicating BASE_DIRECTORY
between two files, a problem that I introduced in 255218@main.
Additionally, I remove a stale declaration for XDGDBusProxy::makePath,
which I forgot to delete after removing the function in the same commit.

Finally, always add the extra sandbox paths to the sandbox. These were
originally extra paths for the web process only, but changed to be extra
paths for both web process and D-Bus proxy. It&apos;s no longer needed except
for the web process, but there&apos;s no particular reason to limit it
either. I&apos;m changing this here only because it&apos;s right next to the code
I&apos;m editing anyway, and it&apos;s odd to be adding extra sandbox paths
specifically for the D-Bus proxy process.

Canonical link: <a href="https://commits.webkit.org/255530@main">https://commits.webkit.org/255530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14ccf3e88d44de3761eb1e9dabe7f156cd62d263

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102570 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2058 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30397 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85246 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98507 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79333 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84190 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36801 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79244 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34601 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27452 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3831 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38471 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81872 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37309 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18514 "Passed tests") | 
<!--EWS-Status-Bubble-End-->