### PR TITLE
CompletionHandler cannot be called from arbitrary thread

### DIFF
--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TestWTF_SOURCES
     Tests/WTF/CompactRefPtr.cpp
     Tests/WTF/CompactRefPtrTuple.cpp
     Tests/WTF/CompactUniquePtrTuple.cpp
+    Tests/WTF/CompletionHandlerTests.cpp
     Tests/WTF/ConcurrentPtrHashSet.cpp
     Tests/WTF/Condition.cpp
     Tests/WTF/CrossThreadCopier.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -575,6 +575,7 @@
 		7B9FC5D628A5326A007570E7 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F4FFAA01ED3D0DE00F7111F /* ImageIO.framework */; };
 		7BA3936C271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BA3936B271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm */; };
 		7BAA4A9028CA14AE004CE938 /* StreamConnectionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */; };
+		7BB8BDE428F0781A00129836 /* CompletionHandlerTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BB8BDDC28F0781A00129836 /* CompletionHandlerTests.cpp */; };
 		7BF5017828E55F7A0008BB16 /* StackTraceTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5017028E55F7A0008BB16 /* StackTraceTest.cpp */; };
 		7C3965061CDD74F90094DBB8 /* ColorTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C3965051CDD74F90094DBB8 /* ColorTests.cpp */; };
 		7C486BA11AA12567003F6F9B /* bundle-file.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7C486BA01AA1254B003F6F9B /* bundle-file.html */; };
@@ -2712,6 +2713,7 @@
 		7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamConnectionTests.cpp; sourceTree = "<group>"; };
 		7BB754AF274E39A100D00EC1 /* TestUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestUtilities.h; sourceTree = "<group>"; };
 		7BB754B0274E39A100D00EC1 /* TestUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestUtilities.cpp; sourceTree = "<group>"; };
+		7BB8BDDC28F0781A00129836 /* CompletionHandlerTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CompletionHandlerTests.cpp; sourceTree = "<group>"; };
 		7BF5017028E55F7A0008BB16 /* StackTraceTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StackTraceTest.cpp; sourceTree = "<group>"; };
 		7C1AF7931E8DCBAB002645B9 /* PrepareForMoveToWindow.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PrepareForMoveToWindow.mm; sourceTree = "<group>"; };
 		7C3965051CDD74F90094DBB8 /* ColorTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ColorTests.cpp; sourceTree = "<group>"; };
@@ -4983,6 +4985,7 @@
 				FF5D0CB3283221AD00F3278A /* CompactRefPtr.cpp */,
 				E302BDA92404B92300865277 /* CompactRefPtrTuple.cpp */,
 				9B0C051824FDFB7000F2FE31 /* CompactUniquePtrTuple.cpp */,
+				7BB8BDDC28F0781A00129836 /* CompletionHandlerTests.cpp */,
 				0F30CB5B1FCE1792004B5323 /* ConcurrentPtrHashSet.cpp */,
 				0FEAE3671B7D19CB00CE17F2 /* Condition.cpp */,
 				278DE64B22B8D611004E0E7A /* CrossThreadCopier.cpp */,
@@ -5940,6 +5943,7 @@
 				FF5D0CB4283221AD00F3278A /* CompactRefPtr.cpp in Sources */,
 				E302BDAA2404B92400865277 /* CompactRefPtrTuple.cpp in Sources */,
 				9B0C051924FDFB7D00F2FE31 /* CompactUniquePtrTuple.cpp in Sources */,
