### PR TITLE
Cross-Origin-Embedder-Policy incorrectly blocks scripts on cache hit

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-worker-script-revalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-worker-script-revalidation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS COEP: require-corp with revalidated worker script
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-worker-script-revalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-worker-script-revalidation.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<title>COEP and dedicated worker</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/worker-support.js"></script>
+<body>
+<script>
+
+promise_test(async (t) => {
+  const worker1 = new Worker("/html/cross-origin-embedder-policy/resources/dedicated-worker-supporting-revalidation.py");
+  worker1.onerror = t.unreached_func('Worker.onerror should not be called for first worker');
+  worker1.postMessage("foo");
+  const result1 = await waitForMessage(worker1);
+  assert_equals(result1.data, 'LOADED');
+
+  // Load the worker a second time, which should trigger revalidation of the cached resource.
+  const worker2 = new Worker("/html/cross-origin-embedder-policy/resources/dedicated-worker-supporting-revalidation.py");
+  worker2.onerror = t.unreached_func('Worker.onerror should not be called worker second worker');
+  worker2.postMessage("foo");
+  const result2 = await waitForMessage(worker2);
+  assert_equals(result2.data, 'LOADED');
+}, 'COEP: require-corp with revalidated worker script');
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/resources/dedicated-worker-supporting-revalidation.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/resources/dedicated-worker-supporting-revalidation.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+
+def main(request, response):
+    headers = []
+    if request.headers.get(b'if-none-match', None):
+        status = 304, u"Not Modified"
+        return status, headers, u""
+    else:
+        headers.append((b"Content-Type", b"text/javascript"))
+        headers.append((b"Cross-Origin-Embedder-Policy", b"require-corp"))
+        headers.append((b"Cache-Control", b"private, max-age=0, must-revalidate"))
+        headers.append((b"ETag", b"abcdef"))
+        status = 200, u"OK"
+        return status, headers, u"self.onmessage = (e) => { self.postMessage('LOADED'); };"

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -855,6 +855,9 @@ void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedRespon
                 auto crossOriginResourcePolicy = m_cacheEntryForValidation->response().httpHeaderField(HTTPHeaderName::CrossOriginResourcePolicy);
                 if (!crossOriginResourcePolicy.isEmpty())
                     m_response.setHTTPHeaderField(HTTPHeaderName::CrossOriginResourcePolicy, crossOriginResourcePolicy);
+                auto crossOriginEmbedderPolicy = m_cacheEntryForValidation->response().httpHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicy);
+                if (!crossOriginEmbedderPolicy.isEmpty())
+                    m_response.setHTTPHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicy, crossOriginEmbedderPolicy);
                 m_cacheEntryForValidation = nullptr;
             }
         } else


### PR DESCRIPTION
#### 126473bd1f9b742a3748fac9d58549504db485d0
<pre>
Cross-Origin-Embedder-Policy incorrectly blocks scripts on cache hit
<a href="https://bugs.webkit.org/show_bug.cgi?id=245346">https://bugs.webkit.org/show_bug.cgi?id=245346</a>
rdar://100389164

Reviewed by Brent Fulgham.

* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-worker-script-revalidation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-worker-script-revalidation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/resources/dedicated-worker-supporting-revalidation.py: Added.
(main):
Add WPT test coverage (which I will upstream).

* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::shouldInterruptWorkerLoadForCrossOriginEmbedderPolicy):
(WebKit::NetworkResourceLoader::didReceiveResponse):
If the response is a 304 revalidation response, make sure we get its COEP header from the cached
response to avoid blocking by the COEP logic. This is similar to what we were already doing for
the CORP header.

Canonical link: <a href="https://commits.webkit.org/255302@main">https://commits.webkit.org/255302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc18ae57110b1e4eb4df85b4e3754b4c08c6136d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101835 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161902 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1265 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29686 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98025 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/786 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78571 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27733 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82708 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36108 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16329 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33851 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17431 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3676 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37726 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36556 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->