### PR TITLE
JSC DFG Number.prototype.toString does not throw an exception when the parameter is Object

### DIFF
--- a/JSTests/stress/number-prototype-to-string-dfg-bad-this-value-radix-10.js
+++ b/JSTests/stress/number-prototype-to-string-dfg-bad-this-value-radix-10.js
@@ -1,0 +1,25 @@
+let successCount = 0, errorCount = 0;
+
+function numberToString(thisValue) {
+    try {
+        Number.prototype.toString.call(thisValue, 10);
+        successCount++;
+    } catch {
+        errorCount++;
+    }
+}
+
+(function() {
+    const runs = 1e6;
+
+    for (let i = 0; i < runs; i++) {
+        numberToString({});
+        numberToString(i);
+    }
+
+    if (successCount !== runs)
+        throw new Error(`Bad value: ${successCount}!`);
+
+    if (errorCount !== runs)
+        throw new Error(`Bad value: ${errorCount}!`);
+})();

--- a/JSTests/stress/number-prototype-to-string-dfg-bad-this-value-radix-absent.js
+++ b/JSTests/stress/number-prototype-to-string-dfg-bad-this-value-radix-absent.js
@@ -1,0 +1,25 @@
+let successCount = 0, errorCount = 0;
+
+function numberToString(thisValue) {
+    try {
+        Number.prototype.toString.call(thisValue);
+        successCount++;
+    } catch {
+        errorCount++;
+    }
+}
+
+(function() {
+    const runs = 1e6;
+
+    for (let i = 0; i < runs; i++) {
+        numberToString({});
+        numberToString(i);
+    }
+
+    if (successCount !== runs)
+        throw new Error(`Bad value: ${successCount}!`);
+
+    if (errorCount !== runs)
+        throw new Error(`Bad value: ${errorCount}!`);
+})();

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3733,7 +3733,7 @@ bool ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, CallVaria
             insertChecks();
             Node* thisNumber = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
             if (argumentCountIncludingThis == 1) {
-                Node* resultNode = addToGraph(ToString, thisNumber);
+                Node* resultNode = addToGraph(NumberToStringWithValidRadixConstant, OpInfo(10), thisNumber);
                 setResult(resultNode);
             } else {
                 Node* radix = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -957,7 +957,7 @@ private:
                 if (radixValue && radixValue.isInt32()) {
                     int32_t radix = radixValue.asInt32();
                     if (2 <= radix && radix <= 36) {
-                        if (radix == 10) {
+                        if (radix == 10 && node->child1()->shouldSpeculateNumber()) {
                             node->setOpAndDefaultFlags(ToString);
                             node->clearFlags(NodeMustGenerate);
                             node->child2() = Edge();

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2725,6 +2725,7 @@ private:
             break;
         }
 
+        case NumberToStringWithValidRadixConstant:
         case NumberToStringWithRadix: {
             if (node->child1()->shouldSpeculateInt32())
                 fixEdge<Int32Use>(node->child1());
@@ -2732,7 +2733,13 @@ private:
                 fixEdge<Int52RepUse>(node->child1());
             else
                 fixEdge<DoubleRepUse>(node->child1());
-            fixEdge<Int32Use>(node->child2());
+
+            if (op == NumberToStringWithRadix)
+                fixEdge<Int32Use>(node->child2());
+            else if (node->validRadixConstant() == 10 && node->child1()->shouldSpeculateNumber()) {
+                node->setOp(ToString);
+                node->resetOpInfo();
+            }
             break;
         }
 
@@ -2970,7 +2977,6 @@ private:
         case PutByIdWithThis:
         case PutByValWithThis:
         case CompareEqPtr:
-        case NumberToStringWithValidRadixConstant:
         case GetGlobalThis:
         case ExtractValueFromWeakMapGet:
         case CPUIntrinsic:

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -3332,6 +3332,12 @@ public:
         return OptionSet<JSPropertyNameEnumerator::Flag>::fromRaw(m_opInfo2.as<unsigned>());
     }
 
+    void resetOpInfo()
+    {
+        m_opInfo = OpInfoWrapper();
+        m_opInfo2 = OpInfoWrapper();
+    }
+
     void dumpChildren(PrintStream& out)
     {
         if (!child1())


### PR DESCRIPTION
#### c828d44d6aa2a3537edec55adffb06de4ee23892
<pre>
JSC DFG Number.prototype.toString does not throw an exception when the parameter is Object
<a href="https://bugs.webkit.org/show_bug.cgi?id=245463">https://bugs.webkit.org/show_bug.cgi?id=245463</a>
&lt;rdar://problem/100494175&gt;

Reviewed by Yusuke Suzuki.

This change aligns DFG implementations of Number.prototype.toString(), called with radix of 10
or without radix parameter, with the spec [1] by emitting NumberToStringWithValidRadixConstant
DFG node instead of ToString, so the TypeError is thrown for non-number |this| values.

In order to emit the simplest DFG node possible, and to enable future optimizations,
NumberToStringWithValidRadixConstant with radix of 10 is still converted to ToString
for numeric callees only.

[1]: <a href="https://tc39.es/ecma262/#sec-number.prototype.tostring">https://tc39.es/ecma262/#sec-number.prototype.tostring</a> (step 1)

* JSTests/stress/number-prototype-to-string-dfg-bad-this-value-radix-10.js: Added.
* JSTests/stress/number-prototype-to-string-dfg-bad-this-value-radix-absent.js: Added.
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNode.h:

Canonical link: <a href="https://commits.webkit.org/256086@main">https://commits.webkit.org/256086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0dba896120a0482eeb72d8831446bac734d8b39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3771 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/27492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104236 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3836 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31962 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86915 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100277 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80978 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29777 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/27492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/72672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85792 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38366 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/27492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80982 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/27492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27824 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4203 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40125 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83651 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42092 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/27492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18896 "Passed tests") | 
<!--EWS-Status-Bubble-End-->