### PR TITLE
MouseEventInit should take movementX and movementY

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerlock/constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerlock/constructor-expected.txt
@@ -2,5 +2,5 @@ Create Pointer Lock events and check each default value.
 
 
 PASS Default event values for mouse event interface and its pointer lock extensions.
-FAIL Default event values for pointerlockerror using a dictionary assert_equals: expected 10 but got 0
+PASS Default event values for pointerlockerror using a dictionary
 

--- a/LayoutTests/pointer-lock/mouse-event-api-expected.txt
+++ b/LayoutTests/pointer-lock/mouse-event-api-expected.txt
@@ -1,5 +1,7 @@
 PASS mouseEvent.movementX is defined.
 PASS mouseEvent.movementY is defined.
+PASS mouseEvent.movementX is 1 / 4096
+PASS mouseEvent.movementY is 1 / 8196
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/pointer-lock/mouse-event-api.html
+++ b/LayoutTests/pointer-lock/mouse-event-api.html
@@ -8,6 +8,9 @@
     var mouseEvent = document.createEvent("MouseEvent");
     shouldBeDefined("mouseEvent.movementX");
     shouldBeDefined("mouseEvent.movementY");
+    mouseEvent = new MouseEvent("pointerlockerror", {movementX: 1 / 4096, movementY: 1 / 8196});
+    shouldBe('mouseEvent.movementX', '1 / 4096');
+    shouldBe('mouseEvent.movementY', '1 / 8196');
 </script>
 <script src="../http/tests/resources/js-test-post.js"></script>
 </body>

--- a/Source/WebCore/dom/DragEvent.cpp
+++ b/Source/WebCore/dom/DragEvent.cpp
@@ -44,11 +44,11 @@ Ref<DragEvent> DragEvent::createForBindings()
 }
 
 Ref<DragEvent> DragEvent::create(const AtomString& type, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    const IntPoint& screenLocation, const IntPoint& windowLocation, const IntPoint& movementDelta, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
+    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
     EventTarget* relatedTarget, double force, unsigned short syntheticClickType, DataTransfer* dataTransfer, IsSimulated isSimulated, IsTrusted isTrusted)
 {
     return adoptRef(*new DragEvent(type, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail,
-        screenLocation, windowLocation, movementDelta, modifiers, button, buttons, relatedTarget, force, syntheticClickType, dataTransfer, isSimulated, isTrusted));
+        screenLocation, windowLocation, movementX, movementY, modifiers, button, buttons, relatedTarget, force, syntheticClickType, dataTransfer, isSimulated, isTrusted));
 }
 
 DragEvent::DragEvent(const AtomString& eventType, DragEventInit&& init)
@@ -59,9 +59,9 @@ DragEvent::DragEvent(const AtomString& eventType, DragEventInit&& init)
 
 DragEvent::DragEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
     MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    const IntPoint& screenLocation, const IntPoint& windowLocation, const IntPoint& movementDelta, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
+    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
     EventTarget* relatedTarget, double force, unsigned short syntheticClickType, DataTransfer* dataTransfer, IsSimulated isSimulated, IsTrusted isTrusted)
-    : MouseEvent(eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation, movementDelta, modifiers, button, buttons, relatedTarget, force, syntheticClickType, isSimulated, isTrusted)
+    : MouseEvent(eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation, movementX, movementY, modifiers, button, buttons, relatedTarget, force, syntheticClickType, isSimulated, isTrusted)
     , m_dataTransfer(dataTransfer)
 {
 }

