### PR TITLE
[results.webkit.org] Support test names with ?

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/suite_controller.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/suite_controller.py
@@ -24,7 +24,7 @@ from flask import abort, jsonify, request
 from resultsdbpy.controller.commit_controller import uuid_range_for_query, HasCommitContext
 from resultsdbpy.controller.configuration import Configuration
 from resultsdbpy.controller.configuration_controller import configuration_for_query
-from webkitflaskpy.util import AssertRequest, query_as_kwargs, limit_for_query, boolean_query
+from webkitflaskpy.util import AssertRequest, query_as_kwargs, limit_for_query, boolean_query, unescape_argument
 
 
 def time_range_for_query():
@@ -61,6 +61,7 @@ class SuiteController(HasCommitContext):
     @limit_for_query(DEFAULT_LIMIT)
     @configuration_for_query()
     @time_range_for_query()
+    @unescape_argument(suite=['?', '#'])
     def find_run_results(
         self, suite=None, configurations=None, recent=None,
         branch=None, begin=None, end=None,

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/test_controller.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/test_controller.py
@@ -27,7 +27,7 @@ from resultsdbpy.controller.configuration import Configuration
 from resultsdbpy.controller.configuration_controller import configuration_for_query
 from resultsdbpy.controller.suite_controller import time_range_for_query
 from resultsdbpy.model.test_context import Expectations
-from webkitflaskpy.util import AssertRequest, query_as_kwargs, limit_for_query, boolean_query
+from webkitflaskpy.util import AssertRequest, query_as_kwargs, limit_for_query, boolean_query, unescape_argument
 
 
 class TestController(HasCommitContext):
@@ -39,6 +39,10 @@ class TestController(HasCommitContext):
 
     @query_as_kwargs()
     @limit_for_query(DEFAULT_LIMIT)
+    @unescape_argument(
+        suite=['?', '#'],
+        test=['?', '#'],
+    )
     def list_tests(self, suite=None, test=None, limit=None, **kwargs):
         AssertRequest.is_type(['GET'])
         AssertRequest.query_kwargs_empty(**kwargs)
@@ -57,6 +61,10 @@ class TestController(HasCommitContext):
     @limit_for_query(DEFAULT_LIMIT)
     @configuration_for_query()
     @time_range_for_query()
+    @unescape_argument(
+        suite=['?', '#'],
+        test=['?', '#'],
+    )
     def find_test_result(
         self, suite=None, test=None,
         configurations=None, recent=None,
@@ -109,6 +117,10 @@ class TestController(HasCommitContext):
     @commit_for_query()
     @limit_for_query(100)
     @configuration_for_query()
+    @unescape_argument(
+        suite=['?', '#'],
+        test=['?', '#'],
+    )
     def summarize_test_results(
         self, suite=None, test=None,
         configurations=None, recent=None,

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/common.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/common.js
@@ -139,6 +139,21 @@ function escapeHTML(text) {
   });
 }
 
+function escapeEndpoint(text) {
+    if (!text)
+        return text;
+    return text.replace(/[#?]/g, function(character) {
+        switch (character) {
+            case '#':
+                return '$23';
+            case '?':
+                return '$3F';
+            default:
+                return character;
+        }
+  });
+}
+
 function linkify(text) {
     return text.replace(/\b(https?|rdar):\/{2}[^\s<>&]+[^\.\s<>&,]/gmi, `<a href="$&" target="_blank">$&</a>`);
 }
@@ -197,4 +212,4 @@ function elapsedTime(startTimestamp, endTimestamp)
     return result;
 }
 
-export {deepCompare, ErrorDisplay, queryToParams, paramsToQuery, QueryModifier, escapeHTML, linkify, percentage, elapsedTime};
+export {deepCompare, ErrorDisplay, queryToParams, paramsToQuery, QueryModifier, escapeHTML, escapeEndpoint, linkify, percentage, elapsedTime};

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
@@ -24,7 +24,7 @@
 import {ArchiveRouter} from '/assets/js/archiveRouter.js';
 import {CommitBank} from '/assets/js/commit.js';
 import {Configuration} from '/assets/js/configuration.js';
-import {deepCompare, ErrorDisplay, escapeHTML, paramsToQuery, queryToParams, linkify} from '/assets/js/common.js';
+import {deepCompare, ErrorDisplay, escapeHTML, paramsToQuery, queryToParams, linkify, escapeEndpoint} from '/assets/js/common.js';
 import {Expectations} from '/assets/js/expectations.js';
 import {InvestigateDrawer} from '/assets/js/investigate.js';
 import {ToolTip} from '/assets/js/tooltip.js';
