### PR TITLE
Turn 'delegates scrolling' into an enum

### DIFF
--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -2684,14 +2684,15 @@ void FrameView::contentsResized()
         updateTiledBackingAdaptiveSizing();
 }
 
-void FrameView::delegatesScrollingDidChange()
+void FrameView::delegatedScrollingModeDidChange()
 {
-    RenderView* renderView = this->renderView();
+    auto* renderView = this->renderView();
     if (!renderView)
         return;
 
     RenderLayerCompositor& compositor = renderView->compositor();
     // When we switch to delegatesScrolling mode, we should destroy the scrolling/clipping layers in RenderLayerCompositor.
+    // FIXME: Is this right? What turns compositing back on?
     if (compositor.usesCompositing()) {
         ASSERT(compositor.usesCompositing());
         compositor.enableCompositingMode(false);

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -785,7 +785,7 @@ private:
     void scrollToFocusedElementTimerFired();
     void scrollToFocusedElementInternal();
 
-    void delegatesScrollingDidChange() final;
+    void delegatedScrollingModeDidChange() final;
 
     void unobscuredContentSizeChanged() final;
     

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -189,13 +189,13 @@ void ScrollView::setPaintsEntireContents(bool paintsEntireContents)
     m_paintsEntireContents = paintsEntireContents;
 }
 
-void ScrollView::setDelegatesScrolling(bool delegatesScrolling)
+void ScrollView::setDelegatedScrollingMode(DelegatedScrollingMode delegatedScrollingMode)
 {
-    if (m_delegatesScrolling == delegatesScrolling)
+    if (m_delegatedScrollingMode == delegatedScrollingMode)
         return;
 
-    m_delegatesScrolling = delegatesScrolling;
-    delegatesScrollingDidChange();
+    m_delegatedScrollingMode = delegatedScrollingMode;
+    delegatedScrollingModeDidChange();
 }
 
 IntPoint ScrollView::contentsScrollPosition() const
@@ -578,12 +578,15 @@ IntSize ScrollView::overhangAmount() const
 bool ScrollView::managesScrollbars() const
 {
 #if PLATFORM(IOS_FAMILY)
+    // FIXME: We should be able to remove this. iOS should always hit the DelegatedToNativeScrollView condition below.
     return false;
 #else
     if (platformWidget())
         return false;
-    if (delegatesScrolling())
+
+    if (delegatedScrollingMode() == DelegatedScrollingMode::DelegatedToNativeScrollView)
         return false;
+
     return true;
 #endif
 }

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3640,7 +3640,7 @@ bool RenderLayerCompositor::requiresScrollLayer(RootLayerAttachment attachment) 
     auto& frameView = m_renderView.frameView();
 
     // This applies when the application UI handles scrolling, in which case RenderLayerCompositor doesn't need to manage it.
-    if (frameView.delegatesScrolling() && isMainFrameCompositor())
+    if (frameView.delegatedScrollingMode() == DelegatedScrollingMode::DelegatedToNativeScrollView && isMainFrameCompositor())
         return false;
 
     // We need to handle our own scrolling if we're:

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2320,7 +2320,7 @@ ExceptionOr<void> Internals::setDelegatesScrolling(bool enabled)
     if (!document || !document->view() || !document->page() || &document->page()->mainFrame() != document->frame())
         return Exception { InvalidAccessError };
 
-    document->view()->setDelegatesScrolling(enabled);
+    document->view()->setDelegatedScrollingMode(enabled ? DelegatedScrollingMode::DelegatedToNativeScrollView : DelegatedScrollingMode::NotDelegated);
     return { };
 }
 

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -62,6 +62,11 @@ void DrawingAreaProxy::startReceivingMessages()
     process().addMessageReceiver(Messages::DrawingAreaProxy::messageReceiverName(), m_identifier, *this);
 }
 
+DelegatedScrollingMode DrawingAreaProxy::delegatedScrollingMode() const
+{
+    return DelegatedScrollingMode::NotDelegated;
+}
+
 bool DrawingAreaProxy::setSize(const IntSize& size, const IntSize& scrollDelta)
 { 
     if (m_size == size && scrollDelta.isZero())

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -44,6 +44,10 @@ class MachSendRight;
 }
 #endif
 