--- a/Source/WebCore/dom/DragEvent.h
+++ b/Source/WebCore/dom/DragEvent.h
@@ -44,7 +44,7 @@ public:
     static Ref<DragEvent> create(const AtomString& eventType, DragEventInit&&);
     static Ref<DragEvent> createForBindings();
     static Ref<DragEvent> create(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
-        const IntPoint& screenLocation, const IntPoint& windowLocation, const IntPoint& movementDelta, OptionSet<Modifier>, short button, unsigned short buttons,
+        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, short button, unsigned short buttons,
         EventTarget* relatedTarget, double force, unsigned short syntheticClickType, DataTransfer* = nullptr, IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
 
 
@@ -53,7 +53,7 @@ public:
 private:
     DragEvent(const AtomString& eventType, DragEventInit&&);
     DragEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
-        const IntPoint& screenLocation, const IntPoint& windowLocation, const IntPoint& movementDelta, OptionSet<Modifier>, short button, unsigned short buttons,
+        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, short button, unsigned short buttons,
         EventTarget* relatedTarget, double force, unsigned short syntheticClickType, DataTransfer*, IsSimulated, IsTrusted);
     DragEvent();
 

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -57,32 +57,32 @@ Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, RefPtr<WindowPro
     auto isComposed = !isMouseEnterOrLeave ? IsComposed::Yes : IsComposed::No;
 
     return MouseEvent::create(eventType, canBubble, isCancelable, isComposed, event.timestamp().approximateMonotonicTime(), WTFMove(view), detail,
-        event.globalPosition(), event.position(), event.movementDelta(),
+        event.globalPosition(), event.position(), event.movementDelta().x(), event.movementDelta().y(),
         event.modifiers(), event.button(), event.buttons(), relatedTarget, event.force(), event.syntheticClickType());
 }
 
 Ref<MouseEvent> MouseEvent::create(const AtomString& type, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    const IntPoint& screenLocation, const IntPoint& windowLocation, const IntPoint& movementDelta, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
+    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
     EventTarget* relatedTarget, double force, unsigned short syntheticClickType, IsSimulated isSimulated, IsTrusted isTrusted)
 {
     return adoptRef(*new MouseEvent(type, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail,
-        screenLocation, windowLocation, movementDelta, modifiers, button, buttons, relatedTarget, force, syntheticClickType, isSimulated, isTrusted));
+        screenLocation, windowLocation, movementX, movementY, modifiers, button, buttons, relatedTarget, force, syntheticClickType, isSimulated, isTrusted));
 }
 
 Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, RefPtr<WindowProxy>&& view, int detail,
     int screenX, int screenY, int clientX, int clientY, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
     unsigned short syntheticClickType, EventTarget* relatedTarget)
 {
-    return adoptRef(*new MouseEvent(eventType, canBubble, isCancelable, isComposed, WTFMove(view), detail, { screenX, screenY }, { clientX, clientY }, { }, modifiers, button, buttons, syntheticClickType, relatedTarget));
+    return adoptRef(*new MouseEvent(eventType, canBubble, isCancelable, isComposed, WTFMove(view), detail, { screenX, screenY }, { clientX, clientY }, 0, 0, modifiers, button, buttons, syntheticClickType, relatedTarget));
 }
 
 MouseEvent::MouseEvent() = default;
 
 MouseEvent::MouseEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
     MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    const IntPoint& screenLocation, const IntPoint& windowLocation, const IntPoint& movementDelta, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
+    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
     EventTarget* relatedTarget, double force, unsigned short syntheticClickType, IsSimulated isSimulated, IsTrusted isTrusted)
-    : MouseRelatedEvent(eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation, movementDelta, modifiers, isSimulated, isTrusted)
+    : MouseRelatedEvent(eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation, movementX, movementY, modifiers, isSimulated, isTrusted)
     , m_button(button == -2 ? 0 : button)
     , m_buttons(buttons)
     , m_syntheticClickType(button == -2 ? 0 : syntheticClickType)
@@ -93,9 +93,9 @@ MouseEvent::MouseEvent(const AtomString& eventType, CanBubble canBubble, IsCance
 }
 
 MouseEvent::MouseEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
