### PR TITLE
Support text style based formatting in WKWebView

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -741,6 +741,8 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 
 - (void)_simulateMouseMove:(NSEvent *)event WK_API_AVAILABLE(macos(13.0));
 
+- (void)_setFont:(NSFont *)font sender:(id)sender WK_API_AVAILABLE(macos(WK_MAC_TBA));
+
 @end
 
 #endif // !TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1677,6 +1677,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return _impl->mouseMoved(event);
 }
 
+- (void)_setFont:(NSFont *)font sender:(id)sender
+{
+    _impl->setFontForWebView(font, sender);
+}
+
 @end // WKWebView (WKPrivateMac)
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3805,6 +3805,10 @@ WEBCORE_COMMAND_FOR_WEBVIEW(pasteAndMatchStyle);
     changes.setFontSize(font.pointSize);
     changes.setBold(font.traits & UIFontTraitBold);
     changes.setItalic(font.traits & UIFontTraitItalic);
+
+    if (NSString *textStyleAttribute = [font.fontDescriptor.fontAttributes objectForKey:UIFontDescriptorTextStyleAttribute])
+        changes.setFontFamily(textStyleAttribute);
+
     _page->changeFont(WTFMove(changes));
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -336,6 +336,8 @@ public:
     void prepareForMoveToWindow(NSWindow *targetWindow, WTF::Function<void()>&& completionHandler);
     NSWindow *targetWindowForMovePreparation() const { return m_targetWindowForMovePreparation.get(); }
 
+    void setFontForWebView(NSFont *, id);
+
     void updateSecureInputState();
     void resetSecureInputState();
     bool inSecureInputState() const { return m_inSecureInputState; }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2421,6 +2421,24 @@ void WebViewImpl::prepareForMoveToWindow(NSWindow *targetWindow, WTF::Function<v
     m_viewInWindowChangeWasDeferred = false;
 }
 
+void WebViewImpl::setFontForWebView(NSFont *font, id sender)
+{
+    NSFontManager *fontManager = [NSFontManager sharedFontManager];
+    NSFontTraitMask fontTraits = [fontManager traitsOfFont:font];
+
+    WebCore::FontChanges changes;
+    changes.setFontFamily(font.familyName);
+    changes.setFontName(font.fontName);
+    changes.setFontSize(font.pointSize);
+    changes.setBold(fontTraits & NSBoldFontMask);
+    changes.setItalic(fontTraits & NSItalicFontMask);
+
+    if (NSString *textStyleAttribute = [font.fontDescriptor objectForKey:(__bridge NSString *)kCTFontDescriptorTextStyleAttribute])
+        changes.setFontFamily(textStyleAttribute);
+
+    m_page->changeFont(WTFMove(changes));
+}
+
 void WebViewImpl::updateSecureInputState()
 {
     if (![[m_view window] isKeyWindow] || !isFocused()) {


### PR DESCRIPTION
#### 72d33310959128180edfd50213f746ee34d9465a
<pre>
Support text style based formatting in WKWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=246261">https://bugs.webkit.org/show_bug.cgi?id=246261</a>
rdar://100631963

Reviewed by Wenson Hsieh and Devin Rousso.

This PR adds support for text style based formatting in WKWebView for Cocoa
platforms. Clients may now set the font of a WKWebView to one of the Apple
platform text style fonts, such as `UICTFontTextStyleCallout`.

The SPI `[WKWebView _setFont:sender:]` has been added to macOS to match the
existing SPI on iOS.

Conversly, when the current text selection changes, clients may use the
existing delegate method `[WKUIDelegate _webView:didChangeFontAttributes:]`
to query for the platform text style, if any, via

```
[[[fontAttributes objectForKey:@&quot;NSFont&quot;] fontDescriptor] objectForKey:(__bridge NSString *)kCTFontDescriptorTextStyleAttribute];
```

which will return an `NSString *` matching one of the `UICTFontTextStyle` constants.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setFont:sender:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _setFontForWebView:sender:]):
This now checks if the font provided is a system text style font, and if so,
overrides the font family attribute to specify the exact style instead of the
current generic system font.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::_setFontForWebView):
This has effectively the same implementation as its iOS counterpart.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FontAttributes.mm:
(-[AppleFontTextStyleUIDelegate _webView:didChangeFontAttributes:]):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/255375@main">https://commits.webkit.org/255375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcbc215abe9a5c619e4bc08af586266a5477294e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102046 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1490 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29885 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84703 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98212 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/976 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78782 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27918 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70955 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36305 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34061 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17683 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3728 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40313 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36824 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->