### PR TITLE
A/B test results should only highlight when p-value <= 0.05

### DIFF
--- a/Websites/perf.webkit.org/public/v3/models/test-group.js
+++ b/Websites/perf.webkit.org/public/v3/models/test-group.js
@@ -217,20 +217,20 @@ class TestGroup extends LabeledObject {
             result.changeType = summary.changeType;
             result.label = summary.changeLabel;
 
-
-            const constructSignificanceLabel = (probabilityRange) => !!probabilityRange.range[0] ? `significant with ${(probabilityRange.range[0] * 100).toFixed()}% probability` : 'insignificant';
+            const isStatisticallySignificant = (probabilityRange) => probabilityRange && probabilityRange.range && probabilityRange.range[0] && probabilityRange.range[0] >= 0.95;
+            const constructSignificanceLabel = (probabilityRange) => isStatisticallySignificant(probabilityRange) ? `significant with ${(probabilityRange.range[0] * 100).toFixed()}% probability` : 'insignificant';
 
             const probabilityRangeForMean = Statistics.probabilityRangeForWelchsT(beforeValues, afterValues);
             const significanceLabelForMean = constructSignificanceLabel(probabilityRangeForMean);
             result.fullLabelForMean = `${result.label} (${significanceLabelForMean})`;
-            result.isStatisticallySignificantForMean = !!probabilityRangeForMean.range[0];
+            result.isStatisticallySignificantForMean = isStatisticallySignificant(probabilityRangeForMean);
             result.probabilityRangeForMean = probabilityRangeForMean.range;
 
             const adaptMeasurementToSamples = (measurement) => ({sum: measurement.sum, squareSum: measurement.squareSum, sampleSize: measurement.iterationCount});
             const probabilityRangeForIndividual = Statistics.probabilityRangeForWelchsTForMultipleSamples(beforeMeasurements.map(adaptMeasurementToSamples), afterMeasurements.map(adaptMeasurementToSamples));
             const significanceLabelForIndividual = constructSignificanceLabel(probabilityRangeForIndividual);
             result.fullLabelForIndividual = `${result.label} (${significanceLabelForIndividual})`;
-            result.isStatisticallySignificantForIndividual = !!probabilityRangeForIndividual.range[0];
+            result.isStatisticallySignificantForIndividual = isStatisticallySignificant(probabilityRangeForIndividual.range[0]);
             result.probabilityRangeForIndividual = probabilityRangeForIndividual.range;
 
             if (hasCompleted)


### PR DESCRIPTION
#### c616083bd1a52f9aa4df6b45bc5beb85388d1dc8
<pre>
A/B test results should only highlight when p-value &lt;= 0.05
<a href="https://bugs.webkit.org/show_bug.cgi?id=246224">https://bugs.webkit.org/show_bug.cgi?id=246224</a>
rdar://100648227

Reviewed by Ryosuke Niwa.

Engineers uses p-value &lt;= 0.05 to consider an A/B test result to be significant.
Update the UI to match this behavior.

* Websites/perf.webkit.org/public/v3/models/test-group.js:
(TestGroup._computeRequestedCommitSets):

Canonical link: <a href="https://commits.webkit.org/255351@main">https://commits.webkit.org/255351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4e1a52584d6b45e81299a76fe3731b8318a4f89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101975 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1413 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29811 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84628 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98141 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/918 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78710 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27866 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70907 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36234 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16459 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17619 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3697 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40256 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1670 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36753 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->