### PR TITLE
[WK2] Start removal of legacy decoding methods from ArgumentCoder specializations

### DIFF
--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -62,9 +62,12 @@ template<typename T> struct SimpleArgumentCoder {
         encoder.encodeFixedLengthData(reinterpret_cast<const uint8_t*>(&t), sizeof(T), alignof(T));
     }
 
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, T& t)
+    static std::optional<T> decode(Decoder& decoder)
     {
-        return decoder.decodeFixedLengthData(reinterpret_cast<uint8_t*>(&t), sizeof(T), alignof(T));
+        T value;
+        if (!decoder.decodeFixedLengthData(reinterpret_cast<uint8_t*>(&value), sizeof(T), alignof(T)))
+            return std::nullopt;
+        return value;
     }
 };
 
@@ -297,18 +300,6 @@ template<typename T> struct ArgumentCoder<OptionSet<T>> {
     }
 
     template<typename Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, OptionSet<T>& optionSet)
-    {
-        typename OptionSet<T>::StorageType value;
-        if (!decoder.decode(value))
-            return false;
-        optionSet = OptionSet<T>::fromRaw(value);
-        if (!WTF::isValidOptionSet(optionSet))
-            return false;
-        return true;
-    }
-
-    template<typename Decoder>
     static std::optional<OptionSet<T>> decode(Decoder& decoder)
     {
         std::optional<typename OptionSet<T>::StorageType> value;
@@ -333,25 +324,6 @@ template<typename T> struct ArgumentCoder<std::optional<T>> {
 
         encoder << true;
         encoder << optional.value();
-    }
-
-    template<typename Decoder> static WARN_UNUSED_RETURN bool decode(Decoder& decoder, std::optional<T>& optional)
-    {
-        bool isEngaged;
-        if (!decoder.decode(isEngaged))
-            return false;
-
-        if (!isEngaged) {
-            optional = std::nullopt;
-            return true;
-        }
-
-        T value;
-        if (!decoder.decode(value))
-            return false;
-
-        optional = WTFMove(value);
-        return true;
     }
 
     template<typename Decoder> static std::optional<std::optional<T>> decode(Decoder& decoder)
@@ -385,26 +357,6 @@ template<typename T> struct ArgumentCoder<Box<T>> {
     }
 
     template<typename Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, Box<T>& box)
-    {
-        bool isEngaged;
-        if (!decoder.decode(isEngaged))
-            return false;
-
-        if (!isEngaged) {
-            box = nullptr;
-            return true;
-        }
-
-        Box<T> value = Box<T>::create();
-        if (!decoder.decode(*value))
-            return false;
-
-        box = WTFMove(value);
-        return true;
-    }
-
-    template<typename Decoder>
     static std::optional<Box<T>> decode(Decoder& decoder)
     {
         std::optional<bool> isEngaged;
@@ -427,22 +379,6 @@ template<typename T, typename U> struct ArgumentCoder<std::pair<T, U>> {
     static void encode(Encoder& encoder, const std::pair<T, U>& pair)
     {
         encoder << pair.first << pair.second;
-    }
-
-    template<typename Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, std::pair<T, U>& pair)
-    {
-        T first;
-        if (!decoder.decode(first))
-            return false;
-
-        U second;
-        if (!decoder.decode(second))
-            return false;
-
-        pair.first = first;
-        pair.second = second;
-        return true;
     }
 
     template<typename Decoder>
@@ -572,19 +508,17 @@ template<typename KeyType, typename ValueType> struct ArgumentCoder<WTF::KeyValu
     }
 
     template<typename Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, WTF::KeyValuePair<KeyType, ValueType>& pair)
+    static std::optional<WTF::KeyValuePair<KeyType, ValueType>> decode(Decoder& decoder)
     {
-        KeyType key;
-        if (!decoder.decode(key))
-            return false;
+        auto key = decoder.template decode<KeyType>();
+        if (!key)
+            return std::nullopt;
 
-        ValueType value;
-        if (!decoder.decode(value))
-            return false;
+        auto value = decoder.template decode<ValueType>();
+        if (!value)
+            return std::nullopt;
 
-        pair.key = key;
-        pair.value = value;
-        return true;
+        return WTF::KeyValuePair { WTFMove(*key), WTFMove(*value) };
     }
 };
 
