### PR TITLE
[run-webkit-tests] Support user specifying variant directly

### DIFF
--- a/Tools/Scripts/webkitpy/common/find_files.py
+++ b/Tools/Scripts/webkitpy/common/find_files.py
@@ -73,13 +73,21 @@ def _normalized_find(filesystem, paths, skipped_directories, file_filter, direct
           Glob patterns are ok.
     """
 
-    def sort_by_directory_key(files_list):
-        if not directory_sort_key:
-            return files_list[:]
+    sort_fn = (lambda lst: sorted(lst, key=directory_sort_key)) if directory_sort_key else (lambda lst: lst[:])
 
-        return sorted(files_list, key=directory_sort_key)
+    def sorted_paths_generator(path, function):
+        base_path, separator, variant = path.partition('?')
+        if not separator:
+            return sort_fn(function(base_path))
+        # This isn't perfect, you won't be able glob the variant parts of the test name,
+        # but this is ultimately a design flaw stemming from a layout test not being a file
+        result = ['{}{}{}'.format(part, separator, variant) for part in function(base_path)]
+        if result:
+            return sort_fn(result)
+        return sort_fn(function(path))
 
-    paths_to_walk = itertools.chain(*(sort_by_directory_key(filesystem.glob(path)) for path in paths))
-
-    all_files = itertools.chain(*(sort_by_directory_key(filesystem.files_under(path, skipped_directories, file_filter)) for path in paths_to_walk))
+    paths_to_walk = itertools.chain(*(sorted_paths_generator(path, filesystem.glob) for path in paths))
+    all_files = itertools.chain(*(sorted_paths_generator(
+        path, lambda p: filesystem.files_under(p, skipped_directories, file_filter),
+    ) for path in paths_to_walk))
     return all_files

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
@@ -148,6 +148,7 @@ class LayoutTestFinder(object):
             if ".any." not in f:
                 expanded.append(f)
                 continue
+            f, variant_separator, passed_variant = f.partition('?')
             opened_file = fs.open_text_file_for_reading(f)
             try:
                 first_line = opened_file.readline()
@@ -164,7 +165,8 @@ class LayoutTestFinder(object):
                         variants.append(variant)
                 if variants:
                     for variant in variants:
-                        expanded.append(f + variant)
+                        if not passed_variant or variant.startswith(variant_separator + passed_variant):
+                            expanded.append(f + variant)
                 else:
                     expanded.append(f)
             except UnicodeDecodeError:

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py
@@ -197,6 +197,11 @@ class LayoutTestFinderTests(unittest.TestCase, TestCaseMixin):
         tests = [t.test_path for t in finder.find_tests_by_path(['failures/expected/i[m]age.html'])]
         self.assertEqual(tests, ['failures/expected/image.html'])
 
+    def test_find_glob_query(self):
+        finder = self.finder
+        tests = [t.test_path for t in finder.find_tests_by_path(['failures/expected/image.html?variant'])]
+        self.assertEqual(tests, ['failures/expected/image.html?variant'])
+
     def test_find_glob_mixed_file_type_sorted(self):
         finder = self.finder
         # this should expand the *, sort the result, then recurse;


### PR DESCRIPTION
#### f8b4d273d3df3adce27c788f8ee7c58d776f5921
<pre>
[run-webkit-tests] Support user specifying variant directly
<a href="https://bugs.webkit.org/show_bug.cgi?id=246228">https://bugs.webkit.org/show_bug.cgi?id=246228</a>
rdar://100907445

Reviewed by Elliott Williams.

* Tools/Scripts/webkitpy/common/find_files.py:
(_normalized_find): Consider variants of a single test file.
(_normalized_find.sorted_paths_generator):
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py:
(LayoutTestFinder._expand_variants): Handle specific variant as argument.
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py:
(LayoutTestFinderTests.test_find_glob_query):

Canonical link: <a href="https://commits.webkit.org/255305@main">https://commits.webkit.org/255305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb0d3f4a5a34ca4afc06cb006a7c87e0a655b718

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1326 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/101882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1324 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97753 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78618 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/84533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/95668 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/36145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33901 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3677 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37771 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39671 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->