### PR TITLE
[iOS] the second pointer region request in a row can sometimes get stuck

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10124,7 +10124,7 @@ static BOOL applicationIsKnownToIgnoreMouseEvents(const char* &warningVersion)
     interactionInformationRequest.includeCaretContext = true;
     interactionInformationRequest.includeHasDoubleClickHandler = false;
 
-    BOOL didSynchronouslyReplyWithApproximation = false;
+    __block BOOL didSynchronouslyReplyWithApproximation = false;
     if (![self _currentPositionInformationIsValidForRequest:interactionInformationRequest] && self.webView._editable && !_positionInformation.shouldNotUseIBeamInEditableContent) {
         didSynchronouslyReplyWithApproximation = true;
         completion([UIPointerRegion regionWithRect:self.bounds identifier:editablePointerRegionIdentifier]);
@@ -10144,14 +10144,14 @@ static BOOL applicationIsKnownToIgnoreMouseEvents(const char* &warningVersion)
         if (!_deferredPointerInteractionRequest)
             _hasOutstandingPointerInteractionRequest = NO;
 
-        if (didSynchronouslyReplyWithApproximation) {
+        if (didSynchronouslyReplyWithApproximation)
             [interaction invalidate];
-            return;
-        }
-
-        completion([self pointerRegionForPositionInformation:interactionInformation point:request.location]);
+        else
+            completion([self pointerRegionForPositionInformation:interactionInformation point:request.location]);
 
         if (_deferredPointerInteractionRequest) {
+            didSynchronouslyReplyWithApproximation = false;
+
             auto deferredRequest = std::exchange(_deferredPointerInteractionRequest, std::nullopt);
             [self doAfterPositionInformationUpdate:^(WebKit::InteractionInformationAtPosition interactionInformation) {
                 replyHandler(interactionInformation, deferredRequest->second.get());


### PR DESCRIPTION
#### 4901da06c405340faa26761b8c47c1fe49025574
<pre>
[iOS] the second pointer region request in a row can sometimes get stuck
<a href="https://bugs.webkit.org/show_bug.cgi?id=246241">https://bugs.webkit.org/show_bug.cgi?id=246241</a>
&lt;rdar://problem/100143379&gt;

Reviewed by Tim Horton.

If a second pointer region request is made before the UIProcess is given updated position info, and
the first pointer region request was handled synchronously with an approximation, the second pointer
request&apos;s `completion` (which was saved/deferred) will never be called due to an early return.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _pointerInteraction:regionForRequest:defaultRegion:completion:]):

Canonical link: <a href="https://commits.webkit.org/255457@main">https://commits.webkit.org/255457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fda08f358a7cf4e051467082880dd52da367f9ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101880 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1321 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29717 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84530 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98055 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/830 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78615 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27768 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70811 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36143 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16363 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33898 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17465 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3782 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37768 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40173 "1 flakes 3 failures") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36591 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->