### PR TITLE
Non-unified build fixes after 255307@main

### DIFF
--- a/Source/WebCore/Modules/reporting/ReportingScope.h
+++ b/Source/WebCore/Modules/reporting/ReportingScope.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ContextDestructionObserver.h"
+#include "ViolationReportType.h"
 #include <wtf/Deque.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/IsoMalloc.h>

--- a/Source/WebCore/Modules/reporting/ViolationReportType.h
+++ b/Source/WebCore/Modules/reporting/ViolationReportType.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/EnumTraits.h>
+
 namespace WebCore {
 
 enum class ViolationReportType : uint8_t {

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -28,6 +28,7 @@
 #if ENABLE(FULLSCREEN_API)
 #include "DocumentFullscreen.h"
 
+#include "Element.h"
 #include "EventLoop.h"
 #include "JSDOMPromiseDeferred.h"
 

--- a/Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp
@@ -29,6 +29,7 @@
 #include "DocumentOrShadowRootFullscreen.h"
 
 #include "Document.h"
+#include "Element.h"
 #include "FullscreenManager.h"
 #include "TreeScope.h"
 

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -30,6 +30,7 @@
 
 #include "Chrome.h"
 #include "ChromeClient.h"
+#include "DOMWindow.h"
 #include "ElementInlines.h"
 #include "EventLoop.h"
 #include "EventNames.h"


### PR DESCRIPTION
#### 49c3b49aa9c288cc07dba3c8ac565c61d0404225
<pre>
Non-unified build fixes after 255307@main

Unreviewed build fixes.

* Source/WebCore/Modules/reporting/ReportingScope.h: Add missing
  ViolationReportType.h header.
* Source/WebCore/Modules/reporting/ViolationReportType.h: Add missing
  wtf/EnumTraits.h header.
* Source/WebCore/dom/DocumentFullscreen.cpp: Add missing Element.h
  header.
* Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp: Ditto.
* Source/WebCore/dom/FullscreenManager.cpp: Add missing DOMWindow.h
  header.

Canonical link: <a href="https://commits.webkit.org/255327@main">https://commits.webkit.org/255327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed0c3450abe8b6dfb8ca76364f8d5a812f4c28de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101953 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1393 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29788 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84608 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98120 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/899 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78689 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27841 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70881 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36213 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16429 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33971 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17564 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3694 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40236 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36690 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->