@@ -597,17 +531,6 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
         encoder << static_cast<uint64_t>(vector.size());
         for (size_t i = 0; i < vector.size(); ++i)
             encoder << vector[i];
-    }
-
-    template<typename Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, Vector<T, inlineCapacity, OverflowHandler, minCapacity>& vector)
-    {
-        std::optional<Vector<T, inlineCapacity, OverflowHandler, minCapacity>> optional;
-        decoder >> optional;
-        if (!optional)
-            return false;
-        vector = WTFMove(*optional);
-        return true;
     }
 
     template<typename Decoder>
@@ -637,34 +560,6 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
     {
         encoder << static_cast<uint64_t>(vector.size());
         encoder.encodeFixedLengthData(reinterpret_cast<const uint8_t*>(vector.data()), vector.size() * sizeof(T), alignof(T));
-    }
-
-    template<typename Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, Vector<T, inlineCapacity, OverflowHandler, minCapacity>& vector)
-    {
-        uint64_t decodedSize;
-        if (!decoder.decode(decodedSize))
-            return false;
-
-        if (!isInBounds<size_t>(decodedSize))
-            return false;
-
-        auto size = static_cast<size_t>(decodedSize);
-
-        // Since we know the total size of the elements, we can allocate the vector in
-        // one fell swoop. Before allocating we must however make sure that the decoder buffer
-        // is big enough.
-        if (!decoder.template bufferIsLargeEnoughToContain<T>(size))
-            return false;
-
-        Vector<T, inlineCapacity, OverflowHandler, minCapacity> temp;
-        temp.grow(size);
-
-        if (!decoder.decodeFixedLengthData(reinterpret_cast<uint8_t*>(temp.data()), size * sizeof(T), alignof(T)))
-            return false;
-
-        vector.swap(temp);
-        return true;
     }
 
     template<typename Decoder>
@@ -739,17 +634,6 @@ template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTrai
 
         return hashMap;
     }
-
-    template<typename Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, HashMapType& hashMap)
-    {
-        std::optional<HashMapType> tempHashMap;
-        decoder >> tempHashMap;
-        if (!tempHashMap)
-            return false;
-        hashMap.swap(*tempHashMap);
-        return true;
-    }
 };
 
 template<typename KeyArg, typename HashArg, typename KeyTraitsArg, typename HashTableTraits> struct ArgumentCoder<HashSet<KeyArg, HashArg, KeyTraitsArg, HashTableTraits>> {
@@ -761,18 +645,6 @@ template<typename KeyArg, typename HashArg, typename KeyTraitsArg, typename Hash
         encoder << static_cast<uint64_t>(hashSet.size());
         for (typename HashSetType::const_iterator it = hashSet.begin(), end = hashSet.end(); it != end; ++it)
             encoder << *it;
-    }
-
-    template<typename Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, HashSetType& hashSet)
-    {
-        std::optional<HashSetType> tempHashSet;
-        decoder >> tempHashSet;
-        if (!tempHashSet)
-            return false;
-
-        hashSet.swap(tempHashSet.value());
-        return true;
     }
 
     template<typename Decoder>
@@ -817,33 +689,32 @@ template<typename KeyArg, typename HashArg, typename KeyTraitsArg> struct Argume
     }
 
     template<typename Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, HashCountedSetType& hashCountedSet)
