### PR TITLE
Add command line option to enable/disable ResourceLoadStatistics when launching MiniBrowser

### DIFF
--- a/Tools/MiniBrowser/playstation/MainWindow.cpp
+++ b/Tools/MiniBrowser/playstation/MainWindow.cpp
@@ -32,16 +32,19 @@
 #include "URLBar.h"
 #include "WebViewWindow.h"
 #include <KeyboardCodes.h>
+#include <WebKit/WKPage.h>
 #include <WebKit/WKString.h>
+#include <WebKit/WKWebsiteDataStoreRef.h>
 #include <sstream>
 #include <toolkitten/Application.h>
+#include <vector>
 
 constexpr int LineHeight = 40;
 constexpr int FontSize = 32;
 
 using namespace toolkitten;
 
-MainWindow::MainWindow(const char* requestedURL)
+MainWindow::MainWindow(const std::vector<std::string>& options)
 {
     IntSize size = Application::singleton().windowSize();
     auto windowWidth = size.w;
@@ -106,7 +109,26 @@ MainWindow::MainWindow(const char* requestedURL)
     }});
 
     createNewWebView(nullptr);
-    activeWebView()->loadURL(requestedURL ? requestedURL : "https://webkit.org");
+
+    std::string requestedURL = "https://webkit.org";
+
+    parseOptions(options, requestedURL);
+
+    activeWebView()->loadURL(requestedURL.c_str());
+}
+
+void MainWindow::parseOptions(const std::vector<std::string>& options, std::string& requestedURL)
+{
+    auto context = WebContext::singleton();
+    WKWebsiteDataStoreRef websiteDataStore = context->websiteDataStore();
+    for (auto& option : options) {
+        if (!option.compare("--resource-load-statistics-enabled"))
+            WKWebsiteDataStoreSetResourceLoadStatisticsEnabled(websiteDataStore, true);                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
+        else if (!option.compare("--resource-load-statistics-disabled"))
+            WKWebsiteDataStoreSetResourceLoadStatisticsEnabled(websiteDataStore, false);
+        else
+            requestedURL = option;
+    }
 }
 
 void MainWindow::paintSelf(toolkitten::IntPoint)

--- a/Tools/MiniBrowser/playstation/MainWindow.h
+++ b/Tools/MiniBrowser/playstation/MainWindow.h
@@ -28,6 +28,7 @@
 #include <WebKit/WKBase.h>
 #include <list>
 #include <toolkitten/Widget.h>
+#include <vector>
 
 class TitleBar;
 class URLBar;
@@ -35,7 +36,7 @@ class WebViewWindow;
 
 class MainWindow final : public toolkitten::Widget {
 public:
-    MainWindow(const char*);
+    MainWindow(const std::vector<std::string>& options);
 
     WebViewWindow* activeWebView();
 
@@ -50,6 +51,7 @@ private:
     void setActiveWebView(WebViewWindow*);
     void switchActiveWebView(int delta);
     void closeWebView(WebViewWindow*);
+    void parseOptions(const std::vector<std::string>& options, std::string& requestedURL);
 
     TitleBar* m_titleBar { nullptr };
     URLBar* m_urlBar { nullptr };

--- a/Tools/MiniBrowser/playstation/main.cpp
+++ b/Tools/MiniBrowser/playstation/main.cpp
@@ -93,7 +93,8 @@ int main(int argc, char *argv[])
     auto& app = Application::singleton();
     app.init(&applicationClient);
 
-    auto mainWindow = std::make_unique<MainWindow>(argc > 1 ? argv[1] : nullptr);
+    const std::vector<std::string> options(argv + 1, argv + argc);
+    auto mainWindow = std::make_unique<MainWindow>(options);
     mainWindow->setFocused();
     app.setRootWidget(std::move(mainWindow));
 


### PR DESCRIPTION
#### 404718d45a0c05091d7700a11c7368e206eee8c2
<pre>
Add command line option to enable/disable ResourceLoadStatistics when launching MiniBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=246233">https://bugs.webkit.org/show_bug.cgi?id=246233</a>

Reviewed by Fujii Hironori.

Use the options --resource-load-statistics-enabled and --resource-load-statistics-disabled to enable and disable ResourceLoadStatistics respectively. It is disabled by default.

* Tools/MiniBrowser/playstation/main.cpp:
(main):
* Tools/MiniBrowser/playstation/MainWindow:
(MainWindow::MainWindow):
(MainWindow::parseOptions):
* Tools/MiniBrowser/playstation/MainWindow.h:

Canonical link: <a href="https://commits.webkit.org/255703@main">https://commits.webkit.org/255703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87e7fe5c7adf01632ba9bedfd090fa5353a2bc41

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23998 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/103031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2559 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30857 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85724 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99018 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79808 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83702 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37240 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35066 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3941 "Build is in progress. Recent messages:Cleaned up git repository; Checked out pull request; Verified commit is squashed; Reviewed by Fujii Hironori; Validated commit message; Compiled WebKit (warnings); Running layout-tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38940 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1847 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37798 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->