-    RefPtr<WindowProxy>&& view, int detail, const IntPoint& screenLocation, const IntPoint& clientLocation, const IntPoint& movementDelta,
+    RefPtr<WindowProxy>&& view, int detail, const IntPoint& screenLocation, const IntPoint& clientLocation, double movementX, double movementY,
     OptionSet<Modifier> modifiers, short button, unsigned short buttons, unsigned short syntheticClickType, EventTarget* relatedTarget)
-    : MouseRelatedEvent(eventType, canBubble, isCancelable, isComposed, MonotonicTime::now(), WTFMove(view), detail, screenLocation, { }, movementDelta, modifiers, IsSimulated::No)
+    : MouseRelatedEvent(eventType, canBubble, isCancelable, isComposed, MonotonicTime::now(), WTFMove(view), detail, screenLocation, { }, movementX, movementY, modifiers, IsSimulated::No)
     , m_button(button == -2 ? 0 : button)
     , m_buttons(buttons)
     , m_syntheticClickType(button == -2 ? 0 : syntheticClickType)

--- a/Source/WebCore/dom/MouseEvent.h
+++ b/Source/WebCore/dom/MouseEvent.h
@@ -45,7 +45,7 @@ class MouseEvent : public MouseRelatedEvent {
     WTF_MAKE_ISO_ALLOCATED(MouseEvent);
 public:
     WEBCORE_EXPORT static Ref<MouseEvent> create(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
-        const IntPoint& screenLocation, const IntPoint& windowLocation, const IntPoint& movementDelta, OptionSet<Modifier>, short button, unsigned short buttons,
+        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, short button, unsigned short buttons,
         EventTarget* relatedTarget, double force, unsigned short syntheticClickType, IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
 
     WEBCORE_EXPORT static Ref<MouseEvent> create(const AtomString& eventType, RefPtr<WindowProxy>&&, const PlatformMouseEvent&, int detail, Node* relatedTarget);
@@ -89,11 +89,11 @@ public:
 
 protected:
     MouseEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
-        const IntPoint& screenLocation, const IntPoint& windowLocation, const IntPoint& movementDelta, OptionSet<Modifier>, short button, unsigned short buttons,
+        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, short button, unsigned short buttons,
         EventTarget* relatedTarget, double force, unsigned short syntheticClickType, IsSimulated, IsTrusted);
 
     MouseEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, RefPtr<WindowProxy>&&, int detail,
-        const IntPoint& screenLocation, const IntPoint& clientLocation, const IntPoint& movementDelta, OptionSet<Modifier>, short button, unsigned short buttons,
+        const IntPoint& screenLocation, const IntPoint& clientLocation, double movementX, double movementY, OptionSet<Modifier>, short button, unsigned short buttons,
         unsigned short syntheticClickType, EventTarget* relatedTarget);
 
     MouseEvent(const AtomString& type, const MouseEventInit&);

--- a/Source/WebCore/dom/MouseEvent.idl
+++ b/Source/WebCore/dom/MouseEvent.idl
@@ -40,8 +40,8 @@
 
     boolean getModifierState(DOMString keyArg);
 
-    [Conditional=POINTER_LOCK] readonly attribute long movementX;
-    [Conditional=POINTER_LOCK] readonly attribute long movementY;
+    [Conditional=POINTER_LOCK] readonly attribute double movementX;
+    [Conditional=POINTER_LOCK] readonly attribute double movementY;
     [Conditional=MOUSE_FORCE_EVENTS, ImplementedAs=force]readonly attribute double webkitForce;
 
     // FIXME: relatedTarget should be of type EventTarget? but we need to use any to support a quirk for iAd Producer (rdar://problem/30640101).

--- a/Source/WebCore/dom/MouseEventInit.idl
+++ b/Source/WebCore/dom/MouseEventInit.idl
@@ -30,6 +30,9 @@ dictionary MouseEventInit : EventModifierInit {
     long clientX = 0;
     long clientY = 0;
 
+    [Conditional=POINTER_LOCK] double movementX = 0;
+    [Conditional=POINTER_LOCK] double movementY = 0;
+
     short button = 0;
     unsigned short buttons = 0;
     EventTarget? relatedTarget = null;

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -38,10 +38,11 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(MouseRelatedEvent);
 
 MouseRelatedEvent::MouseRelatedEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
     MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    const IntPoint& screenLocation, const IntPoint& windowLocation, const IntPoint& movementDelta, OptionSet<Modifier> modifiers, IsSimulated isSimulated, IsTrusted isTrusted)