+namespace WebCore {
+enum class DelegatedScrollingMode : uint8_t;
+}
+
 namespace WebKit {
 
 class LayerTreeContext;
@@ -66,7 +70,7 @@ public:
 
     void startReceivingMessages();
 
-    virtual bool usesDelegatedScrolling() const { return false; }
+    virtual WebCore::DelegatedScrollingMode delegatedScrollingMode() const;
 
     virtual void deviceScaleFactorDidChange() = 0;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -68,8 +68,7 @@ public:
 #endif
 
 private:
-    bool usesDelegatedScrolling() const final { return true; }
-
+    WebCore::DelegatedScrollingMode delegatedScrollingMode() const override;
     void sizeDidChange() final;
     void deviceScaleFactorDidChange() final;
     void windowKindDidChange() final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -37,6 +37,7 @@
 #import <WebCore/AnimationFrameRate.h>
 #import <WebCore/GraphicsContextCG.h>
 #import <WebCore/IOSurfacePool.h>
+#import <WebCore/ScrollView.h>
 #import <WebCore/WebActionDisablingCALayerDelegate.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/MachSendRight.h>
@@ -189,6 +190,10 @@ RemoteLayerTreeDrawingAreaProxy::~RemoteLayerTreeDrawingAreaProxy()
 #endif
 }
 
+DelegatedScrollingMode RemoteLayerTreeDrawingAreaProxy::delegatedScrollingMode() const
+{
+    return DelegatedScrollingMode::DelegatedToNativeScrollView;
+}
 
 std::unique_ptr<RemoteLayerTreeHost> RemoteLayerTreeDrawingAreaProxy::detachRemoteLayerTreeHost()
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -1589,7 +1589,7 @@ void WebFrameLoaderClient::transitionToCommittedForNewPage()
     auto* drawingArea = webPage->drawingArea();
     view->setViewExposedRect(drawingArea->viewExposedRect());
     if (isMainFrame)
-        view->setDelegatesScrolling(drawingArea->usesDelegatedScrolling());
+        view->setDelegatedScrollingMode(drawingArea->delegatedScrollingMode());
 
     webPage->corePage()->setDelegatesScaling(drawingArea->usesDelegatedPageScaling());
 #endif
@@ -1599,7 +1599,7 @@ void WebFrameLoaderClient::transitionToCommittedForNewPage()
 
 #if USE(COORDINATED_GRAPHICS)
     if (shouldUseFixedLayout) {
-        view->setDelegatesScrolling(shouldUseFixedLayout);
+        view->setDelegatedScrollingMode(shouldUseFixedLayout ? DelegatedScrollingMode::DelegatedToNativeScrollView : DelegatedScrollingMode::NotDelegated);
         view->setPaintsEntireContents(shouldUseFixedLayout);
         return;
     }

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
@@ -31,6 +31,7 @@
 #include "WebPageCreationParameters.h"
 #include "WebProcess.h"
 #include <WebCore/DisplayRefreshMonitor.h>
+#include <WebCore/ScrollView.h>
 #include <WebCore/TransformationMatrix.h>
 
 // Subclasses
@@ -81,6 +82,11 @@ DrawingArea::DrawingArea(DrawingAreaType type, DrawingAreaIdentifier identifier,
 DrawingArea::~DrawingArea()
 {
     removeMessageReceiverIfNeeded();
+}
+
+DelegatedScrollingMode DrawingArea::delegatedScrollingMode() const
+{
+    return DelegatedScrollingMode::NotDelegated;
 }
 
 void DrawingArea::dispatchAfterEnsuringUpdatedScrollPosition(WTF::Function<void ()>&& function)

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -57,6 +57,7 @@ class FrameView;
 class GraphicsLayer;
 class GraphicsLayerFactory;
 struct ViewportAttributes;
+enum class DelegatedScrollingMode : uint8_t;
 }
 
 namespace WebKit {
@@ -109,8 +110,8 @@ public:
     virtual void mainFrameScrollabilityChanged(bool) { }
 
     virtual bool supportsAsyncScrolling() const { return false; }
-    virtual bool usesDelegatedScrolling() const { return false; }
     virtual bool usesDelegatedPageScaling() const { return false; }
+    virtual WebCore::DelegatedScrollingMode delegatedScrollingMode() const;
 
     virtual bool shouldUseTiledBackingForFrameView(const WebCore::FrameView&) const { return false; }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -81,8 +81,8 @@ private:
     void updatePreferences(const WebPreferencesStore&) override;
 
     bool supportsAsyncScrolling() const override { return true; }
-    bool usesDelegatedScrolling() const override { return true; }
     bool usesDelegatedPageScaling() const override { return true; }
+    WebCore::DelegatedScrollingMode delegatedScrollingMode() const override;
 
     void setLayerTreeStateIsFrozen(bool) override;
     bool layerTreeStateIsFrozen() const override { return m_isRenderingSuspended; }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -48,6 +48,7 @@
 #import <WebCore/PageOverlayController.h>
 #import <WebCore/RenderLayerCompositor.h>
 #import <WebCore/RenderView.h>
+#import <WebCore/ScrollView.h>
 #import <WebCore/Settings.h>
 #import <WebCore/TiledBacking.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
@@ -190,6 +191,11 @@ void RemoteLayerTreeDrawingArea::setDeviceScaleFactor(float deviceScaleFactor)
     m_webPage.setDeviceScaleFactor(deviceScaleFactor);
 }
 #endif
