### PR TITLE
Add margin when comptuing baseline position for tables.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/baseline-rules/inline-table-inline-block-baseline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/baseline-rules/inline-table-inline-block-baseline-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+<title>CSS Box Alignment Test: inline-block and inline-table baselines</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-export">
+<style>
+.container {
+    border: solid 1px black;
+}
+.block {
+    display: inline-block;
+    background: aqua;
+}
+.table {
+    display: inline-table;
+    font-size: 40px;
+    background: tan;
+}
+.margin {
+    margin-block-start: 50px;
+}
+</style>
+<body>
+<div class="container">
+<div class="margin">
+    <div class="block">aaa</div>
+    <table class="table" cellspacing="0" cellpadding="0"><td>bbb</table>
+</div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/baseline-rules/inline-table-inline-block-baseline-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/baseline-rules/inline-table-inline-block-baseline-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+<title>CSS Box Alignment Test: inline-block and inline-table baselines</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-export">
+<style>
+.container {
+    border: solid 1px black;
+}
+.block {
+    display: inline-block;
+    background: aqua;
+}
+.table {
+    display: inline-table;
+    font-size: 40px;
+    background: tan;
+}
+.margin {
+    margin-block-start: 50px;
+}
+</style>
+<body>
+<div class="container">
+<div class="margin">
+    <div class="block">aaa</div>
+    <table class="table" cellspacing="0" cellpadding="0"><td>bbb</table>
+</div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/baseline-rules/inline-table-inline-block-baseline-vert-rl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/baseline-rules/inline-table-inline-block-baseline-vert-rl-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+<title>CSS Box Alignment Test: inline-block and inline-table baseline synthesis</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-export">
+<style>
+.container {
+    border: solid 1px black;
+    writing-mode: vertical-rl;
+}
+.block {
+    display: inline-block;
+    background: aqua;
+}
+.table {
+    display: inline-table;
+    font-size: 40px;
+    background: tan;
+}
+.margin {
+    margin-block-start: 50px;
+}
+</style>
+<body>
+<div class="container">
+<div class="margin">
+    <div class="block">aaa</div>
+    <table class="table" cellspacing="0" cellpadding="0"><td>bbb</table>
+</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/baseline-rules/inline-table-inline-block-baseline-vert-rl-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/baseline-rules/inline-table-inline-block-baseline-vert-rl-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+<title>CSS Box Alignment Test: inline-block and inline-table baseline synthesis</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-export">
+<style>
+.container {
+    border: solid 1px black;
+    writing-mode: vertical-rl;
+}
+.block {
+    display: inline-block;
+    background: aqua;
+}
+.table {
+    display: inline-table;
+    font-size: 40px;
+    background: tan;
+}
+.margin {
+    margin-block-start: 50px;
+}
+</style>
+<body>
+<div class="container">
+<div class="margin">
+    <div class="block">aaa</div>
+    <table class="table" cellspacing="0" cellpadding="0"><td>bbb</table>
+</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/baseline-rules/inline-table-inline-block-baseline-vert-rl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/baseline-rules/inline-table-inline-block-baseline-vert-rl.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+<title>CSS Box Alignment Test: inline-block and inline-table baseline synthesis</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-export">
+<link rel="match" href="inline-table-inline-block-baseline-vert-rl-ref.html">
+<style>
+.container {
+    border: solid 1px black;
+    writing-mode: vertical-rl;
+}
+.block {
+    display: inline-block;
+    background: aqua;
+}
+.table {
+    display: inline-table;
+    font-size: 40px;
+    background: tan;
+    margin-block-start: 50px;
+}
+</style>
+<body>
+<div class="container">
+    <div class="block">aaa</div>
+    <table class="table" cellspacing="0" cellpadding="0"><td>bbb</table>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/baseline-rules/inline-table-inline-block-baseline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/baseline-rules/inline-table-inline-block-baseline.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+<title>CSS Box Alignment Test: inline-block and inline-table baselines</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-export">
+<link rel="match" href="inline-table-inline-block-baseline-ref.html">
+<style>
+.container {
+    border: solid 1px black;
+}
+.block {
+    display: inline-block;
+    background: aqua;
+}
+.table {
+    display: inline-table;
+    font-size: 40px;
+    background: tan;
+    margin-block-start: 50px;
+}
+</style>
+<body>
+<div class="container">
+    <div class="block">aaa</div>
+    <table class="table" cellspacing="0" cellpadding="0"><td>bbb</table>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -1508,9 +1508,9 @@ RenderTableCell* RenderTable::cellAfter(const RenderTableCell* cell) const
 
 LayoutUnit RenderTable::baselinePosition(FontBaseline baselineType, bool firstLine, LineDirectionMode direction, LinePositionMode linePositionMode) const
 {
-    return valueOrCompute(firstLineBaseline(), [&] {
-        return RenderBox::baselinePosition(baselineType, firstLine, direction, linePositionMode);
-    });
+    if (auto baselinePos = firstLineBaseline())
+        return (direction == HorizontalLine ? marginTop() : marginRight()) + baselinePos.value();
+    return RenderBox::baselinePosition(baselineType, firstLine, direction, linePositionMode);
 }
 
 std::optional<LayoutUnit> RenderTable::inlineBlockBaseline(LineDirectionMode) const


### PR DESCRIPTION
#### c0048e83eb237ba2dba8a01bfc46bf0de42412a2
<pre>
Add margin when comptuing baseline position for tables.
<a href="https://bugs.webkit.org/show_bug.cgi?id=97239">https://bugs.webkit.org/show_bug.cgi?id=97239</a>
rdar://problem/100910532

Reviewed by Brent Fulgham.

After computing the baseline of a table, we need to take into
consideration any margins that are shifting the element. Without adding
the margin to the baseline, any items that are basline against the table
may become offset by that amount.

* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::baselinePosition const):

Canonical link: <a href="https://commits.webkit.org/255357@main">https://commits.webkit.org/255357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e32f9b57b4b6ce2456628d7719f92096437a52ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101944 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162170 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96157 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1385 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29781 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84599 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98111 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/891 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78680 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27832 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70873 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36205 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16416 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33962 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17545 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3713 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40227 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36671 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->