+    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, IsSimulated isSimulated, IsTrusted isTrusted)
     : UIEventWithKeyState(eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, modifiers, isTrusted)
     , m_screenLocation(screenLocation)
-    , m_movementDelta(movementDelta)
+    , m_movementX(movementX)
+    , m_movementY(movementY)
     , m_isSimulated(isSimulated == IsSimulated::Yes)
 {
     init(m_isSimulated, windowLocation);
@@ -49,14 +50,15 @@ MouseRelatedEvent::MouseRelatedEvent(const AtomString& eventType, CanBubble canB
 
 MouseRelatedEvent::MouseRelatedEvent(const AtomString& type, IsCancelable isCancelable, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, const IntPoint& globalLocation, OptionSet<Modifier> modifiers)
     : MouseRelatedEvent(type, CanBubble::Yes, isCancelable, IsComposed::Yes, timestamp,
-        WTFMove(view), 0, globalLocation, globalLocation /* Converted in init */, { }, modifiers, IsSimulated::No)
+        WTFMove(view), 0, globalLocation, globalLocation /* Converted in init */, 0, 0, modifiers, IsSimulated::No)
 {
 }
 
 MouseRelatedEvent::MouseRelatedEvent(const AtomString& eventType, const MouseRelatedEventInit& initializer, IsTrusted isTrusted)
     : UIEventWithKeyState(eventType, initializer)
     , m_screenLocation(IntPoint(initializer.screenX, initializer.screenY))
-    , m_movementDelta(IntPoint(0, 0))
+    , m_movementX(initializer.movementX)
+    , m_movementY(initializer.movementY)
 {
     ASSERT_UNUSED(isTrusted, isTrusted == IsTrusted::No);
     init(false, IntPoint(0, 0));

--- a/Source/WebCore/dom/MouseRelatedEvent.h
+++ b/Source/WebCore/dom/MouseRelatedEvent.h
@@ -33,6 +33,8 @@ class FrameView;
 struct MouseRelatedEventInit : public EventModifierInit {
     int screenX { 0 };
     int screenY { 0 };
+    double movementX { 0 };
+    double movementY { 0 };
 };
 
 // Internal only: Helper class for what's common between mouse and wheel events.
@@ -48,8 +50,8 @@ public:
     const IntPoint& screenLocation() const { return m_screenLocation; }
     int clientX() const { return m_clientLocation.x(); }
     int clientY() const { return m_clientLocation.y(); }
-    int movementX() const { return m_movementDelta.x(); }
-    int movementY() const { return m_movementDelta.y(); }
+    double movementX() const { return m_movementX; }
+    double movementY() const { return m_movementY; }
 
     const LayoutPoint& clientLocation() const { return m_clientLocation; }
     int layerX() override;
@@ -77,7 +79,7 @@ public:
 protected:
     MouseRelatedEvent() = default;
     MouseRelatedEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime, RefPtr<WindowProxy>&&, int detail,
-        const IntPoint& screenLocation, const IntPoint& windowLocation, const IntPoint& movementDelta, OptionSet<Modifier> modifiers,
+        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers,
         IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
     MouseRelatedEvent(const AtomString& type, IsCancelable, MonotonicTime, RefPtr<WindowProxy>&&, const IntPoint& globalLocation, OptionSet<Modifier>);
     MouseRelatedEvent(const AtomString& type, const MouseRelatedEventInit&, IsTrusted = IsTrusted::No);
@@ -94,7 +96,8 @@ protected:
     // Expose these so MouseEvent::initMouseEvent can set them.
     IntPoint m_screenLocation;
     LayoutPoint m_clientLocation;
-    LayoutPoint m_movementDelta;
+    double m_movementX { 0 };
+    double m_movementY { 0 };
 
 private:
     void init(bool isSimulated, const IntPoint&);

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -92,7 +92,9 @@ PointerEvent::PointerEvent(const AtomString& type, Init&& initializer)
 }
 
 PointerEvent::PointerEvent(const AtomString& type, short button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
-    : MouseEvent(type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), mouseEvent.view(), mouseEvent.detail(), mouseEvent.screenLocation(), { mouseEvent.clientX(), mouseEvent.clientY() }, { mouseEvent.movementX(), mouseEvent.movementY() }, mouseEvent.modifierKeys(), button, mouseEvent.buttons(), mouseEvent.syntheticClickType(), mouseEvent.relatedTarget())
+    : MouseEvent(type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), mouseEvent.view(), mouseEvent.detail(), mouseEvent.screenLocation(),
+        { mouseEvent.clientX(), mouseEvent.clientY() }, mouseEvent.movementX(), mouseEvent.movementY(), mouseEvent.modifierKeys(), button, mouseEvent.buttons(),
+        mouseEvent.syntheticClickType(), mouseEvent.relatedTarget())
     , m_pointerId(pointerId)
     , m_pointerType(pointerType)
     , m_isPrimary(true)