+
+DelegatedScrollingMode RemoteLayerTreeDrawingArea::delegatedScrollingMode() const
+{
+    return DelegatedScrollingMode::DelegatedToNativeScrollView;
+}
 
 void RemoteLayerTreeDrawingArea::setLayerTreeStateIsFrozen(bool isFrozen)
 {

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
@@ -49,7 +49,7 @@ namespace WebKit {
 
 class LayerHostingContext;
 
-class TiledCoreAnimationDrawingArea : public DrawingArea {
+class TiledCoreAnimationDrawingArea final : public DrawingArea {
 public:
     TiledCoreAnimationDrawingArea(WebPage&, const WebPageCreationParameters&);
     virtual ~TiledCoreAnimationDrawingArea();

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1451,7 +1451,7 @@ void WebFrameLoaderClient::transitionToCommittedForNewPage()
 
     if (isMainFrame) {
 #if PLATFORM(IOS_FAMILY)
-        coreView->setDelegatesScrolling(true);
+        coreView->setDelegatedScrollingMode(WebCore::DelegatedScrollingMode::DelegatedToNativeScrollView);
 #endif
         coreView->setParentVisible(true);
     }


### PR DESCRIPTION
#### cfc548338e845e58f76d89f9af85bdd1b85ab657
<pre>
Turn &apos;delegates scrolling&apos; into an enum
<a href="https://bugs.webkit.org/show_bug.cgi?id=246299">https://bugs.webkit.org/show_bug.cgi?id=246299</a>
rdar://100995741

Reviewed by Tim Horton.

&apos;delegatesScrolling&apos; currently assumes that whatever is taking over scrolling provides scrollbars.
With UI-side compositing on macOS, we want to continue to have WebCore create scrollbars, so this
bool needs to be more fine-grained.

This change converts the bool into an enum class with three values: NotDelegated,
DelegatedToNativeScrollView, DelegatedToWebKit. Most code continues to work as before
by testing mode != NotDelegated, but we use DelegatedToWebKit to control whether scrollbars
are created.

Both DrawingArea, and DrawingAreaProxy have delegatedScrollingMode(), and RemoteLayerTreeDrawingArea*
override the default to return `DelegatedToNativeScrollView`. A future subclass will use
`DelegatedToWebKit`.

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::delegatedScrollingModeDidChange):
(WebCore::FrameView::delegatesScrollingDidChange): Deleted.
* Source/WebCore/page/FrameView.h:
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::setDelegatedScrollingMode):
(WebCore::ScrollView::managesScrollbars const):
(WebCore::ScrollView::setDelegatesScrolling): Deleted.
* Source/WebCore/platform/ScrollView.h:
(WebCore::ScrollView::delegatedScrollingMode const):
(WebCore::ScrollView::delegatesScrolling const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::requiresScrollLayer const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setDelegatesScrolling):
* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
(WebKit::DrawingAreaProxy::delegatedScrollingMode const):
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::usesDelegatedScrolling const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::delegatedScrollingMode const):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::transitionToCommittedForNewPage):
* Source/WebKit/WebProcess/WebPage/DrawingArea.cpp:
(WebKit::DrawingArea::delegatedScrollingMode const):
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::supportsAsyncScrolling const):
(WebKit::DrawingArea::usesDelegatedScrolling const): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::delegatedScrollingMode const):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::transitionToCommittedForNewPage):

Canonical link: <a href="https://commits.webkit.org/255382@main">https://commits.webkit.org/255382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd98ba076d0252930e5855bb40396c8a16a2da61

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102102 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1554 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29942 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84757 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98265 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1025 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78843 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27960 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82618 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36360 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34123 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17738 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3725 "Found 1 new test failure: imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37996 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40364 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1688 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36881 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->