@@ -460,7 +460,7 @@ class TimelineFromEndpoint {
                 params[key] = sharedParams[key];
             const query = paramsToQuery(params);
 
-            fetch(query ? this.endpoint + '?' + query : this.endpoint).then(response => {
+            fetch(query ? escapeEndpoint(this.endpoint) + '?' + query : escapeEndpoint(this.endpoint)).then(response => {
                 response.json().then(json => {
                     if (myDispatch !== this.latestDispatch)
                         return;

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/investigate.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/investigate.html
@@ -30,7 +30,7 @@
 <script type="module">
 import {ArchiveRouter} from '/assets/js/archiveRouter.js';
 import {CommitBank} from '/assets/js/commit.js';
-import {ErrorDisplay, QueryModifier, paramsToQuery, queryToParams, percentage, elapsedTime, escapeHTML} from '/assets/js/common.js';
+import {ErrorDisplay, QueryModifier, paramsToQuery, queryToParams, percentage, elapsedTime, escapeHTML, escapeEndpoint} from '/assets/js/common.js';
 import {Configuration} from '/assets/js/configuration.js';
 import {Expectations} from '/assets/js/expectations.js';
 import {Drawer, BranchSelector, ConfigurationSelectors} from '/assets/js/drawer.js';
@@ -288,7 +288,7 @@ class SuiteFailuresView {
 
         agregateConnfiguration.forEach(configToSearch => {
             const resultParams = Object.assign(configToSearch.toParams(), rangeParams);
-            fetch(`/api/results/${this.suite}?${paramsToQuery(resultParams)}`).then(response => {
+            fetch(`/api/results/${escapeEndpoint(this.suite)}?${paramsToQuery(resultParams)}`).then(response => {
                 response.json().then(json => {
                     let minUuid = Math.round(new Date().getTime()/10);
                     let maxUuid = 0;

--- a/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/util_unittest.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/util_unittest.py
@@ -23,7 +23,7 @@
 import unittest
 
 from werkzeug.exceptions import BadRequest
-from webkitflaskpy.util import boolean_query, limit_for_query
+from webkitflaskpy.util import boolean_query, limit_for_query, unescape_argument
 
 
 class UtilTest(unittest.TestCase):
@@ -48,3 +48,19 @@ class UtilTest(unittest.TestCase):
         self.assertRaises(BadRequest, func, limit=['string'])
         self.assertRaises(BadRequest, func, limit=['0'])
         self.assertRaises(BadRequest, func, limit=['-1'])
+
+    def test_unescape_decorator(self):
+        @unescape_argument(
+            value=['?', '#'],
+        )
+        def func(value=None):
+            return value
+
+        self.assertEqual(func(value='test'), 'test')
+        self.assertEqual(func(value='test$3Fvalue'), 'test?value')
+        self.assertEqual(
+            func(value=('test$3Fvalue1', 'test$3Fvalue2')),
+            ('test?value1', 'test?value2'),
+        )
+        self.assertEqual(func(value='test$40value'), 'test$40value')
+        self.assertEqual(func(value='test$23value'), 'test#value')


### PR DESCRIPTION
#### 660e00402272d055860a8bd136e241a2ab54724e
<pre>
[results.webkit.org] Support test names with ?
<a href="https://bugs.webkit.org/show_bug.cgi?id=246240">https://bugs.webkit.org/show_bug.cgi?id=246240</a>
rdar://100917146

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/suite_controller.py:
(SuiteController): Unescape suite and test names.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/test_controller.py:
(TestController): Unescape suite and test names.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/common.js: Add function to escape certain
endpoint paths.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js:
(TimelineFromEndpoint.prototype.reload): Escape suite and test names.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/investigate.html:
* Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/util.py:
(unescape_argument): Decorator which un-escapes the specified URL parameters for the specified characters.
* Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/util_unittest.py:
(UtilTest.test_unescape_decorator):

Canonical link: <a href="https://commits.webkit.org/255344@main">https://commits.webkit.org/255344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b1c849ac82385e4f3d2d3281f94bcd03130d925

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101883 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/161938 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1325 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29720 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84534 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98058 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/836 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78619 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27771 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/95669 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70814 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36146 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16371 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/91148 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33902 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17473 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37772 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40180 "Found 2 new test failures: imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h264_annexb, imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_annexb (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1667 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36599 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->