@@ -100,7 +102,7 @@ PointerEvent::PointerEvent(const AtomString& type, short button, const MouseEven
 }
 
 PointerEvent::PointerEvent(const AtomString& type, PointerID pointerId, const String& pointerType, IsPrimary isPrimary)
-    : MouseEvent(type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), nullptr, 0, { }, { }, { }, { }, 0, 0, 0, nullptr)
+    : MouseEvent(type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), nullptr, 0, { }, { }, 0, 0, { }, 0, 0, 0, nullptr)
     , m_pointerId(pointerId)
     , m_pointerType(pointerType)
     , m_isPrimary(isPrimary == IsPrimary::Yes)

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -48,7 +48,7 @@ private:
     SimulatedMouseEvent(const AtomString& eventType, RefPtr<WindowProxy>&& view, RefPtr<Event>&& underlyingEvent, Element& target, SimulatedClickSource source)
         : MouseEvent(eventType, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes,
             underlyingEvent ? underlyingEvent->timeStamp() : MonotonicTime::now(), WTFMove(view), /* detail */ 0,
-            { }, { }, { }, modifiersFromUnderlyingEvent(underlyingEvent), 0, 0, nullptr, 0, 0, IsSimulated::Yes,
+            { }, { }, 0, 0, modifiersFromUnderlyingEvent(underlyingEvent), 0, 0, nullptr, 0, 0, IsSimulated::Yes,
             source == SimulatedClickSource::UserAgent ? IsTrusted::Yes : IsTrusted::No)
     {
         setUnderlyingEvent(underlyingEvent.get());

--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -60,7 +60,7 @@ inline WheelEvent::WheelEvent(const AtomString& type, const Init& initializer)
 
 inline WheelEvent::WheelEvent(const PlatformWheelEvent& event, RefPtr<WindowProxy>&& view, IsCancelable isCancelable)
     : MouseEvent(eventNames().wheelEvent, CanBubble::Yes, isCancelable, IsComposed::Yes, event.timestamp().approximateMonotonicTime(), WTFMove(view), 0,
-        event.globalPosition(), event.position() , { }, event.modifiers(), 0, 0, nullptr, 0, 0, IsSimulated::No, IsTrusted::Yes)
+        event.globalPosition(), event.position() , 0, 0, event.modifiers(), 0, 0, nullptr, 0, 0, IsSimulated::No, IsTrusted::Yes)
     , m_wheelDelta(event.wheelTicksX() * TickMultiplier, event.wheelTicksY() * TickMultiplier)
     , m_deltaX(-event.deltaX())
     , m_deltaY(-event.deltaY())

