### PR TITLE
[macOS] TV app crashes when unparenting a web view while setting up Apple One

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrepareForMoveToWindow.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrepareForMoveToWindow.mm
@@ -32,6 +32,7 @@
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>
@@ -55,6 +56,19 @@ TEST(WKWebView, PrepareForMoveToWindow)
     TestWebKitAPI::Util::run(&isDone);
 }
 
+TEST(WKWebView, PrepareToUnparentView)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView synchronouslyLoadTestPageNamed:@"simple"];
+
+    __block bool done = false;
+    [webView _prepareForMoveToWindow:nil completionHandler:^{
+        [webView removeFromSuperview];
+        done = true;
+    }];
+
+    TestWebKitAPI::Util::run(&done);
+}
 
 TEST(WKWebView, PrepareForMoveToWindowThenClose)
 {


### PR DESCRIPTION
#### 69059cf01c1250dbde4796c1df60efd4e08e02b0
<pre>
[macOS] TV app crashes when unparenting a web view while setting up Apple One
<a href="https://bugs.webkit.org/show_bug.cgi?id=246250">https://bugs.webkit.org/show_bug.cgi?id=246250</a>
rdar://97021716

Reviewed by Devin Rousso.

Make it safe for WebKit clients to use `-_prepareForMoveToWindow:completionHandler:` before
unparenting a web view. Currently, this results in an Objective-C exception due to
`-[WKWindowVisibilityObserver stopObserving:]` being called twice in a row. Because we&apos;ve already
removed the &quot;contentLayoutRect&quot; and &quot;titlebarAppearsTransparent&quot; key path observers during the first
call, the second call throws an exception.

Make `WKWindowVisibilityObserver` robust in this scenario by keeping track of the `NSWindow` we&apos;re
currently observing, so that we never end up trying to either install duplicate key path observers,
or attempt to remove nonexistent observers.

Test: WKWebView.PrepareToUnparentView

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKWindowVisibilityObserver startObserving:]):
(-[WKWindowVisibilityObserver stopObserving:]):
(-[WKWindowVisibilityObserver _observeWindow:]):

Add a helper method to make it easy to safely change the observed window (see above for more
details).

* Tools/TestWebKitAPI/Tests/WebKitCocoa/PrepareForMoveToWindow.mm:

Canonical link: <a href="https://commits.webkit.org/255359@main">https://commits.webkit.org/255359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/122bca4af7af819c066056da876df0595c7a9c24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101937 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162181 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1379 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29771 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84591 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98104 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/885 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78673 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27823 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70862 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36199 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16409 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33955 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17530 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3715 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40221 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36657 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->