+    static std::optional<HashCountedSetType> decode(Decoder& decoder)
     {
-        uint64_t hashCountedSetSize;
-        if (!decoder.decode(hashCountedSetSize))
-            return false;
+        auto hashCountedSetSize = decoder.template decode<uint64_t>();
+        if (!hashCountedSetSize)
+            return std::nullopt;
 
-        HashCountedSetType tempHashCountedSet;
-        for (uint64_t i = 0; i < hashCountedSetSize; ++i) {
-            KeyArg key;
-            if (!decoder.decode(key))
-                return false;
+        HashCountedSetType hashCountedSet;
+        for (uint64_t i = 0; i < *hashCountedSetSize; ++i) {
+            auto key = decoder.template decode<KeyArg>();
+            if (!key)
+                return std::nullopt;
 
-            unsigned count;
-            if (!decoder.decode(count))
-                return false;
+            auto count = decoder.template decode<unsigned>();
+            if (!count)
+                return std::nullopt;
 
             if (UNLIKELY(!HashCountedSetType::isValidValue(key)))
-                return false;
+                return std::nullopt;
 
-            if (UNLIKELY(!tempHashCountedSet.add(key, count).isNewEntry)) {
+            if (UNLIKELY(!hashCountedSet.add(WTFMove(*key), count).isNewEntry)) {
                 // The hash counted set already has the specified key, bail.
-                return false;
+                return std::nullopt;
             }
         }
 
-        hashCountedSet.swap(tempHashCountedSet);
-        return true;
+        return hashCountedSet;
     }
 };
 
@@ -970,14 +841,13 @@ template<typename... Types> struct ArgumentCoder<std::variant<Types...>> {
 template<> struct ArgumentCoder<WallTime> {
     template<typename Encoder>
     static void encode(Encoder&, const WallTime&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WallTime&);
     template<typename Decoder>
     static std::optional<WallTime> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<AtomString> {
     static void encode(Encoder&, const AtomString&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, AtomString&);
+    static std::optional<AtomString> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<CString> {
@@ -990,7 +860,6 @@ template<> struct ArgumentCoder<CString> {
 template<> struct ArgumentCoder<String> {
     template<typename Encoder>
     static void encode(Encoder&, const String&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, String&);
     template<typename Decoder>
     static std::optional<String> decode(Decoder&);
 };
@@ -1002,7 +871,7 @@ template<> struct ArgumentCoder<StringView> {
 
 template<> struct ArgumentCoder<SHA1::Digest> {
     static void encode(Encoder&, const SHA1::Digest&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, SHA1::Digest&);
+    static std::optional<SHA1::Digest> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<std::monostate> {
@@ -1018,7 +887,7 @@ template<> struct ArgumentCoder<std::monostate> {
 
 template<> struct ArgumentCoder<std::nullptr_t> {
     static void encode(Encoder&, const std::nullptr_t&) { }
-    static WARN_UNUSED_RETURN bool decode(Decoder&, std::nullptr_t&) { return true; }
+    static std::optional<std::nullptr_t> decode(Decoder&) { return { std::nullptr_t { } }; };
 };
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/darwin/ArgumentCodersDarwin.h
+++ b/Source/WebKit/Platform/IPC/darwin/ArgumentCodersDarwin.h
@@ -46,7 +46,7 @@ template<> struct ArgumentCoder<WTF::MachSendRight> {
 #if HAVE(AUDIT_TOKEN)
 template<> struct ArgumentCoder<audit_token_t> {
     static void encode(Encoder&, const audit_token_t&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, audit_token_t&);
+    static std::optional<audit_token_t> decode(Decoder&);
 };
 #endif
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -139,14 +139,7 @@ using namespace WebKit;
 #define DEFINE_SIMPLE_ARGUMENT_CODER_FOR_SOURCE(Type) \
     template<typename Encoder> \
     void ArgumentCoder<Type>::encode(Encoder& encoder, const Type& value) { SimpleArgumentCoder<Type>::encode(encoder, value); } \
-    bool ArgumentCoder<Type>::decode(Decoder& decoder, Type& value) { return SimpleArgumentCoder<Type>::decode(decoder, value); } \
-    std::optional<Type> ArgumentCoder<Type>::decode(Decoder& decoder) \
-    { \
-        Type value; \
-        if (!decode(decoder, value)) \
-            return std::nullopt; \
-        return value; \
-    } \
+    std::optional<Type> ArgumentCoder<Type>::decode(Decoder& decoder) { return SimpleArgumentCoder<Type>::decode(decoder); } \
     template void ArgumentCoder<Type>::encode<Encoder>(Encoder&, const Type&); \
     template void ArgumentCoder<Type>::encode<StreamConnectionEncoder>(StreamConnectionEncoder&, const Type&);
 
@@ -272,10 +265,10 @@ void ArgumentCoder<RectEdges<bool>>::encode(Encoder& encoder, const RectEdges<bo
 {
     SimpleArgumentCoder<RectEdges<bool>>::encode(encoder, boxEdges);
 }
-    
-bool ArgumentCoder<RectEdges<bool>>::decode(Decoder& decoder, RectEdges<bool>& boxEdges)
+
+std::optional<RectEdges<bool>> ArgumentCoder<RectEdges<bool>>::decode(Decoder& decoder)
 {
-    return SimpleArgumentCoder<RectEdges<bool>>::decode(decoder, boxEdges);
+    return SimpleArgumentCoder<RectEdges<bool>>::decode(decoder);
 }
 
 #if ENABLE(META_VIEWPORT)
@@ -284,17 +277,9 @@ void ArgumentCoder<ViewportArguments>::encode(Encoder& encoder, const ViewportAr
     SimpleArgumentCoder<ViewportArguments>::encode(encoder, viewportArguments);
 }
 
-bool ArgumentCoder<ViewportArguments>::decode(Decoder& decoder, ViewportArguments& viewportArguments)
-{
-    return SimpleArgumentCoder<ViewportArguments>::decode(decoder, viewportArguments);
-}
-
 std::optional<ViewportArguments> ArgumentCoder<ViewportArguments>::decode(Decoder& decoder)
 {
-    ViewportArguments viewportArguments;
-    if (!SimpleArgumentCoder<ViewportArguments>::decode(decoder, viewportArguments))
-        return std::nullopt;
-    return viewportArguments;
+    return SimpleArgumentCoder<ViewportArguments>::decode(decoder);
 }
 
 #endif // ENABLE(META_VIEWPORT)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -221,7 +221,6 @@ namespace IPC {
 #define DEFINE_SIMPLE_ARGUMENT_CODER_FOR_HEADER(Type) \
     template<> struct ArgumentCoder<Type> { \
         template<typename Encoder> static void encode(Encoder&, const Type&); \
-        static WARN_UNUSED_RETURN bool decode(Decoder&, Type&); \
         static std::optional<Type> decode(Decoder&); \
     };
 
@@ -261,13 +260,12 @@ template<> struct ArgumentCoder<WebCore::CertificateInfo> {
 
 template<> struct ArgumentCoder<WebCore::RectEdges<bool>> {
     static void encode(Encoder&, const WebCore::RectEdges<bool>&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::RectEdges<bool>&);
+    static std::optional<WebCore::RectEdges<bool>> decode(Decoder&);
 };
 
 #if ENABLE(META_VIEWPORT)
 template<> struct ArgumentCoder<WebCore::ViewportArguments> {
     static void encode(Encoder&, const WebCore::ViewportArguments&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ViewportArguments&);
     static std::optional<WebCore::ViewportArguments> decode(Decoder&);
 };
 


### PR DESCRIPTION
#### 52376c23850374ac0e295dd006d1c9ae4a93c241
<pre>
[WK2] Start removal of legacy decoding methods from ArgumentCoder specializations
<a href="https://bugs.webkit.org/show_bug.cgi?id=246254">https://bugs.webkit.org/show_bug.cgi?id=246254</a>

Reviewed by NOBODY (OOPS!).

Start removing legacy IPC decoding methods from different ArgumentCoder specializations
in the WebKit layer. The removed methods are replaced by existing or now-provided
modern, std::optional&lt;&gt;-based decoding methods.

This patch covers ArgumentCoder specializations in the ArgumentCoders.h header as well
as uses of SimpleArgumentCoder.

* Source/WebKit/Platform/IPC/ArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WallTime&gt;::decode):
(IPC::ArgumentCoder&lt;AtomString&gt;::decode):
(IPC::ArgumentCoder&lt;SHA1::Digest&gt;::decode):
(IPC::ArgumentCoder&lt;audit_token_t&gt;::decode):
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::SimpleArgumentCoder::decode):
(IPC::ArgumentCoder&lt;std::nullptr_t&gt;::decode):
* Source/WebKit/Platform/IPC/darwin/ArgumentCodersDarwin.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;RectEdges&lt;bool&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;ViewportArguments&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52376c23850374ac0e295dd006d1c9ae4a93c241

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101948 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1389 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29783 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98115 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/895 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78684 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27835 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82427 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70875 "Found 2 new API test failures: /TestWTF:WTF_WordLock.ManyContendedLongSections, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/children-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36209 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16425 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33966 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17558 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40231 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36684 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->