--- a/Source/WebCore/dom/ios/MouseEventIOS.cpp
+++ b/Source/WebCore/dom/ios/MouseEventIOS.cpp
@@ -50,7 +50,9 @@ static AtomString mouseEventType(PlatformTouchPoint::TouchPhaseType phase)
 
 Ref<MouseEvent> MouseEvent::create(const PlatformTouchEvent& event, unsigned index, Ref<WindowProxy>&& view, IsCancelable cancelable)
 {
-    return adoptRef(*new MouseEvent(mouseEventType(event.touchPhaseAtIndex(index)), CanBubble::Yes, cancelable, IsComposed::Yes, event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), { }, event.modifiers(), 0, 0, nullptr, 0, 0, IsSimulated::No, IsTrusted::Yes));
+    return adoptRef(*new MouseEvent(mouseEventType(event.touchPhaseAtIndex(index)), CanBubble::Yes, cancelable, IsComposed::Yes,
+        event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), 0, 0,
+        event.modifiers(), 0, 0, nullptr, 0, 0, IsSimulated::No, IsTrusted::Yes));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ios/PointerEventIOS.cpp
+++ b/Source/WebCore/dom/ios/PointerEventIOS.cpp
@@ -74,7 +74,8 @@ Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTou
 }
 
 PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view)
-    : MouseEvent(type, typeCanBubble(type), isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), { }, event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, 0, IsSimulated::No, IsTrusted::Yes)
+    : MouseEvent(type, typeCanBubble(type), isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0,
+        event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), 0, 0, event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, 0, IsSimulated::No, IsTrusted::Yes)
     , m_pointerId(event.touchIdentifierAtIndex(index))
     , m_width(2 * event.radiusXAtIndex(index))
     , m_height(2 * event.radiusYAtIndex(index))

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2273,7 +2273,7 @@ bool EventHandler::dispatchDragEvent(const AtomString& eventType, Element& dragT
 
     auto dragEvent = DragEvent::create(eventType, Event::CanBubble::Yes, Event::IsCancelable::Yes, Event::IsComposed::Yes,
         event.timestamp().approximateMonotonicTime(), &m_frame.windowProxy(), 0,
-        event.globalPosition(), event.position(), event.movementDelta(),
+        event.globalPosition(), event.position(), event.movementDelta().x(), event.movementDelta().y(),
         event.modifiers(), 0, 0, nullptr, event.force(), NoTap, &dataTransfer);
 
     dragTarget.dispatchEvent(dragEvent);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1866,7 +1866,7 @@ void WebPage::navigateToPDFLinkWithSimulatedClick(const String& url, IntPoint do
     // FIXME: Set modifier keys.
     // FIXME: This should probably set IsSimulated::Yes.
     auto mouseEvent = MouseEvent::create(eventNames().clickEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes, Event::IsComposed::Yes,
-        MonotonicTime::now(), nullptr, singleClick, screenPoint, documentPoint, { }, { }, 0, 0, nullptr, 0, WebCore::NoTap);
+        MonotonicTime::now(), nullptr, singleClick, screenPoint, documentPoint, 0, 0, { }, 0, 0, nullptr, 0, WebCore::NoTap);
 
     mainFrame->loader().changeLocation(mainFrameDocument->completeURL(url), emptyAtom(), mouseEvent.ptr(), ReferrerPolicy::NoReferrer, ShouldOpenExternalURLsPolicy::ShouldAllow);
 }

--- a/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
+++ b/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
@@ -463,7 +463,7 @@ static const float PAGE_HEIGHT_INSET = 4.0f * 2.0f;
         return;
 
     auto event = MouseEvent::create(eventNames().clickEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes, Event::IsComposed::Yes,
-        MonotonicTime::now(), nullptr, 1, { }, { }, { }, { }, 0, 0, nullptr, 0, 0, MouseEvent::IsSimulated::Yes);
+        MonotonicTime::now(), nullptr, 1, { }, { }, 0, 0, { }, 0, 0, nullptr, 0, 0, MouseEvent::IsSimulated::Yes);
 
     // Call to the frame loader because this is where our security checks are made.
     Frame* frame = core([_dataSource webFrame]);

