### PR TITLE
Add AllowShared to EncodedVideoChunkInit data

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.crossOriginIsolated.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.crossOriginIsolated.https.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test construction and copyTo() using a SharedArrayBuffer Type error
-FAIL Test construction and copyTo() using a Uint8Array(SharedArrayBuffer) Type error
+PASS Test construction and copyTo() using a SharedArrayBuffer
+PASS Test construction and copyTo() using a Uint8Array(SharedArrayBuffer)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.crossOriginIsolated.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.crossOriginIsolated.https.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test construction and copyTo() using a SharedArrayBuffer Type error
-FAIL Test construction and copyTo() using a Uint8Array(SharedArrayBuffer) Type error
+PASS Test construction and copyTo() using a SharedArrayBuffer
+PASS Test construction and copyTo() using a Uint8Array(SharedArrayBuffer)
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl
@@ -48,5 +48,5 @@ typedef [EnforceRange] unsigned long long WebCodecsEncodedVideoChunkInitDuration
   required WebCodecsEncodedVideoChunkType type;
   WebCodecsEncodedVideoChunkInitTimestamp timestamp;
   WebCodecsEncodedVideoChunkInitDuration duration;
-  required BufferSource data;
+  required [AllowShared] BufferSource data;
 };


### PR DESCRIPTION
#### 0b9c1e67cb8431b3713f6a143ed09ecffae96626
<pre>
Add AllowShared to EncodedVideoChunkInit data
<a href="https://bugs.webkit.org/show_bug.cgi?id=246272">https://bugs.webkit.org/show_bug.cgi?id=246272</a>
rdar://problem/100969969

Reviewed by Eric Carlson.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.crossOriginIsolated.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-video-chunk.crossOriginIsolated.https.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl:

Canonical link: <a href="https://commits.webkit.org/255387@main">https://commits.webkit.org/255387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5b01f1bf1b3bddc2d6d929887df5e5e2e44a9b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/101998 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162264 "Reverted pull request changes (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1438 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29836 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98164 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/938 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78734 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27883 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70921 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36257 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16477 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34013 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17640 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3733 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40276 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36775 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->