### PR TITLE
Add _WKWebExtensionContext and WebKit::WebExtensionContext.

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -148,6 +148,7 @@ $(PROJECT_DIR)/Shared/ShareableBitmap.serialization.in
 $(PROJECT_DIR)/Shared/TextFlags.serialization.in
 $(PROJECT_DIR)/Shared/WebConnection.messages.in
 $(PROJECT_DIR)/Shared/WebCoreArgumentCoders.serialization.in
+$(PROJECT_DIR)/Shared/WebExtensionContextParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebExtensionControllerParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUBindGroupEntry.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUBlendComponent.serialization.in
@@ -183,6 +184,7 @@ $(PROJECT_DIR)/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Cocoa/VideoFullscreenManagerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Downloads/DownloadProxy.messages.in
 $(PROJECT_DIR)/UIProcess/DrawingAreaProxy.messages.in
+$(PROJECT_DIR)/UIProcess/Extensions/WebExtensionContext.messages.in
 $(PROJECT_DIR)/UIProcess/Extensions/WebExtensionController.messages.in
 $(PROJECT_DIR)/UIProcess/GPU/GPUProcessProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Inspector/RemoteWebInspectorUIProxy.messages.in
@@ -222,6 +224,7 @@ $(PROJECT_DIR)/WebProcess/Automation/WebAutomationSessionProxy.js
 $(PROJECT_DIR)/WebProcess/Automation/WebAutomationSessionProxy.messages.in
 $(PROJECT_DIR)/WebProcess/Cache/WebCacheStorageConnection.messages.in
 $(PROJECT_DIR)/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.messages.in
+$(PROJECT_DIR)/WebProcess/Extensions/WebExtensionContextProxy.messages.in
 $(PROJECT_DIR)/WebProcess/Extensions/WebExtensionControllerProxy.messages.in
 $(PROJECT_DIR)/WebProcess/FullScreen/WebFullScreenManager.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/GPUProcessConnection.messages.in

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -512,6 +512,12 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebDeviceOrientationUpdateProviderMe
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebDeviceOrientationUpdateProviderProxyMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebDeviceOrientationUpdateProviderProxyMessagesReplies.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebExtensionContextMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebExtensionContextMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebExtensionContextMessagesReplies.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebExtensionContextProxyMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebExtensionContextProxyMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebExtensionContextProxyMessagesReplies.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebExtensionControllerMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebExtensionControllerMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebExtensionControllerMessagesReplies.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -180,6 +180,7 @@ MESSAGE_RECEIVERS = \
 	UIProcess/WebProcessPool \
         UIProcess/WebScreenOrientationManagerProxy \
 	UIProcess/Downloads/DownloadProxy \
+	UIProcess/Extensions/WebExtensionContext \
 	UIProcess/Extensions/WebExtensionController \
 	UIProcess/Media/AudioSessionRoutingArbitratorProxy \
 	UIProcess/Media/RemoteMediaSessionCoordinatorProxy \
@@ -187,6 +188,7 @@ MESSAGE_RECEIVERS = \
 	UIProcess/SpeechRecognitionServer \
 	UIProcess/XR/PlatformXRSystem \
 	WebProcess/Databases/IndexedDB/WebIDBConnectionToServer \
+	WebProcess/Extensions/WebExtensionContextProxy \
 	WebProcess/Extensions/WebExtensionControllerProxy \
 	WebProcess/GPU/GPUProcessConnection \
 	WebProcess/GPU/graphics/RemoteRenderingBackendProxy \
@@ -462,6 +464,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/LayerTreeContext.serialization.in \
 	Shared/TextFlags.serialization.in \
 	Shared/WebCoreArgumentCoders.serialization.in \
+	Shared/WebExtensionContextParameters.serialization.in \
 	Shared/WebExtensionControllerParameters.serialization.in \
 	Shared/mac/SecItemResponseData.serialization.in \
 	Shared/WebsiteDataStoreParameters.serialization.in \

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -24,8 +24,15 @@
  */
 
 #import <wtf/RetainPtr.h>
+#import <wtf/UUID.h>
+#import <wtf/WallTime.h>
 
+OBJC_CLASS NSArray;
+OBJC_CLASS NSDate;
 OBJC_CLASS NSDictionary;
