### PR TITLE
[Live Range Selection] A few tests fail due to behavior difference in VisibleSelection::selectionFromContentsOfNode

### DIFF
--- a/LayoutTests/editing/deleting/paste-with-transparent-background-color-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/paste-with-transparent-background-color-live-range-expected.txt
@@ -1,0 +1,19 @@
+This tests cutting and pasting a content with inline "background: transparent;" into a document with a style rule that overrides this style.
+WebKit should preserve the inline style declaration. To manually test, cut and paste "hello world WebKit" below. "world" should not be highlighted in blue.
+
+Before cut and paste:
+| "<#selection-anchor>hello "
+| <span>
+|   class="test"
+|   style="background: transparent;"
+|   "world"
+| " WebKit<#selection-focus>"
+
+After cut and paste:
+| "hello "
+| <span>
+|   class="test"
+|   style="background-color: transparent;"
+|   "world"
+| " WebKit<#selection-caret>"
+| <br>

--- a/LayoutTests/editing/deleting/paste-with-transparent-background-color-live-range.html
+++ b/LayoutTests/editing/deleting/paste-with-transparent-background-color-live-range.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html style="background: transparent; text-decoration: none">
+<body>
+<p id="description">This tests cutting and pasting a content with inline "background: transparent;" into a document with a style rule that overrides this style.
+WebKit should preserve the inline style declaration. To manually test, cut and paste "hello world WebKit" below. "world" should not be highlighted in blue.</p>
+<style>
+.test {
+    background: blue;
+}
+</style>
+<div id="container" contenteditable>hello <span class=test style="background: transparent;">world</span> WebKit</div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+Markup.description(document.getElementById('description').textContent);
+
+document.getElementById('container').focus();
+document.execCommand('SelectAll', false, null);
+
+Markup.dump(document.getElementById('container'), 'Before cut and paste');
+
+document.execCommand('Cut', false, null);
+document.execCommand('Paste', false, null);
+
+Markup.dump(document.getElementById('container'), 'After cut and paste');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/execCommand/delete-selection-has-style-live-range-expected.txt
+++ b/LayoutTests/editing/execCommand/delete-selection-has-style-live-range-expected.txt
@@ -1,0 +1,32 @@
+This tests deleting a selection that has a styling element in it. Should move styling elements to head to prevent style loss.
+
+styling elements have been moved:
+| "\n        "
+| <div>
+|   <#selection-caret>
+|   <br>
+| "\n    "
+| <style>
+|   " .text { color:red; } "
+| <link>
+|   href="../editingStyle.css"
+|   rel="stylesheet"
+|   type="text/css"
+
+styling elements are back to their original place:
+| "\n        "
+| <div>
+|   " <#selection-anchor>hide styling elements in --> "
+| "\n        "
+| <style>
+|   " .text { color:red; } "
+| "\n        "
+| <link>
+|   href="../editingStyle.css"
+|   rel="stylesheet"
+|   type="text/css"
+| "\n        "
+| <div>
+|   class="text"
+|   " between<#selection-focus> "
+| "\n    "

--- a/LayoutTests/editing/execCommand/delete-selection-has-style-live-range.html
+++ b/LayoutTests/editing/execCommand/delete-selection-has-style-live-range.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<body>
+    <div id="description">This tests deleting a selection that has a styling element in it. Should move styling elements to head to prevent style loss.</div>
+    <div id="rootEditableElement" contentEditable="true">
+        <div> hide styling elements in --> </div>
+        <style> .text { color:red; } </style>
+        <link rel="stylesheet" type="text/css" href="../editingStyle.css" />
+        <div class = "text"> between </div>
+    </div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+Markup.description(document.getElementById('description').textContent);
+document.getElementById('rootEditableElement').focus();
+document.execCommand("SelectAll");
+document.execCommand("Delete");
+Markup.dump('rootEditableElement', 'styling elements have been moved');
+document.execCommand("Undo");
+Markup.dump('rootEditableElement', 'styling elements are back to their original place');
+</script>
+</body></html>

--- a/LayoutTests/editing/input/select-all-clear-input-method-live-range-expected.txt
+++ b/LayoutTests/editing/input/select-all-clear-input-method-live-range-expected.txt
@@ -1,0 +1,6 @@
+This tests selecting all with an open input method composition.
+To manually test, type some letter in the editable region below and then select all.
+WebKit should not delete contents.
+| <div>
+|   contenteditable=""
+|   "<#selection-anchor>PASS<#selection-focus>"

