### PR TITLE
Web Inspector: hard to disable inline breakpoints without entirely removing them

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/BreakpointInlineWidget.css
+++ b/Source/WebInspectorUI/UserInterface/Views/BreakpointInlineWidget.css
@@ -25,16 +25,30 @@
 
 .inline-widget.breakpoint {
     display: inline-block;
+    position: relative;
     width: 10px;
     height: 10px;
     margin-inline-end: 1px;
     vertical-align: -1px;
-    clip-path: polygon(0% 50%, 5px 100%, 100% 100%, 100% 0, 5px 0);
-    transform: scaleX(-1);
+    clip-path: path(evenodd, "M 0 0 L 5 0 L 10 5 L 5 10 L 0 10 Z");
     cursor: default;
 }
 
-.inline-widget.breakpoint:not(.disabled) {
+.inline-widget.breakpoint.placeholder::before {
+    display: block;
+    width: 100%;
+    height: 100%;
+    content: "";
+    background-color: var(--breakpoint-color);
+    opacity: 0.7;
+    clip-path: path(evenodd, "M 0 0 L 5 0 L 10 5 L 5 10 L 0 10 M 1 1 L 4.5 1 L 8.5 5 L 4.5 9 L 1 9 Z");
+}
+
+.inline-widget.breakpoint:not(.resolved) {
+    filter: grayscale();
+}
+
+.inline-widget.breakpoint:not(.placeholder, .disabled) {
     background-color: var(--breakpoint-color);
 }
 
@@ -44,11 +58,11 @@
 
 .inline-widget.breakpoint.auto-continue::after {
     position: absolute;
-    right: 5px;
+    top: 2px;
+    right: 2px;
     width: 3px;
-    height: 10px;
+    height: 6px;
     content: "";
-    clip-path: polygon(0 20%, 100% 50%, 0 80%);
+    clip-path: polygon(0 0, 100% 50%, 0 100%);
     background-color: var(--selected-foreground-color);
-    transform: scaleX(-1);
 }

--- a/Source/WebInspectorUI/UserInterface/Views/BreakpointInlineWidget.js
+++ b/Source/WebInspectorUI/UserInterface/Views/BreakpointInlineWidget.js
@@ -48,6 +48,8 @@ WI.BreakpointInlineWidget = class BreakpointInlineWidget
         this._element.addEventListener("click", this._handleClick.bind(this));
         this._element.addEventListener("contextmenu", this._handleContextmenu.bind(this));
 
+        WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.BreakpointsEnabledDidChange, this._handleBreakpointsEnabledDidChange, this);
+
         this._update();
     }
 
@@ -61,7 +63,9 @@ WI.BreakpointInlineWidget = class BreakpointInlineWidget
 
     _update()
     {
-        this._element.classList.toggle("disabled", !this._breakpoint || this._breakpoint.disabled);
+        this._element.classList.toggle("placeholder", !this._breakpoint);
+        this._element.classList.toggle("resolved", this._breakpoint?.resolved || WI.debuggerManager.breakpointsEnabled);
+        this._element.classList.toggle("disabled", !!this._breakpoint?.disabled);
         this._element.classList.toggle("auto-continue", !!this._breakpoint?.autoContinue);
     }
 
@@ -86,10 +90,7 @@ WI.BreakpointInlineWidget = class BreakpointInlineWidget
     _handleClick(event)
     {
         if (this._breakpoint) {
-            if (this._breakpoint.disabled)
-                this._breakpoint.disabled = false;
-            else
-                this._breakpoint.remove();
+            this._breakpoint.disabled = !this._breakpoint.disabled;
             return;
         }
 
@@ -119,6 +120,11 @@ WI.BreakpointInlineWidget = class BreakpointInlineWidget
                 });
             });
         }
+    }
+
+    _handleBreakpointsEnabledDidChange(event)
+    {
+        this._update();
     }
 
     _handleBreakpointDisabledStateChanged(event)


### PR DESCRIPTION
#### 6ccba2787ef21faafedfda05a69e84064f1a07e8
<pre>
Web Inspector: hard to disable inline breakpoints without entirely removing them
<a href="https://bugs.webkit.org/show_bug.cgi?id=246234">https://bugs.webkit.org/show_bug.cgi?id=246234</a>

Reviewed by Patrick Angle.

This better matches the user expectation that clicking will toggle the disabled state, not remove
the (inline) breakpoint. Removing the (inline) breakpoint can be done via context menu, dragging the
breakpoint icon out of the gutter are for that line, or pressing delete when that breakpoint is
selected in the Breakpoints section of the navigation sidebar in the Sources Tab.

In order to differentiate a placeholder inline breakpoint vs an existing breakpoint, the former is
rendered as the outline of a breakpoint icon, whereas the latter is a solid color (unless it&apos;s set
to auto-continue, in which case it will have a small carve-out in the arrow).

* Source/WebInspectorUI/UserInterface/Views/BreakpointInlineWidget.js:
(WI.BreakpointInlineWidget):
(WI.BreakpointInlineWidget.prototype._update):
(WI.BreakpointInlineWidget.prototype._handleClick):
(WI.BreakpointInlineWidget.prototype._handleBreakpointsEnabledDidChange): Added.
* Source/WebInspectorUI/UserInterface/Views/BreakpointInlineWidget.css:
(.inline-widget.breakpoint):
(.inline-widget.breakpoint.placeholder::before): Added.
(.inline-widget.breakpoint:not(.resolved)): Added.
(.inline-widget.breakpoint:not(.placeholder, .disabled)): Renamed from `.inline-widget.breakpoint:not(.disabled)`.
(.inline-widget.breakpoint.auto-continue::after):
Drive-by: Also handle when breakpoints are globally disabled.

Canonical link: <a href="https://commits.webkit.org/255292@main">https://commits.webkit.org/255292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fde8ad35ccfac9c77c2e6f03d9117b6a03770560

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1291 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/22578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/101856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/161915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1287 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/29698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97713 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/84507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/22578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/36124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/22578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/33871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/22578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/37743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1656 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39634 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/22578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->