--- a/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
@@ -960,7 +960,7 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
     if (button != noButton) {
         // FIXME: Use createPlatformMouseEvent instead.
         event = WebCore::MouseEvent::create(WebCore::eventNames().clickEvent, WebCore::Event::CanBubble::Yes, WebCore::Event::IsCancelable::Yes, WebCore::Event::IsComposed::Yes,
-            MonotonicTime::now(), nullptr, [nsEvent clickCount], { }, { }, { }, WebCore::modifiersForEvent(nsEvent),
+            MonotonicTime::now(), nullptr, [nsEvent clickCount], { }, { }, 0, 0, WebCore::modifiersForEvent(nsEvent),
             button, [NSEvent pressedMouseButtons], nullptr, WebCore::ForceAtClick, 0, WebCore::MouseEvent::IsSimulated::Yes);
     }
 


### PR DESCRIPTION
#### a68933526b8cc69a1342601b01ac252c71c56ba0
<pre>
MouseEventInit should take movementX and movementY
<a href="https://bugs.webkit.org/show_bug.cgi?id=246067">https://bugs.webkit.org/show_bug.cgi?id=246067</a>

Reviewed by Chris Dumez.

Added movementX and movementY to MouseEventInit and made them double instead of LayoutUnit
to match the latest specification:
<a href="https://w3c.github.io/pointerlock/#extensions-to-the-mouseevent-interface">https://w3c.github.io/pointerlock/#extensions-to-the-mouseevent-interface</a>

* LayoutTests/imported/w3c/web-platform-tests/pointerlock/constructor-expected.txt:
* LayoutTests/pointer-lock/mouse-event-api-expected.txt:
* LayoutTests/pointer-lock/mouse-event-api.html:
* Source/WebCore/dom/DragEvent.cpp:
(WebCore::DragEvent::create):
(WebCore::DragEvent::DragEvent):
* Source/WebCore/dom/DragEvent.h:
* Source/WebCore/dom/MouseEvent.cpp:
(WebCore::MouseEvent::create):
(WebCore::MouseEvent::MouseEvent):
* Source/WebCore/dom/MouseEvent.h:
* Source/WebCore/dom/MouseEvent.idl:
* Source/WebCore/dom/MouseEventInit.idl:
* Source/WebCore/dom/MouseRelatedEvent.cpp:
(WebCore::MouseRelatedEvent::MouseRelatedEvent):
* Source/WebCore/dom/MouseRelatedEvent.h:
(WebCore::MouseRelatedEvent::movementX const):
(WebCore::MouseRelatedEvent::movementY const):
* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/dom/SimulatedClick.cpp:
* Source/WebCore/dom/WheelEvent.cpp:
(WebCore::WheelEvent::WheelEvent):
* Source/WebCore/dom/ios/MouseEventIOS.cpp:
(WebCore::MouseEvent::create):
* Source/WebCore/dom/ios/PointerEventIOS.cpp:
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::dispatchDragEvent):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::navigateToPDFLinkWithSimulatedClick):
* Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm:
(-[WebPDFViewPlaceholder simulateClickOnLinkToURL:]):
* Source/WebKitLegacy/mac/WebView/WebPDFView.mm:
(-[WebPDFView PDFViewWillClickOnLink:withURL:]):

Canonical link: <a href="https://commits.webkit.org/255328@main">https://commits.webkit.org/255328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29c4716d8d0d57405c5eba56d31d50827e749032

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92158 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101945 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1386 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29779 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84600 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98112 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/892 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78681 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27833 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70872 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36206 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16418 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33963 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17547 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40228 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1662 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36673 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->