--- a/LayoutTests/editing/input/select-all-clear-input-method-live-range.html
+++ b/LayoutTests/editing/input/select-all-clear-input-method-live-range.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<body>
+<p>This tests selecting all with an open input method composition.
+To manually test, type some letter in the editable region below and then select all.
+WebKit should not delete contents.</p>
+<div id="container"><div contenteditable>PAS</div></div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+if (window.testRunner) {
+    var container = document.getElementById('container');
+    container.firstChild.focus();
+    getSelection().setPosition(container.firstChild.firstChild, 3);
+    if (window.textInputController) {
+        Markup.description(document.getElementsByTagName('p')[0].textContent);
+
+        textInputController.setMarkedText("S", 0, 1);
+        document.execCommand('selectAll', false, null);
+
+        Markup.dump(container);
+    } else
+        Markup.description('FAIL - This test requires textInputController');
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/pasteboard/contenteditable-pre-2-live-range-expected.txt
+++ b/LayoutTests/editing/pasteboard/contenteditable-pre-2-live-range-expected.txt
@@ -1,0 +1,14 @@
+This test copies and pastes content inside pre that is an editing host. WebKit should not clone pre.
+To manually test, cut and paste "hello\nworld" WebKit should not nest pre (no red borders).
+
+Before cut paste:
+| <pre>
+|   "<#selection-anchor>hello"
+|   <br>
+|   "world<#selection-focus>"
+
+After cut paste:
+| <pre>
+|   "hello"
+|   <br>
+|   "world<#selection-caret>"

--- a/LayoutTests/editing/pasteboard/contenteditable-pre-2-live-range.html
+++ b/LayoutTests/editing/pasteboard/contenteditable-pre-2-live-range.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<body>
+<p id="description">This test copies and pastes content inside pre that is an editing host. WebKit should not clone pre.
+To manually test, cut and paste "hello\nworld" WebKit should not nest pre (no red borders).</p>
+<style> body > *[contenteditable] {border: solid 2px blue;} pre > pre, div > pre {border: solid 2px red;} </style>
+<div contenteditable><pre>hello<br>world</pre></div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+Markup.description(document.getElementById('description').textContent);
+
+var container = document.querySelector('div');
+container.focus();
+document.execCommand('selectAll', false, null);
+
+Markup.dump(container, 'Before cut paste');
+
+document.execCommand('cut', false, null);
+document.execCommand('paste', false, null);
+
+Markup.dump(container, 'After cut paste');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/pasteboard/copy-paste-content-starting-and-ending-canvas-live-range-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-paste-content-starting-and-ending-canvas-live-range-expected.txt
@@ -1,0 +1,44 @@
+This tests selecting all, copying, and pasting a content that starts and ends with canvas elements.
+To manually test, copy and paste the content below:
+
+Before paste:
+| "\n"
+| <#selection-anchor>
+| <canvas>
+|   height="100"
+|   style="border: 1px solid black"
+|   width="100"
+| "\nsome text\n"
+| <canvas>
+|   height="100"
+|   style="border: 1px solid black"
+|   width="100"
+| "\nsome more text\n"
+| <canvas>
+|   height="100"
+|   style="border: 1px solid black"
+|   width="100"
+| <#selection-focus>
+| "\n"
+
+After paste:
+| <canvas>
+|   height="100"
+|   style="border: 1px solid black;"
+|   width="100"
+| " "
+| "some text"
+| " "
+| <canvas>
+|   height="100"
+|   style="border: 1px solid black;"
+|   width="100"
+| " "
+| "some more text"
+| " "
+| <canvas>
+|   height="100"
+|   style="border: 1px solid black;"
+|   width="100"
+| <#selection-caret>
+| <br>

--- a/LayoutTests/editing/pasteboard/copy-paste-content-starting-and-ending-canvas-live-range.html
+++ b/LayoutTests/editing/pasteboard/copy-paste-content-starting-and-ending-canvas-live-range.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<body>
+<p id="description">This tests selecting all, copying, and pasting a content that starts and ends with canvas elements.
+To manually test, copy and paste the content below:</p>
+<div id="editor" contenteditable>
+<canvas width="100" height="100" style="border: 1px solid black"></canvas>
+some text
+<canvas width="100" height="100" style="border: 1px solid black"></canvas>
+some more text
+<canvas width="100" height="100" style="border: 1px solid black"></canvas>
+</div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+Markup.description(document.getElementById('description').textContent);
+
+var editor = document.getElementById('editor');
+editor.focus();
+document.execCommand('selectAll');
+
+document.execCommand('copy');
+Markup.dump(editor, 'Before paste');
+
+if (document.queryCommandSupported('copy') && document.queryCommandSupported('paste')) {
+    document.execCommand('paste');
+    Markup.dump(editor, 'After paste');
+} else
+    editor.onpaste = function () { setTimeout(function () { Markup.dump(editor, 'After paste'); }, 0); }
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/pasteboard/preserve-line-break-at-end-of-pasted-content-live-range-expected.txt
+++ b/LayoutTests/editing/pasteboard/preserve-line-break-at-end-of-pasted-content-live-range-expected.txt
@@ -1,0 +1,18 @@
+This tests for a bug where newlines would not be preserved during copy/paste. Below you should see two paragraphs containing "Hello World!" and an empty third paragraph with the caret in it.
+
+Before copy and paste:
+| "<#selection-anchor>Hello World!"
+| <div>
+|   id="div"
+|   <#selection-focus>
+|   <br>
+
+After copy and paste:
+| "Hello World!"
+| <div>
+|   id="div"
+|   "Hello World!"
+|   <br>
+| <div>
+|   <#selection-caret>
+|   <br>

--- a/LayoutTests/editing/pasteboard/preserve-line-break-at-end-of-pasted-content-live-range.html
+++ b/LayoutTests/editing/pasteboard/preserve-line-break-at-end-of-pasted-content-live-range.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<body>
+<p id="description">This tests for a bug where newlines would not be preserved during copy/paste. Below you should see two paragraphs containing "Hello World!" and an empty third paragraph with the caret in it.</p>
+<div id="root" contenteditable="true">Hello World!<div id="div"><br></div></div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+Markup.description(document.getElementById('description').textContent);
+
+root = document.getElementById("root");
+root.focus();
+document.execCommand("SelectAll");
+document.execCommand("Copy");
+
+Markup.dump(root, 'Before copy and paste');
+
+selection = window.getSelection();
+div = document.getElementById("div");
+selection.setPosition(div, 0);
+document.execCommand("Paste");
+
+Markup.dump(root, 'After copy and paste');
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/select-all-user-select-none-live-range-expected.txt
+++ b/LayoutTests/editing/selection/select-all-user-select-none-live-range-expected.txt
@@ -1,0 +1,1 @@
+Test Passed

--- a/LayoutTests/editing/selection/select-all-user-select-none-live-range.html
+++ b/LayoutTests/editing/selection/select-all-user-select-none-live-range.html
@@ -1,0 +1,21 @@
+<html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+    <head>
+        <style>
+        body {
+            -webkit-user-select: none;
+        }
+        </style>
+        <script>
+            function test() {
+                if (window.testRunner)
+                    testRunner.dumpAsText();
+                document.execCommand('SelectAll');
+                if (window.getSelection().toString() == "")
+                    document.body.innerHTML = "Test Passed";
+            }
+        </script>
+    </head>
+    <body onload="test()">
+    Test Failed (this should not be selected)
+    </body>
+</html>

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -83,7 +83,7 @@ VisibleSelection::VisibleSelection(const SimpleRange& range, Affinity affinity, 
 VisibleSelection VisibleSelection::selectionFromContentsOfNode(Node* node)
 {
     ASSERT(!editingIgnoresContent(*node));
-    return VisibleSelection(firstPositionInNode(node), lastPositionInNode(node));
+    return VisibleSelection(VisiblePosition { firstPositionInNode(node) }, VisiblePosition { lastPositionInNode(node) });
 }
 
 Position VisibleSelection::anchor() const


### PR DESCRIPTION
#### aef26c62b048ca1c59f33b5013e9d0c5f8eb18ad
<pre>
[Live Range Selection] A few tests fail due to behavior difference in VisibleSelection::selectionFromContentsOfNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=246284">https://bugs.webkit.org/show_bug.cgi?id=246284</a>

Reviewed by Darin Adler.

Explicitly canonicalize selection start &amp; end in VisibleSelection::selectionFromContentsOfNode so that
enabling live range selection wouldn&apos;t cause a new test failure.

Also add variants of the tests that enable live range selection.

* LayoutTests/editing/deleting/paste-with-transparent-background-color-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/paste-with-transparent-background-color-live-range.html: Added.
* LayoutTests/editing/execCommand/delete-selection-has-style-live-range-expected.txt: Added.
* LayoutTests/editing/execCommand/delete-selection-has-style-live-range.html: Added.
* LayoutTests/editing/input/select-all-clear-input-method-live-range-expected.txt: Added.
* LayoutTests/editing/input/select-all-clear-input-method-live-range.html: Added.
* LayoutTests/editing/pasteboard/contenteditable-pre-2-live-range-expected.txt: Added.
* LayoutTests/editing/pasteboard/contenteditable-pre-2-live-range.html: Added.
* LayoutTests/editing/pasteboard/copy-paste-content-starting-and-ending-canvas-live-range-expected.txt: Added.
* LayoutTests/editing/pasteboard/copy-paste-content-starting-and-ending-canvas-live-range.html: Added.
* LayoutTests/editing/pasteboard/preserve-line-break-at-end-of-pasted-content-live-range-expected.txt: Added.
* LayoutTests/editing/pasteboard/preserve-line-break-at-end-of-pasted-content-live-range.html: Added.
* LayoutTests/editing/selection/select-all-user-select-none-live-range-expected.txt: Added.
* LayoutTests/editing/selection/select-all-user-select-none-live-range.html: Added.
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::selectionFromContentsOfNode):

Canonical link: <a href="https://commits.webkit.org/255372@main">https://commits.webkit.org/255372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fe3f87192a21ed0e39d7a4562eee505fcb15c3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102045 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1489 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29884 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84702 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98211 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/975 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78781 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27916 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82558 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/70953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36304 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34060 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17682 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37933 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40312 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1682 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36823 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->