+OBJC_CLASS NSSet;
+OBJC_CLASS NSString;
+OBJC_CLASS NSUUID;
 
 namespace WebKit {
 
@@ -67,5 +74,11 @@ T *objectForKey(const RetainPtr<NSDictionary>& dictionary, id key, bool returnin
 }
 
 NSString *escapeCharactersInString(NSString *, NSString *charactersToEscape);
+
+NSDate *toAPI(const WallTime&);
+WallTime toImpl(NSDate *);
+
+NSUUID *toAPI(const UUID&);
+UUID toImpl(NSUUID *);
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -213,4 +213,44 @@ NSString *escapeCharactersInString(NSString *string, NSString *charactersToEscap
     return result;
 }
 
+NSUUID *toAPI(const UUID& uuid)
+{
+    if (!uuid)
+        return nil;
+
+    return [[NSUUID alloc] initWithUUIDBytes:uuid.toSpan().data()];
+}
+
+UUID toImpl(NSUUID *uuid)
+{
+    if (!uuid)
+        return UUID(0);
+
+    uuid_t bytes;
+    [uuid getUUIDBytes:bytes];
+    return UUID(bytes);
+}
+
+NSDate *toAPI(const WallTime& time)
+{
+    if (std::isnan(time))
+        return nil;
+
+    if (std::isinf(time))
+        return NSDate.distantFuture;
+
+    return [NSDate dateWithTimeIntervalSince1970:time.secondsSinceEpoch().value()];
+}
+
+WallTime toImpl(NSDate *date)
+{
+    if (!date)
+        return WallTime::nan();
+
+    if ([date isEqualToDate:NSDate.distantFuture])
+        return WallTime::infinity();
+
+    return WallTime::fromRawSeconds(date.timeIntervalSince1970);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -177,6 +177,7 @@ public:
         VisitedLinkStore,
 #if ENABLE(WK_WEB_EXTENSIONS)
         WebExtension,
+        WebExtensionContext,
         WebExtensionController,
         WebExtensionMatchPattern,
 #endif
@@ -431,6 +432,7 @@ template<> struct EnumTraits<API::Object::Type> {
         API::Object::Type::VisitedLinkStore,
 #if ENABLE(WK_WEB_EXTENSIONS)
         API::Object::Type::WebExtension,
+        API::Object::Type::WebExtensionContext,
         API::Object::Type::WebExtensionController,
         API::Object::Type::WebExtensionMatchPattern,
 #endif

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -105,6 +105,7 @@
 #endif
 
 #if ENABLE(WK_WEB_EXTENSIONS)
+#import "_WKWebExtensionContextInternal.h"
 #import "_WKWebExtensionControllerInternal.h"
 #import "_WKWebExtensionInternal.h"
 #import "_WKWebExtensionMatchPatternInternal.h"
@@ -400,6 +401,10 @@ void* Object::newObject(size_t size, Type type)
 #if ENABLE(WK_WEB_EXTENSIONS)
     case Type::WebExtension:
         wrapper = [_WKWebExtension alloc];
+        break;
+
+    case Type::WebExtensionContext:
+        wrapper = [_WKWebExtensionContext alloc];
         break;
 
     case Type::WebExtensionController:

--- a/Source/WebKit/Shared/WebExtensionContextIdentifier.h
+++ b/Source/WebKit/Shared/WebExtensionContextIdentifier.h
@@ -27,36 +27,13 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#include "APIObject.h"
-#include "MessageReceiver.h"
-#include "WebExtensionControllerIdentifier.h"
-#include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/ObjectIdentifier.h>
 
 namespace WebKit {
 
-struct WebExtensionControllerParameters;
+enum WebExtensionContextIdentifierType { };
+using WebExtensionContextIdentifier = ObjectIdentifier<WebExtensionContextIdentifierType>;
 
-class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExtensionController>, public IPC::MessageReceiver {
-    WTF_MAKE_NONCOPYABLE(WebExtensionController);
-
-public:
-    static Ref<WebExtensionController> create() { return adoptRef(*new WebExtensionController); }
-    static WebExtensionController* get(WebExtensionControllerIdentifier);
-
-    explicit WebExtensionController();
-    ~WebExtensionController();
-
-    WebExtensionControllerIdentifier identifier() const { return m_identifier; }
-    WebExtensionControllerParameters parameters() const;
-
-private:
-    // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-
-    WebExtensionControllerIdentifier m_identifier;
-};
-
-} // namespace WebKit
+}
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/WebExtensionContextParameters.h
+++ b/Source/WebKit/Shared/WebExtensionContextParameters.h
@@ -27,34 +27,12 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#include "APIObject.h"
-#include "MessageReceiver.h"
-#include "WebExtensionControllerIdentifier.h"
-#include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
+#include "WebExtensionContextIdentifier.h"
 
 namespace WebKit {
 
-struct WebExtensionControllerParameters;
-
-class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExtensionController>, public IPC::MessageReceiver {
-    WTF_MAKE_NONCOPYABLE(WebExtensionController);
-
-public:
-    static Ref<WebExtensionController> create() { return adoptRef(*new WebExtensionController); }
-    static WebExtensionController* get(WebExtensionControllerIdentifier);
-
-    explicit WebExtensionController();
-    ~WebExtensionController();
-
-    WebExtensionControllerIdentifier identifier() const { return m_identifier; }
-    WebExtensionControllerParameters parameters() const;
-
-private:
-    // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-
-    WebExtensionControllerIdentifier m_identifier;
+struct WebExtensionContextParameters {
+    WebExtensionContextIdentifier identifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/WebExtensionContextParameters.serialization.in
@@ -1,0 +1,27 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+struct WebKit::WebExtensionContextParameters {
+    WebKit::WebExtensionContextIdentifier identifier;
+}
+#endif

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -537,6 +537,7 @@ UIProcess/Automation/WebAutomationSession.cpp @no-unify
 UIProcess/Downloads/DownloadProxy.cpp
 UIProcess/Downloads/DownloadProxyMap.cpp
 
+UIProcess/Extensions/WebExtensionContext.cpp
 UIProcess/Extensions/WebExtensionController.cpp
 
 UIProcess/Gamepad/UIGamepad.cpp
@@ -611,6 +612,7 @@ WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
 
 WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
 
+WebProcess/Extensions/WebExtensionContextProxy.cpp
 WebProcess/Extensions/WebExtensionControllerProxy.cpp
 
 WebProcess/FileAPI/BlobRegistryProxy.cpp

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -90,10 +90,10 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @property (readonly, nonatomic) NSSet<_WKWebExtensionPermission> *requestedPermissions;
 @property (readonly, nonatomic) NSSet<_WKWebExtensionPermission> *optionalPermissions;
 
-@property (readonly, nonatomic) NSSet<_WKWebExtensionMatchPattern *> *requestedPermissionOrigins;
-@property (readonly, nonatomic) NSSet<_WKWebExtensionMatchPattern *> *optionalPermissionOrigins;
+@property (readonly, nonatomic) NSSet<_WKWebExtensionMatchPattern *> *requestedPermissionMatchPatterns;
+@property (readonly, nonatomic) NSSet<_WKWebExtensionMatchPattern *> *optionalPermissionMatchPatterns;
 
-@property (readonly, nonatomic) NSSet<_WKWebExtensionMatchPattern *> *allRequestedOrigins;
+@property (readonly, nonatomic) NSSet<_WKWebExtensionMatchPattern *> *allRequestedMatchPatterns;
 
 @property (readonly, nonatomic) BOOL hasBackgroundContent;
 @property (readonly, nonatomic) BOOL backgroundContentIsPersistent;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -162,37 +162,27 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 
 - (NSSet<_WKWebExtensionPermission> *)requestedPermissions
 {
-    return _webExtension->requestedPermissions();
+    return WebKit::toAPI(_webExtension->requestedPermissions());
 }
 
 - (NSSet<_WKWebExtensionPermission> *)optionalPermissions
 {
-    return _webExtension->optionalPermissions();
+    return WebKit::toAPI(_webExtension->optionalPermissions());
 }
 
-static inline NSSet<_WKWebExtensionMatchPattern *> *toAPI(const HashSet<Ref<WebKit::WebExtensionMatchPattern>>& patterns)
+- (NSSet<_WKWebExtensionMatchPattern *> *)requestedPermissionMatchPatterns
 {
-    NSMutableSet<_WKWebExtensionMatchPattern *> *result = [NSMutableSet setWithCapacity:patterns.size()];
-
-    for (auto& matchPattern : patterns)
-        [result addObject:WebKit::wrapper(matchPattern)];
-
-    return [result copy];
+    return toAPI(_webExtension->requestedPermissionMatchPatterns());
 }
 
-- (NSSet<_WKWebExtensionMatchPattern *> *)requestedPermissionOrigins
+- (NSSet<_WKWebExtensionMatchPattern *> *)optionalPermissionMatchPatterns
 {
-    return toAPI(_webExtension->requestedPermissionOrigins());
+    return toAPI(_webExtension->optionalPermissionMatchPatterns());
 }
 
-- (NSSet<_WKWebExtensionMatchPattern *> *)optionalPermissionOrigins
+- (NSSet<_WKWebExtensionMatchPattern *> *)allRequestedMatchPatterns
 {
-    return toAPI(_webExtension->optionalPermissionOrigins());
-}
-
-- (NSSet<_WKWebExtensionMatchPattern *> *)allRequestedOrigins
-{
-    return toAPI(_webExtension->allRequestedOrigins());
+    return toAPI(_webExtension->allRequestedMatchPatterns());
 }
 
 - (NSArray<NSError *> *)errors
@@ -321,17 +311,17 @@ static inline NSSet<_WKWebExtensionMatchPattern *> *toAPI(const HashSet<Ref<WebK
     return nil;
 }
 
-- (NSSet<_WKWebExtensionMatchPattern *> *)requestedPermissionOrigins
+- (NSSet<_WKWebExtensionMatchPattern *> *)requestedPermissionMatchPatterns
 {
     return nil;
 }
 
-- (NSSet<_WKWebExtensionMatchPattern *> *)optionalPermissionOrigins
+- (NSSet<_WKWebExtensionMatchPattern *> *)optionalPermissionMatchPatterns
 {
     return nil;
 }
 
-- (NSSet<_WKWebExtensionMatchPattern *> *)allRequestedOrigins
+- (NSSet<_WKWebExtensionMatchPattern *> *)allRequestedMatchPatterns
 {
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+#import <Foundation/Foundation.h>
+
+#import <WebKit/_WKWebExtensionMatchPattern.h>
+#import <WebKit/_WKWebExtensionPermission.h>
+
+@class _WKWebExtension;
+@class _WKWebExtensionController;
+@protocol _WKWebExtensionTab;
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, _WKWebExtensionContextPermissionState) {
+    _WKWebExtensionContextPermissionStateDeniedExplicitly    = -3,
+    _WKWebExtensionContextPermissionStateDeniedImplicitly    = -2,
+    _WKWebExtensionContextPermissionStateRequestedImplicitly = -1,
+    _WKWebExtensionContextPermissionStateUnknown             = 0,
+    _WKWebExtensionContextPermissionStateRequestedExplicitly = 1,
+    _WKWebExtensionContextPermissionStateGrantedImplicitly   = 2,
+    _WKWebExtensionContextPermissionStateGrantedExplicitly   = 3,
+} NS_SWIFT_NAME(_WKWebExtensionContext.PermissionState) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN NSNotificationName const _WKWebExtensionContextPermissionsWereGrantedNotification NS_SWIFT_NAME(_WKWebExtensionContext.permissionsWereGrantedNotification);
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN NSNotificationName const _WKWebExtensionContextPermissionsWereDeniedNotification NS_SWIFT_NAME(_WKWebExtensionContext.permissionsWereDeniedNotification);
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN NSNotificationName const _WKWebExtensionContextGrantedPermissionsWereRemovedNotification NS_SWIFT_NAME(_WKWebExtensionContext.grantedPermissionsWereRemovedNotification);
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN NSNotificationName const _WKWebExtensionContextDeniedPermissionsWereRemovedNotification NS_SWIFT_NAME(_WKWebExtensionContext.deniedPermissionsWereRemovedNotification);
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN NSNotificationName const _WKWebExtensionContextPermissionMatchPatternsWereGrantedNotification NS_SWIFT_NAME(_WKWebExtensionContext.permissionMatchPatternsWereGrantedNotification);
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN NSNotificationName const _WKWebExtensionContextPermissionMatchPatternsWereDeniedNotification NS_SWIFT_NAME(_WKWebExtensionContext.permissionMatchPatternsWereDeniedNotification);
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN NSNotificationName const _WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification NS_SWIFT_NAME(_WKWebExtensionContext.grantedPermissionMatchPatternsWereRemovedNotification);
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN NSNotificationName const _WKWebExtensionContextDeniedPermissionMatchPatternsWereRemovedNotification NS_SWIFT_NAME(_WKWebExtensionContext.deniedPermissionMatchPatternsWereRemovedNotification);
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+typedef NSString * _WKWebExtensionContextNotificationUserInfoKey NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAME(_WKWebExtensionContext.NotificationUserInfoKey);
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotificationUserInfoKeyPermissions;
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotificationUserInfoKeyMatchPatterns;
+
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@interface _WKWebExtensionContext : NSObject
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)contextWithExtension:(_WKWebExtension *)extension;
+
+- (instancetype)initWithExtension:(_WKWebExtension *)extension NS_DESIGNATED_INITIALIZER;
+
+@property (nonatomic, readonly, strong) _WKWebExtension *extension;
+@property (nonatomic, readonly, weak) _WKWebExtensionController *extensionController;
+
+@property (nonatomic, copy) NSURL *baseURL;
+@property (nonatomic, copy) NSString *uniqueIdentifier;
+
+// Granted permissions with their expiration date. Never includes expired entries at time of access.
+@property (nonatomic, copy) NSDictionary<_WKWebExtensionPermission, NSDate *> *grantedPermissions;
+@property (nonatomic, copy) NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *grantedPermissionMatchPatterns;
+
+// Denied permissions with their expiration date. Never includes expired entries at time of access.
+@property (nonatomic, copy) NSDictionary<_WKWebExtensionPermission, NSDate *> *deniedPermissions;
+@property (nonatomic, copy) NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *deniedPermissionMatchPatterns;
+
+// When set to YES, this allows an extension to upgrade to asking for all URLs
+// without actually granting all URLs from an optional permissions request.
+@property (nonatomic) BOOL requestedOptionalAccessToAllHosts;
+
+// All permissions currently allowed, including non-expired granted permissions.
+@property (nonatomic, readonly, copy) NSSet<_WKWebExtensionPermission> *currentPermissions;
+@property (nonatomic, readonly, copy) NSSet<_WKWebExtensionMatchPattern *> *currentPermissionMatchPatterns;
+
+- (BOOL)hasPermission:(_WKWebExtensionPermission)permission;
+- (BOOL)hasPermission:(_WKWebExtensionPermission)permission inTab:(nullable id <_WKWebExtensionTab>)tab;
+
+- (BOOL)hasAccessToURL:(NSURL *)url;
+- (BOOL)hasAccessToURL:(NSURL *)url inTab:(nullable id <_WKWebExtensionTab>)tab;
+
+// Specifically checks for any <all_urls> patterns. It does not check for all hosts patterns.
+// This is needed for APIs like tabs.captureVisibleTab that need to check specifically for <all_urls>.
+// You likely want to use hasPermissionToAccessAllHosts instead.
+@property (nonatomic, readonly) BOOL hasAccessToAllURLs;
+
+// Checks for any <all_urls>, or all hosts patterns.
+@property (nonatomic, readonly) BOOL hasAccessToAllHosts;
+
+- (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission;
+- (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission inTab:(nullable id <_WKWebExtensionTab>)tab;
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission;
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission expirationDate:(nullable NSDate *)expirationDate;
+
+- (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url NS_SWIFT_NAME(permissionState(forURL:));
+- (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url inTab:(nullable id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(permissionState(forURL:in:));
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url;
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url expirationDate:(nullable NSDate *)expirationDate;
+
+- (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern;
+- (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern inTab:(nullable id <_WKWebExtensionTab>)tab;
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern;
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(nullable NSDate *)expirationDate;
+
+- (void)userGesturePerformedInTab:(id <_WKWebExtensionTab>)tab;
+- (BOOL)hasActiveUserGestureInTab:(id <_WKWebExtensionTab>)tab;
+- (void)cancelUserGestureForTab:(id <_WKWebExtensionTab>)tab;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -1,0 +1,650 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "_WKWebExtensionContextInternal.h"
+
+#import "CocoaHelpers.h"
+#import "WebExtension.h"
+#import "WebExtensionContext.h"
+#import "_WKWebExtensionControllerInternal.h"
+#import "_WKWebExtensionInternal.h"
+#import "_WKWebExtensionMatchPatternInternal.h"
+#import "_WKWebExtensionTab.h"
+#import <WebCore/WebCoreObjCExtras.h>
+
+NSNotificationName const _WKWebExtensionContextPermissionsWereGrantedNotification = @"_WKWebExtensionContextPermissionsWereGranted";
+NSNotificationName const _WKWebExtensionContextPermissionsWereDeniedNotification = @"_WKWebExtensionContextPermissionsWereDenied";
+NSNotificationName const _WKWebExtensionContextGrantedPermissionsWereRemovedNotification = @"_WKWebExtensionContextGrantedPermissionsWereRemoved";
+NSNotificationName const _WKWebExtensionContextDeniedPermissionsWereRemovedNotification = @"_WKWebExtensionContextDeniedPermissionsWereRemoved";
+
+NSNotificationName const _WKWebExtensionContextPermissionMatchPatternsWereGrantedNotification = @"_WKWebExtensionContextPermissionMatchPatternsWereGranted";
+NSNotificationName const _WKWebExtensionContextPermissionMatchPatternsWereDeniedNotification = @"_WKWebExtensionContextPermissionMatchPatternsWereDenied";
+NSNotificationName const _WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification = @"_WKWebExtensionContextGrantedPermissionMatchPatternsWereRemoved";
+NSNotificationName const _WKWebExtensionContextDeniedPermissionMatchPatternsWereRemovedNotification = @"_WKWebExtensionContextDeniedPermissionMatchPatternsWereRemoved";
+
+_WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotificationUserInfoKeyPermissions = @"permissions";
+_WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotificationUserInfoKeyMatchPatterns = @"matchPatterns";
+
+@implementation _WKWebExtensionContext
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
++ (instancetype)contextWithExtension:(_WKWebExtension *)extension
+{
+    NSParameterAssert(extension);
+
+    return [[self alloc] initWithExtension:extension];
+}
+
+- (instancetype)initWithExtension:(_WKWebExtension *)extension
+{
+    NSParameterAssert(extension);
+
+    if (!(self = [super init]))
+        return nil;
+
+    API::Object::constructInWrapper<WebKit::WebExtensionContext>(self, extension._webExtension);
+
+    return self;
+}
+
+- (void)dealloc
+{
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtensionContext.class, self))
+        return;
+
+    _webExtensionContext->~WebExtensionContext();
+}
+
+- (_WKWebExtension *)extension
+{
+    return wrapper(&_webExtensionContext->extension());
+}
+
+- (_WKWebExtensionController *)extensionController
+{
+    return wrapper(_webExtensionContext->extensionController());
+}
+
+- (NSURL *)baseURL
+{
+    return _webExtensionContext->baseURL();
+}
+
+- (void)setBaseURL:(NSURL *)baseURL
+{
+    NSParameterAssert(baseURL);
+
+    _webExtensionContext->setBaseURL(baseURL);
+}
+
+- (NSString *)uniqueIdentifier
+{
+    return _webExtensionContext->uniqueIdentifier();
+}
+
+- (void)setUniqueIdentifier:(NSString *)uniqueIdentifier
+{
+    NSParameterAssert(uniqueIdentifier);
+
+    _webExtensionContext->setUniqueIdentifier(uniqueIdentifier);
+}
+
+static inline WallTime toImpl(NSDate *date)
+{
+    return date ? WebKit::toImpl(date) : WebKit::toImpl(NSDate.distantFuture);
+}
+
+static inline NSDictionary<_WKWebExtensionPermission, NSDate *> *toAPI(const WebKit::WebExtensionContext::PermissionsMap& permissions)
+{
+    NSMutableDictionary<_WKWebExtensionPermission, NSDate *> *result = [NSMutableDictionary dictionaryWithCapacity:permissions.size()];
+
+    for (auto& entry : permissions)
+        [result setObject:WebKit::toAPI(entry.value) forKey:entry.key];
+
+    return [result copy];
+}
+
+static inline NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *toAPI(const WebKit::WebExtensionContext::PermissionMatchPatternsMap& permissionMatchPatterns)
+{
+    NSMutableDictionary<_WKWebExtensionMatchPattern *, NSDate *> *result = [NSMutableDictionary dictionaryWithCapacity:permissionMatchPatterns.size()];
+
+    for (auto& entry : permissionMatchPatterns)
+        [result setObject:WebKit::toAPI(entry.value) forKey:wrapper(entry.key)];
+
+    return [result copy];
+}
+
+static inline WebKit::WebExtensionContext::PermissionsMap toImpl(NSDictionary<_WKWebExtensionPermission, NSDate *> *permissions)
+{
+    __block WebKit::WebExtensionContext::PermissionsMap result;
+    result.reserveInitialCapacity(permissions.count);
+
+    [permissions enumerateKeysAndObjectsUsingBlock:^(_WKWebExtensionPermission permission, NSDate *date, BOOL *) {
+        result.set(permission, toImpl(date));
+    }];
+
+    return result;
+}
+
+static inline WebKit::WebExtensionContext::PermissionMatchPatternsMap toImpl(NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *permissionMatchPatterns)
+{
+    __block WebKit::WebExtensionContext::PermissionMatchPatternsMap result;
+    result.reserveInitialCapacity(permissionMatchPatterns.count);
+
+    [permissionMatchPatterns enumerateKeysAndObjectsUsingBlock:^(_WKWebExtensionMatchPattern *origin, NSDate *date, BOOL *) {
+        result.set(origin._webExtensionMatchPattern, toImpl(date));
+    }];
+
+    return result;
+}
+
+- (NSDictionary<_WKWebExtensionPermission, NSDate *> *)grantedPermissions
+{
+    return toAPI(_webExtensionContext->grantedPermissions());
+}
+
+- (void)setGrantedPermissions:(NSDictionary<_WKWebExtensionPermission, NSDate *> *)grantedPermissions
+{
+    NSParameterAssert(grantedPermissions);
+
+    _webExtensionContext->setGrantedPermissions(toImpl(grantedPermissions));
+}
+
+- (NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *)grantedPermissionMatchPatterns
+{
+    return toAPI(_webExtensionContext->grantedPermissionMatchPatterns());
+}
+
+- (void)setGrantedPermissionMatchPatterns:(NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *)grantedPermissionMatchPatterns
+{
+    NSParameterAssert(grantedPermissionMatchPatterns);
+
+    _webExtensionContext->setGrantedPermissionMatchPatterns(toImpl(grantedPermissionMatchPatterns));
+}
+
+- (NSDictionary<_WKWebExtensionPermission, NSDate *> *)deniedPermissions
+{
+    return toAPI(_webExtensionContext->deniedPermissions());
+}
+
+- (void)setDeniedPermissions:(NSDictionary<_WKWebExtensionPermission, NSDate *> *)deniedPermissions
+{
+    NSParameterAssert(deniedPermissions);
+
+    _webExtensionContext->setDeniedPermissions(toImpl(deniedPermissions));
+}
+
+- (NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *)deniedPermissionMatchPatterns
+{
+    return toAPI(_webExtensionContext->deniedPermissionMatchPatterns());
+}
+
+- (void)setDeniedPermissionMatchPatterns:(NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *)deniedPermissionMatchPatterns
+{
+    NSParameterAssert(deniedPermissionMatchPatterns);
+
+    _webExtensionContext->setDeniedPermissionMatchPatterns(toImpl(deniedPermissionMatchPatterns));
+}
+
+- (BOOL)requestedOptionalAccessToAllHosts
+{
+    return _webExtensionContext->requestedOptionalAccessToAllHosts();
+}
+
+- (void)setRequestedOptionalAccessToAllHosts:(BOOL)requested
+{
+    return _webExtensionContext->setRequestedOptionalAccessToAllHosts(requested);
+}
+
+static inline NSSet<_WKWebExtensionPermission> *toAPI(const WebKit::WebExtensionContext::PermissionsMap::KeysConstIteratorRange& permissions)
+{
+    NSMutableSet<_WKWebExtensionPermission> *result = [NSMutableSet setWithCapacity:permissions.size()];
+
+    for (auto& permission : permissions)
+        [result addObject:permission];
+
+    return [result copy];
+}
+
+static inline NSSet<_WKWebExtensionMatchPattern *> *toAPI(const WebKit::WebExtensionContext::PermissionMatchPatternsMap::KeysConstIteratorRange& permissionMatchPatterns)
+{
+    NSMutableSet<_WKWebExtensionMatchPattern *> *result = [NSMutableSet setWithCapacity:permissionMatchPatterns.size()];
+
+    for (auto& origin : permissionMatchPatterns)
+        [result addObject:wrapper(origin)];
+
+    return [result copy];
+}
+
+- (NSSet<_WKWebExtensionPermission> *)currentPermissions
+{
+    return toAPI(_webExtensionContext->currentPermissions());
+}
+
+- (NSSet<_WKWebExtensionMatchPattern *> *)currentPermissionMatchPatterns
+{
+    return toAPI(_webExtensionContext->currentPermissionMatchPatterns());
+}
+
+- (BOOL)hasPermission:(_WKWebExtensionPermission)permission
+{
+    NSParameterAssert(permission);
+
+    return [self hasPermission:permission inTab:nil];
+}
+
+- (BOOL)hasPermission:(_WKWebExtensionPermission)permission inTab:(id<_WKWebExtensionTab>)tab
+{
+    NSParameterAssert(permission);
+
+    return _webExtensionContext->hasPermission(permission, tab);
+}
+
+- (BOOL)hasAccessToURL:(NSURL *)url
+{
+    NSParameterAssert(url);
+
+    return [self hasAccessToURL:url inTab:nil];
+}
+
+- (BOOL)hasAccessToURL:(NSURL *)url inTab:(id<_WKWebExtensionTab>)tab
+{
+    NSParameterAssert(url);
+
+    return _webExtensionContext->hasPermission(url, tab);
+}
+
+static inline _WKWebExtensionContextPermissionState toAPI(WebKit::WebExtensionContext::PermissionState state)
+{
+    switch (state) {
+    case WebKit::WebExtensionContext::PermissionState::DeniedExplicitly:
+        return _WKWebExtensionContextPermissionStateDeniedExplicitly;
+    case WebKit::WebExtensionContext::PermissionState::DeniedImplicitly:
+        return _WKWebExtensionContextPermissionStateDeniedImplicitly;
+    case WebKit::WebExtensionContext::PermissionState::RequestedImplicitly:
+        return _WKWebExtensionContextPermissionStateRequestedImplicitly;
+    case WebKit::WebExtensionContext::PermissionState::Unknown:
+        return _WKWebExtensionContextPermissionStateUnknown;
+    case WebKit::WebExtensionContext::PermissionState::RequestedExplicitly:
+        return _WKWebExtensionContextPermissionStateRequestedExplicitly;
+    case WebKit::WebExtensionContext::PermissionState::GrantedImplicitly:
+        return _WKWebExtensionContextPermissionStateGrantedImplicitly;
+    case WebKit::WebExtensionContext::PermissionState::GrantedExplicitly:
+        return _WKWebExtensionContextPermissionStateGrantedExplicitly;
+    }
+}
+
+static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensionContextPermissionState state)
+{
+    switch (state) {
+    case _WKWebExtensionContextPermissionStateDeniedExplicitly:
+        return WebKit::WebExtensionContext::PermissionState::DeniedExplicitly;
+    case _WKWebExtensionContextPermissionStateDeniedImplicitly:
+        return WebKit::WebExtensionContext::PermissionState::DeniedImplicitly;
+    case _WKWebExtensionContextPermissionStateRequestedImplicitly:
+        return WebKit::WebExtensionContext::PermissionState::RequestedImplicitly;
+    case _WKWebExtensionContextPermissionStateUnknown:
+        return WebKit::WebExtensionContext::PermissionState::Unknown;
+    case _WKWebExtensionContextPermissionStateRequestedExplicitly:
+        return WebKit::WebExtensionContext::PermissionState::RequestedExplicitly;
+    case _WKWebExtensionContextPermissionStateGrantedImplicitly:
+        return WebKit::WebExtensionContext::PermissionState::GrantedImplicitly;
+    case _WKWebExtensionContextPermissionStateGrantedExplicitly:
+        return WebKit::WebExtensionContext::PermissionState::GrantedExplicitly;
+    }
+}
+
+- (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission
+{
+    NSParameterAssert(permission);
+
+    return [self permissionStateForPermission:permission inTab:nil];
+}
+
+- (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission inTab:(id<_WKWebExtensionTab>)tab
+{
+    NSParameterAssert(permission);
+
+    return toAPI(_webExtensionContext->permissionState(permission, tab));
+}
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission
+{
+    NSParameterAssert(state == _WKWebExtensionContextPermissionStateDeniedExplicitly || state == _WKWebExtensionContextPermissionStateUnknown || state == _WKWebExtensionContextPermissionStateGrantedExplicitly);
+    NSParameterAssert(permission);
+
+    [self setPermissionState:state forPermission:permission expirationDate:nil];
+}
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission expirationDate:(NSDate *)expirationDate
+{
+    NSParameterAssert(state == _WKWebExtensionContextPermissionStateDeniedExplicitly || state == _WKWebExtensionContextPermissionStateUnknown || state == _WKWebExtensionContextPermissionStateGrantedExplicitly);
+    NSParameterAssert(permission);
+
+    _webExtensionContext->setPermissionState(toImpl(state), permission, toImpl(expirationDate));
+}
+
+- (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url
+{
+    NSParameterAssert(url);
+
+    return [self permissionStateForURL:url inTab:nil];
+}
+
+- (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url inTab:(id<_WKWebExtensionTab>)tab
+{
+    NSParameterAssert(url);
+
+    return toAPI(_webExtensionContext->permissionState(url, tab));
+}
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url
+{
+    NSParameterAssert(url);
+
+    [self setPermissionState:state forURL:url expirationDate:nil];
+}
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url expirationDate:(NSDate *)expirationDate
+{
+    NSParameterAssert(url);
+
+    _webExtensionContext->setPermissionState(toImpl(state), url, toImpl(expirationDate));
+}
+
+- (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern
+{
+    NSParameterAssert(pattern);
+
+    return [self permissionStateForMatchPattern:pattern inTab:nil];
+}
+
+- (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern inTab:(id<_WKWebExtensionTab>)tab
+{
+    NSParameterAssert(pattern);
+
+    return toAPI(_webExtensionContext->permissionState(pattern._webExtensionMatchPattern, tab));
+}
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern
+{
+    NSParameterAssert(state == _WKWebExtensionContextPermissionStateDeniedExplicitly || state == _WKWebExtensionContextPermissionStateUnknown || state == _WKWebExtensionContextPermissionStateGrantedExplicitly);
+    NSParameterAssert(pattern);
+
+    [self setPermissionState:state forMatchPattern:pattern expirationDate:nil];
+}
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(NSDate *)expirationDate
+{
+    NSParameterAssert(state == _WKWebExtensionContextPermissionStateDeniedExplicitly || state == _WKWebExtensionContextPermissionStateUnknown || state == _WKWebExtensionContextPermissionStateGrantedExplicitly);
+    NSParameterAssert(pattern);
+
+    _webExtensionContext->setPermissionState(toImpl(state), pattern._webExtensionMatchPattern, toImpl(expirationDate));
+}
+
+- (BOOL)hasAccessToAllURLs
+{
+    return _webExtensionContext->hasAccessToAllURLs();
+}
+
+- (BOOL)hasAccessToAllHosts
+{
+    return _webExtensionContext->hasAccessToAllHosts();
+}
+
+- (void)userGesturePerformedInTab:(id<_WKWebExtensionTab>)tab
+{
+    NSParameterAssert(tab);
+
+    _webExtensionContext->userGesturePerformed(tab);
+}
+
+- (BOOL)hasActiveUserGestureInTab:(id<_WKWebExtensionTab>)tab
+{
+    NSParameterAssert(tab);
+
+    return _webExtensionContext->hasActiveUserGesture(tab);
+}
+
+- (void)cancelUserGestureForTab:(id<_WKWebExtensionTab>)tab
+{
+    NSParameterAssert(tab);
+
+    _webExtensionContext->cancelUserGesture(tab);
+}
+
+#pragma mark WKObject protocol implementation
+
+- (API::Object&)_apiObject
+{
+    return *_webExtensionContext;
+}
+
+- (WebKit::WebExtensionContext&)_webExtensionContext
+{
+    return *_webExtensionContext;
+}
+
+#else // ENABLE(WK_WEB_EXTENSIONS)
+
++ (instancetype)contextWithExtension:(_WKWebExtension *)extension
+{
+    return nil;
+}
+
+- (instancetype)initWithExtension:(_WKWebExtension *)extension
+{
+    return nil;
+}
+
+- (_WKWebExtension *)extension
+{
+    return nil;
+}
+
+- (_WKWebExtensionController *)extensionController
+{
+    return nil;
+}
+
+- (NSURL *)baseURL
+{
+    return nil;
+}
+
+- (void)setBaseURL:(NSURL *)baseURL
+{
+}
+
+- (NSString *)uniqueIdentifier
+{
+    return nil;
+}
+
+- (void)setUniqueIdentifier:(NSString *)uniqueIdentifier
+{
+}
+
+- (NSDictionary<_WKWebExtensionPermission, NSDate *> *)grantedPermissions
+{
+    return nil;
+}
+
+- (void)setGrantedPermissions:(NSDictionary<_WKWebExtensionPermission, NSDate *> *)grantedPermissions
+{
+}
+
+- (NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *)grantedPermissionMatchPatterns
+{
+    return nil;
+}
+
+- (void)setGrantedPermissionMatchPatterns:(NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *)grantedPermissionMatchPatterns
+{
+}
+
+- (NSDictionary<_WKWebExtensionPermission, NSDate *> *)deniedPermissions
+{
+    return nil;
+}
+
+- (void)setDeniedPermissions:(NSDictionary<_WKWebExtensionPermission, NSDate *> *)deniedPermissions
+{
+}
+
+- (NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *)deniedPermissionMatchPatterns
+{
+    return nil;
+}
+
+- (void)setDeniedPermissionMatchPatterns:(NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *)deniedPermissionMatchPatterns
+{
+}
+
+- (BOOL)requestedOptionalAccessToAllHosts
+{
+    return NO;
+}
+
+- (void)setRequestedOptionalAccessToAllHosts:(BOOL)requested
+{
+}
+
+- (NSSet<_WKWebExtensionPermission> *)currentPermissions
+{
+    return nil;
+}
+
+- (NSSet<_WKWebExtensionMatchPattern *> *)currentPermissionMatchPatterns
+{
+    return nil;
+}
+
+- (BOOL)hasPermission:(_WKWebExtensionPermission)permission
+{
+    return NO;
+}
+
+- (BOOL)hasPermission:(_WKWebExtensionPermission)permission inTab:(id<_WKWebExtensionTab>)tab
+{
+    return NO;
+}
+
+- (BOOL)hasAccessToURL:(NSURL *)url
+{
+    return NO;
+}
+
+- (BOOL)hasAccessToURL:(NSURL *)url inTab:(id<_WKWebExtensionTab>)tab
+{
+    return NO;
+}
+
+- (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission
+{
+    return _WKWebExtensionContextPermissionStateUnknown;
+}
+
+- (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission inTab:(id<_WKWebExtensionTab>)tab
+{
+    return _WKWebExtensionContextPermissionStateUnknown;
+}
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission
+{
+}
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission expirationDate:(NSDate *)expirationDate
+{
+}
+
+- (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url
+{
+    return _WKWebExtensionContextPermissionStateUnknown;
+}
+
+- (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url inTab:(id<_WKWebExtensionTab>)tab
+{
+    return _WKWebExtensionContextPermissionStateUnknown;
+}
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url
+{
+}
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url expirationDate:(NSDate *)expirationDate
+{
+}
+
+- (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern
+{
+    return _WKWebExtensionContextPermissionStateUnknown;
+}
+
+- (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern inTab:(id<_WKWebExtensionTab>)tab
+{
+    return _WKWebExtensionContextPermissionStateUnknown;
+}
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern
+{
+}
+
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(NSDate *)expirationDate
+{
+}
+
+- (BOOL)hasAccessToAllURLs
+{
+    return NO;
+}
+
+- (BOOL)hasAccessToAllHosts
+{
+    return NO;
+}
+
+- (void)userGesturePerformedInTab:(id<_WKWebExtensionTab>)tab
+{
+}
+
+- (BOOL)hasActiveUserGestureInTab:(id<_WKWebExtensionTab>)tab
+{
+    return NO;
+}
+
+- (void)cancelUserGestureForTab:(id<_WKWebExtensionTab>)tab
+{
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextInternal.h
@@ -23,40 +23,26 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#import "_WKWebExtensionContextPrivate.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#include "APIObject.h"
-#include "MessageReceiver.h"
-#include "WebExtensionControllerIdentifier.h"
-#include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
+#import "WKObject.h"
+#import "WebExtensionContext.h"
 
 namespace WebKit {
-
-struct WebExtensionControllerParameters;
-
-class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExtensionController>, public IPC::MessageReceiver {
-    WTF_MAKE_NONCOPYABLE(WebExtensionController);
-
-public:
-    static Ref<WebExtensionController> create() { return adoptRef(*new WebExtensionController); }
-    static WebExtensionController* get(WebExtensionControllerIdentifier);
-
-    explicit WebExtensionController();
-    ~WebExtensionController();
-
-    WebExtensionControllerIdentifier identifier() const { return m_identifier; }
-    WebExtensionControllerParameters parameters() const;
-
-private:
-    // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-
-    WebExtensionControllerIdentifier m_identifier;
+template<> struct WrapperTraits<WebExtensionContext> {
+    using WrapperClass = _WKWebExtensionContext;
 };
+}
 
-} // namespace WebKit
+@interface _WKWebExtensionContext () <WKObject> {
+@package
+    API::ObjectStorage<WebKit::WebExtensionContext> _webExtensionContext;
+}
+
+@property (nonatomic, readonly) WebKit::WebExtensionContext& _webExtensionContext;
+
+@end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextPrivate.h
@@ -23,40 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#import <WebKit/_WKWebExtensionContext.h>
 
-#if ENABLE(WK_WEB_EXTENSIONS)
+NS_ASSUME_NONNULL_BEGIN
 
-#include "APIObject.h"
-#include "MessageReceiver.h"
-#include "WebExtensionControllerIdentifier.h"
-#include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
+@interface _WKWebExtensionContext ()
 
-namespace WebKit {
+@end
 
-struct WebExtensionControllerParameters;
-
-class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExtensionController>, public IPC::MessageReceiver {
-    WTF_MAKE_NONCOPYABLE(WebExtensionController);
-
-public:
-    static Ref<WebExtensionController> create() { return adoptRef(*new WebExtensionController); }
-    static WebExtensionController* get(WebExtensionControllerIdentifier);
-
-    explicit WebExtensionController();
-    ~WebExtensionController();
-
-    WebExtensionControllerIdentifier identifier() const { return m_identifier; }
-    WebExtensionControllerParameters parameters() const;
-
-private:
-    // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-
-    WebExtensionControllerIdentifier m_identifier;
-};
-
-} // namespace WebKit
-
-#endif // ENABLE(WK_WEB_EXTENSIONS)
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+#import <Foundation/Foundation.h>
+
+@class WKWebView;
+@class _WKWebExtensionContext;
+@protocol _WKWebExtensionWindow;
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_OPTIONS(NSUInteger, _WKWebExtensionTabChangedProperties) {
+    _WKWebExtensionTabChangedPropertiesNone       = 0,
+    _WKWebExtensionTabChangedPropertiesLoading    = 1 << 1,
+    _WKWebExtensionTabChangedPropertiesTitle      = 1 << 2,
+    _WKWebExtensionTabChangedPropertiesURL        = 1 << 3,
+    _WKWebExtensionTabChangedPropertiesSize       = 1 << 4,
+    _WKWebExtensionTabChangedPropertiesZoomFactor = 1 << 5,
+    _WKWebExtensionTabChangedPropertiesAudible    = 1 << 6,
+    _WKWebExtensionTabChangedPropertiesMuted      = 1 << 7,
+    _WKWebExtensionTabChangedPropertiesPinned     = 1 << 8,
+    _WKWebExtensionTabChangedPropertiesReaderMode = 1 << 9,
+    _WKWebExtensionTabChangedPropertiesAll        = NSUIntegerMax,
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@protocol _WKWebExtensionTab <NSObject>
+@optional
+
+- (id <_WKWebExtensionTab>)parentTabForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (id <_WKWebExtensionWindow>)windowForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (WKWebView *)mainWebViewForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (NSArray<WKWebView *> *)webViewsForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (NSString *)tabTitleForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (BOOL)isSelectedForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (BOOL)isPinnedTabForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (BOOL)isEphemeralForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (BOOL)isReaderModeAvailableForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (BOOL)isShowingReaderModeForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (void)toggleReaderModeForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (BOOL)isAudibleForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (BOOL)isMutedForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (void)muteForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (void)unmuteForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (CGSize)sizeForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (double)zoomFactorForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (NSURL *)urlForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (NSURL *)pendingURLForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (BOOL)isLoadingCompleteForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (void)detectWebpageLocaleForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSLocale * _Nullable locale))completionHandler;
+
+- (void)loadURL:(NSURL *)url forWebExtensionContext:(_WKWebExtensionContext *)context NS_SWIFT_NAME(load(url:forWebExtensionContext:));
+- (void)reloadForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (void)reloadFromOriginForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (void)goBackForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (void)goForwardForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (void)closeForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (void)selectForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+#import <Foundation/Foundation.h>
+
+@class _WKWebExtensionContext;
+@protocol _WKWebExtensionTab;
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, _WKWebExtensionWindowType) {
+    _WKWebExtensionWindowTypeNormal,
+    _WKWebExtensionWindowTypePopup,
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+typedef NS_ENUM(NSInteger, _WKWebExtensionWindowState) {
+    _WKWebExtensionWindowStateNormal,
+    _WKWebExtensionWindowStateMinimized,
+    _WKWebExtensionWindowStateMaximized,
+    _WKWebExtensionWindowStateFullscreen,
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@protocol _WKWebExtensionWindow <NSObject>
+@optional
+
+- (NSArray<id <_WKWebExtensionTab>> *)tabsForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (id <_WKWebExtensionTab>)activeTabForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (_WKWebExtensionWindowType)windowTypeForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (_WKWebExtensionWindowState)windowStateForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (BOOL)isFocusedForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (BOOL)isEphemeralForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (BOOL)isPopupWindowForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+- (NSRect)frameForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1,0 +1,825 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionContext.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "_WKWebExtensionContextInternal.h"
+#import "_WKWebExtensionPermission.h"
+#import "_WKWebExtensionTab.h"
+
+// This number was chosen arbitrarily based on testing with some popular extensions.
+static constexpr size_t maximumCachedPermissionResults = 256;
+
+namespace WebKit {
+
+WebExtensionContext::WebExtensionContext(Ref<WebExtension>&& extension)
+    : WebExtensionContext()
+{
+    m_extension = extension.ptr();
+
+    StringBuilder baseURLBuilder;
+    baseURLBuilder.append("webkit-extension://", uniqueIdentifier(), "/");
+
+    m_baseURL = URL { baseURLBuilder.toString() };
+}
+
+void WebExtensionContext::setBaseURL(URL&& url)
+{
+    ASSERT(!isLoaded());
+    if (isLoaded())
+        return;
+
+    if (!url.isValid())
+        return;
+
+    StringBuilder baseURLBuilder;
+    baseURLBuilder.append(url.protocol(), "://", url.host(), "/");
+
+    m_baseURL = URL { baseURLBuilder.toString() };
+}
+
+bool WebExtensionContext::isURLForThisExtension(const URL& url)
+{
+    return protocolHostAndPortAreEqual(baseURL(), url);
+}
+
+void WebExtensionContext::setUniqueIdentifier(String&& uniqueIdentifier)
+{
+    ASSERT(!isLoaded());
+    if (isLoaded())
+        return;
+
+    if (uniqueIdentifier.isEmpty())
+        uniqueIdentifier = m_baseURL.host().toString();
+
+    m_uniqueIdentifier = uniqueIdentifier;
+}
+
+const WebExtensionContext::PermissionsMap& WebExtensionContext::grantedPermissions()
+{
+    return removeExpired(m_grantedPermissions, _WKWebExtensionContextGrantedPermissionsWereRemovedNotification);
+}
+
+void WebExtensionContext::setGrantedPermissions(PermissionsMap&& grantedPermissions)
+{
+    PermissionsSet removedPermissions;
+    for (auto& entry : m_grantedPermissions)
+        removedPermissions.add(entry.key);
+
+    m_grantedPermissions = removeExpired(grantedPermissions);
+
+    PermissionsSet addedPermissions;
+    for (auto& entry : m_grantedPermissions) {
+        if (removedPermissions.contains(entry.key)) {
+            removedPermissions.remove(entry.key);
+            continue;
+        }
+
+        addedPermissions.add(entry.key);
+    }
+
+    if (addedPermissions.isEmpty() && removedPermissions.isEmpty())
+        return;
+
+    removeDeniedPermissions(addedPermissions);
+
+    postAsyncNotification(_WKWebExtensionContextGrantedPermissionsWereRemovedNotification, removedPermissions);
+    postAsyncNotification(_WKWebExtensionContextPermissionsWereGrantedNotification, addedPermissions);
+}
+
+const WebExtensionContext::PermissionsMap& WebExtensionContext::deniedPermissions()
+{
+    return removeExpired(m_deniedPermissions, _WKWebExtensionContextDeniedPermissionsWereRemovedNotification);
+}
+
+void WebExtensionContext::setDeniedPermissions(PermissionsMap&& deniedPermissions)
+{
+    PermissionsSet removedPermissions;
+    for (auto& entry : m_deniedPermissions)
+        removedPermissions.add(entry.key);
+
+    m_deniedPermissions = removeExpired(deniedPermissions);
+
+    PermissionsSet addedPermissions;
+    for (auto& entry : m_deniedPermissions) {
+        if (removedPermissions.contains(entry.key)) {
+            removedPermissions.remove(entry.key);
+            continue;
+        }
+
+        addedPermissions.add(entry.key);
+    }
+
+    if (addedPermissions.isEmpty() && removedPermissions.isEmpty())
+        return;
+
+    removeGrantedPermissions(addedPermissions);
+
+    postAsyncNotification(_WKWebExtensionContextDeniedPermissionsWereRemovedNotification, removedPermissions);
+    postAsyncNotification(_WKWebExtensionContextPermissionsWereDeniedNotification, addedPermissions);
+}
+
+const WebExtensionContext::PermissionMatchPatternsMap& WebExtensionContext::grantedPermissionMatchPatterns()
+{
+    return removeExpired(m_grantedPermissionMatchPatterns, _WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification);
+}
+
+void WebExtensionContext::setGrantedPermissionMatchPatterns(PermissionMatchPatternsMap&& grantedPermissionMatchPatterns)
+{
+    MatchPatternSet removedMatchPatterns;
+    for (auto& entry : m_grantedPermissionMatchPatterns)
+        removedMatchPatterns.add(entry.key);
+
+    m_grantedPermissionMatchPatterns = removeExpired(grantedPermissionMatchPatterns);
+
+    MatchPatternSet addedMatchPatterns;
+    for (auto& entry : m_grantedPermissionMatchPatterns) {
+        if (removedMatchPatterns.contains(entry.key)) {
+            removedMatchPatterns.remove(entry.key);
+            continue;
+        }
+
+        addedMatchPatterns.add(entry.key);
+    }
+
+    if (addedMatchPatterns.isEmpty() && removedMatchPatterns.isEmpty())
+        return;
+
+    removeDeniedPermissionMatchPatterns(addedMatchPatterns, EqualityOnly::Yes);
+    clearCachedPermissionStates();
+
+    postAsyncNotification(_WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification, removedMatchPatterns);
+    postAsyncNotification(_WKWebExtensionContextPermissionMatchPatternsWereGrantedNotification, addedMatchPatterns);
+}
+
+const WebExtensionContext::PermissionMatchPatternsMap& WebExtensionContext::deniedPermissionMatchPatterns()
+{
+    return removeExpired(m_deniedPermissionMatchPatterns, _WKWebExtensionContextDeniedPermissionMatchPatternsWereRemovedNotification);
+}
+
+void WebExtensionContext::setDeniedPermissionMatchPatterns(PermissionMatchPatternsMap&& deniedPermissionMatchPatterns)
+{
+    MatchPatternSet removedMatchPatterns;
+    for (auto& entry : m_deniedPermissionMatchPatterns)
+        removedMatchPatterns.add(entry.key);
+
+    m_deniedPermissionMatchPatterns = removeExpired(deniedPermissionMatchPatterns);
+
+    MatchPatternSet addedMatchPatterns;
+    for (auto& entry : m_deniedPermissionMatchPatterns) {
+        if (removedMatchPatterns.contains(entry.key)) {
+            removedMatchPatterns.remove(entry.key);
+            continue;
+        }
+
+        addedMatchPatterns.add(entry.key);
+    }
+
+    if (addedMatchPatterns.isEmpty() && removedMatchPatterns.isEmpty())
+        return;
+
+    removeGrantedPermissionMatchPatterns(addedMatchPatterns, EqualityOnly::Yes);
+    clearCachedPermissionStates();
+
+    postAsyncNotification(_WKWebExtensionContextDeniedPermissionMatchPatternsWereRemovedNotification, removedMatchPatterns);
+    postAsyncNotification(_WKWebExtensionContextPermissionMatchPatternsWereDeniedNotification, addedMatchPatterns);
+}
+
+void WebExtensionContext::postAsyncNotification(NSNotificationName notificationName, PermissionsSet& permissions)
+{
+    if (permissions.isEmpty())
+        return;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [NSNotificationCenter.defaultCenter postNotificationName:notificationName object:wrapper() userInfo:@{ _WKWebExtensionContextNotificationUserInfoKeyPermissions: toAPI(permissions) }];
+    });
+}
+
+void WebExtensionContext::postAsyncNotification(NSNotificationName notificationName, MatchPatternSet& matchPatterns)
+{
+    if (matchPatterns.isEmpty())
+        return;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [NSNotificationCenter.defaultCenter postNotificationName:notificationName object:wrapper() userInfo:@{ _WKWebExtensionContextNotificationUserInfoKeyMatchPatterns: toAPI(matchPatterns) }];
+    });
+}
+
+void WebExtensionContext::grantPermissions(PermissionsSet&& permissions, WallTime expirationDate)
+{
+    if (permissions.isEmpty())
+        return;
+
+    for (auto& permission : permissions)
+        m_grantedPermissions.add(permission, expirationDate);
+
+    removeDeniedPermissions(permissions);
+
+    postAsyncNotification(_WKWebExtensionContextPermissionsWereGrantedNotification, permissions);
+}
+
+void WebExtensionContext::denyPermissions(PermissionsSet&& permissions, WallTime expirationDate)
+{
+    if (permissions.isEmpty())
+        return;
+
+    for (auto& permission : permissions)
+        m_deniedPermissions.add(permission, expirationDate);
+
+    removeGrantedPermissions(permissions);
+
+    postAsyncNotification(_WKWebExtensionContextPermissionsWereDeniedNotification, permissions);
+}
+
+void WebExtensionContext::grantPermissionMatchPatterns(MatchPatternSet&& permissionMatchPatterns, WallTime expirationDate)
+{
+    if (permissionMatchPatterns.isEmpty())
+        return;
+
+    for (auto& pattern : permissionMatchPatterns)
+        m_grantedPermissionMatchPatterns.add(pattern, expirationDate);
+
+    removeDeniedPermissionMatchPatterns(permissionMatchPatterns, EqualityOnly::Yes);
+    clearCachedPermissionStates();
+
+    postAsyncNotification(_WKWebExtensionContextPermissionMatchPatternsWereGrantedNotification, permissionMatchPatterns);
+}
+
+void WebExtensionContext::denyPermissionMatchPatterns(MatchPatternSet&& permissionMatchPatterns, WallTime expirationDate)
+{
+    if (permissionMatchPatterns.isEmpty())
+        return;
+
+    for (auto& pattern : permissionMatchPatterns)
+        m_deniedPermissionMatchPatterns.add(pattern, expirationDate);
+
+    removeGrantedPermissionMatchPatterns(permissionMatchPatterns, EqualityOnly::Yes);
+    clearCachedPermissionStates();
+
+    postAsyncNotification(_WKWebExtensionContextPermissionMatchPatternsWereDeniedNotification, permissionMatchPatterns);
+}
+
+void WebExtensionContext::removeGrantedPermissions(PermissionsSet& permissionsToRemove)
+{
+    removePermissions(m_grantedPermissions, permissionsToRemove, _WKWebExtensionContextGrantedPermissionsWereRemovedNotification);
+}
+
+void WebExtensionContext::removeGrantedPermissionMatchPatterns(MatchPatternSet& matchPatternsToRemove, EqualityOnly equalityOnly)
+{
+    removePermissionMatchPatterns(m_grantedPermissionMatchPatterns, matchPatternsToRemove, equalityOnly, _WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification);
+}
+
+void WebExtensionContext::removeDeniedPermissions(PermissionsSet& permissionsToRemove)
+{
+    removePermissions(m_deniedPermissions, permissionsToRemove, _WKWebExtensionContextDeniedPermissionsWereRemovedNotification);
+}
+
+void WebExtensionContext::removeDeniedPermissionMatchPatterns(MatchPatternSet& matchPatternsToRemove, EqualityOnly equalityOnly)
+{
+    removePermissionMatchPatterns(m_deniedPermissionMatchPatterns, matchPatternsToRemove, equalityOnly, _WKWebExtensionContextDeniedPermissionsWereRemovedNotification);
+}
+
+void WebExtensionContext::removePermissions(PermissionsMap& permissionMap, PermissionsSet& permissionsToRemove, NSNotificationName notificationName)
+{
+    if (permissionsToRemove.isEmpty())
+        return;
+
+    PermissionsSet removedPermissions;
+    permissionMap.removeIf([&](auto& entry) {
+        if (permissionsToRemove.contains(entry.key)) {
+            removedPermissions.add(entry.key);
+            return true;
+        }
+
+        return false;
+    });
+
+    if (removedPermissions.isEmpty() || !notificationName)
+        return;
+
+    postAsyncNotification(notificationName, removedPermissions);
+}
+
+void WebExtensionContext::removePermissionMatchPatterns(PermissionMatchPatternsMap& matchPatternMap, MatchPatternSet& matchPatternsToRemove, EqualityOnly equalityOnly, NSNotificationName notificationName)
+{
+    if (matchPatternsToRemove.isEmpty())
+        return;
+
+    MatchPatternSet removedMatchPatterns;
+    matchPatternMap.removeIf([&](auto& entry) {
+        if (matchPatternsToRemove.contains(entry.key)) {
+            removedMatchPatterns.add(entry.key);
+            return true;
+        }
+
+        if (equalityOnly == EqualityOnly::Yes)
+            return false;
+
+        for (auto& patternToRemove : matchPatternsToRemove) {
+            if (patternToRemove->matchesPattern(entry.key, WebExtensionMatchPattern::Options::IgnorePaths)) {
+                removedMatchPatterns.add(entry.key);
+                return true;
+            }
+        }
+
+        return false;
+    });
+
+    if (removedMatchPatterns.isEmpty() || !notificationName)
+        return;
+
+    clearCachedPermissionStates();
+
+    postAsyncNotification(notificationName, removedMatchPatterns);
+}
+
+WebExtensionContext::PermissionsMap& WebExtensionContext::removeExpired(PermissionsMap& permissionMap, NSNotificationName notificationName)
+{
+    WallTime currentTime = WallTime::now();
+
+    PermissionsSet removedPermissions;
+    permissionMap.removeIf([&](auto& entry) {
+        if (entry.value <= currentTime) {
+            removedPermissions.add(entry.key);
+            return true;
+        }
+
+        return false;
+    });
+
+    if (removedPermissions.isEmpty() || !notificationName)
+        return permissionMap;
+
+    postAsyncNotification(notificationName, removedPermissions);
+
+    return permissionMap;
+}
+
+WebExtensionContext::PermissionMatchPatternsMap& WebExtensionContext::removeExpired(PermissionMatchPatternsMap& matchPatternMap, NSNotificationName notificationName)
+{
+    WallTime currentTime = WallTime::now();
+
+    MatchPatternSet removedMatchPatterns;
+    matchPatternMap.removeIf([&](auto& entry) {
+        if (entry.value <= currentTime) {
+            removedMatchPatterns.add(entry.key);
+            return true;
+        }
+
+        return false;
+    });
+
+    if (removedMatchPatterns.isEmpty() || !notificationName)
+        return matchPatternMap;
+
+    clearCachedPermissionStates();
+
+    postAsyncNotification(notificationName, removedMatchPatterns);
+
+    return matchPatternMap;
+}
+
+bool WebExtensionContext::hasPermission(const String& permission, _WKWebExtensionTab *tab, OptionSet<PermissionStateOptions> options)
+{
+    ASSERT(!permission.isEmpty());
+
+    options.add(PermissionStateOptions::SkipRequestedPermissions);
+
+    switch (permissionState(permission, tab, options)) {
+    case PermissionState::Unknown:
+    case PermissionState::DeniedImplicitly:
+    case PermissionState::DeniedExplicitly:
+    case PermissionState::RequestedImplicitly:
+    case PermissionState::RequestedExplicitly:
+        return false;
+
+    case PermissionState::GrantedImplicitly:
+    case PermissionState::GrantedExplicitly:
+        return true;
+    }
+}
+
+bool WebExtensionContext::hasPermission(const URL& url, _WKWebExtensionTab *tab, OptionSet<PermissionStateOptions> options)
+{
+    options.add(PermissionStateOptions::SkipRequestedPermissions);
+
+    switch (permissionState(url, tab, options)) {
+    case PermissionState::Unknown:
+    case PermissionState::DeniedImplicitly:
+    case PermissionState::DeniedExplicitly:
+    case PermissionState::RequestedImplicitly:
+    case PermissionState::RequestedExplicitly:
+        return false;
+
+    case PermissionState::GrantedImplicitly:
+    case PermissionState::GrantedExplicitly:
+        return true;
+    }
+}
+
+WebExtensionContext::PermissionState WebExtensionContext::permissionState(const String& permission, _WKWebExtensionTab *tab, OptionSet<PermissionStateOptions> options)
+{
+    ASSERT(!permission.isEmpty());
+
+    if (tab && hasActiveUserGesture(tab)) {
+        // An active user gesture grants the "tabs" permission.
+        if (permission == String(_WKWebExtensionPermissionTabs))
+            return PermissionState::GrantedExplicitly;
+    }
+
+    if (!WebExtension::supportedPermissions().contains(permission))
+        return PermissionState::Unknown;
+
+    if (deniedPermissions().contains(permission))
+        return PermissionState::DeniedExplicitly;
+
+    if (grantedPermissions().contains(permission))
+        return PermissionState::GrantedExplicitly;
+
+    if (options.contains(PermissionStateOptions::SkipRequestedPermissions))
+        return PermissionState::Unknown;
+
+    if (extension().hasRequestedPermission(permission))
+        return PermissionState::RequestedExplicitly;
+
+    return PermissionState::Unknown;
+}
+
+WebExtensionContext::PermissionState WebExtensionContext::permissionState(const URL& coreURL, _WKWebExtensionTab *tab, OptionSet<PermissionStateOptions> options)
+{
+    if (coreURL.isEmpty())
+        return PermissionState::Unknown;
+
+    if (isURLForThisExtension(coreURL))
+        return PermissionState::GrantedImplicitly;
+
+    NSURL *url = coreURL;
+    ASSERT(url);
+
+    if (!WebExtensionMatchPattern::validSchemes().contains(url.scheme))
+        return PermissionState::Unknown;
+
+    if (tab && [[m_temporaryTabPermissionMatchPatterns objectForKey:tab] matchesURL:url])
+        return PermissionState::GrantedExplicitly;
+
+    bool skipRequestedPermissions = options.contains(PermissionStateOptions::SkipRequestedPermissions);
+
+    // Access the maps here to remove any expired entries, and only do it once for this call.
+    auto& grantedPermissionMatchPatterns = this->grantedPermissionMatchPatterns();
+    auto& deniedPermissionMatchPatterns = this->deniedPermissionMatchPatterns();
+
+    // If the cache still has the URL, then it has not expired.
+    if (m_cachedPermissionURLs.contains(coreURL)) {
+        PermissionState cachedState = m_cachedPermissionStates.get(coreURL);
+
+        // We only want to return an unknown cached state if the SkippingRequestedPermissions option isn't used.
+        if (cachedState != PermissionState::Unknown || skipRequestedPermissions) {
+            // Move the URL to the end, so it stays in the cache longer as a recent hit.
+            m_cachedPermissionURLs.appendOrMoveToLast(coreURL);
+
+            if ((cachedState == PermissionState::RequestedExplicitly || cachedState == PermissionState::RequestedImplicitly) && skipRequestedPermissions)
+                return PermissionState::Unknown;
+
+            return cachedState;
+        }
+    }
+
+    auto cacheResultAndReturn = ^PermissionState(PermissionState result) {
+        m_cachedPermissionURLs.appendOrMoveToLast(coreURL);
+        m_cachedPermissionStates.set(coreURL, result);
+
+        ASSERT(m_cachedPermissionURLs.size() == m_cachedPermissionURLs.size());
+
+        if (m_cachedPermissionURLs.size() <= maximumCachedPermissionResults)
+            return result;
+
+        URL firstCachedURL = m_cachedPermissionURLs.takeFirst();
+        m_cachedPermissionStates.remove(firstCachedURL);
+
+        ASSERT(m_cachedPermissionURLs.size() == m_cachedPermissionURLs.size());
+
+        return result;
+    };
+
+    // First, check for patterns that are specific to certain domains, ignoring wildcard host patterns that
+    // match all hosts. The order is denied, then granted. This makes sure denied takes precedence over granted.
+
+    auto urlMatchesPatternIgnoringWildcardHostPatterns = ^(WebExtensionMatchPattern& pattern) {
+        if (pattern.matchesAllHosts())
+            return false;
+        return pattern.matchesURL(url);
+    };
+
+    for (auto& deniedPermissionEntry : deniedPermissionMatchPatterns) {
+        if (urlMatchesPatternIgnoringWildcardHostPatterns(deniedPermissionEntry.key))
+            return cacheResultAndReturn(PermissionState::DeniedExplicitly);
+    }
+
+    for (auto& grantedPermissionEntry : grantedPermissionMatchPatterns) {
+        if (urlMatchesPatternIgnoringWildcardHostPatterns(grantedPermissionEntry.key))
+            return cacheResultAndReturn(PermissionState::GrantedExplicitly);
+    }
+
+    // Next, check for patterns that are wildcard host patterns that match all hosts (<all_urls>, *://*/*, etc),
+    // also checked in denied, then granted order. Doing these wildcard patterns separately allows for blanket
+    // patterns to be set as default policies while allowing for specific domains to still be granted or denied.
+
+    auto urlMatchesWildcardHostPatterns = ^(WebExtensionMatchPattern& pattern) {
+        if (!pattern.matchesAllHosts())
+            return false;
+        return pattern.matchesURL(url);
+    };
+
+    for (auto& deniedPermissionEntry : deniedPermissionMatchPatterns) {
+        if (urlMatchesWildcardHostPatterns(deniedPermissionEntry.key))
+            return cacheResultAndReturn(PermissionState::DeniedImplicitly);
+    }
+
+    for (auto& grantedPermissionEntry : grantedPermissionMatchPatterns) {
+        if (urlMatchesWildcardHostPatterns(grantedPermissionEntry.key))
+            return cacheResultAndReturn(PermissionState::GrantedImplicitly);
+    }
+
+    // Finally, check for requested patterns, allowing any pattern that matches. This is the default state
+    // of the extension before any patterns are granted or denied, so it should always be last.
+
+    if (skipRequestedPermissions)
+        return cacheResultAndReturn(PermissionState::Unknown);
+
+    auto requestedMatchPatterns = m_extension->allRequestedMatchPatterns();
+    for (auto& requestedMatchPattern : requestedMatchPatterns) {
+        if (urlMatchesPatternIgnoringWildcardHostPatterns(requestedMatchPattern))
+            return cacheResultAndReturn(PermissionState::RequestedExplicitly);
+
+        if (urlMatchesWildcardHostPatterns(requestedMatchPattern))
+            return cacheResultAndReturn(PermissionState::RequestedImplicitly);
+    }
+
+    if (options.contains(PermissionStateOptions::RequestedWithTabsPermission) && hasPermission(_WKWebExtensionPermissionTabs, tab, options))
+        return PermissionState::RequestedImplicitly;
+
+    return cacheResultAndReturn(PermissionState::Unknown);
+}
+
+WebExtensionContext::PermissionState WebExtensionContext::permissionState(WebExtensionMatchPattern& pattern, _WKWebExtensionTab *tab, OptionSet<PermissionStateOptions> options)
+{
+    if (!pattern.isValid())
+        return PermissionState::Unknown;
+
+    if (pattern.matchesURL(baseURL()))
+        return PermissionState::GrantedImplicitly;
+
+    if (!pattern.matchesAllURLs() && !WebExtensionMatchPattern::validSchemes().contains(pattern.scheme()))
+        return PermissionState::Unknown;
+
+    if (tab && [[m_temporaryTabPermissionMatchPatterns objectForKey:tab] matchesPattern:pattern.wrapper()])
+        return PermissionState::GrantedExplicitly;
+
+    // Access the maps here to remove any expired entries, and only do it once for this call.
+    auto& grantedPermissionMatchPatterns = this->grantedPermissionMatchPatterns();
+    auto& deniedPermissionMatchPatterns = this->deniedPermissionMatchPatterns();
+
+    // First, check for patterns that are specific to certain domains, ignoring wildcard host patterns that
+    // match all hosts. The order is denied, then granted. This makes sure denied takes precedence over granted.
+
+    auto urlMatchesPatternIgnoringWildcardHostPatterns = ^(WebExtensionMatchPattern& otherPattern) {
+        if (pattern.matchesAllHosts())
+            return false;
+        return pattern.matchesPattern(otherPattern);
+    };
+
+    for (auto& deniedPermissionEntry : deniedPermissionMatchPatterns) {
+        if (urlMatchesPatternIgnoringWildcardHostPatterns(deniedPermissionEntry.key))
+            return PermissionState::DeniedExplicitly;
+    }
+
+    for (auto& grantedPermissionEntry : grantedPermissionMatchPatterns) {
+        if (urlMatchesPatternIgnoringWildcardHostPatterns(grantedPermissionEntry.key))
+            return PermissionState::GrantedExplicitly;
+    }
+
+    // Next, check for patterns that are wildcard host patterns that match all hosts (<all_urls>, *://*/*, etc),
+    // also checked in denied, then granted order. Doing these wildcard patterns separately allows for blanket
+    // patterns to be set as default policies while allowing for specific domains to still be granted or denied.
+
+    auto urlMatchesWildcardHostPatterns = ^(WebExtensionMatchPattern& otherPattern) {
+        if (!pattern.matchesAllHosts())
+            return false;
+        return pattern.matchesPattern(otherPattern);
+    };
+
+    for (auto& deniedPermissionEntry : deniedPermissionMatchPatterns) {
+        if (urlMatchesWildcardHostPatterns(deniedPermissionEntry.key))
+            return PermissionState::DeniedImplicitly;
+    }
+
+    for (auto& grantedPermissionEntry : grantedPermissionMatchPatterns) {
+        if (urlMatchesWildcardHostPatterns(grantedPermissionEntry.key))
+            return PermissionState::GrantedImplicitly;
+    }
+
+    // Finally, check for requested patterns, allowing any pattern that matches. This is the default state
+    // of the extension before any patterns are granted or denied, so it should always be last.
+
+    if (options.contains(PermissionStateOptions::SkipRequestedPermissions))
+        return PermissionState::Unknown;
+
+    auto requestedMatchPatterns = m_extension->allRequestedMatchPatterns();
+    for (auto& requestedMatchPattern : requestedMatchPatterns) {
+        if (urlMatchesPatternIgnoringWildcardHostPatterns(requestedMatchPattern))
+            return PermissionState::RequestedExplicitly;
+
+        if (urlMatchesWildcardHostPatterns(requestedMatchPattern))
+            return PermissionState::RequestedImplicitly;
+    }
+
+    if (options.contains(PermissionStateOptions::RequestedWithTabsPermission) && hasPermission(_WKWebExtensionPermissionTabs, tab, options))
+        return PermissionState::RequestedImplicitly;
+
+    return PermissionState::Unknown;
+}
+
+void WebExtensionContext::setPermissionState(PermissionState state, const String& permission, WallTime expirationDate)
+{
+    ASSERT(!permission.isEmpty());
+
+    switch (state) {
+    case PermissionState::DeniedExplicitly:
+        denyPermissions({ permission }, expirationDate);
+        break;
+
+    case PermissionState::Unknown: {
+        PermissionsSet permissionsToRemove = { permission };
+        removeGrantedPermissions(permissionsToRemove);
+        removeDeniedPermissions(permissionsToRemove);
+        break;
+    }
+
+    case PermissionState::GrantedExplicitly:
+        grantPermissions({ permission }, expirationDate);
+        break;
+
+    case PermissionState::DeniedImplicitly:
+    case PermissionState::RequestedImplicitly:
+    case PermissionState::RequestedExplicitly:
+    case PermissionState::GrantedImplicitly:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+}
+
+void WebExtensionContext::setPermissionState(PermissionState state, const URL& url, WallTime expirationDate)
+{
+    ASSERT(!url.isEmpty());
+
+    auto pattern = WebExtensionMatchPattern::getOrCreate(url.protocol().toString(), url.host().toString(), url.path().toString());
+    if (!pattern)
+        return;
+
+    setPermissionState(state, *pattern, expirationDate);
+}
+
+void WebExtensionContext::setPermissionState(PermissionState state, WebExtensionMatchPattern& pattern, WallTime expirationDate)
+{
+    ASSERT(pattern.isValid());
+
+    switch (state) {
+    case PermissionState::DeniedExplicitly:
+        denyPermissionMatchPatterns({ pattern }, expirationDate);
+        break;
+
+    case PermissionState::Unknown: {
+        MatchPatternSet patternsToRemove = { pattern };
+        removeGrantedPermissionMatchPatterns(patternsToRemove, EqualityOnly::Yes);
+        removeDeniedPermissionMatchPatterns(patternsToRemove, EqualityOnly::Yes);
+        break;
+    }
+
+    case PermissionState::GrantedExplicitly:
+        grantPermissionMatchPatterns({ pattern }, expirationDate);
+        break;
+
+    case PermissionState::DeniedImplicitly:
+    case PermissionState::RequestedImplicitly:
+    case PermissionState::RequestedExplicitly:
+    case PermissionState::GrantedImplicitly:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+}
+
+void WebExtensionContext::clearCachedPermissionStates()
+{
+    m_cachedPermissionStates.clear();
+    m_cachedPermissionURLs.clear();
+}
+
+bool WebExtensionContext::hasAccessToAllURLs()
+{
+    for (auto& pattern : currentPermissionMatchPatterns()) {
+        if (pattern->matchesAllURLs())
+            return true;
+    }
+
+    return false;
+}
+
+bool WebExtensionContext::hasAccessToAllHosts()
+{
+    for (auto& pattern : currentPermissionMatchPatterns()) {
+        if (pattern->matchesAllHosts())
+            return true;
+    }
+
+    return false;
+}
+
+void WebExtensionContext::userGesturePerformed(_WKWebExtensionTab *tab)
+{
+    ASSERT(tab);
+
+    // Nothing else to do if the extension does not have the activeTab permissions.
+    if (!hasPermission(_WKWebExtensionPermissionActiveTab))
+        return;
+
+    if (![tab respondsToSelector:@selector(urlForWebExtensionContext:)])
+        return;
+
+    NSURL *currentURL = [tab urlForWebExtensionContext:wrapper()];
+    if (!currentURL)
+        return;
+
+    _WKWebExtensionMatchPattern *pattern = [m_temporaryTabPermissionMatchPatterns objectForKey:tab];
+
+    // Nothing to do if the tab already has a pattern matching the current URL.
+    if (pattern && [pattern matchesURL:currentURL])
+        return;
+
+    // A pattern should not exist, since it should be cleared in cancelUserGesture
+    // on any navigation between different hosts.
+    ASSERT(!pattern);
+
+    if (!m_temporaryTabPermissionMatchPatterns)
+        m_temporaryTabPermissionMatchPatterns = [NSMapTable weakToStrongObjectsMapTable];
+
+    // Grant the tab a temporary permission to access to a pattern matching the current URL's scheme and host for all paths.
+    pattern = [_WKWebExtensionMatchPattern matchPatternWithScheme:currentURL.scheme host:currentURL.host path:@"/*"];
+    [m_temporaryTabPermissionMatchPatterns setObject:pattern forKey:tab];
+}
+
+bool WebExtensionContext::hasActiveUserGesture(_WKWebExtensionTab *tab) const
+{
+    ASSERT(tab);
+
+    if (!m_temporaryTabPermissionMatchPatterns)
+        return false;
+
+    if (![tab respondsToSelector:@selector(urlForWebExtensionContext:)])
+        return false;
+
+    NSURL *currentURL = [tab urlForWebExtensionContext:wrapper()];
+    return [[m_temporaryTabPermissionMatchPatterns objectForKey:tab] matchesURL:currentURL];
+}
+
+void WebExtensionContext::cancelUserGesture(_WKWebExtensionTab *tab)
+{
+    ASSERT(tab);
+
+    if (!m_temporaryTabPermissionMatchPatterns)
+        return;
+
+    [m_temporaryTabPermissionMatchPatterns removeObjectForKey:tab];
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "APIObject.h"
+#include "MessageReceiver.h"
+#include "WebExtension.h"
+#include "WebExtensionContextIdentifier.h"
+#include "WebExtensionController.h"
+#include "WebExtensionMatchPattern.h"
+#include <wtf/Forward.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+#include <wtf/ListHashSet.h>
+#include <wtf/RefPtr.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/URLHash.h>
+#include <wtf/UUID.h>
+#include <wtf/WeakPtr.h>
+
+#if PLATFORM(COCOA)
+OBJC_CLASS NSDictionary;
+OBJC_CLASS NSMapTable;
+OBJC_CLASS NSString;
+OBJC_CLASS NSURL;
+OBJC_CLASS NSUUID;
+OBJC_CLASS _WKWebExtensionContext;
+OBJC_PROTOCOL(_WKWebExtensionTab);
+#endif
+
+namespace WebKit {
+
+class WebExtension;
+class WebExtensionController;
+struct WebExtensionContextParameters;
+
+class WebExtensionContext : public API::ObjectImpl<API::Object::Type::WebExtensionContext>, public IPC::MessageReceiver {
+    WTF_MAKE_NONCOPYABLE(WebExtensionContext);
+
+public:
+    template<typename... Args>
+    static Ref<WebExtension> create(Args&&... args)
+    {
+        return adoptRef(*new WebExtensionContext(std::forward<Args>(args)...));
+    }
+
+    static WebExtensionContext* get(WebExtensionContextIdentifier);
+
+    explicit WebExtensionContext(Ref<WebExtension>&&);
+
+    ~WebExtensionContext();
+
+    using PermissionsMap = HashMap<String, WallTime>;
+    using PermissionMatchPatternsMap = HashMap<Ref<WebExtensionMatchPattern>, WallTime>;
+
+    using PermissionsSet = WebExtension::PermissionsSet;
+    using MatchPatternSet = WebExtension::MatchPatternSet;
+
+    enum class EqualityOnly : bool { No, Yes };
+
+    enum class PermissionState : int8_t {
+        DeniedExplicitly    = -3,
+        DeniedImplicitly    = -2,
+        RequestedImplicitly = -1,
+        Unknown             = 0,
+        RequestedExplicitly = 1,
+        GrantedImplicitly   = 2,
+        GrantedExplicitly   = 3,
+    };
+
+    enum class PermissionStateOptions : uint8_t {
+        RequestedWithTabsPermission = 1 << 0, // Request access to a URL if the extension also has the "tabs" permission.
+        SkipRequestedPermissions    = 1 << 1, // Don't check requested permissions.
+    };
+
+    WebExtensionContextIdentifier identifier() const { return m_identifier; }
+    WebExtensionContextParameters parameters() const;
+
+#if PLATFORM(COCOA)
+    bool isLoaded() const { return !!m_extensionController; }
+
+    WebExtension& extension() const { return *m_extension; }
+    WebExtensionController* extensionController() const { return m_extensionController.get(); }
+
+    URL baseURL() const { return m_baseURL; }
+    void setBaseURL(URL&&);
+
+    bool isURLForThisExtension(const URL&);
+
+    const String& uniqueIdentifier() const { return m_uniqueIdentifier; }
+    void setUniqueIdentifier(String&&);
+
+    const PermissionsMap& grantedPermissions();
+    void setGrantedPermissions(PermissionsMap&&);
+
+    const PermissionsMap& deniedPermissions();
+    void setDeniedPermissions(PermissionsMap&&);
+
+    const PermissionMatchPatternsMap& grantedPermissionMatchPatterns();
+    void setGrantedPermissionMatchPatterns(PermissionMatchPatternsMap&&);
+
+    const PermissionMatchPatternsMap& deniedPermissionMatchPatterns();
+    void setDeniedPermissionMatchPatterns(PermissionMatchPatternsMap&&);
+
+    bool requestedOptionalAccessToAllHosts() const { return m_requestedOptionalAccessToAllHosts; }
+    void setRequestedOptionalAccessToAllHosts(bool requested) { m_requestedOptionalAccessToAllHosts = requested; }
+
+    void grantPermissions(PermissionsSet&&, WallTime expirationDate = WallTime::infinity());
+    void denyPermissions(PermissionsSet&&, WallTime expirationDate = WallTime::infinity());
+
+    void grantPermissionMatchPatterns(MatchPatternSet&&, WallTime expirationDate = WallTime::infinity());
+    void denyPermissionMatchPatterns(MatchPatternSet&&, WallTime expirationDate = WallTime::infinity());
+
+    void removeGrantedPermissions(PermissionsSet&);
+    void removeGrantedPermissionMatchPatterns(MatchPatternSet&, EqualityOnly);
+
+    void removeDeniedPermissions(PermissionsSet&);
+    void removeDeniedPermissionMatchPatterns(MatchPatternSet&, EqualityOnly);
+
+    PermissionsMap::KeysConstIteratorRange currentPermissions() { return grantedPermissions().keys(); }
+    PermissionMatchPatternsMap::KeysConstIteratorRange currentPermissionMatchPatterns() { return grantedPermissionMatchPatterns().keys(); }
+
+    bool hasAccessToAllURLs();
+    bool hasAccessToAllHosts();
+
+    bool hasPermission(const String& permission, _WKWebExtensionTab * = nil, OptionSet<PermissionStateOptions> = { });
+    bool hasPermission(const URL&, _WKWebExtensionTab * = nil, OptionSet<PermissionStateOptions> = { PermissionStateOptions::RequestedWithTabsPermission });
+
+    PermissionState permissionState(const String& permission, _WKWebExtensionTab * = nil, OptionSet<PermissionStateOptions> = { });
+    void setPermissionState(PermissionState, const String& permission, WallTime expirationDate = WallTime::infinity());
+
+    PermissionState permissionState(const URL&, _WKWebExtensionTab * = nil, OptionSet<PermissionStateOptions> = { PermissionStateOptions::RequestedWithTabsPermission });
+    void setPermissionState(PermissionState, const URL&, WallTime expirationDate = WallTime::infinity());
+
+    PermissionState permissionState(WebExtensionMatchPattern&, _WKWebExtensionTab * = nil, OptionSet<PermissionStateOptions> = { PermissionStateOptions::RequestedWithTabsPermission });
+    void setPermissionState(PermissionState, WebExtensionMatchPattern&, WallTime expirationDate = WallTime::infinity());
+
+    void clearCachedPermissionStates();
+
+    void userGesturePerformed(_WKWebExtensionTab *);
+    bool hasActiveUserGesture(_WKWebExtensionTab *) const;
+    void cancelUserGesture(_WKWebExtensionTab *);
+
+    _WKWebExtensionContext *wrapper() const { return (_WKWebExtensionContext *)API::ObjectImpl<API::Object::Type::WebExtensionContext>::wrapper(); }
+#endif
+
+private:
+    explicit WebExtensionContext();
+
+#if PLATFORM(COCOA)
+    void postAsyncNotification(NSString *notificationName, PermissionsSet&);
+    void postAsyncNotification(NSString *notificationName, MatchPatternSet&);
+
+    void removePermissions(PermissionsMap&, PermissionsSet&, NSString *notificationName);
+    void removePermissionMatchPatterns(PermissionMatchPatternsMap&, MatchPatternSet&, EqualityOnly, NSString *notificationName);
+
+    PermissionsMap& removeExpired(PermissionsMap&, NSString *notificationName = nil);
+    PermissionMatchPatternsMap& removeExpired(PermissionMatchPatternsMap&, NSString *notificationName = nil);
+#endif
+
+    // IPC::MessageReceiver.
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+
+    WebExtensionContextIdentifier m_identifier;
+
+#if PLATFORM(COCOA)
+    RefPtr<WebExtension> m_extension;
+    WeakPtr<WebExtensionController> m_extensionController;
+
+    URL m_baseURL;
+    String m_uniqueIdentifier = UUID::createVersion4().toString();
+
+    PermissionsMap m_grantedPermissions;
+    PermissionsMap m_deniedPermissions;
+
+    PermissionMatchPatternsMap m_grantedPermissionMatchPatterns;
+    PermissionMatchPatternsMap m_deniedPermissionMatchPatterns;
+
+    ListHashSet<URL> m_cachedPermissionURLs;
+    HashMap<URL, PermissionState> m_cachedPermissionStates;
+
+    RetainPtr<NSMapTable> m_temporaryTabPermissionMatchPatterns;
+
+    bool m_requestedOptionalAccessToAllHosts = false;
+#endif
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -23,40 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#include "APIObject.h"
-#include "MessageReceiver.h"
-#include "WebExtensionControllerIdentifier.h"
-#include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
+messages -> WebExtensionContext {
 
-namespace WebKit {
-
-struct WebExtensionControllerParameters;
-
-class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExtensionController>, public IPC::MessageReceiver {
-    WTF_MAKE_NONCOPYABLE(WebExtensionController);
-
-public:
-    static Ref<WebExtensionController> create() { return adoptRef(*new WebExtensionController); }
-    static WebExtensionController* get(WebExtensionControllerIdentifier);
-
-    explicit WebExtensionController();
-    ~WebExtensionController();
-
-    WebExtensionControllerIdentifier identifier() const { return m_identifier; }
-    WebExtensionControllerParameters parameters() const;
-
-private:
-    // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-
-    WebExtensionControllerIdentifier m_identifier;
-};
-
-} // namespace WebKit
+}
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -39,8 +39,7 @@ using namespace WebCore;
 
 static HashMap<WebExtensionControllerIdentifier, WebExtensionController*>& webExtensionControllers()
 {
-    ASSERT(RunLoop::isMain());
-    static NeverDestroyed<HashMap<WebExtensionControllerIdentifier, WebExtensionController*>> controllers;
+    static MainThreadNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WebExtensionController*>> controllers;
     return controllers;
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -38,6 +38,7 @@ OBJC_CLASS NSError;
 OBJC_CLASS NSSet;
 OBJC_CLASS NSString;
 OBJC_CLASS NSURL;
+OBJC_CLASS _WKWebExtensionMatchPattern;
 #endif
 
 namespace WebKit {
@@ -67,6 +68,8 @@ public:
 
     ~WebExtensionMatchPattern() { }
 
+    using URLSchemeSet = HashSet<String>;
+
     enum class Options : uint8_t {
         IgnoreSchemes        = 1 << 0, // Ignore the scheme component when matching.
         IgnorePaths          = 1 << 1, // Ignore the path component when matching.
@@ -74,8 +77,8 @@ public:
     };
 
 #if PLATFORM(COCOA)
-    static NSSet *validSchemes();
-    static NSSet *supportedSchemes();
+    static const URLSchemeSet& validSchemes();
+    static const URLSchemeSet& supportedSchemes();
 
     bool operator==(const WebExtensionMatchPattern&) const;
     bool operator!=(const WebExtensionMatchPattern& other) const { return !(*this == other); }
@@ -97,6 +100,8 @@ public:
     NSArray *expandedStrings() const;
 
     unsigned hash() const { return m_hash; }
+
+    _WKWebExtensionMatchPattern *wrapper() const { return (_WKWebExtensionMatchPattern *)API::ObjectImpl<API::Object::Type::WebExtensionMatchPattern>::wrapper(); }
 #endif
 
 private:

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -371,7 +371,22 @@
 		1AFDE6621954E9B100C48FFA /* APISessionState.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AFDE6601954E9B100C48FFA /* APISessionState.h */; };
 		1AFE436618B6C081009C7A48 /* UIDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AFE436418B6C081009C7A48 /* UIDelegate.h */; };
 		1BBBE4A019B66C53006B7D81 /* RemoteWebInspectorUIMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1BBBE49E19B66C53006B7D81 /* RemoteWebInspectorUIMessageReceiver.cpp */; };
+		1C0234CD28A00FE400AC1E5B /* WebExtensionContextMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C0234C828A00FA800AC1E5B /* WebExtensionContextMessageReceiver.cpp */; };
+		1C0234CE28A00FE600AC1E5B /* WebExtensionContextProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C0234CB28A00FA900AC1E5B /* WebExtensionContextProxyMessageReceiver.cpp */; };
+		1C0234CF28A00FF000AC1E5B /* WebExtensionContextMessagesReplies.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0234C728A00FA800AC1E5B /* WebExtensionContextMessagesReplies.h */; };
+		1C0234D028A00FF000AC1E5B /* WebExtensionContextProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0234C928A00FA800AC1E5B /* WebExtensionContextProxyMessages.h */; };
+		1C0234D128A00FF000AC1E5B /* WebExtensionContextProxyMessagesReplies.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0234CA28A00FA800AC1E5B /* WebExtensionContextProxyMessagesReplies.h */; };
+		1C0234D228A00FF000AC1E5B /* WebExtensionContextMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0234CC28A00FA900AC1E5B /* WebExtensionContextMessages.h */; };
+		1C0234D428A0135600AC1E5B /* _WKWebExtensionContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C0234D328A0135600AC1E5B /* _WKWebExtensionContext.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C0234D728A013D900AC1E5B /* _WKWebExtensionContextPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0234D528A013D900AC1E5B /* _WKWebExtensionContextPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C0234D828A013D900AC1E5B /* _WKWebExtensionContextInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0234D628A013D900AC1E5B /* _WKWebExtensionContextInternal.h */; };
+		1C0234D928A01B1C00AC1E5B /* WebExtensionContextIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0234BF28A00DCF00AC1E5B /* WebExtensionContextIdentifier.h */; };
+		1C0234DA28A01B2100AC1E5B /* WebExtensionContextParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0234BE28A00DCF00AC1E5B /* WebExtensionContextParameters.h */; };
+		1C0234DC28A0268C00AC1E5B /* WebExtensionContextCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C0234DB28A0268B00AC1E5B /* WebExtensionContextCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C049838289AF5AD0010308B /* _WKWebExtensionPermission.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C049837289AF5AD0010308B /* _WKWebExtensionPermission.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C04983E289AFF9B0010308B /* _WKWebExtensionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C04983A289AFF9B0010308B /* _WKWebExtensionContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C049840289AFF9B0010308B /* _WKWebExtensionTab.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C04983C289AFF9B0010308B /* _WKWebExtensionTab.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C049841289AFF9B0010308B /* _WKWebExtensionWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C04983D289AFF9B0010308B /* _WKWebExtensionWindow.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C0A19471C8FF1A800FE0EBB /* WebAutomationSessionProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0A19451C8FF1A800FE0EBB /* WebAutomationSessionProxy.h */; };
 		1C0A19531C8FFDFB00FE0EBB /* WebAutomationSessionProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C0A19511C8FFDFB00FE0EBB /* WebAutomationSessionProxyMessageReceiver.cpp */; };
 		1C0A19541C8FFDFB00FE0EBB /* WebAutomationSessionProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0A19521C8FFDFB00FE0EBB /* WebAutomationSessionProxyMessages.h */; };
@@ -3424,7 +3439,28 @@
 		1AFE436418B6C081009C7A48 /* UIDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIDelegate.h; sourceTree = "<group>"; };
 		1AFF48FE1833DE78009AB15A /* WKDeprecatedFunctions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKDeprecatedFunctions.cpp; sourceTree = "<group>"; };
 		1BBBE49E19B66C53006B7D81 /* RemoteWebInspectorUIMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RemoteWebInspectorUIMessageReceiver.cpp; path = DerivedSources/WebKit/RemoteWebInspectorUIMessageReceiver.cpp; sourceTree = BUILT_PRODUCTS_DIR; };
+		1C0234BE28A00DCF00AC1E5B /* WebExtensionContextParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionContextParameters.h; sourceTree = "<group>"; };
+		1C0234BF28A00DCF00AC1E5B /* WebExtensionContextIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionContextIdentifier.h; sourceTree = "<group>"; };
+		1C0234C128A00E7D00AC1E5B /* WebExtensionContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionContext.cpp; sourceTree = "<group>"; };
+		1C0234C228A00E7D00AC1E5B /* WebExtensionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionContext.h; sourceTree = "<group>"; };
+		1C0234C328A00E7E00AC1E5B /* WebExtensionContext.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionContext.messages.in; sourceTree = "<group>"; };
+		1C0234C428A00E9E00AC1E5B /* WebExtensionContextProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionContextProxy.cpp; sourceTree = "<group>"; };
+		1C0234C528A00E9E00AC1E5B /* WebExtensionContextProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionContextProxy.messages.in; sourceTree = "<group>"; };
+		1C0234C628A00E9F00AC1E5B /* WebExtensionContextProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionContextProxy.h; sourceTree = "<group>"; };
+		1C0234C728A00FA800AC1E5B /* WebExtensionContextMessagesReplies.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionContextMessagesReplies.h; sourceTree = "<group>"; };
+		1C0234C828A00FA800AC1E5B /* WebExtensionContextMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionContextMessageReceiver.cpp; sourceTree = "<group>"; };
+		1C0234C928A00FA800AC1E5B /* WebExtensionContextProxyMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionContextProxyMessages.h; sourceTree = "<group>"; };
+		1C0234CA28A00FA800AC1E5B /* WebExtensionContextProxyMessagesReplies.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionContextProxyMessagesReplies.h; sourceTree = "<group>"; };
+		1C0234CB28A00FA900AC1E5B /* WebExtensionContextProxyMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionContextProxyMessageReceiver.cpp; sourceTree = "<group>"; };
+		1C0234CC28A00FA900AC1E5B /* WebExtensionContextMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionContextMessages.h; sourceTree = "<group>"; };
+		1C0234D328A0135600AC1E5B /* _WKWebExtensionContext.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionContext.mm; sourceTree = "<group>"; };
+		1C0234D528A013D900AC1E5B /* _WKWebExtensionContextPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionContextPrivate.h; sourceTree = "<group>"; };
+		1C0234D628A013D900AC1E5B /* _WKWebExtensionContextInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionContextInternal.h; sourceTree = "<group>"; };
+		1C0234DB28A0268B00AC1E5B /* WebExtensionContextCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextCocoa.mm; sourceTree = "<group>"; };
 		1C049837289AF5AD0010308B /* _WKWebExtensionPermission.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionPermission.mm; sourceTree = "<group>"; };
+		1C04983A289AFF9B0010308B /* _WKWebExtensionContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionContext.h; sourceTree = "<group>"; };
+		1C04983C289AFF9B0010308B /* _WKWebExtensionTab.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionTab.h; sourceTree = "<group>"; };
+		1C04983D289AFF9B0010308B /* _WKWebExtensionWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionWindow.h; sourceTree = "<group>"; };
 		1C0A19441C8FF1A800FE0EBB /* WebAutomationSessionProxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebAutomationSessionProxy.cpp; sourceTree = "<group>"; };
 		1C0A19451C8FF1A800FE0EBB /* WebAutomationSessionProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebAutomationSessionProxy.h; sourceTree = "<group>"; };
 		1C0A19481C8FF30E00FE0EBB /* WebAutomationSessionProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebAutomationSessionProxy.messages.in; sourceTree = "<group>"; };
@@ -3813,6 +3849,7 @@
 		1CBBE49F19B66C53006B7D81 /* WebInspectorUIMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebInspectorUIMessages.h; path = DerivedSources/WebKit/WebInspectorUIMessages.h; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CBD753C2747AA31004FA0FF /* WebGPUObjectHeap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebGPUObjectHeap.cpp; sourceTree = "<group>"; };
 		1CBD753D2747AA31004FA0FF /* WebGPUObjectHeap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUObjectHeap.h; sourceTree = "<group>"; };
+		1CBEE26128F334D6006D1A02 /* WebExtensionContextParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionContextParameters.serialization.in; sourceTree = "<group>"; };
 		1CBF9012271018B5000C457D /* QualifiedResourceHeap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QualifiedResourceHeap.h; sourceTree = "<group>"; };
 		1CC23B1B288732A800D0A65A /* WebExtensionController.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionController.messages.in; sourceTree = "<group>"; };
 		1CC23B1C288732A800D0A65A /* WebExtensionController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionController.h; sourceTree = "<group>"; };
@@ -8203,6 +8240,9 @@
 				BC032DAF10F4380F0058C15A /* WebEvent.h */,
 				BC032DB010F4380F0058C15A /* WebEventConversion.cpp */,
 				BC032DB110F4380F0058C15A /* WebEventConversion.h */,
+				1C0234BF28A00DCF00AC1E5B /* WebExtensionContextIdentifier.h */,
+				1C0234BE28A00DCF00AC1E5B /* WebExtensionContextParameters.h */,
+				1CBEE26128F334D6006D1A02 /* WebExtensionContextParameters.serialization.in */,
 				1C3BEB482887415100E66E38 /* WebExtensionControllerIdentifier.h */,
 				1C3BEB46288740AE00E66E38 /* WebExtensionControllerParameters.h */,
 				1C4B7BBF28E7A43F00B7265A /* WebExtensionControllerParameters.serialization.in */,
@@ -8573,6 +8613,7 @@
 			isa = PBXGroup;
 			children = (
 				1C627477288A1DDE00CED3A2 /* WebExtensionCocoa.mm */,
+				1C0234DB28A0268B00AC1E5B /* WebExtensionContextCocoa.mm */,
 				1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */,
 			);
 			path = Cocoa;
@@ -8872,6 +8913,9 @@
 			children = (
 				1C627476288A1DDE00CED3A2 /* Cocoa */,
 				1C3BEB5E2888710500E66E38 /* WebExtension.h */,
+				1C0234C128A00E7D00AC1E5B /* WebExtensionContext.cpp */,
+				1C0234C228A00E7D00AC1E5B /* WebExtensionContext.h */,
+				1C0234C328A00E7E00AC1E5B /* WebExtensionContext.messages.in */,
 				1CC23B1D288732A800D0A65A /* WebExtensionController.cpp */,
 				1CC23B1C288732A800D0A65A /* WebExtensionController.h */,
 				1CC23B1B288732A800D0A65A /* WebExtensionController.messages.in */,
@@ -8883,6 +8927,9 @@
 		1CC23B1E288732F600D0A65A /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				1C0234C428A00E9E00AC1E5B /* WebExtensionContextProxy.cpp */,
+				1C0234C628A00E9F00AC1E5B /* WebExtensionContextProxy.h */,
+				1C0234C528A00E9E00AC1E5B /* WebExtensionContextProxy.messages.in */,
 				1CC23B21288732F600D0A65A /* WebExtensionControllerProxy.cpp */,
 				1CC23B20288732F600D0A65A /* WebExtensionControllerProxy.h */,
 				1CC23B1F288732F600D0A65A /* WebExtensionControllerProxy.messages.in */,
@@ -9861,6 +9908,10 @@
 				574728D3234570AE001700AF /* _WKWebAuthenticationPanelInternal.h */,
 				1C3BEB6C288883E200E66E38 /* _WKWebExtension.h */,
 				1C3BEB6E288883E200E66E38 /* _WKWebExtension.mm */,
+				1C04983A289AFF9B0010308B /* _WKWebExtensionContext.h */,
+				1C0234D328A0135600AC1E5B /* _WKWebExtensionContext.mm */,
+				1C0234D628A013D900AC1E5B /* _WKWebExtensionContextInternal.h */,
+				1C0234D528A013D900AC1E5B /* _WKWebExtensionContextPrivate.h */,
 				1C3BEB5728875CE400E66E38 /* _WKWebExtensionController.h */,
 				1C3BEB5528875CE400E66E38 /* _WKWebExtensionController.mm */,
 				1C3BEB5628875CE400E66E38 /* _WKWebExtensionControllerInternal.h */,
@@ -9873,6 +9924,8 @@
 				1C8B2362289AE89400020CDC /* _WKWebExtensionPermission.h */,
 				1C049837289AF5AD0010308B /* _WKWebExtensionPermission.mm */,
 				1C3BEB6F288883E300E66E38 /* _WKWebExtensionPrivate.h */,
+				1C04983C289AFF9B0010308B /* _WKWebExtensionTab.h */,
+				1C04983D289AFF9B0010308B /* _WKWebExtensionWindow.h */,
 				1AE286761C7E76510069AC4F /* _WKWebsiteDataSize.h */,
 				1AE286751C7E76510069AC4F /* _WKWebsiteDataSize.mm */,
 				1AE2867F1C7F92BF0069AC4F /* _WKWebsiteDataSizeInternal.h */,
@@ -13282,6 +13335,12 @@
 				E3866B072399979D00F88FE9 /* WebDeviceOrientationUpdateProviderMessages.h */,
 				E3866B042399979C00F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp */,
 				E3866B052399979C00F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessages.h */,
+				1C0234C828A00FA800AC1E5B /* WebExtensionContextMessageReceiver.cpp */,
+				1C0234CC28A00FA900AC1E5B /* WebExtensionContextMessages.h */,
+				1C0234C728A00FA800AC1E5B /* WebExtensionContextMessagesReplies.h */,
+				1C0234CB28A00FA900AC1E5B /* WebExtensionContextProxyMessageReceiver.cpp */,
+				1C0234C928A00FA800AC1E5B /* WebExtensionContextProxyMessages.h */,
+				1C0234CA28A00FA800AC1E5B /* WebExtensionContextProxyMessagesReplies.h */,
 				1C3BEB4A2887492600E66E38 /* WebExtensionControllerMessageReceiver.cpp */,
 				1C3BEB492887492600E66E38 /* WebExtensionControllerMessages.h */,
 				1C3BEB4C2887492600E66E38 /* WebExtensionControllerMessagesReplies.h */,
@@ -14151,6 +14210,9 @@
 				5790A6532565DED30077C5A7 /* _WKWebAuthenticationPanelForTesting.h in Headers */,
 				574728D4234570AE001700AF /* _WKWebAuthenticationPanelInternal.h in Headers */,
 				1C3BEB702888842400E66E38 /* _WKWebExtension.h in Headers */,
+				1C04983E289AFF9B0010308B /* _WKWebExtensionContext.h in Headers */,
+				1C0234D828A013D900AC1E5B /* _WKWebExtensionContextInternal.h in Headers */,
+				1C0234D728A013D900AC1E5B /* _WKWebExtensionContextPrivate.h in Headers */,
 				1C3BEB5B28875CE500E66E38 /* _WKWebExtensionController.h in Headers */,
 				1C3BEB5A28875CE500E66E38 /* _WKWebExtensionControllerInternal.h in Headers */,
 				1C3BEB5C28875CE500E66E38 /* _WKWebExtensionControllerPrivate.h in Headers */,
@@ -14160,6 +14222,8 @@
 				1C1CE974288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h in Headers */,
 				1C8B2363289AE89400020CDC /* _WKWebExtensionPermission.h in Headers */,
 				1C3BEB712888842A00E66E38 /* _WKWebExtensionPrivate.h in Headers */,
+				1C049840289AFF9B0010308B /* _WKWebExtensionTab.h in Headers */,
+				1C049841289AFF9B0010308B /* _WKWebExtensionWindow.h in Headers */,
 				1AE286781C7E76510069AC4F /* _WKWebsiteDataSize.h in Headers */,
 				1AE286801C7F92C00069AC4F /* _WKWebsiteDataSizeInternal.h in Headers */,
 				1AFB4C721ADF155D00B33339 /* _WKWebsiteDataStore.h in Headers */,
@@ -15059,6 +15123,12 @@
 				BC032DBB10F4380F0058C15A /* WebEventConversion.h in Headers */,
 				BC111B5D112F629800337BAB /* WebEventFactory.h in Headers */,
 				DDA0A41727E67039005E086E /* WebEventRegion.h in Headers */,
+				1C0234D928A01B1C00AC1E5B /* WebExtensionContextIdentifier.h in Headers */,
+				1C0234D228A00FF000AC1E5B /* WebExtensionContextMessages.h in Headers */,
+				1C0234CF28A00FF000AC1E5B /* WebExtensionContextMessagesReplies.h in Headers */,
+				1C0234DA28A01B2100AC1E5B /* WebExtensionContextParameters.h in Headers */,
+				1C0234D028A00FF000AC1E5B /* WebExtensionContextProxyMessages.h in Headers */,
+				1C0234D128A00FF000AC1E5B /* WebExtensionContextProxyMessagesReplies.h in Headers */,
 				1C3BEB7C2888A01000E66E38 /* WebExtensionController.h in Headers */,
 				1C3BEB7A2888A00800E66E38 /* WebExtensionControllerIdentifier.h in Headers */,
 				1C3BEB502887492F00E66E38 /* WebExtensionControllerMessages.h in Headers */,
@@ -17271,6 +17341,7 @@
 				49FBEFFF239B012F00BD032F /* _WKResourceLoadStatisticsThirdParty.mm in Sources */,
 				99E7189A21F79D9E0055E975 /* _WKTouchEventGenerator.mm in Sources */,
 				1C627479288B2F7400CED3A2 /* _WKWebExtension.mm in Sources */,
+				1C0234D428A0135600AC1E5B /* _WKWebExtensionContext.mm in Sources */,
 				1C62747A288B2F7400CED3A2 /* _WKWebExtensionController.mm in Sources */,
 				1C1CE972288DF5030098D3A1 /* _WKWebExtensionMatchPattern.mm in Sources */,
 				1C049838289AF5AD0010308B /* _WKWebExtensionPermission.mm in Sources */,
@@ -17626,6 +17697,9 @@
 				E3866AE52397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm in Sources */,
 				E3866B092399A2D500F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp in Sources */,
 				1C627478288A1E1D00CED3A2 /* WebExtensionCocoa.mm in Sources */,
+				1C0234DC28A0268C00AC1E5B /* WebExtensionContextCocoa.mm in Sources */,
+				1C0234CD28A00FE400AC1E5B /* WebExtensionContextMessageReceiver.cpp in Sources */,
+				1C0234CE28A00FE600AC1E5B /* WebExtensionContextProxyMessageReceiver.cpp in Sources */,
 				1C3BEB522887492F00E66E38 /* WebExtensionControllerMessageReceiver.cpp in Sources */,
 				1C3BEB532887492F00E66E38 /* WebExtensionControllerProxyMessageReceiver.cpp in Sources */,
 				1C1CE96D288DF46D0098D3A1 /* WebExtensionMatchPatternCocoa.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -24,12 +24,12 @@
  */
 
 #include "config.h"
-#include "WebExtensionControllerProxy.h"
+#include "WebExtensionContextProxy.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#include "WebExtensionControllerMessages.h"
-#include "WebExtensionControllerProxyMessages.h"
+#include "WebExtensionContextMessages.h"
+#include "WebExtensionContextProxyMessages.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -37,36 +37,36 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static HashMap<WebExtensionControllerIdentifier, WebExtensionControllerProxy*>& webExtensionControllerProxies()
+static HashMap<WebExtensionContextIdentifier, WebExtensionContextProxy*>& webExtensionContextProxies()
 {
-    static MainThreadNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WebExtensionControllerProxy*>> controllers;
-    return controllers;
+    static MainThreadNeverDestroyed<HashMap<WebExtensionContextIdentifier, WebExtensionContextProxy*>> contexts;
+    return contexts;
 }
 
-Ref<WebExtensionControllerProxy> WebExtensionControllerProxy::getOrCreate(WebExtensionControllerIdentifier identifier)
+Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(WebExtensionContextIdentifier identifier)
 {
-    auto& webExtensionControllerProxyPtr = webExtensionControllerProxies().add(identifier, nullptr).iterator->value;
-    if (webExtensionControllerProxyPtr)
-        return *webExtensionControllerProxyPtr;
+    auto& webExtensionContextProxyPtr = webExtensionContextProxies().add(identifier, nullptr).iterator->value;
+    if (webExtensionContextProxyPtr)
+        return *webExtensionContextProxyPtr;
 
-    RefPtr<WebExtensionControllerProxy> webExtensionControllerProxy = adoptRef(new WebExtensionControllerProxy(identifier));
-    webExtensionControllerProxyPtr = webExtensionControllerProxy.get();
+    RefPtr<WebExtensionContextProxy> webExtensionContextProxy = adoptRef(new WebExtensionContextProxy(identifier));
+    webExtensionContextProxyPtr = webExtensionContextProxy.get();
 
-    return webExtensionControllerProxy.releaseNonNull();
+    return webExtensionContextProxy.releaseNonNull();
 }
 
-WebExtensionControllerProxy::WebExtensionControllerProxy(WebExtensionControllerIdentifier identifier)
+WebExtensionContextProxy::WebExtensionContextProxy(WebExtensionContextIdentifier identifier)
     : m_identifier(identifier)
 {
-    WebProcess::singleton().addMessageReceiver(Messages::WebExtensionControllerProxy::messageReceiverName(), m_identifier, *this);
+    WebProcess::singleton().addMessageReceiver(Messages::WebExtensionContextProxy::messageReceiverName(), m_identifier, *this);
 }
 
-WebExtensionControllerProxy::~WebExtensionControllerProxy()
+WebExtensionContextProxy::~WebExtensionContextProxy()
 {
-    WebProcess::singleton().removeMessageReceiver(Messages::WebExtensionControllerProxy::messageReceiverName(), m_identifier);
+    WebProcess::singleton().removeMessageReceiver(Messages::WebExtensionContextProxy::messageReceiverName(), m_identifier);
 
-    ASSERT(webExtensionControllerProxies().contains(m_identifier));
-    webExtensionControllerProxies().remove(m_identifier);
+    ASSERT(webExtensionContextProxies().contains(m_identifier));
+    webExtensionContextProxies().remove(m_identifier);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -27,34 +27,30 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#include "APIObject.h"
 #include "MessageReceiver.h"
-#include "WebExtensionControllerIdentifier.h"
+#include "WebExtensionContextIdentifier.h"
 #include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
-struct WebExtensionControllerParameters;
-
-class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExtensionController>, public IPC::MessageReceiver {
-    WTF_MAKE_NONCOPYABLE(WebExtensionController);
+class WebExtensionContextProxy final : public RefCounted<WebExtensionContextProxy>, private IPC::MessageReceiver {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(WebExtensionContextProxy);
 
 public:
-    static Ref<WebExtensionController> create() { return adoptRef(*new WebExtensionController); }
-    static WebExtensionController* get(WebExtensionControllerIdentifier);
+    static Ref<WebExtensionContextProxy> getOrCreate(WebExtensionContextIdentifier);
 
-    explicit WebExtensionController();
-    ~WebExtensionController();
+    ~WebExtensionContextProxy();
 
-    WebExtensionControllerIdentifier identifier() const { return m_identifier; }
-    WebExtensionControllerParameters parameters() const;
+    WebExtensionContextIdentifier identifier() { return m_identifier; }
 
 private:
+    explicit WebExtensionContextProxy(WebExtensionContextIdentifier);
+
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    WebExtensionControllerIdentifier m_identifier;
+    WebExtensionContextIdentifier m_identifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -23,40 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#include "APIObject.h"
-#include "MessageReceiver.h"
-#include "WebExtensionControllerIdentifier.h"
-#include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
+messages -> WebExtensionContextProxy {
 
-namespace WebKit {
-
-struct WebExtensionControllerParameters;
-
-class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExtensionController>, public IPC::MessageReceiver {
-    WTF_MAKE_NONCOPYABLE(WebExtensionController);
-
-public:
-    static Ref<WebExtensionController> create() { return adoptRef(*new WebExtensionController); }
-    static WebExtensionController* get(WebExtensionControllerIdentifier);
-
-    explicit WebExtensionController();
-    ~WebExtensionController();
-
-    WebExtensionControllerIdentifier identifier() const { return m_identifier; }
-    WebExtensionControllerParameters parameters() const;
-
-private:
-    // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-
-    WebExtensionControllerIdentifier m_identifier;
-};
-
-} // namespace WebKit
+}
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM)
 
+#include "GPUProcessConnection.h"
 #include "MediaRecorderIdentifier.h"
 #include "SharedRingBufferStorage.h"
 #include "SharedVideoFrame.h"

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -281,6 +281,7 @@ Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-leaks.mm
 Tests/WebKitCocoa/WKWebExtension.mm
+Tests/WebKitCocoa/WKWebExtensionContext.mm
 Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
 Tests/WebKitCocoa/WKWebViewAlwaysShowsScroller.mm
 Tests/WebKitCocoa/WKWebViewCandidateTests.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2008,6 +2008,7 @@
 		1CB2F27B24F88379000A5BC1 /* OrthogonalFlowAvailableSize.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OrthogonalFlowAvailableSize.mm; sourceTree = "<group>"; };
 		1CB2F27D24F883BE000A5BC1 /* orthogonal-flow-available-size.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "orthogonal-flow-available-size.html"; sourceTree = "<group>"; };
 		1CB9BC371A67482300FE5678 /* WeakPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WeakPtr.cpp; sourceTree = "<group>"; };
+		1CBEE26228F47FA9006D1A02 /* WKWebExtensionContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionContext.mm; sourceTree = "<group>"; };
 		1CC4C7492889072900A3B23D /* CaptivePortalModeFonts.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CaptivePortalModeFonts.mm; sourceTree = "<group>"; };
 		1CC4C74A288909F600A3B23D /* WKPrinting.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKPrinting.mm; sourceTree = "<group>"; };
 		1CC4C74B28890C5400A3B23D /* SVGFont.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = SVGFont.html; sourceTree = "<group>"; };
@@ -4040,6 +4041,7 @@
 				51C683DD1EA134DB00650183 /* WKURLSchemeHandler-1.mm */,
 				5182C22D1F2BCB410059BA7C /* WKURLSchemeHandler-leaks.mm */,
 				1CFAA40828947999009F894D /* WKWebExtension.mm */,
+				1CBEE26228F47FA9006D1A02 /* WKWebExtensionContext.mm */,
 				1CFAA40928974405009F894D /* WKWebExtensionMatchPattern.mm */,
 				5C7148942123A40700FDE3C5 /* WKWebsiteDatastore.mm */,
 				371195AA1FE5797700A1FB92 /* WKWebViewAlwaysShowsScroller.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -251,12 +251,12 @@ TEST(WKWebExtension, PermissionsParsing)
 
     EXPECT_NOT_NULL(testExtension.requestedPermissions);
     EXPECT_EQ(testExtension.requestedPermissions.count, 0ul);
-    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
-    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.requestedPermissionMatchPatterns.count, 0ul);
     EXPECT_NOT_NULL(testExtension.optionalPermissions);
     EXPECT_EQ(testExtension.optionalPermissions.count, 0ul);
-    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
-    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.optionalPermissionMatchPatterns.count, 0ul);
 
     // The "permissions" key alone is defined but is empty.
     testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @[ ] };
@@ -264,124 +264,124 @@ TEST(WKWebExtension, PermissionsParsing)
 
     EXPECT_NOT_NULL(testExtension.requestedPermissions);
     EXPECT_EQ(testExtension.requestedPermissions.count, 0ul);
-    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
-    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.requestedPermissionMatchPatterns.count, 0ul);
     EXPECT_NOT_NULL(testExtension.optionalPermissions);
     EXPECT_EQ(testExtension.optionalPermissions.count, 0ul);
-    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
-    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.optionalPermissionMatchPatterns.count, 0ul);
 
     // The "optional_permissions" key alone is defined but is empty.
     testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NOT_NULL(testExtension.requestedPermissions);
-    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionMatchPatterns);
     EXPECT_NOT_NULL(testExtension.optionalPermissions);
-    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionMatchPatterns);
     EXPECT_EQ(testExtension.requestedPermissions.count, 0ul);
-    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+    EXPECT_EQ(testExtension.requestedPermissionMatchPatterns.count, 0ul);
     EXPECT_EQ(testExtension.optionalPermissions.count, 0ul);
-    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+    EXPECT_EQ(testExtension.optionalPermissionMatchPatterns.count, 0ul);
 
     // The "permissions" and "optional_permissions" keys are defined as invalid types.
     testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @(1), @"optional_permissions": @"foo" };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NOT_NULL(testExtension.requestedPermissions);
-    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionMatchPatterns);
     EXPECT_NOT_NULL(testExtension.optionalPermissions);
-    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionMatchPatterns);
     EXPECT_EQ(testExtension.requestedPermissions.count, 0ul);
-    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+    EXPECT_EQ(testExtension.requestedPermissionMatchPatterns.count, 0ul);
     EXPECT_EQ(testExtension.optionalPermissions.count, 0ul);
-    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+    EXPECT_EQ(testExtension.optionalPermissionMatchPatterns.count, 0ul);
 
     // The "permissions" key is defined with an invalid permission.
     testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @[ @"invalid" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.requestedPermissions, [NSSet set]);
-    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
-    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.requestedPermissionMatchPatterns.count, 0ul);
 
     // The "permissions" key is defined with a valid permission.
     testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @[ @"tabs" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.requestedPermissions, [NSSet setWithArray:@[ @"tabs" ]]);
-    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
-    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.requestedPermissionMatchPatterns.count, 0ul);
 
     // The "permissions" key is defined with a valid and an invalid permission.
     testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @[ @"tabs", @"invalid" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.requestedPermissions, [NSSet setWithArray:(@[ @"tabs" ])]);
-    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
-    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.requestedPermissionMatchPatterns.count, 0ul);
 
     // The "permissions" key is defined with a valid permission and a valid origin.
     testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @[ @"tabs", @"http://www.webkit.org/" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.requestedPermissions, [NSSet setWithArray:@[ @"tabs" ]]);
-    EXPECT_NS_EQUAL(testExtension.requestedPermissionOrigins.anyObject.description, @"http://www.webkit.org/");
+    EXPECT_NS_EQUAL(testExtension.requestedPermissionMatchPatterns.anyObject.description, @"http://www.webkit.org/");
 
     // The "permissions" key is defined with a valid permission and an invalid origin.
     testManifestDictionary = @{ @"manifest_version": @2, @"permissions": @[ @"tabs", @"foo://www.webkit.org/" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.requestedPermissions, [NSSet setWithArray:(@[ @"tabs" ])]);
-    EXPECT_NOT_NULL(testExtension.requestedPermissionOrigins);
-    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.requestedPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.requestedPermissionMatchPatterns.count, 0ul);
 
     // The "optional_permissions" key is defined with an invalid permission.
     testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ @"invalid" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.optionalPermissions, [NSSet set]);
-    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
-    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.optionalPermissionMatchPatterns.count, 0ul);
 
     // The "optional_permissions" key is defined with a valid permission.
     testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ @"tabs" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.optionalPermissions, [NSSet setWithArray:@[ @"tabs" ]]);
-    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
-    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.optionalPermissionMatchPatterns.count, 0ul);
 
     // The "optional_permissions" key is defined with a valid and an invalid permission.
     testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ @"tabs", @"invalid" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.optionalPermissions, [NSSet setWithArray:(@[ @"tabs" ])]);
-    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
-    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.optionalPermissionMatchPatterns.count, 0ul);
 
     // The "optional_permissions" key is defined with a valid permission and a valid origin.
     testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ @"tabs", @"http://www.webkit.org/" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.optionalPermissions, [NSSet setWithArray:@[ @"tabs" ]]);
-    EXPECT_NS_EQUAL(testExtension.optionalPermissionOrigins.anyObject.description, @"http://www.webkit.org/");
+    EXPECT_NS_EQUAL(testExtension.optionalPermissionMatchPatterns.anyObject.description, @"http://www.webkit.org/");
 
     // The "optional_permissions" key is defined with a valid permission and an invalid origin.
     testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ @"tabs", @"foo://www.webkit.org/" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.optionalPermissions, [NSSet setWithArray:(@[ @"tabs" ])]);
-    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
-    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.optionalPermissionMatchPatterns.count, 0ul);
 
     // The "optional_permissions" key is defined with a valid permission and a forbidden optional permission.
     testManifestDictionary = @{ @"manifest_version": @2, @"optional_permissions": @[ @"tabs", @"geolocation" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NS_EQUAL(testExtension.optionalPermissions, [NSSet setWithArray:(@[ @"tabs" ])]);
-    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
-    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.optionalPermissionMatchPatterns.count, 0ul);
 
     // The "optional_permissions" key contains a permission already defined in the "permissions" key.
     testManifestDictionary = @{ @"manifest_version": @2, @"permissions" : @[ @"tabs", @"geolocation" ], @"optional_permissions": @[@"tabs"] };
@@ -395,39 +395,39 @@ TEST(WKWebExtension, PermissionsParsing)
     testManifestDictionary = @{ @"manifest_version": @2, @"permissions" : @[ @"http://www.webkit.org/" ], @"optional_permissions": @[ @"http://www.webkit.org/" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_NS_EQUAL(testExtension.requestedPermissionOrigins.anyObject.description, @"http://www.webkit.org/");
-    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
-    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+    EXPECT_NS_EQUAL(testExtension.requestedPermissionMatchPatterns.anyObject.description, @"http://www.webkit.org/");
+    EXPECT_NOT_NULL(testExtension.optionalPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.optionalPermissionMatchPatterns.count, 0ul);
 
     // Make sure manifest v2 extensions ignore hosts from host_permissions (this should only be checked for manifest v3).
     testManifestDictionary = @{ @"manifest_version": @2, @"permissions" : @[ @"http://www.webkit.org/" ], @"optional_permissions": @[ @"http://www.example.com/" ], @"host_permissions": @[ @"https://webkit.org/" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 1ul);
-    EXPECT_TRUE([testExtension.requestedPermissionOrigins containsObject:[_WKWebExtensionMatchPattern matchPatternWithString:@"http://www.webkit.org/"]]);
-    EXPECT_FALSE([testExtension.requestedPermissionOrigins containsObject:[_WKWebExtensionMatchPattern matchPatternWithString:@"https://webkit.org/"]]);
-    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
-    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 1ul);
-    EXPECT_TRUE([testExtension.optionalPermissionOrigins containsObject:[_WKWebExtensionMatchPattern matchPatternWithString:@"http://www.example.com/"]]);
-    EXPECT_FALSE([testExtension.optionalPermissionOrigins containsObject:[_WKWebExtensionMatchPattern matchPatternWithString:@"https://webkit.org/"]]);
+    EXPECT_EQ(testExtension.requestedPermissionMatchPatterns.count, 1ul);
+    EXPECT_TRUE([testExtension.requestedPermissionMatchPatterns containsObject:[_WKWebExtensionMatchPattern matchPatternWithString:@"http://www.webkit.org/"]]);
+    EXPECT_FALSE([testExtension.requestedPermissionMatchPatterns containsObject:[_WKWebExtensionMatchPattern matchPatternWithString:@"https://webkit.org/"]]);
+    EXPECT_NOT_NULL(testExtension.optionalPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.optionalPermissionMatchPatterns.count, 1ul);
+    EXPECT_TRUE([testExtension.optionalPermissionMatchPatterns containsObject:[_WKWebExtensionMatchPattern matchPatternWithString:@"http://www.example.com/"]]);
+    EXPECT_FALSE([testExtension.optionalPermissionMatchPatterns containsObject:[_WKWebExtensionMatchPattern matchPatternWithString:@"https://webkit.org/"]]);
 
     // Make sure manifest v3 parses hosts from host_permissions, and ignores hosts in permissions and optional_permissions.
     testManifestDictionary = @{ @"manifest_version": @3, @"permissions" : @[ @"http://www.webkit.org/" ], @"optional_permissions": @[ @"http://www.example.com/" ], @"host_permissions": @[ @"https://webkit.org/" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 1ul);
-    EXPECT_NS_EQUAL(testExtension.requestedPermissionOrigins.anyObject.description, @"https://webkit.org/");
-    EXPECT_NOT_NULL(testExtension.optionalPermissionOrigins);
-    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 0ul);
+    EXPECT_EQ(testExtension.requestedPermissionMatchPatterns.count, 1ul);
+    EXPECT_NS_EQUAL(testExtension.requestedPermissionMatchPatterns.anyObject.description, @"https://webkit.org/");
+    EXPECT_NOT_NULL(testExtension.optionalPermissionMatchPatterns);
+    EXPECT_EQ(testExtension.optionalPermissionMatchPatterns.count, 0ul);
 
     // Make sure manifest v3 parses optional_host_permissions.
     testManifestDictionary = @{ @"manifest_version": @3, @"optional_host_permissions": @[ @"http://www.example.com/" ], @"host_permissions": @[ @"https://webkit.org/" ] };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_EQ(testExtension.requestedPermissionOrigins.count, 1ul);
-    EXPECT_NS_EQUAL(testExtension.requestedPermissionOrigins.anyObject.description, @"https://webkit.org/");
-    EXPECT_EQ(testExtension.optionalPermissionOrigins.count, 1ul);
-    EXPECT_NS_EQUAL(testExtension.optionalPermissionOrigins.anyObject.description, @"http://www.example.com/");
+    EXPECT_EQ(testExtension.requestedPermissionMatchPatterns.count, 1ul);
+    EXPECT_NS_EQUAL(testExtension.requestedPermissionMatchPatterns.anyObject.description, @"https://webkit.org/");
+    EXPECT_EQ(testExtension.optionalPermissionMatchPatterns.count, 1ul);
+    EXPECT_NS_EQUAL(testExtension.optionalPermissionMatchPatterns.anyObject.description, @"http://www.example.com/");
 }
 
 TEST(WKWebExtension, BackgroundParsing)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
@@ -1,0 +1,393 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "TestCocoa.h"
+#import <WebKit/WKFoundation.h>
+#import <WebKit/_WKWebExtensionPermission.h>
+#import <WebKit/_WKWebExtensionContextPrivate.h>
+#import <WebKit/_WKWebExtensionMatchPatternPrivate.h>
+#import <WebKit/_WKWebExtensionPrivate.h>
+
+namespace TestWebKitAPI {
+
+TEST(WKWebExtensionContext, DefaultPermissionChecks)
+{
+    // Extensions are expected to have no permissions or access by default.
+    // Only Requested states should be reported with out any granting / denying.
+
+    NSMutableDictionary *testManifestDictionary = [@{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"permissions": @[ ] } mutableCopy];
+    _WKWebExtension *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+
+    EXPECT_NULL(testExtension.errors);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
+    EXPECT_FALSE(testContext.hasAccessToAllURLs);
+    EXPECT_FALSE(testContext.hasAccessToAllHosts);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+
+    testManifestDictionary[@"permissions"] = @[ @"tabs", @"https://*.example.com/*" ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+
+    EXPECT_NULL(testExtension.errors);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
+    EXPECT_FALSE(testContext.hasAccessToAllURLs);
+    EXPECT_FALSE(testContext.hasAccessToAllHosts);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+
+    testManifestDictionary[@"permissions"] = @[ @"tabs", @"<all_urls>" ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+
+    EXPECT_NULL(testExtension.errors);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
+    EXPECT_FALSE(testContext.hasAccessToAllURLs);
+    EXPECT_FALSE(testContext.hasAccessToAllHosts);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+
+    testManifestDictionary[@"permissions"] = @[ @"tabs", @"*://*/*" ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+
+    EXPECT_NULL(testExtension.errors);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
+    EXPECT_FALSE(testContext.hasAccessToAllURLs);
+    EXPECT_FALSE(testContext.hasAccessToAllHosts);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+
+    testManifestDictionary[@"manifest_version"] = @3;
+    testManifestDictionary[@"permissions"] = @[ ];
+    testManifestDictionary[@"host_permissions"] = @[ ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+
+    EXPECT_NULL(testExtension.errors);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
+    EXPECT_FALSE(testContext.hasAccessToAllURLs);
+    EXPECT_FALSE(testContext.hasAccessToAllHosts);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+
+    testManifestDictionary[@"permissions"] = @[ @"tabs" ];
+    testManifestDictionary[@"host_permissions"] = @[ @"https://*.example.com/*" ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+
+    EXPECT_NULL(testExtension.errors);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
+    EXPECT_FALSE(testContext.hasAccessToAllURLs);
+    EXPECT_FALSE(testContext.hasAccessToAllHosts);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+
+    testManifestDictionary[@"host_permissions"] = @[ @"<all_urls>" ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+
+    EXPECT_NULL(testExtension.errors);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
+    EXPECT_FALSE(testContext.hasAccessToAllURLs);
+    EXPECT_FALSE(testContext.hasAccessToAllHosts);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+
+    testManifestDictionary[@"host_permissions"] = @[ @"*://*/*" ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+
+    EXPECT_NULL(testExtension.errors);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
+    EXPECT_FALSE(testContext.hasAccessToAllURLs);
+    EXPECT_FALSE(testContext.hasAccessToAllHosts);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+}
+
+TEST(WKWebExtensionContext, PermissionGranting)
+{
+    NSMutableDictionary *testManifestDictionary = [@{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0" } mutableCopy];
+    testManifestDictionary[@"permissions"] = @[ @"tabs", @"https://*.example.com/*" ];
+
+    // Test defaults.
+    _WKWebExtension *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+
+    EXPECT_NULL(testExtension.errors);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
+    EXPECT_FALSE(testContext.hasAccessToAllURLs);
+    EXPECT_FALSE(testContext.hasAccessToAllHosts);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+
+    // Grant a specific permission.
+    [testContext setPermissionState:_WKWebExtensionContextPermissionStateGrantedExplicitly forPermission:_WKWebExtensionPermissionTabs];
+
+    EXPECT_TRUE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_EQ(testContext.grantedPermissions.count, 1ul);
+
+    // Grant a specific URL.
+    [testContext setPermissionState:_WKWebExtensionContextPermissionStateGrantedExplicitly forURL:[NSURL URLWithString:@"https://example.com/"]];
+
+    EXPECT_TRUE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
+
+    // Deny a specific URL.
+    [testContext setPermissionState:_WKWebExtensionContextPermissionStateDeniedExplicitly forURL:[NSURL URLWithString:@"https://example.com/"]];
+
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 1ul);
+
+    // Deny a specific permission.
+    [testContext setPermissionState:_WKWebExtensionContextPermissionStateDeniedExplicitly forPermission:_WKWebExtensionPermissionTabs];
+
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissions.count, 1ul);
+
+    // Reset all permissions.
+    [testContext setPermissionState:_WKWebExtensionContextPermissionStateUnknown forURL:[NSURL URLWithString:@"https://example.com/"]];
+    [testContext setPermissionState:_WKWebExtensionContextPermissionStateUnknown forPermission:_WKWebExtensionPermissionTabs];
+
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+
+    // Grant the all URLs match pattern.
+    [testContext setPermissionState:_WKWebExtensionContextPermissionStateGrantedExplicitly forMatchPattern:_WKWebExtensionMatchPattern.allURLsMatchPattern];
+
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
+    EXPECT_TRUE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
+
+    // Reset a specific URL (should do nothing).
+    [testContext setPermissionState:_WKWebExtensionContextPermissionStateUnknown forURL:[NSURL URLWithString:@"https://example.com/"]];
+
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
+    EXPECT_TRUE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
+
+    // Deny a specific URL (should do nothing).
+    [testContext setPermissionState:_WKWebExtensionContextPermissionStateDeniedExplicitly forURL:[NSURL URLWithString:@"https://example.com/"]];
+
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 1ul);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateDeniedExplicitly);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
+
+    // Reset all match patterns.
+    testContext.grantedPermissionMatchPatterns = @{ };
+    testContext.deniedPermissionMatchPatterns = @{ };
+
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+
+    // Mass grant with the permission setter.
+    testContext.grantedPermissions = @{ _WKWebExtensionPermissionTabs: NSDate.distantFuture };
+
+    EXPECT_TRUE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_EQ(testContext.grantedPermissions.count, 1ul);
+
+    // Mass deny with the permission setter.
+    testContext.deniedPermissions = @{ _WKWebExtensionPermissionTabs: NSDate.distantFuture };
+
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_EQ(testContext.deniedPermissions.count, 1ul);
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+
+    // Mass grant with the permission setter again.
+    testContext.grantedPermissions = @{ _WKWebExtensionPermissionTabs: NSDate.distantFuture };
+
+    EXPECT_TRUE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_EQ(testContext.grantedPermissions.count, 1ul);
+    EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
+
+    // Mass grant with the match pattern setter.
+    testContext.grantedPermissionMatchPatterns = @{ _WKWebExtensionMatchPattern.allURLsMatchPattern: NSDate.distantFuture };
+
+    EXPECT_TRUE(testContext.hasAccessToAllURLs);
+    EXPECT_TRUE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+
+    // Mass deny with the match pattern setter.
+    testContext.deniedPermissionMatchPatterns = @{ _WKWebExtensionMatchPattern.allURLsMatchPattern: NSDate.distantFuture };
+
+    EXPECT_FALSE(testContext.hasAccessToAllURLs);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 1ul);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+
+    // Mass grant with the match pattern setter again.
+    testContext.grantedPermissionMatchPatterns = @{ _WKWebExtensionMatchPattern.allURLsMatchPattern: NSDate.distantFuture };
+
+    EXPECT_TRUE(testContext.hasAccessToAllURLs);
+    EXPECT_TRUE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+
+    // Reset all permissions.
+    testContext.grantedPermissionMatchPatterns = @{ };
+    testContext.deniedPermissionMatchPatterns = @{ };
+    testContext.grantedPermissions = @{ };
+    testContext.deniedPermissions = @{ };
+
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
+    EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
+
+    // Test granting a match pattern that expire in 2 seconds.
+    [testContext setPermissionState:_WKWebExtensionContextPermissionStateGrantedExplicitly forMatchPattern:_WKWebExtensionMatchPattern.allURLsMatchPattern expirationDate:[NSDate dateWithTimeIntervalSinceNow:2]];
+
+    EXPECT_TRUE(testContext.hasAccessToAllURLs);
+    EXPECT_TRUE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
+
+    // Sleep until after the match pattern expires.
+    sleep(3);
+
+    EXPECT_FALSE(testContext.hasAccessToAllURLs);
+    EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
+    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedExplicitly);
+    EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
+
+    // Test granting a permission that expire in 2 seconds.
+    [testContext setPermissionState:_WKWebExtensionContextPermissionStateGrantedExplicitly forPermission:_WKWebExtensionPermissionTabs expirationDate:[NSDate dateWithTimeIntervalSinceNow:2]];
+
+    EXPECT_TRUE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_EQ(testContext.grantedPermissions.count, 1ul);
+
+    // Sleep until after the permission expires.
+    sleep(3);
+
+    EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
+    EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 476ad6dbea8e2e3d0fe1f72e4c9de6bfcc73189a
<pre>
Add _WKWebExtensionContext and WebKit::WebExtensionContext.
<a href="https://bugs.webkit.org/show_bug.cgi?id=246255">https://bugs.webkit.org/show_bug.cgi?id=246255</a>

Reviewed by Brian Weinstein.

This class represents the runtime environment for an extension, which tracks permission access,
and will eventually handle things like background page loading, injecting content, storage access, etc.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::toAPI):
(WebKit::toImpl):
* Source/WebKit/Shared/API/APIObject.h:
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/Shared/WebExtensionContextIdentifier.h: Added.
* Source/WebKit/Shared/WebExtensionContextParameters.h: Added.
* Source/WebKit/Shared/WebExtensionContextParameters.serialization.in: Added.
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(-[_WKWebExtension requestedPermissions]):
(-[_WKWebExtension optionalPermissions]):
(-[_WKWebExtension requestedPermissionMatchPatterns]):
(-[_WKWebExtension optionalPermissionMatchPatterns]):
(-[_WKWebExtension allRequestedMatchPatterns]):
(-[_WKWebExtension requestedPermissionOrigins]): Deleted.
(-[_WKWebExtension optionalPermissionOrigins]): Deleted.
(-[_WKWebExtension allRequestedOrigins]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm: Added.
(+[_WKWebExtensionContext contextWithExtension:]):
(-[_WKWebExtensionContext initWithExtension:]):
(-[_WKWebExtensionContext dealloc]):
(-[_WKWebExtensionContext extension]):
(-[_WKWebExtensionContext extensionController]):
(-[_WKWebExtensionContext baseURL]):
(-[_WKWebExtensionContext setBaseURL:]):
(-[_WKWebExtensionContext uniqueIdentifier]):
(-[_WKWebExtensionContext setUniqueIdentifier:]):
(toImpl):
(-[_WKWebExtensionContext grantedPermissions]):
(-[_WKWebExtensionContext setGrantedPermissions:]):
(-[_WKWebExtensionContext grantedPermissionMatchPatterns]):
(-[_WKWebExtensionContext setGrantedPermissionMatchPatterns:]):
(-[_WKWebExtensionContext deniedPermissions]):
(-[_WKWebExtensionContext setDeniedPermissions:]):
(-[_WKWebExtensionContext deniedPermissionMatchPatterns]):
(-[_WKWebExtensionContext setDeniedPermissionMatchPatterns:]):
(-[_WKWebExtensionContext requestedOptionalAccessToAllHosts]):
(-[_WKWebExtensionContext setRequestedOptionalAccessToAllHosts:]):
(toAPI):
(-[_WKWebExtensionContext currentPermissions]):
(-[_WKWebExtensionContext currentPermissionMatchPatterns]):
(-[_WKWebExtensionContext hasPermission:]):
(-[_WKWebExtensionContext hasPermission:inTab:]):
(-[_WKWebExtensionContext hasAccessToURL:]):
(-[_WKWebExtensionContext hasAccessToURL:inTab:]):
(-[_WKWebExtensionContext permissionStateForPermission:]):
(-[_WKWebExtensionContext permissionStateForPermission:inTab:]):
(-[_WKWebExtensionContext setPermissionState:forPermission:]):
(-[_WKWebExtensionContext setPermissionState:forPermission:expirationDate:]):
(-[_WKWebExtensionContext permissionStateForURL:]):
(-[_WKWebExtensionContext permissionStateForURL:inTab:]):
(-[_WKWebExtensionContext setPermissionState:forURL:]):
(-[_WKWebExtensionContext setPermissionState:forURL:expirationDate:]):
(-[_WKWebExtensionContext permissionStateForMatchPattern:]):
(-[_WKWebExtensionContext permissionStateForMatchPattern:inTab:]):
(-[_WKWebExtensionContext setPermissionState:forMatchPattern:]):
(-[_WKWebExtensionContext setPermissionState:forMatchPattern:expirationDate:]):
(-[_WKWebExtensionContext hasAccessToAllURLs]):
(-[_WKWebExtensionContext hasAccessToAllHosts]):
(-[_WKWebExtensionContext userGesturePerformedInTab:]):
(-[_WKWebExtensionContext hasActiveUserGestureInTab:]):
(-[_WKWebExtensionContext cancelUserGestureForTab:]):
(-[_WKWebExtensionContext _apiObject]):
(-[_WKWebExtensionContext _webExtensionContext]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextInternal.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextPrivate.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h: Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::hasRequestedPermission const):
(WebKit::WebExtension::supportedPermissions):
(WebKit::WebExtension::requestedPermissions):
(WebKit::WebExtension::optionalPermissions):
(WebKit::WebExtension::requestedPermissionMatchPatterns):
(WebKit::WebExtension::optionalPermissionMatchPatterns):
(WebKit::WebExtension::allRequestedMatchPatterns):
(WebKit::WebExtension::populatePermissionsPropertiesIfNeeded):
(WebKit::toAPI):
(WebKit::WebExtension::requestedPermissionOrigins): Deleted.
(WebKit::WebExtension::optionalPermissionOrigins): Deleted.
(WebKit::WebExtension::allRequestedOrigins): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm: Added.
(WebKit::WebExtensionContext::WebExtensionContext):
(WebKit::WebExtensionContext::setBaseURL):
(WebKit::WebExtensionContext::isURLForThisExtension):
(WebKit::WebExtensionContext::setUniqueIdentifier):
(WebKit::WebExtensionContext::grantedPermissions):
(WebKit::WebExtensionContext::setGrantedPermissions):
(WebKit::WebExtensionContext::deniedPermissions):
(WebKit::WebExtensionContext::setDeniedPermissions):
(WebKit::WebExtensionContext::grantedPermissionMatchPatterns):
(WebKit::WebExtensionContext::setGrantedPermissionMatchPatterns):
(WebKit::WebExtensionContext::deniedPermissionMatchPatterns):
(WebKit::WebExtensionContext::setDeniedPermissionMatchPatterns):
(WebKit::WebExtensionContext::postAsyncNotification):
(WebKit::WebExtensionContext::grantPermissions):
(WebKit::WebExtensionContext::denyPermissions):
(WebKit::WebExtensionContext::grantPermissionMatchPatterns):
(WebKit::WebExtensionContext::denyPermissionMatchPatterns):
(WebKit::WebExtensionContext::removeGrantedPermissions):
(WebKit::WebExtensionContext::removeGrantedPermissionMatchPatterns):
(WebKit::WebExtensionContext::removeDeniedPermissions):
(WebKit::WebExtensionContext::removeDeniedPermissionMatchPatterns):
(WebKit::WebExtensionContext::removePermissions):
(WebKit::WebExtensionContext::removePermissionMatchPatterns):
(WebKit::WebExtensionContext::removeExpired):
(WebKit::WebExtensionContext::hasPermission):
(WebKit::WebExtensionContext::permissionState):
(WebKit::WebExtensionContext::setPermissionState):
(WebKit::WebExtensionContext::clearCachedPermissionStates):
(WebKit::WebExtensionContext::hasAccessToAllURLs):
(WebKit::WebExtensionContext::hasAccessToAllHosts):
(WebKit::WebExtensionContext::userGesturePerformed):
(WebKit::WebExtensionContext::hasActiveUserGesture const):
(WebKit::WebExtensionContext::cancelUserGesture):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm:
(WebKit::WebExtensionMatchPattern::validSchemes):
(WebKit::WebExtensionMatchPattern::supportedSchemes):
(WebKit::patternCache):
(WebKit::WebExtensionMatchPattern::isSupported const):
(WebKit::WebExtensionMatchPattern::expandedStrings const):
(WebKit::WebExtensionMatchPattern::isValidScheme):
(WebKit::WebExtensionMatchPattern::matchesURL):
(WebKit::WebExtensionMatchPattern::matchesPattern):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::wrapper const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp: Added.
(WebKit::WebExtensionContext::get):
(WebKit::WebExtensionContext::WebExtensionContext):
(WebKit::WebExtensionContext::~WebExtensionContext):
(WebKit::WebExtensionContext::parameters const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h: Added.
(WebKit::WebExtensionContext::create):
(WebKit::WebExtensionContext::identifier const):
(WebKit::WebExtensionContext::isLoaded const):
(WebKit::WebExtensionContext::extension const):
(WebKit::WebExtensionContext::extensionController const):
(WebKit::WebExtensionContext::baseURL const):
(WebKit::WebExtensionContext::uniqueIdentifier const):
(WebKit::WebExtensionContext::requestedOptionalAccessToAllHosts const):
(WebKit::WebExtensionContext::setRequestedOptionalAccessToAllHosts):
(WebKit::WebExtensionContext::currentPermissions):
(WebKit::WebExtensionContext::currentPermissionMatchPatterns):
(WebKit::WebExtensionContext::hasPermission):
(WebKit::WebExtensionContext::permissionState):
(WebKit::WebExtensionContext::wrapper const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in: Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
(WebKit::WebExtensionMatchPattern::wrapper const):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp: Added.
(WebKit::WebExtensionContextProxy::getOrCreate):
(WebKit::WebExtensionContextProxy::WebExtensionContextProxy):
(WebKit::WebExtensionContextProxy::~WebExtensionContextProxy):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h: Added.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in: Added.
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h: Include header to fix build.
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp: Ditto.
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm: Added.
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/255374@main">https://commits.webkit.org/255374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46cb7a25b501037186f60a062bf578cb933d40d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92333 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22919 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/102105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1559 "Built successfully") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29946 "Failed to checkout and rebase branch from PR 5177") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97994 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/84760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/82948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/36364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/34127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/17741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/38001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1684 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/39901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/36884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->