### PR TITLE
[GPU Process] Enable drawing form controls for GPU Process on macOS

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/api/dtmf_sender_interface.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/api/dtmf_sender_interface.h
@@ -13,7 +13,6 @@
 
 #include <string>
 
-#include "api/media_stream_interface.h"
 #include "rtc_base/ref_count.h"
 
 namespace webrtc {

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/dtmf_sender.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/dtmf_sender.cc
@@ -13,6 +13,7 @@
 #include <ctype.h>
 #include <string.h>
 
+#include "api/make_ref_counted.h"
 #include "api/task_queue/pending_task_safety_flag.h"
 #include "api/task_queue/task_queue_base.h"
 #include "api/units/time_delta.h"

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/dtmf_sender.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/dtmf_sender.h
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "api/dtmf_sender_interface.h"
+#include "api/make_ref_counted.h"
 #include "api/scoped_refptr.h"
 #include "api/sequence_checker.h"
 #include "api/task_queue/pending_task_safety_flag.h"

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -273,6 +273,7 @@ platform/cocoa/DragDataCocoa.mm
 platform/cocoa/DragImageCocoa.mm
 platform/cocoa/FileMonitorCocoa.mm
 platform/cocoa/KeyEventCocoa.mm
+platform/cocoa/LocalCurrentGraphicsContextSwitcher.cpp
 platform/cocoa/LocalizedStringsCocoa.mm
 platform/cocoa/LowPowerModeNotifier.mm
 platform/cocoa/MIMETypeRegistryCocoa.mm

--- a/Source/WebCore/platform/cocoa/LocalCurrentGraphicsContext.h
+++ b/Source/WebCore/platform/cocoa/LocalCurrentGraphicsContext.h
@@ -33,6 +33,7 @@ namespace WebCore {
 // This class automatically saves and restores the current NSGraphicsContext for
 // functions which call out into AppKit and rely on the currentContext being set
 class LocalCurrentGraphicsContext {
+    WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(LocalCurrentGraphicsContext);
 public:
     WEBCORE_EXPORT LocalCurrentGraphicsContext(GraphicsContext&);

--- a/Source/WebCore/platform/cocoa/LocalCurrentGraphicsContextSwitcher.cpp
+++ b/Source/WebCore/platform/cocoa/LocalCurrentGraphicsContextSwitcher.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LocalCurrentGraphicsContextSwitcher.h"
+
+#if PLATFORM(COCOA)
+
+namespace WebCore {
+
+LocalCurrentGraphicsContextSwitcher::LocalCurrentGraphicsContextSwitcher(GraphicsContext& context, const FloatRect& paintRect, float deviceScaleFactor)
+    : m_savedGraphicsContext(context)
+    , m_paintRect(paintRect)
+{
+    if (!context.hasPlatformContext()) {
+        m_imageBuffer = m_savedGraphicsContext.createImageBuffer(m_paintRect.size(), deviceScaleFactor, DestinationColorSpace::SRGB(), context.renderingMode(), RenderingMethod::Local);
+        if (m_imageBuffer) {
+            m_localContext = makeUnique<LocalCurrentGraphicsContext>(m_imageBuffer->context());
+            return;
+        }
+    }
+    m_localContext = makeUnique<LocalCurrentGraphicsContext>(m_savedGraphicsContext);
+}
+
+LocalCurrentGraphicsContextSwitcher::~LocalCurrentGraphicsContextSwitcher()
+{
+    m_localContext = nullptr;
+    if (m_imageBuffer)
+        m_savedGraphicsContext.drawConsumingImageBuffer(WTFMove(m_imageBuffer), m_paintRect.location());
+}
+
+GraphicsContext& LocalCurrentGraphicsContextSwitcher::context() const
+{
+    if (m_imageBuffer)
+        return m_imageBuffer->context();
+    return m_savedGraphicsContext;
+}
+
+CGContextRef LocalCurrentGraphicsContextSwitcher::cgContext()
+{
+    return m_localContext->cgContext();
+}
+
+FloatRect LocalCurrentGraphicsContextSwitcher::drawingRect() const
+{
+    if (m_imageBuffer)
+        return FloatRect { { }, m_paintRect.size() };
+    return m_paintRect;
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/cocoa/LocalCurrentGraphicsContextSwitcher.h
+++ b/Source/WebCore/platform/cocoa/LocalCurrentGraphicsContextSwitcher.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+
+#include "FloatRect.h"
+#include "LocalCurrentGraphicsContext.h"
+
+namespace WebCore {
+
+class LocalCurrentGraphicsContextSwitcher {
+public:
+    LocalCurrentGraphicsContextSwitcher(GraphicsContext&, const FloatRect& paintRect, float deviceScaleFactor);
+    ~LocalCurrentGraphicsContextSwitcher();
+
+    GraphicsContext& context() const;
+    CGContextRef cgContext();
+    FloatRect drawingRect() const;
+
+private:
+    GraphicsContext& m_savedGraphicsContext;
+    RefPtr<ImageBuffer> m_imageBuffer;
+    FloatRect m_paintRect;
+    std::unique_ptr<LocalCurrentGraphicsContext> m_localContext;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -459,9 +459,6 @@ bool RenderTheme::paint(const RenderBox& box, ControlStates& controlStates, cons
     if (paintInfo.context().paintingDisabled())
         return false;
 
-    if (UNLIKELY(!canPaint(paintInfo, box.settings())))
-        return false;
-
     ControlPart part = box.style().effectiveAppearance();
     IntRect integralSnappedRect = snappedIntRect(rect);
     float deviceScaleFactor = box.document().deviceScaleFactor();

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -176,6 +176,8 @@ private:
     void updateFocusedState(NSCell *, const RenderObject*);
     void updatePressedState(NSCell*, const RenderObject&);
 
+    void drawListButtonForInput(const RenderObject&, GraphicsContext&, const FloatRect& paintRect);
+
     // Helpers for adjusting appearance and for painting
 
     void paintCellAndSetFocusedElementNeedsRepaintIfNecessary(NSCell*, const RenderObject&, const PaintInfo&, const FloatRect&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -480,7 +480,7 @@ RefPtr<ImageBuffer> RemoteDisplayListRecorderProxy::createImageBuffer(const Floa
     }
 
     if (renderingMethod)
-        return Recorder::createImageBuffer(size, resolutionScale, colorSpace, renderingMode, renderingMethod);
+        return Recorder::createImageBuffer(size, resolutionScale, colorSpace, RenderingMode::Unaccelerated, renderingMethod);
 
     // FIXME: Ideally we'd plumb the purpose through for callers of GraphicsContext::createImageBuffer().
     RenderingPurpose purpose = m_imageBuffer ? m_imageBuffer->renderingPurpose() : RenderingPurpose::Unspecified;


### PR DESCRIPTION
#### d305c9cae7959bc8091014ce6fdc8c6f67ca2b87
<pre>
[GPU Process] Enable drawing form controls for GPU Process on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=246264">https://bugs.webkit.org/show_bug.cgi?id=246264</a>
rdar://69408789

Reviewed by NOBODY (OOPS!).

If the GraphicsContext is a display-list recorder, the form control drawing will
be directed to a temporary ImageBuffer. The size of the ImageBuffer will be
paintRect.size(). Instead of drawing at paintRect.location(), we will draw at
{ 0, 0 } in the context of the ImageBuffer. Once the drawing is finished, the
ImageBuffer will be drawn in the layer context at paintRect.location().

To facilitate switching the target context when drawing the form control, the new
class &apos;LocalCurrentGraphicsContextSwitcher&apos; will be introduced. This class will
seamlessly create the ImageBuffer, switch the target context and draw the
ImageBuffer to the layer context when needed. It will also encapsulate an instance
of LocalCurrentGraphicsContext which sets the drawing context to AppKit.

* Source/ThirdParty/libwebrtc/Source/webrtc/api/dtmf_sender_interface.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/dtmf_sender.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/dtmf_sender.h:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/cocoa/LocalCurrentGraphicsContext.h:
* Source/WebCore/platform/cocoa/LocalCurrentGraphicsContextSwitcher.cpp: Added.
(WebCore::LocalCurrentGraphicsContextSwitcher::LocalCurrentGraphicsContextSwitcher):
(WebCore::LocalCurrentGraphicsContextSwitcher::~LocalCurrentGraphicsContextSwitcher):
(WebCore::LocalCurrentGraphicsContextSwitcher::context const):
(WebCore::LocalCurrentGraphicsContextSwitcher::cgContext):
(WebCore::LocalCurrentGraphicsContextSwitcher::drawingRect const):
* Source/WebCore/platform/cocoa/LocalCurrentGraphicsContextSwitcher.h: Added.
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::paintStepper):
(WebCore::ThemeMac::drawCellOrFocusRingWithViewIntoContext):
(WebCore::ThemeMac::paint):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paint):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::drawListButtonForInput):
(WebCore::RenderThemeMac::paintTextField):
(WebCore::RenderThemeMac::paintTextArea):
(WebCore::RenderThemeMac::paintProgressBar):
(WebCore::RenderThemeMac::paintSliderTrack):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::createImageBuffer const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d305c9cae7959bc8091014ce6fdc8c6f67ca2b87

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101966 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162199 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1405 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29803 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84620 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98132 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/911 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78701 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27852 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70892 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36225 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16449 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/33983 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17604 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40248 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36736 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->