+				7BB8BDE428F0781A00129836 /* CompletionHandlerTests.cpp in Sources */,
 				0F30CB5C1FCE1796004B5323 /* ConcurrentPtrHashSet.cpp in Sources */,
 				7C83DEC31D0A590C00FEBCF3 /* Condition.cpp in Sources */,
 				7C83DEA61D0A590C00FEBCF3 /* Counters.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/CompletionHandlerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompletionHandlerTests.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/CompletionHandler.h>
+
+#include "Utilities.h"
+#include <wtf/Threading.h>
+#include <wtf/threads/BinarySemaphore.h>
+
+namespace TestWebKitAPI {
+namespace {
+class CompletionHandlerTest : public testing::Test {
+    void SetUp() override
+    {
+        WTF::initializeMainThread();
+    }
+};
+}
+
+TEST_F(CompletionHandlerTest, SimpleWorks)
+{
+    {
+        CompletionHandler<void()> ch1;
+    }
+
+    bool didCall = false;
+    auto makeCallable = [&didCall] {
+        return [&didCall] { 
+            didCall = true;
+        };
+    };
+    CompletionHandler<void()> ch1 { makeCallable() };
+    ch1();
+    EXPECT_TRUE(didCall);
+
+    didCall = false;
+    CompletionHandler<void()> ch2 { makeCallable(), CompletionHandlerCallThread::MainThread };
+    ch2();
+    EXPECT_TRUE(didCall);
+    didCall = false;
+    CompletionHandler<void()> ch2_1 { makeCallable(), mainThreadLike };
+    ch2_1();
+    EXPECT_TRUE(didCall);
+
+    didCall = false;
+    CompletionHandler<void()> ch3 { makeCallable(), CompletionHandlerCallThread::ConstructionThread };
+    ch3();
+    EXPECT_TRUE(didCall);
+    didCall = false;
+    CompletionHandler<void()> ch3_1 { makeCallable(), currentThreadLike };
+    ch3_1();
+    EXPECT_TRUE(didCall);
+
+    didCall = false;
+    Thread::create(__FUNCTION__, [&] {
+        CompletionHandler<void()> ch6 { makeCallable(), CompletionHandlerCallThread::ConstructionThread };
+        ch6();
+    })->waitForCompletion();
+    EXPECT_TRUE(didCall);
+
+    didCall = false;
+    CompletionHandler<void()> ch4 { makeCallable(), CompletionHandlerCallThread::AnyThread };
+    ch4();
+    EXPECT_TRUE(didCall);
+    didCall = false;
+    CompletionHandler<void()> ch4_1 { makeCallable(), anyThreadLike };
+    ch4_1();
+    EXPECT_TRUE(didCall);
+
+    didCall = false;
+    CompletionHandler<void()> ch5 { makeCallable(),  CompletionHandlerCallThread::AnyThread };
+    Thread::create(__FUNCTION__, [&] {
+        ch5();
+    })->waitForCompletion();
+    EXPECT_TRUE(didCall);
+}
+
+TEST_F(CompletionHandlerTest, CalledHandlerCanBeDestroyedOffThread)
+{
+    bool didCall = false;
+    auto makeCallable = [&didCall] {
+        return [&didCall] { 
+            didCall = true;
+        };
+    };
+    CompletionHandler<void()> ch3 { makeCallable(), CompletionHandlerCallThread::ConstructionThread };
+    ch3();
+    EXPECT_TRUE(didCall);
+
+    bool didDestroy = false;
+    Thread::create(__FUNCTION__, [&] {
+        auto ch = WTFMove(ch3);
+        didDestroy = true;
+    })->waitForCompletion();
+    EXPECT_TRUE(didDestroy);
+}
+
+TEST_F(CompletionHandlerTest, ConstructWithSpecificThreadLikeAssertion)
+{
+    CompletionHandler<void()> ch;
+    BinarySemaphore s;
+    auto t = Thread::create(__FUNCTION__, [&] {
+        s.wait();
+        ch();
+    });
+    bool didCall = false;
+    ch = { 
+        [&didCall] { 
+            didCall = true;
+        }, t->threadLikeAssertion() 
+    };
+    s.signal();
+    t->waitForCompletion();
+    EXPECT_TRUE(didCall);
+}
+
+TEST(CompletionHandlerDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(UncalledHandlerAsserts))
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    ASSERT_DEATH_IF_SUPPORTED({
+        WTF::initializeMainThread();
+        CompletionHandler<void()> ch { [] { } };
+    }, "ASSERTION FAILED: Completion handler should always be called");
+}
+
+TEST(CompletionHandlerDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(DefaultHandlerOnThreadAsserts))
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    ASSERT_DEATH_IF_SUPPORTED({
+        WTF::initializeMainThread();
+        CompletionHandler<void()> ch1 { [] { } };
+        Thread::create(__FUNCTION__, [&] {
+            ch1(); // This should assert.
+        })->waitForCompletion();
+    }, "ASSERTION FAILED: threadLikeAssertion.isCurrent\\(\\)");
+}
+
+TEST(CompletionHandlerDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(MainThreadHandlerOnThreadAsserts))
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    ASSERT_DEATH_IF_SUPPORTED({
+        WTF::initializeMainThread();
+        CompletionHandler<void()> ch1([] { }, CompletionHandlerCallThread::MainThread);
+        Thread::create(__FUNCTION__, [&] {
+            ch1(); // This should assert.
+        })->waitForCompletion();
+    }, "ASSERTION FAILED: threadLikeAssertion.isCurrent\\(\\)");
+
+    ASSERT_DEATH_IF_SUPPORTED({
+        WTF::initializeMainThread();
+        Thread::create(__FUNCTION__, [&] {
+            CompletionHandler<void()> ch1([] { }, CompletionHandlerCallThread::MainThread);
+            ch1(); // This should assert
+        })->waitForCompletion();
+    }, "ASSERTION FAILED: threadLikeAssertion.isCurrent\\(\\)");
+}
+
+TEST(CompletionHandlerDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(ConstructionThreadHandlerOnThreadAsserts))
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    ASSERT_DEATH_IF_SUPPORTED({
+        WTF::initializeMainThread();
+        CompletionHandler<void()> ch1([] { }, CompletionHandlerCallThread::ConstructionThread);
+        Thread::create(__FUNCTION__, [&] {
+            ch1(); // This should assert.
+        })->waitForCompletion();
+    }, "ASSERTION FAILED: threadLikeAssertion.isCurrent\\(\\)");
+
+    ASSERT_DEATH_IF_SUPPORTED({
+        WTF::initializeMainThread();
+        CompletionHandler<void()> ch1;
+        BinarySemaphore s;
+        auto t1 = Thread::create(__FUNCTION__, [&] {
+            ch1 = CompletionHandler<void()>([] { }, CompletionHandlerCallThread::ConstructionThread);
+            s.signal();
+            while (true) { }
+        });
+        s.wait();
+        Thread::create(__FUNCTION__, [&] {
+            ch1(); // This should assert.
+        })->waitForCompletion();
+    }, "ASSERTION FAILED: threadLikeAssertion.isCurrent\\(\\)");
+}
+
+}

--- a/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
@@ -244,12 +244,7 @@ TEST(WTF_RunLoop, CapabilityIsCurrentIsSupported)
     EXPECT_TRUE(result);
 }
 
-#if ASSERT_ENABLED
-#define MAYBE_CapabilityIsCurrentNegativeDeathTest CapabilityIsCurrentNegativeDeathTest
-#else
-#define MAYBE_CapabilityIsCurrentNegativeDeathTest DISABLED_CapabilityIsCurrentNegativeDeathTest
-#endif
-TEST(WTF_RunLoop, MAYBE_CapabilityIsCurrentNegativeDeathTest)
+TEST(WTF_RunLoopDeathTest, MAYBE_ASSERT_ENABLED_DEATH_TEST(CapabilityIsCurrentFailureAsserts))
 {
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH_IF_SUPPORTED({

--- a/Tools/TestWebKitAPI/Utilities.h
+++ b/Tools/TestWebKitAPI/Utilities.h
@@ -26,6 +26,13 @@
 #pragma once
 
 #include <wtf/Seconds.h>
+
+#if ASSERT_ENABLED
+#define MAYBE_ASSERT_ENABLED_DEATH_TEST(name) name##DeathTest
+#else
+#define MAYBE_ASSERT_ENABLED_DEATH_TEST(name) DISABLED_##name##DeathTest
+#endif
+
 namespace TestWebKitAPI::Util {
 
 // Runs a platform runloop until the 'done' flag is true.


### PR DESCRIPTION
#### 62b32a176f306013c753c4c506237d3967eff21c
<pre>
CompletionHandler cannot be called from arbitrary thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=246271">https://bugs.webkit.org/show_bug.cgi?id=246271</a>
rdar://problem/100969234

Reviewed by Chris Dumez.

Add CompletionHandlerCallThread::AnyThread so that one can pass
completion handlers that can be called from an arbitrary thread.

Implement with ThreadLikeAssertion, so that the thread check is
exact.

Add symbolic thread names for specifying the ThreadAssertions.

Make the symbolic thread names as their own types (AnyThreadLike,
... ) so that most of the ThreadLikeAssertion constructing callchains
can be constexpr. Also in future APIs, these can be used in the type
definititions instead of relying on assertions. Example:
CompletionHandler&lt;void(), AnyThreadLike&gt; (if this turns out
to make sense).

* Source/WTF/wtf/CompletionHandler.h:
(WTF::CompletionHandler&lt;Out):
(WTF::CompletionHandlerWithFinalizer&lt;Out):
* Source/WTF/wtf/ThreadAssertions.h:
(WTF::MainThreadLike::operator uint32_t const):
(WTF::CurrentThreadLike::operator uint32_t const):
(WTF::AnyThreadLike::operator uint32_t const):
(WTF::NoneThreadLike::operator uint32_t const):
(WTF::ThreadLikeAssertion::ThreadLikeAssertion):
(WTF::ThreadLikeAssertion::operator=):
(WTF::ThreadLikeAssertion::isCurrent const):
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/CompletionHandlerTests.cpp: Added.
(TestWebKitAPI::TEST_F):
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Utilities.h:

Canonical link: <a href="https://commits.webkit.org/255576@main">https://commits.webkit.org/255576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/112d08e7cbdda906d68befdf87182d19c2f7eb3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102021 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162332 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1462 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29858 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84675 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98186 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/954 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78756 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27905 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82534 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70940 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83650 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36279 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16493 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78647 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34035 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17658 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27210 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3862 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40289 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81269 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39807 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36799 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18087 "Passed tests") | 
<!--EWS-Status-Bubble-End-->